### PR TITLE
[#172059281] Bug service without mail display wrong text

### DIFF
--- a/ts/screens/services/ServiceDetailsScreen.tsx
+++ b/ts/screens/services/ServiceDetailsScreen.tsx
@@ -561,6 +561,20 @@ class ServiceDetailsScreen extends React.Component<Props, State> {
     if (!this.hasChannel(NotificationChannelEnum.EMAIL)) {
       return undefined;
     }
+    const messageForwardingState = this.props.isEmailEnabled
+      ? I18n.t("serviceDetail.enabled")
+      : I18n.t("serviceDetail.disabled");
+
+    const emailForwardingDescription = this.props.isEmailValidated
+      ? I18n.t("serviceDetail.lockedMailAlert", {
+          enabled: messageForwardingState
+        })
+      : I18n.t("serviceDetail.notValidated");
+
+    const emailForwardingLink = this.props.isEmailValidated
+      ? I18n.t("serviceDetail.updatePreferences")
+      : I18n.t("serviceDetail.goTo");
+
     // determine if the switch interaction should be disabled
     const isDisabled =
       // notifications (all channels) are disabled globally
@@ -622,6 +636,18 @@ class ServiceDetailsScreen extends React.Component<Props, State> {
             onValueChange={onValueChange}
           />
         </Row>
+        {/* TODO: it could be implmented to advise on is_inbox_enabled setting too */}
+        {(!this.props.isCustomEmailChannelEnabled ||
+          !this.props.isEmailValidated) && (
+          <Row style={styles.info}>
+            <Text>
+              {emailForwardingDescription}
+              <Text link={true} onPress={this.navigateToEmailPreferences}>
+                {` ${emailForwardingLink}`}
+              </Text>
+            </Text>
+          </Row>
+        )}
       </React.Fragment>
     );
   };
@@ -629,23 +655,9 @@ class ServiceDetailsScreen extends React.Component<Props, State> {
   public render() {
     const { service, serviceId } = this;
 
-    const messageForwardingState = this.props.isEmailEnabled
-      ? I18n.t("serviceDetail.enabled")
-      : I18n.t("serviceDetail.disabled");
-
     // collect the service metadata
     const potServiceMetadata =
       this.props.content.servicesMetadata.byId[serviceId] || pot.none;
-
-    const emailForwardingDescription = this.props.isEmailValidated
-      ? I18n.t("serviceDetail.lockedMailAlert", {
-          enabled: messageForwardingState
-        })
-      : I18n.t("serviceDetail.notValidated");
-
-    const emailForwardingLink = this.props.isEmailValidated
-      ? I18n.t("serviceDetail.updatePreferences")
-      : I18n.t("serviceDetail.goTo");
 
     return (
       <BaseScreenComponent
@@ -660,18 +672,6 @@ class ServiceDetailsScreen extends React.Component<Props, State> {
             {this.getInboxSwitchRow()}
             {this.getPushSwitchRow()}
             {this.getEmailSwitchRow()}
-            {/* TODO: it could be implmented to advise on is_inbox_enabled setting too */}
-            {(!this.props.isCustomEmailChannelEnabled ||
-              !this.props.isEmailValidated) && (
-              <Row style={styles.info}>
-                <Text>
-                  {emailForwardingDescription}
-                  <Text link={true} onPress={this.navigateToEmailPreferences}>
-                    {` ${emailForwardingLink}`}
-                  </Text>
-                </Text>
-              </Row>
-            )}
           </Grid>
 
           <View spacer={true} large={true} />


### PR DESCRIPTION
**Short description:**
Wrong text displayed when opening a ServiceDetailsScreen without email as notification channel.

**List of changes proposed in this pull request:**
Moved the `<Text>` block with all the information related to the email inside the method `getEmailSwitchRow` dedicated to the rendering of this component.

**How to test:**
Open a ServiceDetailsScreen with a service without email as notification channel.

![Schermata 2020-04-07 alle 13 07 08](https://user-images.githubusercontent.com/26501317/78662443-b1382980-78d0-11ea-852a-d52217afd522.png)

