### PR TITLE
[#171812026] Remove READ_PHONE_STATE permission on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="it.teamdigitale.app.italiaapp"
+          xmlns:tools="http://schemas.android.com/tools"
           android:installLocation="auto">
 
   <supports-screens android:smallScreens="true"
@@ -11,6 +12,8 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.VIBRATE" />
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+  <!-- Force removal of READ_PHONE_STATE due to react-native-device-info library see https://github.com/react-native-community/react-native-device-info/issues/955 -->
+  <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove" />
 
   <!-- Required by react-native-calendar-events -->
   <uses-permission android:name="android.permission.READ_CALENDAR" />

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
**Short description:**
This PR forces removal of an unwanted permission on Android: **READ_PHONE_STATE**.
IO app doesn't need that permission, indeed it is injected from [react-native-revide-info](https://github.com/react-native-community/react-native-device-info) library after the last upgrade

see https://github.com/react-native-community/react-native-device-info/issues/955
