### PR TITLE
[#172147176] Added EdgeBorderComponent to Service Detail screen

### DIFF
--- a/ts/screens/services/ServiceDetailsScreen.tsx
+++ b/ts/screens/services/ServiceDetailsScreen.tsx
@@ -57,6 +57,8 @@ import {
 import { logosForService } from "../../utils/services";
 import { showToast } from "../../utils/showToast";
 import { handleItemOnPress } from "../../utils/url";
+import { EmptyListComponent } from "../../components/messages/EmptyListComponent";
+import { EdgeBorderComponent } from "../../components/screens/EdgeBorderComponent";
 
 type NavigationParams = Readonly<{
   service: ServicePublic;
@@ -697,6 +699,9 @@ class ServiceDetailsScreen extends React.Component<Props, State> {
               service.service_id,
               "COPY"
             )}
+          {canRenderItems(this.state.isMarkdownLoaded, potServiceMetadata) && (
+            <EdgeBorderComponent />
+          )}
           <View spacer={true} extralarge={true} />
         </Content>
       </BaseScreenComponent>

--- a/ts/screens/services/ServiceDetailsScreen.tsx
+++ b/ts/screens/services/ServiceDetailsScreen.tsx
@@ -22,6 +22,7 @@ import ButtonDefaultOpacity from "../../components/ButtonDefaultOpacity";
 import BaseScreenComponent, {
   ContextualHelpPropsMarkdown
 } from "../../components/screens/BaseScreenComponent";
+import { EdgeBorderComponent } from "../../components/screens/EdgeBorderComponent";
 import TouchableDefaultOpacity from "../../components/TouchableDefaultOpacity";
 import H4 from "../../components/ui/H4";
 import IconFont from "../../components/ui/IconFont";
@@ -57,8 +58,6 @@ import {
 import { logosForService } from "../../utils/services";
 import { showToast } from "../../utils/showToast";
 import { handleItemOnPress } from "../../utils/url";
-import { EmptyListComponent } from "../../components/messages/EmptyListComponent";
-import { EdgeBorderComponent } from "../../components/screens/EdgeBorderComponent";
 
 type NavigationParams = Readonly<{
   service: ServicePublic;


### PR DESCRIPTION
**Short description:**
This PR adds the EdgeBorderComponent to Service Detail Screen to fix the cutting of the last element in the view.

**List of changes proposed in this pull request:**
- screens/services/ServicesDetailsScreen.tsx

<img height="550" alt="Schermata 2020-04-06 alle 10 14 57" src="https://user-images.githubusercontent.com/3959405/78537427-c5582a00-77ef-11ea-825e-3fcc87c36bf5.png">