### PR TITLE
[#172818099] update success payment screen button content

### DIFF
--- a/ts/screens/wallet/payment/TransactionSuccessScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionSuccessScreen.tsx
@@ -73,7 +73,7 @@ class TransactionSuccessScreen extends React.PureComponent<Props> {
           <BlockButtons
             type={"SingleButton"}
             leftButton={{
-              title: I18n.t("wallet.backToPayments"),
+              title: I18n.t("global.buttons.close"),
               light: true,
               bordered: true,
               onPress: this.props.backToEntrypointPayment


### PR DESCRIPTION
**Short description:**
This pr updates the 'Close' button having that, now, we return to the payment entrypoint.

<img width="603" alt="image" src="https://user-images.githubusercontent.com/38431762/81820505-fcc59f00-9530-11ea-8972-4bb290f3397c.png">

