### PR TITLE
[#172316347] Add workaround to avoid organizations duplication v2

### DIFF
--- a/ts/store/reducers/entities/services/index.ts
+++ b/ts/store/reducers/entities/services/index.ts
@@ -39,7 +39,6 @@ import {
   visibleServicesSelector,
   VisibleServicesState
 } from "./visibleServices";
-import { OrganizationFiscalCode } from "italia-ts-commons/lib/strings";
 
 export type ServicesState = Readonly<{
   byId: ServicesByIdState;

--- a/ts/store/reducers/entities/services/index.ts
+++ b/ts/store/reducers/entities/services/index.ts
@@ -39,6 +39,7 @@ import {
   visibleServicesSelector,
   VisibleServicesState
 } from "./visibleServices";
+import { OrganizationFiscalCode } from "italia-ts-commons/lib/strings";
 
 export type ServicesState = Readonly<{
   byId: ServicesByIdState;
@@ -185,6 +186,28 @@ const isInScope = (
   return false;
 };
 
+// NOTE: this is a workaround not a solution
+// since a service can change its organization fiscal code we could have
+// obsolete data in the store: byOrgFiscalCode could have services that don't belong to organization anymore
+// this cleaning its a workaround, this should be fixed on data loading and not when data are loaded
+// see https://www.pivotaltracker.com/story/show/172316333
+/**
+ * return true if service belongs to the given organization fiscal code
+ * @param service
+ * @param organizationFiscalCode
+ */
+const belongsToOrganization = (
+  service: pot.Pot<ServicePublic, Error>,
+  organizationFiscalCode: string
+) =>
+  pot.getOrElse(
+    pot.map(
+      service,
+      s => s.organization_fiscal_code === organizationFiscalCode
+    ),
+    false
+  );
+
 /**
  * A generalized function to generate sections of organizations including the available services for each organization
  * optional input:
@@ -209,24 +232,12 @@ const getServices = (
       const organizationFiscalCode = fiscalCode;
       const serviceIdsForOrg = services.byOrgFiscalCode[fiscalCode] || [];
 
-      // NOTE: this is a workaround not a solution
-      // since a service can change its organization fiscal code we could have
-      // obsolete data in the store: byOrgFiscalCode could have services that don't belong to organization anymore
-      // this cleaning its a workaround, this should be fixed on data loading and not when data are loaded
-      // see https://www.pivotaltracker.com/story/show/172316333
-      const serviceIdsForOrgCleaned = serviceIdsForOrg.filter(s => {
-        const service = services.byId[s];
-        if (service !== undefined && pot.isSome(service)) {
-          return service.value.organization_fiscal_code === fiscalCode;
-        }
-        return false;
-      });
-
-      const data = serviceIdsForOrgCleaned
+      const data = serviceIdsForOrg
         .map(id => services.byId[id])
         .filter(
           service =>
             isDefined(service) &&
+            belongsToOrganization(service, fiscalCode) && // workaround: see comments above this function definition
             isInScope(service, servicesByScope, scope) &&
             isVisibleService(services.visible, service)
         )


### PR DESCRIPTION
**Short description:**
**NOTE** this is a workaround not a solution

since a service can change its organization fiscal code we could have obsolete data in the store: **_byOrgFiscalCode_** could have services that don't belong to organization anymore this cleaning its a workaround, this should be fixed on data loading and not when data are loaded see https://www.pivotaltracker.com/story/show/172316333

This is a little improvement of this workaround https://github.com/pagopa/io-app/pull/1680