### PR TITLE
[#171743242] Grant back from transaction summary

### DIFF
--- a/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
@@ -136,7 +136,8 @@ class TransactionSummaryScreen extends React.Component<Props> {
         buttonIndex => {
           if (buttonIndex === 0) {
             this.props.resetPayment();
-            this.props.navigation.goBack();
+            this.props.goBack();
+            this.props.goBack();
             showToast(
               I18n.t("wallet.ConfirmPayment.cancelPaymentSuccess"),
               "success"
@@ -468,6 +469,7 @@ const mapDispatchToProps = (dispatch: Dispatch, props: OwnProps) => {
     );
 
   return {
+    backToEntrypointPayment,
     dispatchPaymentVerificaRequest,
     navigateToPaymentTransactionError,
     dispatchNavigateToPaymentManualDataInsertion,


### PR DESCRIPTION
**Short description:**
This pr fixes a bug on navigation on payment 

Steps to reproduce the bug:
1. verify we have at least one added payment method
2. go to message listfind a message linked to payment and press 'pay'
3. from the displayed transaction summary, press next
4. from the displayed 'pay with'  screen select 'change method'
from the change payment method screen, go back until the payment is cancelled:
5.  press back on change method screen
6. press back on the 'pay with' screen
7. press back on the transaction summary screen

8.BEFORE: the focus remains on the transaction summary but the form is empty
8.AFTER: the focus returns to the message list