### PR TITLE
fix: [#174294652] Fix calendar display name on preferences screen

### DIFF
--- a/ts/screens/profile/PreferencesScreen.tsx
+++ b/ts/screens/profile/PreferencesScreen.tsx
@@ -46,7 +46,10 @@ import {
 } from "../../store/reducers/profile";
 import { GlobalState } from "../../store/reducers/types";
 import { openAppSettings } from "../../utils/appSettings";
-import { checkAndRequestPermission } from "../../utils/calendar";
+import {
+  checkAndRequestPermission,
+  convertLocalCalendarName
+} from "../../utils/calendar";
 import {
   getLocalePrimary,
   getLocalePrimaryWithFallback
@@ -219,7 +222,7 @@ class PreferencesScreen extends React.Component<Props, State> {
               )}
               subTitle={
                 this.props.preferredCalendar
-                  ? this.props.preferredCalendar.title
+                  ? convertLocalCalendarName(this.props.preferredCalendar.title)
                   : I18n.t(
                       "profile.preferences.list.preferred_calendar.not_selected"
                     )


### PR DESCRIPTION
**Short description:**
This fixes the display name of the local calendar on some devices like Xiaomi phones.