### PR TITLE
[#174005728,#174005947] All psp are filtered 

### DIFF
--- a/ts/api/pagopa.ts
+++ b/ts/api/pagopa.ts
@@ -59,6 +59,7 @@ import {
   updateWalletUsingPUTDecoder,
   UpdateWalletUsingPUTT
 } from "../../definitions/pagopa/requestTypes";
+import { getLocalePrimaryWithFallback } from "../utils/locale";
 import { fixWalletPspTagsValues } from "../utils/wallet";
 /**
  * A decoder that ignores the content of the payload and only decodes the status
@@ -209,7 +210,10 @@ type GetPspListUsingGETTExtra = MapResponseType<
   ReplaceRequestParams<
     GetPspListUsingGETT,
     // TODO: temporary patch, see https://www.pivotaltracker.com/story/show/161475199
-    TypeofApiParams<GetPspListUsingGETT> & { idWallet?: number }
+    TypeofApiParams<GetPspListUsingGETT> & {
+      idWallet?: number;
+      language?: string;
+    }
   >,
   200,
   PspListResponse
@@ -218,16 +222,18 @@ type GetPspListUsingGETTExtra = MapResponseType<
 const getPspList: GetPspListUsingGETTExtra = {
   method: "get",
   url: () => "/v1/psps",
-  query: ({ idPayment, idWallet }) =>
+  query: ({ idPayment, idWallet, language }) =>
     idWallet
       ? {
           paymentType: "CREDIT_CARD",
           idPayment,
-          idWallet
+          idWallet,
+          language
         }
       : {
           paymentType: "CREDIT_CARD",
-          idPayment
+          idPayment,
+          language
         },
   headers: ParamAuthorizationBearerHeader,
   response_decoder: getPspListUsingGETDecoder(PspListResponse)
@@ -396,9 +402,10 @@ export function PaymentManagerClient(
         idWallet
           ? {
               idPayment,
-              idWallet
+              idWallet,
+              language: getLocalePrimaryWithFallback()
             }
-          : { idPayment }
+          : { idPayment, language: getLocalePrimaryWithFallback() }
       ),
     getPsp: (id: TypeofApiParams<GetPspUsingGETT>["id"]) =>
       flip(withPaymentManagerToken(createFetchRequestForApi(getPsp, options)))({

--- a/ts/screens/profile/LanguagesPreferencesScreen.tsx
+++ b/ts/screens/profile/LanguagesPreferencesScreen.tsx
@@ -15,7 +15,7 @@ import { preferredLanguageSaveSuccess } from "../../store/actions/persistedPrefe
 import { Dispatch } from "../../store/actions/types";
 import { preferredLanguageSelector } from "../../store/reducers/persistedPreferences";
 import { GlobalState } from "../../store/reducers/types";
-import { getLocalePrimary } from "../../utils/locale";
+import { getLocalePrimaryWithFallback } from "../../utils/locale";
 
 type Props = LightModalContextInterface &
   ReturnType<typeof mapDispatchToProps> &
@@ -36,9 +36,7 @@ class LanguagesPreferencesScreen extends React.PureComponent<Props> {
     // if the preferred Lanuage is not set, we check if language is the same in use
     return this.props.preferredLanguage
       .map(l => l === language)
-      .getOrElse(
-        getLocalePrimary(I18n.locale).fold(false, l => l === language)
-      );
+      .getOrElse(getLocalePrimaryWithFallback() === language);
   };
 
   private onLanguageSelected = (language: Locales) => {

--- a/ts/screens/profile/PreferencesScreen.tsx
+++ b/ts/screens/profile/PreferencesScreen.tsx
@@ -47,7 +47,10 @@ import {
 import { GlobalState } from "../../store/reducers/types";
 import { openAppSettings } from "../../utils/appSettings";
 import { checkAndRequestPermission } from "../../utils/calendar";
-import { getLocalePrimary } from "../../utils/locale";
+import {
+  getLocalePrimary,
+  getLocalePrimaryWithFallback
+} from "../../utils/locale";
 type OwnProps = Readonly<{
   navigation: NavigationScreenProp<NavigationState>;
 }>;
@@ -167,7 +170,7 @@ class PreferencesScreen extends React.Component<Props, State> {
     const maybePhoneNumber = this.props.optionMobilePhone;
 
     const language = this.props.preferredLanguage.fold(
-      translateLocale(I18n.locale),
+      translateLocale(getLocalePrimaryWithFallback()),
       l => translateLocale(l)
     );
 

--- a/ts/utils/__tests__/payment.test.ts
+++ b/ts/utils/__tests__/payment.test.ts
@@ -101,8 +101,6 @@ describe("decodePagoPaQrCode", () => {
       Tuple2("PAGOPA|003|322201151398574181|810057500211|01A", none),
       // invalid amount
       Tuple2("PAGOPA|002|322201151398574181|810057500211|01A", none),
-      // invalid amount
-      Tuple2("PAGOPA|002|322201151398574181|810057500211|01A", none),
       // invalid header
       Tuple2("PAPAGO|002|322201151398574181|810057500211|01", none),
       // invalid amount (1 digit instead of >= 2)


### PR DESCRIPTION
**Short description:**
This PR fixes mainly a bug about psp list filtering:
if the retrieved psp has a language not compliant with which one used by the device the psp will be discarded.

Now the language used to retrieve and filter the psp is one of these used by the app: italian or english
If the current language is neither italian or english, en is the fallback

Another fix is about the current language representation. The following screen is on device where the device language is polish

<img src="https://user-images.githubusercontent.com/822471/88528075-6f0d3200-cffe-11ea-9634-c7d39b1d232f.png" height="600"/>
