### PR TITLE
[#173768527] Personal data link not recognized as link

### DIFF
--- a/ts/features/bonusVacanze/screens/BonusInformationScreen.tsx
+++ b/ts/features/bonusVacanze/screens/BonusInformationScreen.tsx
@@ -203,6 +203,7 @@ const BonusInformationScreen: React.FunctionComponent<Props> = props => {
               </Text>
               <TouchableDefaultOpacity
                 onPress={() => handleModalPress(maybeBonusTos.value)}
+                accessibilityRole={"link"}
               >
                 <Text
                   style={styles.disclaimer}


### PR DESCRIPTION
**Short description:**
This pr allows the link "Information on the processing of personal data" inside the screen `BonusInformationScreen` to be recognized as link from a screen reader.