### PR TITLE
[#170899177] Fix footer render condition on RemindEmailValidationOverlay

### DIFF
--- a/ts/components/RemindEmailValidationOverlay.tsx
+++ b/ts/components/RemindEmailValidationOverlay.tsx
@@ -305,7 +305,9 @@ class RemindEmailValidationOverlay extends React.PureComponent<Props, State> {
               </Button>
             )}
         </Content>
-        {this.state.isContentLoadCompleted && this.renderFooter()}
+        {(this.state.emailHasBeenValidate ||
+          this.state.isContentLoadCompleted) &&
+          this.renderFooter()}
       </TopScreenComponent>
     );
   }


### PR DESCRIPTION
**Short description:**
This PR fixes the condition to render the footer in RemindEmailValidationOverlay Screen.
Previously the footer was rendered when the markdown content has been loaded.
But when the email is already validated the markdown component is not included.

**List of changes proposed in this pull request:**
The condition to render the footer is:
the email is validated **OR** the markdown content is loaded


| before  | after |
| ------------- | ------------- |
![before](https://user-images.githubusercontent.com/822471/73189282-6e194780-4124-11ea-881d-7051c999eeb7.gif) | ![after](https://user-images.githubusercontent.com/822471/73189307-796c7300-4124-11ea-8e91-21b2016e874d.gif)

