### PR TITLE
[#175057500] Modify label for transaction details

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -748,7 +748,7 @@ wallet:
     object: Reason
     date: Date and Time
     iuv: IUV code
-    entityCode: Entity fiscal code
+    entityCode: Creditor Entity Fiscal Code
     fee: Fee
     idTransaction: Transaction identification code
     updatedAmount: Updated amount
@@ -767,7 +767,7 @@ wallet:
     info: which allow us to identify the transaction
     link: Where are they?
     noticeCode: Notice Code
-    entityCode: Entity Fiscal Code
+    entityCode: Creditor Entity Fiscal Code
     amount: Amount (€)
     proceed: Proceed with the transaction
     contextualHelpTitle: Manually insert notice

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -777,7 +777,7 @@ wallet:
     object: Causale
     date: Data e ora
     iuv: Codice IUV
-    entityCode: Codice fiscale creditore
+    entityCode: Codice Fiscale Ente Creditore
     updatedAmount: Importo aggiornato
     fee: Costi di transazione
     idTransaction: Codice identificativo della transazione


### PR DESCRIPTION
## Short description
Include a summary of the changes.
Modify the label for the transaction details:
- from `Codice fiscale creditore` to `Codice Fiscale Ente Creditore` 
- from `Entity fiscal code` to `Creditor Entity Fiscal Code`
<img width="279" alt="Screenshot 2020-10-01 at 19 10 20" src="https://user-images.githubusercontent.com/11773070/94841221-fcfc0380-0419-11eb-8173-e01c5b9b4568.png">
