### PR TITLE
feat: [#173735284] Display support_url metadata

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1061,6 +1061,7 @@ services:
   contactsAndInfo: Contacts and info
   contactAddress: Address
   contactPhone: Phone
+  contactSupport: Support
   areasOfInterest:
     selectMessage: Choose the geographical areas (municipalities, regions, etc.) where you reside or that you usually visit to see the relative services here. You can change them at any time.
     selectMessageEmptyOrgs: At the moment it is not possible to add a location. Please pull down to refresh the data and try again.

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1093,6 +1093,7 @@ services:
   contactsAndInfo: Contatti ed informazioni
   contactAddress: Indirizzo
   contactPhone: Telefono
+  contactSupport: Assistenza
   areasOfInterest:
     selectMessage: Scegli le aree geografiche (comuni, regioni, etc.) dove risiedi o che frequenti solitamente per vederne qui i relativi servizi. Potrai modificarle in ogni momento.
     selectMessageEmptyOrgs: Al momento non è possibile aggiungere una località. Per favore trascina in basso per aggiornare i dati e riprova a selezionare un'area.

--- a/ts/screens/services/ServiceDetailsScreen.tsx
+++ b/ts/screens/services/ServiceDetailsScreen.tsx
@@ -53,7 +53,7 @@ import {
 } from "../../utils/profile";
 import { showToast } from "../../utils/showToast";
 import { capitalize, maybeNotNullyString } from "../../utils/strings";
-import { handleItemOnPress } from "../../utils/url";
+import { handleItemOnPress, ItemAction } from "../../utils/url";
 
 type NavigationParams = Readonly<{
   service: ServicePublic;
@@ -120,7 +120,7 @@ function renderInformationRow(
   label: string,
   info: string,
   value: string,
-  valueType?: "MAP" | "COPY" | "LINK"
+  valueType?: ItemAction
 ) {
   return (
     <View style={styles.infoItem}>
@@ -142,7 +142,7 @@ const renderRowWithDefinedValue = (
   data: string | undefined,
   header: string,
   linkingPrefix?: string,
-  valueType?: "MAP" | "COPY" | "LINK"
+  valueType?: ItemAction
 ) =>
   maybeNotNullyString(data).fold(undefined, value =>
     renderInformationRow(

--- a/ts/screens/services/ServiceDetailsScreen.tsx
+++ b/ts/screens/services/ServiceDetailsScreen.tsx
@@ -138,7 +138,7 @@ function renderInformationRow(
   );
 }
 
-const renderIfDefinedAndNotEmpty = (
+const renderRowWithDefinedValue = (
   data: string | undefined,
   header: string,
   linkingPrefix?: string,
@@ -381,24 +381,24 @@ class ServiceDetailsScreen extends React.Component<Props, State> {
       const metadata = potServiceMetadata.value;
       return (
         <React.Fragment>
-          {renderIfDefinedAndNotEmpty(
+          {renderRowWithDefinedValue(
             metadata.address,
             I18n.t("services.contactAddress"),
             undefined,
             "MAP"
           )}
-          {renderIfDefinedAndNotEmpty(
+          {renderRowWithDefinedValue(
             metadata.support_url,
             I18n.t("services.contactSupport")
           )}
-          {renderIfDefinedAndNotEmpty(
+          {renderRowWithDefinedValue(
             metadata.phone,
             I18n.t("services.contactPhone"),
             "tel:"
           )}
-          {renderIfDefinedAndNotEmpty(metadata.email, "Email", "mailto:")}
-          {renderIfDefinedAndNotEmpty(metadata.pec, "PEC", "mailto:")}
-          {renderIfDefinedAndNotEmpty(metadata.web_url, "Web")}
+          {renderRowWithDefinedValue(metadata.email, "Email", "mailto:")}
+          {renderRowWithDefinedValue(metadata.pec, "PEC", "mailto:")}
+          {renderRowWithDefinedValue(metadata.web_url, "Web")}
         </React.Fragment>
       );
     }

--- a/ts/screens/services/ServiceDetailsScreen.tsx
+++ b/ts/screens/services/ServiceDetailsScreen.tsx
@@ -148,7 +148,7 @@ const renderRowWithDefinedValue = (
     renderInformationRow(
       header,
       value,
-      `${fromNullable(linkingPrefix).getOrElse("")}${value}`,
+      `${linkingPrefix || ""}${value}`,
       valueType
     )
   );

--- a/ts/screens/services/ServiceDetailsScreen.tsx
+++ b/ts/screens/services/ServiceDetailsScreen.tsx
@@ -52,7 +52,7 @@ import {
   getEnabledChannelsForService
 } from "../../utils/profile";
 import { showToast } from "../../utils/showToast";
-import { capitalize } from "../../utils/strings";
+import { capitalize, maybeNotNullyString } from "../../utils/strings";
 import { handleItemOnPress } from "../../utils/url";
 
 type NavigationParams = Readonly<{
@@ -137,6 +137,21 @@ function renderInformationRow(
     </View>
   );
 }
+
+const renderIfDefinedAndNotEmpty = (
+  data: string | undefined,
+  header: string,
+  linkingPrefix?: string,
+  valueType?: "MAP" | "COPY" | "LINK"
+) =>
+  maybeNotNullyString(data).fold(undefined, value =>
+    renderInformationRow(
+      header,
+      value,
+      `${fromNullable(linkingPrefix).getOrElse("")}${value}`,
+      valueType
+    )
+  );
 
 // Renders a row in the service information panel as a link
 function renderInformationLinkRow(
@@ -366,29 +381,24 @@ class ServiceDetailsScreen extends React.Component<Props, State> {
       const metadata = potServiceMetadata.value;
       return (
         <React.Fragment>
-          {metadata.address &&
-            renderInformationRow(
-              I18n.t("services.contactAddress"),
-              metadata.address,
-              metadata.address,
-              "MAP"
-            )}
-          {metadata.phone &&
-            renderInformationRow(
-              I18n.t("services.contactPhone"),
-              metadata.phone,
-              `tel:${metadata.phone}`
-            )}
-          {metadata.email &&
-            renderInformationRow(
-              "Email",
-              metadata.email,
-              `mailto:${metadata.email}`
-            )}
-          {metadata.pec &&
-            renderInformationRow("PEC", metadata.pec, `mailto:${metadata.pec}`)}
-          {metadata.web_url &&
-            renderInformationRow("Web", metadata.web_url, metadata.web_url)}
+          {renderIfDefinedAndNotEmpty(
+            metadata.address,
+            I18n.t("services.contactAddress"),
+            undefined,
+            "MAP"
+          )}
+          {renderIfDefinedAndNotEmpty(
+            metadata.support_url,
+            I18n.t("services.contactSupport")
+          )}
+          {renderIfDefinedAndNotEmpty(
+            metadata.phone,
+            I18n.t("services.contactPhone"),
+            "tel:"
+          )}
+          {renderIfDefinedAndNotEmpty(metadata.email, "Email", "mailto:")}
+          {renderIfDefinedAndNotEmpty(metadata.pec, "PEC", "mailto:")}
+          {renderIfDefinedAndNotEmpty(metadata.web_url, "Web")}
         </React.Fragment>
       );
     }

--- a/ts/utils/openMaps.ts
+++ b/ts/utils/openMaps.ts
@@ -1,6 +1,6 @@
-import { Platform } from "react-native";
-import { openLink } from "../components/ui/Markdown/handlers/link";
+import { Linking, Platform } from "react-native";
 import I18n from "../i18n";
+import { showToast } from "./showToast";
 
 export function openMaps(
   streetName: string,
@@ -24,6 +24,8 @@ export function openMaps(
         });
 
   if (url !== undefined) {
-    openLink(url, I18n.t("openMaps.genericError"));
+    Linking.openURL(url).catch(() =>
+      showToast(I18n.t("openMaps.genericError"))
+    );
   }
 }

--- a/ts/utils/url.ts
+++ b/ts/utils/url.ts
@@ -42,16 +42,16 @@ export const getUrlBasepath = (url: string): string => {
   )(url);
 };
 
+export type ItemAction = "MAP" | "COPY" | "LINK";
 /**
  * Return the function to:
  * - copy the value, if valueType is COPY
  * - navigate to the map, if valueType is MAP
  * - navigate to a browser, if valueType is LINK
  */
-
 export function handleItemOnPress(
   value: string,
-  valueType?: "MAP" | "COPY" | "LINK"
+  valueType?: ItemAction
 ): () => void {
   switch (valueType) {
     case "MAP":


### PR DESCRIPTION
**This PR depends on** https://github.com/pagopa/io-services-metadata/pull/134

**Short description:**
Now `support_url` service metadata is displayed in _ServiceDetailScreen_

This PR also does some refactoring and bug fixing:

- added a warp function `renderRowWithDefinedValue` to avoid crashes due to empty strings ("")
- fix `openMap` function that tries to open a weburl