### PR TITLE
[#171487775] Add closing help modal on back button

### DIFF
--- a/ts/components/ContextualHelp.tsx
+++ b/ts/components/ContextualHelp.tsx
@@ -7,7 +7,7 @@
 
 import { Body, Container, Content, H1, Right } from "native-base";
 import * as React from "react";
-import { StyleSheet } from "react-native";
+import { BackHandler, StyleSheet } from "react-native";
 
 import IconFont from "../components/ui/IconFont";
 import ButtonDefaultOpacity from "./ButtonDefaultOpacity";
@@ -28,6 +28,22 @@ const styles = StyleSheet.create({
 });
 
 export class ContextualHelp extends React.Component<Props> {
+  public componentDidMount() {
+    BackHandler.addEventListener("hardwareBackPress", this.handleBackPressed);
+  }
+
+  public componentWillUnmount() {
+    BackHandler.removeEventListener(
+      "hardwareBackPress",
+      this.handleBackPressed
+    );
+  }
+
+  private handleBackPressed = () => {
+    this.props.onClose();
+    return true;
+  };
+
   public render(): React.ReactNode {
     return (
       <Container>

--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -7,7 +7,7 @@ import {
 import * as pot from "italia-ts-commons/lib/pot";
 import { ActionSheet, Content, H1, Text, View } from "native-base";
 import * as React from "react";
-import { BackHandler, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
 import { Col, Grid, Row } from "react-native-easy-grid";
 import { NavigationInjectedProps } from "react-navigation";
 import { connect } from "react-redux";
@@ -73,10 +73,6 @@ type Props = ReturnType<typeof mapStateToProps> &
   LightModalContextInterface &
   OwnProps;
 
-type State = {
-  isHelpVisible: boolean;
-};
-
 const styles = StyleSheet.create({
   child: {
     flex: 1,
@@ -118,45 +114,11 @@ const feeForWallet = (w: Wallet): Option<AmountInEuroCents> =>
     psp => ("0".repeat(10) + `${psp.fixedCost.amount}`) as AmountInEuroCents
   );
 
-class ConfirmPaymentMethodScreen extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      isHelpVisible: false
-    };
-  }
-
-  public componentDidMount() {
-    BackHandler.addEventListener("hardwareBackPress", this.handleBackPress);
-  }
-
-  public componentWillUnmount() {
-    BackHandler.removeEventListener("hardwareBackPress", this.handleBackPress);
-  }
-
-  private handleBackPress = () => {
-    if (this.state.isHelpVisible) {
-      this.setState({
-        isHelpVisible: false
-      });
-      this.props.hideModal();
-      return true;
-    }
-    return false;
-  };
-
+class ConfirmPaymentMethodScreen extends React.Component<Props, never> {
   private showHelp = () => {
-    this.setState({
-      isHelpVisible: true
-    });
     this.props.showModal(
       <ContextualHelp
-        onClose={() => {
-          this.setState({
-            isHelpVisible: false
-          });
-          this.props.hideModal();
-        }}
+        onClose={this.props.hideModal}
         title={I18n.t("wallet.whyAFee.title")}
         body={() => <Markdown>{I18n.t("wallet.whyAFee.text")}</Markdown>}
       />

--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -7,7 +7,7 @@ import {
 import * as pot from "italia-ts-commons/lib/pot";
 import { ActionSheet, Content, H1, Text, View } from "native-base";
 import * as React from "react";
-import { StyleSheet } from "react-native";
+import { BackHandler, StyleSheet } from "react-native";
 import { Col, Grid, Row } from "react-native-easy-grid";
 import { NavigationInjectedProps } from "react-navigation";
 import { connect } from "react-redux";
@@ -73,6 +73,10 @@ type Props = ReturnType<typeof mapStateToProps> &
   LightModalContextInterface &
   OwnProps;
 
+type State = {
+  isHelpVisible: boolean;
+};
+
 const styles = StyleSheet.create({
   child: {
     flex: 1,
@@ -114,11 +118,45 @@ const feeForWallet = (w: Wallet): Option<AmountInEuroCents> =>
     psp => ("0".repeat(10) + `${psp.fixedCost.amount}`) as AmountInEuroCents
   );
 
-class ConfirmPaymentMethodScreen extends React.Component<Props, never> {
+class ConfirmPaymentMethodScreen extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      isHelpVisible: false
+    };
+  }
+
+  public componentDidMount() {
+    BackHandler.addEventListener("hardwareBackPress", this.handleBackPress);
+  }
+
+  public componentWillUnmount() {
+    BackHandler.removeEventListener("hardwareBackPress", this.handleBackPress);
+  }
+
+  private handleBackPress = () => {
+    if (this.state.isHelpVisible) {
+      this.setState({
+        isHelpVisible: false
+      });
+      this.props.hideModal();
+      return true;
+    }
+    return false;
+  };
+
   private showHelp = () => {
+    this.setState({
+      isHelpVisible: true
+    });
     this.props.showModal(
       <ContextualHelp
-        onClose={this.props.hideModal}
+        onClose={() => {
+          this.setState({
+            isHelpVisible: false
+          });
+          this.props.hideModal();
+        }}
         title={I18n.t("wallet.whyAFee.title")}
         body={() => <Markdown>{I18n.t("wallet.whyAFee.text")}</Markdown>}
       />


### PR DESCRIPTION
Close help modal on back button

In the payment confirmation screen, the help modal of the 'Why' label is not closed on the back button