### PR TITLE
[#171742890] Fix ItemSeparatorComponent height

### DIFF
--- a/ts/components/ItemSeparatorComponent.tsx
+++ b/ts/components/ItemSeparatorComponent.tsx
@@ -10,7 +10,7 @@ type Props = Readonly<{
 const styles = StyleSheet.create({
   itemSeparator: {
     backgroundColor: customVariables.itemSeparator,
-    height: 1 / 3
+    height: StyleSheet.hairlineWidth
   },
   horizontalPad: {
     marginLeft: customVariables.contentPadding,


### PR DESCRIPTION
**Short description:**
This PR fix the wrong rendering of the `ItemSeparatorComponent`.

**List of changes proposed in this pull request:**
Change the style `height`to `StyleSheet.hairlineWidth` [hairlineWidth](https://reactnative.dev/docs/stylesheet#hairlinewidth)

**How to test:**
<img src=https://user-images.githubusercontent.com/26501317/78785269-29711e80-79a7-11ea-95d7-5ea698325c0a.png  height=600/>
