### PR TITLE
[#172121293] fix missed space

### DIFF
--- a/ts/components/HorizontalScroll.tsx
+++ b/ts/components/HorizontalScroll.tsx
@@ -88,6 +88,7 @@ export const HorizontalScroll: React.SFC<Props> = props => {
       </ScrollView>
 
       <View style={styles.barContainer}>{barArray}</View>
+      <View spacer={true}/>
     </View>
   );
 };

--- a/ts/components/HorizontalScroll.tsx
+++ b/ts/components/HorizontalScroll.tsx
@@ -25,6 +25,7 @@ const styles = StyleSheet.create({
 
   bar: {
     backgroundColor: variables.brandPrimary,
+    borderRadius: itemWidth / 2,
     width: itemWidth,
     height: itemWidth
   },

--- a/ts/components/HorizontalScroll.tsx
+++ b/ts/components/HorizontalScroll.tsx
@@ -89,7 +89,7 @@ export const HorizontalScroll: React.SFC<Props> = props => {
       </ScrollView>
 
       <View style={styles.barContainer}>{barArray}</View>
-      <View spacer={true}/>
+      <View spacer={true} />
     </View>
   );
 };


### PR DESCRIPTION
**Short description:**
Landing Screen HorizontalScroll:
- reintroduce a space between the footer and the scroll indicator 
- make indicator being rounded not rectangle (it can be appreciated when scrolling)


<img width="396" alt="image" src="https://user-images.githubusercontent.com/38431762/78227207-371d3480-74cd-11ea-971a-765d2942441a.png">
