### PR TITLE
[#172698983] Add missing space in paymentsuccessScreen

### DIFF
--- a/ts/screens/wallet/payment/TransactionSuccessScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionSuccessScreen.tsx
@@ -69,7 +69,7 @@ class TransactionSuccessScreen extends React.PureComponent<Props> {
               onPress: () => this.props.navigateToReceipt(this.transaction)
             }}
           />
-          <View spacer={true}/>
+          <View spacer={true} />
           <BlockButtons
             type={"SingleButton"}
             leftButton={{

--- a/ts/screens/wallet/payment/TransactionSuccessScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionSuccessScreen.tsx
@@ -69,6 +69,7 @@ class TransactionSuccessScreen extends React.PureComponent<Props> {
               onPress: () => this.props.navigateToReceipt(this.transaction)
             }}
           />
+          <View spacer={true}/>
           <BlockButtons
             type={"SingleButton"}
             leftButton={{


### PR DESCRIPTION
**Short description:**
this pr introduces a missed space between the footer buttons of the screen displayed at the end of a sucessfull payment:

<img width="541" alt="image" src="https://user-images.githubusercontent.com/38431762/81576393-7ed68c00-93a8-11ea-98fd-f72b822cf109.png">
