### PR TITLE
[#170014535] Invalidate PM session when email is not validated

### DIFF
--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -68,7 +68,8 @@ import {
   payCreditCardVerificationRequest,
   payCreditCardVerificationSuccess,
   runStartOrResumeAddCreditCardSaga,
-  setFavouriteWalletRequest
+  setFavouriteWalletRequest,
+  setWalletSessionEnabled
 } from "../store/actions/wallet/wallets";
 import { GlobalState } from "../store/reducers/types";
 
@@ -672,6 +673,18 @@ export function* watchWalletSaga(
     paymentManagerClient,
     pmSessionManager
   );
+
+  yield takeLatest(getType(setWalletSessionEnabled), function* handler(
+    action: ActionType<typeof setWalletSessionEnabled>
+  ) {
+    console.warn("A");
+    if (action.payload) {
+      yield call(pmSessionManager.enableSession);
+      console.warn("B");
+      return;
+    }
+    yield call(pmSessionManager.disableSession);
+  });
 
   yield fork(paymentsDeleteUncompletedSaga);
 }

--- a/ts/screens/profile/ProfileMainScreen.tsx
+++ b/ts/screens/profile/ProfileMainScreen.tsx
@@ -48,6 +48,7 @@ import { GlobalState } from "../../store/reducers/types";
 import customVariables from "../../theme/variables";
 import { clipboardSetStringWithFeedback } from "../../utils/clipboard";
 import { setStatusBarColorAndBackground } from "../../utils/statusBar";
+import { setWalletSessionEnabled } from "../../store/actions/wallet/wallets";
 
 type OwnProps = Readonly<{
   navigation: NavigationScreenProp<NavigationState>;
@@ -446,6 +447,17 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
                   this.props.dispatchSessionExpired,
                   true
                 )}
+
+                {this.debugListItem(
+                  "enable wallet session",
+                  this.props.dispatchEnableWalletSession,
+                  false
+                )}
+                {this.debugListItem(
+                  "disable wallet session",
+                  this.props.dispatchDisableWalletSession,
+                  false
+                )}
               </React.Fragment>
             )}
 
@@ -513,7 +525,9 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
       preferencesPagoPaTestEnvironmentSetEnabled({ isPagoPATestEnabled })
     ),
   dispatchPreferencesExperimentalFeaturesSetEnabled: (enabled: boolean) =>
-    dispatch(preferencesExperimentalFeaturesSetEnabled(enabled))
+    dispatch(preferencesExperimentalFeaturesSetEnabled(enabled)),
+  dispatchEnableWalletSession: () => dispatch(setWalletSessionEnabled(true)),
+  dispatchDisableWalletSession: () => dispatch(setWalletSessionEnabled(false))
 });
 
 export default connect(

--- a/ts/screens/profile/ProfileMainScreen.tsx
+++ b/ts/screens/profile/ProfileMainScreen.tsx
@@ -48,7 +48,6 @@ import { GlobalState } from "../../store/reducers/types";
 import customVariables from "../../theme/variables";
 import { clipboardSetStringWithFeedback } from "../../utils/clipboard";
 import { setStatusBarColorAndBackground } from "../../utils/statusBar";
-import { setWalletSessionEnabled } from "../../store/actions/wallet/wallets";
 
 type OwnProps = Readonly<{
   navigation: NavigationScreenProp<NavigationState>;
@@ -447,17 +446,6 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
                   this.props.dispatchSessionExpired,
                   true
                 )}
-
-                {this.debugListItem(
-                  "enable wallet session",
-                  this.props.dispatchEnableWalletSession,
-                  false
-                )}
-                {this.debugListItem(
-                  "disable wallet session",
-                  this.props.dispatchDisableWalletSession,
-                  false
-                )}
               </React.Fragment>
             )}
 
@@ -525,9 +513,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
       preferencesPagoPaTestEnvironmentSetEnabled({ isPagoPATestEnabled })
     ),
   dispatchPreferencesExperimentalFeaturesSetEnabled: (enabled: boolean) =>
-    dispatch(preferencesExperimentalFeaturesSetEnabled(enabled)),
-  dispatchEnableWalletSession: () => dispatch(setWalletSessionEnabled(true)),
-  dispatchDisableWalletSession: () => dispatch(setWalletSessionEnabled(false))
+    dispatch(preferencesExperimentalFeaturesSetEnabled(enabled))
 });
 
 export default connect(

--- a/ts/store/actions/wallet/wallets.ts
+++ b/ts/store/actions/wallet/wallets.ts
@@ -103,6 +103,10 @@ export const setFavouriteWalletFailure = createStandardAction(
   "WALLET_SET_FAVOURITE_FAILURE"
 )<Error>();
 
+export const setWalletSessionEnabled = createStandardAction(
+  "WALLET_SET_SESSION_ENABLED"
+)<boolean>();
+
 type StartOrResumeAddCreditCardSagaPayload = Readonly<{
   creditCard: CreditCard;
   language?: string;
@@ -134,4 +138,5 @@ export type WalletsActions =
   | ActionType<typeof payCreditCardVerificationSuccess>
   | ActionType<typeof payCreditCardVerificationFailure>
   | ActionType<typeof creditCardCheckout3dsRequest>
-  | ActionType<typeof creditCardCheckout3dsSuccess>;
+  | ActionType<typeof creditCardCheckout3dsSuccess>
+  | ActionType<typeof setWalletSessionEnabled>;

--- a/ts/utils/SessionManager.ts
+++ b/ts/utils/SessionManager.ts
@@ -65,14 +65,10 @@ export class SessionManager<T> {
   };
 
   /**
-   * avoid to perform any token refreshing and requests that need token
+   * enable/disable to perform action that need token and token refreshing too
    */
-  public disableSession = async () => await this.setEnabledSession(false);
-
-  /**
-   * enable to perform action that need token and token refreshing too
-   */
-  public enableSession = async () => await this.setEnabledSession(true);
+  public setSessionEnabled = async (enabled: boolean) =>
+    await this.setEnabledSession(enabled);
 
   constructor(
     private refreshSession: () => Promise<Option<T>>,

--- a/ts/utils/SessionManager.ts
+++ b/ts/utils/SessionManager.ts
@@ -13,6 +13,7 @@ import { delay } from "redux-saga";
  */
 export class SessionManager<T> {
   private token?: T;
+  private isSessionEnabled: boolean = true;
   private mutex = new Mutex();
 
   /**
@@ -46,6 +47,33 @@ export class SessionManager<T> {
     return this.token;
   };
 
+  /**
+   * if enabled is false it invalidates the session token
+   * and sets a block to avoid to perform any token refreshing and
+   * requests that need token
+   *
+   * if enable is true the block will be removed and token requesting
+   * will be performed
+   */
+  private setEnabledSession = async (enabled: boolean) => {
+    await this.mutex.runExclusive(() => {
+      this.isSessionEnabled = enabled;
+      if (this.isSessionEnabled === false) {
+        this.token = undefined;
+      }
+    });
+  };
+
+  /**
+   * avoid to perform any token refreshing and requests that need token
+   */
+  public disableSession = async () => await this.setEnabledSession(false);
+
+  /**
+   * enable to perform action that need token and token refreshing too
+   */
+  public enableSession = async () => await this.setEnabledSession(true);
+
   constructor(
     private refreshSession: () => Promise<Option<T>>,
     private maxRetries: number = 3
@@ -66,6 +94,11 @@ export class SessionManager<T> {
     return async () => {
       let count = 0;
       while (count <= this.maxRetries) {
+        if (this.isSessionEnabled === false) {
+          throw new Error(
+            "cant perform any requests cause the session is not enabled"
+          );
+        }
         count += 1;
         await this.exclusiveTokenUpdate();
         if (this.token === undefined) {


### PR DESCRIPTION
**Short description:**
This PR invalidate payment manager session if/when user profile has not an email validated.

**List of changes proposed in this pull request:**
- At the startup the wallet saga checks if the profile has an email validated
- Each time a profile is loaded or updated the wallet saga is triggered and there the session could be stopped or not
