### PR TITLE
[#171644514] Added done button on keyboard

### DIFF
--- a/ts/screens/wallet/payment/ManualDataInsertionScreen.tsx
+++ b/ts/screens/wallet/payment/ManualDataInsertionScreen.tsx
@@ -192,6 +192,7 @@ class ManualDataInsertionScreen extends React.Component<Props, State> {
                 <Label>{I18n.t("wallet.insertManually.noticeCode")}</Label>
                 <Input
                   keyboardType={"numeric"}
+                  returnKeyType={"done"}
                   maxLength={18}
                   onChangeText={value => {
                     this.setState({
@@ -215,6 +216,7 @@ class ManualDataInsertionScreen extends React.Component<Props, State> {
                 <Label>{I18n.t("wallet.insertManually.entityCode")}</Label>
                 <Input
                   keyboardType={"numeric"}
+                  returnKeyType={"done"}
                   maxLength={11}
                   onChangeText={value => {
                     this.setState({
@@ -238,6 +240,7 @@ class ManualDataInsertionScreen extends React.Component<Props, State> {
                 <Label>{I18n.t("wallet.insertManually.amount")}</Label>
                 <Input
                   keyboardType={"numeric"}
+                  returnKeyType={"done"}
                   maxLength={10}
                   value={this.state.inputAmountValue}
                   onChangeText={value =>


### PR DESCRIPTION
Added done button (iOS) on keyboard in insert notice data screen

<table style="width:100%">
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/7993551/77441302-956d5780-6de9-11ea-94a0-a887adde9649.png"/></td>
<td><img src="https://user-images.githubusercontent.com/7993551/77441341-9f8f5600-6de9-11ea-907f-e9322d634a68.png"/></td></tr>
</table> 