### PR TITLE
[#171707334] add a delayer before start again initializeApplicationSaga

### DIFF
--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -1,5 +1,6 @@
 import { isNone, Option } from "fp-ts/lib/Option";
 import * as pot from "italia-ts-commons/lib/pot";
+import { Millisecond } from "italia-ts-commons/lib/units";
 import { NavigationActions, NavigationState } from "react-navigation";
 import { Effect } from "redux-saga";
 import {
@@ -48,6 +49,7 @@ import { GlobalState } from "../store/reducers/types";
 import { PinString } from "../types/PinString";
 import { SagaCallReturnType } from "../types/utils";
 import { deletePin, getPin } from "../utils/keychain";
+import { startTimer } from "../utils/timer";
 import {
   startAndReturnIdentificationResult,
   watchIdentificationRequest
@@ -83,6 +85,7 @@ import {
 } from "./user/userMetadata";
 import { watchWalletSaga } from "./wallet";
 
+const WAIT_INITIALIZE_SAGA = 3000 as Millisecond;
 /**
  * Handles the application startup and the main application logic loop
  */
@@ -180,7 +183,8 @@ function* initializeApplicationSaga(): IterableIterator<Effect> {
   );
 
   if (isNone(maybeUserProfile)) {
-    // Start again if we can't load the profile
+    // Start again if we can't load the profile but wait a wail
+    yield call(startTimer, WAIT_INITIALIZE_SAGA);
     yield put(startApplicationInitialization());
     return;
   }

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -183,7 +183,7 @@ function* initializeApplicationSaga(): IterableIterator<Effect> {
   );
 
   if (isNone(maybeUserProfile)) {
-    // Start again if we can't load the profile but wait a wail
+    // Start again if we can't load the profile but wait a while
     yield call(startTimer, WAIT_INITIALIZE_SAGA);
     yield put(startApplicationInitialization());
     return;


### PR DESCRIPTION
**Short description:**
It could happen profile could be none on app initialization.
This could be due to network errors (e.s timeout) or to decoding failure.
When the profile is none, the app starts requesting profile in loop

**List of changes proposed in this pull request:**
Add a delayer before start again the initialization saga

**How to test:**
Run the [io-dev-api-server](https://github.com/pagopa/io-dev-api-server) and serve a profile that cant be decoded by the app (removing a required field for example)