### PR TITLE
[#174099632] Fix the back handler from transaction detail to cards transactions

### DIFF
--- a/ts/screens/wallet/TransactionDetailsScreen.tsx
+++ b/ts/screens/wallet/TransactionDetailsScreen.tsx
@@ -30,7 +30,6 @@ import { formatDateAsLocal } from "../../utils/dates";
 import { whereAmIFrom } from "../../utils/navigation";
 import { cleanTransactionDescription } from "../../utils/payment";
 import { formatNumberCentsToAmount } from "../../utils/stringBuilder";
-import { RTron } from "../../boot/configureStoreAndPersistor";
 
 type NavigationParams = Readonly<{
   isPaymentCompletedTransaction: boolean;

--- a/ts/screens/wallet/TransactionDetailsScreen.tsx
+++ b/ts/screens/wallet/TransactionDetailsScreen.tsx
@@ -30,6 +30,7 @@ import { formatDateAsLocal } from "../../utils/dates";
 import { whereAmIFrom } from "../../utils/navigation";
 import { cleanTransactionDescription } from "../../utils/payment";
 import { formatNumberCentsToAmount } from "../../utils/stringBuilder";
+import { RTron } from "../../boot/configureStoreAndPersistor";
 
 type NavigationParams = Readonly<{
   isPaymentCompletedTransaction: boolean;
@@ -100,7 +101,12 @@ class TransactionDetailsScreen extends React.Component<Props> {
   }
 
   private handleBackPress = () => {
-    if (whereAmIFrom(this.props.nav).fold(false, r => r === "WALLET_HOME")) {
+    if (
+      whereAmIFrom(this.props.nav).fold(
+        false,
+        r => r === "WALLET_HOME" || r === "WALLET_CARD_TRANSACTION"
+      )
+    ) {
       return this.props.navigation.goBack();
     } else {
       this.props.navigateBackToEntrypointPayment();


### PR DESCRIPTION
**Short description:**
This PR Fixes the not working go back from transaction details' screen to the transactions list of a card

**List of changes proposed in this pull request:**
- ts/screens/wallet/TransactionDetailsScreen.tsx

<img src="https://user-images.githubusercontent.com/3959405/89036552-2bd3fb80-d33d-11ea-9e72-4a27dee863dd.gif" height="550" />
