### PR TITLE
[#174119099] Display app version

### DIFF
--- a/ts/utils/__tests__/appVersion.test.ts
+++ b/ts/utils/__tests__/appVersion.test.ts
@@ -8,7 +8,7 @@ jest.mock("react-native-device-info", () => {
     .mockReturnValueOnce("1.2.3.4");
   return {
     getReadableVersion: appVersionMock,
-    getAppVersion: appVersionMock,
+    getVersion: appVersionMock,
     getBuildNumber: () => 3
   };
 });

--- a/ts/utils/__tests__/appVersion.test.ts
+++ b/ts/utils/__tests__/appVersion.test.ts
@@ -1,14 +1,17 @@
 import { Tuple3 } from "italia-ts-commons/lib/tuples";
 
 jest.mock("react-native-device-info", () => {
-  const appVersionMock = jest
-    .fn()
-    .mockReturnValueOnce("1.1.3")
-    .mockReturnValueOnce("1.1.9")
-    .mockReturnValueOnce("1.2.3.4");
   return {
-    getReadableVersion: appVersionMock,
-    getVersion: appVersionMock,
+    getReadableVersion: jest
+      .fn()
+      .mockReturnValueOnce("1.1.3")
+      .mockReturnValueOnce("1.1.9")
+      .mockReturnValueOnce("1.2.3.4"),
+    getVersion: jest
+      .fn()
+      .mockReturnValueOnce("1.1.3")
+      .mockReturnValueOnce("1.1.9")
+      .mockReturnValueOnce("1.2.3.4"),
     getBuildNumber: () => 3
   };
 });

--- a/ts/utils/__tests__/appVersion.test.ts
+++ b/ts/utils/__tests__/appVersion.test.ts
@@ -1,12 +1,14 @@
 import { Tuple3 } from "italia-ts-commons/lib/tuples";
 
+const appVersionMock = jest
+  .fn()
+  .mockReturnValueOnce("1.1.3")
+  .mockReturnValueOnce("1.1.9")
+  .mockReturnValueOnce("1.2.3.4");
 jest.mock("react-native-device-info", () => {
   return {
-    getReadableVersion: jest
-      .fn()
-      .mockReturnValueOnce("1.1.3")
-      .mockReturnValueOnce("1.1.9")
-      .mockReturnValueOnce("1.2.3.4"),
+    getReadableVersion: appVersionMock,
+    getAppVersion: appVersionMock,
     getBuildNumber: () => 3
   };
 });

--- a/ts/utils/__tests__/appVersion.test.ts
+++ b/ts/utils/__tests__/appVersion.test.ts
@@ -1,11 +1,11 @@
 import { Tuple3 } from "italia-ts-commons/lib/tuples";
 
-const appVersionMock = jest
-  .fn()
-  .mockReturnValueOnce("1.1.3")
-  .mockReturnValueOnce("1.1.9")
-  .mockReturnValueOnce("1.2.3.4");
 jest.mock("react-native-device-info", () => {
+  const appVersionMock = jest
+    .fn()
+    .mockReturnValueOnce("1.1.3")
+    .mockReturnValueOnce("1.1.9")
+    .mockReturnValueOnce("1.2.3.4");
   return {
     getReadableVersion: appVersionMock,
     getAppVersion: appVersionMock,

--- a/ts/utils/appVersion.ts
+++ b/ts/utils/appVersion.ts
@@ -48,7 +48,11 @@ export const isVersionAppSupported = (
   return semSatisfies;
 };
 
-export const getAppVersion = () => DeviceInfo.getReadableVersion();
+export const getAppVersion = () =>
+  Platform.select({
+    ios: DeviceInfo.getReadableVersion(),
+    default: DeviceInfo.getVersion()
+  });
 
 /**
  * return true if the app must be updated


### PR DESCRIPTION
**Short description:**
This PR fixes a wrong representation of app version in Android OS
1.4.0.2 is displayed as 1.4.0.2.3 (3 is the build number)

This fix includes:

- ios family: version within the build number
- andorid family: version without the build number