### PR TITLE
[#172197576] Fixed Status bar behaviour on modal

### DIFF
--- a/ts/components/ContextualHelpModal.tsx
+++ b/ts/components/ContextualHelpModal.tsx
@@ -1,6 +1,6 @@
 import { Body, Container, Content, H1, Right, View } from "native-base";
 import * as React from "react";
-import { InteractionManager, Modal, Platform, StyleSheet } from "react-native";
+import { InteractionManager, Modal, StyleSheet } from "react-native";
 import IconFont from "../components/ui/IconFont";
 import themeVariables from "../theme/variables";
 import { FAQsCategoriesType } from "../utils/faq";

--- a/ts/components/ContextualHelpModal.tsx
+++ b/ts/components/ContextualHelpModal.tsx
@@ -1,6 +1,6 @@
 import { Body, Container, Content, H1, Right, View } from "native-base";
 import * as React from "react";
-import { InteractionManager, Modal, StyleSheet } from "react-native";
+import { InteractionManager, Modal, Platform, StyleSheet } from "react-native";
 import IconFont from "../components/ui/IconFont";
 import themeVariables from "../theme/variables";
 import { FAQsCategoriesType } from "../utils/faq";
@@ -61,6 +61,7 @@ export class ContextualHelpModal extends React.Component<Props, State> {
         visible={this.props.isVisible}
         onShow={onModalShow}
         animationType="slide"
+        transparent={true}
         onRequestClose={onClose}
       >
         <Container>

--- a/ts/components/screens/BaseScreenComponent.tsx
+++ b/ts/components/screens/BaseScreenComponent.tsx
@@ -4,7 +4,9 @@ import { connectStyle } from "native-base-shoutem-theme";
 import mapPropsToStyleNames from "native-base/src/utils/mapPropsToStyleNames";
 import * as React from "react";
 import { TranslationKeys } from "../../../locales/locales";
+import customVariables from "../../theme/variables";
 import { FAQsCategoriesType } from "../../utils/faq";
+import { setStatusBarColorAndBackground } from "../../utils/statusBar";
 import { ContextualHelpModal } from "../ContextualHelpModal";
 import { SearchType } from "../search/SearchButton";
 import Markdown from "../ui/Markdown";
@@ -59,10 +61,22 @@ class BaseScreenComponent extends React.PureComponent<Props, State> {
   }
 
   private showHelp = () => {
+    // tslint:disable-next-line:no-unused-expression
+    this.props.dark &&
+      setStatusBarColorAndBackground(
+        "dark-content",
+        customVariables.colorWhite
+      );
     this.setState({ isHelpVisible: true });
   };
 
   private hideHelp = () => {
+    // tslint:disable-next-line:no-unused-expression
+    this.props.dark &&
+      setStatusBarColorAndBackground(
+        "light-content",
+        customVariables.brandDarkGray
+      );
     this.setState({ isHelpVisible: false });
   };
 

--- a/ts/components/screens/BaseScreenComponent.tsx
+++ b/ts/components/screens/BaseScreenComponent.tsx
@@ -11,7 +11,7 @@ import { ContextualHelpModal } from "../ContextualHelpModal";
 import { SearchType } from "../search/SearchButton";
 import Markdown from "../ui/Markdown";
 import { BaseHeader } from "./BaseHeader";
-import { fromPredicate, fromNullable } from "fp-ts/lib/Option";
+import { fromPredicate } from "fp-ts/lib/Option";
 
 export interface ContextualHelpProps {
   title: string;

--- a/ts/components/screens/BaseScreenComponent.tsx
+++ b/ts/components/screens/BaseScreenComponent.tsx
@@ -11,6 +11,7 @@ import { ContextualHelpModal } from "../ContextualHelpModal";
 import { SearchType } from "../search/SearchButton";
 import Markdown from "../ui/Markdown";
 import { BaseHeader } from "./BaseHeader";
+import { fromPredicate, fromNullable } from "fp-ts/lib/Option";
 
 export interface ContextualHelpProps {
   title: string;
@@ -52,6 +53,10 @@ interface State {
   isHelpVisible: boolean;
 }
 
+const maybeDark = fromPredicate(
+  (isDark: boolean | undefined = undefined) => isDark === true
+);
+
 class BaseScreenComponent extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
@@ -61,22 +66,24 @@ class BaseScreenComponent extends React.PureComponent<Props, State> {
   }
 
   private showHelp = () => {
-    // tslint:disable-next-line:no-unused-expression
-    this.props.dark &&
+    maybeDark(this.props.dark).map(_ =>
       setStatusBarColorAndBackground(
-        "dark-content",
-        customVariables.colorWhite
-      );
+        "light-content",
+        customVariables.brandDarkGray
+      )
+    );
+
     this.setState({ isHelpVisible: true });
   };
 
   private hideHelp = () => {
-    // tslint:disable-next-line:no-unused-expression
-    this.props.dark &&
+    maybeDark(this.props.dark).map(_ =>
       setStatusBarColorAndBackground(
         "light-content",
         customVariables.brandDarkGray
-      );
+      )
+    );
+
     this.setState({ isHelpVisible: false });
   };
 

--- a/ts/components/screens/BaseScreenComponent.tsx
+++ b/ts/components/screens/BaseScreenComponent.tsx
@@ -67,10 +67,7 @@ class BaseScreenComponent extends React.PureComponent<Props, State> {
 
   private showHelp = () => {
     maybeDark(this.props.dark).map(_ =>
-      setStatusBarColorAndBackground(
-        "light-content",
-        customVariables.brandDarkGray
-      )
+      setStatusBarColorAndBackground("dark-content", customVariables.colorWhite)
     );
 
     this.setState({ isHelpVisible: true });

--- a/ts/components/screens/BaseScreenComponent.tsx
+++ b/ts/components/screens/BaseScreenComponent.tsx
@@ -1,3 +1,4 @@
+import { fromPredicate } from "fp-ts/lib/Option";
 import I18n from "i18n-js";
 import { Container } from "native-base";
 import { connectStyle } from "native-base-shoutem-theme";
@@ -11,7 +12,6 @@ import { ContextualHelpModal } from "../ContextualHelpModal";
 import { SearchType } from "../search/SearchButton";
 import Markdown from "../ui/Markdown";
 import { BaseHeader } from "./BaseHeader";
-import { fromPredicate } from "fp-ts/lib/Option";
 
 export interface ContextualHelpProps {
   title: string;

--- a/ts/components/screens/DarkLayout.tsx
+++ b/ts/components/screens/DarkLayout.tsx
@@ -6,12 +6,12 @@ import * as React from "react";
 import {
   ImageSourcePropType,
   RefreshControlProps,
-  StatusBar,
   StyleProp,
   ViewStyle
 } from "react-native";
 import { StyleSheet } from "react-native";
 import customVariables from "../../theme/variables";
+import { setStatusBarColorAndBackground } from "../../utils/statusBar";
 import AnimatedScreenContent from "./AnimatedScreenContent";
 import {
   ContextualHelpProps,
@@ -47,6 +47,13 @@ const styles = StyleSheet.create({
 });
 
 export default class DarkLayout extends React.Component<Props> {
+  public componentDidMount() {
+    setStatusBarColorAndBackground(
+      "light-content",
+      customVariables.brandDarkGray
+    );
+  }
+
   private screenContent() {
     return (
       <React.Fragment>
@@ -69,11 +76,6 @@ export default class DarkLayout extends React.Component<Props> {
         contextualHelp={this.props.contextualHelp}
         contextualHelpMarkdown={this.props.contextualHelpMarkdown}
       >
-        <StatusBar
-          backgroundColor={customVariables.brandDarkGray}
-          barStyle={"light-content"}
-        />
-
         {this.props.hasDynamicSubHeader ? (
           <AnimatedScreenContent
             hideHeader={this.props.hideHeader}


### PR DESCRIPTION
**Short description:**
This PR adds transparency on Contextual Help Modal and manages the transition beetween white and grey color of the status bar.
Previously on android the status bar appeared shadowed.

**List of changes proposed in this pull request:**
- ts/components/screens/BaseScreenComponent.tsx
- ts/components/ContextualHelpModal.tsx
- ts/components/screens/DarkLayout.tsx

**How to test:**
Click on the question mark on the top in any screen

<img src="https://user-images.githubusercontent.com/3959405/78898691-82f34f00-7a74-11ea-99f0-e6710f75567f.gif" height="550"/>