### PR TITLE
[#173430903] Center the content of the InfoScreenComponent

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1274,7 +1274,7 @@ bonus:
       loading: "We are verifying your family's ISEE with INPS\nPlease wait."
       iseeNotAvailable:
         title: "We're sorry.\n ISEE not found."
-        text: "You should submit a DSU for the calculation of the ISEE to obtain the Holiday Bonus.\n\nIf you want, you can immediately make a simulation or request online on the INPS website."
+        text: "You should submit a DSU for the calculation of the ISEE to obtain the \"Bonus Vacanza\".\n\nIf you want, you can immediately make a simulation or request online on the INPS website."
       iseeNotEligible:
         title: We're sorry. Your ISEE exceeds the required threshold.
         text: If it is not correct, or if your family income has changed since the last ISEE created, you can update it by making a new declaration (DSU) on the INPS website.

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1274,7 +1274,7 @@ bonus:
       loading: "We are verifying your family's ISEE with INPS\nPlease wait."
       iseeNotAvailable:
         title: "We're sorry.\n ISEE not found."
-        text: "You should submit a DSU for the calculation of the ISEE to obtain the \"Bonus Vacanza\".\n\nIf you want, you can immediately make a simulation or request online on the INPS website."
+        text: "You should submit a DSU for the calculation of the ISEE to obtain the \"Bonus Vacanze\".\n\nIf you want, you can immediately make a simulation or request online on the INPS website."
       iseeNotEligible:
         title: We're sorry. Your ISEE exceeds the required threshold.
         text: If it is not correct, or if your family income has changed since the last ISEE created, you can update it by making a new declaration (DSU) on the INPS website.
@@ -1319,7 +1319,7 @@ bonus:
           confirm: Continue
     abort:
       title: Cancel
-      body: Do you really want to quit? To request the "Bonus Vacanza" you will have to repeat the process from the beginning.
+      body: Do you really want to quit? To request the "Bonus Vacanze" you will have to repeat the process from the beginning.
       cancel: Back to the request
       confirm: Abort request
       completed: Request aborted

--- a/ts/features/bonusVacanze/components/infoScreen/InfoScreenComponent.tsx
+++ b/ts/features/bonusVacanze/components/infoScreen/InfoScreenComponent.tsx
@@ -6,6 +6,7 @@ import themeVariables from "../../../../theme/variables";
 type Props = {
   image: React.ReactNode;
   title?: string;
+  // this is necessary in order to render text with different formatting
   body?: string | React.ReactNode;
 };
 
@@ -13,7 +14,8 @@ const styles = StyleSheet.create({
   main: {
     padding: themeVariables.contentPadding,
     flex: 1,
-    alignItems: "center"
+    alignItems: "center",
+    justifyContent: "center"
   },
   title: {
     textAlign: "center",
@@ -45,11 +47,8 @@ const renderNode = (body: string | React.ReactNode) => {
 export const InfoScreenComponent: React.FunctionComponent<Props> = props => {
   return (
     <View style={styles.main}>
-      <View spacer={true} extralarge={true} />
-      <View spacer={true} extralarge={true} />
-      <View spacer={true} extralarge={true} />
       {props.image}
-      <View spacer={true} extralarge={true} />
+      <View spacer={true} large={true} />
       {props.title && (
         <>
           <Text style={styles.title} bold={true}>

--- a/ts/features/bonusVacanze/components/infoScreen/imageRendering.tsx
+++ b/ts/features/bonusVacanze/components/infoScreen/imageRendering.tsx
@@ -1,15 +1,25 @@
 import * as React from "react";
-import { Image, ImageSourcePropType } from "react-native";
+import { Dimensions, Image, ImageSourcePropType } from "react-native";
+import { heightPercentageToDP } from "react-native-responsive-screen";
 import IconFont from "../../../../components/ui/IconFont";
 import customVariables from "../../../../theme/variables";
 
 import { StyleSheet } from "react-native";
 
-const infoImageSize = 128;
+const infoImageSize = 102;
+const screenHeight = Dimensions.get("screen").height;
+const maxHeightFullSize = 650;
+
 const styles = StyleSheet.create({
   raster: {
-    width: infoImageSize,
-    height: infoImageSize
+    width:
+      screenHeight >= maxHeightFullSize
+        ? infoImageSize
+        : heightPercentageToDP("11%"),
+    height:
+      screenHeight >= maxHeightFullSize
+        ? infoImageSize
+        : heightPercentageToDP("11%")
   }
 });
 

--- a/ts/features/bonusVacanze/components/infoScreen/imageRendering.tsx
+++ b/ts/features/bonusVacanze/components/infoScreen/imageRendering.tsx
@@ -10,6 +10,9 @@ const infoImageSize = 102;
 const screenHeight = Dimensions.get("screen").height;
 const maxHeightFullSize = 650;
 
+/**
+ * On device with screen size < 650, the image size is reduced
+ */
 const styles = StyleSheet.create({
   raster: {
     width:
@@ -22,7 +25,10 @@ const styles = StyleSheet.create({
         : heightPercentageToDP("11%")
   }
 });
-
+/**
+ * A generic component to render an image with all the settings for a {@link InfoScreenComponent}
+ * @param image
+ */
 export const renderInfoRasterImage = (image: ImageSourcePropType) => (
   <Image source={image} resizeMode={"contain"} style={styles.raster} />
 );


### PR DESCRIPTION
**Short description:**
This pr changes the aspect of the InfoScreenComponent, aligning the vertical content to middle.

iPhone 11            |  iPhone 8
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/26501317/85302197-1ef3fa80-b4a9-11ea-9142-628baf08402d.png" width="300">|  <img src="https://user-images.githubusercontent.com/26501317/85302292-41861380-b4a9-11ea-8559-1a40ec93e2b0.png" width="300">

Android Nexus 5 (1080x1920)    480 xxhdpi         |  
:-------------------------:|
<img src="https://user-images.githubusercontent.com/26501317/85302715-d12bc200-b4a9-11ea-8bdb-957a6c4eebe2.png" width="300">|


**List of changes proposed in this pull request:**
- Modified the layout of `InfoScreenComponent.tsx`
- Changed `imageRendering.tsx` in order to scale the image size when the screen height is too short.
