### PR TITLE
[#171303752] Fixed wallet reducer

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "generate:locales": "ts-node --skip-project -O '{\"lib\":[\"es2015\"]}' scripts/make-locales.ts",
     "generate:content-definitions": "rimraf definitions/content && mkdir -p definitions/content && gen-api-models --api-spec https://raw.githubusercontent.com/pagopa/io-services-metadata/master/definitions.yml --out-dir ./definitions/content",
     "generate:all": "npm-run-all generate:mock-google-services-json generate:api-definitions generate:pagopa-api-definitions generate:content-definitions generate:locales",
-    "locales_unused": "ts-node --skip-project -O '{\"lib\":[\"es2015\"]}' scripts/unused-locales.ts" 
+    "locales_unused": "ts-node --skip-project -O '{\"lib\":[\"es2015\"]}' scripts/unused-locales.ts"
   },
   "dependencies": {
     "@react-native-community/async-storage": "^1.5.0",
@@ -73,8 +73,8 @@
     "react-navigation-redux-helpers": "^3.0.0",
     "react-redux": "6.0.0",
     "reactotron-react-native": "^4.0.2",
-    "reactotron-redux-saga": "2.1.4",
     "reactotron-redux": "^3.1.2",
+    "reactotron-redux-saga": "2.1.4",
     "redux": "4.0.1",
     "redux-logger": "3.0.6",
     "redux-persist": "5.10.0",
@@ -153,7 +153,6 @@
     "@types/prop-types": "15.5.5",
     "fp-ts": "1.12.0",
     "io-ts": "1.8.5"
-    
   },
   "rnpm": {
     "assets": [
@@ -188,5 +187,4 @@
   "browser": {
     "path": "path-browserify"
   }
-  
 }

--- a/ts/components/wallet/card/CardComponent.tsx
+++ b/ts/components/wallet/card/CardComponent.tsx
@@ -25,6 +25,7 @@ import IconFont from "../../ui/IconFont";
 import styles from "./CardComponent.style";
 import Logo from "./Logo";
 import { CreditCardStyles } from "./style";
+import { RTron } from "../../../boot/configureStoreAndPersistor";
 
 // TODO: the "*" character renders differently (i.e. a larger circle) on
 // some devices @https://www.pivotaltracker.com/story/show/159231780
@@ -90,6 +91,7 @@ export default class CardComponent extends React.Component<Props> {
     );
 
   private handleFavoritePress = () => {
+    RTron.log(this.props);
     if (
       (this.props.type === "Full" || this.props.type === "Header") &&
       this.props.onSetFavorite !== undefined &&

--- a/ts/components/wallet/card/CardComponent.tsx
+++ b/ts/components/wallet/card/CardComponent.tsx
@@ -90,7 +90,6 @@ export default class CardComponent extends React.Component<Props> {
     );
 
   private handleFavoritePress = () => {
-    RTron.log(this.props);
     if (
       (this.props.type === "Full" || this.props.type === "Header") &&
       this.props.onSetFavorite !== undefined &&

--- a/ts/components/wallet/card/CardComponent.tsx
+++ b/ts/components/wallet/card/CardComponent.tsx
@@ -25,7 +25,6 @@ import IconFont from "../../ui/IconFont";
 import styles from "./CardComponent.style";
 import Logo from "./Logo";
 import { CreditCardStyles } from "./style";
-import { RTron } from "../../../boot/configureStoreAndPersistor";
 
 // TODO: the "*" character renders differently (i.e. a larger circle) on
 // some devices @https://www.pivotaltracker.com/story/show/159231780

--- a/ts/store/reducers/wallet/wallets.ts
+++ b/ts/store/reducers/wallet/wallets.ts
@@ -32,7 +32,6 @@ import {
 } from "../../actions/wallet/wallets";
 import { IndexedById, toIndexed } from "../../helpers/indexer";
 import { GlobalState } from "../types";
-import { RTron } from "../../../boot/configureStoreAndPersistor";
 
 export type WalletsState = Readonly<{
   walletById: PotFromActions<IndexedById<Wallet>, typeof fetchWalletsFailure>;
@@ -118,7 +117,6 @@ const reducer = (
     case getType(fetchWalletsRequest):
     case getType(paymentUpdateWalletPsp.request):
     case getType(deleteWalletRequest):
-      RTron.log(action);
       return {
         ...state,
         favoriteWalletId: pot.toLoading(state.favoriteWalletId),
@@ -128,7 +126,6 @@ const reducer = (
     case getType(fetchWalletsSuccess):
     case getType(paymentUpdateWalletPsp.success):
     case getType(deleteWalletSuccess):
-      RTron.log(action);
       const wallets = isOfType(getType(paymentUpdateWalletPsp.success), action)
         ? action.payload.wallets
         : action.payload;

--- a/ts/store/reducers/wallet/wallets.ts
+++ b/ts/store/reducers/wallet/wallets.ts
@@ -32,6 +32,7 @@ import {
 } from "../../actions/wallet/wallets";
 import { IndexedById, toIndexed } from "../../helpers/indexer";
 import { GlobalState } from "../types";
+import { RTron } from "../../../boot/configureStoreAndPersistor";
 
 export type WalletsState = Readonly<{
   walletById: PotFromActions<IndexedById<Wallet>, typeof fetchWalletsFailure>;
@@ -117,6 +118,7 @@ const reducer = (
     case getType(fetchWalletsRequest):
     case getType(paymentUpdateWalletPsp.request):
     case getType(deleteWalletRequest):
+      RTron.log(action);
       return {
         ...state,
         favoriteWalletId: pot.toLoading(state.favoriteWalletId),
@@ -126,6 +128,7 @@ const reducer = (
     case getType(fetchWalletsSuccess):
     case getType(paymentUpdateWalletPsp.success):
     case getType(deleteWalletSuccess):
+      RTron.log(action);
       const wallets = isOfType(getType(paymentUpdateWalletPsp.success), action)
         ? action.payload.wallets
         : action.payload;
@@ -134,12 +137,13 @@ const reducer = (
         ...state,
         walletById: pot.some(toIndexed(wallets, _ => _.idWallet))
       };
-      return favouriteWallet !== undefined
-        ? {
-            ...newState,
-            favoriteWalletId: pot.some(favouriteWallet.idWallet)
-          }
-        : newState;
+      return {
+        ...newState,
+        favoriteWalletId:
+          favouriteWallet !== undefined
+            ? pot.some(favouriteWallet.idWallet)
+            : pot.none
+      };
 
     case getType(fetchWalletsFailure):
     case getType(deleteWalletFailure):


### PR DESCRIPTION
**Short description:**
This PR fixes a bug on set wallet as favorite: the bug occur when the user deletes a credit card that was set as favorite. The reducer has a wrong logic: on **fetchWalletsSuccess** if there is not favorite wallet  (this is the case when the user delete one) **favoriteWalletId** is never updated and it has the value setted on previous action **fetchWalletsRequest** (_pot.loading_)<br/>
When the user asks for setting a credit card as favorite, the relative handler does nothing if the state of the **favoriteWalletId** is _pot.loading_<br/>
The fix is to set **favoriteWalletId** to _pot.some_ if there is a favorite wallet or to _pot.none_ if it is not

**How to test:**
- add a credit card
- set the previous credit card as favorite