### PR TITLE
[#174085364] messagesStatus store section cleaning

### DIFF
--- a/ts/sagas/startup/__tests__/watchLoadMessages.test.ts
+++ b/ts/sagas/startup/__tests__/watchLoadMessages.test.ts
@@ -15,9 +15,9 @@ import {
   messagesStateByIdSelector,
   MessageState
 } from "../../../store/reducers/entities/messages/messagesById";
+import { messagesStatusSelector } from "../../../store/reducers/entities/messages/messagesStatus";
 import { servicesByIdSelector } from "../../../store/reducers/entities/services/servicesById";
 import { loadMessages } from "../../startup/watchLoadMessagesSaga";
-import { messagesStatusSelector } from "../../../store/reducers/entities/messages/messagesStatus";
 
 const testMessageId1 = "01BX9NSMKAAAS5PSP2FATZM6BQ";
 const testMessageId2 = "01CD4QN3Q2KS2T791PPMT2H9DM";

--- a/ts/sagas/startup/__tests__/watchLoadMessages.test.ts
+++ b/ts/sagas/startup/__tests__/watchLoadMessages.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../../../store/reducers/entities/messages/messagesById";
 import { servicesByIdSelector } from "../../../store/reducers/entities/services/servicesById";
 import { loadMessages } from "../../startup/watchLoadMessagesSaga";
+import { messagesStatusSelector } from "../../../store/reducers/entities/messages/messagesStatus";
 
 const testMessageId1 = "01BX9NSMKAAAS5PSP2FATZM6BQ";
 const testMessageId2 = "01CD4QN3Q2KS2T791PPMT2H9DM";
@@ -108,14 +109,10 @@ describe("watchLoadMessages", () => {
       const getService = jest.fn();
       testSaga(loadMessages, getMessages, getMessage, getService)
         .next()
-        .select(messagesAllIdsSelector)
-        // Return an empty pot array as messagesAllIdsSelector response
-        .next(pot.some([]))
         .call(getMessages, {})
         // Return an error message as getMessages response
         .next(right({ status: 500, value: { title: "Backend error" } }))
         .put(loadMessagesAction.failure(Error("Backend error")))
-        .next()
         .next()
         .next()
         .isDone();
@@ -127,14 +124,17 @@ describe("watchLoadMessages", () => {
       const getService = jest.fn();
       testSaga(loadMessages, getMessages, getMessage, getService)
         .next()
-        .select(messagesAllIdsSelector)
-        // Return an empty pot array as messagesAllIdsSelector response
-        .next(pot.some([]))
         .call(getMessages, {})
         // Return 200 with a list of 2 messages as getMessages response
         .next(right({ status: 200, value: testMessages }))
         .put(loadMessagesAction.success(testMessages.items.map(_ => _.id)))
         .next()
+        .select(messagesAllIdsSelector)
+        // Return an empty pot array as messagesAllIdsSelector response
+        .next(pot.some([]))
+        .select(messagesStatusSelector)
+        // Return an empty pot array as messagesAllIdsSelector response
+        .next({})
         .select(messagesStateByIdSelector)
         // Return an empty object as messagesByIdSelectors response (no message already stored)
         .next({})
@@ -155,14 +155,17 @@ describe("watchLoadMessages", () => {
       const getService = jest.fn();
       testSaga(loadMessages, getMessages, getMessage, getService)
         .next()
-        .select(messagesAllIdsSelector)
-        // Return an empty pot array as messagesAllIdsSelector response
-        .next(pot.some([]))
         .call(getMessages, {})
         // Return 200 with a list of 2 messages as getMessages response
         .next(right({ status: 200, value: testMessages }))
         .put(loadMessagesAction.success(testMessages.items.map(_ => _.id)))
         .next()
+        .select(messagesAllIdsSelector)
+        // Return an empty pot array as messagesAllIdsSelector response
+        .next(pot.some([]))
+        .select(messagesStatusSelector)
+        // Return an empty pot array as messagesAllIdsSelector response
+        .next({})
         .select(messagesStateByIdSelector)
         // Return an object as messagesByIdSelectors response
         .next({
@@ -183,14 +186,23 @@ describe("watchLoadMessages", () => {
       const getService = jest.fn();
       testSaga(loadMessages, getMessages, getMessage, getService)
         .next()
-        .select(messagesAllIdsSelector)
-        // Return an empty pot array as messagesAllIdsSelector response
-        .next(pot.some(cachedMessagesAllIds))
         .call(getMessages, {})
         // Return 200 with a list of 2 messages as getMessages response
         .next(right({ status: 200, value: testOneMessage }))
         .put(loadMessagesAction.success(testOneMessage.items.map(_ => _.id)))
         .next()
+        .select(messagesAllIdsSelector)
+        // Return an empty pot array as messagesAllIdsSelector response
+        .next(
+          pot.some(
+            cachedMessagesAllIds.filter(
+              id => testOneMessage.items.map(_ => _.id).indexOf(id) === -1
+            )
+          )
+        )
+        .select(messagesStatusSelector)
+        // Return an empty pot array as messagesAllIdsSelector response
+        .next({})
         .put(removeMessagesAction([testMessageMeta2.meta.id]))
         .next()
         .select(messagesStateByIdSelector)

--- a/ts/sagas/startup/watchLoadMessagesSaga.ts
+++ b/ts/sagas/startup/watchLoadMessagesSaga.ts
@@ -35,6 +35,7 @@ import { servicesByIdSelector } from "../../store/reducers/entities/services/ser
 import { GlobalState } from "../../store/reducers/types";
 import { SagaCallReturnType } from "../../types/utils";
 import { uniqueItem } from "../../utils/enumerables";
+import { messagesStatusSelector } from "../../store/reducers/entities/messages/messagesStatus";
 
 /**
  * A generator to load messages from the Backend.
@@ -48,12 +49,6 @@ export function* loadMessages(
   // We are using try...finally to manage task cancellation
   // @https://redux-saga.js.org/docs/advanced/TaskCancellation.html
   try {
-    // Load already cached messages ids from the store
-    const potCachedMessagesAllIds: ReturnType<
-      typeof messagesAllIdsSelector
-    > = yield select<GlobalState>(messagesAllIdsSelector);
-    const cachedMessagesAllIds = pot.getOrElse(potCachedMessagesAllIds, []);
-
     // Request the list of messages from the Backend
     const response: SagaCallReturnType<typeof getMessages> = yield call(
       getMessages,
@@ -82,11 +77,30 @@ export function* loadMessages(
 
         yield put(loadMessagesAction.success(responseItemsIds));
 
+        // Load already cached messages ids from the store
+        const potCachedMessagesAllIds: ReturnType<
+          typeof messagesAllIdsSelector
+        > = yield select<GlobalState>(messagesAllIdsSelector);
+        const cachedMessagesAllIds = pot.getOrElse(potCachedMessagesAllIds, []);
+
         // Calculate the ids of the message no more visible that we need
         // to remove from the cache.
-        const messagesIdsToRemoveFromCache = cachedMessagesAllIds.filter(
+        const messageIds = cachedMessagesAllIds.filter(
           _ => responseItemsIds.indexOf(_) < 0
         );
+
+        // Load already cached messages status ids from the store
+        const messagesStatusMapping: ReturnType<
+          typeof messagesStatusSelector
+        > = yield select<GlobalState>(messagesStatusSelector);
+        const messagesStatusIds = Object.keys(messagesStatusMapping).filter(
+          _ => responseItemsIds.indexOf(_) < 0
+        );
+
+        const messagesIdsToRemoveFromCache = Array.from(
+          new Set([...messageIds, ...messagesStatusIds])
+        );
+
         // Remove the details of the no more visible messages from the
         // redux store.
         if (messagesIdsToRemoveFromCache.length > 0) {

--- a/ts/sagas/startup/watchLoadMessagesSaga.ts
+++ b/ts/sagas/startup/watchLoadMessagesSaga.ts
@@ -31,11 +31,11 @@ import {
 import { loadServiceDetail } from "../../store/actions/services";
 import { messagesAllIdsSelector } from "../../store/reducers/entities/messages/messagesAllIds";
 import { messagesStateByIdSelector } from "../../store/reducers/entities/messages/messagesById";
+import { messagesStatusSelector } from "../../store/reducers/entities/messages/messagesStatus";
 import { servicesByIdSelector } from "../../store/reducers/entities/services/servicesById";
 import { GlobalState } from "../../store/reducers/types";
 import { SagaCallReturnType } from "../../types/utils";
 import { uniqueItem } from "../../utils/enumerables";
-import { messagesStatusSelector } from "../../store/reducers/entities/messages/messagesStatus";
 
 /**
  * A generator to load messages from the Backend.
@@ -97,6 +97,8 @@ export function* loadMessages(
           _ => responseItemsIds.indexOf(_) < 0
         );
 
+        // Calculate the ids of the message no more visible that we need
+        // to remove from the messagesStatus cache.
         const messagesIdsToRemoveFromCache = Array.from(
           new Set([...messageIds, ...messagesStatusIds])
         );

--- a/ts/store/reducers/entities/__tests__/messagesStatus.ts
+++ b/ts/store/reducers/entities/__tests__/messagesStatus.ts
@@ -1,0 +1,119 @@
+import { createStandardAction } from "typesafe-actions";
+import { CreatedMessageWithContent } from "../../../../../definitions/backend/CreatedMessageWithContent";
+import { FiscalCode } from "../../../../../definitions/backend/FiscalCode";
+import { MessageContent } from "../../../../../definitions/backend/MessageContent";
+import {
+  loadMessage,
+  removeMessages,
+  setMessageReadState,
+  setMessagesArchivedState
+} from "../../../actions/messages";
+import { Action } from "../../../actions/types";
+import reducer, {
+  EMPTY_MESSAGE_STATUS,
+  MessagesStatus
+} from "../messages/messagesStatus";
+
+export const dymmyAction = createStandardAction("DUMMY")();
+
+const messageWithContent = {
+  created_at: new Date(),
+  fiscal_code: "RSSMRA83A12H501D" as FiscalCode,
+  id: "93726BD8-D29C-48F2-AE6D-2F",
+  sender_service_id: "dev-service_0",
+  time_to_live: 3600,
+  content: {
+    subject: "Subject - test 1",
+    markdown: "markdown",
+    due_date: new Date(),
+    payment_data: {
+      notice_number: "012345678912345678",
+      amount: 406,
+      invalid_after_due_date: false
+    }
+  } as MessageContent
+} as CreatedMessageWithContent;
+
+describe("messagesStatus reducer", () => {
+  it("should return the initial state", () => {
+    expect(reducer(undefined, (dymmyAction as unknown) as Action)).toEqual({});
+  });
+
+  it("should return the loaded message with default value", () => {
+    [1, 2, 3].forEach(_ => {
+      // should return always the same state (cause the id is the same)
+      const state = reducer(undefined, loadMessage.success(messageWithContent));
+      expect(state).toEqual({ [messageWithContent.id]: EMPTY_MESSAGE_STATUS });
+      testLength(state, 1);
+    });
+  });
+
+  it("should return the loaded message with default value", () => {
+    const state = reducer(
+      { [messageWithContent.id]: EMPTY_MESSAGE_STATUS },
+      loadMessage.success({ ...messageWithContent, id: "NEW_ID" })
+    );
+    expect(state.NEW_ID).toEqual(EMPTY_MESSAGE_STATUS);
+    testLength(state, 2);
+  });
+
+  it("should return the loaded message with read state to true", () => {
+    expect(
+      reducer(undefined, setMessageReadState(messageWithContent.id, true))
+    ).toEqual({
+      [messageWithContent.id]: { ...EMPTY_MESSAGE_STATUS, isRead: true }
+    });
+  });
+
+  it("should return the loaded message with read state to false", () => {
+    expect(
+      reducer(undefined, setMessageReadState(messageWithContent.id, false))
+    ).toEqual({
+      [messageWithContent.id]: { ...EMPTY_MESSAGE_STATUS, isRead: false }
+    });
+  });
+
+  it("should return the loaded message with isArchived state to true", () => {
+    expect(
+      reducer(
+        undefined,
+        setMessagesArchivedState([messageWithContent.id], true)
+      )
+    ).toEqual({
+      [messageWithContent.id]: { ...EMPTY_MESSAGE_STATUS, isArchived: true }
+    });
+  });
+
+  it("should return the loaded message with isArchived state to false", () => {
+    expect(
+      reducer(
+        undefined,
+        setMessagesArchivedState([messageWithContent.id], false)
+      )
+    ).toEqual({
+      [messageWithContent.id]: { ...EMPTY_MESSAGE_STATUS, isArchived: false }
+    });
+  });
+
+  it("should return the state without the removed message", () => {
+    const state = reducer(
+      {
+        "1": EMPTY_MESSAGE_STATUS,
+        "2": EMPTY_MESSAGE_STATUS,
+        "3": EMPTY_MESSAGE_STATUS,
+        "4": EMPTY_MESSAGE_STATUS
+      },
+      setMessageReadState("4", true)
+    );
+    testLength(state, 4);
+    const stateAfterRemove = reducer(state, removeMessages(["1", "2", "3"]));
+    testLength(stateAfterRemove, 1);
+    expect(stateAfterRemove).toEqual({
+      4: { ...EMPTY_MESSAGE_STATUS, isRead: true }
+    });
+  });
+});
+
+const testLength = (state: MessagesStatus, expectedLength: number) => {
+  expect(Object.keys(state).length).toEqual(expectedLength);
+};

--- a/ts/store/reducers/entities/messages/messagesStatus.ts
+++ b/ts/store/reducers/entities/messages/messagesStatus.ts
@@ -83,8 +83,6 @@ const reducer = (
         }
         return { ...acc, [curr]: state[curr] };
       }, {});
-    case getType(clearCache):
-      return INITIAL_STATE;
     default:
       return state;
   }

--- a/ts/store/reducers/entities/messages/messagesStatus.ts
+++ b/ts/store/reducers/entities/messages/messagesStatus.ts
@@ -7,7 +7,6 @@ import {
   setMessageReadState,
   setMessagesArchivedState
 } from "../../../actions/messages";
-import { clearCache } from "../../../actions/profile";
 import { Action } from "../../../actions/types";
 import { GlobalState } from "../../types";
 

--- a/ts/store/reducers/entities/messages/messagesStatus.ts
+++ b/ts/store/reducers/entities/messages/messagesStatus.ts
@@ -3,6 +3,7 @@ import { createSelector } from "reselect";
 import { getType } from "typesafe-actions";
 import {
   loadMessage,
+  removeMessages,
   setMessageReadState,
   setMessagesArchivedState
 } from "../../../actions/messages";
@@ -59,21 +60,29 @@ const reducer = (
       const updatedMessageStates = ids.reduce<{
         [key: string]: MessageStatus;
       }>((accumulator, id) => {
-        const prevState = state[id];
-        if (prevState !== undefined) {
-          // tslint:disable-next-line:no-object-mutation
-          accumulator[id] = {
+        // if misses, set the default values for given message
+        const prevState = state[id] || EMPTY_MESSAGE_STATUS;
+        return {
+          ...accumulator,
+          [id]: {
             ...prevState,
             isArchived: archived
-          };
-        }
-        return accumulator;
+          }
+        };
       }, {});
       return {
         ...state,
         ...updatedMessageStates
       };
     }
+    case getType(removeMessages):
+      const idsToRemove = action.payload;
+      return Object.keys(state).reduce((acc, curr) => {
+        if (idsToRemove.indexOf(curr) !== -1) {
+          return acc;
+        }
+        return { ...acc, [curr]: state[curr] };
+      }, {});
     case getType(clearCache):
       return INITIAL_STATE;
     default:

--- a/ts/store/reducers/entities/messages/messagesStatus.ts
+++ b/ts/store/reducers/entities/messages/messagesStatus.ts
@@ -77,7 +77,7 @@ const reducer = (
     }
     case getType(removeMessages):
       const idsToRemove = action.payload;
-      return Object.keys(state).reduce((acc, curr) => {
+      return Object.keys(state).reduce((acc: MessagesStatus, curr: string) => {
         if (idsToRemove.indexOf(curr) !== -1) {
           return acc;
         }

--- a/ts/store/reducers/entities/messages/messagesStatus.ts
+++ b/ts/store/reducers/entities/messages/messagesStatus.ts
@@ -7,6 +7,7 @@ import {
   setMessageReadState,
   setMessagesArchivedState
 } from "../../../actions/messages";
+import { clearCache } from "../../../actions/profile";
 import { Action } from "../../../actions/types";
 import { GlobalState } from "../../types";
 
@@ -82,6 +83,8 @@ const reducer = (
         }
         return { ...acc, [curr]: state[curr] };
       }, {});
+    case getType(clearCache):
+      return INITIAL_STATE;
     default:
       return state;
   }

--- a/ts/store/reducers/entities/messages/messagesStatus.ts
+++ b/ts/store/reducers/entities/messages/messagesStatus.ts
@@ -77,12 +77,15 @@ const reducer = (
     }
     case getType(removeMessages):
       const idsToRemove = action.payload;
-      return Object.keys(state).reduce((acc: MessagesStatus, curr: string) => {
-        if (idsToRemove.indexOf(curr) !== -1) {
-          return acc;
-        }
-        return { ...acc, [curr]: state[curr] };
-      }, {});
+      return Object.keys(state).reduce<MessagesStatus>(
+        (acc: MessagesStatus, curr: string) => {
+          if (idsToRemove.indexOf(curr) !== -1) {
+            return acc;
+          }
+          return { ...acc, [curr]: state[curr] };
+        },
+        {} as MessagesStatus
+      );
     case getType(clearCache):
       return INITIAL_STATE;
     default:

--- a/ts/store/reducers/index.ts
+++ b/ts/store/reducers/index.ts
@@ -146,7 +146,8 @@ export function createRootReducer(
           (isActionOf(logoutFailure, action) &&
             !action.payload.options.keepUserData))
           ? ({
-              authentication: { _persist: state.authentication._persist }
+              authentication: { _persist: state.authentication._persist },
+              entities: { messagesStatus: state.entities.messagesStatus }
             } as GlobalState)
           : state;
     }


### PR DESCRIPTION
**Short description:**
This PR adds a little improvement on messagesStatus store section
By adding the handling of `removeMessages` action, the reducer can clean all entries that are no longer needed: i.e when the messagesStatus store contains a messageId (one or more) that is not present in the loaded messages (different user or message delete)

Starting from the cleaning, the messagesStatus won't be deleted on logout (explicit or implicit (session expired)) 