### PR TITLE
[#170745720] fix refresh national services

### DIFF
--- a/ts/screens/services/ServicesHomeScreen.tsx
+++ b/ts/screens/services/ServicesHomeScreen.tsx
@@ -640,6 +640,10 @@ class ServicesHomeScreen extends React.Component<Props, State> {
       potUserMetadata,
       isLoadingServices
     } = this.props;
+    const isRefreshing =
+      isLoadingServices ||
+      pot.isLoading(potUserMetadata) ||
+      pot.isUpdating(potUserMetadata);
     return (
       <AnimatedTabs
         tabContainerStyle={[styles.tabBarContainer, styles.tabBarUnderline]}
@@ -683,11 +687,7 @@ class ServicesHomeScreen extends React.Component<Props, State> {
           <ServicesTab
             isLocal={true}
             sections={localTabSections}
-            isRefreshing={
-              isLoadingServices ||
-              pot.isLoading(potUserMetadata) ||
-              pot.isUpdating(potUserMetadata)
-            }
+            isRefreshing={isRefreshing}
             onRefresh={this.refreshScreenContent}
             onServiceSelect={this.onServiceSelect}
             handleOnLongPressItem={this.handleOnLongPressItem}
@@ -713,11 +713,7 @@ class ServicesHomeScreen extends React.Component<Props, State> {
         >
           <ServicesTab
             sections={nationalTabSections}
-            isRefreshing={
-              isLoadingServices ||
-              pot.isLoading(potUserMetadata) ||
-              pot.isUpdating(potUserMetadata)
-            }
+            isRefreshing={isRefreshing}
             onRefresh={this.refreshScreenContent}
             onServiceSelect={this.onServiceSelect}
             handleOnLongPressItem={this.handleOnLongPressItem}
@@ -734,11 +730,7 @@ class ServicesHomeScreen extends React.Component<Props, State> {
         >
           <ServicesTab
             sections={allTabSections}
-            isRefreshing={
-              isLoadingServices ||
-              pot.isLoading(potUserMetadata) ||
-              pot.isUpdating(potUserMetadata)
-            }
+            isRefreshing={isRefreshing}
             onRefresh={this.refreshScreenContent}
             onServiceSelect={this.onServiceSelect}
             handleOnLongPressItem={this.handleOnLongPressItem}

--- a/ts/screens/services/ServicesHomeScreen.tsx
+++ b/ts/screens/services/ServicesHomeScreen.tsx
@@ -713,7 +713,11 @@ class ServicesHomeScreen extends React.Component<Props, State> {
         >
           <ServicesTab
             sections={nationalTabSections}
-            isRefreshing={isLoadingServices || pot.isLoading(potUserMetadata)}
+            isRefreshing={
+              isLoadingServices ||
+              pot.isLoading(potUserMetadata) ||
+              pot.isUpdating(potUserMetadata)
+            }
             onRefresh={this.refreshScreenContent}
             onServiceSelect={this.onServiceSelect}
             handleOnLongPressItem={this.handleOnLongPressItem}

--- a/ts/store/reducers/content.ts
+++ b/ts/store/reducers/content.ts
@@ -200,7 +200,7 @@ export default function content(
     case getType(loadVisibleServicesByScope.request):
       return {
         ...state,
-        servicesByScope: pot.noneLoading
+        servicesByScope: pot.toLoading(state.servicesByScope)
       };
 
     case getType(loadVisibleServicesByScope.success):


### PR DESCRIPTION
This PR fixed pull-refresh in the "National" Services tab, now if a list of services is already displayed, it remains displayed during loading

![refresh-services](https://user-images.githubusercontent.com/2670647/73763005-23757c00-4771-11ea-9b04-6f0fb5ddfe1f.gif)
