### PR TITLE
[#172580555] Fix selected organizations listed in all services tab

### DIFF
--- a/ts/store/reducers/entities/services/__tests__/index.test.ts
+++ b/ts/store/reducers/entities/services/__tests__/index.test.ts
@@ -72,18 +72,38 @@ const customServices: ServicesState = {
       service_id: "42" as ServiceId,
       service_name: "service1" as ServiceName,
       version: 1
+    }),
+    ["43"]: pot.someLoading({
+      department_name: "test" as DepartmentName,
+      organization_fiscal_code: "5" as OrganizationFiscalCode,
+      organization_name: "same_organization_name" as OrganizationName,
+      service_id: "43" as ServiceId,
+      service_name: "service1" as ServiceName,
+      version: 1
+    }),
+    ["44"]: pot.someLoading({
+      department_name: "test" as DepartmentName,
+      organization_fiscal_code: "6" as OrganizationFiscalCode,
+      organization_name: "same_organization_name" as OrganizationName,
+      service_id: "44" as ServiceId,
+      service_name: "service1" as ServiceName,
+      version: 1
     })
   },
   byOrgFiscalCode: {
     ["2"]: ["21" as ServiceId, "22" as ServiceId] as ReadonlyArray<ServiceId>,
     ["3"]: ["31" as ServiceId] as ReadonlyArray<ServiceId>,
-    ["4"]: ["41" as ServiceId, "42" as ServiceId] as ReadonlyArray<ServiceId>
+    ["4"]: ["41" as ServiceId, "42" as ServiceId] as ReadonlyArray<ServiceId>,
+    ["5"]: ["43" as ServiceId] as ReadonlyArray<ServiceId>,
+    ["6"]: ["44" as ServiceId] as ReadonlyArray<ServiceId>
   },
   visible: pot.some([
     { service_id: "11", version: 1 } as ServiceTuple,
     { service_id: "21", version: 1 } as ServiceTuple,
     { service_id: "22", version: 1 } as ServiceTuple,
-    { service_id: "41", version: 1 } as ServiceTuple
+    { service_id: "41", version: 1 } as ServiceTuple,
+    { service_id: "43", version: 1 } as ServiceTuple,
+    { service_id: "44", version: 1 } as ServiceTuple
   ]),
   readState: {
     ["21"]: true
@@ -106,12 +126,22 @@ const customOrganizations: OrganizationsState = {
     {
       name: "organization4",
       fiscalCode: "4"
+    },
+    {
+      name: "same_organization_name",
+      fiscalCode: "5"
+    },
+    {
+      name: "same_organization_name",
+      fiscalCode: "6"
     }
   ],
   nameByFiscalCode: {
     ["2" as OrganizationFiscalCode]: "organizzazion2" as NonEmptyString,
     ["3" as OrganizationFiscalCode]: "organizzazion3" as NonEmptyString,
-    ["4" as OrganizationFiscalCode]: "organizzazion4" as NonEmptyString
+    ["4" as OrganizationFiscalCode]: "organizzazion4" as NonEmptyString,
+    ["5" as OrganizationFiscalCode]: "same_organization_name" as NonEmptyString,
+    ["6" as OrganizationFiscalCode]: "same_organization_name" as NonEmptyString
   }
 };
 
@@ -189,6 +219,34 @@ describe("notSelectedServicesSectionsSelector", () => {
         organizationName: customOrganizations.nameByFiscalCode["4"] as string,
         organizationFiscalCode: "4" as OrganizationFiscalCode,
         data: [customServices.byId["41"]]
+      },
+      {
+        organizationName: customOrganizations.nameByFiscalCode["5"] as string,
+        organizationFiscalCode: "5" as OrganizationFiscalCode,
+        data: [customServices.byId["43"], customServices.byId["44"]]
+      }
+    ]);
+  });
+});
+
+describe("notSelectedServicesSectionsSelector", () => {
+  it("should return all the visible services with scope equal to both NATIONAL and LOCAL not included in organizationsOfInterest", () => {
+    const servicesByScope: pot.Pot<ServicesByScope, Error> = pot.some({
+      LOCAL: ["43"],
+      NATIONAL: ["21"]
+    });
+    expect(
+      notSelectedServicesSectionsSelector.resultFunc(
+        customServices,
+        customOrganizations.nameByFiscalCode,
+        servicesByScope,
+        ["4", "5"] // this organization has the same name of another organization (id:6)
+      )
+    ).toStrictEqual([
+      {
+        organizationName: customOrganizations.nameByFiscalCode["2"] as string,
+        organizationFiscalCode: "2" as OrganizationFiscalCode,
+        data: [customServices.byId["21"]]
       }
     ]);
   });
@@ -213,7 +271,7 @@ describe("servicesBadgeValueSelector", () => {
         customServices.readState,
         true
       )
-    ).toBe(3);
+    ).toBe(5);
   });
 
   it("should return 0 if the first load is not yet completed", () => {


### PR DESCRIPTION
**Short description:**
This PR fixes a bug on listing organizations in _**all**_ tab
If an organization is selected by the user it shouldn't be listed in all services.
This bug was introduced by this PR https://github.com/pagopa/io-app/pull/1681 that merges two or more organizations having the same name