### PR TITLE
[#172553600] hide bottom bar if message payment is paid

### DIFF
--- a/ts/components/messages/MessageCTABar.tsx
+++ b/ts/components/messages/MessageCTABar.tsx
@@ -227,9 +227,8 @@ class MessageCTABar extends React.PureComponent<Props> {
    * Display description on message deadlines
    */
   private renderBottomContainer = () => {
-
-    if(this.paid){
-      return undefined
+    if (this.paid) {
+      return undefined;
     }
 
     const { small } = this.props;

--- a/ts/components/messages/MessageCTABar.tsx
+++ b/ts/components/messages/MessageCTABar.tsx
@@ -227,6 +227,11 @@ class MessageCTABar extends React.PureComponent<Props> {
    * Display description on message deadlines
    */
   private renderBottomContainer = () => {
+
+    if(this.paid){
+      return undefined
+    }
+
     const { small } = this.props;
 
     // If in the message detail and the payment is not expired


### PR DESCRIPTION
**Short description:**
This pr solve a bug on the message detail: if paid, we don't care anymore if the message is expiring or if it is expired:

<img width="606" alt="image" src="https://user-images.githubusercontent.com/38431762/81703047-60d25f80-946c-11ea-86e6-9f38e2a2889a.png">


NOTE: the bug is only on the current version of the CTA bar which will be overwritten by next pr