### PR TITLE
fix(Payments): [#174837301] Fixes wrong toast shown on add wallet error

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -652,8 +652,8 @@ wallet:
       message: This payment method will be available in a future release
   add: add
   delete:
-    successful: Card successfully deleted
-    failed: The card could not be deleted
+    successful: Card successfully removed
+    failed: The card could not be removed
     alert: 'The payment method used for payment of the transaction has been removed from the wallet'
   newPaymentMethod:
     add: add
@@ -890,7 +890,7 @@ cardComponent:
   setFavourite: Set as favourite
   unsetFavourite: Remove from favourites
   deleteTitle: Do you want to proceed?
-  deleteMsg: This will delete the payment method
+  deleteMsg: This payment method will be removed
   neverUsed: Never used
   lastUsage: Last usage
   detailsAndTransactions: Details and transactions

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -673,8 +673,8 @@ wallet:
       message: Questo metodo di pagamento sarà disponibile in una versione futura
   add: aggiungi
   delete:
-    successful: Carta cancellata correttamente
-    failed: Impossibile cancellare la carta
+    successful: Carta rimossa correttamente
+    failed: Impossibile rimuovere la carta
     alert: "Il metodo di pagamento usato per la transazione non è più presente nel portafoglio"
   newPaymentMethod:
     add: aggiungi
@@ -919,7 +919,7 @@ cardComponent:
   setFavourite: Imposta come preferita
   unsetFavourite: Rimuovi dai preferiti
   deleteTitle: Procedere con l'operazione?
-  deleteMsg: Questo cancellerà il metodo di pagamento
+  deleteMsg: Questo metodo di pagamento verrà rimosso
   neverUsed: Mai utilizzata
   lastUsage: Ultimo utilizzo
   detailsAndTransactions: Dettagli e transazioni

--- a/ts/screens/wallet/ConfirmCardDetailsScreen.tsx
+++ b/ts/screens/wallet/ConfirmCardDetailsScreen.tsx
@@ -244,7 +244,6 @@ const mapDispatchToProps = (
   const navigateToNextScreen = (maybeWallet: Option<Wallet>) => {
     const inPayment = props.navigation.getParam("inPayment");
     if (inPayment.isSome()) {
-      showToast(I18n.t("wallet.newPaymentMethod.successful"), "success");
       const { rptId, initialAmount, verifica, idPayment } = inPayment.value;
       dispatchPickPspOrConfirm(dispatch)(
         rptId,
@@ -296,7 +295,10 @@ const mapDispatchToProps = (
         runStartOrResumeAddCreditCardSaga({
           creditCard,
           setAsFavorite,
-          onSuccess: addedWallet => navigateToNextScreen(some(addedWallet)),
+          onSuccess: addedWallet => {
+            showToast(I18n.t("wallet.newPaymentMethod.successful"), "success");
+            navigateToNextScreen(some(addedWallet));
+          },
           onFailure: error => {
             showToast(
               I18n.t(


### PR DESCRIPTION
## Short description
This PR fixes a wrongly displayed success toast when actually the payment method is not correctly added.
Fixes on some texts.

## How to test
- Start a payment
- Change payment method and add a new one
- Insert wrong data (such as wrong expiration date)
- Confirm the method via webview and wait the API to refuse the method

<img height="550" src="https://user-images.githubusercontent.com/3959405/94562648-e01ecf00-0265-11eb-9554-b336d15fd7aa.png"/>
