### PR TITLE
fix(Bonus Pagamenti Digitali): [#175647501,#175647625] Fixes render on single period found and automatic scroll

### DIFF
--- a/ts/components/HorizontalScroll.tsx
+++ b/ts/components/HorizontalScroll.tsx
@@ -59,7 +59,7 @@ export const HorizontalScroll: React.FunctionComponent<Props> = (
       setTimeout(() => {
         if (scrollRef.current) {
           scrollRef.current.scrollTo({
-            x: scrollOffset * Dimensions.get("window").width,
+            x: scrollOffset,
             y: 0,
             animated: false
           });
@@ -103,6 +103,7 @@ export const HorizontalScroll: React.FunctionComponent<Props> = (
         ref={scrollRef}
         horizontal={true}
         showsHorizontalScrollIndicator={false}
+        scrollEnabled={props.cards.length > 1}
         scrollEventThrottle={props.cards.length}
         pagingEnabled={true}
         onScroll={event => {
@@ -127,7 +128,9 @@ export const HorizontalScroll: React.FunctionComponent<Props> = (
         {props.cards}
       </ScrollView>
 
-      <View style={styles.barContainer}>{barArray}</View>
+      {props.cards.length > 1 && (
+        <View style={styles.barContainer}>{barArray}</View>
+      )}
       <View spacer={true} />
     </View>
   );

--- a/ts/features/bonus/bpd/screens/details/BpdPeriodSelector.tsx
+++ b/ts/features/bonus/bpd/screens/details/BpdPeriodSelector.tsx
@@ -66,7 +66,7 @@ const BpdPeriodSelector: React.FunctionComponent<Props> = props => {
   return (
     <View style={[IOStyles.flex]}>
       {pot.isSome(props.periodsWithAmount) &&
-        props.periodsWithAmount.value.length > 1 && (
+        props.periodsWithAmount.value.length > 0 && (
           <HorizontalScroll
             indexToScroll={indexOfSelectedPeriod}
             onCurrentElement={selectPeriod}


### PR DESCRIPTION
## Short description
This PR fixes the single period render and the scrollTo selected period from wallet home screen of BPDCard carousel.

### Single period available
<img height="550" src="https://user-images.githubusercontent.com/3959405/98667277-7c042600-234e-11eb-9ffd-51a039f0b6cb.gif"/>

### ScrollTo selected period
<img height="550" src="https://user-images.githubusercontent.com/3959405/98666628-9093ee80-234d-11eb-8662-ca1d5b7ad9ad.gif"/>