### PR TITLE
fix(Payments): [#174646257] Display notice in place of IUV

### DIFF
--- a/ios/fastlane/README.md
+++ b/ios/fastlane/README.md
@@ -12,7 +12,7 @@ Install _fastlane_ using
 ```
 [sudo] gem install fastlane -NV
 ```
-or alternatively using `brew install fastlane`
+or alternatively using `brew cask install fastlane`
 
 # Available Actions
 ## iOS

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -590,7 +590,7 @@ payment:
   noPsp: You have yet to select a PSP
   changePsp: Change PSP
   IUV: IUV
-  IUV_extended: Identificativo Univoco di Versamento (IUV)
+  IUV_extended: Identificativo Univoco di Versamento
   notice: Notice
   noticeCode: Notice code
   recipientFiscalCode: Recipient fiscal code

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -590,6 +590,7 @@ payment:
   noPsp: You have yet to select a PSP
   changePsp: Change PSP
   IUV: IUV
+  IUV_extended: Identificativo Univoco di Versamento (IUV)
   notice: Notice
   noticeCode: Notice code
   recipientFiscalCode: Recipient fiscal code

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -611,7 +611,7 @@ payment:
   noPsp: Non hai ancora selezionato un PSP
   changePsp: Cambia PSP
   IUV: IUV
-  IUV_extended: Identificativo Univoco di Versamento (IUV)
+  IUV_extended: Identificativo Univoco di Versamento
   notice: Avviso
   noticeCode: Codice avviso
   recipientFiscalCode: Codice fiscale beneficiario

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -611,6 +611,7 @@ payment:
   noPsp: Non hai ancora selezionato un PSP
   changePsp: Cambia PSP
   IUV: IUV
+  IUV_extended: Identificativo Univoco di Versamento (IUV)
   notice: Avviso
   noticeCode: Codice avviso
   recipientFiscalCode: Codice fiscale beneficiario

--- a/ts/screens/wallet/TransactionDetailsScreen.tsx
+++ b/ts/screens/wallet/TransactionDetailsScreen.tsx
@@ -36,8 +36,8 @@ import { formatDateAsLocal } from "../../utils/dates";
 import { whereAmIFrom } from "../../utils/navigation";
 import {
   cleanTransactionDescription,
-  getTransactionCodiceAvviso,
-  getTransactionFee
+  getTransactionFee,
+  getTransactionIUV
 } from "../../utils/payment";
 import { formatNumberCentsToAmount } from "../../utils/stringBuilder";
 
@@ -173,14 +173,12 @@ class TransactionDetailsScreen extends React.Component<Props, State> {
       transactionWallet.creditCard &&
       transactionWallet.creditCard.brand;
 
-    const codiceAvviso = getTransactionCodiceAvviso(
-      transaction.description
-    ).toUndefined();
+    const iuv = getTransactionIUV(transaction.description).toUndefined();
 
     const idTransaction = transaction.id;
     return {
       fullReason: transaction.description,
-      codiceAvviso,
+      iuv,
       idTransaction,
       paymentMethodBrand,
       paymentMethodIcon,
@@ -236,8 +234,7 @@ class TransactionDetailsScreen extends React.Component<Props, State> {
             </Text>
           )}
           <View spacer={true} large={true} />
-          {data.codiceAvviso &&
-            standardRow(I18n.t("payment.noticeCode"), data.codiceAvviso)}
+          {data.iuv && standardRow(I18n.t("payment.IUV"), data.iuv)}
           {/** transaction date */}
           <View spacer={true} xsmall={true} />
           <View spacer={true} large={true} />

--- a/ts/utils/__tests__/payment.test.ts
+++ b/ts/utils/__tests__/payment.test.ts
@@ -90,7 +90,9 @@ describe("cleanTransactionDescription", () => {
       ],
       [
         "/RFB/000001234556859/143.00",
-        `${I18n.t("payment.IUV_extended")} 000001234556859`
+        `${I18n.t("payment.IUV_extended")} (${I18n.t(
+          "payment.IUV"
+        )}) 000001234556859`
       ],
       ["/XYZ/TXT/some text", "some text"],
       ["/TXT/some text", "some text"],

--- a/ts/utils/__tests__/payment.test.ts
+++ b/ts/utils/__tests__/payment.test.ts
@@ -10,14 +10,15 @@ import { PaymentNoticeNumber } from "../../../definitions/backend/PaymentNoticeN
 import { Transaction } from "../../types/pagopa";
 import {
   cleanTransactionDescription,
-  getTransactionCodiceAvviso,
-  getTransactionFee
+  getTransactionFee,
+  getTransactionIUV
 } from "../payment";
 import {
   decodePagoPaQrCode,
   getAmountFromPaymentAmount,
   getRptIdFromNoticeNumber
 } from "../payment";
+import I18n from "react-native-i18n";
 
 describe("getAmountFromPaymentAmount", () => {
   const aPaymentAmount = PaymentAmount.decode(1).value as PaymentAmount;
@@ -87,7 +88,10 @@ describe("cleanTransactionDescription", () => {
         "/RFS/0123456789012/666.98/TXT/ actual description/other text",
         "actual description"
       ],
-      ["/RFB/000001234556859/143.00", "Notice n. 000001234556859"],
+      [
+        "/RFB/000001234556859/143.00",
+        `${I18n.t("payment.IUV_extended")} 000001234556859`
+      ],
       ["/XYZ/TXT/some text", "some text"],
       ["/TXT/some text", "some text"],
       ["TXT/some text", "some text"],
@@ -189,7 +193,7 @@ describe("getTransactionFee", () => {
   });
 });
 
-describe("getTransactionCodiceAvviso", () => {
+describe("getTransactionIUV", () => {
   [
     Tuple2(
       "/RFB/02000000000495213/0.01/TXT/TRANSACTION DESCRIPTION",
@@ -207,10 +211,18 @@ describe("getTransactionCodiceAvviso", () => {
       "RFA/02000000000495213/0.01/TXT/TRANSACTION DESCRIPTION",
       some("02000000000495213")
     ),
+    Tuple2(
+      "/RFS/02000000000495213/0.01/TXT/TRANSACTION DESCRIPTION",
+      some("02000000000495213")
+    ),
+    Tuple2(
+      "RFS/02000000000495213/0.01/TXT/TRANSACTION DESCRIPTION",
+      some("02000000000495213")
+    ),
     Tuple2("", none),
     Tuple2("RFC/02000000000495213/0.01/TXT/TRANSACTION DESCRIPTION", none),
     Tuple2("RFB/", none)
   ].forEach(tuple => {
-    expect(getTransactionCodiceAvviso(tuple.e1)).toEqual(tuple.e2);
+    expect(getTransactionIUV(tuple.e1)).toEqual(tuple.e2);
   });
 });

--- a/ts/utils/payment.ts
+++ b/ts/utils/payment.ts
@@ -129,9 +129,9 @@ export const cleanTransactionDescription = (description: string): string => {
 
   return descriptionParts.length > 1
     ? descriptionParts[descriptionParts.length - 1].split("/")[0].trim()
-    : getTransactionCodiceAvviso(description) // try to extract codice avviso from description
+    : getTransactionIUV(description) // try to extract codice avviso from description
         .chain(maybeNotNullyString)
-        .map(ca => `${I18n.t("payment.notice")} n. ${ca}`)
+        .map(ca => `${I18n.t("payment.IUV_extended")} ${ca}`)
         .getOrElse(description);
 };
 
@@ -210,7 +210,7 @@ export const getTransactionFee = (
 };
 
 // try to extract codice avviso from transaction description
-export const getTransactionCodiceAvviso = (
+export const getTransactionIUV = (
   transactionDescription: string
 ): Option<string> => {
   const description = transactionDescription.trim();

--- a/ts/utils/payment.ts
+++ b/ts/utils/payment.ts
@@ -131,7 +131,10 @@ export const cleanTransactionDescription = (description: string): string => {
     ? descriptionParts[descriptionParts.length - 1].split("/")[0].trim()
     : getTransactionIUV(description) // try to extract codice avviso from description
         .chain(maybeNotNullyString)
-        .map(ca => `${I18n.t("payment.IUV_extended")} ${ca}`)
+        .map(
+          ca =>
+            `${I18n.t("payment.IUV_extended")} (${I18n.t("payment.IUV")}) ${ca}`
+        )
         .getOrElse(description);
 };
 
@@ -209,7 +212,8 @@ export const getTransactionFee = (
   return fromNullable(maybeFee).map(formatFunc).toNullable();
 };
 
-// try to extract codice avviso from transaction description
+// try to extract IUV from transaction description
+// see https://docs.italia.it/italia/pagopa/pagopa-codici-docs/it/stabile/_docs/Capitolo3.html
 export const getTransactionIUV = (
   transactionDescription: string
 ): Option<string> => {


### PR DESCRIPTION
## Short description
Displaying second section extracted from transaction description as notice [is an error ](https://docs.italia.it/italia/pagopa/pagopa-codici-docs/it/stabile/_docs/Capitolo3.html)

Now `Identificativo Univoco di Versamento (IUV)` will be shown in replacement

