### PR TITLE
[#173984610] Android alpha build is created at each master commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -539,7 +539,7 @@ workflows:
             - lint-typescript
           filters:
             tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
             branches:
               ignore: /.*/
           #              only: \d\.\d\.\d(\.rc-\d+)?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,21 +502,21 @@ workflows:
 
   release:
     jobs:
-      - compile-typescript
+      - compile-typescript:
           filters:
             tags:
               only: /^config-test.*/
             branches:
               ignore: /.*/
 
-      - run-tests
+      - run-tests:
           filters:
             tags:
               only: /^config-test.*/
             branches:
               ignore: /.*/
 
-      - lint-typescript
+      - lint-typescript:
           filters:
             tags:
               only: /^config-test.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,15 +503,13 @@ workflows:
       # Build Android alpha release only on master branch when a new tag is pushed
 #      - alpha-release-android:
       - io_check_uris:
-          requires:
-            - compile-typescript
-            - run-tests
-            - lint-typescript
+          #requires:
+          #  - compile-typescript
+          #  - run-tests
+          #  - lint-typescript
           filters:
             tags:
               only: \d\.\d\.\d(\.rc-\d+)?
-            branches:
-              only: 173984610-create-android-build-with-tag-only
   # nightly workflow to check pagopa specs (runs only on master branch)
   # if prod and dev specs are different
   # a slack notification will be sent on channel #io-status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,16 +503,17 @@ workflows:
       # Build Android alpha release only on master branch when a new tag is pushed
 #      - alpha-release-android:
       - io_check_uris:
-          #requires:
-          #  - compile-typescript
-          #  - run-tests
-          #  - lint-typescript
+          requires:
+            - compile-typescript
+            - run-tests
+            - lint-typescript
           filters:
             tags:
               only: /^config-test.*/
             branches:
               ignore: /.*/
 #              only: \d\.\d\.\d(\.rc-\d+)?
+
           #  branches:
           #    only: 173984610-create-android-build-with-tag-only
   # nightly workflow to check pagopa specs (runs only on master branch)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -539,7 +539,7 @@ workflows:
             - lint-typescript
           filters:
             tags:
-              only: \d\.\d\.\d(\.rc-\d+)?
+              only: /^\d+\.\d+\.\d+(-rc\.[0-9]+)?/
             branches:
               ignore: /.*/
           #              only: \d\.\d\.\d(\.rc-\d+)?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,28 +505,28 @@ workflows:
       - compile-typescript:
           filters:
             tags:
-              only: /^config-test.*/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
             branches:
               ignore: /.*/
 
       - run-tests:
           filters:
             tags:
-              only: /^config-test.*/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
             branches:
               ignore: /.*/
 
       - lint-typescript:
           filters:
             tags:
-              only: /^config-test.*/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
             branches:
               ignore: /.*/
 
       - run-danger:
           filters:
             tags:
-              only: /^config-test.*/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
             branches:
               ignore: /.*/
 
@@ -539,7 +539,7 @@ workflows:
             - lint-typescript
           filters:
             tags:
-              only: /[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
             branches:
               ignore: /.*/
           #              only: \d\.\d\.\d(\.rc-\d+)?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,22 +500,19 @@ workflows:
           requires:
             - test-ios-e2e-build
 
-  build-android:
-    jobs:
       # Build Android alpha release only on master branch when a new tag is pushed
-      #      - alpha-release-android:
+#      - alpha-release-android:
       - io_check_uris:
           #requires:
           #  - compile-typescript
           #  - run-tests
           #  - lint-typescript
-          filters:
-            tags:
-              only: ciao
-          #              only: \d\.\d\.\d(\.rc-\d+)?
+        filters:
+          tags:
+            only: ciao
+#              only: \d\.\d\.\d(\.rc-\d+)?
           #  branches:
           #    only: 173984610-create-android-build-with-tag-only
-
   # nightly workflow to check pagopa specs (runs only on master branch)
   # if prod and dev specs are different
   # a slack notification will be sent on channel #io-status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,6 +468,8 @@ workflows:
 
       - run-danger:
           filters:
+            tags:
+              only: /.*/
             branches:
               ignore: master
 
@@ -480,6 +482,8 @@ workflows:
             - run-tests
             - lint-typescript
           filters:
+            tags:
+              only: /.*/
             branches:
               ignore: master
 
@@ -511,8 +515,8 @@ workflows:
             tags:
               only: /^config-test.*/
 #              only: \d\.\d\.\d(\.rc-\d+)?
-            branches:
-                only: master
+          #  branches:
+          #    only: 173984610-create-android-build-with-tag-only
   # nightly workflow to check pagopa specs (runs only on master branch)
   # if prod and dev specs are different
   # a slack notification will be sent on channel #io-status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -511,8 +511,8 @@ workflows:
             tags:
               only: /^config-test.*/
 #              only: \d\.\d\.\d(\.rc-\d+)?
-          branches:
-              only: master
+            branches:
+                only: master
   # nightly workflow to check pagopa specs (runs only on master branch)
   # if prod and dev specs are different
   # a slack notification will be sent on channel #io-status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -511,8 +511,8 @@ workflows:
             tags:
               only: /^config-test.*/
 #              only: \d\.\d\.\d(\.rc-\d+)?
-          #  branches:
-          #    only: 173984610-create-android-build-with-tag-only
+          branches:
+              only: master
   # nightly workflow to check pagopa specs (runs only on master branch)
   # if prod and dev specs are different
   # a slack notification will be sent on channel #io-status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,8 +468,6 @@ workflows:
 
       - run-danger:
           filters:
-            tags:
-              only: /.*/
             branches:
               ignore: master
 
@@ -482,8 +480,6 @@ workflows:
             - run-tests
             - lint-typescript
           filters:
-            tags:
-              only: /.*/
             branches:
               ignore: master
 
@@ -504,8 +500,15 @@ workflows:
           requires:
             - test-ios-e2e-build
 
+
+  # nightly workflow to check pagopa specs (runs only on master branch)
+  # if prod and dev specs are different
+  # a slack notification will be sent on channel #io-status
+
+  deploy:
+    jobs:
       # Build Android alpha release only on master branch when a new tag is pushed
-#      - alpha-release-android:
+      #      - alpha-release-android:
       - io_check_uris:
           #requires:
           #  - compile-typescript
@@ -514,12 +517,10 @@ workflows:
           filters:
             tags:
               only: /^config-test.*/
-#              only: \d\.\d\.\d(\.rc-\d+)?
+          #              only: \d\.\d\.\d(\.rc-\d+)?
           #  branches:
           #    only: 173984610-create-android-build-with-tag-only
-  # nightly workflow to check pagopa specs (runs only on master branch)
-  # if prod and dev specs are different
-  # a slack notification will be sent on channel #io-status
+
   nightly-pagopa-specs-check:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -501,16 +501,17 @@ workflows:
             - test-ios-e2e-build
 
       # Build Android alpha release only on master branch when a new tag is pushed
-      #- alpha-release-android:
-      #    requires:
-      #      - compile-typescript
-      #      - run-tests
-      #      - lint-typescript
-      #    filters:
-      #      tags:
-      #        only: \d\.\d\.\d(\.rc-\d+)?
-      #      branches:
-      #        only: master
+#      - alpha-release-android:
+      - io_check_uris:
+          requires:
+            - compile-typescript
+            - run-tests
+            - lint-typescript
+          filters:
+            tags:
+              only: \d\.\d\.\d(\.rc-\d+)?
+            branches:
+              only: 173984610-create-android-build-with-tag-only
   # nightly workflow to check pagopa specs (runs only on master branch)
   # if prod and dev specs are different
   # a slack notification will be sent on channel #io-status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,15 +500,8 @@ workflows:
           requires:
             - test-ios-e2e-build
 
-
-  # nightly workflow to check pagopa specs (runs only on master branch)
-  # if prod and dev specs are different
-  # a slack notification will be sent on channel #io-status
-
-  deploy:
-    jobs:
       # Build Android alpha release only on master branch when a new tag is pushed
-      #      - alpha-release-android:
+#      - alpha-release-android:
       - io_check_uris:
           #requires:
           #  - compile-typescript
@@ -517,9 +510,14 @@ workflows:
           filters:
             tags:
               only: /^config-test.*/
-          #              only: \d\.\d\.\d(\.rc-\d+)?
+            branches:
+              ignore: /.*/
+#              only: \d\.\d\.\d(\.rc-\d+)?
           #  branches:
           #    only: 173984610-create-android-build-with-tag-only
+  # nightly workflow to check pagopa specs (runs only on master branch)
+  # if prod and dev specs are different
+  # a slack notification will be sent on channel #io-status
 
   nightly-pagopa-specs-check:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,8 @@ android_jars_cache_key: &android_jars_cache_key jars-{{ checksum "android/build.
 
 ios_gems_cache_key: &ios_gems_cache_key ruby-{{ checksum "Gemfile.lock" }}
 
+release_tag: &release_tag /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
+
 # nodejs builds
 defaults_js: &defaults_js
   <<: *defaults
@@ -505,28 +507,28 @@ workflows:
       - compile-typescript:
           filters:
             tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
+              only: *release_tag
             branches:
               ignore: /.*/
 
       - run-tests:
           filters:
             tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
+              only: *release_tag
             branches:
               ignore: /.*/
 
       - lint-typescript:
           filters:
             tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
+              only: *release_tag
             branches:
               ignore: /.*/
 
       - run-danger:
           filters:
             tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
+              only: *release_tag
             branches:
               ignore: /.*/
 
@@ -539,7 +541,7 @@ workflows:
             - lint-typescript
           filters:
             tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
+              only: *release_tag
             branches:
               ignore: /.*/
           #              only: \d\.\d\.\d(\.rc-\d+)?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -539,7 +539,7 @@ workflows:
             - lint-typescript
           filters:
             tags:
-              only: /^\d+\.\d+\.\d+(-rc\.[0-9]+)?/
+              only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?/
             branches:
               ignore: /.*/
           #              only: \d\.\d\.\d(\.rc-\d+)?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -539,7 +539,7 @@ workflows:
             - lint-typescript
           filters:
             tags:
-              only: /^\d\.\d\.\d(\.rc-\d+)?
+              only: \d\.\d\.\d(\.rc-\d+)?
             branches:
               ignore: /.*/
           #              only: \d\.\d\.\d(\.rc-\d+)?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,8 +500,38 @@ workflows:
           requires:
             - test-ios-e2e-build
 
+  release:
+    jobs:
+      - compile-typescript
+          filters:
+            tags:
+              only: /^config-test.*/
+            branches:
+              ignore: /.*/
+
+      - run-tests
+          filters:
+            tags:
+              only: /^config-test.*/
+            branches:
+              ignore: /.*/
+
+      - lint-typescript
+          filters:
+            tags:
+              only: /^config-test.*/
+            branches:
+              ignore: /.*/
+
+      - run-danger:
+          filters:
+            tags:
+              only: /^config-test.*/
+            branches:
+              ignore: /.*/
+
       # Build Android alpha release only on master branch when a new tag is pushed
-#      - alpha-release-android:
+      #      - alpha-release-android:
       - io_check_uris:
           requires:
             - compile-typescript
@@ -512,14 +542,14 @@ workflows:
               only: /^config-test.*/
             branches:
               ignore: /.*/
-#              only: \d\.\d\.\d(\.rc-\d+)?
+          #              only: \d\.\d\.\d(\.rc-\d+)?
 
           #  branches:
           #    only: 173984610-create-android-build-with-tag-only
+
   # nightly workflow to check pagopa specs (runs only on master branch)
   # if prod and dev specs are different
   # a slack notification will be sent on channel #io-status
-
   nightly-pagopa-specs-check:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,7 +509,10 @@ workflows:
           #  - lint-typescript
           filters:
             tags:
-              only: \d\.\d\.\d(\.rc-\d+)?
+              only: ciao
+#              only: \d\.\d\.\d(\.rc-\d+)?
+          #  branches:
+          #    only: 173984610-create-android-build-with-tag-only
   # nightly workflow to check pagopa specs (runs only on master branch)
   # if prod and dev specs are different
   # a slack notification will be sent on channel #io-status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -539,7 +539,7 @@ workflows:
             - lint-typescript
           filters:
             tags:
-              only: /^config-test.*/
+              only: /^\d\.\d\.\d(\.rc-\d+)?
             branches:
               ignore: /.*/
           #              only: \d\.\d\.\d(\.rc-\d+)?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,6 +502,7 @@ workflows:
           requires:
             - test-ios-e2e-build
 
+  # Release workflow triggered only when a new release tag is pushed
   release:
     jobs:
       - compile-typescript:
@@ -532,9 +533,8 @@ workflows:
             branches:
               ignore: /.*/
 
-      # Build Android alpha release only on master branch when a new tag is pushed
-      #      - alpha-release-android:
-      - io_check_uris:
+      # Build Android alpha release & submit to play store
+      - alpha-release-android:
           requires:
             - compile-typescript
             - run-tests
@@ -544,10 +544,6 @@ workflows:
               only: *release_tag
             branches:
               ignore: /.*/
-          #              only: \d\.\d\.\d(\.rc-\d+)?
-
-          #  branches:
-          #    only: 173984610-create-android-build-with-tag-only
 
   # nightly workflow to check pagopa specs (runs only on master branch)
   # if prod and dev specs are different

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -507,9 +507,9 @@ workflows:
           #  - compile-typescript
           #  - run-tests
           #  - lint-typescript
-        filters:
-          tags:
-            only: ciao
+          filters:
+            tags:
+              only: /^config-test.*/
 #              only: \d\.\d\.\d(\.rc-\d+)?
           #  branches:
           #    only: 173984610-create-android-build-with-tag-only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,8 +500,10 @@ workflows:
           requires:
             - test-ios-e2e-build
 
+  build-android:
+    jobs:
       # Build Android alpha release only on master branch when a new tag is pushed
-#      - alpha-release-android:
+      #      - alpha-release-android:
       - io_check_uris:
           #requires:
           #  - compile-typescript
@@ -510,9 +512,10 @@ workflows:
           filters:
             tags:
               only: ciao
-#              only: \d\.\d\.\d(\.rc-\d+)?
+          #              only: \d\.\d\.\d(\.rc-\d+)?
           #  branches:
           #    only: 173984610-create-android-build-with-tag-only
+
   # nightly workflow to check pagopa specs (runs only on master branch)
   # if prod and dev specs are different
   # a slack notification will be sent on channel #io-status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -539,7 +539,7 @@ workflows:
             - lint-typescript
           filters:
             tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
+              only: /[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?/
             branches:
               ignore: /.*/
           #              only: \d\.\d\.\d(\.rc-\d+)?


### PR DESCRIPTION
**Short description:**
This pr allows to generate a new Android release only when a new version tag is pushed (regardless of the branch).

**List of changes proposed in this pull request:**
- Added a `release` workflow, triggered only when a new release tag is pushed.