### PR TITLE
Replace backspace character in keypads.

### DIFF
--- a/ts/components/Pinpad/KeyPad.tsx
+++ b/ts/components/Pinpad/KeyPad.tsx
@@ -43,7 +43,7 @@ const styles = StyleSheet.create({
   },
 
   buttonTextLabel: {
-    fontSize: radius - 5
+    fontSize: radius + 4
   },
 
   white: {
@@ -118,7 +118,7 @@ const renderPinRow = (
           renderPinCol(
             el.e1,
             el.e2,
-            el.e1.length === 1 ? "digit" : "label",
+            RegExp(/^[0-9]$/).test(el.e1) ? "digit" : "label",
             `pinpad-digit-${el.e2}`,
             buttonType,
             isDisabled

--- a/ts/components/Pinpad/index.tsx
+++ b/ts/components/Pinpad/index.tsx
@@ -131,7 +131,7 @@ class Pinpad extends React.PureComponent<Props, State> {
               )
             : undefined,
         Tuple2(pinPadValues[0], () => this.handlePinDigit(pinPadValues[0])),
-        Tuple2("<", this.deleteLastDigit)
+        Tuple2("⌫", this.deleteLastDigit)
       ]
     ];
   };


### PR DESCRIPTION
Replace backspace character in keypads with ERASE TO THE LEFT (U+232B),
to make the button meaning clearer.

### Before
![before](https://user-images.githubusercontent.com/788293/80964982-14ef3d00-8e12-11ea-898b-fc6d09f9fd21.png)

### After
![after](https://user-images.githubusercontent.com/788293/80964989-17ea2d80-8e12-11ea-93ab-52bf4ea109fa.jpg)
