### PR TITLE
feat(Bonus Pagamenti Digitali): [#175731715] Display app version in bpd overlay

### DIFF
--- a/ts/features/bonus/bpd/components/BpdTestOverlay.tsx
+++ b/ts/features/bonus/bpd/components/BpdTestOverlay.tsx
@@ -1,6 +1,6 @@
 import { View } from "native-base";
-import { useState } from "react";
 import * as React from "react";
+import { useState } from "react";
 import { Platform, StyleSheet } from "react-native";
 
 import { getStatusBarHeight, isIphoneX } from "react-native-iphone-x-helper";
@@ -10,10 +10,10 @@ import {
   bpdApiSitUrlPrefix,
   bpdApiUatUrlPrefix,
   bpdApiUrlPrefix,
-  bpdEnabled,
   pagoPaApiUrlPrefix,
   pagoPaApiUrlPrefixTest
 } from "../../../../config";
+import { getAppVersion } from "../../../../utils/appVersion";
 
 const styles = StyleSheet.create({
   versionContainer: {
@@ -59,13 +59,11 @@ export const BpdTestOverlay: React.FunctionComponent = () => {
           <Label
             style={styles.versionText}
             onPress={() => setEnabled(!enabled)}
-          >{`🛠️BPD TEST VERSION🛠️`}</Label>
+          >{`🛠️ BPD TEST VERSION 🛠️`}</Label>
           <Body
             style={styles.versionText}
             onPress={() => setEnabled(!enabled)}
-          >{`${
-            bpdEnabled ? "active" : "not active"
-          } - bpd: ${bpdEndpointStr} - PM: ${pmEndpointStr}`}</Body>
+          >{`${getAppVersion()} - bpd: ${bpdEndpointStr} - PM: ${pmEndpointStr}`}</Body>
         </>
       ) : null}
     </View>


### PR DESCRIPTION
# Short description
This pr changes the Bpd overlay in order to display the app version instead of the activation of the feature flag ( all the bpd version will have the feature flat activated).

![Schermata 2020-11-15 alle 14 13 18](https://user-images.githubusercontent.com/26501317/99185843-b73a9680-274c-11eb-826d-60f0c2eb8e91.png)
