### PR TITLE
[#172075548] Hold alpha android releases on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -491,14 +491,14 @@ workflows:
             - test-ios-e2e-build
 
       # Build Android alpha release only on master branch
-      - alpha-release-android:
-          requires:
-            - compile-typescript
-            - run-tests
-            - lint-typescript
-          filters:
-            branches:
-              only: master
+      #- alpha-release-android:
+      #    requires:
+      #      - compile-typescript
+      #      - run-tests
+      #      - lint-typescript
+      #    filters:
+      #      branches:
+      #        only: master
   # nightly workflow to check pagopa specs (runs only on master branch)
   # if prod and dev specs are different
   # a slack notification will be sent on channel #io-status


### PR DESCRIPTION
**Short description:**
This PR removes, temporary, automatic releases on the alpha Android track.
It is due to leave to Google review program 48h to complete the review of our RC submitted on 30th March 2020