### PR TITLE
[#172531916] Reduce contextual help title font size

### DIFF
--- a/ts/components/ContextualHelpModal.tsx
+++ b/ts/components/ContextualHelpModal.tsx
@@ -1,4 +1,4 @@
-import { Body, Container, Content, H1, H3, Right, View } from "native-base";
+import { Body, Container, Content, H3, Right, View } from "native-base";
 import * as React from "react";
 import { InteractionManager, Modal, StyleSheet } from "react-native";
 import IconFont from "../components/ui/IconFont";

--- a/ts/components/ContextualHelpModal.tsx
+++ b/ts/components/ContextualHelpModal.tsx
@@ -1,4 +1,4 @@
-import { Body, Container, Content, H1, Right, View } from "native-base";
+import { Body, Container, Content, H1, H3, Right, View } from "native-base";
 import * as React from "react";
 import { InteractionManager, Modal, StyleSheet } from "react-native";
 import IconFont from "../components/ui/IconFont";
@@ -85,7 +85,7 @@ export class ContextualHelpModal extends React.Component<Props, State> {
               contentContainerStyle={styles.contentContainerStyle}
               noPadded={true}
             >
-              <H1>{this.props.title}</H1>
+              <H3>{this.props.title}</H3>
               {this.state.content}
               {this.props.faqCategories &&
                 this.props.contentLoaded && (


### PR DESCRIPTION
**Short description:**
This pr updates the dimension of the title in the Contextual Help Modal

BEFORE:
<img width="326" alt="image" src="https://user-images.githubusercontent.com/38431762/80378197-98ea7780-889c-11ea-86d0-9522709d9f92.png">


AFTER:
<img width="328" alt="image" src="https://user-images.githubusercontent.com/38431762/80378118-79ebe580-889c-11ea-8b48-6040b9dd36f1.png">
