### PR TITLE
[#172526234] Fixes the lock on CieNFCOverlay screen

### DIFF
--- a/ts/components/cie/CieNfcOverlay.tsx
+++ b/ts/components/cie/CieNfcOverlay.tsx
@@ -6,7 +6,7 @@ import { Content, Text } from "native-base";
 import * as React from "react";
 import { Alert, StyleSheet } from "react-native";
 import I18n from "../../i18n";
-import { abortOnboarding } from "../../store/actions/onboarding";
+import { resetToAuthenticationRoute } from "../../store/actions/navigation";
 import { ReduxProps } from "../../store/actions/types";
 import variables from "../../theme/variables";
 import { openNFCSettings } from "../../utils/cie";
@@ -43,7 +43,7 @@ export default class CieNfcOverlay extends React.PureComponent<Props> {
         {
           text: I18n.t("global.buttons.exit"),
           style: "default",
-          onPress: () => this.props.dispatch(abortOnboarding())
+          onPress: () => this.props.dispatch(resetToAuthenticationRoute)
         }
       ]
     );


### PR DESCRIPTION
**Short description:**
This PR fixes the blocking transition on CieNfcOverlay screen when trying to go back.

**List of changes proposed in this pull request:**
- ts/components/cie/CieNfcOverlay.tsx

**How to test:**
Disable NFC on smartphone and Login with CIE after PIN insertion, go back from Enable NFC screen without enabling NFC