### PR TITLE
[#172577116] Track failure on mixpanel when trying to load a missing municipality

### DIFF
--- a/ts/sagas/contentLoaders.ts
+++ b/ts/sagas/contentLoaders.ts
@@ -179,7 +179,7 @@ export function* watchContentMunicipalityLoadSaga(): Iterator<Effect> {
       yield put(
         contentMunicipalityLoad.failure({
           error: e,
-          codiceCatastale: codiceCatastale as string
+          codiceCatastale
         })
       );
     }

--- a/ts/sagas/contentLoaders.ts
+++ b/ts/sagas/contentLoaders.ts
@@ -176,7 +176,12 @@ export function* watchContentMunicipalityLoadSaga(): Iterator<Effect> {
         throw response.value;
       }
     } catch (e) {
-      yield put(contentMunicipalityLoad.failure(e));
+      yield put(
+        contentMunicipalityLoad.failure({
+          error: e,
+          codiceCatastale: codiceCatastale as string
+        })
+      );
     }
   });
 }

--- a/ts/store/actions/content.ts
+++ b/ts/store/actions/content.ts
@@ -12,6 +12,11 @@ type ServiceMetadataFailure = {
   serviceId: string;
 };
 
+type MunicipalityFailure = {
+  error: Error;
+  codiceCatastale: string;
+};
+
 type ServiceLetadataSuccess = {
   serviceId: string;
   data: ServiceMetadataState;
@@ -30,7 +35,7 @@ export const contentMunicipalityLoad = createAsyncAction(
 )<
   CodiceCatastale,
   { codiceCatastale: CodiceCatastale; data: MunicipalityMetadata },
-  Error
+  MunicipalityFailure
 >();
 
 export const loadVisibleServicesByScope = createAsyncAction(

--- a/ts/store/middlewares/analytics.ts
+++ b/ts/store/middlewares/analytics.ts
@@ -23,7 +23,10 @@ import {
   sessionInformationLoadSuccess,
   sessionInvalid
 } from "../actions/authentication";
-import { loadServiceMetadata } from "../actions/content";
+import {
+  contentMunicipalityLoad,
+  loadServiceMetadata
+} from "../actions/content";
 import { instabugReportClosed, instabugReportOpened } from "../actions/debug";
 import {
   identificationCancel,
@@ -245,6 +248,12 @@ const trackAction = (mp: NonNullable<typeof mixpanel>) => (
         reason: action.payload.message
       });
 
+    // track when a missing municipality is detected
+    case getType(contentMunicipalityLoad.failure):
+      return mp.track(action.type, {
+        reason: action.payload.error.message,
+        codice_catastale: action.payload.codiceCatastale
+      });
     // download / delete profile
     case getType(upsertUserDataProcessing.success):
       return mp.track(action.type, action.payload);

--- a/ts/store/reducers/content.ts
+++ b/ts/store/reducers/content.ts
@@ -192,9 +192,9 @@ export default function content(
         municipality: {
           codiceCatastale: pot.toError(
             state.municipality.codiceCatastale,
-            action.payload
+            action.payload.error
           ),
-          data: pot.toError(state.municipality.data, action.payload)
+          data: pot.toError(state.municipality.data, action.payload.error)
         }
       };
 


### PR DESCRIPTION
**Short description:**
This pr allows to track when a municipality request is not available in `io-services-metadata`.

**List of changes proposed in this pull request:**
- Changed the payload of `contentMunicipalityLoad.failure` adding the `codiceCatastale`.
- Send the message to MixPanel when there is an event of `contentMunicipalityLoad.failure`

**How to test:**
Using the `dev` server, temporarily remove the handler:
```typescript
app.get(`${staticContentRootPath}/municipalities/:A/:B/:CODE`, (_, res) => {
   res.json(municipality);
 });
```
and check if the event is correctly registered on mixpanel using the jql:
```javascript
function main() {
  return Events({
    from_date: "2020-xx-xx",
    to_date: "2020-xx-xx"
  })
  .groupBy(
    ["properties.codice_catastale"],
    mixpanel.reducer.count()
  );
}
```