### PR TITLE
[#173899093] Fix wrong color for PaymentMethodList Item

### DIFF
--- a/ts/components/wallet/PaymentMethodsList.tsx
+++ b/ts/components/wallet/PaymentMethodsList.tsx
@@ -117,7 +117,7 @@ const AddMethodStyle = StyleSheet.create({
   notImplementedText: {
     fontSize: 10,
     lineHeight: Platform.OS === "ios" ? 14 : 16,
-    color: customVariables.brandDarkGray
+    color: customVariables.colorWhite
   },
   centeredContents: {
     alignItems: "center"


### PR DESCRIPTION
**Short description:**
Change the text color for the badge in PaymentMethodList Item

Before            |  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/26501317/87950569-bdbf4700-caa7-11ea-8eac-38f3bb4832b0.png" width="300">|  <img src="https://user-images.githubusercontent.com/26501317/87950584-c7e14580-caa7-11ea-8d5f-f389fdb790b5.png" width="300">
