### PR TITLE
[#172503613] Send hash(cf) to instabug

### DIFF
--- a/ts/sagas/profile.ts
+++ b/ts/sagas/profile.ts
@@ -45,10 +45,11 @@ export function* loadProfile(
       // tslint:disable-next-line:no-useless-cast
       const initializedProfile = response.value.value as InitializedProfile;
       yield put(profileLoadSuccess(initializedProfile));
+
       // send the hash of fiscal code to Instabug
-      sha256(initializedProfile.fiscal_code).then(hashCF =>
-        setInstabugUserAttribute("fiscalcode", hashCF)
-      );
+      sha256(initializedProfile.fiscal_code)
+        .then(hashCF => setInstabugUserAttribute("fiscalcode", hashCF))
+        .catch();
 
       return some(response.value.value);
     }

--- a/ts/sagas/profile.ts
+++ b/ts/sagas/profile.ts
@@ -43,7 +43,7 @@ export function* loadProfile(
       // BEWARE: we need to cast to UserProfileUnion to make UserProfile a
       // discriminated union!
       // tslint:disable-next-line:no-useless-cast
-      const initializedProfile = response.value.value as InitializedProfile;
+      const initializedProfile = response.value.value;
       yield put(profileLoadSuccess(initializedProfile));
 
       // send the hash of fiscal code to Instabug

--- a/ts/sagas/profile.ts
+++ b/ts/sagas/profile.ts
@@ -46,8 +46,8 @@ export function* loadProfile(
       const initializedProfile = response.value.value as InitializedProfile;
       yield put(profileLoadSuccess(initializedProfile));
       // send the hash of fiscal code to Instabug
-      sha256(initializedProfile.fiscal_code).then(hash =>
-        setInstabugUserAttribute("fiscalcode", hash)
+      sha256(initializedProfile.fiscal_code).then(hashCF =>
+        setInstabugUserAttribute("fiscalcode", hashCF)
       );
 
       return some(response.value.value);


### PR DESCRIPTION
**Short description:**
With this pr the hash of the CF is sent to Instabug.

**List of changes proposed in this pull request:**
- `ts/sagas/profile.ts` now send to Instabug the hash of cf when the profile is loaded.

**How to test:**
Create a instabug report and see if the attribute is available.