### PR TITLE
[#172886678] Changed expiring state calculation

### DIFF
--- a/ts/utils/dates.ts
+++ b/ts/utils/dates.ts
@@ -30,6 +30,7 @@ export function formatDateAsReminder(
  * It provides the format of the date depending on the system locale (DD/MM or MM/DD as default)
  * @param date
  * @param includeYear: true if the year should be included (DD/MM/YY or MM/DD/YY)
+ * @param extendedYear
  */
 export function formatDateAsLocal(
   date: Date,
@@ -88,7 +89,7 @@ export function isExpired(expireMonth: number, expireYear: number): boolean {
  */
 export const getExpireStatus = (date: Date): ExpireStatus => {
   const remainingMilliseconds = date.getTime() - Date.now();
-  return remainingMilliseconds > 1000 * 60 * 60 * 24
+  return remainingMilliseconds > 1000 * 60 * 60 * 24 * 7
     ? "VALID"
     : remainingMilliseconds > 0
       ? "EXPIRING"


### PR DESCRIPTION
**Short description:**
This pr changes the calculation of the `expiring` state. Now an `expiring` state is returned when there are seven days left (instead of one day left).
This change impacts graphically on expiring messages, where now the user will see messages with expiration less than or equal to seven days.

Before            |  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/26501317/82448708-64886680-9aaa-11ea-86c3-4f3935c0762a.png" width="300">|  <img src="https://user-images.githubusercontent.com/26501317/82449343-5e46ba00-9aab-11ea-947b-2f46c9fe2287.gif" width="300">

**List of changes proposed in this pull request:**
- changed the calculation in `ts/utils/dates.ts`

**How to test:**
In the expiring messages tab, all the messages with due date less than equal to seven days should be with the red button.