### PR TITLE
[#171743242] Fixes back from Transaction summary screen to the payment entrypoint

### DIFF
--- a/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
@@ -135,9 +135,8 @@ class TransactionSummaryScreen extends React.Component<Props> {
         },
         buttonIndex => {
           if (buttonIndex === 0) {
+            this.props.backToEntrypointPayment();
             this.props.resetPayment();
-            this.props.goBack();
-            this.props.goBack();
             showToast(
               I18n.t("wallet.ConfirmPayment.cancelPaymentSuccess"),
               "success"
@@ -469,7 +468,7 @@ const mapDispatchToProps = (dispatch: Dispatch, props: OwnProps) => {
     );
 
   return {
-    backToEntrypointPayment,
+    backToEntrypointPayment: () => dispatch(backToEntrypointPayment()),
     dispatchPaymentVerificaRequest,
     navigateToPaymentTransactionError,
     dispatchNavigateToPaymentManualDataInsertion,


### PR DESCRIPTION
**Short description:**
This PR improves the navigation from transaction summary to the payment entrypoint

**List of changes proposed in this pull request:**
- ts/screens/wallet/payment/TransactionSummaryScreen.tsx