### PR TITLE
fix: [#174317167] Hide no pagopa network label if user choose to navigate to pick psp screen

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -694,7 +694,7 @@ wallet:
     title: Choose the manager
     info: This card does not belong to the pagoPA payment network.
     infoBold: Choose the economic operator
-    info2: (PSP) which will have to manage yout payment.
+    info2: (PSP) which will have to manage your payment.
     link: Find out more
     maxFee: Maximum fee
     onUpdateWalletPspFailure: Operation failed, please retry

--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -317,7 +317,8 @@ const mapDispatchToProps = (dispatch: Dispatch, props: OwnProps) => {
           verifica: props.navigation.getParam("verifica"),
           idPayment: props.navigation.getParam("idPayment"),
           psps: props.navigation.getParam("psps"),
-          wallet: props.navigation.getParam("wallet")
+          wallet: props.navigation.getParam("wallet"),
+          chooseToChange: true
         })
       ),
     onCancel: () => {

--- a/ts/screens/wallet/payment/PickPspScreen.tsx
+++ b/ts/screens/wallet/payment/PickPspScreen.tsx
@@ -37,6 +37,7 @@ type NavigationParams = Readonly<{
   idPayment: string;
   psps: ReadonlyArray<Psp>;
   wallet: Wallet;
+  chooseToChange?: boolean;
 }>;
 
 type OwnProps = NavigationInjectedProps<NavigationParams>;
@@ -143,7 +144,8 @@ class PickPspScreen extends React.Component<Props> {
           <View spacer={true} />
           <View style={styles.padded}>
             <Text>
-              {`${I18n.t("wallet.pickPsp.info")} `}
+              {!this.props.navigation.getParam("chooseToChange") &&
+                `${I18n.t("wallet.pickPsp.info")} `}
               <Text bold={true}>{`${I18n.t("wallet.pickPsp.infoBold")} `}</Text>
               <Text>{`${I18n.t("wallet.pickPsp.info2")} `}</Text>
             </Text>


### PR DESCRIPTION
**Short description:**
This PR adds a logic to hide the _This card does not belong to the pagoPA payment network._ label on `PickPspScreen` if the user choose to navigate to the screen.

**How to test:**
Run the app on pagoPa test environment, start a payment and navigate to change PSP chosen

<img height="550" src="https://user-images.githubusercontent.com/3959405/91418229-2b525600-e852-11ea-8959-94b7d0cb13de.png"/>