### PR TITLE
[#173828514] Fixes customGoBack not accessible

### DIFF
--- a/ts/components/RemindEmailValidationOverlay.tsx
+++ b/ts/components/RemindEmailValidationOverlay.tsx
@@ -40,6 +40,7 @@ import BlockButtons from "./ui/BlockButtons";
 import FooterWithButtons from "./ui/FooterWithButtons";
 import IconFont from "./ui/IconFont";
 import Markdown from "./ui/Markdown";
+import TouchableDefaultOpacity from "./TouchableDefaultOpacity";
 
 type OwnProp = {
   closeModalAndNavigateToEmailInsertScreen: () => void;
@@ -235,7 +236,14 @@ class RemindEmailValidationOverlay extends React.PureComponent<Props, State> {
     );
 
   private customOnboardingGoBack = (
-    <IconFont name={"io-back"} onPress={this.handleOnboardingGoBack} />
+    <TouchableDefaultOpacity
+      onPress={this.handleOnboardingGoBack}
+      accessible={true}
+      accessibilityLabel={I18n.t("global.buttons.back")}
+      accessibilityRole={"button"}
+    >
+      <IconFont name={"io-back"} />
+    </TouchableDefaultOpacity>
   );
 
   private onMainProps: TopScreenComponentProps = {
@@ -335,6 +343,7 @@ class RemindEmailValidationOverlay extends React.PureComponent<Props, State> {
       <TopScreenComponent
         {...(isOnboardingCompleted ? this.onMainProps : this.onBoardingProps)}
         contextualHelpMarkdown={this.contextualHelpMarkdown}
+        avoidNavigationEventsUsage={true}
       >
         <Content bounces={false}>
           <View spacer={true} extralarge={true} />

--- a/ts/components/RemindEmailValidationOverlay.tsx
+++ b/ts/components/RemindEmailValidationOverlay.tsx
@@ -36,11 +36,11 @@ import { ContextualHelpPropsMarkdown } from "./screens/BaseScreenComponent";
 import TopScreenComponent, {
   TopScreenComponentProps
 } from "./screens/TopScreenComponent";
+import TouchableDefaultOpacity from "./TouchableDefaultOpacity";
 import BlockButtons from "./ui/BlockButtons";
 import FooterWithButtons from "./ui/FooterWithButtons";
 import IconFont from "./ui/IconFont";
 import Markdown from "./ui/Markdown";
-import TouchableDefaultOpacity from "./TouchableDefaultOpacity";
 
 type OwnProp = {
   closeModalAndNavigateToEmailInsertScreen: () => void;

--- a/ts/components/screens/TopScreenComponent.tsx
+++ b/ts/components/screens/TopScreenComponent.tsx
@@ -14,6 +14,7 @@ interface OwnProps {
     onPress: () => void;
   };
   faqCategories?: ReadonlyArray<FAQsCategoriesType>;
+  avoidNavigationEventsUsage?: boolean;
 }
 
 type BaseScreenComponentProps =
@@ -48,7 +49,8 @@ class TopScreenComponent extends React.PureComponent<Props> {
       searchType,
       customRightIcon,
       customGoBack,
-      faqCategories
+      faqCategories,
+      avoidNavigationEventsUsage
     } = this.props;
 
     return (
@@ -66,6 +68,7 @@ class TopScreenComponent extends React.PureComponent<Props> {
         searchType={searchType}
         customRightIcon={customRightIcon}
         customGoBack={customGoBack}
+        avoidNavigationEventsUsage={avoidNavigationEventsUsage}
       >
         {this.props.children}
       </BaseScreenComponent>

--- a/ts/screens/profile/FiscalCodeScreen.tsx
+++ b/ts/screens/profile/FiscalCodeScreen.tsx
@@ -141,15 +141,18 @@ class FiscalCodeScreen extends React.PureComponent<Props, State> {
     return true;
   };
 
-  private customOnboardingGoBack = (
-    <IconFont
-      name={"io-back"}
-      style={{ color: customVariables.colorWhite }}
-      onPress={async () => {
-        await this.resetAppBrightness();
-        this.goBack();
-      }}
-    />
+  private customGoBack = (
+    <TouchableDefaultOpacity
+      onPress={this.handleBackPress}
+      accessible={true}
+      accessibilityLabel={I18n.t("global.buttons.back")}
+      accessibilityRole={"button"}
+    >
+      <IconFont
+        name={"io-back"}
+        style={{ color: customVariables.colorWhite }}
+      />
+    </TouchableDefaultOpacity>
   );
 
   public render() {
@@ -157,7 +160,7 @@ class FiscalCodeScreen extends React.PureComponent<Props, State> {
       <React.Fragment>
         <DarkLayout
           allowGoBack={true}
-          customGoBack={this.customOnboardingGoBack}
+          customGoBack={this.customGoBack}
           headerBody={
             <TouchableDefaultOpacity onPress={this.goBack}>
               <Text white={true}>{I18n.t("profile.fiscalCode.title")}</Text>


### PR DESCRIPTION
**Short description:**
This PR adds accessibility on screen and components using customGoBack which wasn't recognized by screen reader

Adds the `avoidNavigationEventsUsage` prop on `TopScreenComponent` to avoid the crash error when EmailValidationOverlay shows up