### PR TITLE
[#166572994] Fix payment ID infinite polling

### DIFF
--- a/ts/api/backend.ts
+++ b/ts/api/backend.ts
@@ -50,11 +50,11 @@ import {
   UpsertUserMetadataT
 } from "../../definitions/backend/requestTypes";
 
-import { SessionToken } from "../types/SessionToken";
-import { constantPollingFetch, defaultRetryingFetch } from "../utils/fetch";
-import { Millisecond } from "italia-ts-commons/lib/units";
 import { DeferredPromise } from "italia-ts-commons/lib/promises";
 import { Tuple2 } from "italia-ts-commons/lib/tuples";
+import { Millisecond } from "italia-ts-commons/lib/units";
+import { SessionToken } from "../types/SessionToken";
+import { constantPollingFetch, defaultRetryingFetch } from "../utils/fetch";
 
 //
 // Other helper types

--- a/ts/api/backend.ts
+++ b/ts/api/backend.ts
@@ -56,6 +56,19 @@ import { Millisecond } from "italia-ts-commons/lib/units";
 import { SessionToken } from "../types/SessionToken";
 import { constantPollingFetch, defaultRetryingFetch } from "../utils/fetch";
 
+/**
+ * We will retry for as many times when polling for a payment ID.
+ * The total maximum time we are going to wait will be:
+ *
+ * PAYMENT_ID_MAX_POLLING_RETRIES * PAYMENT_ID_RETRY_DELAY
+ */
+const PAYMENT_ID_MAX_POLLING_RETRIES = 180;
+
+/**
+ * How much time to wait between retries when polling for a payment ID
+ */
+const PAYMENT_ID_RETRY_DELAY = 1000 as Millisecond;
+
 //
 // Other helper types
 //
@@ -350,13 +363,13 @@ export function BackendClient(
     postAttivaRpt: withBearerToken(
       createFetchRequestForApi(attivaRptT, options)
     ),
-    getPaymentId: (maxPollingRetries: number, retryDelay: Millisecond) => {
+    getPaymentId: () => {
       // since we could abort the polling a new constantPollingFetch and DeferredPromise are created
       const shouldAbortPaymentIdPollingRequest = DeferredPromise<boolean>();
       const fetchPolling = constantPollingFetch(
         shouldAbortPaymentIdPollingRequest.e1,
-        maxPollingRetries,
-        retryDelay
+        PAYMENT_ID_MAX_POLLING_RETRIES,
+        PAYMENT_ID_RETRY_DELAY
       );
       const request = withBearerToken(
         createFetchRequestForApi(getPaymentIdT, {

--- a/ts/api/backend.ts
+++ b/ts/api/backend.ts
@@ -366,8 +366,9 @@ export function BackendClient(
     getPaymentId: () => {
       // since we could abort the polling a new constantPollingFetch and DeferredPromise are created
       const shouldAbortPaymentIdPollingRequest = DeferredPromise<boolean>();
+      const shouldAbort = shouldAbortPaymentIdPollingRequest.e1;
       const fetchPolling = constantPollingFetch(
-        shouldAbortPaymentIdPollingRequest.e1,
+        shouldAbort,
         PAYMENT_ID_MAX_POLLING_RETRIES,
         PAYMENT_ID_RETRY_DELAY
       );

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -468,9 +468,9 @@ function* deleteActivePaymentSaga() {
     GlobalState
   >(_ => _.wallet.payment.paymentId);
   const maybePaymentId = pot.toOption(potPaymentId);
+  // stop polling
   shouldAbortPaymentIdPollingRequest.e2(true);
   if (maybePaymentId.isSome()) {
-    shouldAbortPaymentIdPollingRequest.e2(true);
     yield put(
       paymentDeletePayment.request({ paymentId: maybePaymentId.value })
     );

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -82,7 +82,6 @@ import { SessionToken } from "../types/SessionToken";
 import { defaultRetryingFetch } from "../utils/fetch";
 
 import { DeferredPromise } from "italia-ts-commons/lib/promises";
-import { Millisecond } from "italia-ts-commons/lib/units";
 import ROUTES from "../navigation/routes";
 import { profileLoadSuccess, profileUpsert } from "../store/actions/profile";
 import { isProfileEmailValidatedSelector } from "../store/reducers/profile";
@@ -107,19 +106,6 @@ import {
   setFavouriteWalletRequestHandler,
   updateWalletPspRequestHandler
 } from "./wallet/pagopaApis";
-
-/**
- * We will retry for as many times when polling for a payment ID.
- * The total maximum time we are going to wait will be:
- *
- * PAYMENT_ID_MAX_POLLING_RETRIES * PAYMENT_ID_RETRY_DELAY
- */
-const PAYMENT_ID_MAX_POLLING_RETRIES = 180;
-
-/**
- * How much time to wait between retries when polling for a payment ID
- */
-const PAYMENT_ID_RETRY_DELAY = 1000 as Millisecond;
 
 /**
  * Configure the max number of retries and delay between retries when polling
@@ -642,10 +628,7 @@ export function* watchWalletSaga(
     // getPaymentId is a tuple2
     // e1: deferredPromise, used to abort the constantPollingFetch
     // e2: the fetch to execute
-    const getPaymentId = pollingPagopaNodoClient.getPaymentId(
-      PAYMENT_ID_MAX_POLLING_RETRIES,
-      PAYMENT_ID_RETRY_DELAY
-    );
+    const getPaymentId = pollingPagopaNodoClient.getPaymentId();
     shouldAbortPaymentIdPollingRequest = getPaymentId.e1;
     yield call(paymentIdPollingRequestHandler, getPaymentId, action);
   });

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -112,14 +112,14 @@ import {
  * We will retry for as many times when polling for a payment ID.
  * The total maximum time we are going to wait will be:
  *
- * PAYMENT_ID_MAX_POLLING_RETRIES * PAYMENT_ID_RETRY_DELAY_MILLIS (milliseconds)
+ * PAYMENT_ID_MAX_POLLING_RETRIES * PAYMENT_ID_RETRY_DELAY
  */
 const PAYMENT_ID_MAX_POLLING_RETRIES = 180;
 
 /**
  * How much time to wait between retries when polling for a payment ID
  */
-const PAYMENT_ID_RETRY_DELAY_MILLIS = 1000 as Millisecond;
+const PAYMENT_ID_RETRY_DELAY = 1000 as Millisecond;
 
 /**
  * Configure the max number of retries and delay between retries when polling
@@ -644,7 +644,7 @@ export function* watchWalletSaga(
     // e2: the fetch to execute
     const getPaymentId = pollingPagopaNodoClient.getPaymentId(
       PAYMENT_ID_MAX_POLLING_RETRIES,
-      PAYMENT_ID_RETRY_DELAY_MILLIS
+      PAYMENT_ID_RETRY_DELAY
     );
     shouldAbortPaymentIdPollingRequest = getPaymentId.e1;
     yield call(paymentIdPollingRequestHandler, getPaymentId, action);

--- a/ts/sagas/wallet/pagopaApis.ts
+++ b/ts/sagas/wallet/pagopaApis.ts
@@ -650,7 +650,7 @@ export function* paymentAttivaRequestHandler(
  * Polls the backend for the paymentId linked to the payment context code
  */
 export function* paymentIdPollingRequestHandler(
-  getPaymentIdApi: ReturnType<typeof BackendClient>["getPaymentId"],
+  getPaymentIdApi: ReturnType<ReturnType<typeof BackendClient>["getPaymentId"]>,
   action: ActionType<typeof paymentIdPolling["request"]>
 ) {
   // successfully request the payment activation
@@ -661,8 +661,8 @@ export function* paymentIdPollingRequestHandler(
       typeof isPagoPATestEnabledSelector
     > = yield select<GlobalState>(isPagoPATestEnabledSelector);
 
-    const response: SagaCallReturnType<typeof getPaymentIdApi> = yield call(
-      getPaymentIdApi,
+    const response: SagaCallReturnType<typeof getPaymentIdApi.e2> = yield call(
+      getPaymentIdApi.e2,
       {
         codiceContestoPagamento: action.payload.codiceContestoPagamento,
         test: isPagoPATestEnabled

--- a/ts/sagas/wallet/pagopaApis.ts
+++ b/ts/sagas/wallet/pagopaApis.ts
@@ -661,8 +661,9 @@ export function* paymentIdPollingRequestHandler(
       typeof isPagoPATestEnabledSelector
     > = yield select<GlobalState>(isPagoPATestEnabledSelector);
 
-    const response: SagaCallReturnType<typeof getPaymentIdApi.e2> = yield call(
-      getPaymentIdApi.e2,
+    const getPaymentId = getPaymentIdApi.e2;
+    const response: SagaCallReturnType<typeof getPaymentId> = yield call(
+      getPaymentId,
       {
         codiceContestoPagamento: action.payload.codiceContestoPagamento,
         test: isPagoPATestEnabled

--- a/ts/utils/fetch.ts
+++ b/ts/utils/fetch.ts
@@ -43,8 +43,7 @@ function retryingFetch(
     _ => _.status === 429,
     retryLogic
   );
-  // TODO: remove the cast once we upgrade to tsc >= 3.1 (https://www.pivotaltracker.com/story/show/170819445)
-  return retriableFetch(retryWithTransient429s)(timeoutFetch as typeof fetch);
+  return retriableFetch(retryWithTransient429s)(timeoutFetch);
 }
 
 /**

--- a/ts/utils/fetch.ts
+++ b/ts/utils/fetch.ts
@@ -95,6 +95,7 @@ export function retryLogicForTransientResponseError(
  * createFetchRequestForApi when creating "getPaymentId"
  */
 export const constantPollingFetch = (
+  shouldAbort: Promise<boolean>,
   retries: number,
   delay: number,
   timeout: Millisecond = 1000 as Millisecond
@@ -119,5 +120,7 @@ export const constantPollingFetch = (
   );
 
   // TODO: remove the cast once we upgrade to tsc >= 3.1 (https://www.pivotaltracker.com/story/show/170819445)
-  return retriableFetch(retryWithTransient404s)(timeoutFetch as typeof fetch);
+  return retriableFetch(retryWithTransient404s, shouldAbort)(
+    timeoutFetch as typeof fetch
+  );
 };


### PR DESCRIPTION
**Short description:**
This PR fixes infinite polling on payment id requests

- create a new backend client for every polling request
- each client has its own deferredPromise
- on cancel polling request, backend client will be stopped by using the relative deferredPromise instance