### PR TITLE
[#172247431] Handle android disabled switch color

### DIFF
--- a/ts/components/ui/Switch.tsx
+++ b/ts/components/ui/Switch.tsx
@@ -2,13 +2,21 @@ import { NativeBase, Switch as NBSwitch } from "native-base";
 import * as React from "react";
 import { Platform } from "react-native";
 
+import { fromPredicate } from "fp-ts/lib/Option";
 import variables from "../../theme/variables";
 
+const maybeDisabled = fromPredicate(
+  (isDisabled: boolean | undefined = undefined) => isDisabled === true
+);
 /**
  * NativeBase Switch component styled with the app's brand primary color
  */
 export default class Switch extends React.Component<NativeBase.Switch> {
   public render() {
+    const thumbColor: string = maybeDisabled(this.props.disabled)
+      .map(_ => variables.brandPrimaryLight)
+      .getOrElse(variables.contentPrimaryBackground);
+
     return (
       <NBSwitch
         // Stick
@@ -23,7 +31,7 @@ export default class Switch extends React.Component<NativeBase.Switch> {
         thumbColor={
           Platform.OS === "android"
             ? this.props.value
-              ? variables.contentPrimaryBackground
+              ? thumbColor
               : variables.brandLightGray
             : "default"
         }


### PR DESCRIPTION
**Short description:**
This PR changes the color of the Switch if it's disabled on Android

**List of changes proposed in this pull request:**
- ts/components/ui/Switch.tsx

<img height="600" src="https://user-images.githubusercontent.com/3959405/78985335-cc04db00-7b28-11ea-8504-5758bf5a2f6a.png"/>