### PR TITLE
[#173794022] Fixes LightModal half screen bug

### DIFF
--- a/ts/components/ui/LightModal.tsx
+++ b/ts/components/ui/LightModal.tsx
@@ -4,7 +4,14 @@
  */
 
 import React from "react";
-import { Animated, Dimensions, Easing, Modal, StyleSheet } from "react-native";
+import {
+  Animated,
+  Dimensions,
+  Easing,
+  Modal,
+  StyleSheet,
+  View
+} from "react-native";
 import { isScreenReaderEnabled } from "../../utils/accessibility";
 
 export type LightModalContextInterface = Readonly<{
@@ -173,10 +180,14 @@ export class LightModalProvider extends React.Component<Props, State> {
 
   public showModal = async (childComponent: React.ReactNode) => {
     const isScreenReaderActive = await isScreenReaderEnabled();
-    const component = isScreenReaderActive ? (
-      <Modal>{childComponent}</Modal>
-    ) : (
-      childComponent
+    const component = (
+      <View style={[styles.container]}>
+        {isScreenReaderActive ? (
+          <Modal>{childComponent}</Modal>
+        ) : (
+          childComponent
+        )}
+      </View>
     );
     this.setState({
       component


### PR DESCRIPTION
**Short description:**
This PR fixes the half screen visualization on LightModal visualization.

**List of changes proposed in this pull request:**
- ts/components/ui/LightModal.tsx

***Before***
<img height="550" alt="Schermata 2020-07-14 alle 15 52 50" src="https://user-images.githubusercontent.com/3959405/87434059-4f334280-c5ea-11ea-80bb-b117d667e5f6.png">

***After***
<img height="550" alt="Schermata 2020-07-14 alle 15 52 50" src="https://user-images.githubusercontent.com/3959405/87433847-15fad280-c5ea-11ea-843c-6b3bbdb1f471.png">
