### PR TITLE
[#173703926] Restore ToS accept button state

### DIFF
--- a/ts/components/TosWebviewComponent.tsx
+++ b/ts/components/TosWebviewComponent.tsx
@@ -1,6 +1,5 @@
 import { View } from "native-base";
 import * as React from "react";
-import { Alert, NativeScrollEvent } from "react-native";
 import WebView from "react-native-webview";
 import I18n from "../i18n";
 import { AVOID_ZOOM_JS, closeInjectedScript } from "../utils/webview";
@@ -16,43 +15,7 @@ type Props = {
   onExit: () => void;
 };
 
-const scrollEndTolerance = 600;
-
 const TosWebviewComponent: React.FunctionComponent<Props> = (props: Props) => {
-  const [scrollEnd, setScrollEnd] = React.useState(false);
-
-  const handleScroll = (event: any) => {
-    if (event === undefined || event === null) {
-      return;
-    }
-    const scrollEvent = event.nativeEvent as NativeScrollEvent;
-    if (!scrollEnd && scrollEvent && scrollEvent.contentSize.height > 0) {
-      const scrollEnded =
-        scrollEvent.contentOffset &&
-        scrollEvent.contentSize &&
-        scrollEvent.contentOffset.y > 0 &&
-        scrollEvent.contentSize.height - scrollEvent.contentOffset.y <
-          scrollEndTolerance;
-      setScrollEnd(scrollEnded);
-      return;
-    }
-  };
-
-  const onContinue = () => {
-    scrollEnd
-      ? props.onAcceptTos()
-      : Alert.alert(
-          I18n.t("onboarding.tos.alert.title"),
-          I18n.t("onboarding.tos.alert.message"),
-          [
-            {
-              text: I18n.t("global.buttons.cancel"),
-              style: "cancel"
-            }
-          ]
-        );
-  };
-
   return (
     <>
       <View style={{ flex: 1 }}>
@@ -60,7 +23,6 @@ const TosWebviewComponent: React.FunctionComponent<Props> = (props: Props) => {
           textZoom={100}
           style={{ flex: 1 }}
           onLoadEnd={props.handleLoadEnd}
-          onScroll={handleScroll}
           onError={props.handleError}
           source={{ uri: props.url }}
           onMessage={props.handleWebViewMessage}
@@ -79,9 +41,8 @@ const TosWebviewComponent: React.FunctionComponent<Props> = (props: Props) => {
           }}
           rightButton={{
             block: true,
-            primary: scrollEnd,
-            gray: !scrollEnd,
-            onPress: onContinue,
+            primary: true,
+            onPress: props.onAcceptTos,
             title: I18n.t("onboarding.tos.accept")
           }}
         />

--- a/ts/screens/onboarding/TosScreen.tsx
+++ b/ts/screens/onboarding/TosScreen.tsx
@@ -194,13 +194,15 @@ class TosScreen extends React.PureComponent<Props, State> {
         }
       >
         <SafeAreaView style={styles.webViewContainer}>
-          <View style={styles.alert}>
-            <Text>
-              {this.props.hasAcceptedOldTosVersion
-                ? I18n.t("profile.main.privacy.privacyPolicy.updated")
-                : I18n.t("profile.main.privacy.privacyPolicy.infobox")}
-            </Text>
-          </View>
+          {!this.props.hasAcceptedCurrentTos && (
+            <View style={styles.alert}>
+              <Text>
+                {this.props.hasAcceptedOldTosVersion
+                  ? I18n.t("profile.main.privacy.privacyPolicy.updated")
+                  : I18n.t("profile.main.privacy.privacyPolicy.infobox")}
+              </Text>
+            </View>
+          )}
           {this.renderError()}
           {!this.state.hasError && (
             <TosWebviewComponent
@@ -246,6 +248,10 @@ function mapStateToProps(state: GlobalState) {
   return {
     isOnbardingCompleted: isOnboardingCompletedSelector(state),
     isLoading: pot.isUpdating(potProfile),
+    hasAcceptedCurrentTos: pot.getOrElse(
+      pot.map(potProfile, p => p.accepted_tos_version === tosVersion),
+      false
+    ),
     hasAcceptedOldTosVersion: pot.getOrElse(
       pot.map(
         potProfile,


### PR DESCRIPTION
**Short description:**

- restore the "Accept" button state as **enabled** by default
- fix a bug that occurs by visiting tos from Profile section: an info box is shown even when the user has already accepted the ToS