### PR TITLE
[#171981450] Fix pin insertion on biometric authentication failure

### DIFF
--- a/ts/IdentificationModal.tsx
+++ b/ts/IdentificationModal.tsx
@@ -26,7 +26,6 @@ import { authenticateConfig } from "./utils/biometric";
 import { getFingerprintSettings } from "./sagas/startup/checkAcknowledgedFingerprintSaga";
 
 import { BiometryPrintableSimpleType } from "./screens/onboarding/FingerprintScreen";
-import { RTron } from "./boot/configureStoreAndPersistor";
 
 type Props = ReturnType<typeof mapStateToProps> & ReduxProps;
 

--- a/ts/IdentificationModal.tsx
+++ b/ts/IdentificationModal.tsx
@@ -397,7 +397,6 @@ class IdentificationModal extends React.PureComponent<Props, State> {
         if (isDebugBiometricIdentificationEnabled) {
           Alert.alert("identification.biometric.title", `KO: ${error.code}`);
         }
-        RTron.log("onFingerprintRequest", error);
         if (
           error.code !== "USER_CANCELED" &&
           error.code !== "SYSTEM_CANCELED"

--- a/ts/IdentificationModal.tsx
+++ b/ts/IdentificationModal.tsx
@@ -26,6 +26,7 @@ import { authenticateConfig } from "./utils/biometric";
 import { getFingerprintSettings } from "./sagas/startup/checkAcknowledgedFingerprintSaga";
 
 import { BiometryPrintableSimpleType } from "./screens/onboarding/FingerprintScreen";
+import { RTron } from "./boot/configureStoreAndPersistor";
 
 type Props = ReturnType<typeof mapStateToProps> & ReduxProps;
 
@@ -390,20 +391,20 @@ class IdentificationModal extends React.PureComponent<Props, State> {
         onIdentificationSuccessHandler();
       })
       .catch((error: AuthenticationError) => {
+        // some error occured enable pin insertion
+        this.setState({
+          canInsertPin: true
+        });
         if (isDebugBiometricIdentificationEnabled) {
           Alert.alert("identification.biometric.title", `KO: ${error.code}`);
         }
+        RTron.log("onFingerprintRequest", error);
         if (
           error.code !== "USER_CANCELED" &&
           error.code !== "SYSTEM_CANCELED"
         ) {
           this.setState({
             identificationByBiometryState: "failure"
-          });
-        } else {
-          // if the user dismissed the biometric dialog, unlock the pin insertion
-          this.setState({
-            canInsertPin: true
           });
         }
         onIdentificationFailureHandler();

--- a/ts/IdentificationModal.tsx
+++ b/ts/IdentificationModal.tsx
@@ -390,7 +390,7 @@ class IdentificationModal extends React.PureComponent<Props, State> {
         onIdentificationSuccessHandler();
       })
       .catch((error: AuthenticationError) => {
-        // some error occured enable pin insertion
+        // some error occured, enable pin insertion
         this.setState({
           canInsertPin: true
         });


### PR DESCRIPTION
**Short description:**
This PR fixes a bug on pin insertion.
If biometric authentication failed the user can't insert the pin.

**Steps to reproduce**
- request face id
- face id failure
- choose "use pin"
- can't type any digits on pin pad
