### PR TITLE
fix(ui): Don't use the arrows if there's no submenu.

### DIFF
--- a/ts/screens/profile/ProfileMainScreen.tsx
+++ b/ts/screens/profile/ProfileMainScreen.tsx
@@ -412,6 +412,7 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
               title={I18n.t("identification.unlockCode.reset.button_short")}
               subTitle={I18n.t("identification.unlockCode.reset.tip_short")}
               onPress={this.confirmResetAlert}
+              hideIcon={true}
             />
 
             {/* Logout/Exit */}
@@ -419,6 +420,7 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
               title={I18n.t("profile.main.logout")}
               subTitle={I18n.t("profile.logout.menulabel")}
               onPress={this.onLogoutPress}
+              hideIcon={true}
               isLastItem={true}
             />
 


### PR DESCRIPTION
Remove the arrows in ListComponents if the item leads to an immediate
action (ie. there's no submenu).

| Before  | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/788293/88934688-37fa8300-d281-11ea-8266-e9bd367eeb18.png )  | ![after](https://user-images.githubusercontent.com/788293/88934729-447edb80-d281-11ea-8f16-5d47cb51ba66.png)  |