### PR TITLE
[#173322606] Fix RootContainer re-renders

### DIFF
--- a/ts/RootContainer.tsx
+++ b/ts/RootContainer.tsx
@@ -16,25 +16,18 @@ import { LightModalRoot } from "./components/ui/LightModal";
 import VersionInfoOverlay from "./components/VersionInfoOverlay";
 import { shouldDisplayVersionInfoOverlay } from "./config";
 import Navigation from "./navigation";
-import IdentificationModal from "./screens/modal/IdentificationModal";
-import SystemOffModal from "./screens/modal/SystemOffModal";
-import UpdateAppModal from "./screens/modal/UpdateAppModal";
 import {
   applicationChangeState,
   ApplicationState
 } from "./store/actions/application";
 import { navigateToDeepLink, setDeepLink } from "./store/actions/deepLink";
 import { navigateBack } from "./store/actions/navigation";
-import { isBackendServicesStatusOffSelector } from "./store/reducers/backendStatus";
 import { GlobalState } from "./store/reducers/types";
 import { getNavigateActionFromDeepLink } from "./utils/deepLink";
 
-import { fromNullable } from "fp-ts/lib/Option";
 import { setLocale } from "./i18n";
-import { serverInfoDataSelector } from "./store/reducers/backendInfo";
+import RootModal from "./screens/modal/RootModal";
 import { preferredLanguageSelector } from "./store/reducers/persistedPreferences";
-// Check min version app supported
-import { isUpdateNeeded } from "./utils/appVersion";
 
 type Props = ReturnType<typeof mapStateToProps> & typeof mapDispatchToProps;
 
@@ -131,21 +124,6 @@ class RootContainer extends React.PureComponent<Props> {
     }
   }
 
-  private get getModal() {
-    // avoid app usage if backend systems are OFF
-    if (this.props.isBackendServicesStatusOff) {
-      return <SystemOffModal />;
-    }
-    const isAppOutOfDate = fromNullable(this.props.backendInfo)
-      .map(bi => isUpdateNeeded(bi, "min_app_version"))
-      .getOrElse(false);
-    // if the app is out of date, force a screen to update it
-    if (isAppOutOfDate) {
-      return <UpdateAppModal />;
-    }
-    return <IdentificationModal />;
-  }
-
   public render() {
     // FIXME: perhaps instead of navigating to a "background"
     //        screen, we can make this screen blue based on
@@ -163,7 +141,7 @@ class RootContainer extends React.PureComponent<Props> {
         )}
         <Navigation />
         {shouldDisplayVersionInfoOverlay && <VersionInfoOverlay />}
-        {this.getModal}
+        <RootModal />
         <LightModalRoot />
       </Root>
     );
@@ -173,9 +151,7 @@ class RootContainer extends React.PureComponent<Props> {
 const mapStateToProps = (state: GlobalState) => ({
   preferredLanguage: preferredLanguageSelector(state),
   deepLinkState: state.deepLink,
-  isDebugModeEnabled: state.debug.isDebugModeEnabled,
-  isBackendServicesStatusOff: isBackendServicesStatusOffSelector(state),
-  backendInfo: serverInfoDataSelector(state)
+  isDebugModeEnabled: state.debug.isDebugModeEnabled
 });
 
 const mapDispatchToProps = {

--- a/ts/screens/modal/RootModal.tsx
+++ b/ts/screens/modal/RootModal.tsx
@@ -12,7 +12,7 @@ import UpdateAppModal from "./UpdateAppModal";
 type Props = ReturnType<typeof mapStateToProps>;
 
 /**
- * This is a wrapper of all possibile modals the app can show in an automatic way, in this order:
+ * This is a wrapper of all possibile modals the app can show (without user interaction), in this order:
  * - SystemOffModal -> when backend systems are off the app avoids its usage by showing a modal
  * - UpdateAppModal -> when the backend is not compliant anymore with the app, this modal is shown to force an update
  * - IdentificationModal -> the default case. It renders it self only if an identification action is required

--- a/ts/screens/modal/RootModal.tsx
+++ b/ts/screens/modal/RootModal.tsx
@@ -1,0 +1,40 @@
+import { fromNullable } from "fp-ts/lib/Option";
+import * as React from "react";
+import { connect } from "react-redux";
+import { serverInfoDataSelector } from "../../store/reducers/backendInfo";
+import { isBackendServicesStatusOffSelector } from "../../store/reducers/backendStatus";
+import { GlobalState } from "../../store/reducers/types";
+import { isUpdateNeeded } from "../../utils/appVersion";
+import IdentificationModal from "./IdentificationModal";
+import SystemOffModal from "./SystemOffModal";
+import UpdateAppModal from "./UpdateAppModal";
+
+type Props = ReturnType<typeof mapStateToProps>;
+
+/**
+ * This is a wrapper of all possibile modals the app can show in an automatic way, in this order:
+ * - SystemOffModal -> when backend systems are off the app avoids its usage by showing a modal
+ * - UpdateAppModal -> when the backend is not compliant anymore with the app, this modal is shown to force an update
+ * - IdentificationModal -> the default case. It renders it self only if an identification action is required
+ */
+export const RootModal: React.FunctionComponent<Props> = (props: Props) => {
+  // avoid app usage if backend systems are OFF
+  if (props.isBackendServicesStatusOff) {
+    return <SystemOffModal />;
+  }
+  const isAppOutOfDate = fromNullable(props.backendInfo)
+    .map(bi => isUpdateNeeded(bi, "min_app_version"))
+    .getOrElse(false);
+  // if the app is out of date, force a screen to update it
+  if (isAppOutOfDate) {
+    return <UpdateAppModal />;
+  }
+  return <IdentificationModal />;
+};
+
+const mapStateToProps = (state: GlobalState) => ({
+  isBackendServicesStatusOff: isBackendServicesStatusOffSelector(state),
+  backendInfo: serverInfoDataSelector(state)
+});
+
+export default connect(mapStateToProps)(RootModal);


### PR DESCRIPTION
**Short description:**
Due to a scheduled update (checking if the min version is still compliant with the backend) the RootContainer inner state changes on each round.

The fix consists in a new component that holds the state of updates and shows a modal if it is needed.

This is what happens on every update: since a re-render is ordered the webview shows a refresh 
<img src="https://user-images.githubusercontent.com/822471/84589751-10ff0380-ae31-11ea-8f5e-34cd93412e8d.gif" height="600"/>
