### PR TITLE
[#171231382] Fix bug on migration of servicesbyscope

### DIFF
--- a/ts/boot/configureStoreAndPersistor.ts
+++ b/ts/boot/configureStoreAndPersistor.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from "@react-native-community/async-storage";
+import * as pot from "italia-ts-commons/lib/pot";
 import { NavigationState } from "react-navigation";
 import { createReactNavigationReduxMiddleware } from "react-navigation-redux-helpers";
-
 import { applyMiddleware, compose, createStore, Reducer } from "redux";
 import { createLogger } from "redux-logger";
 import {
@@ -34,7 +34,7 @@ import { configureReactotron } from "./configureRectotron";
 /**
  * Redux persist will migrate the store to the current version
  */
-const CURRENT_REDUX_STORE_VERSION = 8;
+const CURRENT_REDUX_STORE_VERSION = 9;
 
 // see redux-persist documentation:
 // https://github.com/rt2zz/redux-persist/blob/master/docs/migrations.md
@@ -162,6 +162,19 @@ const migrations: MigrationManifest = {
           ...(state as PersistedGlobalState).content.servicesMetadata,
           byId: {}
         }
+      }
+    };
+  },
+
+  // Version 9
+  // we fix a bug on the version 8 of the migration implying a no proper creation of the content segment of store
+  // (the servicesByScope state was not properly initialized)
+  "9": (state: PersistedState) => {
+    return {
+      ...state,
+      content: {
+        ...(state as PersistedGlobalState).content,
+        servicesByScope: pot.none
       }
     };
   }


### PR DESCRIPTION
**Short description:**
The pr is aimed to solve a bug on the migration of the redux store which caused a white screen in the 

**List of changes proposed in this pull request:**
The error involves the `servicesByScope` state, which is used to evaluate the badge value on the service tab icon. The bug is solved by manually initializing the state within a migration, the state is no more assumed as undefined.

**How to test:**
Shift from version 27 (completing the authentication and onboarding) to master to replicate the error.