### PR TITLE
[#169952327] grant the session expiration causes the app restarts

### DIFF
--- a/ts/sagas/startup/watchSessionExpiredSaga.ts
+++ b/ts/sagas/startup/watchSessionExpiredSaga.ts
@@ -1,17 +1,27 @@
 import { Effect } from "redux-saga";
-import { put, takeLatest } from "redux-saga/effects";
+import { put, select, takeLatest } from "redux-saga/effects";
 import { getType } from "typesafe-actions";
+import { startApplicationInitialization } from "../../store/actions/application";
 import {
   logoutRequest,
   sessionExpired
 } from "../../store/actions/authentication";
+import { isLoggedInWithSessionInfo } from "../../store/reducers/authentication";
 
 /**
  * Handles the expiration of the session while the user is using the app.
  */
 export function* watchSessionExpiredSaga(): IterableIterator<Effect> {
   yield takeLatest(getType(sessionExpired), function*() {
-    // Send to backend the request of soft logout
-    yield put(logoutRequest({ keepUserData: true }));
+    const isSessionOpened = yield select(isLoggedInWithSessionInfo);
+
+    if (isSessionOpened) {
+      // the app has opened a session, we need to request to backend to close it and restart the application
+      // we get it by a soft logout
+      yield put(logoutRequest({ keepUserData: true }));
+    } else {
+      // the app has not yet an opened session, just restart the application
+      yield put(startApplicationInitialization());
+    }
   });
 }


### PR DESCRIPTION
**Short description:**
This pr is aimed to solve a bug on session expiration. It shifts the fork of the saga that checks it as soon the authentication is completed.

BEFORE:
If I am on the email validation screens during the onboarding, if it occurs the LOAD_PROFILE_FAILURE, the app remains to the current screen

AFTER:
If I am on the email validation screens during the onboarding, if it occurs the LOAD_PROFILE_FAILURE, the app returns to the landing screen and the session expiration toast is displayed

**How to test:**
- Update `isProfileEmailValidatedSelector` and `isProfileFirstOnBoarding` selectors to return always true, 
- log in with a device A until the REmindEmailValidationOverlay is displayed
-log in with another device B
- wait on device A until the polling of the profile is repeated