### PR TITLE
[#172122233] update loader opacity to avoid color overlap

### DIFF
--- a/ts/screens/authentication/cie/CieConsentDataUsageScreen.tsx
+++ b/ts/screens/authentication/cie/CieConsentDataUsageScreen.tsx
@@ -157,7 +157,10 @@ class CieConsentDataUsageScreen extends React.PureComponent<Props, State> {
 
   public render(): React.ReactNode {
     return (
-      <LoadingSpinnerOverlay isLoading={this.state.isLoading}>
+      <LoadingSpinnerOverlay
+        loadingOpacity={1.0}
+        isLoading={this.state.isLoading}
+      >
         <TopScreenComponent
           goBack={this.handleGoBack}
           headerTitle={I18n.t("authentication.cie.genericTitle")}


### PR DESCRIPTION
**Short description:**
It affects the loader displayed in CieConsentDataUsageScreen

AFTER: 
<img width="215" alt="image" src="https://user-images.githubusercontent.com/38431762/78234368-59b44b00-74d7-11ea-9088-41ee17ba01a1.png">
