### PR TITLE
[#148019361] Add analytics for SPID login

### DIFF
--- a/js/actions/login.js
+++ b/js/actions/login.js
@@ -9,19 +9,52 @@
 import type { Action, ThunkAction, Dispatch, GetState } from './types'
 import { requestUserProfile } from './user'
 
+const LOGIN = 'LOGGED_IN'
+const LOGIN_INTENT = 'LOG_IN_INTENT'
+const LOGIN_PROVIDER = 'LOG_IN_PROVIDER'
+const LOGIN_ERROR = 'LOG_IN_ERROR'
+
+/**
+ * Dispatched when the user taps on SPID Login
+ */
+function logInIntent(): Action {
+  return {
+    type: LOGIN_INTENT,
+  }
+}
+
+/**
+ * Dispatched when the user selects the SPID provider
+ */
+function selectIdpidp(idp: Object): Action {
+  return {
+    type: LOGIN_PROVIDER,
+    data: idp
+  }
+}
+
 /**
  * Logs the user in, setting the provided auth token and SPID IdP
  */
 function logIn(token: string, idpId: string): ThunkAction {
   return (dispatch: Dispatch, getState: GetState) => {
     dispatch({
-      type: 'LOGGED_IN',
+      type: LOGIN,
       data: {
         token,
         idpId,
       }
     })
     requestUserProfile()(dispatch, getState)
+  }
+}
+
+function logInError(error: string): Action {
+  return {
+    type: LOGIN_ERROR,
+    data: {
+      error,
+    }
   }
 }
 
@@ -35,6 +68,14 @@ function logOut(): Action {
 }
 
 module.exports = {
+  logInIntent,
+  selectIdpidp,
   logIn,
-  logOut
+  logInError,
+  logOut,
+
+  LOGIN_INTENT,
+  LOGIN_PROVIDER,
+  LOGIN,
+  LOGIN_ERROR,
 }

--- a/js/actions/types.js
+++ b/js/actions/types.js
@@ -9,7 +9,10 @@
 import type { ApiUserProfile } from '../utils/api'
 
 export type Action =
+  | { type: 'LOG_IN_INTENT' }
+  | { type: 'LOG_IN_PROVIDER', data: { idp: Object } }
   | { type: 'LOGGED_IN', data: { token: string, idpId: string } }
+  | { type: 'LOG_IN_ERROR', data: { error: string } }
   | { type: 'LOGGED_OUT' }
   | { type: 'REQUEST_USER_PROFILE' }
   | { type: 'RECEIVE_USER_PROFILE', profile: ApiUserProfile, receivedAt: number }

--- a/js/components/LoginScreen.js
+++ b/js/components/LoginScreen.js
@@ -28,9 +28,7 @@ import type { Dispatch } from '../actions/types'
 import { SpidLoginButton } from './SpidLoginButton'
 import SpidSubscribeComponent from './SpidSubscribeComponent'
 
-const {
-	logIn,
-} = require('../actions')
+import { logInIntent, selectIdpidp, logIn, logInError } from '../actions'
 
 import { ROUTES } from '../utils/constants'
 
@@ -123,10 +121,17 @@ class LoginScreen extends React.Component {
             <H2 style={StyleSheet.flatten(styles.titleText)}>benvenuto nella tua</H2>
             <H1 style={StyleSheet.flatten(styles.titleText)}>Cittadinanza Digitale</H1>
           </View>
-          <SpidLoginButton onSpidLogin={(token, idpId) => {
-            this.props.dispatch(logIn(token, idpId))
-            this.props.navigation.navigate(ROUTES.PROFILE)
-          }} />
+          <SpidLoginButton
+						onSelectIdp={(idp) => this.props.dispatch(selectIdpidp(idp))}
+						onSpidLoginIntent={() => this.props.dispatch(logInIntent())}
+						onSpidLogin={(token, idpId) => {
+							this.props.dispatch(logIn(token, idpId))
+							this.props.navigation.navigate(ROUTES.PROFILE)
+						}}
+						onSpidLoginError={(error) => {
+							this.props.dispatch(logInError(error))
+						}}
+					/>
           <View style={{ height: 10 }} />
           <SpidSubscribeComponent />
           <View style={{ height: 60 }} />

--- a/js/components/SpidLoginButton.js
+++ b/js/components/SpidLoginButton.js
@@ -169,7 +169,9 @@ class IdpSelectionScreen extends React.Component {
 
   props: {
     closeModal: () => void,
+    onSelectIdp: (Object) => void,
     onSpidLogin: (string, string) => void,
+    onSpidLoginError: (string) => void,
   }
 
   state: {
@@ -178,6 +180,9 @@ class IdpSelectionScreen extends React.Component {
 
   constructor(props) {
     super(props)
+
+    this.createButtons = this.createButtons.bind(this)
+
     this.state = {
       selectedIdp: null,
     }
@@ -199,6 +204,7 @@ class IdpSelectionScreen extends React.Component {
     return idps.map((idp: IdentityProvider) => {
       return (
         <Button iconRight light block key={idp.id} style={StyleSheet.flatten(styles.idpButton)} onPress={() => {
+          this.props.onSelectIdp(idp)
           this.selectIdp(idp)
         }}>
           <Image
@@ -265,12 +271,13 @@ class IdpSelectionScreen extends React.Component {
     }
   }
 
-  _handleSpidError() {
+  _handleSpidError(err) {
     Alert.alert(
           'Errore login',
           'Mi spiace, si è verificato un errore durante l\'accesso, potresti riprovare?',
           { text: 'OK' },
         )
+    this.props.onSpidLoginError(err)
     this.resetIdp()
   }
 
@@ -283,7 +290,10 @@ class IdpSelectionScreen extends React.Component {
 export class SpidLoginButton extends React.Component {
 
   props: {
+    onSpidLoginIntent: () => void,
+    onSelectIdp: (Object) => void,
     onSpidLogin: (string, string) => void,
+    onSpidLoginError: (string) => void,
   }
 
   state = {
@@ -305,7 +315,9 @@ export class SpidLoginButton extends React.Component {
           visible={this.state.isModalVisible}
           >
          <IdpSelectionScreen
+           onSelectIdp={this.props.onSelectIdp}
            onSpidLogin={this.props.onSpidLogin}
+           onSpidLoginError={this.props.onSpidLoginError}
            closeModal={() => {
              this.setModalVisible(false)
            }}/>
@@ -315,6 +327,7 @@ export class SpidLoginButton extends React.Component {
           block light bordered
           style={{backgroundColor: '#0066CC'}}
           onPress={() => {
+            this.props.onSpidLoginIntent()
             this.setModalVisible(true)
           }}
         >

--- a/js/middlewares/analytics.js
+++ b/js/middlewares/analytics.js
@@ -3,7 +3,7 @@ import Mixpanel from 'react-native-mixpanel'
 import { has } from 'lodash'
 import { sha256 } from 'react-native-sha256'
 
-import { APPSTATE_CHANGE } from '../actions'
+import { APPSTATE_CHANGE, LOGIN_INTENT, LOGIN_PROVIDER, LOGIN } from '../actions'
 import * as persist from 'redux-persist/constants'
 
 /*
@@ -24,6 +24,25 @@ const actionTracking = (store) => (next) => (action) => {
   let result = next(action)
 
   switch (action.type) {
+    case LOGIN_INTENT: {
+      Mixpanel.track('Login')
+      break
+    }
+    case LOGIN_PROVIDER: {
+      const { id, name } = result.data
+      Mixpanel.trackWithProperties('Provider', {
+        id,
+        name,
+      })
+      break
+    }
+    case LOGIN: {
+      const { idpId } = result.data
+      Mixpanel.trackWithProperties('Login Success', {
+        idpId,
+      })
+      break
+    }
     case APPSTATE_CHANGE: {
       Mixpanel.track(result.data)
       break
@@ -77,7 +96,7 @@ const screenTracking = ({ getState }) => (next) => (action) => {
 
   if (nextScreen !== currentScreen) {
     Mixpanel.track(nextScreen)
-    //Track event with properties
+    // Track event with properties
     // Mixpanel.trackWithProperties(nextScreen, { button_type: 'yellow button', button_text: 'magic button' })
   }
   return result


### PR DESCRIPTION
Continues from #25 

# Adds
- `Login`, `LoginIntent`, `LoginProvider` actions
- `Login`, `LoginIntent`, `LoginProvider` tracking in analytics middleware

# Demo
![screen shot 2017-07-03 at 10 57 50](https://user-images.githubusercontent.com/735227/27785609-7b0c2a22-5fde-11e7-8070-1bc7cf605a0c.png)

