### PR TITLE
feat(Bonus Vacanze): [#174693564] Remove footer when bonus is not active

### DIFF
--- a/ts/features/bonusVacanze/screens/ActiveBonusScreen.tsx
+++ b/ts/features/bonusVacanze/screens/ActiveBonusScreen.tsx
@@ -67,7 +67,6 @@ import {
 } from "../utils/bonus";
 import { Label } from "../../../components/core/typography/Label";
 import { IOColors } from "../../../components/core/variables/IOColors";
-import BlockButtons from "../../../components/ui/BlockButtons";
 import { ActivateBonusDiscrepancies } from "./activation/request/ActivateBonusDiscrepancies";
 
 type QRCodeContents = {
@@ -450,21 +449,7 @@ const ActiveBonusScreen: React.FunctionComponent<Props> = (props: Props) => {
   );
 
   const renderFooterButtons = () =>
-    bonus && isBonusActive(bonus) ? (
-      renderBonusActiveButtons()
-    ) : (
-      <>
-        <BlockButtons
-          type="SingleButton"
-          leftButton={{
-            bordered: true,
-            title: I18n.t("global.buttons.cancel"),
-            onPress: props.goBack
-          }}
-        />
-        <View spacer={true} />
-      </>
-    );
+    bonus && isBonusActive(bonus) ? renderBonusActiveButtons() : undefined;
 
   const renderInformationBlock = (
     icon: string,

--- a/ts/features/bonusVacanze/screens/ActiveBonusScreen.tsx
+++ b/ts/features/bonusVacanze/screens/ActiveBonusScreen.tsx
@@ -449,7 +449,7 @@ const ActiveBonusScreen: React.FunctionComponent<Props> = (props: Props) => {
   );
 
   const renderFooterButtons = () =>
-    bonus && isBonusActive(bonus) ? renderBonusActiveButtons() : undefined;
+    bonus && isBonusActive(bonus) && renderBonusActiveButtons();
 
   const renderInformationBlock = (
     icon: string,


### PR DESCRIPTION
## Short description
If the bonus is not active (redeemed, failed) then the footer won't be shown

| before  | now |
| ------------- | ------------- |
![before](https://user-images.githubusercontent.com/822471/92392888-43ae5480-f11f-11ea-9fec-12659074c017.png) | ![now](https://user-images.githubusercontent.com/822471/92392916-5163da00-f11f-11ea-893b-112939f18667.png)




