### PR TITLE
[#172941125] Add "payment-support" tag to instabug payment assistance requests

### DIFF
--- a/ts/screens/wallet/PaymentHistoryDetailsScreen.tsx
+++ b/ts/screens/wallet/PaymentHistoryDetailsScreen.tsx
@@ -4,6 +4,7 @@
  * add new ones
  */
 import { fromNullable } from "fp-ts/lib/Option";
+import Instabug from "instabug-reactnative";
 import * as pot from "italia-ts-commons/lib/pot";
 import { Text, View } from "native-base";
 import * as React from "react";
@@ -189,6 +190,7 @@ class PaymentHistoryDetailsScreen extends React.Component<Props> {
   );
 
   private instabugLogAndOpenReport = () => {
+    Instabug.appendTags(["payment-support"]);
     pot.map(this.props.profile, p => {
       instabugLog(
         getPaymentHistoryDetails(this.props.navigation.getParam("payment"), p),


### PR DESCRIPTION
**Short description:**
This pr adds the tag "payment-support" when a new payment assistance request is sent to instabug.

**List of changes proposed in this pull request:**
- ` Instabug.appendTags(["payment-support"]);`

**How to test:**
Send a Instabug request from the payment assistance section.