### PR TITLE
[#172075979] Fix services loading

### DIFF
--- a/ts/store/reducers/entities/services/__tests__/index.test.ts
+++ b/ts/store/reducers/entities/services/__tests__/index.test.ts
@@ -25,6 +25,8 @@ import { ServiceTuple } from "../../../../../../definitions/backend/ServiceTuple
 import { ServicesByScope } from "../../../../../../definitions/content/ServicesByScope";
 import { UserMetadataState } from "../../../userMetadata";
 import { OrganizationsState } from "../../organizations";
+import { ServicesByIdState } from "../servicesById";
+import { VisibleServicesState } from "../visibleServices";
 
 const customPotUserMetadata: UserMetadataState = pot.some({
   version: 1,
@@ -260,6 +262,44 @@ describe("visibleServicesDetailLoadStateSelector", () => {
         customServices.visible
       )
     ).toBe(pot.noneLoading);
+  });
+
+  it("should do be pot.some when a service is loading but it is some", () => {
+    const data = {
+      byId: {
+        "azure-deployc49a": {
+          kind: "PotSomeLoading",
+          value: {
+            available_notification_channels: ["EMAIL", "WEBHOOK"],
+            department_name: "Progetto IO",
+            organization_fiscal_code: "15376371009",
+            organization_name: "IO - L'app dei servizi pubblici",
+            service_id: "azure-deployc49a",
+            service_name: "Novità e aggiornamenti",
+            version: 2
+          }
+        }
+      },
+      byOrgFiscalCode: {
+        "15376371009": ["azure-deployc49a"]
+      },
+      visible: {
+        kind: "PotSome",
+        value: [
+          {
+            scope: "NATIONAL",
+            service_id: "azure-deployc49a",
+            version: 1
+          }
+        ]
+      }
+    };
+    expect(
+      visibleServicesDetailLoadStateSelector.resultFunc(
+        data.byId as ServicesByIdState,
+        data.visible as VisibleServicesState
+      )
+    ).toEqual(pot.some(undefined));
   });
 });
 

--- a/ts/store/reducers/entities/services/index.ts
+++ b/ts/store/reducers/entities/services/index.ts
@@ -93,7 +93,9 @@ function getServicesLoadState<T>(
     // check if there is at least one service in loading state
     const areServicesLoading =
       pot.isLoading(visibleServices) ||
-      visibleServicesById.some(vs => vs === undefined || pot.isLoading(vs));
+      visibleServicesById.some(
+        vs => vs === undefined || (pot.isNone(vs) && pot.isLoading(vs))
+      );
 
     // check if there is at least one service in error state
     const isServicesLoadFailed =


### PR DESCRIPTION
**Short description:**
This PR fixes a bug on services selector  **[visibleServicesDetailLoadStateSelector](https://github.com/pagopa/io-app/blob/f670e37c303101e280cff965f32373723015efea/ts/store/reducers/entities/services/index.ts#L94)**
The bug is on evaluating if there are some services still in loading:

```typescript
const areServicesLoading =
      pot.isLoading(visibleServices) ||
      visibleServicesById.some(
        vs => vs === undefined || pot.isLoading(vs)
      );
```
bug: if at least one service is in state **_someLoading_**, **_areServicesLoading_** -> true

Another issue is about: Why does service hold the state _**someLoading**_?
This will be investigated in another PR btw the data returned by the API, for this specific service (azure-deployc49a), could be not synced: **_version_** mismatches

#### services list https://app-backend.io.italia.it/api/v1/services
```json
...
{
"scope": "NATIONAL",
"service_id": "https://app-backend.io.italia.it/api/v1/services/azure-deployc49a",
"version": 1
}
```
#### service detail https://app-backend.io.italia.it/api/v1/services/azure-deployc49a
```json
{
"available_notification_channels":[
"EMAIL",
"WEBHOOK"
],
"department_name": "Progetto IO",
"organization_fiscal_code": "15376371009",
"organization_name": "IO - L'app dei servizi pubblici",
"service_id": "azure-deployc49a",
"service_name": "Novità e aggiornamenti",
"version": 2
}
```