### PR TITLE
[#173400880] Reset navigation history when navigating through bonus list and information

### DIFF
--- a/ts/features/bonusVacanze/screens/AvailableBonusScreen.tsx
+++ b/ts/features/bonusVacanze/screens/AvailableBonusScreen.tsx
@@ -11,6 +11,7 @@ import GenericErrorComponent from "../../../components/screens/GenericErrorCompo
 import FooterWithButtons from "../../../components/ui/FooterWithButtons";
 import I18n from "../../../i18n";
 import { navigateBack } from "../../../store/actions/navigation";
+import { navigationHistoryPop } from "../../../store/actions/navigationHistory";
 import { Dispatch } from "../../../store/actions/types";
 import { GlobalState } from "../../../store/reducers/types";
 import variables from "../../../theme/variables";
@@ -113,8 +114,10 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   navigateBack: () => dispatch(navigateBack()),
   loadAvailableBonuses: () => dispatch(availableBonusesLoad.request()),
   // TODO Add the param to navigate to proper bonus by name (?)
-  navigateToBonusRequest: (bonusItem: BonusAvailable) =>
-    dispatch(navigateToBonusRequestInformation({ bonusItem }))
+  navigateToBonusRequest: (bonusItem: BonusAvailable) => {
+    dispatch(navigateToBonusRequestInformation({ bonusItem }));
+    dispatch(navigationHistoryPop(1));
+  }
 });
 
 export default connect(

--- a/ts/features/bonusVacanze/screens/BonusInformationScreen.tsx
+++ b/ts/features/bonusVacanze/screens/BonusInformationScreen.tsx
@@ -17,6 +17,7 @@ import { LightModalContextInterface } from "../../../components/ui/LightModal";
 import Markdown from "../../../components/ui/Markdown";
 import I18n from "../../../i18n";
 import { navigateBack } from "../../../store/actions/navigation";
+import { navigationHistoryPop } from "../../../store/actions/navigationHistory";
 import customVariables from "../../../theme/variables";
 import { maybeNotNullyString } from "../../../utils/strings";
 import TosBonusComponent from "../components/TosBonusComponent";
@@ -192,8 +193,10 @@ const BonusInformationScreen: React.FunctionComponent<Props> = props => {
 };
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  // TODO add bonus request action or just navigate to TOS screen (?)
-  requestBonusActivation: () => dispatch(checkBonusEligibility.request()),
+  requestBonusActivation: () => {
+    dispatch(checkBonusEligibility.request());
+    dispatch(navigationHistoryPop(1));
+  },
   navigateBack: () => dispatch(navigateBack())
 });
 


### PR DESCRIPTION
**Short description:**
This PR cleans the history stack when navigating from wallet home to the request of bonus activation

**List of changes proposed in this pull request:**
- ts/features/bonusVacanze/screens/AvailableBonusScreen.tsx
- ts/features/bonusVacanze/screens/BonusInformationScreen.tsx

<img height="550" src="https://user-images.githubusercontent.com/3959405/85310580-7350a780-b4b4-11ea-83d6-9c84b7d6c42d.gif"/>