### PR TITLE
feat(Bonus Pagamenti Digitali): [#175717926,#175717778,#175717794] Don't save rejected iban as valid iban, wrong "skip" CTA when edit iban from detail screen, added toast to confirm an IBAN insertion

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1699,6 +1699,7 @@ bonus:
         text2: "is not registered to"
       loading:
         "We are verifying your IBAN\n\nPlease wait."
+      success: "IBAN successfully entered"
     details:
       howItWorks:
         title: "How does Cashback work?"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1731,6 +1731,7 @@ bonus:
         text2: "non risulta intestato a"
       loading:
         "Stiamo verificando il tuo IBAN\n\nTi preghiamo di attendere."
+      success: "IBAN inserito con successo"
     details:
       howItWorks:
         title: "Come funziona il Cashback?"

--- a/ts/features/bonus/bpd/screens/iban/MainIbanScreen.tsx
+++ b/ts/features/bonus/bpd/screens/iban/MainIbanScreen.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { GlobalState } from "../../../../../store/reducers/types";
+import { showToast } from "../../../../../utils/showToast";
 import { isError, isLoading, isReady } from "../../model/RemoteValue";
 import { IbanStatus } from "../../saga/networking/patchCitizenIban";
 import {
@@ -10,6 +11,8 @@ import {
   bpdIbanInsertionResetScreen
 } from "../../store/actions/iban";
 import { bpdUpsertIbanSelector } from "../../store/reducers/details/activation/payoffInstrument";
+import { isBpdOnboardingOngoing } from "../../store/reducers/onboarding/ongoing";
+import I18n from "../../../../../i18n";
 import IbanLoadingUpsert from "./IbanLoadingUpsert";
 import IbanInsertionScreen from "./insertion/IbanInsertionScreen";
 import IbanKoNotOwned from "./ko/IbanKONotOwned";
@@ -32,6 +35,9 @@ const chooseRenderScreen = (props: Props) => {
       case IbanStatus.CANT_VERIFY:
         props.reset();
         props.completed();
+        if (!props.onboardingOngoing) {
+          showToast(I18n.t("bonus.bpd.iban.success"), "success");
+        }
     }
   }
   return <IbanInsertionScreen />;
@@ -50,7 +56,8 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 });
 
 const mapStateToProps = (state: GlobalState) => ({
-  upsertValue: bpdUpsertIbanSelector(state)
+  upsertValue: bpdUpsertIbanSelector(state),
+  onboardingOngoing: isBpdOnboardingOngoing(state)
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(MainIbanScreen);

--- a/ts/features/bonus/bpd/screens/iban/insertion/IbanInsertionComponent.tsx
+++ b/ts/features/bonus/bpd/screens/iban/insertion/IbanInsertionComponent.tsx
@@ -17,6 +17,7 @@ type Props = {
   onIbanConfirm: (iban: Iban) => void;
   onContinue: () => void;
   startIban?: string;
+  cancelText: string;
 };
 
 // https://en.wikipedia.org/wiki/International_Bank_Account_Number
@@ -28,22 +29,14 @@ const loadLocales = () => ({
   title: I18n.t("bonus.bpd.iban.insertion.title"),
   body1: I18n.t("bonus.bpd.iban.insertion.body1"),
   body2: I18n.t("bonus.bpd.iban.insertion.body2"),
-  ibanDescription: I18n.t("bonus.bpd.iban.iban"),
-  skip: I18n.t("global.buttons.skip")
+  ibanDescription: I18n.t("bonus.bpd.iban.iban")
 });
 
 export const IbanInsertionComponent: React.FunctionComponent<Props> = props => {
   const [iban, setIban] = useState(props.startIban ?? "");
   const isInvalidIban = iban.length > 0 && Iban.decode(iban).isLeft();
   const userCanContinue = !isInvalidIban && iban.length > 0;
-  const {
-    headerTitle,
-    title,
-    body1,
-    body2,
-    ibanDescription,
-    skip
-  } = loadLocales();
+  const { headerTitle, title, body1, body2, ibanDescription } = loadLocales();
 
   return (
     <BaseScreenComponent goBack={props.onBack} headerTitle={headerTitle}>
@@ -73,7 +66,7 @@ export const IbanInsertionComponent: React.FunctionComponent<Props> = props => {
             onRight={() => Iban.decode(iban).map(props.onIbanConfirm)}
             onCancel={props.onContinue}
             rightText={I18n.t("global.buttons.continue")}
-            leftText={skip}
+            leftText={props.cancelText}
           />,
           true
         )}

--- a/ts/features/bonus/bpd/screens/iban/insertion/IbanInsertionScreen.tsx
+++ b/ts/features/bonus/bpd/screens/iban/insertion/IbanInsertionScreen.tsx
@@ -27,7 +27,7 @@ const IbanInsertionScreen: React.FunctionComponent<Props> = props => (
     onIbanConfirm={props.submitIban}
     startIban={props.prefillIban}
     cancelText={
-      props.onboarding
+      props.onboardingOngoing
         ? I18n.t("global.buttons.skip")
         : I18n.t("global.buttons.cancel")
     }
@@ -42,7 +42,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 
 const mapStateToProps = (state: GlobalState) => ({
   prefillIban: bpdIbanPrefillSelector(state),
-  onboarding: isBpdOnboardingOngoing(state)
+  onboardingOngoing: isBpdOnboardingOngoing(state)
 });
 
 export default connect(

--- a/ts/features/bonus/bpd/screens/iban/insertion/IbanInsertionScreen.tsx
+++ b/ts/features/bonus/bpd/screens/iban/insertion/IbanInsertionScreen.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { Iban } from "../../../../../../../definitions/backend/Iban";
+import I18n from "../../../../../../i18n";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import {
   bpdIbanInsertionCancel,
@@ -9,6 +10,7 @@ import {
   bpdUpsertIban
 } from "../../../store/actions/iban";
 import { bpdIbanPrefillSelector } from "../../../store/reducers/details/activation";
+import { isBpdOnboardingOngoing } from "../../../store/reducers/onboarding/ongoing";
 import { IbanInsertionComponent } from "./IbanInsertionComponent";
 
 export type Props = ReturnType<typeof mapDispatchToProps> &
@@ -24,6 +26,11 @@ const IbanInsertionScreen: React.FunctionComponent<Props> = props => (
     onContinue={props.continue}
     onIbanConfirm={props.submitIban}
     startIban={props.prefillIban}
+    cancelText={
+      props.onboarding
+        ? I18n.t("global.buttons.skip")
+        : I18n.t("global.buttons.cancel")
+    }
   />
 );
 
@@ -34,7 +41,8 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 });
 
 const mapStateToProps = (state: GlobalState) => ({
-  prefillIban: bpdIbanPrefillSelector(state)
+  prefillIban: bpdIbanPrefillSelector(state),
+  onboarding: isBpdOnboardingOngoing(state)
 });
 
 export default connect(

--- a/ts/features/bonus/bpd/store/reducers/__test__/payoffInstruments.test.ts
+++ b/ts/features/bonus/bpd/store/reducers/__test__/payoffInstruments.test.ts
@@ -1,0 +1,140 @@
+import { Iban } from "../../../../../../../definitions/backend/Iban";
+import { applicationChangeState } from "../../../../../../store/actions/application";
+import { appReducer } from "../../../../../../store/reducers";
+import { GlobalState } from "../../../../../../store/reducers/types";
+import {
+  remoteError,
+  remoteLoading,
+  remoteReady,
+  remoteUndefined
+} from "../../../model/RemoteValue";
+import { IbanStatus } from "../../../saga/networking/patchCitizenIban";
+import { bpdUpsertIban } from "../../actions/iban";
+
+jest.mock("@react-native-community/async-storage", () => ({
+  AsyncStorage: jest.fn()
+}));
+
+jest.mock("react-native-share", () => ({
+  open: jest.fn()
+}));
+
+describe("test state with action bpdUpsertIban", () => {
+  const globalState: GlobalState = appReducer(
+    undefined,
+    applicationChangeState("active")
+  );
+
+  expect(
+    globalState.bonus.bpd.details.activation.payoffInstr.enrolledValue
+  ).toBe(remoteUndefined);
+
+  expect(
+    globalState.bonus.bpd.details.activation.payoffInstr.upsert.outcome
+  ).toBe(remoteUndefined);
+
+  it("check the state after a bpdUpsertIban.request", () => {
+    const upsertResult = appReducer(
+      globalState,
+      bpdUpsertIban.request("IT12313" as Iban)
+    );
+    expect(
+      upsertResult.bonus.bpd.details.activation.payoffInstr.enrolledValue
+    ).toBe(remoteUndefined);
+    expect(
+      upsertResult.bonus.bpd.details.activation.payoffInstr.upsert.outcome
+    ).toBe(remoteLoading);
+  });
+  it("check the state after a bpdUpsertIban.success CANT_VERIFY", () => {
+    const newIban = "IT123" as Iban;
+    const result = appReducer(
+      globalState,
+      bpdUpsertIban.success({
+        status: IbanStatus.CANT_VERIFY,
+        payoffInstr: newIban
+      })
+    );
+
+    expect(
+      result.bonus.bpd.details.activation.payoffInstr.enrolledValue
+    ).toStrictEqual(remoteReady(newIban));
+    expect(
+      result.bonus.bpd.details.activation.payoffInstr.upsert
+    ).toStrictEqual({
+      outcome: remoteReady("CANT_VERIFY" as IbanStatus),
+      value: newIban
+    });
+  });
+  it("check the state after a bpdUpsertIban.success OK", () => {
+    const newIban = "IT123" as Iban;
+    const result = appReducer(
+      globalState,
+      bpdUpsertIban.success({
+        status: IbanStatus.OK,
+        payoffInstr: newIban
+      })
+    );
+
+    expect(
+      result.bonus.bpd.details.activation.payoffInstr.enrolledValue
+    ).toStrictEqual(remoteReady(newIban));
+    expect(
+      result.bonus.bpd.details.activation.payoffInstr.upsert
+    ).toStrictEqual({
+      outcome: remoteReady("OK" as IbanStatus),
+      value: newIban
+    });
+  });
+  it("check the state after a bpdUpsertIban.success NOT_VALID", () => {
+    const result = appReducer(
+      globalState,
+      bpdUpsertIban.success({
+        status: IbanStatus.NOT_VALID,
+        payoffInstr: undefined
+      })
+    );
+
+    expect(
+      result.bonus.bpd.details.activation.payoffInstr.enrolledValue
+    ).toStrictEqual(remoteUndefined);
+    expect(
+      result.bonus.bpd.details.activation.payoffInstr.upsert
+    ).toStrictEqual({
+      outcome: remoteReady("NOT_VALID" as IbanStatus),
+      value: undefined
+    });
+  });
+  it("check the state after a bpdUpsertIban.success NOT_OWNED", () => {
+    const result = appReducer(
+      globalState,
+      bpdUpsertIban.success({
+        status: IbanStatus.NOT_OWNED,
+        payoffInstr: undefined
+      })
+    );
+
+    expect(
+      result.bonus.bpd.details.activation.payoffInstr.enrolledValue
+    ).toStrictEqual(remoteUndefined);
+    expect(
+      result.bonus.bpd.details.activation.payoffInstr.upsert
+    ).toStrictEqual({
+      outcome: remoteReady("NOT_OWNED" as IbanStatus),
+      value: undefined
+    });
+  });
+  it("check the state after a bpdUpsertIban.failure", () => {
+    const error = new Error("Error!");
+    const result = appReducer(globalState, bpdUpsertIban.failure(error));
+
+    expect(
+      result.bonus.bpd.details.activation.payoffInstr.enrolledValue
+    ).toStrictEqual(remoteUndefined);
+    expect(
+      result.bonus.bpd.details.activation.payoffInstr.upsert
+    ).toStrictEqual({
+      outcome: remoteError(error),
+      value: undefined
+    });
+  });
+});

--- a/ts/features/bonus/bpd/store/reducers/details/activation/payoffInstrument.ts
+++ b/ts/features/bonus/bpd/store/reducers/details/activation/payoffInstrument.ts
@@ -51,10 +51,12 @@ const paymentInstrumentValueReducer = (
       return remoteLoading;
     case getType(bpdLoadActivationStatus.success):
       return remoteReady(action.payload.payoffInstr);
+    // Update the effective value only if the upsert is OK or CANT_VERIFY
     case getType(bpdUpsertIban.success):
-      return action.payload.status === IbanStatus.NOT_VALID
-        ? state
-        : remoteReady(action.payload.payoffInstr);
+      return action.payload.status === IbanStatus.OK ||
+        action.payload.status === IbanStatus.CANT_VERIFY
+        ? remoteReady(action.payload.payoffInstr)
+        : state;
     case getType(bpdLoadActivationStatus.failure):
       return remoteError(action.payload);
   }
@@ -83,10 +85,7 @@ const paymentInstrumentUpsertReducer = (
       };
     case getType(bpdUpsertIban.success):
       return {
-        value:
-          action.payload.status === IbanStatus.NOT_VALID
-            ? state.value
-            : action.payload.payoffInstr,
+        value: action.payload.payoffInstr ?? state.value,
         outcome: remoteReady(action.payload.status)
       };
     case getType(bpdUpsertIban.failure):


### PR DESCRIPTION
## Short description
This pr fixes a bug that it showed an iban that had failed to enter as a registered iban, changes the "cancel" cta when iban change does not occur during onboarding and adds a confirm toast when the IBAN has been entered successfully.

<img src=https://user-images.githubusercontent.com/26501317/99433299-9f5e4080-290d-11eb-8747-f006b4d4d9e6.gif width=300 />

## List of changes proposed in this pull request
- Changed `MainIbanScreen` in order to shows a toast when the insertion is successful (not during the onboarding).
- Changed `IbanInsertionComponent` in order to shows different CTA ("skip" during onboarding, "cancel" from details)
- Changed `reducers/details/activation/payoffInstrument`  in order to fix a display bug.
- Added test ` ts/features/bonus/bpd/store/reducers/__test__/payoffInstruments.test.ts ` to test the state changed with the action `bpdUpsertIban`

## How to test
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
