### PR TITLE
[#168726573] Improve landscape Fiscal code barcode readability

### DIFF
--- a/ts/components/FiscalCodeComponent.tsx
+++ b/ts/components/FiscalCodeComponent.tsx
@@ -85,10 +85,10 @@ const cardSpacerL = 16 * landscapeScaleFactor;
 const cardLargeSpacerL = 24 * landscapeScaleFactor;
 const cardLineHeightL = 26 * landscapeScaleFactor;
 
-const barCodeHeightL = 107 * landscapeScaleFactor;
-const barCodeWidthL = 512 * landscapeScaleFactor;
-const barCodeMarginLeftL = 170 * landscapeScaleFactor;
-const barCodeMarginTopL = 164 * landscapeScaleFactor;
+const barCodeHeightL = 110 * landscapeScaleFactor;
+const barCodeWidthL = 520 * landscapeScaleFactor;
+const barCodeMarginLeftL = 168 * landscapeScaleFactor;
+const barCodeMarginTopL = 180 * landscapeScaleFactor;
 
 const fiscalCodeHeightL =
   -94 * landscapeScaleFactor + // rotation correction factor
@@ -289,7 +289,7 @@ const styles = StyleSheet.create({
   },
 
   landscapeFacSimile: {
-    marginTop: 295 * landscapeScaleFactor,
+    marginTop: 290 * landscapeScaleFactor,
     position: "absolute",
     color: customVariables.brandDarkestGray,
     fontSize: textFontSizeL,
@@ -413,7 +413,7 @@ export default class FiscalCodeComponent extends React.Component<Props> {
         <Barcode
           value={fiscalCode}
           format={"CODE128"}
-          background={"transparent"}
+          background={"white"}
           height={barCodeHeightL - 5}
           width={(barCodeWidthL - 5) / 211} // 211= 16*11 + 35: number of characters in the fiscal code barcode with CODE128
         />

--- a/ts/components/FiscalCodeComponent.tsx
+++ b/ts/components/FiscalCodeComponent.tsx
@@ -88,7 +88,7 @@ const cardLineHeightL = 26 * landscapeScaleFactor;
 const barCodeHeightL = 110 * landscapeScaleFactor;
 const barCodeWidthL = 520 * landscapeScaleFactor;
 const barCodeMarginLeftL = 168 * landscapeScaleFactor;
-const barCodeMarginTopL = 180 * landscapeScaleFactor;
+const barCodeMarginTopL = 181 * landscapeScaleFactor;
 
 const fiscalCodeHeightL =
   -94 * landscapeScaleFactor + // rotation correction factor


### PR DESCRIPTION
**Short description:**
This PR improves the readability of the Barcode on the Fiscalcode landscape component.

**List of changes proposed in this pull request:**
- FiscalCodeComponent.tsx. Styles values


<img src="https://user-images.githubusercontent.com/3959405/78353459-5c33a500-75aa-11ea-8869-febd4c62bbe4.png" width="480" heigth="512"/>
