### PR TITLE
[#171629235] replace deprecated method 

### DIFF
--- a/ts/screens/services/ServiceDetailsScreen.tsx
+++ b/ts/screens/services/ServiceDetailsScreen.tsx
@@ -200,7 +200,7 @@ class ServiceDetailsScreen extends React.Component<Props, State> {
     };
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public componentWillUpdate(nextProps: Props) {
     if (pot.isError(nextProps.profile) && !pot.isError(this.props.profile)) {
       // in case of new or resolved errors while updating the profile, we show a toast and
       // reset the UI to match the state of the profile preferences

--- a/ts/screens/services/ServiceDetailsScreen.tsx
+++ b/ts/screens/services/ServiceDetailsScreen.tsx
@@ -200,8 +200,8 @@ class ServiceDetailsScreen extends React.Component<Props, State> {
     };
   }
 
-  public componentWillUpdate(nextProps: Props) {
-    if (pot.isError(nextProps.profile) && !pot.isError(this.props.profile)) {
+  public componentDidUpdate(prevProps: Props) {
+    if (pot.isError(this.props.profile) && !pot.isError(prevProps.profile)) {
       // in case of new or resolved errors while updating the profile, we show a toast and
       // reset the UI to match the state of the profile preferences
       showToast(
@@ -210,8 +210,8 @@ class ServiceDetailsScreen extends React.Component<Props, State> {
       );
 
       const uiEnabledChannels = getEnabledChannelsForService(
-        nextProps.profile,
-        nextProps.navigation.getParam("service").service_id
+        this.props.profile,
+        this.props.navigation.getParam("service").service_id
       );
       this.setState({
         uiEnabledChannels


### PR DESCRIPTION
**Short description:**
Replace the deprecated method componentWillReceiveProps  with componentWillUpdate

**How to test:**
the changes do not affect the functionality:
go to service detail -> switch off data transfer/local server -> try to enable/disable switch on notifications
Result: as the answer to the request is received, the switch return to the previous value and an error toast is displayed