### PR TITLE
[#172275302] Fixed missing separator on "About IO Beta" menu voice

### DIFF
--- a/ts/screens/profile/ProfileMainScreen.tsx
+++ b/ts/screens/profile/ProfileMainScreen.tsx
@@ -354,7 +354,6 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
               title={I18n.t("profile.main.privacy.title")}
               subTitle={I18n.t("profile.main.privacy.description")}
               onPress={() => navigation.navigate(ROUTES.PROFILE_PRIVACY_MAIN)}
-              isLastItem={true}
             />
 
             {/* APP IO */}


### PR DESCRIPTION
**Short description:**
Adds the missing separator above "About IO Beta" menu item

**List of changes proposed in this pull request:**
- ts/screens/profile/ProfileMainScreen.tsx

<img height="550" src="https://user-images.githubusercontent.com/3959405/79197990-0628f200-7e33-11ea-99d8-1f230680f08f.png"/>