### PR TITLE
[#173417354] Show all the active bonuses for the user

### DIFF
--- a/ts/components/wallet/WalletLayout.tsx
+++ b/ts/components/wallet/WalletLayout.tsx
@@ -82,7 +82,7 @@ const styles = StyleSheet.create({
     backgroundColor: customVariables.colorWhite
   }
 });
-const HEADER_HEIGHT = 250;
+
 export default class WalletLayout extends React.Component<Props> {
   private dynamicSubHeader() {
     return (

--- a/ts/components/wallet/WalletLayout.tsx
+++ b/ts/components/wallet/WalletLayout.tsx
@@ -29,7 +29,7 @@ import H5 from "../ui/H5";
 type Props = Readonly<{
   title: string;
   allowGoBack: boolean;
-  topContentHeight: number;
+  topContentHeight?: number;
   hasDynamicSubHeader: boolean;
   topContent?: React.ReactNode;
   hideHeader?: boolean;
@@ -82,7 +82,7 @@ const styles = StyleSheet.create({
     backgroundColor: customVariables.colorWhite
   }
 });
-
+const HEADER_HEIGHT = 250;
 export default class WalletLayout extends React.Component<Props> {
   private dynamicSubHeader() {
     return (

--- a/ts/components/wallet/WalletLayout.tsx
+++ b/ts/components/wallet/WalletLayout.tsx
@@ -29,6 +29,7 @@ import H5 from "../ui/H5";
 type Props = Readonly<{
   title: string;
   allowGoBack: boolean;
+  topContentHeight: number;
   hasDynamicSubHeader: boolean;
   topContent?: React.ReactNode;
   hideHeader?: boolean;
@@ -118,7 +119,7 @@ export default class WalletLayout extends React.Component<Props> {
         contentStyle={contentStyle}
         hasDynamicSubHeader={this.props.hasDynamicSubHeader}
         dynamicSubHeader={this.dynamicSubHeader()}
-        topContentHeight={250}
+        topContentHeight={this.props.topContentHeight}
         topContent={this.props.topContent}
         hideHeader={hideHeader}
         footerContent={footerContent}

--- a/ts/features/bonusVacanze/components/RequestBonus.tsx
+++ b/ts/features/bonusVacanze/components/RequestBonus.tsx
@@ -17,7 +17,7 @@ type OwnProps = {
     validFrom?: Date,
     validTo?: Date
   ) => void;
-  activeBonus: pot.Pot<BonusActivationWithQrCode, Error>;
+  activeBonuses: ReadonlyArray<pot.Pot<BonusActivationWithQrCode, Error>>;
   availableBonusesList: BonusesAvailable;
 };
 
@@ -44,7 +44,7 @@ const styles = StyleSheet.create({
 const RequestBonus: React.FunctionComponent<OwnProps> = (props: OwnProps) => {
   const {
     onButtonPress,
-    activeBonus,
+    activeBonuses,
     onBonusPress,
     availableBonusesList
   } = props;
@@ -56,6 +56,7 @@ const RequestBonus: React.FunctionComponent<OwnProps> = (props: OwnProps) => {
     .map(b => b.valid_from)
     .toUndefined();
   const validTo = maybeBonusVacanzeCategory.map(b => b.valid_to).toUndefined();
+
   return (
     <React.Fragment>
       <SectionCardComponent
@@ -63,18 +64,19 @@ const RequestBonus: React.FunctionComponent<OwnProps> = (props: OwnProps) => {
         onPress={onButtonPress}
         isNew={true}
       />
-      {!pot.isLoading(activeBonus) &&
-        pot.isSome(activeBonus) && (
-          <View style={styles.preview}>
-            <BonusCardComponent
-              bonus={activeBonus.value}
-              preview={true}
-              onPress={() =>
-                onBonusPress(activeBonus.value, validFrom, validTo)
-              }
-            />
-          </View>
-        )}
+      {activeBonuses.map(
+        bonus =>
+          !pot.isLoading(bonus) &&
+          pot.isSome(bonus) && (
+            <View key={bonus.value.id} style={styles.preview}>
+              <BonusCardComponent
+                bonus={bonus.value}
+                preview={true}
+                onPress={() => onBonusPress(bonus.value, validFrom, validTo)}
+              />
+            </View>
+          )
+      )}
     </React.Fragment>
   );
 };

--- a/ts/features/bonusVacanze/screens/ActiveBonusScreen.tsx
+++ b/ts/features/bonusVacanze/screens/ActiveBonusScreen.tsx
@@ -11,6 +11,7 @@ import { withLightModalContext } from "../../../components/helpers/withLightModa
 import ItemSeparatorComponent from "../../../components/ItemSeparatorComponent";
 import { ContextualHelpPropsMarkdown } from "../../../components/screens/BaseScreenComponent";
 import DarkLayout from "../../../components/screens/DarkLayout";
+import { EdgeBorderComponent } from "../../../components/screens/EdgeBorderComponent";
 import GenericErrorComponent from "../../../components/screens/GenericErrorComponent";
 import TouchableDefaultOpacity from "../../../components/TouchableDefaultOpacity";
 import BlockButtons from "../../../components/ui/BlockButtons";
@@ -42,7 +43,6 @@ import {
   isBonusActive,
   validityInterval
 } from "../utils/bonus";
-import { EdgeBorderComponent } from "../../../components/screens/EdgeBorderComponent";
 
 type QRCodeContents = {
   [key: string]: string;

--- a/ts/features/bonusVacanze/screens/ActiveBonusScreen.tsx
+++ b/ts/features/bonusVacanze/screens/ActiveBonusScreen.tsx
@@ -42,6 +42,7 @@ import {
   isBonusActive,
   validityInterval
 } from "../utils/bonus";
+import { EdgeBorderComponent } from "../../../components/screens/EdgeBorderComponent";
 
 type QRCodeContents = {
   [key: string]: string;
@@ -422,6 +423,7 @@ const ActiveBonusScreen: React.FunctionComponent<Props> = (props: Props) => {
                   )}
             </Text>
           </View>
+          <EdgeBorderComponent />
         </View>
       </View>
     </DarkLayout>

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -490,6 +490,7 @@ class WalletHomeScreen extends React.PureComponent<Props> {
         title={I18n.t("wallet.wallet")}
         allowGoBack={false}
         appLogo={true}
+        topContentHeight={this.getHeaderHeight()}
         hasDynamicSubHeader={true}
         topContent={headerContent}
         footerContent={footerContent}
@@ -501,6 +502,12 @@ class WalletHomeScreen extends React.PureComponent<Props> {
       >
         {this.newMethodAdded ? this.newMethodAddedContent : transactionContent}
       </WalletLayout>
+    );
+  }
+
+  private getHeaderHeight() {
+    return (
+      250 + (bonusVacanzeEnabled ? this.props.allActiveBonus.length * 65 : 0)
     );
   }
 }

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -264,11 +264,7 @@ class WalletHomeScreen extends React.PureComponent<Props> {
         {bonusVacanzeEnabled && (
           <RequestBonus
             onButtonPress={this.props.navigateToBonusList}
-            activeBonus={
-              this.props.allActiveBonus.length > 0
-                ? this.props.allActiveBonus[0]
-                : pot.none
-            }
+            activeBonuses={this.props.allActiveBonus}
             availableBonusesList={this.props.availableBonusesList}
             onBonusPress={this.props.navigateToBonusDetail}
           />
@@ -312,7 +308,7 @@ class WalletHomeScreen extends React.PureComponent<Props> {
         {bonusVacanzeEnabled && (
           <RequestBonus
             onButtonPress={this.props.navigateToBonusList}
-            activeBonus={pot.none}
+            activeBonuses={this.props.allActiveBonus}
             availableBonusesList={this.props.availableBonusesList}
             onBonusPress={this.props.navigateToBonusDetail}
           />


### PR DESCRIPTION
**Short description:**
This PR adds the handling on wallet home for multiple active bonuses

**List of changes proposed in this pull request:**
- ts/features/bonusVacanze/components/RequestBonus.tsx
- ts/features/bonusVacanze/screens/ActiveBonusScreen.tsx
- ts/screens/wallet/WalletHomeScreen.tsx

<img src="https://user-images.githubusercontent.com/3959405/85138814-be17b880-b243-11ea-97fa-603195d70e8e.gif" height="550" />
