### PR TITLE
[#172932681] Reset pin if the onboarding is aborted

### DIFF
--- a/ts/sagas/startup/watchAbortOnboardingSaga.ts
+++ b/ts/sagas/startup/watchAbortOnboardingSaga.ts
@@ -1,13 +1,15 @@
 import { Effect } from "redux-saga";
-import { put, take } from "redux-saga/effects";
+import { call, put, take } from "redux-saga/effects";
 import { getType } from "typesafe-actions";
 
 import { startApplicationInitialization } from "../../store/actions/application";
 import { sessionInvalid } from "../../store/actions/authentication";
 import { abortOnboarding } from "../../store/actions/onboarding";
+import { deletePin } from "../../utils/keychain";
 
 export function* watchAbortOnboardingSaga(): Iterator<Effect> {
   yield take(getType(abortOnboarding));
+  yield call(deletePin);
   // invalidate the session
   yield put(sessionInvalid());
   // initialize the app from scratch (forcing an onboarding flow)


### PR DESCRIPTION
**Short description:**
This pr fixes a bug that allow to save the pin if the onboarding is aborted.

<img src=https://user-images.githubusercontent.com/26501317/82423366-f466ea00-9a83-11ea-9a95-49fb951b43a2.gif width=300/>

**List of changes proposed in this pull request:**
- call `deletePin` when `abortOnboarding` is dispatched.

**How to test:**
Do the onboarding without complete it and abort. Restart again and verify if the pin is asked again.