### PR TITLE
[#172493528] Fixes EdgeBorderComponent on Message Detail

### DIFF
--- a/ts/components/messages/MessageDetailComponent.tsx
+++ b/ts/components/messages/MessageDetailComponent.tsx
@@ -20,6 +20,7 @@ import { MultiImage } from "../ui/MultiImage";
 import MessageCTABar from "./MessageCTABar";
 import MessageDetailRawInfoComponent from "./MessageDetailRawInfoComponent";
 import MessageMarkdown from "./MessageMarkdown";
+import { EdgeBorderComponent } from "../screens/EdgeBorderComponent";
 
 type OwnProps = {
   message: CreatedMessageWithContent;
@@ -201,6 +202,7 @@ export default class MessageDetailComponent extends React.PureComponent<Props> {
         <MessageMarkdown webViewStyle={styles.webview}>
           {message.content.markdown}
         </MessageMarkdown>
+        <EdgeBorderComponent />
       </View>
     );
   }

--- a/ts/components/messages/MessageDetailComponent.tsx
+++ b/ts/components/messages/MessageDetailComponent.tsx
@@ -13,6 +13,7 @@ import { clipboardSetStringWithFeedback } from "../../utils/clipboard";
 import { messageNeedsCTABar } from "../../utils/messages";
 import { logosForService } from "../../utils/services";
 import ButtonDefaultOpacity from "../ButtonDefaultOpacity";
+import { EdgeBorderComponent } from "../screens/EdgeBorderComponent";
 import TouchableDefaultOpacity from "../TouchableDefaultOpacity";
 import H4 from "../ui/H4";
 import H6 from "../ui/H6";
@@ -20,7 +21,6 @@ import { MultiImage } from "../ui/MultiImage";
 import MessageCTABar from "./MessageCTABar";
 import MessageDetailRawInfoComponent from "./MessageDetailRawInfoComponent";
 import MessageMarkdown from "./MessageMarkdown";
-import { EdgeBorderComponent } from "../screens/EdgeBorderComponent";
 
 type OwnProps = {
   message: CreatedMessageWithContent;

--- a/ts/screens/messages/MessageDetailScreen.tsx
+++ b/ts/screens/messages/MessageDetailScreen.tsx
@@ -15,7 +15,6 @@ import MessageDetailComponent from "../../components/messages/MessageDetailCompo
 import BaseScreenComponent, {
   ContextualHelpPropsMarkdown
 } from "../../components/screens/BaseScreenComponent";
-import { EdgeBorderComponent } from "../../components/screens/EdgeBorderComponent";
 import I18n from "../../i18n";
 import { loadServiceMetadata } from "../../store/actions/content";
 import {
@@ -311,7 +310,6 @@ export class MessageDetailScreen extends React.PureComponent<Props, never> {
         faqCategories={["messages_detail"]}
       >
         {this.renderCurrentState()}
-        <EdgeBorderComponent />
       </BaseScreenComponent>
     );
   }


### PR DESCRIPTION
**Short description:**
This PR fixes the cut message text from EdgeBorderComponent.

**List of changes proposed in this pull request:**
- ts/components/messages/MessageDetailComponent.tsx
- ts/screens/messages/MessageDetailScreen.tsx

### Before:
<img height="600" src="https://user-images.githubusercontent.com/3959405/80352792-b6a3e680-8874-11ea-8c0d-a85c0f7b56a7.png" />

### After
<img height="600" src="https://user-images.githubusercontent.com/3959405/80353023-097d9e00-8875-11ea-9082-990d2d854bb6.gif" />