### PR TITLE
fix(Bonus Vacanze): [#175058176] Fixes the color of bonus status badge text

### DIFF
--- a/ts/features/bonus/bonusVacanze/screens/ActiveBonusScreen.tsx
+++ b/ts/features/bonus/bonusVacanze/screens/ActiveBonusScreen.tsx
@@ -617,7 +617,7 @@ const ActiveBonusScreen: React.FunctionComponent<Props> = (props: Props) => {
                       <Text
                         style={styles.statusText}
                         semibold={true}
-                        dark={true}
+                        dark={!isBonusActive(bonus)}
                       >
                         {maybeStatusDescription.value}
                       </Text>


### PR DESCRIPTION
## Short description
This PR fixes the colors of the text inside the status badge of bonus detail screen

### Redeemed Bonus
<img height="550" src="https://user-images.githubusercontent.com/3959405/94702981-a66dc700-033e-11eb-9cb9-d9a26915c9f6.png"/>

### Active Bonus
<img height="550" src="https://user-images.githubusercontent.com/3959405/94703163-d7e69280-033e-11eb-8a52-3a7b9ed885e8.png"/>