### PR TITLE
[#173469785] Fix display Bonus Vacanze Detail content

### DIFF
--- a/ts/components/ui/Markdown/index.tsx
+++ b/ts/components/ui/Markdown/index.tsx
@@ -191,6 +191,7 @@ const convertOldDemoMarkdownTag = (markdown: string) =>
 type OwnProps = {
   children: string;
   animated?: boolean;
+  extraBodyHeight?: number;
   useCustomSortedList?: boolean;
   onLoadEnd?: () => void;
   onLinkClicked?: (url: string) => void;
@@ -293,10 +294,10 @@ class Markdown extends React.PureComponent<Props, State> {
   }
 
   public render() {
-    const { webViewStyle } = this.props;
+    const { extraBodyHeight, webViewStyle } = this.props;
     const { html, htmlBodyHeight } = this.state;
     const containerStyle: ViewStyle = {
-      height: htmlBodyHeight
+      height: htmlBodyHeight + (extraBodyHeight || 0)
     };
 
     const isLoading =

--- a/ts/features/bonusVacanze/data/availableBonuses.ts
+++ b/ts/features/bonusVacanze/data/availableBonuses.ts
@@ -14,7 +14,11 @@ Il valore del bonus cambia in base al numero di componenti del nucleo familiare:
 L’incentivo può essere paragonato a uno sconto pari all’80% del valore del bonus, che viene applicato dalla struttura turistica al momento del pagamento della vacanza. Il restante 20% sarà fruito in forma di detrazione fiscale in fase di dichiarazione dei redditi.
 
 #### Chi, dove e quando può spenderlo?
-Ciascun membro del nucleo famigliare può usufruire del bonus. Il bonus vacanze è spendibile in un’unica soluzione per acquistare soggiorni di almeno tre notti nelle strutture ricettive italiane, dal 1 luglio al 31 dicembre 2020. Il pagamento deve essere eseguito direttamente alla struttura e deve essere documentato tramite la fattura elettronica o attraverso un altro documento commerciale in cui sia indicato il codice fiscale del beneficiario.
+Ciascun membro del nucleo famigliare può usufruire del bonus. 
+
+Il bonus vacanze è spendibile in un’unica soluzione per acquistare soggiorni di almeno tre notti nelle strutture ricettive italiane, dal 1 luglio al 31 dicembre 2020. 
+
+Il pagamento deve essere eseguito direttamente alla struttura e deve essere documentato tramite la fattura elettronica o attraverso un altro documento commerciale in cui sia indicato il codice fiscale del beneficiario.
 
 #### Come funziona il processo di richiesta?
 L’app IO è l’unico canale attraverso cui richiedere il bonus. Puoi richiedere il bonus se hai un ISEE valido e inferiore alla soglia di 40.000€.
@@ -27,9 +31,7 @@ Questi sono i passaggi che ti chiederemo di effettuare:
 - conferma la richiesta con il tuo PIN dispositivo o utilizzando il biometrico;
 - invieremo la tua richiesta ad Agenzia delle Entrate che la validerà;
 - il tuo bonus sarà poi visibile nella sezione Pagamenti.
-
-Se durante il processo, i dati relativi all’ISEE e al tuo nucleo familiare non dovessero essere corretti, ti preghiamo di verificare direttamente con il servizio clienti di INPS.`;
-
+`;
 export const availableBonuses: BonusesAvailable = [
   {
     id_type: ID_BONUS_VACANZE_TYPE,

--- a/ts/features/bonusVacanze/screens/BonusInformationScreen.tsx
+++ b/ts/features/bonusVacanze/screens/BonusInformationScreen.tsx
@@ -80,6 +80,8 @@ const styles = StyleSheet.create({
 // the number of markdown component inside BonusInformationScreen
 const markdownComponents = 1;
 const loadingOpacity = 0.9;
+// for long content markdown computed height should be not enough
+const extraMarkdownBodyHeight = 20;
 /**
  * A screen to explain how the bonus activation works and how it will be assigned
  */
@@ -164,7 +166,10 @@ const BonusInformationScreen: React.FunctionComponent<Props> = props => {
           <View spacer={true} />
           <ItemSeparatorComponent noPadded={true} />
           <View spacer={true} />
-          <Markdown onLoadEnd={onMarkdownLoaded}>
+          <Markdown
+            extraBodyHeight={extraMarkdownBodyHeight}
+            onLoadEnd={onMarkdownLoaded}
+          >
             {bonusTypeLocalizedContent.content}
           </Markdown>
           {maybeBonusTos.isSome() && (


### PR DESCRIPTION
**Short description:**
The bonus vacanze content is cutted.
This is because the markdown component compute an height that is not enough to display the whole content

| before  | now |
| ------------- | ------------- |
![before](https://user-images.githubusercontent.com/822471/85407500-938b6f80-b563-11ea-9e44-47f0599da37e.png) | ![now](https://user-images.githubusercontent.com/822471/85407537-a0a85e80-b563-11ea-873e-6a3baf54beba.png)


