### PR TITLE
[#173998756] Fixes font-size on Markdown component

### DIFF
--- a/ts/components/ui/Markdown/index.tsx
+++ b/ts/components/ui/Markdown/index.tsx
@@ -25,7 +25,6 @@ import { AVOID_ZOOM_JS, closeInjectedScript } from "../../../utils/webview";
 import { handleLinkMessage } from "./handlers/link";
 import { NOTIFY_BODY_HEIGHT_SCRIPT, NOTIFY_LINK_CLICK_SCRIPT } from "./script";
 import { WebViewMessage } from "./types";
-import { RTron } from "../../../boot/configureStoreAndPersistor";
 
 const INJECTED_JAVASCRIPT = `
 ${NOTIFY_LINK_CLICK_SCRIPT}
@@ -308,7 +307,6 @@ class Markdown extends React.PureComponent<Props, State> {
     const isLoading =
       html === undefined || (html !== "" && htmlBodyHeight === 0);
 
-    RTron.log(html);
     return (
       <React.Fragment>
         {isLoading && (

--- a/ts/components/ui/Markdown/index.tsx
+++ b/ts/components/ui/Markdown/index.tsx
@@ -25,6 +25,7 @@ import { AVOID_ZOOM_JS, closeInjectedScript } from "../../../utils/webview";
 import { handleLinkMessage } from "./handlers/link";
 import { NOTIFY_BODY_HEIGHT_SCRIPT, NOTIFY_LINK_CLICK_SCRIPT } from "./script";
 import { WebViewMessage } from "./types";
+import { RTron } from "../../../boot/configureStoreAndPersistor";
 
 const INJECTED_JAVASCRIPT = `
 ${NOTIFY_LINK_CLICK_SCRIPT}
@@ -71,7 +72,7 @@ body {
   margin: 0;
   padding: 0;
   color: ${customVariables.textColor};
-  font-size: 16px;
+  font-size: ${customVariables.fontSize1}px;
   font-family: 'Titillium Web';
 }
 
@@ -81,6 +82,7 @@ h1, h2, h3, h4, h5, h6 {
 
 p {
   margin-block-start: 0;
+  font-size: ${customVariables.fontSize1}px;
 }
 
 ul, ol {
@@ -306,6 +308,7 @@ class Markdown extends React.PureComponent<Props, State> {
     const isLoading =
       html === undefined || (html !== "" && htmlBodyHeight === 0);
 
+    RTron.log(html);
     return (
       <React.Fragment>
         {isLoading && (

--- a/ts/features/bonusVacanze/screens/BonusInformationScreen.tsx
+++ b/ts/features/bonusVacanze/screens/BonusInformationScreen.tsx
@@ -43,12 +43,12 @@ type Props = OwnProps &
 
 const CSS_STYLE = `
 body {
-  font-size: ${customVariables.fontSizeSmall}px;
+  font-size: ${customVariables.fontSize1}px;
   color: ${customVariables.brandDarkestGray}
 }
 
 h4 {
-  font-size: ${customVariables.fontSize1}px;
+  font-size: ${customVariables.fontSize2}px;
 }
 `;
 


### PR DESCRIPTION
**Short description:**
This PR improves the font-size on bonus vacanze information screen and unifies the font-size of markdown component

**List of changes proposed in this pull request:**
- ts/components/ui/Markdown/index.tsx
- ts/features/bonusVacanze/screens/BonusInformationScreen.tsx

## Before
<img height="550" alt="Schermata 2020-07-27 alle 12 23 23" src="https://user-images.githubusercontent.com/3959405/88531939-fad58d00-d003-11ea-8d00-5249aeeaf1c7.png">

## After
<img height="550" alt="Schermata 2020-07-27 alle 12 20 48" src="https://user-images.githubusercontent.com/3959405/88531748-9d414080-d003-11ea-86ec-c0f98ea888a9.png">

