### PR TITLE
chore: [#174841069] Add scope for some project epic labels

### DIFF
--- a/scripts/changelog/ts/__mocks__/storyMock.ts
+++ b/scripts/changelog/ts/__mocks__/storyMock.ts
@@ -32,6 +32,11 @@ export const scopeLabelAndroid: Label = {
   name: "changelog-scope:android"
 };
 
+export const scopeLabelEpicBpd: Label = {
+  ...baseLabel,
+  name: "epic-bpd"
+};
+
 export const scopeLabelNotAllowed: Label = {
   ...baseLabel,
   name: "changelog-scope:not-allowed"
@@ -55,6 +60,11 @@ export const bonusVacanzeStoryWithScopeLabel: Story = {
 export const singleAndroidLabelStory: Story = {
   ...baseStory,
   labels: [scopeLabelAndroid]
+};
+
+export const singleEpicBpdStory: Story = {
+  ...baseStory,
+  labels: [scopeLabelEpicBpd]
 };
 
 export const androidLabelAndOtherStory: Story = {

--- a/scripts/changelog/ts/__tests__/changelog.test.ts
+++ b/scripts/changelog/ts/__tests__/changelog.test.ts
@@ -7,7 +7,8 @@ import {
   bonusVacanzeStoryWithScopeLabel,
   clashScopeLabelStory,
   scopeLabelNotAllowedStory,
-  singleAndroidLabelStory
+  singleAndroidLabelStory,
+  singleEpicBpdStory
 } from "../__mocks__/storyMock";
 import { getChangelogScope, getStoryChangelogScope } from "../changelog";
 
@@ -42,6 +43,17 @@ describe("Test pivotal Utility", () => {
     expect(eitherScope.isRight()).toBeTruthy();
     if (eitherScope.isRight() && eitherScope.value.isSome()) {
       expect(eitherScope.value.value).toBe("Android");
+      return;
+    }
+    fail(
+      "Condition eitherScope.isRight() && eitherScope.value.isSome() not satisfied"
+    );
+  });
+  it("getStoryChangelogScope on a story with epic label should return Right,string", () => {
+    const eitherScope = getStoryChangelogScope(singleEpicBpdStory);
+    expect(eitherScope.isRight()).toBeTruthy();
+    if (eitherScope.isRight() && eitherScope.value.isSome()) {
+      expect(eitherScope.value.value).toBe("Bonus Pagamenti Digitali");
       return;
     }
     fail(

--- a/scripts/changelog/ts/changelog.ts
+++ b/scripts/changelog/ts/changelog.ts
@@ -28,7 +28,9 @@ const allowedScope = new Map<string, string>([
   ["profile", "Profile"],
   ["privacy", "Privacy"],
   ["security", "Security"],
-  ["accessibility", "Accessibility"]
+  ["accessibility", "Accessibility"],
+  ["bpd", "Bonus Pagamenti Digitali"],
+  ["myportal", "MyPortal"]
 ]);
 
 // a list of project ids associated with a specific scope
@@ -40,7 +42,7 @@ const projectToScope = new Map<number, string>([
 const cleanChangelogRegex = /^(fix(\(.+\))?!?: |feat(\(.+\))?!?: |chore(\(.+\))?!?: )?(.*)$/;
 
 // pattern used to recognize a scope label
-const regex = /changelog-scope:(.*)/m;
+const regex = /(changelog-scope:|epic-)(.*)/m;
 
 /**
  * Clean the title from previous changelog prefix to update in case of changes


### PR DESCRIPTION
## Short description
This pr allows to add changelog scope for the stories that belong to an epic project label (`epic-bpd` and `epic-myportal` at the moment).

## List of changes proposed in this pull request
- Changed regular expression to identify valid label in `scripts/changelog/ts/changelog.ts`.
- Added display name for `bpd` and `myportal` in `scripts/changelog/ts/changelog.ts`.

## How to test
Added new test case to `scripts/changelog/ts/__tests__/changelog.test.ts`
