### PR TITLE
fix: [#175009303] downgrade react-native-keychain

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "react-native-image-pan-zoom": "^2.1.11",
     "react-native-image-picker": "^0.28.1",
     "react-native-keyboard-aware-scroll-view": "^0.9.1",
-    "react-native-keychain": "^6.2.0",
+    "react-native-keychain": "^3.1.3",
     "react-native-lewin-qrcode": "^1.1.0",
     "react-native-linear-gradient": "^2.5.6",
     "react-native-masked-text": "^1.13.0",

--- a/ts/utils/keychain.ts
+++ b/ts/utils/keychain.ts
@@ -23,8 +23,8 @@ export async function setGenericPasswordWithDefaultAccessibleOption(
   username: string,
   password: string,
   options?: Keychain.Options
-): Promise<boolean> {
-  const result = await Keychain.setGenericPassword(username, password, {
+) {
+  return Keychain.setGenericPassword(username, password, {
     ...options,
     // The data in the keychain item can be accessed only while the device is unlocked by the user.
     // This is recommended for items that need to be accessible only while the application is in the foreground. Items
@@ -32,7 +32,6 @@ export async function setGenericPasswordWithDefaultAccessibleOption(
     // these items will not be present.
     accessible: Keychain.ACCESSIBLE.WHEN_UNLOCKED_THIS_DEVICE_ONLY
   });
-  return result !== false;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -9694,10 +9694,10 @@ react-native-keyboard-aware-scroll-view@^0.9.1:
     prop-types "^15.6.2"
     react-native-iphone-x-helper "^1.0.3"
 
-react-native-keychain@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-6.2.0.tgz#8f4cff503aad367141db5aea0189ead9240c28ff"
-  integrity sha512-U6fnOQRJPq+c0Abl+FoYy9v0H3kQU587tMamU/o+MoBSUScFLE3DQpkyT1PW4NF5IObgiGuqQdmjC2KgtBpjGA==
+react-native-keychain@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-3.1.3.tgz#fce176e7b95243cecda1896a7e6bdfe0335d778a"
+  integrity sha512-eWUbjYJge4icX8FhWJk/OPlyGxPnW9bZDysBX3WwOG37iurdH692HKnM2Ih+S+0te65RytImvUrcVnHVBbumYg==
 
 react-native-lewin-qrcode@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Short description
Downgrade [react-native-keychain](https://github.com/oblador/react-native-keychain) to version 3.1.3 because it seems to cause few issues on the store (persist and ephemeral)

- increase startup load time (+ 3/4 seconds)
- some persisted store sections lose data

It mainly causes the user loses its session and then he must login again
