### PR TITLE
[#173443457] Clean the store on loadAllBonusActivation

### DIFF
--- a/ts/features/bonusVacanze/store/reducers/allActive.ts
+++ b/ts/features/bonusVacanze/store/reducers/allActive.ts
@@ -7,6 +7,7 @@ import { Action } from "../../../../store/actions/types";
 import { GlobalState } from "../../../../store/reducers/types";
 import {
   bonusVacanzeActivation,
+  loadAllBonusActivations,
   loadBonusVacanzeFromId
 } from "../actions/bonusVacanze";
 
@@ -19,6 +20,10 @@ const reducer = (
   action: Action
 ): AllActiveState => {
   switch (action.type) {
+    // loading all active bonuses
+    case getType(loadAllBonusActivations.request):
+      // When we call `/activations` API the state needs to be cleaned up or the bonus will append when the payload changes
+      return INITIAL_STATE;
     // bonus from id
     case getType(loadBonusVacanzeFromId.request):
       const cachedValue = state[action.payload];

--- a/ts/store/reducers/persistedPreferences.ts
+++ b/ts/store/reducers/persistedPreferences.ts
@@ -4,6 +4,7 @@
 import { fromNullable, Option } from "fp-ts/lib/Option";
 import * as pot from "italia-ts-commons/lib/pot";
 import { Calendar } from "react-native-calendar-events";
+import { createSelector } from "reselect";
 import { isActionOf } from "typesafe-actions";
 import { Locales } from "../../../locales/locales";
 import {
@@ -17,7 +18,6 @@ import {
 } from "../actions/persistedPreferences";
 import { Action } from "../actions/types";
 import { GlobalState } from "./types";
-import { createSelector } from "reselect";
 
 export type PersistedPreferencesState = Readonly<{
   isFingerprintEnabled?: boolean;

--- a/ts/store/reducers/persistedPreferences.ts
+++ b/ts/store/reducers/persistedPreferences.ts
@@ -1,7 +1,7 @@
 /**
  * A reducer for persisted preferences.
  */
-import { fromNullable } from "fp-ts/lib/Option";
+import { fromNullable, Option } from "fp-ts/lib/Option";
 import * as pot from "italia-ts-commons/lib/pot";
 import { Calendar } from "react-native-calendar-events";
 import { isActionOf } from "typesafe-actions";
@@ -17,6 +17,7 @@ import {
 } from "../actions/persistedPreferences";
 import { Action } from "../actions/types";
 import { GlobalState } from "./types";
+import { createSelector } from "reselect";
 
 export type PersistedPreferencesState = Readonly<{
   isFingerprintEnabled?: boolean;
@@ -108,6 +109,12 @@ export const preferredCalendarSelector = (state: GlobalState) =>
 export const isFingerprintEnabledSelector = (state: GlobalState) =>
   state.persistedPreferences.isFingerprintEnabled;
 
+export const persistedPreferencesSelector = (state: GlobalState) =>
+  state.persistedPreferences;
+
 // returns the preferred language as an Option from the persisted store
-export const preferredLanguageSelector = (state: GlobalState) =>
-  fromNullable(state.persistedPreferences.preferredLanguage);
+export const preferredLanguageSelector = createSelector<
+  GlobalState,
+  PersistedPreferencesState,
+  Option<Locales>
+>(persistedPreferencesSelector, pps => fromNullable(pps.preferredLanguage));


### PR DESCRIPTION
**Short description:**
This PR adds the store cleaning when requesting all bonus ids.

**List of changes proposed in this pull request:**
- ts/features/bonusVacanze/store/reducers/allActive.ts


**How to test:**
Load all active bonus from dev-server, change it's payload and reload data from App.