### PR TITLE
[#172355932] disable network logger only when in release mode

### DIFF
--- a/ts/boot/configureInstabug.ts
+++ b/ts/boot/configureInstabug.ts
@@ -6,6 +6,7 @@ import { instabugToken } from "../config";
 import I18n from "../i18n";
 import { IdentityProvider } from "../models/IdentityProvider";
 import variables from "../theme/variables";
+import { isDevEnv } from "../utils/environment";
 
 type InstabugLocales = { [k in Locales]: Instabug.locale };
 
@@ -44,8 +45,13 @@ const InstabugLogger: InstabugLoggerType = {
 export const initialiseInstabug = () => {
   // Initialise Instabug for iOS. The Android initialisation is inside MainApplication.java
   Instabug.startWithToken(instabugToken, [Instabug.invocationEvent.none]);
-  // avoid Instabug to log network requests
-  NetworkLogger.setEnabled(false);
+  // it seems NetworkLogger.setEnabled(false) turns off all network interceptions
+  // this may cause an empty timeline in Reactotron too
+  if (!isDevEnv) {
+    // avoid Instabug to log network requests
+    NetworkLogger.setEnabled(false);
+  }
+
   // Set primary color for iOS. The Android's counterpart is inside MainApplication.java
   Instabug.setPrimaryColor(variables.contentPrimaryBackground);
 


### PR DESCRIPTION
**Short description:**
This PR fixes a strange Instabug behavior: when we turn off network logger, Instabug turn off all network interceptions also for other tools (ex Reactotron)

see https://github.com/Instabug/Instabug-React-Native/blob/f311ece05205be408bce1ec1e052b25b4c967299/modules/NetworkLogger.js#L21

To avoid this, we turn off network logger only when we are in no-dev envirnment