### PR TITLE
fix: [#175030743] Some store sections are not cleaned when session expires

### DIFF
--- a/ts/sagas/startup/watchSessionExpiredSaga.ts
+++ b/ts/sagas/startup/watchSessionExpiredSaga.ts
@@ -1,28 +1,19 @@
-import { call, Effect, put, select, takeLatest } from "redux-saga/effects";
+import { call, Effect, put, takeLatest } from "redux-saga/effects";
 import { getType } from "typesafe-actions";
 import { startApplicationInitialization } from "../../store/actions/application";
-import {
-  logoutRequest,
-  sessionExpired
-} from "../../store/actions/authentication";
-import { isLoggedInWithSessionInfo } from "../../store/reducers/authentication";
+import { sessionExpired } from "../../store/actions/authentication";
 import { deletePin } from "../../utils/keychain";
+import { clearCache } from "../../store/actions/profile";
 
 /**
  * Handles the expiration of the session while the user is using the app.
  */
 export function* watchSessionExpiredSaga(): IterableIterator<Effect> {
   yield takeLatest(getType(sessionExpired), function* () {
-    const isSessionOpened = yield select(isLoggedInWithSessionInfo);
-
+    // delete saved pin
     yield call(deletePin);
-    if (isSessionOpened) {
-      // the app has opened a session, we need to request to backend to close it and restart the application
-      // we get it by a soft logout
-      yield put(logoutRequest({ keepUserData: false }));
-    } else {
-      // the app has not yet an opened session, just restart the application
-      yield put(startApplicationInitialization());
-    }
+    yield put(clearCache());
+    // start again the application
+    yield put(startApplicationInitialization());
   });
 }


### PR DESCRIPTION
## Short description
`content.municipality` isn't restored to initial state when session expires (30day elapsed or the user does a login into another device)

This PR dispatches `clearCache` when `sessionExpired` is detected
It also removes the logout step: this is useless since when the session is expired there is no valid token to use for logout
