### PR TITLE
[#173394174] Add qrcode white background

### DIFF
--- a/ts/features/bonusVacanze/screens/ActiveBonusScreen.tsx
+++ b/ts/features/bonusVacanze/screens/ActiveBonusScreen.tsx
@@ -213,7 +213,8 @@ const ActiveBonusScreen: React.FunctionComponent<Props> = (props: Props) => {
     // When mounting the component starts a polling to update the bonus information at runtime
     props.startPollingBonusFromId(bonusFromNav.id);
 
-    if (bonus) {
+    const needToLoad = Object.keys(qrCode).length === 0;
+    if (bonus && needToLoad) {
       readBase64Svg(bonus)
         .then(cc => setQRCode(cc))
         .catch(_ => undefined);

--- a/ts/features/bonusVacanze/screens/ActiveBonusScreen.tsx
+++ b/ts/features/bonusVacanze/screens/ActiveBonusScreen.tsx
@@ -3,7 +3,7 @@ import * as pot from "italia-ts-commons/lib/pot";
 import { Badge, Text, View } from "native-base";
 import * as React from "react";
 import { StyleSheet } from "react-native";
-import { SvgXml } from "react-native-svg";
+import Svg, { Rect, SvgXml } from "react-native-svg";
 import { NavigationInjectedProps } from "react-navigation";
 import { connect } from "react-redux";
 import { BonusActivationWithQrCode } from "../../../../definitions/bonus_vacanze/BonusActivationWithQrCode";
@@ -60,6 +60,7 @@ type Props = NavigationInjectedProps<NavigationParams> &
   ReturnType<typeof mapStateToProps> &
   LightModalContextInterface;
 
+const qrCodeSize = 168;
 const styles = StyleSheet.create({
   emptyHeader: { height: 90 },
   title: {
@@ -70,7 +71,7 @@ const styles = StyleSheet.create({
     position: "absolute",
     top: -144,
     resizeMode: "stretch",
-    height: 168,
+    height: qrCodeSize,
     width: "100%",
     shadowColor: "#000",
     shadowOffset: {
@@ -82,6 +83,7 @@ const styles = StyleSheet.create({
     zIndex: 7,
     elevation: 7,
     alignSelf: "center",
+    alignItems: "center",
     backgroundColor: variables.contentPrimaryBackground
   },
   center: {
@@ -141,8 +143,11 @@ const styles = StyleSheet.create({
 });
 
 const renderQRCode = (base64: string) =>
-  fromNullable(base64).fold(null, s => (
-    <SvgXml xml={s} height="100%" width="100%" />
+  fromNullable(base64).fold(null, xml => (
+    <Svg height={qrCodeSize} width={qrCodeSize} viewBox="0 0 100 100">
+      <Rect fill="#ffffff" height="100%" width="100%" />
+      <SvgXml xml={xml} />
+    </Svg>
   ));
 
 const renderFiscalCodeLine = (name: string, cf: string) => {

--- a/ts/features/bonusVacanze/screens/ActiveBonusScreen.tsx
+++ b/ts/features/bonusVacanze/screens/ActiveBonusScreen.tsx
@@ -3,7 +3,7 @@ import * as pot from "italia-ts-commons/lib/pot";
 import { Badge, Text, View } from "native-base";
 import * as React from "react";
 import { StyleSheet } from "react-native";
-import Svg, { Rect, SvgXml } from "react-native-svg";
+import { SvgXml } from "react-native-svg";
 import { NavigationInjectedProps } from "react-navigation";
 import { connect } from "react-redux";
 import { BonusActivationWithQrCode } from "../../../../definitions/bonus_vacanze/BonusActivationWithQrCode";
@@ -86,6 +86,11 @@ const styles = StyleSheet.create({
     alignItems: "center",
     backgroundColor: variables.contentPrimaryBackground
   },
+  qrCodeContainer: {
+    backgroundColor: "white",
+    width: qrCodeSize,
+    height: qrCodeSize
+  },
   center: {
     alignSelf: "center"
   },
@@ -144,10 +149,9 @@ const styles = StyleSheet.create({
 
 const renderQRCode = (base64: string) =>
   fromNullable(base64).fold(null, xml => (
-    <Svg height={qrCodeSize} width={qrCodeSize} viewBox="0 0 100 100">
-      <Rect fill="#ffffff" height="100%" width="100%" />
-      <SvgXml xml={xml} />
-    </Svg>
+    <View style={styles.qrCodeContainer}>
+      <SvgXml xml={xml} height={qrCodeSize} width={qrCodeSize} />
+    </View>
   ));
 
 const renderFiscalCodeLine = (name: string, cf: string) => {


### PR DESCRIPTION
**Short description:**
Since the SVG of the QrCode provided by the IO API has a transparent background, this PR adds a white View as background.
Furthermore it adds some logic to avoid to reload the Qrcode (from base64 -> ascii) each time state changes

| before  | after |
| ------------- | ------------- |
![before](https://user-images.githubusercontent.com/822471/85001363-d90aff80-b153-11ea-8344-ef03bdafff1b.png) | ![after](https://user-images.githubusercontent.com/822471/85001387-e45e2b00-b153-11ea-99c5-93990025a83d.png)

