### PR TITLE
[#172794872] Add payment outcome inside payment detail

### DIFF
--- a/ts/components/wallet/PaymentsHistoryList.tsx
+++ b/ts/components/wallet/PaymentsHistoryList.tsx
@@ -56,49 +56,47 @@ export const getIuv = (data: RptId): string => {
 };
 
 const notAvailable = I18n.t("global.remoteStates.notAvailable");
+export const getPaymentHistoryInfo = (
+  paymentHistory: PaymentHistory,
+  paymentCheckout: Option<boolean>
+) => {
+  return paymentCheckout.fold(
+    {
+      text11: I18n.t("payment.details.state.incomplete"),
+      text3: getIuv(paymentHistory.data),
+      color: customVariables.badgeYellow
+    },
+    success => {
+      if (success) {
+        return {
+          text11: I18n.t("payment.details.state.successful"),
+          text3: fromNullable(paymentHistory.verified_data).fold(
+            notAvailable,
+            vd =>
+              fromNullable(vd.causaleVersamento).fold(notAvailable, cv => cv)
+          ),
+          color: customVariables.brandHighlight
+        };
+      }
 
+      return {
+        text11: I18n.t("payment.details.state.failed"),
+        text3: getIuv(paymentHistory.data),
+        color: customVariables.brandDanger
+      };
+    }
+  );
+};
 /**
  * Payments List component
  */
 
 export default class PaymentHistoryList extends React.Component<Props> {
-  private getPaymentHistoryInfo = (
-    paymentHistory: PaymentHistory,
-    paymentCheckout: Option<boolean>
-  ) => {
-    return paymentCheckout.fold(
-      {
-        text11: I18n.t("payment.details.state.incomplete"),
-        text3: getIuv(paymentHistory.data),
-        color: customVariables.badgeYellow
-      },
-      success => {
-        if (success) {
-          return {
-            text11: I18n.t("payment.details.state.successful"),
-            text3: fromNullable(paymentHistory.verified_data).fold(
-              notAvailable,
-              vd =>
-                fromNullable(vd.causaleVersamento).fold(notAvailable, cv => cv)
-            ),
-            color: customVariables.brandHighlight
-          };
-        }
-
-        return {
-          text11: I18n.t("payment.details.state.failed"),
-          text3: getIuv(paymentHistory.data),
-          color: customVariables.brandDanger
-        };
-      }
-    );
-  };
-
   private renderHistoryPaymentItem = (
     info: ListRenderItemInfo<PaymentHistory>
   ) => {
     const paymentCheckout = isPaymentDoneSuccessfully(info.item);
-    const paymentInfo = this.getPaymentHistoryInfo(info.item, paymentCheckout);
+    const paymentInfo = getPaymentHistoryInfo(info.item, paymentCheckout);
 
     const datetime: string = `${formatDateAsLocal(
       new Date(info.item.started_at),

--- a/ts/screens/wallet/PaymentHistoryDetailsScreen.tsx
+++ b/ts/screens/wallet/PaymentHistoryDetailsScreen.tsx
@@ -19,9 +19,13 @@ import {
 } from "../../boot/configureInstabug";
 import ButtonDefaultOpacity from "../../components/ButtonDefaultOpacity";
 import ItemSeparatorComponent from "../../components/ItemSeparatorComponent";
+import { BadgeComponent } from "../../components/screens/BadgeComponent";
 import BaseScreenComponent from "../../components/screens/BaseScreenComponent";
 import IconFont from "../../components/ui/IconFont";
-import { getIuv } from "../../components/wallet/PaymentsHistoryList";
+import {
+  getIuv,
+  getPaymentHistoryInfo
+} from "../../components/wallet/PaymentsHistoryList";
 import { SlidedContentComponent } from "../../components/wallet/SlidedContentComponent";
 import I18n from "../../i18n";
 import {
@@ -60,7 +64,7 @@ const styles = StyleSheet.create({
     paddingRight: 10
   },
   box: {
-    marginTop: 10,
+    marginTop: 2,
     marginBottom: 10,
     flexDirection: "column",
     justifyContent: "flex-start"
@@ -120,6 +124,11 @@ const styles = StyleSheet.create({
     lineHeight: 24,
     color: customVariables.brandPrimary
   },
+  paymentOutcome: {
+    justifyContent: "flex-start",
+    flexDirection: "row",
+    alignItems: "center"
+  },
   helpButtonText: {
     paddingRight: 10,
     paddingBottom: 0,
@@ -127,6 +136,13 @@ const styles = StyleSheet.create({
     fontSize: 14,
     lineHeight: 20,
     color: customVariables.brandPrimary
+  },
+
+  text11: {
+    fontSize: 14,
+    paddingLeft: 8,
+    lineHeight: 18,
+    color: customVariables.brandDarkestGray
   }
 });
 
@@ -198,6 +214,10 @@ class PaymentHistoryDetailsScreen extends React.Component<Props> {
   );
   public render(): React.ReactNode {
     const payment = this.props.navigation.getParam("payment");
+    const paymentCheckout = isPaymentDoneSuccessfully(payment);
+    const paymentInfo = getPaymentHistoryInfo(payment, paymentCheckout);
+    const paymentOutcomeDescription = paymentInfo.text11;
+    const paymentOutcomeColor = paymentInfo.color;
     const errorDetail = fromNullable(
       renderErrorTransactionMessage(payment.failure)
     );
@@ -249,6 +269,11 @@ class PaymentHistoryDetailsScreen extends React.Component<Props> {
               <Text>{I18n.t("payment.details.info.title")}</Text>
             </View>
             <ItemSeparatorComponent noPadded={true} />
+            <View spacer={true} />
+            <View style={styles.paymentOutcome}>
+              <BadgeComponent color={paymentOutcomeColor} />
+              <Text style={styles.text11}>{paymentOutcomeDescription}</Text>
+            </View>
             <View style={styles.box}>
               {paymentOutCome.isSome() && paymentOutCome.value ? (
                 <React.Fragment>

--- a/ts/utils/payment.ts
+++ b/ts/utils/payment.ts
@@ -146,11 +146,13 @@ export const getPaymentHistoryDetails = (
   const failureDetails = fromNullable(payment.failure)
     .map(pf => `- errore: ${pf}`)
     .getOrElse("");
-  return profileDetails
-    .concat(separator)
-    .concat(paymentDetails)
-    .concat(separator)
-    .concat(ccp)
-    .concat(separator)
-    .concat(failureDetails);
+  return profileDetails.concat(
+    separator,
+    paymentDetails,
+    paymentDetails,
+    separator,
+    ccp,
+    separator,
+    failureDetails
+  );
 };


### PR DESCRIPTION
**Short description:**
- Add payment outcome inside payment detail screen
- Improve function to get payment details as log

| before  | after |
| ------------- | ------------- |
![before](https://user-images.githubusercontent.com/822471/81699409-96c11500-9467-11ea-80c7-fda305c94747.png) | ![after](https://user-images.githubusercontent.com/822471/81699429-a0e31380-9467-11ea-8d35-8943e5107e43.png)
