### PR TITLE
[#170821365] Added patch to fix refresh control on ios

### DIFF
--- a/patches/react-native+0.60.5.patch
+++ b/patches/react-native+0.60.5.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/react-native/React/Views/RCTRefreshControl.m b/node_modules/react-native/React/Views/RCTRefreshControl.m
+index 26856be..b72fb27 100644
+--- a/node_modules/react-native/React/Views/RCTRefreshControl.m
++++ b/node_modules/react-native/React/Views/RCTRefreshControl.m
+@@ -57,6 +57,7 @@ - (void)beginRefreshingProgrammatically
+   _refreshingProgrammatically = YES;
+   // When using begin refreshing we need to adjust the ScrollView content offset manually.
+   UIScrollView *scrollView = (UIScrollView *)self.superview;
++  [self sizeToFit];
+   CGPoint offset = {scrollView.contentOffset.x, scrollView.contentOffset.y - self.frame.size.height};
+ 
+   // `beginRefreshing` must be called after the animation is done. This is why it is impossible


### PR DESCRIPTION
Added patch to fix refresh control on ios - This patch was already present for the previous version of react-native

When updating the contents of the services home, the loader must always be displayed during loading