### PR TITLE
[#172580983] Avoid close modal if report type isn't a bug

### DIFF
--- a/ts/components/screens/BaseScreenComponent.tsx
+++ b/ts/components/screens/BaseScreenComponent.tsx
@@ -93,7 +93,23 @@ class BaseScreenComponent extends React.PureComponent<Props, State> {
   }
 
   private handleOnRequestAssistance = (type: BugReporting.reportType) => {
-    this.setState({ contextualHelpModalAnimation: "none" }, () => {
+    // don't close modal if the report isn't a bug (bug brings a screenshot)
+    if (type !== BugReporting.reportType.bug) {
+      this.setState(
+        { requestReport: some(type) },
+        this.handleOnContextualHelpDismissed
+      );
+
+      return;
+    }
+    const contextualHelpModalAnimation = Platform.select<
+      ModalBaseProps["animationType"]
+    >({
+      ios: "slide",
+      android: "none",
+      default: "none"
+    });
+    this.setState({ contextualHelpModalAnimation }, () => {
       this.setState({ isHelpVisible: false }, () => {
         this.setState({ requestReport: some(type) }, () => {
           // since in Android we have no way to handle Modal onDismiss event https://reactnative.dev/docs/modal#ondismiss

--- a/ts/components/screens/BaseScreenComponent.tsx
+++ b/ts/components/screens/BaseScreenComponent.tsx
@@ -105,7 +105,6 @@ class BaseScreenComponent extends React.PureComponent<Props, State> {
       ModalBaseProps["animationType"]
     >({
       ios: "slide",
-      android: "none",
       default: "none"
     });
     this.setState({ contextualHelpModalAnimation }, () => {

--- a/ts/components/screens/BaseScreenComponent.tsx
+++ b/ts/components/screens/BaseScreenComponent.tsx
@@ -99,7 +99,6 @@ class BaseScreenComponent extends React.PureComponent<Props, State> {
         { requestReport: some(type) },
         this.handleOnContextualHelpDismissed
       );
-
       return;
     }
     const contextualHelpModalAnimation = Platform.select<


### PR DESCRIPTION
**Short description:**
This PRs 

- restores slide animation when the modal of the contextual help is closed (iOS only).
- avoids modal closing when user request a report that doesn't bring a screenshot
