### PR TITLE
feat(Bonus Pagamenti Digitali): [#175269179] Transaction details

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1670,6 +1670,17 @@ bonus:
       transaction:
         title: "Your transactions"
         goToButton: "Transactions detail"
+        detail:
+          title: "Detail of the transaction"
+          paymentCircuit: "Payment circuit"
+          transactionAmount: "Transaction amount"
+          cashbackAmount: "Cashback amount"
+          acquirerId: "Acquirer transaction ID"
+          issuerId: "Issuer transaction ID"
+          maxCashbackWarning: "For each transaction you can get a maximum cashback of € {{amount}}."
+          maxCashbackForPeriodWarning: "You have already reached the maximum refund for this period."
+          refundWarning: "This transaction is a refund, so the related cashback has been deducted."
+          canceled: "Refund"
       paymentMethods:
         noPaymentMethods: "You must add at least one payment method to start collecting the necessary transactions"
       card:

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1679,7 +1679,7 @@ bonus:
           issuerId: "Issuer transaction ID"
           maxCashbackWarning: "For each transaction you can get a maximum cashback of € {{amount}}."
           maxCashbackForPeriodWarning: "You have already reached the maximum refund for this period."
-          refundWarning: "This transaction is a refund, so the related cashback has been deducted."
+          canceledOperationWarning: "This transaction is a refund, so the related cashback has been deducted."
           canceled: "Refund"
       paymentMethods:
         noPaymentMethods: "You must add at least one payment method to start collecting the necessary transactions"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1702,6 +1702,17 @@ bonus:
       transaction:
         title: "Le tue transazioni"
         goToButton: "Dettaglio transazioni"
+        detail:
+          title: "Dettaglio della transazione"
+          paymentCircuit: "Circuito di pagamento"
+          transactionAmount: "Importo transazione"
+          cashbackAmount: "Importo cashback"
+          acquirerId: "ID transazione Acquirer"
+          issuerId: "ID transazione Issuer"
+          maxCashbackWarning: "Per ogni transazione puoi ottenere un cashback massimo di € {{amount}}."
+          maxCashbackForPeriodWarning: "Hai già raggiunto il rimborso massimo previsto per questo periodo."
+          canceledOperationWarning: "Questa transazione è un rimborso, perciò è stato decurtato il relativo cashback."
+          canceled: "Storno"
       paymentMethods:
         noPaymentMethods: "Devi aggiungere almeno un metodo di pagamento per iniziare a collezionare le transazioni necessarie"
       card:

--- a/ts/components/bottomSheet/BottomSheetHeader.tsx
+++ b/ts/components/bottomSheet/BottomSheetHeader.tsx
@@ -4,6 +4,7 @@ import { Text, View } from "native-base";
 import customVariables from "../../theme/variables";
 import I18n from "../../i18n";
 import ButtonDefaultOpacity from "../ButtonDefaultOpacity";
+import { H3 } from "../core/typography/H3";
 import IconFont from "../ui/IconFont";
 import { IOStyles } from "../core/variables/IOStyles";
 import { IOColors } from "../core/variables/IOColors";
@@ -49,9 +50,7 @@ export const BottomSheetHeader: React.FunctionComponent<Props> = ({
   onClose
 }: Props) => (
   <View style={styles.row}>
-    <Text style={styles.title} semibold={true}>
-      {title}
-    </Text>
+    <H3>{title}</H3>
     <ButtonDefaultOpacity
       style={styles.modalClose}
       onPress={onClose}

--- a/ts/components/bottomSheet/BottomSheetHeader.tsx
+++ b/ts/components/bottomSheet/BottomSheetHeader.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { StyleSheet } from "react-native";
-import { Text, View } from "native-base";
+import { View } from "native-base";
 import customVariables from "../../theme/variables";
 import I18n from "../../i18n";
 import ButtonDefaultOpacity from "../ButtonDefaultOpacity";

--- a/ts/components/core/typography/Monospace.tsx
+++ b/ts/components/core/typography/Monospace.tsx
@@ -5,7 +5,7 @@ import { ExternalTypographyProps, TypographyProps } from "./common";
 import { typographyFactory } from "./Factory";
 
 type AllowedColors = Extract<IOColorType, "bluegrey">;
-type AllowedWeight = Extract<IOFontWeight, "Regular">;
+type AllowedWeight = Extract<IOFontWeight, "Regular" | "SemiBold">;
 
 type OwnProps = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>

--- a/ts/components/core/variables/IOStyles.ts
+++ b/ts/components/core/variables/IOStyles.ts
@@ -15,6 +15,7 @@ export const IOStyles = {
     paddingRight: themeVariables.contentPadding
   },
   row: {
+    flex: 1,
     flexDirection: "row"
   }
 };

--- a/ts/features/bonus/bpd/components/transactionItem/BaseBpdTransactionItem.tsx
+++ b/ts/features/bonus/bpd/components/transactionItem/BaseBpdTransactionItem.tsx
@@ -1,6 +1,12 @@
 import { View } from "native-base";
 import * as React from "react";
-import { Image, ImageSourcePropType, StyleSheet } from "react-native";
+import {
+  Image,
+  ImageSourcePropType,
+  StyleSheet,
+  TouchableOpacity,
+  TouchableWithoutFeedbackProps
+} from "react-native";
 import { H4 } from "../../../../../components/core/typography/H4";
 import { H5 } from "../../../../../components/core/typography/H5";
 import { ShadowBox } from "../../screens/details/components/summary/base/ShadowBox";
@@ -10,7 +16,7 @@ type Props = {
   title: string;
   subtitle: string;
   rightText: string;
-};
+} & Pick<TouchableWithoutFeedbackProps, "onPress">;
 
 const styles = StyleSheet.create({
   row: {
@@ -38,7 +44,7 @@ const styles = StyleSheet.create({
  * @constructor
  */
 export const BaseBpdTransactionItem: React.FunctionComponent<Props> = props => (
-  <View style={{ marginVertical: 4 }}>
+  <TouchableOpacity style={{ marginVertical: 4 }} onPress={props.onPress}>
     <ShadowBox>
       <View style={[styles.body, styles.row]}>
         <View style={[styles.row]}>
@@ -57,5 +63,5 @@ export const BaseBpdTransactionItem: React.FunctionComponent<Props> = props => (
         </H4>
       </View>
     </ShadowBox>
-  </View>
+  </TouchableOpacity>
 );

--- a/ts/features/bonus/bpd/components/transactionItem/BpdTransactionItem.tsx
+++ b/ts/features/bonus/bpd/components/transactionItem/BpdTransactionItem.tsx
@@ -52,7 +52,7 @@ export const BpdTransactionItem: React.FunctionComponent<Props> = props => {
       image={props.transaction.image}
       subtitle={getSubtitle(props.transaction)}
       rightText={formatNumberAmount(props.transaction.cashback)}
-      onPress={() => openModalBox()}
+      onPress={openModalBox}
     />
   );
 };

--- a/ts/features/bonus/bpd/components/transactionItem/BpdTransactionItem.tsx
+++ b/ts/features/bonus/bpd/components/transactionItem/BpdTransactionItem.tsx
@@ -13,6 +13,7 @@ export type EnhancedBpdTransaction = {
   image: ImageSourcePropType;
   title: string;
   keyId: string;
+  maxCashbackForTransactionAmount: number | undefined;
 } & BpdTransaction;
 
 type Props = {

--- a/ts/features/bonus/bpd/components/transactionItem/BpdTransactionItem.tsx
+++ b/ts/features/bonus/bpd/components/transactionItem/BpdTransactionItem.tsx
@@ -1,13 +1,18 @@
+import { useBottomSheetModal } from "@gorhom/bottom-sheet";
 import * as React from "react";
 import { ImageSourcePropType } from "react-native";
+import I18n from "../../../../../i18n";
+import { bottomSheetContent } from "../../../../../utils/bottomSheet";
 import { format } from "../../../../../utils/dates";
 import { formatNumberAmount } from "../../../../../utils/stringBuilder";
+import { BpdTransactionDetailComponent } from "../../screens/details/transaction/detail/BpdTransactionDetailComponent";
 import { BpdTransaction } from "../../store/actions/transactions";
 import { BaseBpdTransactionItem } from "./BaseBpdTransactionItem";
 
 export type EnhancedBpdTransaction = {
   image: ImageSourcePropType;
   title: string;
+  keyId: string;
 } & BpdTransaction;
 
 type Props = {
@@ -24,11 +29,29 @@ const getSubtitle = (transaction: BpdTransaction) =>
     transaction.amount
   )} `;
 
-export const BpdTransactionItem: React.FunctionComponent<Props> = props => (
-  <BaseBpdTransactionItem
-    title={props.transaction.title}
-    image={props.transaction.image}
-    subtitle={getSubtitle(props.transaction)}
-    rightText={formatNumberAmount(props.transaction.cashback)}
-  />
-);
+export const BpdTransactionItem: React.FunctionComponent<Props> = props => {
+  const { present, dismiss } = useBottomSheetModal();
+
+  const openModalBox = async () => {
+    const bottomSheetProps = await bottomSheetContent(
+      <BpdTransactionDetailComponent transaction={props.transaction} />,
+      I18n.t("bonus.bonusVacanze.name"),
+      522,
+      dismiss
+    );
+
+    present(bottomSheetProps.content, {
+      ...bottomSheetProps.config
+    });
+  };
+
+  return (
+    <BaseBpdTransactionItem
+      title={props.transaction.title}
+      image={props.transaction.image}
+      subtitle={getSubtitle(props.transaction)}
+      rightText={formatNumberAmount(props.transaction.cashback)}
+      onPress={() => openModalBox()}
+    />
+  );
+};

--- a/ts/features/bonus/bpd/components/transactionItem/BpdTransactionItem.tsx
+++ b/ts/features/bonus/bpd/components/transactionItem/BpdTransactionItem.tsx
@@ -36,7 +36,7 @@ export const BpdTransactionItem: React.FunctionComponent<Props> = props => {
   const openModalBox = async () => {
     const bottomSheetProps = await bottomSheetContent(
       <BpdTransactionDetailComponent transaction={props.transaction} />,
-      I18n.t("bonus.bonusVacanze.name"),
+      I18n.t("bonus.bpd.details.transaction.detail.title"),
       522,
       dismiss
     );

--- a/ts/features/bonus/bpd/saga/networking/transactions.ts
+++ b/ts/features/bonus/bpd/saga/networking/transactions.ts
@@ -24,9 +24,17 @@ const mapNetworkCircuitType: Map<string, CircuitType> = new Map<
   string,
   CircuitType
 >([
-  ["PagoBancomat", "PagoBancomat"],
-  ["Visa", "PagoBancomat"],
-  ["Mastercard", "PagoBancomat"]
+  ["00", "PagoBancomat"],
+  ["01", "Visa"],
+  ["02", "Mastercard"],
+  ["03", "Amex"],
+  ["04", "JCB"],
+  ["05", "UnionPay"],
+  ["06", "Diners"],
+  ["07", "PostePay"],
+  ["08", "BancomatPay"],
+  ["09", "SatisPay"],
+  ["10", "Private"]
 ]);
 
 // convert a network payload amount into the relative app domain model
@@ -40,7 +48,7 @@ const convertTransactions = (
     awardPeriodId,
     circuitType: fromNullable(
       mapNetworkCircuitType.get(nt.circuitType)
-    ).getOrElse("PagoBancomat") // TODO which is the right default? maybe 'Unknown' can be added to CircuitType literal union?
+    ).getOrElse("Unknown") // TODO which is the right default? maybe 'Unknown' can be added to CircuitType literal union?
   }));
   return {
     results,
@@ -50,6 +58,7 @@ const convertTransactions = (
 
 /**
  * Networking code to request the transactions for a specified period.
+ * @param winningTransactions
  * @param action
  */
 export function* bpdLoadTransactionsSaga(

--- a/ts/features/bonus/bpd/screens/details/transaction/BpdTransactionsScreen.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/BpdTransactionsScreen.tsx
@@ -1,7 +1,7 @@
 import * as pot from "italia-ts-commons/lib/pot";
 import { View } from "native-base";
 import * as React from "react";
-import { SafeAreaView, ScrollView } from "react-native";
+import { FlatList, SafeAreaView } from "react-native";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { H1 } from "../../../../../../components/core/typography/H1";
@@ -9,11 +9,18 @@ import { IOStyles } from "../../../../../../components/core/variables/IOStyles";
 import BaseScreenComponent from "../../../../../../components/screens/BaseScreenComponent";
 import I18n from "../../../../../../i18n";
 import { GlobalState } from "../../../../../../store/reducers/types";
-import { BpdTransactionItem } from "../../../components/transactionItem/BpdTransactionItem";
+import {
+  BpdTransactionItem,
+  EnhancedBpdTransaction
+} from "../../../components/transactionItem/BpdTransactionItem";
 import { bpdDisplayTransactionsSelector } from "../../../store/reducers/details/combiner";
 
 export type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
+
+const dataForFlatList = (
+  transactions: pot.Pot<ReadonlyArray<EnhancedBpdTransaction>, Error>
+) => pot.getOrElse(transactions, []);
 
 /**
  * Display all the transactions for a specific period
@@ -27,14 +34,13 @@ const BpdTransactionsScreen: React.FunctionComponent<Props> = props => (
         <View spacer={true} large={true} />
         <H1>{I18n.t("bonus.bpd.details.transaction.title")}</H1>
         <View spacer={true} />
-        <ScrollView style={IOStyles.flex}>
-          {pot.isSome(props.transactionForSelectedPeriod) &&
-            props.transactionForSelectedPeriod.value.map(
-              (transaction, index) => (
-                <BpdTransactionItem key={index} transaction={transaction} />
-              )
-            )}
-        </ScrollView>
+        <FlatList
+          data={dataForFlatList(props.transactionForSelectedPeriod)}
+          renderItem={transaction => (
+            <BpdTransactionItem transaction={transaction.item} />
+          )}
+          keyExtractor={t => t.keyId}
+        />
       </View>
     </SafeAreaView>
   </BaseScreenComponent>

--- a/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionDetailComponent.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionDetailComponent.tsx
@@ -1,0 +1,137 @@
+import { View } from "native-base";
+import * as React from "react";
+import { Image, StyleProp, StyleSheet, TextStyle } from "react-native";
+import CopyButtonComponent from "../../../../../../../components/CopyButtonComponent";
+import { Body } from "../../../../../../../components/core/typography/Body";
+import { H4 } from "../../../../../../../components/core/typography/H4";
+import { Monospace } from "../../../../../../../components/core/typography/Monospace";
+import { IOColors } from "../../../../../../../components/core/variables/IOColors";
+import { IOStyles } from "../../../../../../../components/core/variables/IOStyles";
+import I18n from "../../../../../../../i18n";
+import { format } from "../../../../../../../utils/dates";
+import { formatNumberAmount } from "../../../../../../../utils/stringBuilder";
+import {
+  KeyValueRow,
+  KeyValueTable
+} from "../../../../../bonusVacanze/components/keyValueTable/KeyValueTable";
+import { EnhancedBpdTransaction } from "../../../../components/transactionItem/BpdTransactionItem";
+import { H5 } from "../../../../../../../components/core/typography/H5";
+
+type Props = { transaction: EnhancedBpdTransaction };
+
+const styles = StyleSheet.create({
+  image: { width: 48, height: 30 },
+  rowId: {
+    flexDirection: "row",
+    justifyContent: "space-between"
+  }
+});
+
+const loadLocales = () => ({
+  paymentMethod: I18n.t("wallet.paymentMethod"),
+  acquirerId: I18n.t("bonus.bpd.details.transaction.detail.acquirerId"),
+  issuerId: I18n.t("bonus.bpd.details.transaction.detail.issuerId")
+});
+
+const keyStyle: StyleProp<TextStyle> = {
+  fontSize: 14
+};
+
+const valueStyle: StyleProp<TextStyle> = {
+  fontWeight: "500",
+  color: IOColors.bluegreyDark
+};
+
+const getRows = (
+  transaction: EnhancedBpdTransaction
+): ReadonlyArray<KeyValueRow> => [
+  {
+    key: {
+      text: I18n.t("payment.details.info.dateAndTime"),
+      style: keyStyle
+    },
+    value: {
+      text: format(transaction.trxDate, "DD MMM YYYY, HH:mm"),
+      style: valueStyle
+    }
+  },
+  {
+    key: {
+      text: I18n.t("bonus.bpd.details.transaction.detail.paymentCircuit"),
+      style: keyStyle
+    },
+    value: {
+      text: transaction.circuitType,
+      style: valueStyle
+    }
+  },
+  {
+    key: {
+      text: I18n.t("bonus.bpd.details.transaction.detail.transactionAmount"),
+      style: keyStyle
+    },
+    value: {
+      text: `€ ${formatNumberAmount(transaction.amount)}`,
+      style: valueStyle
+    }
+  },
+  {
+    key: {
+      text: I18n.t("bonus.bpd.details.transaction.detail.cashbackAmount"),
+      style: keyStyle
+    },
+    value: {
+      text: `€ ${formatNumberAmount(transaction.cashback)}`,
+      style: valueStyle
+    }
+  }
+];
+
+type IdBlockProps = {
+  title: string;
+  value: string;
+};
+
+const IdBlock = (props: IdBlockProps) => (
+  <View>
+    <H5 weight={"Regular"}>{props.title}</H5>
+    <View style={styles.rowId}>
+      <Monospace weight={"SemiBold"}>{props.value}</Monospace>
+      <CopyButtonComponent textToCopy={props.value} />
+    </View>
+  </View>
+);
+
+/**
+ * This screen shows the details about a single transaction.
+ * https://pagopa.invisionapp.com/console/IO---Cashback---Dettaglio-e-transazioni-ckg6bcpcr0ryb016nas1h4nbf/ckg6cwqfc03uf012khxbr6mun/play
+ * @param props
+ * @constructor
+ */
+export const BpdTransactionDetailComponent: React.FunctionComponent<Props> = props => {
+  const { paymentMethod, acquirerId, issuerId } = loadLocales();
+
+  return (
+    <View>
+      <View spacer={true} />
+      <Body>{paymentMethod}</Body>
+      <View spacer={true} />
+      <View style={[IOStyles.flex, IOStyles.row]}>
+        <Image source={props.transaction.image} style={styles.image} />
+        <View hspacer={true} small={true} />
+        <H4>{props.transaction.title}</H4>
+      </View>
+      <View spacer={true} />
+      {/* using the keyvaluetable with custom style in order to be quick */}
+      <KeyValueTable
+        leftFlex={1}
+        rightFlex={1}
+        rows={getRows(props.transaction)}
+      />
+      <View spacer={true} />
+      <IdBlock title={acquirerId} value={props.transaction.idTrxAcquirer} />
+      <View spacer={true} />
+      <IdBlock title={issuerId} value={props.transaction.idTrxIssuer} />
+    </View>
+  );
+};

--- a/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionDetailComponent.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionDetailComponent.tsx
@@ -96,7 +96,7 @@ const Table = (props: Props) => (
         {I18n.t("bonus.bpd.details.transaction.detail.cashbackAmount")}
       </H5>
       <H4 weight={"SemiBold"} color={"bluegreyDark"}>
-        {`€ ${formatNumberAmount(props.transaction.cashback)}`}
+        {formatNumberAmount(props.transaction.cashback, true)}
       </H4>
     </View>
   </View>

--- a/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionDetailComponent.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionDetailComponent.tsx
@@ -1,21 +1,17 @@
-import { View } from "native-base";
+import { Badge, Text, View } from "native-base";
 import * as React from "react";
-import { Image, StyleProp, StyleSheet, TextStyle } from "react-native";
+import { Image, StyleSheet } from "react-native";
 import CopyButtonComponent from "../../../../../../../components/CopyButtonComponent";
 import { Body } from "../../../../../../../components/core/typography/Body";
 import { H4 } from "../../../../../../../components/core/typography/H4";
+import { H5 } from "../../../../../../../components/core/typography/H5";
 import { Monospace } from "../../../../../../../components/core/typography/Monospace";
 import { IOColors } from "../../../../../../../components/core/variables/IOColors";
 import { IOStyles } from "../../../../../../../components/core/variables/IOStyles";
 import I18n from "../../../../../../../i18n";
 import { format } from "../../../../../../../utils/dates";
 import { formatNumberAmount } from "../../../../../../../utils/stringBuilder";
-import {
-  KeyValueRow,
-  KeyValueTable
-} from "../../../../../bonusVacanze/components/keyValueTable/KeyValueTable";
 import { EnhancedBpdTransaction } from "../../../../components/transactionItem/BpdTransactionItem";
-import { H5 } from "../../../../../../../components/core/typography/H5";
 import { BpdTransactionWarning } from "./BpdTransactionWarning";
 
 type Props = { transaction: EnhancedBpdTransaction };
@@ -25,6 +21,17 @@ const styles = StyleSheet.create({
   rowId: {
     flexDirection: "row",
     justifyContent: "space-between"
+  },
+  badgeText: {
+    color: IOColors.red,
+    fontSize: 12
+  },
+  badge: {
+    backgroundColor: IOColors.white,
+    borderColor: IOColors.red,
+    borderWidth: 1,
+    top: -10,
+    height: 25
   }
 });
 
@@ -34,64 +41,66 @@ const loadLocales = () => ({
   issuerId: I18n.t("bonus.bpd.details.transaction.detail.issuerId")
 });
 
-const keyStyle: StyleProp<TextStyle> = {
-  fontSize: 14
-};
-
-const valueStyle: StyleProp<TextStyle> = {
-  fontWeight: "500",
-  color: IOColors.bluegreyDark
-};
-
-const getRows = (
-  transaction: EnhancedBpdTransaction
-): ReadonlyArray<KeyValueRow> => [
-  {
-    key: {
-      text: I18n.t("payment.details.info.dateAndTime"),
-      style: keyStyle
-    },
-    value: {
-      text: format(transaction.trxDate, "DD MMM YYYY, HH:mm"),
-      style: valueStyle
-    }
-  },
-  {
-    key: {
-      text: I18n.t("bonus.bpd.details.transaction.detail.paymentCircuit"),
-      style: keyStyle
-    },
-    value: {
-      text: transaction.circuitType,
-      style: valueStyle
-    }
-  },
-  {
-    key: {
-      text: I18n.t("bonus.bpd.details.transaction.detail.transactionAmount"),
-      style: keyStyle
-    },
-    value: {
-      text: `€ ${formatNumberAmount(transaction.amount)}`,
-      style: valueStyle
-    }
-  },
-  {
-    key: {
-      text: I18n.t("bonus.bpd.details.transaction.detail.cashbackAmount"),
-      style: keyStyle
-    },
-    value: {
-      text: `€ ${formatNumberAmount(transaction.cashback)}`,
-      style: valueStyle
-    }
-  }
-];
-
 type IdBlockProps = {
   title: string;
   value: string;
 };
+
+const CancelBadge = () => (
+  <Badge style={styles.badge}>
+    <Text semibold={true} style={styles.badgeText}>
+      {I18n.t("bonus.bpd.details.transaction.detail.canceled")}
+    </Text>
+  </Badge>
+);
+
+const Table = (props: Props) => (
+  <View>
+    <View style={styles.rowId}>
+      <H5 weight={"Regular"} color={"bluegrey"}>
+        {I18n.t("payment.details.info.dateAndTime")}
+      </H5>
+      <H4 weight={"SemiBold"} color={"bluegreyDark"}>
+        {format(props.transaction.trxDate, "DD MMM YYYY, HH:mm")}
+      </H4>
+    </View>
+    <View spacer={true} small={true} />
+    <View style={styles.rowId}>
+      <H5 weight={"Regular"} color={"bluegrey"}>
+        {I18n.t("bonus.bpd.details.transaction.detail.paymentCircuit")}
+      </H5>
+      <H4 weight={"SemiBold"} color={"bluegreyDark"}>
+        {props.transaction.circuitType}
+      </H4>
+    </View>
+    <View spacer={true} small={true} />
+    <View style={styles.rowId}>
+      <H5 weight={"Regular"} color={"bluegrey"}>
+        {I18n.t("bonus.bpd.details.transaction.detail.transactionAmount")}
+      </H5>
+      <View style={styles.rowId}>
+        {props.transaction.amount < 0 && (
+          <>
+            <CancelBadge />
+            <View hspacer={true} />
+          </>
+        )}
+        <H4 weight={"SemiBold"} color={"bluegreyDark"}>
+          {`€ ${formatNumberAmount(props.transaction.amount)}`}
+        </H4>
+      </View>
+    </View>
+    <View spacer={true} small={true} />
+    <View style={styles.rowId}>
+      <H5 weight={"Regular"} color={"bluegrey"}>
+        {I18n.t("bonus.bpd.details.transaction.detail.cashbackAmount")}
+      </H5>
+      <H4 weight={"SemiBold"} color={"bluegreyDark"}>
+        {`€ ${formatNumberAmount(props.transaction.cashback)}`}
+      </H4>
+    </View>
+  </View>
+);
 
 const IdBlock = (props: IdBlockProps) => (
   <View>
@@ -124,11 +133,7 @@ export const BpdTransactionDetailComponent: React.FunctionComponent<Props> = pro
       </View>
       <View spacer={true} />
       {/* using the keyvaluetable with custom style in order to be quick */}
-      <KeyValueTable
-        leftFlex={1}
-        rightFlex={1}
-        rows={getRows(props.transaction)}
-      />
+      <Table transaction={props.transaction} />
       <BpdTransactionWarning transaction={props.transaction} />
       <View spacer={true} />
       <IdBlock title={acquirerId} value={props.transaction.idTrxAcquirer} />

--- a/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionDetailComponent.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionDetailComponent.tsx
@@ -86,7 +86,7 @@ const Table = (props: Props) => (
           </>
         )}
         <H4 weight={"SemiBold"} color={"bluegreyDark"}>
-          {`€ ${formatNumberAmount(props.transaction.amount)}`}
+          {formatNumberAmount(props.transaction.amount, true)}
         </H4>
       </View>
     </View>

--- a/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionDetailComponent.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionDetailComponent.tsx
@@ -16,6 +16,7 @@ import {
 } from "../../../../../bonusVacanze/components/keyValueTable/KeyValueTable";
 import { EnhancedBpdTransaction } from "../../../../components/transactionItem/BpdTransactionItem";
 import { H5 } from "../../../../../../../components/core/typography/H5";
+import { BpdTransactionWarning } from "./BpdTransactionWarning";
 
 type Props = { transaction: EnhancedBpdTransaction };
 
@@ -128,6 +129,7 @@ export const BpdTransactionDetailComponent: React.FunctionComponent<Props> = pro
         rightFlex={1}
         rows={getRows(props.transaction)}
       />
+      <BpdTransactionWarning transaction={props.transaction} />
       <View spacer={true} />
       <IdBlock title={acquirerId} value={props.transaction.idTrxAcquirer} />
       <View spacer={true} />

--- a/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionWarning.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionWarning.tsx
@@ -1,0 +1,63 @@
+import * as React from "react";
+import { View } from "native-base";
+import { InfoBox } from "../../../../../../../components/box/InfoBox";
+import { Body } from "../../../../../../../components/core/typography/Body";
+import I18n from "../../../../../../../i18n";
+import { EnhancedBpdTransaction } from "../../../../components/transactionItem/BpdTransactionItem";
+
+type Props = { transaction: EnhancedBpdTransaction };
+
+/**
+ * Displays a warning when certain conditions occur
+ * @param props
+ * @constructor
+ */
+export const BpdTransactionWarning: React.FunctionComponent<Props> = props => {
+  if (
+    props.transaction.maxCashbackForTransactionAmount ===
+    props.transaction.cashback
+  ) {
+    return (
+      <>
+        <View spacer={true} />
+        <InfoBox>
+          <Body>
+            {I18n.t("bonus.bpd.details.transaction.detail.maxCashbackWarning", {
+              amount: props.transaction.maxCashbackForTransactionAmount
+            })}
+          </Body>
+        </InfoBox>
+      </>
+    );
+  }
+  if (props.transaction.cashback === 0) {
+    return (
+      <>
+        <View spacer={true} />
+        <InfoBox>
+          <Body>
+            {I18n.t(
+              "bonus.bpd.details.transaction.detail.maxCashbackForPeriodWarning"
+            )}
+          </Body>
+        </InfoBox>
+      </>
+    );
+  }
+  if (props.transaction.cashback <= 0) {
+    return (
+      <>
+        <View spacer={true} />
+        <InfoBox>
+          <Body>
+            {I18n.t(
+              "bonus.bpd.details.transaction.detail.canceledOperationWarning"
+            )}
+          </Body>
+        </InfoBox>
+      </>
+    );
+  }
+
+  return null;
+};

--- a/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionWarning.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionWarning.tsx
@@ -30,20 +30,6 @@ export const BpdTransactionWarning: React.FunctionComponent<Props> = props => {
       </>
     );
   }
-  if (props.transaction.cashback === 0) {
-    return (
-      <>
-        <View spacer={true} />
-        <InfoBox>
-          <Body>
-            {I18n.t(
-              "bonus.bpd.details.transaction.detail.maxCashbackForPeriodWarning"
-            )}
-          </Body>
-        </InfoBox>
-      </>
-    );
-  }
   if (props.transaction.cashback <= 0) {
     return (
       <>
@@ -51,13 +37,14 @@ export const BpdTransactionWarning: React.FunctionComponent<Props> = props => {
         <InfoBox>
           <Body>
             {I18n.t(
-              "bonus.bpd.details.transaction.detail.canceledOperationWarning"
+              props.transaction.cashback < 0
+                ? "bonus.bpd.details.transaction.detail.canceledOperationWarning"
+                : "bonus.bpd.details.transaction.detail.maxCashbackForPeriodWarning"
             )}
           </Body>
         </InfoBox>
       </>
     );
   }
-
   return null;
 };

--- a/ts/features/bonus/bpd/store/actions/transactions.ts
+++ b/ts/features/bonus/bpd/store/actions/transactions.ts
@@ -3,7 +3,19 @@ import { HPan } from "./paymentMethods";
 import { AwardPeriodId, WithAwardPeriodId } from "./periods";
 
 // TODO: placeholder, TBD how to map the circuit Type
-export type CircuitType = "PagoBancomat" | "Visa" | "Mastercard";
+export type CircuitType =
+  | "PagoBancomat"
+  | "Visa"
+  | "Mastercard"
+  | "Amex"
+  | "JCB"
+  | "UnionPay"
+  | "Diners"
+  | "PostePay"
+  | "BancomatPay"
+  | "SatisPay"
+  | "Private"
+  | "Unknown";
 
 /**
  * The single transaction acquired in a cashback period

--- a/ts/features/bonus/bpd/store/reducers/details/combiner.ts
+++ b/ts/features/bonus/bpd/store/reducers/details/combiner.ts
@@ -171,6 +171,9 @@ const getTitleFromBancomat = (
     .map(abi => abi.name)
     .getOrElse(I18n.t("wallet.methods.bancomat.name"));
 
+const getId = (transaction: BpdTransaction) =>
+  `${transaction.awardPeriodId}${transaction.trxDate}${transaction.hashPan}${transaction.idTrxAcquirer}${transaction.idTrxIssuer}${transaction.amount}`;
+
 /**
  * Enhance a {@link BpdTransaction} with an image and a title, using the wallet and the abilist
  */
@@ -193,7 +196,8 @@ export const bpdDisplayTransactionsSelector = createSelector<
               .getOrElse(cardIcons.UNKNOWN),
             title: pickWalletFromHashpan(t.hashPan, wallet)
               .map(w2 => getTitleFromWallet(w2, abiList))
-              .getOrElse(FOUR_UNICODE_CIRCLES)
+              .getOrElse(FOUR_UNICODE_CIRCLES),
+            keyId: getId(t)
           } as EnhancedBpdTransaction)
       )
     )

--- a/ts/features/bonus/bpd/store/reducers/details/combiner.ts
+++ b/ts/features/bonus/bpd/store/reducers/details/combiner.ts
@@ -22,6 +22,7 @@ import { BpdTransaction } from "../../actions/transactions";
 import { bpdEnabledSelector } from "./activation";
 import { bpdAllAmountSelector } from "./amounts";
 import { bpdPeriodsSelector } from "./periods";
+import { bpdSelectedPeriodSelector } from "./selectedPeriod";
 import { bpdTransactionsForSelectedPeriod } from "./transactions";
 
 /**
@@ -182,10 +183,16 @@ export const bpdDisplayTransactionsSelector = createSelector<
   pot.Pot<ReadonlyArray<BpdTransaction>, Error>,
   pot.Pot<ReadonlyArray<PatchedWalletV2>, Error>,
   ReadonlyArray<Abi>,
+  BpdPeriod | undefined,
   pot.Pot<ReadonlyArray<EnhancedBpdTransaction>, Error>
 >(
-  [bpdTransactionsForSelectedPeriod, walletV2Selector, abiListSelector],
-  (potTransactions, wallet, abiList) =>
+  [
+    bpdTransactionsForSelectedPeriod,
+    walletV2Selector,
+    abiListSelector,
+    bpdSelectedPeriodSelector
+  ],
+  (potTransactions, wallet, abiList, period) =>
     pot.map(potTransactions, transactions =>
       transactions.map(
         t =>
@@ -197,7 +204,8 @@ export const bpdDisplayTransactionsSelector = createSelector<
             title: pickWalletFromHashpan(t.hashPan, wallet)
               .map(w2 => getTitleFromWallet(w2, abiList))
               .getOrElse(FOUR_UNICODE_CIRCLES),
-            keyId: getId(t)
+            keyId: getId(t),
+            maxCashbackForTransactionAmount: period?.maxTransactionCashback
           } as EnhancedBpdTransaction)
       )
     )


### PR DESCRIPTION
## Short description
This pr adds the bottomsheet with details for a transaction.

Normal            |  MaxTransactionCashback
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/26501317/98588015-4a964680-22cb-11eb-9769-d3487dbd5d63.png" width="300">|  <img src="https://user-images.githubusercontent.com/26501317/98588048-57b33580-22cb-11eb-95d0-aa72a5bac6a0.png" width="300">


MaxPeriodCashback            |  CancelTransaction
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/26501317/98588102-6ac60580-22cb-11eb-94d0-bf8312954185.png" width="300">|  <img src="https://user-images.githubusercontent.com/26501317/98588140-7ca7a880-22cb-11eb-9aa5-90072f32e95b.png" width="300">

## List of changes proposed in this pull request
- Added `keyId: string;  maxCashbackForTransactionAmount: number | undefined;` to `EnhancedBpdTransaction`.
- Added `BpdTransactionDetailComponent`  to render a transaction detail.
- Added 

## How to test
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
