### PR TITLE
[#173414551] Navigate to BonusDetails after activation success

### DIFF
--- a/ts/features/bonusVacanze/screens/activation/ActivateBonusCompletedScreen.tsx
+++ b/ts/features/bonusVacanze/screens/activation/ActivateBonusCompletedScreen.tsx
@@ -9,7 +9,7 @@ import { FooterStackButton } from "../../components/buttons/FooterStackButtons";
 import { renderInfoRasterImage } from "../../components/infoScreen/imageRendering";
 import { InfoScreenComponent } from "../../components/infoScreen/InfoScreenComponent";
 import { bonusVacanzaStyle } from "../../components/Styles";
-import { completeBonusVacanze } from "../../store/actions/bonusVacanze";
+import { completeBonusVacanzeActivation } from "../../store/actions/bonusVacanze";
 import { bonusVacanzeLogo } from "../../store/reducers/availableBonusesTypes";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
@@ -55,8 +55,7 @@ const mapStateToProps = (state: GlobalState) => ({
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  // TODO: replace with the event to go in the next screen
-  onConfirm: () => dispatch(completeBonusVacanze())
+  onConfirm: () => dispatch(completeBonusVacanzeActivation())
 });
 
 export default connect(

--- a/ts/features/bonusVacanze/store/actions/bonusVacanze.ts
+++ b/ts/features/bonusVacanze/store/actions/bonusVacanze.ts
@@ -68,8 +68,7 @@ export const bonusVacanzeActivation = createAsyncAction(
   "BONUS_ACTIVATION_FAILURE"
 )<void, BonusVacanzeActivationPayload, Error>();
 
-// TODO: remove with the true action
-export const completeBonusVacanze = createStandardAction(
+export const completeBonusVacanzeActivation = createStandardAction(
   "BONUS_ACTIVATION_COMPLETE"
 )();
 
@@ -82,4 +81,5 @@ export type BonusActions =
   | ActionType<typeof loadAllBonusActivations>
   | ActionType<typeof startLoadBonusFromIdPolling>
   | ActionType<typeof cancelBonusRequest>
+  | ActionType<typeof completeBonusVacanzeActivation>
   | ActionType<typeof cancelLoadBonusFromIdPolling>;

--- a/ts/features/bonusVacanze/store/sagas/activation/__tests__/handleBonusActivationTests.ts
+++ b/ts/features/bonusVacanze/store/sagas/activation/__tests__/handleBonusActivationTests.ts
@@ -10,7 +10,7 @@ import BONUSVACANZE_ROUTES from "../../../../navigation/routes";
 import {
   bonusVacanzeActivation,
   cancelBonusRequest,
-  completeBonusVacanze
+  completeBonusVacanzeActivation
 } from "../../../actions/bonusVacanze";
 import { handleBonusActivationSaga } from "../handleBonusActivationSaga";
 import {
@@ -84,7 +84,7 @@ const expectSagaFactory = (
     actionToVerify
       .reduce((acc, val) => acc.put(val), baseSaga)
       // when the last event completeBonusVacanze is received, the navigation stack is popped
-      .dispatch(completeBonusVacanze())
+      .dispatch(completeBonusVacanzeActivation())
       .put(navigationHistoryPop(1))
       .run()
       .then(results => {

--- a/ts/features/bonusVacanze/store/sagas/activation/__tests__/mockData.ts
+++ b/ts/features/bonusVacanze/store/sagas/activation/__tests__/mockData.ts
@@ -7,6 +7,7 @@ import {
   navigateToBonusActivationCompleted,
   navigateToBonusActivationLoading,
   navigateToBonusActivationTimeout,
+  navigateToBonusActiveDetailScreen,
   navigateToBonusAlreadyExists,
   navigateToEligibilityExpired
 } from "../../../../navigation/action";
@@ -50,6 +51,7 @@ export const activationSuccess: NetworkingResults = {
   }),
   expectedActions: [
     navigateToBonusActivationCompleted(),
+    navigateToBonusActiveDetailScreen({ bonus: mockedBonus }),
     navigationHistoryPop(1)
   ]
 };

--- a/ts/features/bonusVacanze/store/sagas/activation/handleBonusActivationSaga.ts
+++ b/ts/features/bonusVacanze/store/sagas/activation/handleBonusActivationSaga.ts
@@ -97,7 +97,7 @@ export function* activationWorker(activationSaga: BonusActivationSagaType) {
 export function* handleBonusActivationSaga(
   activationSaga: BonusActivationSagaType
 ): SagaIterator {
-  // an event of checkBonusEligibility.request trigger a new workflow for the eligibility
+  // an event of bonusVacanzeActivation.request trigger a new workflow for the activation
 
   const { cancelAction } = yield race({
     activation: call(activationWorker, activationSaga),

--- a/ts/features/bonusVacanze/store/sagas/activation/handleBonusActivationSaga.ts
+++ b/ts/features/bonusVacanze/store/sagas/activation/handleBonusActivationSaga.ts
@@ -10,6 +10,7 @@ import {
   navigateToBonusActivationCompleted,
   navigateToBonusActivationLoading,
   navigateToBonusActivationTimeout,
+  navigateToBonusActiveDetailScreen,
   navigateToBonusAlreadyExists,
   navigateToEligibilityExpired
 } from "../../../navigation/action";
@@ -17,7 +18,7 @@ import BONUSVACANZE_ROUTES from "../../../navigation/routes";
 import {
   bonusVacanzeActivation,
   cancelBonusRequest,
-  completeBonusVacanze
+  completeBonusVacanzeActivation
 } from "../../actions/bonusVacanze";
 import { BonusActivationProgressEnum } from "../../reducers/activation";
 import { bonusActivationSaga } from "./getBonusActivationSaga";
@@ -75,15 +76,23 @@ export function* activationWorker(activationSaga: BonusActivationSagaType) {
   }
 
   // the saga complete with the bonusVacanzeActivation.request action
-  // TODO: replace with the next true action
-  yield take(completeBonusVacanze);
+  yield take(completeBonusVacanzeActivation);
+
+  if (
+    progress.type === getType(bonusVacanzeActivation.success) &&
+    progress.payload.activation
+  ) {
+    yield put(
+      navigateToBonusActiveDetailScreen({ bonus: progress.payload.activation })
+    );
+  }
 }
 
 /**
  * Entry point; This saga orchestrate the activation phase.
  * There are two condition to exit from this saga:
  * - cancelBonusActivation
- * - ??? next screen event ???
+ * - completeBonusVacanze
  */
 export function* handleBonusActivationSaga(
   activationSaga: BonusActivationSagaType


### PR DESCRIPTION
**Short description:**
This pr allows to see the details of the bonus after the activation success.
<img src=https://user-images.githubusercontent.com/26501317/85116627-e8ef1600-b21d-11ea-823d-00e767db292c.gif width=300 />

**List of changes proposed in this pull request:**
- Dispatch the navigation event `navigateToBonusActiveDetailScreen` after the activation is completed

**How to test:**
- Complete the bonus activation flow
- Execute `handleBonusActivationTests`