### PR TITLE
[#172316347] Add workaround to avoid organizations duplication

### DIFF
--- a/ts/store/reducers/entities/services/index.ts
+++ b/ts/store/reducers/entities/services/index.ts
@@ -209,7 +209,20 @@ const getServices = (
       const organizationFiscalCode = fiscalCode;
       const serviceIdsForOrg = services.byOrgFiscalCode[fiscalCode] || [];
 
-      const data = serviceIdsForOrg
+      // NOTE: this is a workaround not a solution
+      // since a service can change its organization fiscal code we could have
+      // obsolete data in the store: byOrgFiscalCode could have services that don't belong to organization anymore
+      // this cleaning its a workround, this should be fixed on data loading and not when data are loaded
+      // see https://www.pivotaltracker.com/story/show/172316333
+      const serviceIdsForOrgCleaned = serviceIdsForOrg.filter(s => {
+        const service = services.byId[s];
+        if (service !== undefined && pot.isSome(service)) {
+          return service.value.organization_fiscal_code === fiscalCode;
+        }
+        return false;
+      });
+
+      const data = serviceIdsForOrgCleaned
         .map(id => services.byId[id])
         .filter(
           service =>

--- a/ts/store/reducers/entities/services/index.ts
+++ b/ts/store/reducers/entities/services/index.ts
@@ -212,7 +212,7 @@ const getServices = (
       // NOTE: this is a workaround not a solution
       // since a service can change its organization fiscal code we could have
       // obsolete data in the store: byOrgFiscalCode could have services that don't belong to organization anymore
-      // this cleaning its a workround, this should be fixed on data loading and not when data are loaded
+      // this cleaning its a workaround, this should be fixed on data loading and not when data are loaded
       // see https://www.pivotaltracker.com/story/show/172316333
       const serviceIdsForOrgCleaned = serviceIdsForOrg.filter(s => {
         const service = services.byId[s];


### PR DESCRIPTION
**Short description:**
**NOTE** this is a workaround not a solution

since a service can change its organization fiscal code we could have obsolete data in the store: **_byOrgFiscalCode_** could have services that don't belong to organization anymore this cleaning its a workaround, this should be fixed on data loading and not when data are loaded see https://www.pivotaltracker.com/story/show/172316333