### PR TITLE
feat: [#173190756] Update profile on language selection

### DIFF
--- a/ts/screens/profile/LanguagesPreferencesScreen.tsx
+++ b/ts/screens/profile/LanguagesPreferencesScreen.tsx
@@ -3,6 +3,7 @@ import * as pot from "italia-ts-commons/lib/pot";
 import * as React from "react";
 import { Alert } from "react-native";
 import { connect } from "react-redux";
+import { fromNullable } from "fp-ts/lib/Option";
 import { Locales, TranslationKeys } from "../../../locales/locales";
 import { withLightModalContext } from "../../components/helpers/withLightModalContext";
 import { ContextualHelpPropsMarkdown } from "../../components/screens/BaseScreenComponent";
@@ -23,7 +24,6 @@ import {
 import { profileUpsert } from "../../store/actions/profile";
 import { withLoadingSpinner } from "../../components/helpers/withLoadingSpinner";
 import { profileSelector } from "../../store/reducers/profile";
-import { fromNullable } from "fp-ts/lib/Option";
 import { showToast } from "../../utils/showToast";
 
 type Props = LightModalContextInterface &

--- a/ts/store/actions/profile.ts
+++ b/ts/store/actions/profile.ts
@@ -27,7 +27,7 @@ export const profileLoadFailure = createAction(
   resolve => (error: Error) => resolve(error, { error: true })
 );
 
-type ProfileUpsertPayload = Partial<Omit<ExtendedProfile, "version">>;
+type ProfileUpsertPayload = Partial<Omit<InitializedProfile, "version">>;
 
 export const profileUpsert = createAsyncAction(
   "PROFILE_UPSERT_REQUEST",

--- a/ts/store/actions/profile.ts
+++ b/ts/store/actions/profile.ts
@@ -10,7 +10,6 @@ import {
   createAsyncAction,
   createStandardAction
 } from "typesafe-actions";
-import { ExtendedProfile } from "../../../definitions/backend/ExtendedProfile";
 import { InitializedProfile } from "../../../definitions/backend/InitializedProfile";
 
 export const resetProfileState = createStandardAction("RESET_PROFILE_STATE")();

--- a/ts/utils/locale.ts
+++ b/ts/utils/locale.ts
@@ -39,6 +39,8 @@ const localePreferredLanguageMapping = new Map<Locales, PreferredLanguageEnum>([
   ["it", PreferredLanguageEnum.it_IT],
   ["en", PreferredLanguageEnum.en_GB]
 ]);
+
+// from a given Locales return the relative PreferredLanguageEnum (fallback is en_GB)
 export const fromLocaleToPreferredLanguage = (
   locale: Locales
 ): PreferredLanguageEnum =>

--- a/ts/utils/locale.ts
+++ b/ts/utils/locale.ts
@@ -1,6 +1,7 @@
-import { Option, some } from "fp-ts/lib/Option";
+import { fromNullable, Option, some } from "fp-ts/lib/Option";
 import { Locales } from "../../locales/locales";
 import I18n, { translations } from "../i18n";
+import { PreferredLanguageEnum } from "../../definitions/backend/PreferredLanguage";
 /**
  * Helpers for handling locales
  */
@@ -33,3 +34,14 @@ export const getLocalePrimaryWithFallback = (fallback: Locales = "en") =>
     .filter(l => translations.some(t => t.toLowerCase() === l.toLowerCase()))
     .map(s => s as Locales)
     .getOrElse(fallback);
+
+const localePreferredLanguageMapping = new Map<Locales, PreferredLanguageEnum>([
+  ["it", PreferredLanguageEnum.it_IT],
+  ["en", PreferredLanguageEnum.en_GB]
+]);
+export const fromLocaleToPreferredLanguage = (
+  locale: Locales
+): PreferredLanguageEnum =>
+  fromNullable(localePreferredLanguageMapping.get(locale)).getOrElse(
+    PreferredLanguageEnum.en_GB
+  );


### PR DESCRIPTION
## Short description
This PR update the user's profile when he/she selects the language which he wants use.

this is the flow how looks like now:

- pick a language
- update the profile and show loading
- check when the update finishes
- if update went well show a modal to inform the app should be restarted
- if update went wrong show a toast with an error message
