### PR TITLE
[#173353526] Fix transaction details crash

### DIFF
--- a/ts/components/wallet/PaymentSummaryComponent.tsx
+++ b/ts/components/wallet/PaymentSummaryComponent.tsx
@@ -61,7 +61,7 @@ const styles = StyleSheet.create({
  */
 export const PaymentSummaryComponent = (props: Props) => {
   const renderItem = (label: string, value?: string) => {
-    if (isNullyOrEmpty(props.recipient)) {
+    if (isNullyOrEmpty(value)) {
       return null;
     }
     return (

--- a/ts/components/wallet/PaymentSummaryComponent.tsx
+++ b/ts/components/wallet/PaymentSummaryComponent.tsx
@@ -3,9 +3,9 @@ import * as React from "react";
 import { Image, ImageSourcePropType, StyleSheet } from "react-native";
 import I18n from "../../i18n";
 import customVariables from "../../theme/variables";
+import { isNullyOrEmpty } from "../../utils/strings";
 import ItemSeparatorComponent from "../ItemSeparatorComponent";
 import { BadgeComponent } from "../screens/BadgeComponent";
-import { isNullyOrEmpty } from "../../utils/strings";
 
 type Props = Readonly<{
   title: string;

--- a/ts/components/wallet/PaymentSummaryComponent.tsx
+++ b/ts/components/wallet/PaymentSummaryComponent.tsx
@@ -5,6 +5,7 @@ import I18n from "../../i18n";
 import customVariables from "../../theme/variables";
 import ItemSeparatorComponent from "../ItemSeparatorComponent";
 import { BadgeComponent } from "../screens/BadgeComponent";
+import { isNullyOrEmpty } from "../../utils/strings";
 
 type Props = Readonly<{
   title: string;
@@ -59,17 +60,22 @@ const styles = StyleSheet.create({
  * This component displays the transaction details
  */
 export const PaymentSummaryComponent = (props: Props) => {
-  const renderItem = (label: string, value: string) => (
-    <React.Fragment>
-      <Text small={true} style={props.dark && styles.lighterGray}>
-        {label}
-      </Text>
-      <Text bold={true} dark={!props.dark} white={props.dark}>
-        {value}
-      </Text>
-      <View spacer={true} />
-    </React.Fragment>
-  );
+  const renderItem = (label: string, value?: string) => {
+    if (isNullyOrEmpty(props.recipient)) {
+      return null;
+    }
+    return (
+      <React.Fragment>
+        <Text small={true} style={props.dark && styles.lighterGray}>
+          {label}
+        </Text>
+        <Text bold={true} dark={!props.dark} white={props.dark}>
+          {value}
+        </Text>
+        <View spacer={true} />
+      </React.Fragment>
+    );
+  };
 
   const paymentStatus = props.paymentStatus && (
     <React.Fragment>
@@ -103,16 +109,14 @@ export const PaymentSummaryComponent = (props: Props) => {
 
       <View style={styles.row}>
         <View style={styles.column}>
-          {props.recipient &&
-            renderItem(I18n.t("wallet.recipient"), props.recipient)}
+          {renderItem(I18n.t("wallet.recipient"), props.recipient)}
 
-          {props.description &&
-            renderItem(
-              I18n.t("wallet.firstTransactionSummary.object"),
-              props.description
-            )}
+          {renderItem(
+            I18n.t("wallet.firstTransactionSummary.object"),
+            props.description
+          )}
 
-          {props.iuv && renderItem(I18n.t("payment.IUV"), props.iuv)}
+          {renderItem(I18n.t("payment.IUV"), props.iuv)}
         </View>
 
         {props.image !== undefined && <Image source={props.image} />}

--- a/ts/utils/__tests__/string.test.ts
+++ b/ts/utils/__tests__/string.test.ts
@@ -1,4 +1,4 @@
-import { capitalize } from "../strings";
+import { capitalize, isNullyOrEmpty } from "../strings";
 
 describe("capitalize", () => {
   it("should return a string where each word has first char in uppercase-1", () => {
@@ -19,5 +19,27 @@ describe("capitalize", () => {
 
   it("should return a string where each word has first char in uppercase-5", () => {
     expect(capitalize("   hello,world   ", ",")).toEqual("   Hello,World   ");
+  });
+});
+
+describe("null or empty", () => {
+  it("should return true", () => {
+    expect(isNullyOrEmpty(undefined)).toBeTruthy();
+  });
+
+  it("should return false", () => {
+    expect(isNullyOrEmpty("hello")).toBeFalsy();
+  });
+
+  it("should return true", () => {
+    expect(isNullyOrEmpty("    ")).toBeTruthy();
+  });
+
+  it("should return true", () => {
+    expect(isNullyOrEmpty("")).toBeTruthy();
+  });
+
+  it("should return true", () => {
+    expect(isNullyOrEmpty(null)).toBeTruthy();
   });
 });

--- a/ts/utils/strings.ts
+++ b/ts/utils/strings.ts
@@ -71,6 +71,5 @@ ${cap}${city}${province}`.trim();
  * determine if the text is undefined or empty (or composed only by blanks)
  * @param text
  */
-export const isNullyOrEmpty = (text: string | undefined | null) => {
-  return (text || "").trim().length === 0;
-};
+export const isNullyOrEmpty = (text: string | null | undefined) =>
+  fromNullable(text).fold(true, t => t.trim().length === 0);

--- a/ts/utils/strings.ts
+++ b/ts/utils/strings.ts
@@ -66,3 +66,11 @@ export const formatTextRecipient = (e: EnteBeneficiario): string => {
 ${address}${civicNumber}\n
 ${cap}${city}${province}`.trim();
 };
+
+/**
+ * determine if the text is undefined or empty (or composed only by blanks)
+ * @param text
+ */
+export const isNullyOrEmpty = (text: string | undefined | null) => {
+  return (text || "").trim().length === 0;
+};


### PR DESCRIPTION
**Short description:**
This PR fixes a bug on transaction details.
Due to a wrong statement the app try to render an empty text

Buggy code
`stringValue && <SomeComponent>` fails when `stringValue===""`
this is because:
- `undefined && <SomeComponent>` -> `undefined` 
- `"some text" && <SomeComponent>` -> `<SomeComponent>` 
- `"" && <SomeComponent>` -> `""` 
It goes fine only when _stringValue_ is not undefined and with length > 0

| before  | fixed |
| ------------- | ------------- |
![before](https://user-images.githubusercontent.com/822471/84764579-3c6b2500-afce-11ea-881a-29092e350294.png) | ![fixed](https://user-images.githubusercontent.com/822471/84764692-6d4b5a00-afce-11ea-8a26-27da5fc5f439.png)




