### PR TITLE
fix(Bonus Pagamenti Digitali): [#175410649] Codec fails on add bancomat response

### DIFF
--- a/ts/api/pagopa.ts
+++ b/ts/api/pagopa.ts
@@ -65,7 +65,7 @@ import {
 import { getLocalePrimaryWithFallback } from "../utils/locale";
 import { fixWalletPspTagsValues } from "../utils/wallet";
 import {
-  addWalletsBancomatCardUsingPOSTDefaultDecoder,
+  addWalletsBancomatCardUsingPOSTDecoder,
   AddWalletsBancomatCardUsingPOSTT,
   getAbiListUsingGETDefaultDecoder,
   GetAbiListUsingGETT,
@@ -420,7 +420,9 @@ const addPans: AddWalletsBancomatCardUsingPOSTT = {
   query: () => ({}),
   headers: composeHeaderProducers(tokenHeaderProducer, ApiHeaderJson),
   body: p => JSON.stringify(p.bancomatCardsRequest),
-  response_decoder: addWalletsBancomatCardUsingPOSTDefaultDecoder()
+  response_decoder: addWalletsBancomatCardUsingPOSTDecoder(
+    PatchedWalletV2ListResponse
+  )
 };
 
 const withPaymentManagerToken = <P extends { Bearer: string }, R>(


### PR DESCRIPTION
## Short description
This PR changes the codec used in add bancomat response.
The right one is `PatchedWalletV2ListResponse`
