### PR TITLE
[#173707422] Get static assets and data from IO CDN

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -29,7 +29,7 @@ TOT_MESSAGE_FETCH_WORKERS=5
 # shuffle pin pad to proceed with the payment
 SHUFFLE_PINPAD_ON_PAYMENT=NO
 # Repository of app content
-CONTENT_REPO_URL='https://raw.githubusercontent.com/pagopa/io-services-metadata/master'
+CONTENT_REPO_URL='https://assets.cdn.io.italia.it'
 # Privacy url to load in TOS Screen
 PRIVACY_URL='https://io.italia.it/app-content/tos_privacy.html'
 INSTABUG_TOKEN='5c2d0f12fa12f9afc535585e5b7a9e79'

--- a/ts/api/content.ts
+++ b/ts/api/content.ts
@@ -28,7 +28,7 @@ type GetServiceT = IGetApiRequestType<
 
 const getServiceT: GetServiceT = {
   method: "get",
-  url: params => `/services-data/${params.serviceId.toUpperCase()}.json`,
+  url: params => `/services/${params.serviceId.toLocaleLowerCase()}.json`,
   query: _ => ({}),
   headers: _ => ({}),
   response_decoder: basicResponseDecoder(ServiceMetadata)

--- a/ts/api/content.ts
+++ b/ts/api/content.ts
@@ -28,7 +28,7 @@ type GetServiceT = IGetApiRequestType<
 
 const getServiceT: GetServiceT = {
   method: "get",
-  url: params => `/services/${params.serviceId.toLocaleLowerCase()}.json`,
+  url: params => `/services/${params.serviceId.toLowerCase()}.json`,
   query: _ => ({}),
   headers: _ => ({}),
   response_decoder: basicResponseDecoder(ServiceMetadata)

--- a/ts/api/content.ts
+++ b/ts/api/content.ts
@@ -28,7 +28,7 @@ type GetServiceT = IGetApiRequestType<
 
 const getServiceT: GetServiceT = {
   method: "get",
-  url: params => `/services/${params.serviceId.toLowerCase()}.json`,
+  url: params => `/services-data/${params.serviceId.toUpperCase()}.json`,
   query: _ => ({}),
   headers: _ => ({}),
   response_decoder: basicResponseDecoder(ServiceMetadata)


### PR DESCRIPTION
**Short description:**
This PR change the endpoint for static assets/data from [io-services-metadata](https://github.com/pagopa/io-services-metadata) to IO-CDN

