### PR TITLE
[#171981909] Fix identification request on exit app

### DIFF
--- a/ts/store/middlewares/navigationHistory.ts
+++ b/ts/store/middlewares/navigationHistory.ts
@@ -9,6 +9,7 @@ import {
 } from "react-navigation";
 import { Middleware } from "redux";
 import I18n from "../../i18n";
+import { identificationRequest } from "../actions/identification";
 import { navigationRestore } from "../actions/navigation";
 import {
   navigationHistoryPop,
@@ -99,6 +100,8 @@ export function createNavigationHistoryMiddleware(): Middleware<
           ) {
             lastExitRequestTime = none;
             exitApp();
+            // if the user wants exit the app the identification must be requested
+            store.dispatch(identificationRequest());
           } else {
             Toast.show({ text: I18n.t("exit.pressAgain") });
           }


### PR DESCRIPTION
**Short description:**
This PR fixes a bug that occurs when user wants leave the app then he comes back and no identification is requested

**List of changes proposed in this pull request:**
On Android:
- back press until exit the app
- re-open the app
- no identification is requested
