### PR TITLE
[#172474643] Fixes CIE cancel on loading screen critical error

### DIFF
--- a/ts/screens/authentication/cie/CiePinScreen.tsx
+++ b/ts/screens/authentication/cie/CiePinScreen.tsx
@@ -54,23 +54,17 @@ class CiePinScreen extends React.PureComponent<Props, State> {
   }
 
   private onProceedToCardReaderScreen = (url: string) => {
+    const ciePin = this.state.pin;
     this.setState({ url }, () => {
+      this.props.navigation.navigate({
+        routeName: ROUTES.CIE_CARD_READER_SCREEN,
+        params: { ciePin, authorizationUri: url }
+      });
       this.props.hideModal();
     });
   };
 
-  private onHiddenModal = () => {
-    const ciePin = this.state.pin;
-    this.setState({ pin: "" }, () => {
-      this.props.navigation.navigate({
-        routeName: ROUTES.CIE_CARD_READER_SCREEN,
-        params: { ciePin, authorizationUri: this.state.url }
-      });
-    });
-  };
-
   private showModal = () => {
-    this.props.setOnHiddenModal(this.onHiddenModal);
     this.props.requestNfcEnabledCheck();
     Keyboard.dismiss();
 


### PR DESCRIPTION
**Short description:**
This PR fixes the device error when user cancel the CIE authorization loading

**List of changes proposed in this pull request:**
- ts/screens/authentication/cie/CiePinScreen.tsx

**How to test:**
Login with CIE, insert a PIN on loading screen click "Cancel" button or use the hardware back button to cancel the request