### PR TITLE
[#173984555] Change Android gradle versionName format

### DIFF
--- a/scripts/changelog/gradle_updater.js
+++ b/scripts/changelog/gradle_updater.js
@@ -9,6 +9,8 @@
  *
  */
 
+const versionModule = require("./version_utility.js");
+
 const versionNameRegex = /(versionName ")(.+)(")/gm;
 
 module.exports.readVersion = function(contents) {
@@ -22,6 +24,10 @@ function replaceVersionName(match, version, p1, p2, p3) {
 
 module.exports.writeVersion = function(contents, version) {
   // replace the old version (match #2 group) of regex, with the new version
+
+  const buildNumber = versionModule.androidGetBuildVersion(version);
+  version = buildNumber !== undefined ? version + `.${buildNumber}` : version;
+
   contents = contents.replace(versionNameRegex, (substr, ...args) =>
     replaceVersionName(substr, version, ...args)
   );

--- a/scripts/changelog/gradle_updater.js
+++ b/scripts/changelog/gradle_updater.js
@@ -25,8 +25,12 @@ function replaceVersionName(match, version, p1, p2, p3) {
 module.exports.writeVersion = function(contents, version) {
   // replace the old version (match #2 group) of regex, with the new version
 
+  const versionClean = versionModule.getVersion(version);
   const buildNumber = versionModule.androidGetBuildVersion(version);
-  version = buildNumber !== undefined ? version + `.${buildNumber}` : version;
+  version =
+    buildNumber !== undefined
+      ? version + `${versionClean}.${buildNumber}`
+      : version;
 
   contents = contents.replace(versionNameRegex, (substr, ...args) =>
     replaceVersionName(substr, version, ...args)

--- a/scripts/changelog/gradle_updater.js
+++ b/scripts/changelog/gradle_updater.js
@@ -28,9 +28,7 @@ module.exports.writeVersion = function(contents, version) {
   const versionClean = versionModule.getVersion(version);
   const buildNumber = versionModule.androidGetBuildVersion(version);
   version =
-    buildNumber !== undefined
-      ? version + `${versionClean}.${buildNumber}`
-      : version;
+    buildNumber !== undefined ? `${versionClean}.${buildNumber}` : version;
 
   contents = contents.replace(versionNameRegex, (substr, ...args) =>
     replaceVersionName(substr, version, ...args)

--- a/scripts/changelog/version_utility.js
+++ b/scripts/changelog/version_utility.js
@@ -47,3 +47,7 @@ module.exports.iosGetBuildVersion = function(rawVersion, currentBuildVersion) {
     ? getRC(rawVersion)
     : parseInt(currentBuildVersion, 10) + 1;
 };
+
+module.exports.androidGetBuildVersion = function(rawVersion) {
+  return isRc(rawVersion) ? getRC(rawVersion) : undefined;
+};


### PR DESCRIPTION
**Short description:**
This pr changes the format of the `versionName` value for Android.

 Released version | Android previous`versionName` | Android new`versionName` 
:---------:|:---------:|:---------:
1.0.0 | 1.0.0 | 1.0.0  
1.1.0-rc.0 | 1.1.0-rc.0 | 1.1.0.0 
1.1.0-rc.1 | 1.1.0-rc.1 |  1.1.0.1
1.1.0 | 1.1.0 |  1.1.0 
1.1.1-rc.0 | 1.1.1-rc.0 | 1.1.1.0

**List of changes proposed in this pull request:**
- Changed `gradle_updater.js ` to support the new syntax