### PR TITLE
[#173815288] Fixes bonus header title color

### DIFF
--- a/ts/features/bonusVacanze/screens/ActiveBonusScreen.tsx
+++ b/ts/features/bonusVacanze/screens/ActiveBonusScreen.tsx
@@ -78,10 +78,6 @@ const styles = StyleSheet.create({
   flex: {
     flex: 1
   },
-  title: {
-    color: variables.lightGray,
-    fontSize: variables.fontSize1
-  },
   image: {
     position: "absolute",
     top: -144,
@@ -362,11 +358,7 @@ const ActiveBonusScreen: React.FunctionComponent<Props> = (props: Props) => {
   return !props.isError && bonus ? (
     <DarkLayout
       bounces={false}
-      headerBody={
-        <TouchableDefaultOpacity onPress={props.goBack} style={styles.center}>
-          <Text style={styles.title}>{I18n.t("bonus.bonusVacanze.name")}</Text>
-        </TouchableDefaultOpacity>
-      }
+      title={I18n.t("bonus.bonusVacanze.name")}
       contextualHelpMarkdown={contextualHelpMarkdown}
       faqCategories={["bonus_detail"]}
       allowGoBack={true}


### PR DESCRIPTION
**Short description:**
This PR fixes the bonus detail header title color

<img height="550" alt="Schermata 2020-07-21 alle 17 13 18" src="https://user-images.githubusercontent.com/3959405/88072568-7acba500-cb75-11ea-8e93-5409baeaa16d.png">