### PR TITLE
fix(Bonus Pagamenti Digitali): [#175715662] Buttons in bottomsheet don't dispatch onPress event

### DIFF
--- a/ts/components/ButtonDefaultOpacity.tsx
+++ b/ts/components/ButtonDefaultOpacity.tsx
@@ -1,6 +1,12 @@
 import { Button, NativeBase } from "native-base";
 import * as React from "react";
+import {
+  State,
+  TapGestureHandler,
+  TapGestureHandlerStateChangeEvent
+} from "react-native-gesture-handler";
 import customVariables from "../theme/variables";
+import { isIos } from "../utils/platform";
 import { calculateSlop } from "./core/accessibility";
 
 const defaultActiveOpacity = 1.0;
@@ -27,21 +33,41 @@ const getSlopForCurrentButton = (props: Props) => {
 /**
  * return Button component where the activeOpacity is 1.0 by default
  * instead of 0.2 https://github.com/facebook/react-native/blob/3042407f43b69994abc00350681f1f0a79683bfd/Libraries/Components/Touchable/TouchableOpacity.js#L149
+ *
+ * In certain cases on Android devices, the native-base button doesn't dispatch the onPress event
+ * Because of this, on Android, we wrap the button in a TapGestureHandler and the onPress is handled manually
+ * (this surely happen when a button is used inside a BottomSheet)
  */
 const ButtonDefaultOpacity = (props: Props) => {
   const slop = getSlopForCurrentButton(props);
-  return (
+  const button = (
     <Button
       {...{
         ...props,
         activeOpacity: props.activeOpacity || defaultActiveOpacity
       }}
+      onPress={isIos ? props.onPress : undefined}
       accessible={true} // allows with TalkBack the feedback request to touch for button activation
       accessibilityRole={"button"}
       hitSlop={{ top: slop, bottom: slop }}
     >
       {props.children}
     </Button>
+  );
+
+  return isIos ? (
+    button
+  ) : (
+    <TapGestureHandler
+      onHandlerStateChange={(event: TapGestureHandlerStateChangeEvent) => {
+        // call on press when touch ends
+        if (props.onPress && event.nativeEvent.state === State.END) {
+          props.onPress();
+        }
+      }}
+    >
+      {button}
+    </TapGestureHandler>
   );
 };
 


### PR DESCRIPTION
## Short description
When you use a `Button` (from `native-base`) inside a `ButtomSheet`, it doesn't dispatch the `onPress` event.
Thir PR fixes that bug by wrapping the button inside a `TapGestureHandler`
