### PR TITLE
feat(Bonus Pagamenti Digitali): [#175185419] Nesting WalletV2 inside Wallet

### DIFF
--- a/ts/types/pagopa.ts
+++ b/ts/types/pagopa.ts
@@ -139,7 +139,7 @@ export const Wallet = repP(
   t.union([Psp, t.undefined]),
   "Wallet"
 );
-// add v2 optional fields. It may contain a PatchedWalletV2 object
+// add v2 optional field. It may contain a PatchedWalletV2 object
 const WalletV1V2 = t.intersection([Wallet, t.partial({ v2: PatchedWalletV2 })]);
 export type Wallet = t.TypeOf<typeof WalletV1V2>;
 

--- a/ts/types/pagopa.ts
+++ b/ts/types/pagopa.ts
@@ -94,6 +94,38 @@ export const Psp = repP(
 );
 export type Psp = t.TypeOf<typeof Psp>;
 
+/** A refined WalletV2
+ * reasons:
+ * - createDate and updateDate are generated from spec as UTCISODateFromString instead of DateFromString
+ * - info is required
+ * - info is CardInfo and not PaymentMethodInfo (empty interface)
+ */
+
+// required attributes
+
+const WalletV2O = t.partial({
+  updateDate: t.string,
+  createDate: DateFromString,
+  onboardingChannel: t.string,
+  favourite: t.boolean
+});
+
+// optional attributes
+const WalletV2R = t.interface({
+  enableableFunctions: t.readonlyArray(t.string, "array of string"),
+  info: CardInfo,
+  idWallet: t.Integer,
+  pagoPA: t.boolean,
+  walletType: enumType<WalletTypeEnum>(WalletTypeEnum, "walletType")
+});
+
+export const PatchedWalletV2 = t.intersection(
+  [WalletV2R, WalletV2O],
+  "WalletV2"
+);
+
+export type PatchedWalletV2 = t.TypeOf<typeof PatchedWalletV2>;
+
 /**
  * A refined Wallet
  */
@@ -107,7 +139,9 @@ export const Wallet = repP(
   t.union([Psp, t.undefined]),
   "Wallet"
 );
-export type Wallet = t.TypeOf<typeof Wallet>;
+// add v2 optional fields. It may contain a PatchedWalletV2 object
+const WalletV1V2 = t.intersection([Wallet, t.partial({ v2: PatchedWalletV2 })]);
+export type Wallet = t.TypeOf<typeof WalletV1V2>;
 
 /**
  * A Wallet that has not being saved yet
@@ -291,38 +325,6 @@ export const PagoPAErrorResponse = t.type({
 });
 
 export type PagoPAErrorResponse = t.TypeOf<typeof PagoPAErrorResponse>;
-
-/**
- * reasons:
- * - createDate and updateDate are generated from spec as UTCISODateFromString instead of DateFromString
- * - info is required
- * - info is CardInfo and not PaymentMethodInfo (empty interface)
- */
-
-// required attributes
-
-const WalletV2O = t.partial({
-  updateDate: t.string,
-  createDate: DateFromString,
-  onboardingChannel: t.string,
-  favourite: t.boolean
-});
-
-// optional attributes
-const WalletV2R = t.interface({
-  enableableFunctions: t.readonlyArray(t.string, "array of string"),
-  info: CardInfo,
-  idWallet: t.Integer,
-  pagoPA: t.boolean,
-  walletType: enumType<WalletTypeEnum>(WalletTypeEnum, "walletType")
-});
-
-export const PatchedWalletV2 = t.intersection(
-  [WalletV2R, WalletV2O],
-  "WalletV2"
-);
-
-export type PatchedWalletV2 = t.TypeOf<typeof PatchedWalletV2>;
 
 const WalletV2ListResponseR = t.interface({});
 

--- a/ts/utils/wallet.ts
+++ b/ts/utils/wallet.ts
@@ -104,6 +104,7 @@ export const convertWalletV2toWalletV1 = (
     lastUsage: walletV2.updateDate ? new Date(walletV2.updateDate) : undefined,
     isPspToIgnore: false,
     registeredNexi: false,
-    saved: true
+    saved: true,
+    v2: walletV2
   };
 };


### PR DESCRIPTION
## Short description
This PR nests `walletV2` value inside a new optional field `v2` inside `Wallet`

### how to test
- generate models from spec `yarn generate:all`
- set feature flag `bpdEnabled` to true

### note
field `v2` will be undefined if `bpdEnabled === false` -> get wallets from v1 api

![Schermata 2020-10-22 alle 18](https://user-images.githubusercontent.com/822471/96905769-306e0300-1499-11eb-8c60-4990719dde4d.jpg)

