### PR TITLE
[#172576541] Add attach command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "react-native start",
     "run-ios": "react-native run-ios",
     "run-android": "react-native run-android",
+    "attach": "react-native attach",
     "postinstall": "patch-package && rn-nodeify --install path,buffer && chmod +x ./bin/add-ios-source-maps.sh && ./bin/add-ios-source-maps.sh && chmod +x ./bin/add-ios-env-config.sh && ./bin/add-ios-env-config.sh",
     "test": "jest",
     "prettify": "prettier --write \"ts/**/*.ts*\"",


### PR DESCRIPTION
**Short description:**
This PR add the `attach` command to package.json in order to debug the application with others third party tools (eg: webstorm).

**List of changes proposed in this pull request:**
Added `"attach": "react-native attach"` in scripts section.