### PR TITLE
[#173353035] UI corrections to wallet header screen

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1260,7 +1260,7 @@ bonus:
     amount: Max amount
     applicant: Applicant FC
     bonusClaim: Who can claim the bonus?
-    shareMessage: "This is the code of your bonus:"
+    shareMessage: "This is the code of your Bonus Vacanze:"
     checkBonusEligibility:
       loading: Checking bonus eligibility
     cta:
@@ -1329,7 +1329,7 @@ bonus:
     family:
       title: "Who can claim the bonus?"
   bonusList:
-    title: Add subsidy
+    title: Add bonus or discount
     contentTitle: Select one of the available bonus
   request: Request a new bonus
   requestLabel: Bonuses and discounts

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1292,7 +1292,7 @@ bonus:
     amount: Importo massimo
     applicant: CF richiedente
     bonusClaim: Chi può riscuotere il bonus?
-    shareMessage: "Questo è il codice del tuo bonus:"
+    shareMessage: "Questo è il codice del tuo Bonus Vacanze:"
     checkBonusEligibility:
       loading: Verifico l'idoneità per l'accesso al bonus
     cta:
@@ -1361,7 +1361,7 @@ bonus:
     family:
       title: "Chi può riscuotere il bonus?"
   bonusList:
-    title: Aggiungi sovvenzione
+    title: Aggiungi bonus o sconto
     contentTitle: Seleziona uno dei bonus disponibili
   request: Richiedi un nuovo bonus
   requestLabel: Bonus e sconti

--- a/ts/components/wallet/card/CardComponent.style.ts
+++ b/ts/components/wallet/card/CardComponent.style.ts
@@ -9,11 +9,10 @@ export default StyleSheet.create({
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.1,
     shadowRadius: 1.5,
-    elevation: 3,
-
+    elevation: -7,
+    zIndex: -7,
     backgroundColor: variables.brandGray,
     borderRadius: 8,
-    marginBottom: -1,
     marginLeft: 0,
     marginRight: 0
   },

--- a/ts/components/wallet/card/CardComponent.tsx
+++ b/ts/components/wallet/card/CardComponent.tsx
@@ -310,10 +310,9 @@ export default class CardComponent extends React.Component<Props> {
             </View>
             <View>{this.renderTopRightCorner()}</View>
           </View>
-
+          {hasFlatBottom && <View spacer={true} />}
           {this.renderBody(wallet.creditCard)}
         </View>
-
         {this.renderFooterRow()}
       </View>
     );

--- a/ts/components/wallet/card/RotatedCards.tsx
+++ b/ts/components/wallet/card/RotatedCards.tsx
@@ -11,32 +11,16 @@ import CardComponent from "./CardComponent";
 import Logo from './Logo';
 
 const styles = StyleSheet.create({
-  firstCard: {
+  rotadedCard: {
+    shadowColor: "#000",
+    marginBottom: -30,
     flex: 1,
     shadowRadius: 10,
     shadowOpacity: 0.15,
-    transform: [{ perspective: 700 }, { rotateX: "-20deg" }, { scaleX: 0.98 }],
-    zIndex: -10
+    transform: [{ perspective: 1200 }, { rotateX: "-20deg" }, { scaleX: 0.99 }],
   },
-  secondCard: {
-    flex: 1,
-    shadowRadius: 10,
-    shadowOpacity: 0.15,
-    transform: [
-      { perspective: 700 },
-      { rotateX: "-20deg" },
-      { translateY: -(58 / 2 + 20) * (1 - Math.cos(20)) }, // card preview height: 58
-      { scaleX: 0.98 }
-    ],
-    zIndex: -10
-  },
-  containerOneCard: {
-    marginBottom: -4,
-    marginTop: -(58 / 2) * (1 - Math.cos(20)) 
-  },
-  containerTwoCards: {
-    marginBottom: -(58 / 2 + 1),
-    marginTop: -(58 / 2) * (1 - Math.cos(20))
+  container: {
+    marginBottom: -4
   }
 });
 
@@ -54,7 +38,7 @@ export class RotatedCards extends React.PureComponent<Props, {}> {
     const FOUR_UNICODE_CIRCLES = "\u25cf".repeat(4);
     const HIDDEN_CREDITCARD_NUMBERS = `${FOUR_UNICODE_CIRCLES} `.repeat(4);
     return(
-      <View style={[styles.firstCard, styles.containerOneCard]}>
+      <View style={[styles.rotadedCard]}>
         <View style={[CreditCardStyles.card,CreditCardStyles.flatBottom]}>
           <View style={[CreditCardStyles.cardInner, CreditCardStyles.row]}>
             <View
@@ -86,27 +70,21 @@ export class RotatedCards extends React.PureComponent<Props, {}> {
           {this.emptyCardPreview()}
         </View> 
       ) : (
-        <View
-          style={
-            wallets.length === 2
-              ? styles.containerTwoCards
-              : styles.containerOneCard
-          }
-        >
-          <View spacer={true} />
+        <View style={styles.container}>
           <TouchableDefaultOpacity onPress={onClick}>
-            <View style={styles.firstCard}>
+            <View style={styles.rotadedCard}>
               <CardComponent type={cardType} wallet={wallets[0]} />
             </View>
             {typeof wallets[1] !== "undefined" && (
-              <React.Fragment>
-                <View spacer={true}/>
-                <View style={styles.secondCard}>
-                  <CardComponent type={cardType} wallet={wallets[1]} />
-                </View>
-              </React.Fragment>
+              <>
+              <View spacer={true} />
+              <View style={styles.rotadedCard}>
+                <CardComponent type={cardType} wallet={wallets[1]} />
+              </View>
+              </>
             )}
           </TouchableDefaultOpacity>
+          <View spacer={true}/>
         </View>
       )  
     );

--- a/ts/components/wallet/card/SectionCardComponent.tsx
+++ b/ts/components/wallet/card/SectionCardComponent.tsx
@@ -4,7 +4,6 @@ import { Platform, StyleSheet } from "react-native";
 import IconFont from "../../../components/ui/IconFont";
 import I18n from "../../../i18n";
 import customVariables from "../../../theme/variables";
-import { AddPaymentMethodButton } from "../AddPaymentMethodButton";
 import TouchableDefaultOpacity from "../../TouchableDefaultOpacity";
 
 type Props = {
@@ -12,6 +11,7 @@ type Props = {
   label: string;
   isError?: boolean;
   isNew?: boolean;
+  isBlue?: boolean;
 };
 
 const styles = StyleSheet.create({
@@ -57,10 +57,15 @@ const styles = StyleSheet.create({
     zIndex: -7,
     elevation: -7,
     height: 88,
-    backgroundColor: customVariables.brandDarkGray,
     borderRadius: 8,
     marginLeft: 0,
     marginRight: 0
+  },
+  cardGrey: {
+    backgroundColor: customVariables.brandDarkGray
+  },
+  cardBlue: {
+    backgroundColor: customVariables.brandPrimary
   },
   flatBottom: {
     borderBottomLeftRadius: 0,
@@ -89,11 +94,17 @@ const styles = StyleSheet.create({
 });
 
 const SectionCardComponent: React.FunctionComponent<Props> = (props: Props) => {
-  const { label, onPress, isNew, isError } = props;
+  const { label, onPress, isNew, isError, isBlue } = props;
   return (
     <View style={styles.rotateCard}>
       <TouchableDefaultOpacity onPress={onPress}>
-        <View style={[styles.card, styles.flatBottom]}>
+        <View
+          style={[
+            styles.card,
+            styles.flatBottom,
+            isBlue ? styles.cardBlue : styles.cardGrey
+          ]}
+        >
           <View style={[styles.cardInner]}>
             <View style={[styles.flexRow]}>
               <View style={styles.flexRow2}>

--- a/ts/components/wallet/card/SectionCardComponent.tsx
+++ b/ts/components/wallet/card/SectionCardComponent.tsx
@@ -1,6 +1,6 @@
 import { Badge, Text, View } from "native-base";
 import * as React from "react";
-import { Platform, StyleSheet } from "react-native";
+import { Platform, StyleSheet, ViewStyle } from "react-native";
 import IconFont from "../../../components/ui/IconFont";
 import I18n from "../../../i18n";
 import customVariables from "../../../theme/variables";
@@ -11,7 +11,7 @@ type Props = {
   label: string;
   isError?: boolean;
   isNew?: boolean;
-  isBlue?: boolean;
+  cardStyle?: ViewStyle;
 };
 
 const styles = StyleSheet.create({
@@ -64,9 +64,6 @@ const styles = StyleSheet.create({
   cardGrey: {
     backgroundColor: customVariables.brandDarkGray
   },
-  cardBlue: {
-    backgroundColor: customVariables.brandPrimary
-  },
   flatBottom: {
     borderBottomLeftRadius: 0,
     borderBottomRightRadius: 0
@@ -94,16 +91,12 @@ const styles = StyleSheet.create({
 });
 
 const SectionCardComponent: React.FunctionComponent<Props> = (props: Props) => {
-  const { label, onPress, isNew, isError, isBlue } = props;
+  const { label, onPress, isNew, isError, cardStyle } = props;
   return (
     <View style={styles.rotateCard}>
       <TouchableDefaultOpacity onPress={onPress}>
         <View
-          style={[
-            styles.card,
-            styles.flatBottom,
-            isBlue ? styles.cardBlue : styles.cardGrey
-          ]}
+          style={[styles.card, styles.flatBottom, cardStyle || styles.cardGrey]}
         >
           <View style={[styles.cardInner]}>
             <View style={[styles.flexRow]}>

--- a/ts/components/wallet/card/SectionCardComponent.tsx
+++ b/ts/components/wallet/card/SectionCardComponent.tsx
@@ -1,9 +1,11 @@
 import { Badge, Text, View } from "native-base";
 import * as React from "react";
 import { Platform, StyleSheet } from "react-native";
+import IconFont from "../../../components/ui/IconFont";
 import I18n from "../../../i18n";
 import customVariables from "../../../theme/variables";
 import { AddPaymentMethodButton } from "../AddPaymentMethodButton";
+import TouchableDefaultOpacity from "../../TouchableDefaultOpacity";
 
 type Props = {
   onPress: () => void;
@@ -46,41 +48,43 @@ const styles = StyleSheet.create({
     paddingTop: 13
   },
   card: {
-    // iOS and Andorid card shadow
-    shadowColor: "#000",
     shadowOffset: {
       width: 0,
       height: 3
     },
     shadowOpacity: 0.29,
     shadowRadius: 4.65,
-    zIndex: 7,
-    elevation: 7,
+    zIndex: -7,
+    elevation: -7,
+    height: 88,
     backgroundColor: customVariables.brandDarkGray,
     borderRadius: 8,
     marginLeft: 0,
-    marginRight: 0,
-    marginTop: 20
+    marginRight: 0
   },
   flatBottom: {
     borderBottomLeftRadius: 0,
     borderBottomRightRadius: 0
   },
   rotateCard: {
-    marginBottom: -(58 / 2 + 4),
+    shadowColor: "#000",
+    marginBottom: -35,
     flex: 1,
     shadowRadius: 10,
     shadowOpacity: 0.15,
-    transform: [
-      { perspective: 700 },
-      { rotateX: "-20deg" },
-      { scaleX: 0.98 },
-      { translateY: -(58 / 2 + 20) * (1 - Math.cos(20)) }
-    ]
+    transform: [{ perspective: 1200 }, { rotateX: "-20deg" }, { scaleX: 0.99 }]
   },
   rotateText: {
-    flex: 1,
-    transform: [{ perspective: 700 }, { rotateX: "20deg" }, { scaleX: 0.98 }]
+    flex: 1
+  },
+  button: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "flex-end"
+  },
+  labelButton: {
+    marginLeft: customVariables.fontSizeBase / 4,
+    color: customVariables.colorWhite
   }
 });
 
@@ -88,33 +92,44 @@ const SectionCardComponent: React.FunctionComponent<Props> = (props: Props) => {
   const { label, onPress, isNew, isError } = props;
   return (
     <View style={styles.rotateCard}>
-      <View style={[styles.card, styles.flatBottom]}>
-        <View style={[styles.cardInner]}>
-          <View style={[styles.flexRow, styles.rotateText]}>
-            <View style={styles.flexRow2}>
-              <Text style={[styles.brandLightGray, styles.headerText]}>
-                {label}
-              </Text>
-              {isNew && (
-                <Badge style={styles.badgeColor}>
-                  <Text semibold={true} style={styles.badgeText}>
-                    {I18n.t("wallet.methods.newCome")}
-                  </Text>
-                </Badge>
-              )}
-            </View>
-            <View>
+      <TouchableDefaultOpacity onPress={onPress}>
+        <View style={[styles.card, styles.flatBottom]}>
+          <View style={[styles.cardInner]}>
+            <View style={[styles.flexRow]}>
+              <View style={styles.flexRow2}>
+                <Text style={[styles.brandLightGray, styles.headerText]}>
+                  {label}
+                </Text>
+                {isNew && (
+                  <Badge style={styles.badgeColor}>
+                    <Text semibold={true} style={styles.badgeText}>
+                      {I18n.t("wallet.methods.newCome")}
+                    </Text>
+                  </Badge>
+                )}
+              </View>
               {!isError && (
-                <AddPaymentMethodButton
-                  onPress={onPress}
-                  iconSize={customVariables.fontSize2}
-                  labelSize={customVariables.fontSizeSmall}
-                />
+                <View style={[styles.labelButton, styles.flexRow2]}>
+                  <IconFont
+                    name="io-plus"
+                    color={customVariables.colorWhite}
+                    size={customVariables.fontSize2}
+                  />
+                  <Text
+                    bold={true}
+                    style={[
+                      styles.labelButton,
+                      { fontSize: customVariables.fontSizeSmall }
+                    ]}
+                  >
+                    {I18n.t("wallet.newPaymentMethod.add").toUpperCase()}
+                  </Text>
+                </View>
               )}
             </View>
           </View>
         </View>
-      </View>
+      </TouchableDefaultOpacity>
     </View>
   );
 };

--- a/ts/features/bonusVacanze/components/BonusCardComponent.tsx
+++ b/ts/features/bonusVacanze/components/BonusCardComponent.tsx
@@ -194,10 +194,7 @@ const BonusCardComponent: React.FunctionComponent<Props> = (props: Props) => {
             </Text>
             <Text style={[styles.colorWhite, { fontSize: 20 }]}>{"€"}</Text>
           </View>
-          <Image
-            source={require("../../../../img/bonus/bonusVacanze/logo_BonusVacanze_White.png")}
-            style={styles.previewLogo}
-          />
+          <Image source={bonusVacanzeWhiteLogo} style={styles.previewLogo} />
         </TouchableDefaultOpacity>
       </View>
     );

--- a/ts/features/bonusVacanze/components/BonusCardComponent.tsx
+++ b/ts/features/bonusVacanze/components/BonusCardComponent.tsx
@@ -43,6 +43,17 @@ const styles = StyleSheet.create({
     marginBottom: -20,
     height: 88
   },
+  previewContainer: {
+    shadowColor: "#000",
+    shadowOffset: {
+      width: 0,
+      height: 12
+    },
+    shadowOpacity: 0.58,
+    shadowRadius: 16.0,
+    zIndex: 0,
+    elevation: 0
+  },
   row: {
     flexDirection: "row",
     alignItems: "center",
@@ -168,22 +179,27 @@ const BonusCardComponent: React.FunctionComponent<Props> = (props: Props) => {
 
   const renderPreviewCard = () => {
     return (
-      <TouchableDefaultOpacity
-        style={[styles.row, styles.spaced]}
-        onPress={props.onPress}
-      >
-        <View style={[styles.row]}>
-          <Text bold={true} style={[styles.colorWhite, styles.previewName]}>
-            {I18n.t("bonus.bonusVacanza.name")}
-          </Text>
-          <View hspacer={true} large={true} />
-          <Text bold={true} style={[styles.colorWhite, styles.previewAmount]}>
-            {bonus.dsu_request.max_amount}
-          </Text>
-          <Text style={[styles.colorWhite, styles.fontLarge]}>{"€"}</Text>
-        </View>
-        <Image source={bonusVacanzeWhiteLogo} style={styles.previewLogo} />
-      </TouchableDefaultOpacity>
+      <View style={styles.preview}>
+        <TouchableDefaultOpacity
+          style={[styles.row, styles.spaced]}
+          onPress={props.onPress}
+        >
+          <View style={[styles.row]}>
+            <Text bold={true} style={[styles.colorWhite, styles.previewName]}>
+              {I18n.t("bonus.bonusVacanza.name")}
+            </Text>
+            <View hspacer={true} large={true} />
+            <Text bold={true} style={[styles.colorWhite, styles.previewAmount]}>
+              {bonus.dsu_request.max_amount}
+            </Text>
+            <Text style={[styles.colorWhite, { fontSize: 20 }]}>{"€"}</Text>
+          </View>
+          <Image
+            source={require("../../../../img/bonus/bonusVacanze/logo_BonusVacanze_White.png")}
+            style={styles.previewLogo}
+          />
+        </TouchableDefaultOpacity>
+      </View>
     );
   };
 

--- a/ts/features/bonusVacanze/components/RequestBonus.tsx
+++ b/ts/features/bonusVacanze/components/RequestBonus.tsx
@@ -63,18 +63,17 @@ const RequestBonus: React.FunctionComponent<OwnProps> = (props: OwnProps) => {
         onPress={onButtonPress}
         isNew={true}
       />
-      {!pot.isLoading(activeBonus) &&
-        pot.isSome(activeBonus) && (
-          <View style={styles.preview}>
-            <BonusCardComponent
-              bonus={activeBonus.value}
-              preview={true}
-              onPress={() =>
-                onBonusPress(activeBonus.value, validFrom, validTo)
-              }
-            />
-          </View>
-        )}
+      {!pot.isLoading(activeBonus) && pot.isSome(activeBonus) ? (
+        <View style={styles.preview}>
+          <BonusCardComponent
+            bonus={activeBonus.value}
+            preview={true}
+            onPress={() => onBonusPress(activeBonus.value, validFrom, validTo)}
+          />
+        </View>
+      ) : (
+        <View spacer={true} xsmall={true} />
+      )}
     </React.Fragment>
   );
 };

--- a/ts/features/bonusVacanze/components/RequestBonus.tsx
+++ b/ts/features/bonusVacanze/components/RequestBonus.tsx
@@ -7,9 +7,9 @@ import { BonusActivationWithQrCode } from "../../../../definitions/bonus_vacanze
 import { BonusesAvailable } from "../../../../definitions/content/BonusesAvailable";
 import SectionCardComponent from "../../../components/wallet/card/SectionCardComponent";
 import I18n from "../../../i18n";
+import customVariables from "../../../theme/variables";
 import { ID_BONUS_VACANZE_TYPE } from "../utils/bonus";
 import BonusCardComponent from "./BonusCardComponent";
-import customVariables from "../../../theme/variables";
 
 type OwnProps = {
   onButtonPress: () => void;

--- a/ts/features/bonusVacanze/components/RequestBonus.tsx
+++ b/ts/features/bonusVacanze/components/RequestBonus.tsx
@@ -19,6 +19,7 @@ type OwnProps = {
   ) => void;
   activeBonus: pot.Pot<BonusActivationWithQrCode, Error>;
   availableBonusesList: BonusesAvailable;
+  noMethod: boolean;
 };
 
 const styles = StyleSheet.create({
@@ -46,7 +47,8 @@ const RequestBonus: React.FunctionComponent<OwnProps> = (props: OwnProps) => {
     onButtonPress,
     activeBonus,
     onBonusPress,
-    availableBonusesList
+    availableBonusesList,
+    noMethod
   } = props;
   const maybeBonusVacanzeCategory = fromNullable(
     availableBonusesList.find(bi => bi.id_type === ID_BONUS_VACANZE_TYPE)
@@ -62,6 +64,7 @@ const RequestBonus: React.FunctionComponent<OwnProps> = (props: OwnProps) => {
         label={I18n.t("bonus.requestLabel")}
         onPress={onButtonPress}
         isNew={true}
+        isBlue={noMethod}
       />
       {!pot.isLoading(activeBonus) && pot.isSome(activeBonus) ? (
         <View style={styles.preview}>

--- a/ts/features/bonusVacanze/components/RequestBonus.tsx
+++ b/ts/features/bonusVacanze/components/RequestBonus.tsx
@@ -9,6 +9,7 @@ import SectionCardComponent from "../../../components/wallet/card/SectionCardCom
 import I18n from "../../../i18n";
 import { ID_BONUS_VACANZE_TYPE } from "../utils/bonus";
 import BonusCardComponent from "./BonusCardComponent";
+import customVariables from "../../../theme/variables";
 
 type OwnProps = {
   onButtonPress: () => void;
@@ -64,9 +65,13 @@ const RequestBonus: React.FunctionComponent<OwnProps> = (props: OwnProps) => {
         label={I18n.t("bonus.requestLabel")}
         onPress={onButtonPress}
         isNew={true}
-        isBlue={noMethod}
+        cardStyle={
+          noMethod
+            ? { backgroundColor: customVariables.brandPrimary }
+            : undefined
+        }
       />
-      {!pot.isLoading(activeBonus) && pot.isSome(activeBonus) ? (
+      {pot.isSome(activeBonus) ? (
         <View style={styles.preview}>
           <BonusCardComponent
             bonus={activeBonus.value}

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -215,7 +215,7 @@ class WalletHomeScreen extends React.PureComponent<Props> {
     BackHandler.removeEventListener("hardwareBackPress", this.handleBackPress);
   }
 
-  private cardHeader(isError: boolean = false) {
+  private cardHeader(isError: boolean = false, isBlue: boolean = false) {
     return (
       <SectionCardComponent
         label={I18n.t("wallet.paymentMethods")}
@@ -225,6 +225,7 @@ class WalletHomeScreen extends React.PureComponent<Props> {
           )
         }
         isError={isError}
+        isBlue={isBlue}
       />
     );
   }
@@ -232,10 +233,12 @@ class WalletHomeScreen extends React.PureComponent<Props> {
   private cardPreview(wallets: ReadonlyArray<Wallet>) {
     // we have to render only wallets of credit card type
     const validWallets = wallets.filter(w => w.type === TypeEnum.CREDIT_CARD);
+    const noMethod =
+      validWallets.length === 0 && this.props.allActiveBonus.length === 0;
     return (
       <View>
         <View spacer={true} />
-        {validWallets.length === 0 && (
+        {noMethod && (
           <React.Fragment>
             <Text white={true} style={styles.addDescription}>
               {I18n.t("wallet.newPaymentMethod.addDescription")}
@@ -244,7 +247,7 @@ class WalletHomeScreen extends React.PureComponent<Props> {
             <View spacer={true} small={true} />
           </React.Fragment>
         )}
-        {this.cardHeader()}
+        {this.cardHeader(false, noMethod)}
         {validWallets.length > 0 ? (
           <RotatedCards
             cardType="Preview"
@@ -265,6 +268,7 @@ class WalletHomeScreen extends React.PureComponent<Props> {
                 ? this.props.allActiveBonus[0]
                 : pot.none
             }
+            noMethod={noMethod}
             availableBonusesList={this.props.availableBonusesList}
             onBonusPress={this.props.navigateToBonusDetail}
           />

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -246,20 +246,16 @@ class WalletHomeScreen extends React.PureComponent<Props> {
         )}
         {this.cardHeader()}
         {validWallets.length > 0 ? (
-          <View>
-            <RotatedCards
-              cardType="Preview"
-              wallets={
-                validWallets.length === 1
-                  ? [validWallets[0]]
-                  : [validWallets[0], validWallets[1]]
-              }
-              onClick={this.props.navigateToWalletList}
-            />
-          </View>
-        ) : (
-          <View spacer={true} small={true} />
-        )}
+          <RotatedCards
+            cardType="Preview"
+            wallets={
+              validWallets.length === 1
+                ? [validWallets[0]]
+                : [validWallets[0], validWallets[1]]
+            }
+            onClick={this.props.navigateToWalletList}
+          />
+        ) : null}
         {/* Display this item only if the flag is enabled */}
         {bonusVacanzeEnabled && (
           <RequestBonus

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -225,7 +225,9 @@ class WalletHomeScreen extends React.PureComponent<Props> {
           )
         }
         isError={isError}
-        isBlue={isBlue}
+        cardStyle={
+          isBlue ? { backgroundColor: customVariables.brandPrimary } : undefined
+        }
       />
     );
   }

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -292,6 +292,7 @@ class WalletHomeScreen extends React.PureComponent<Props> {
   }
 
   private errorWalletsHeader() {
+    const noMethod = this.props.allActiveBonus.length === 0;
     return (
       <View>
         <Text style={[styles.white, styles.inLineSpace]}>
@@ -315,6 +316,7 @@ class WalletHomeScreen extends React.PureComponent<Props> {
             activeBonus={pot.none}
             availableBonusesList={this.props.availableBonusesList}
             onBonusPress={this.props.navigateToBonusDetail}
+            noMethod={noMethod}
           />
         )}
       </View>


### PR DESCRIPTION
**Short description:**
This PR adds some UI Fixes on wallet home header

**List of changes proposed in this pull request:**
- Card dimensions updated to mockups
- if no payment method or bonus is available the section cards are blue
- corrects some typos and labels

<img height="550" alt="Schermata 2020-06-19 alle 13 02 09" src="https://user-images.githubusercontent.com/3959405/85126718-530fb700-b22e-11ea-9537-521d4ba8dece.png">

<img height="550" alt="Schermata 2020-06-19 alle 13 01 27" src="https://user-images.githubusercontent.com/3959405/85126722-56a33e00-b22e-11ea-8a9a-1faba40b310d.png">

<img height="550" alt="Schermata 2020-06-19 alle 13 01 03" src="https://user-images.githubusercontent.com/3959405/85126725-573bd480-b22e-11ea-8d7f-40707396ce71.png">
