### PR TITLE
chore(Bonus Pagamenti Digitali): [#175329922] Add Bpd Test Overlay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,11 +37,15 @@ MIXPANEL_TOKEN='0cb505dace6f4b3ceb9e17c7fcd7c66f'
 GCM_SENDER_ID='260468725946'
 BONUS_VACANZE_ENABLED=NO
 MYPORTAL_ENABLED=NO
-BPD_ENABLED=NO
 # enable playgrounds inside developer section
 PLAYGROUNDS_ENABLED=NO
-# endpoint BPD API
+# BPD configuration
+BPD_ENABLED=NO
+BPD_TEST_OVERLAY=NO
+# BPD endpoint
 BPD_API_URL_PREFIX=https://bpd-dev.azure-api.net
+BPD_API_SIT='https://bpd-dev.azure-api.net'
+BPD_API_UAT='https://test.cstar.pagopa.it'
 
 
 

--- a/.env.local
+++ b/.env.local
@@ -36,11 +36,15 @@ INSTABUG_TOKEN='5c2d0f12fa12f9afc535585e5b7a9e79'
 MIXPANEL_TOKEN='0cb505dace6f4b3ceb9e17c7fcd7c66f'
 GCM_SENDER_ID='260468725946'
 BONUS_VACANZE_ENABLED=YES
-BPD_ENABLED=NO
 MYPORTAL_ENABLED=NO
 # enable playgrounds inside developer section
 PLAYGROUNDS_ENABLED=NO
+# BPD configuration
+BPD_ENABLED=NO
+BPD_TEST_OVERLAY=NO
 # endpoint BPD API
 BPD_API_URL_PREFIX='http://127.0.0.1:3000/bonus'
+BPD_API_SIT='https://bpd-dev.azure-api.net'
+BPD_API_UAT='https://test.cstar.pagopa.it'
 
 

--- a/.env.production
+++ b/.env.production
@@ -37,8 +37,12 @@ MIXPANEL_TOKEN='0cb505dace6f4b3ceb9e17c7fcd7c66f'
 GCM_SENDER_ID='260468725946'
 BONUS_VACANZE_ENABLED=YES
 MYPORTAL_ENABLED=NO
-BPD_ENABLED=NO
 # enable playgrounds inside developer section
 PLAYGROUNDS_ENABLED=NO
+# BPD configuration
+BPD_ENABLED=NO
+BPD_TEST_OVERLAY=NO
 # endpoint BPD API
 BPD_API_URL_PREFIX=https://bpd-dev.azure-api.net
+BPD_API_SIT='https://bpd-dev.azure-api.net'
+BPD_API_UAT='https://test.cstar.pagopa.it'

--- a/ts/RootContainer.tsx
+++ b/ts/RootContainer.tsx
@@ -14,7 +14,8 @@ import configurePushNotifications from "./boot/configurePushNotification";
 import FlagSecureComponent from "./components/FlagSecure";
 import { LightModalRoot } from "./components/ui/LightModal";
 import VersionInfoOverlay from "./components/VersionInfoOverlay";
-import { shouldDisplayVersionInfoOverlay } from "./config";
+import { bpdTestOverlay, shouldDisplayVersionInfoOverlay } from "./config";
+import { BpdTestOverlay } from "./features/bonus/bpd/components/BpdTestOverlay";
 import Navigation from "./navigation";
 import {
   applicationChangeState,
@@ -139,6 +140,7 @@ class RootContainer extends React.PureComponent<Props> {
         {Platform.OS === "android" && <FlagSecureComponent />}
         <Navigation />
         {shouldDisplayVersionInfoOverlay && <VersionInfoOverlay />}
+        {bpdTestOverlay && <BpdTestOverlay />}
         <RootModal />
         <LightModalRoot />
       </Root>

--- a/ts/config.ts
+++ b/ts/config.ts
@@ -48,8 +48,12 @@ export const bonusVacanzeEnabled: boolean =
 export const myPortalEnabled: boolean = Config.MYPORTAL_ENABLED === "YES";
 
 export const bpdEnabled: boolean = Config.BPD_ENABLED === "YES";
+export const bpdTestOverlay: boolean = Config.BPD_TEST_OVERLAY === "YES";
 
 export const bpdApiUrlPrefix: string = Config.BPD_API_URL_PREFIX;
+
+export const bpdApiSitUrlPrefix: string = Config.BPD_API_SIT;
+export const bpdApiUatUrlPrefix: string = Config.BPD_API_UAT;
 
 export const isPlaygroundsEnabled: boolean =
   Config.PLAYGROUNDS_ENABLED === "YES";

--- a/ts/features/bonus/bpd/components/BpdTestOverlay.tsx
+++ b/ts/features/bonus/bpd/components/BpdTestOverlay.tsx
@@ -1,0 +1,73 @@
+import { View } from "native-base";
+import { useState } from "react";
+import * as React from "react";
+import { Platform, StyleSheet } from "react-native";
+
+import { getStatusBarHeight, isIphoneX } from "react-native-iphone-x-helper";
+import { Body } from "../../../../components/core/typography/Body";
+import { Label } from "../../../../components/core/typography/Label";
+import {
+  bpdApiSitUrlPrefix,
+  bpdApiUatUrlPrefix,
+  bpdApiUrlPrefix,
+  bpdEnabled,
+  pagoPaApiUrlPrefix,
+  pagoPaApiUrlPrefixTest
+} from "../../../../config";
+
+const styles = StyleSheet.create({
+  versionContainer: {
+    position: "absolute",
+    top: Platform.select({
+      ios: 20 + (isIphoneX() ? getStatusBarHeight() : 0),
+      android: 0
+    }),
+    left: 0,
+    right: 0,
+    bottom: 0,
+    justifyContent: "flex-start",
+    alignItems: "center",
+    zIndex: 1000
+  },
+  versionText: {
+    padding: 2,
+    backgroundColor: "#ffffffaa"
+  }
+});
+
+/**
+ * Temp overlay created to avoid ambiguity when test bpd versions are released.
+ * TODO: remove after the release of bpd
+ * @constructor
+ */
+export const BpdTestOverlay: React.FunctionComponent = () => {
+  const [enabled, setEnabled] = useState(true);
+  const bpdEndpointStr =
+    bpdApiUrlPrefix === bpdApiSitUrlPrefix
+      ? "SIT"
+      : bpdApiUrlPrefix === bpdApiUatUrlPrefix
+      ? "UAT"
+      : "PROD";
+
+  const pmEndpointStr =
+    pagoPaApiUrlPrefix === pagoPaApiUrlPrefixTest ? "UAT" : "PROD";
+
+  return (
+    <View style={styles.versionContainer} pointerEvents="box-none">
+      {enabled ? (
+        <>
+          <Label
+            style={styles.versionText}
+            onPress={() => setEnabled(!enabled)}
+          >{`🛠️BPD TEST VERSION🛠️`}</Label>
+          <Body
+            style={styles.versionText}
+            onPress={() => setEnabled(!enabled)}
+          >{`${
+            bpdEnabled ? "active" : "not active"
+          } - bpd: ${bpdEndpointStr} - PM: ${pmEndpointStr}`}</Body>
+        </>
+      ) : null}
+    </View>
+  );
+};


### PR DESCRIPTION
## Short description
This pr adds a Bpd test overlay, in order to avoid ambiguity when test bpd versions are released.

![Schermata 2020-10-19 alle 15 41 54](https://user-images.githubusercontent.com/26501317/96459309-47ef8680-1222-11eb-9258-c5b84586ecd7.png)

## Features:
- Enabled with `BPD_TEST_OVERLAY=YES`
- Tap on the text to dismiss the overlay.
- Informs the user if bpd is enabled, the BPD endpoint type (SIT, UAT, PROD) the PM endpoint type (UAT, PROD)
