### PR TITLE
[#172886190] Automatically add the tag "services-loading-error" on instabug

### DIFF
--- a/ts/screens/services/ServicesHomeScreen.tsx
+++ b/ts/screens/services/ServicesHomeScreen.tsx
@@ -22,6 +22,7 @@
  *
  */
 import { Option } from "fp-ts/lib/Option";
+import Instabug from "instabug-reactnative";
 import * as pot from "italia-ts-commons/lib/pot";
 import { Tab, Tabs, Text, View } from "native-base";
 import * as React from "react";
@@ -345,7 +346,9 @@ class ServicesHomeScreen extends React.Component<Props, State> {
     openInstabugBugReport();
   };
   /*TODO: remove this method after the resolution of https://www.pivotaltracker.com/story/show/172431153 */
+  private instabugReportTag = "services-loading-error";
   private sendDataToInstabug() {
+    Instabug.appendTags([this.instabugReportTag]);
     instabugLog(
       "userMetadata: " + JSON.stringify(this.props.potUserMetadata),
       TypeLogs.INFO


### PR DESCRIPTION
**Short description:**
This pr automatically adds the tag `services-loading-error` when a bug report is sent from the the `ServicesHomeScreen`.

**List of changes proposed in this pull request:**
- Added the method `Instabug.appendTags([this.instabugReportTag]);`

**How to test:**
Send a bug report from the `ServicesHomeScreen` and verify that the new report on istabug have the tag `services-loading-error`.