### PR TITLE
[#172260732] Remove email field as required in Instabug report

### DIFF
--- a/ts/components/InstabugButtons.tsx
+++ b/ts/components/InstabugButtons.tsx
@@ -69,7 +69,8 @@ class InstabugButtonsComponent extends React.PureComponent<Props, State> {
     this.setState({ instabugReportType: some(bug) });
     this.props.dispatchIBReportOpen(bug);
     BugReporting.showWithOptions(BugReporting.reportType.bug, [
-      BugReporting.option.commentFieldRequired
+      BugReporting.option.commentFieldRequired,
+      BugReporting.option.emailFieldHidden
     ]);
   };
 


### PR DESCRIPTION
**Short description:**
Remove email field as required in Instabug report

This is how it looks like now
<img src="https://user-images.githubusercontent.com/822471/78985110-3d905980-7b28-11ea-96a3-ac676b48bfb9.png" height="600" />