### PR TITLE
feat(Bonus Pagamenti Digitali): [#174970898] Handle citizen not found as not enrolled to BPD

### DIFF
--- a/ts/features/bonus/bpd/saga/networking/index.ts
+++ b/ts/features/bonus/bpd/saga/networking/index.ts
@@ -21,11 +21,11 @@ export function* executeAndDispatch(
     );
     if (enrollCitizenIOResult.isRight()) {
       if (enrollCitizenIOResult.value.status === 200) {
-        const citizen = enrollCitizenIOResult.value.value;
+        const { enabled, payoffInstr } = enrollCitizenIOResult.value.value;
         yield put(
           action.success({
-            enabled: citizen.enabled,
-            payoffInstr: citizen.payoffInstr
+            enabled,
+            payoffInstr
           })
         );
         return;

--- a/ts/features/bonus/bpd/saga/networking/index.ts
+++ b/ts/features/bonus/bpd/saga/networking/index.ts
@@ -21,7 +21,21 @@ export function* executeAndDispatch(
     );
     if (enrollCitizenIOResult.isRight()) {
       if (enrollCitizenIOResult.value.status === 200) {
-        yield put(action.success(enrollCitizenIOResult.value.value));
+        const citizen = enrollCitizenIOResult.value.value;
+        yield put(
+          action.success({
+            enabled: citizen.enabled,
+            payoffInstr: citizen.payoffInstr
+          })
+        );
+        return;
+      } else if (enrollCitizenIOResult.value.status === 404) {
+        yield put(
+          action.success({
+            enabled: false,
+            payoffInstr: undefined
+          })
+        );
         return;
       }
       throw new Error(`response status ${enrollCitizenIOResult.value.status}`);

--- a/ts/features/bonus/bpd/store/actions/details.ts
+++ b/ts/features/bonus/bpd/store/actions/details.ts
@@ -1,5 +1,4 @@
 import { ActionType, createAsyncAction } from "typesafe-actions";
-import { CitizenResource } from "../../../../../../definitions/bpd/citizen/CitizenResource";
 import { Iban } from "../../../../../../definitions/backend/Iban";
 import { IbanStatus } from "../../saga/networking/patchCitizenIban";
 
@@ -20,7 +19,7 @@ export const bpdLoadActivationStatus = createAsyncAction(
   "BPD_LOAD_ACTIVATION_STATUS_REQUEST",
   "BPD_LOAD_ACTIVATION_STATUS_SUCCESS",
   "BPD_LOAD_ACTIVATION_STATUS_FAILURE"
-)<void, CitizenResource, Error>();
+)<void, BpdActivationPayload, Error>();
 
 // represent the outcome of iban upsert
 export type IbanUpsertResult = { payoffInstr?: Iban; status: IbanStatus };

--- a/ts/features/bonus/bpd/store/actions/onboarding.ts
+++ b/ts/features/bonus/bpd/store/actions/onboarding.ts
@@ -3,7 +3,7 @@ import {
   createAsyncAction,
   createStandardAction
 } from "typesafe-actions";
-import { CitizenResource } from "../../../../../../definitions/bpd/citizen/CitizenResource";
+import { BpdActivationPayload } from "./details";
 
 /**
  * Enroll the user to the bpd program
@@ -13,7 +13,7 @@ export const bpdEnrollUserToProgram = createAsyncAction(
   "BPD_ENROLL_REQUEST",
   "BPD_ENROLL_SUCCESS",
   "BPD_ENROLL_FAILURE"
-)<void, CitizenResource, Error>();
+)<void, BpdActivationPayload, Error>();
 
 /**
  * Start the onboarding workflow


### PR DESCRIPTION
## Short description
This PR handles status code 404 on response of these API:

- `bpd/io/citizen` GET (load citizen info)
- `bpd/io/citizen` PUT (enroll citizen to BPD)

when the response is 404 the app business logic stores these values
- `enabled = false` and `payoffInstr = undefined`

![Schermata 2020-09-30 alle 10 20 09](https://user-images.githubusercontent.com/822471/94660902-9afea980-0306-11eb-9956-2739d1ea2da0.png)

