### PR TITLE
feat(Bonus Pagamenti Digitali): [#175682399] Bancomat card preview in wallet

### DIFF
--- a/ts/components/wallet/card/CardComponent.tsx
+++ b/ts/components/wallet/card/CardComponent.tsx
@@ -26,8 +26,7 @@ import { CreditCardStyles } from "./style";
 
 // TODO: the "*" character renders differently (i.e. a larger circle) on
 // some devices @https://www.pivotaltracker.com/story/show/159231780
-const FOUR_UNICODE_CIRCLES = "\u25cf".repeat(4);
-const HIDDEN_CREDITCARD_NUMBERS = `${FOUR_UNICODE_CIRCLES} `.repeat(3);
+const FOUR_UNICODE_CIRCLES = "●".repeat(4);
 
 interface BaseProps {
   wallet: Wallet;
@@ -300,7 +299,7 @@ export default class CardComponent extends React.Component<Props> {
           <View style={[styles.row, styles.spaced]}>
             <View style={styles.row}>
               <Text style={[CreditCardStyles.smallTextStyle]}>
-                {`${HIDDEN_CREDITCARD_NUMBERS}`}
+                {`${FOUR_UNICODE_CIRCLES} `}
               </Text>
               <Text style={[CreditCardStyles.largeTextStyle]}>
                 {`${wallet.creditCard.pan.slice(-4)}`}

--- a/ts/components/wallet/card/RotatedCards.tsx
+++ b/ts/components/wallet/card/RotatedCards.tsx
@@ -32,8 +32,7 @@ const styles = StyleSheet.create({
   }
 });
 
-const FOUR_UNICODE_CIRCLES = "\u25cf".repeat(4);
-const HIDDEN_CREDITCARD_NUMBERS = `${FOUR_UNICODE_CIRCLES} `.repeat(4);
+const FOUR_UNICODE_CIRCLES = "●".repeat(4);
 
 interface Props {
   // tslint-prettier doesn't yet support the readonly tuple syntax
@@ -55,7 +54,7 @@ export class RotatedCards extends React.PureComponent<Props> {
           <View style={[CreditCardStyles.cardInner, CreditCardStyles.row]}>
             <View style={[CreditCardStyles.row, CreditCardStyles.numberArea]}>
               <Text style={[CreditCardStyles2.smallTextStyle]}>
-                {`${HIDDEN_CREDITCARD_NUMBERS}`}
+                {`${FOUR_UNICODE_CIRCLES}`}
               </Text>
             </View>
             <View style={CreditCardStyles.cardLogo}>

--- a/ts/features/wallet/component/CardPreview.tsx
+++ b/ts/features/wallet/component/CardPreview.tsx
@@ -2,7 +2,6 @@ import { View } from "native-base";
 import * as React from "react";
 import { Platform, StyleSheet } from "react-native";
 import { Label } from "../../../components/core/typography/Label";
-import { IOStyles } from "../../../components/core/variables/IOStyles";
 import TouchableDefaultOpacity from "../../../components/TouchableDefaultOpacity";
 import I18n from "../../../i18n";
 import variables from "../../../theme/variables";
@@ -11,7 +10,7 @@ type Props = {};
 
 const styles = StyleSheet.create({
   card: {
-    // iOS and Andorid card shadow
+    // iOS and Android card shadow
     shadowColor: "#000",
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.1,
@@ -46,7 +45,7 @@ const styles = StyleSheet.create({
     shadowRadius: 10,
     shadowOpacity: 0.15,
     transform: [{ perspective: 1200 }, { rotateX: "-20deg" }, { scaleX: 0.99 }],
-    height: 90
+    height: 95
   },
   shadowBox: {
     marginBottom: -15,
@@ -58,30 +57,28 @@ const styles = StyleSheet.create({
 });
 
 /**
- * A Generic preview card layout
+ * A Generic preview card layout extracted from {@link CardComponent} and simplified.
+ * Can be used to render a generic wallet preview card.
+ * TODO: in this phase the CardComponent is preserved and no refactoring has been done on the pre-existing code
  * @param props
  * @constructor
  */
 export const CardPreview: React.FunctionComponent<Props> = props => (
-  <TouchableDefaultOpacity
-    onPress={() => console.log("asd")}
-    accessible={true}
-    accessibilityLabel={I18n.t("wallet.accessibility.cardsPreview")}
-    accessibilityRole={"button"}
-  >
+  <>
+    {/* In order to render the shadow on android */}
     {Platform.OS === "android" && <View style={styles.shadowBox} />}
-    <View style={styles.rotatedCard}>
+    <TouchableDefaultOpacity
+      onPress={() => console.log("asd")}
+      accessible={true}
+      accessibilityLabel={I18n.t("wallet.accessibility.cardsPreview")}
+      accessibilityRole={"button"}
+      style={styles.rotatedCard}
+    >
       <View style={[styles.card]}>
         <View style={[styles.cardInner]}>
           <View style={[styles.row, styles.spaced]}>
             <View style={styles.row}>
               <Label>Ciao</Label>
-              {/* <Text style={[CreditCardStyles.smallTextStyle]}> */}
-              {/*  {`${FOUR_UNICODE_CIRCLES} `} */}
-              {/* </Text> */}
-              {/* <Text style={[CreditCardStyles.largeTextStyle]}> */}
-              {/*  {`${wallet.creditCard.pan.slice(-4)}`} */}
-              {/* </Text> */}
             </View>
             <View>
               <Label>DX</Label>
@@ -90,6 +87,6 @@ export const CardPreview: React.FunctionComponent<Props> = props => (
           <View spacer={true} />
         </View>
       </View>
-    </View>
-  </TouchableDefaultOpacity>
+    </TouchableDefaultOpacity>
+  </>
 );

--- a/ts/features/wallet/component/CardPreview.tsx
+++ b/ts/features/wallet/component/CardPreview.tsx
@@ -5,7 +5,11 @@ import TouchableDefaultOpacity from "../../../components/TouchableDefaultOpacity
 import I18n from "../../../i18n";
 import variables from "../../../theme/variables";
 
-type Props = { left: React.ReactNode; image: ImageSourcePropType };
+type Props = {
+  left: React.ReactNode;
+  image: ImageSourcePropType;
+  onPress?: () => void;
+};
 
 const styles = StyleSheet.create({
   card: {
@@ -67,7 +71,7 @@ export const CardPreview: React.FunctionComponent<Props> = props => (
     {/* In order to render the shadow on android */}
     {Platform.OS === "android" && <View style={styles.shadowBox} />}
     <TouchableDefaultOpacity
-      onPress={() => console.log("card")}
+      onPress={props.onPress}
       accessible={true}
       accessibilityLabel={I18n.t("wallet.accessibility.cardsPreview")}
       accessibilityRole={"button"}

--- a/ts/features/wallet/component/CardPreview.tsx
+++ b/ts/features/wallet/component/CardPreview.tsx
@@ -1,12 +1,11 @@
 import { View } from "native-base";
 import * as React from "react";
-import { Platform, StyleSheet } from "react-native";
-import { Label } from "../../../components/core/typography/Label";
+import { Image, ImageSourcePropType, Platform, StyleSheet } from "react-native";
 import TouchableDefaultOpacity from "../../../components/TouchableDefaultOpacity";
 import I18n from "../../../i18n";
 import variables from "../../../theme/variables";
 
-type Props = {};
+type Props = { left: React.ReactNode; image: ImageSourcePropType };
 
 const styles = StyleSheet.create({
   card: {
@@ -68,7 +67,7 @@ export const CardPreview: React.FunctionComponent<Props> = props => (
     {/* In order to render the shadow on android */}
     {Platform.OS === "android" && <View style={styles.shadowBox} />}
     <TouchableDefaultOpacity
-      onPress={() => console.log("asd")}
+      onPress={() => console.log("card")}
       accessible={true}
       accessibilityLabel={I18n.t("wallet.accessibility.cardsPreview")}
       accessibilityRole={"button"}
@@ -77,11 +76,9 @@ export const CardPreview: React.FunctionComponent<Props> = props => (
       <View style={[styles.card]}>
         <View style={[styles.cardInner]}>
           <View style={[styles.row, styles.spaced]}>
-            <View style={styles.row}>
-              <Label>Ciao</Label>
-            </View>
+            <View style={styles.row}>{props.left}</View>
             <View>
-              <Label>DX</Label>
+              <Image source={props.image} style={styles.cardLogo} />
             </View>
           </View>
           <View spacer={true} />

--- a/ts/features/wallet/component/CardPreview.tsx
+++ b/ts/features/wallet/component/CardPreview.tsx
@@ -76,10 +76,8 @@ export const CardPreview: React.FunctionComponent<Props> = props => (
       <View style={[styles.card]}>
         <View style={[styles.cardInner]}>
           <View style={[styles.row, styles.spaced]}>
-            <View style={styles.row}>{props.left}</View>
-            <View>
-              <Image source={props.image} style={styles.cardLogo} />
-            </View>
+            {props.left}
+            <Image source={props.image} style={styles.cardLogo} />
           </View>
           <View spacer={true} />
         </View>

--- a/ts/features/wallet/component/CardPreview.tsx
+++ b/ts/features/wallet/component/CardPreview.tsx
@@ -1,0 +1,95 @@
+import { View } from "native-base";
+import * as React from "react";
+import { Platform, StyleSheet } from "react-native";
+import { Label } from "../../../components/core/typography/Label";
+import { IOStyles } from "../../../components/core/variables/IOStyles";
+import TouchableDefaultOpacity from "../../../components/TouchableDefaultOpacity";
+import I18n from "../../../i18n";
+import variables from "../../../theme/variables";
+
+type Props = {};
+
+const styles = StyleSheet.create({
+  card: {
+    // iOS and Andorid card shadow
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 1.5,
+    elevation: -7,
+    zIndex: -7,
+    backgroundColor: variables.brandGray,
+    borderRadius: 8,
+    marginLeft: 0,
+    marginRight: 0
+  },
+  cardInner: {
+    paddingBottom: 16,
+    paddingLeft: 16,
+    paddingRight: 16,
+    paddingTop: 18
+  },
+  row: {
+    flexDirection: "row"
+  },
+  spaced: {
+    justifyContent: "space-between"
+  },
+  cardLogo: {
+    height: 30,
+    width: 48
+  },
+  rotatedCard: {
+    shadowColor: "#000",
+    marginBottom: -30,
+    flex: 1,
+    shadowRadius: 10,
+    shadowOpacity: 0.15,
+    transform: [{ perspective: 1200 }, { rotateX: "-20deg" }, { scaleX: 0.99 }],
+    height: 90
+  },
+  shadowBox: {
+    marginBottom: -15,
+    borderRadius: 8,
+    borderTopWidth: 8,
+    borderTopColor: "rgba(0,0,0,0.1)",
+    height: 15
+  }
+});
+
+/**
+ * A Generic preview card layout
+ * @param props
+ * @constructor
+ */
+export const CardPreview: React.FunctionComponent<Props> = props => (
+  <TouchableDefaultOpacity
+    onPress={() => console.log("asd")}
+    accessible={true}
+    accessibilityLabel={I18n.t("wallet.accessibility.cardsPreview")}
+    accessibilityRole={"button"}
+  >
+    {Platform.OS === "android" && <View style={styles.shadowBox} />}
+    <View style={styles.rotatedCard}>
+      <View style={[styles.card]}>
+        <View style={[styles.cardInner]}>
+          <View style={[styles.row, styles.spaced]}>
+            <View style={styles.row}>
+              <Label>Ciao</Label>
+              {/* <Text style={[CreditCardStyles.smallTextStyle]}> */}
+              {/*  {`${FOUR_UNICODE_CIRCLES} `} */}
+              {/* </Text> */}
+              {/* <Text style={[CreditCardStyles.largeTextStyle]}> */}
+              {/*  {`${wallet.creditCard.pan.slice(-4)}`} */}
+              {/* </Text> */}
+            </View>
+            <View>
+              <Label>DX</Label>
+            </View>
+          </View>
+          <View spacer={true} />
+        </View>
+      </View>
+    </View>
+  </TouchableDefaultOpacity>
+);

--- a/ts/features/wallet/component/WalletV2PreviewCards.tsx
+++ b/ts/features/wallet/component/WalletV2PreviewCards.tsx
@@ -1,0 +1,42 @@
+import * as pot from "italia-ts-commons/lib/pot";
+import * as React from "react";
+import { connect } from "react-redux";
+import { Dispatch } from "redux";
+import { GlobalState } from "../../../store/reducers/types";
+import { bancomatSelector } from "../../../store/reducers/wallet/wallets";
+import { BancomatWalletPreview } from "../onboarding/bancomat/components/BancomatWalletPreview";
+
+type Props = ReturnType<typeof mapDispatchToProps> &
+  ReturnType<typeof mapStateToProps>;
+
+/**
+ * The new wallet preview that renders all the new v2 methods.
+ * Atm the legacy types (credit card) are rendered with the old method.
+ * TODO: will render also satispay, bancomat pay
+ * @constructor
+ */
+const WalletV2PreviewCards: React.FunctionComponent<Props> = props => (
+  <>
+    {pot.getOrElse(
+      pot.map(props.bancomatList, walletv2 => (
+        <>
+          {walletv2.map(w2 => (
+            <BancomatWalletPreview key={w2.idWallet} bancomat={w2} />
+          ))}
+        </>
+      )),
+      null
+    )}
+  </>
+);
+
+const mapDispatchToProps = (_: Dispatch) => ({});
+
+const mapStateToProps = (state: GlobalState) => ({
+  bancomatList: bancomatSelector(state)
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(WalletV2PreviewCards);

--- a/ts/features/wallet/onboarding/bancomat/components/BancomatWalletPreview.tsx
+++ b/ts/features/wallet/onboarding/bancomat/components/BancomatWalletPreview.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { Image, ImageStyle, StyleProp, StyleSheet } from "react-native";
 import pagoBancomatImage from "../../../../../../img/wallet/cards-icons/pagobancomat.png";
 import { Body } from "../../../../../components/core/typography/Body";
+import { IOStyles } from "../../../../../components/core/variables/IOStyles";
 import { EnhancedBancomat } from "../../../../../store/reducers/wallet/wallets";
 import { CardPreview } from "../../../component/CardPreview";
 import { useImageResize } from "../screens/hooks/useImageResize";
@@ -23,7 +24,7 @@ const BASE_IMG_H = 20;
  */
 const renderLeft = (props: Props, size: Option<[number, number]>) =>
   size.fold(
-    <Body>
+    <Body style={IOStyles.flex} numberOfLines={1}>
       {props.bancomat.abiInfo?.name ?? I18n.t("wallet.methods.bancomat.name")}
     </Body>,
     imgDim => {

--- a/ts/features/wallet/onboarding/bancomat/components/BancomatWalletPreview.tsx
+++ b/ts/features/wallet/onboarding/bancomat/components/BancomatWalletPreview.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { StyleSheet } from "react-native";
+import pagoBancomatImage from "../../../../../../img/wallet/cards-icons/pagobancomat.png";
+import { Body } from "../../../../../components/core/typography/Body";
+import { EnhancedBancomat } from "../../../../../store/reducers/wallet/wallets";
+import { CardPreview } from "../../../component/CardPreview";
+
+type Props = { bancomat: EnhancedBancomat };
+
+const styles = StyleSheet.create({});
+
+export const BancomatWalletPreview: React.FunctionComponent<Props> = props => (
+  <CardPreview
+    left={<Body>{props.bancomat.abiInfo?.name}</Body>}
+    image={pagoBancomatImage}
+  />
+);

--- a/ts/features/wallet/onboarding/bancomat/components/BancomatWalletPreview.tsx
+++ b/ts/features/wallet/onboarding/bancomat/components/BancomatWalletPreview.tsx
@@ -1,17 +1,55 @@
+import { Option } from "fp-ts/lib/Option";
 import * as React from "react";
-import { StyleSheet } from "react-native";
+import { Image, ImageStyle, StyleProp, StyleSheet } from "react-native";
 import pagoBancomatImage from "../../../../../../img/wallet/cards-icons/pagobancomat.png";
 import { Body } from "../../../../../components/core/typography/Body";
 import { EnhancedBancomat } from "../../../../../store/reducers/wallet/wallets";
 import { CardPreview } from "../../../component/CardPreview";
+import { useImageResize } from "../screens/hooks/useImageResize";
+import I18n from "../../../../../i18n";
 
 type Props = { bancomat: EnhancedBancomat };
 
 const styles = StyleSheet.create({});
 
-export const BancomatWalletPreview: React.FunctionComponent<Props> = props => (
-  <CardPreview
-    left={<Body>{props.bancomat.abiInfo?.name}</Body>}
-    image={pagoBancomatImage}
-  />
-);
+const BASE_IMG_W = 160;
+const BASE_IMG_H = 20;
+
+/**
+ * Render the image (if available) or the bank name (if available)
+ * or the generic bancomat string (final fallback).
+ * @param props
+ * @param size
+ */
+const renderLeft = (props: Props, size: Option<[number, number]>) =>
+  size.fold(
+    <Body>
+      {props.bancomat.abiInfo?.name ?? I18n.t("wallet.methods.bancomat.name")}
+    </Body>,
+    imgDim => {
+      const imageUrl = props.bancomat.abiInfo?.logoUrl;
+      const imageStyle: StyleProp<ImageStyle> = {
+        width: imgDim[0],
+        height: imgDim[1],
+        resizeMode: "contain"
+      };
+      return imageUrl ? (
+        <Image source={{ uri: imageUrl }} style={imageStyle} />
+      ) : null;
+    }
+  );
+
+export const BancomatWalletPreview: React.FunctionComponent<Props> = props => {
+  const imgDimensions = useImageResize(
+    BASE_IMG_W,
+    BASE_IMG_H,
+    props.bancomat.abiInfo?.logoUrl
+  );
+
+  return (
+    <CardPreview
+      left={renderLeft(props, imgDimensions)}
+      image={pagoBancomatImage}
+    />
+  );
+};

--- a/ts/features/wallet/onboarding/bancomat/components/BancomatWalletPreview.tsx
+++ b/ts/features/wallet/onboarding/bancomat/components/BancomatWalletPreview.tsx
@@ -38,6 +38,11 @@ const renderLeft = (props: Props, size: Option<[number, number]>) =>
     }
   );
 
+/**
+ * A card preview for a bancomat card
+ * @param props
+ * @constructor
+ */
 export const BancomatWalletPreview: React.FunctionComponent<Props> = props => {
   const imgDimensions = useImageResize(
     BASE_IMG_W,

--- a/ts/features/wallet/onboarding/bancomat/components/BancomatWalletPreview.tsx
+++ b/ts/features/wallet/onboarding/bancomat/components/BancomatWalletPreview.tsx
@@ -1,17 +1,15 @@
 import { Option } from "fp-ts/lib/Option";
 import * as React from "react";
-import { Image, ImageStyle, StyleProp, StyleSheet } from "react-native";
+import { Image, ImageStyle, StyleProp } from "react-native";
 import pagoBancomatImage from "../../../../../../img/wallet/cards-icons/pagobancomat.png";
 import { Body } from "../../../../../components/core/typography/Body";
 import { IOStyles } from "../../../../../components/core/variables/IOStyles";
+import I18n from "../../../../../i18n";
 import { EnhancedBancomat } from "../../../../../store/reducers/wallet/wallets";
 import { CardPreview } from "../../../component/CardPreview";
 import { useImageResize } from "../screens/hooks/useImageResize";
-import I18n from "../../../../../i18n";
 
 type Props = { bancomat: EnhancedBancomat };
-
-const styles = StyleSheet.create({});
 
 const BASE_IMG_W = 160;
 const BASE_IMG_H = 20;

--- a/ts/features/wallet/onboarding/store/abi.ts
+++ b/ts/features/wallet/onboarding/store/abi.ts
@@ -48,7 +48,13 @@ const abiReducer = (
 
 export default abiReducer;
 
-export const abiSelector = (state: GlobalState): AbiState => state.wallet.abi;
+/**
+ * AbiState, memoized
+ */
+export const abiSelector = createSelector(
+  [(state: GlobalState) => state.wallet.abi],
+  abi => abi
+);
 
 // return the abi list as array
 export const abiListSelector = createSelector<

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -58,6 +58,7 @@ import { navSelector } from "../../store/reducers/navigationHistory";
 import { paymentsHistorySelector } from "../../store/reducers/payments/history";
 import { isPagoPATestEnabledSelector } from "../../store/reducers/persistedPreferences";
 import { GlobalState } from "../../store/reducers/types";
+import { creditCardAttemptionsSelector } from "../../store/reducers/wallet/creditCard";
 import {
   areMoreTransactionsAvailable,
   getTransactionsLoadedLength,
@@ -70,7 +71,7 @@ import { Transaction, Wallet } from "../../types/pagopa";
 import { isUpdateNeeded } from "../../utils/appVersion";
 import { getCurrentRouteKey } from "../../utils/navigation";
 import { setStatusBarColorAndBackground } from "../../utils/statusBar";
-import { creditCardAttemptionsSelector } from "../../store/reducers/wallet/creditCard";
+import WalletV2PreviewCards from "../../features/wallet/component/WalletV2PreviewCards";
 
 type NavigationParams = Readonly<{
   newMethodAdded: boolean;
@@ -276,8 +277,10 @@ class WalletHomeScreen extends React.PureComponent<Props> {
             onClick={this.props.navigateToWalletTransactionsScreen}
           />
         ) : null}
-        {/* Display this item only if the flag is enabled */}
+        {/* new payment method rendering (bancomat, bancomatPay, satispay) */}
+        {bpdEnabled && <WalletV2PreviewCards />}
 
+        {/* Display this item only if the flag is enabled */}
         {bonusVacanzeEnabled && (
           <RequestBonus
             onButtonPress={this.props.navigateToBonusList}


### PR DESCRIPTION
## Short description
This pr adds the preview item in the wallet for the bancomat.

`bankLogo !== undefined`           |  `bankLogo === undefined && bankName !== undefined` | `bankLogo === undefined && bankName === undefined`
:-------------------------:|:---------------------:|:-----------------:
<img src="https://user-images.githubusercontent.com/26501317/99182510-a16da700-2735-11eb-80cf-b390e49fbe83.png" width="300">|  <img src="https://user-images.githubusercontent.com/26501317/99182540-c8c47400-2735-11eb-88e6-9764080fdc77.png" width="300"> | <img src="https://user-images.githubusercontent.com/26501317/99182574-f6a9b880-2735-11eb-9a1a-ec7ab0e5ac33.png" width="300">

<img src=https://user-images.githubusercontent.com/26501317/99182958-b861c880-2738-11eb-8dae-4853a3caa083.png width=300 />

*on Android*

## List of changes proposed in this pull request
- Changed the credit card representation format from `●●●● ●●●● ●●●● 1234` to `●●●● 1234`.
- Added `CardPreview`, a generic compontent to represent a card in the wallet (extracted an simplified from `CardComponent (preview mode)`
- Added `WalletV2PreviewCards` that will reders all the preview cards of v2 type (only bancomat atm).
- Added `BancomatWalletPreview` in order to render a preview of a bancomat.
- Added `bancomatSelector` to filter the bancomat from the wallet and add the missing data from the `Abi`
