### PR TITLE
feat(Bonus Pagamenti Digitali): [#175796300] WalletV2 could be Card, CreditCard, Satispay, Bancomatpay

### DIFF
--- a/ts/components/wallet/card/Logo.tsx
+++ b/ts/components/wallet/card/Logo.tsx
@@ -4,8 +4,6 @@
  */
 import * as React from "react";
 import { Image, ImageStyle, StyleProp, StyleSheet } from "react-native";
-import { CardInfo } from "../../../../definitions/pagopa/walletv2/CardInfo";
-import { CreditCard } from "../../../types/pagopa";
 import { CreditCardType } from "../../../types/pagopa";
 import { getResourceNameFromUrl } from "../../../utils/url";
 
@@ -34,6 +32,7 @@ const cardMapIcon: { [key in string]: any } = {
 };
 
 import defaultCardIcon from "../../../../img/wallet/cards-icons/unknown.png";
+import { CardInfo } from "../../../../definitions/pagopa/CardInfo";
 /**
  * pagoPA's "brandLogo" field contains an url to an image
  * From the given url it will check if there is a matching and an icon will be returned
@@ -43,11 +42,11 @@ import defaultCardIcon from "../../../../img/wallet/cards-icons/unknown.png";
  * for more info check https://www.pivotaltracker.com/story/show/165067615
  * @param creditcard the creditcard objects from which retrieve the icon
  */
-export const getCardIconFromBrandLogo = (creditcard: CreditCard | CardInfo) => {
-  if (!creditcard.brandLogo) {
+export const getCardIconFromBrandLogo = (cardInfo: CardInfo) => {
+  if (!cardInfo.brandLogo) {
     return defaultCardIcon;
   }
-  const imageName = getResourceNameFromUrl(creditcard.brandLogo);
+  const imageName = getResourceNameFromUrl(cardInfo.brandLogo);
   return imageName && cardMapIcon[imageName]
     ? cardMapIcon[imageName]
     : defaultCardIcon;
@@ -62,7 +61,7 @@ const styles = StyleSheet.create({
 });
 
 type Props = Readonly<{
-  item?: CreditCard;
+  item?: CardInfo;
   imageStyle?: StyleProp<ImageStyle>;
   pspLogo?: string;
 }>;

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/BancomatBpdToggle.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/BancomatBpdToggle.tsx
@@ -4,8 +4,8 @@ import { fromNullable } from "fp-ts/lib/Option";
 import { Dispatch } from "redux";
 import pagoBancomatImage from "../../../../../../img/wallet/cards-icons/pagobancomat.png";
 import {
-  EnableableFunctionsTypeEnum,
-  WalletV2WithInfo
+  BancomatPaymentMethod,
+  EnableableFunctionsTypeEnum
 } from "../../../../../types/pagopa";
 import { HPan } from "../../store/actions/paymentMethods";
 import { hasFunctionEnabled } from "../../../../../utils/walletv2";
@@ -15,11 +15,10 @@ import { GlobalState } from "../../../../../store/reducers/types";
 import { loadAbi } from "../../../../wallet/onboarding/bancomat/store/actions";
 import { useActionOnFocus } from "../../../../../utils/hooks/useOnFocus";
 import { abiSelector } from "../../../../wallet/onboarding/store/abi";
-import { CardInfo } from "../../../../../../definitions/pagopa/walletv2/CardInfo";
 import PaymentMethodBpdToggle from "./base/PaymentMethodBpdToggle";
 
 type Props = {
-  card: WalletV2WithInfo<CardInfo>;
+  card: BancomatPaymentMethod;
 } & ReturnType<typeof mapStateToProps> &
   ReturnType<typeof mapDispatchToProps>;
 
@@ -29,6 +28,7 @@ type Props = {
  * @constructor
  */
 const BancomatBpdToggle: React.FunctionComponent<Props> = props => {
+  const bancomat = props.card.info.bancomat;
   const [abiDescription, setAbiDescription] = React.useState(
     I18n.t("wallet.methods.bancomat.name")
   );
@@ -36,13 +36,13 @@ const BancomatBpdToggle: React.FunctionComponent<Props> = props => {
   // when the component is focused
   // load abi if abi list is empty and card has a valid issuerAbiCode
   useActionOnFocus(() => {
-    if (props.card.info.issuerAbiCode && !isReady(props.abis)) {
+    if (bancomat.issuerAbiCode && !isReady(props.abis)) {
       props.loadAbi();
     }
   });
 
   React.useEffect(() => {
-    fromNullable(props.card.info.issuerAbiCode).map(iac => {
+    fromNullable(bancomat.issuerAbiCode).map(iac => {
       fromNullable(getValueOrElse(props.abis, null))
         .map(abi => abi[iac])
         .chain(fromNullable)
@@ -54,10 +54,10 @@ const BancomatBpdToggle: React.FunctionComponent<Props> = props => {
 
   return (
     <PaymentMethodBpdToggle
-      hPan={props.card.info.hashPan as HPan}
+      hPan={bancomat.hashPan as HPan}
       icon={pagoBancomatImage}
       hasBpdCapability={hasFunctionEnabled(
-        props.card.wallet,
+        props.card,
         EnableableFunctionsTypeEnum.BPD
       )}
       caption={abiDescription}

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/BancomatBpdToggle.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/BancomatBpdToggle.tsx
@@ -5,7 +5,7 @@ import { Dispatch } from "redux";
 import pagoBancomatImage from "../../../../../../img/wallet/cards-icons/pagobancomat.png";
 import {
   EnableableFunctionsTypeEnum,
-  PatchedWalletV2
+  WalletV2WithInfo
 } from "../../../../../types/pagopa";
 import { HPan } from "../../store/actions/paymentMethods";
 import { hasFunctionEnabled } from "../../../../../utils/walletv2";
@@ -15,10 +15,11 @@ import { GlobalState } from "../../../../../store/reducers/types";
 import { loadAbi } from "../../../../wallet/onboarding/bancomat/store/actions";
 import { useActionOnFocus } from "../../../../../utils/hooks/useOnFocus";
 import { abiSelector } from "../../../../wallet/onboarding/store/abi";
+import { CardInfo } from "../../../../../../definitions/pagopa/walletv2/CardInfo";
 import PaymentMethodBpdToggle from "./base/PaymentMethodBpdToggle";
 
 type Props = {
-  card: PatchedWalletV2;
+  card: WalletV2WithInfo<CardInfo>;
 } & ReturnType<typeof mapStateToProps> &
   ReturnType<typeof mapDispatchToProps>;
 
@@ -56,7 +57,7 @@ const BancomatBpdToggle: React.FunctionComponent<Props> = props => {
       hPan={props.card.info.hashPan as HPan}
       icon={pagoBancomatImage}
       hasBpdCapability={hasFunctionEnabled(
-        props.card,
+        props.card.wallet,
         EnableableFunctionsTypeEnum.BPD
       )}
       caption={abiDescription}

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/BpdPaymentMethodToggleFactory.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/BpdPaymentMethodToggleFactory.tsx
@@ -20,13 +20,5 @@ export const bpdToggleFactory = (paymentMethod: PaymentMethod) => {
       />
     );
   }
-  if (isBancomat(paymentMethod)) {
-    return (
-      <CardBpdToggle
-        key={getPaymentMethodHash(paymentMethod.info)}
-        card={paymentMethod}
-      />
-    );
-  }
   return null;
 };

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/BpdPaymentMethodToggleFactory.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/BpdPaymentMethodToggleFactory.tsx
@@ -1,6 +1,11 @@
 import * as React from "react";
 import { WalletTypeEnum } from "../../../../../../definitions/pagopa/walletv2/WalletV2";
-import { PatchedWalletV2 } from "../../../../../types/pagopa";
+import { PatchedWalletV2, WalletV2WithInfo } from "../../../../../types/pagopa";
+import {
+  getWalletV2Haspan,
+  isCard
+} from "../../../../../store/reducers/wallet/wallets";
+import { CardInfo } from "../../../../../../definitions/pagopa/walletv2/CardInfo";
 import BancomatBpdToggle from "./BancomatBpdToggle";
 import { CardBpdToggle } from "./CardBpdToggle";
 
@@ -9,13 +14,19 @@ import { CardBpdToggle } from "./CardBpdToggle";
  * @param wallet
  */
 export const bpdToggleFactory = (wallet: PatchedWalletV2) => {
-  switch (wallet.walletType) {
-    case WalletTypeEnum.Bancomat:
-      return <BancomatBpdToggle key={wallet.info.hashPan} card={wallet} />;
-    case WalletTypeEnum.Card:
-      return <CardBpdToggle key={wallet.info.hashPan} card={wallet} />;
-    default:
-      // TODO: temp, default view with default icon
-      return <CardBpdToggle key={wallet.info.hashPan} card={wallet} />;
+  const walletWithInfo: WalletV2WithInfo<CardInfo> = {
+    wallet,
+    info: wallet.info
+  };
+  if (isCard(wallet, wallet.info)) {
+    return wallet.walletType === WalletTypeEnum.Bancomat ? (
+      <BancomatBpdToggle key={wallet.info.hashPan} card={walletWithInfo} />
+    ) : (
+      <CardBpdToggle key={wallet.info.hashPan} card={walletWithInfo} />
+    );
   }
+  // TODO: temp, default view with default icon
+  return (
+    <CardBpdToggle key={getWalletV2Haspan(wallet)} card={walletWithInfo} />
+  );
 };

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/BpdPaymentMethodToggleFactory.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/BpdPaymentMethodToggleFactory.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { WalletTypeEnum } from "../../../../../../definitions/pagopa/walletv2/WalletV2";
 import { PatchedWalletV2, WalletV2WithInfo } from "../../../../../types/pagopa";
 import {
-  getWalletV2Haspan,
+  getWalletV2Hashpan,
   isCard
 } from "../../../../../store/reducers/wallet/wallets";
 import { CardInfo } from "../../../../../../definitions/pagopa/walletv2/CardInfo";
@@ -27,6 +27,6 @@ export const bpdToggleFactory = (wallet: PatchedWalletV2) => {
   }
   // TODO: temp, default view with default icon
   return (
-    <CardBpdToggle key={getWalletV2Haspan(wallet)} card={walletWithInfo} />
+    <CardBpdToggle key={getWalletV2Hashpan(wallet)} card={walletWithInfo} />
   );
 };

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/BpdPaymentMethodToggleFactory.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/BpdPaymentMethodToggleFactory.tsx
@@ -1,32 +1,32 @@
 import * as React from "react";
-import { WalletTypeEnum } from "../../../../../../definitions/pagopa/walletv2/WalletV2";
-import { PatchedWalletV2, WalletV2WithInfo } from "../../../../../types/pagopa";
+import { getPaymentMethodHash } from "../../../../../store/reducers/wallet/wallets";
 import {
-  getPaymentMethodHash,
-  isCard
-} from "../../../../../store/reducers/wallet/wallets";
-import { CardInfo } from "../../../../../../definitions/pagopa/walletv2/CardInfo";
-import BancomatBpdToggle from "./BancomatBpdToggle";
+  isBancomat,
+  isCreditCard,
+  PaymentMethod
+} from "../../../../../types/pagopa";
 import { CardBpdToggle } from "./CardBpdToggle";
 
 /**
  * Return a specific toggle based on the WalletTypeEnum
  * @param wallet
  */
-export const bpdToggleFactory = (wallet: PatchedWalletV2) => {
-  const walletWithInfo: WalletV2WithInfo<CardInfo> = {
-    wallet,
-    info: wallet.info
-  };
-  if (isCard(wallet, wallet.info)) {
-    return wallet.walletType === WalletTypeEnum.Bancomat ? (
-      <BancomatBpdToggle key={wallet.info.hashPan} card={walletWithInfo} />
-    ) : (
-      <CardBpdToggle key={wallet.info.hashPan} card={walletWithInfo} />
+export const bpdToggleFactory = (paymentMethod: PaymentMethod) => {
+  if (isCreditCard(paymentMethod) || isBancomat(paymentMethod)) {
+    return (
+      <CardBpdToggle
+        key={getPaymentMethodHash(paymentMethod.info)}
+        card={paymentMethod}
+      />
     );
   }
-  // TODO: temp, default view with default icon
-  return (
-    <CardBpdToggle key={getPaymentMethodHash(wallet)} card={walletWithInfo} />
-  );
+  if (isBancomat(paymentMethod)) {
+    return (
+      <CardBpdToggle
+        key={getPaymentMethodHash(paymentMethod.info)}
+        card={paymentMethod}
+      />
+    );
+  }
+  return null;
 };

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/BpdPaymentMethodToggleFactory.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/BpdPaymentMethodToggleFactory.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { WalletTypeEnum } from "../../../../../../definitions/pagopa/walletv2/WalletV2";
 import { PatchedWalletV2, WalletV2WithInfo } from "../../../../../types/pagopa";
 import {
-  getWalletV2Hashpan,
+  getPaymentMethodHash,
   isCard
 } from "../../../../../store/reducers/wallet/wallets";
 import { CardInfo } from "../../../../../../definitions/pagopa/walletv2/CardInfo";
@@ -27,6 +27,6 @@ export const bpdToggleFactory = (wallet: PatchedWalletV2) => {
   }
   // TODO: temp, default view with default icon
   return (
-    <CardBpdToggle key={getWalletV2Hashpan(wallet)} card={walletWithInfo} />
+    <CardBpdToggle key={getPaymentMethodHash(wallet)} card={walletWithInfo} />
   );
 };

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/BpdPaymentMethodToggleFactory.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/BpdPaymentMethodToggleFactory.tsx
@@ -5,6 +5,7 @@ import {
   isCreditCard,
   PaymentMethod
 } from "../../../../../types/pagopa";
+import BancomatBpdToggle from "./BancomatBpdToggle";
 import { CardBpdToggle } from "./CardBpdToggle";
 
 /**
@@ -12,9 +13,17 @@ import { CardBpdToggle } from "./CardBpdToggle";
  * @param wallet
  */
 export const bpdToggleFactory = (paymentMethod: PaymentMethod) => {
-  if (isCreditCard(paymentMethod) || isBancomat(paymentMethod)) {
+  if (isCreditCard(paymentMethod)) {
     return (
       <CardBpdToggle
+        key={getPaymentMethodHash(paymentMethod.info)}
+        card={paymentMethod}
+      />
+    );
+  }
+  if (isBancomat(paymentMethod)) {
+    return (
+      <BancomatBpdToggle
         key={getPaymentMethodHash(paymentMethod.info)}
         card={paymentMethod}
       />

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/CardBpdToggle.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/CardBpdToggle.tsx
@@ -34,7 +34,7 @@ export const CardBpdToggle: React.FunctionComponent<Props> = props => {
         props.card,
         EnableableFunctionsTypeEnum.BPD
       )}
-      caption={`${FOUR_UNICODE_CIRCLES} ${card.blurredNumber ?? ""}`}
+      caption={`${FOUR_UNICODE_CIRCLES} ${card.blurredNumber}`}
     />
   );
 };

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/CardBpdToggle.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/CardBpdToggle.tsx
@@ -1,16 +1,18 @@
 import * as React from "react";
 import { getCardIconFromBrandLogo } from "../../../../../components/wallet/card/Logo";
 import {
+  BancomatPaymentMethod,
+  CreditCardPaymentMethod,
   EnableableFunctionsTypeEnum,
-  WalletV2WithInfo
+  isCreditCard
 } from "../../../../../types/pagopa";
 import { HPan } from "../../store/actions/paymentMethods";
 import { hasFunctionEnabled } from "../../../../../utils/walletv2";
-import { CardInfo } from "../../../../../../definitions/pagopa/walletv2/CardInfo";
+import { getPaymentMethodHash } from "../../../../../store/reducers/wallet/wallets";
 import PaymentMethodBpdToggle from "./base/PaymentMethodBpdToggle";
 
 type Props = {
-  card: WalletV2WithInfo<CardInfo>;
+  card: CreditCardPaymentMethod | BancomatPaymentMethod;
 };
 
 const FOUR_UNICODE_CIRCLES = "●".repeat(4);
@@ -20,14 +22,19 @@ const FOUR_UNICODE_CIRCLES = "●".repeat(4);
  * @param props
  * @constructor
  */
-export const CardBpdToggle: React.FunctionComponent<Props> = props => (
-  <PaymentMethodBpdToggle
-    hPan={props.card.info.hashPan as HPan}
-    icon={getCardIconFromBrandLogo(props.card.info)}
-    hasBpdCapability={hasFunctionEnabled(
-      props.card.wallet,
-      EnableableFunctionsTypeEnum.BPD
-    )}
-    caption={`${FOUR_UNICODE_CIRCLES} ${props.card.info.blurredNumber ?? ""}`}
-  />
-);
+export const CardBpdToggle: React.FunctionComponent<Props> = props => {
+  const card = isCreditCard(props.card)
+    ? props.card.info.creditCard
+    : props.card.info.bancomat;
+  return (
+    <PaymentMethodBpdToggle
+      hPan={getPaymentMethodHash(props.card.info) as HPan}
+      icon={getCardIconFromBrandLogo(card)}
+      hasBpdCapability={hasFunctionEnabled(
+        props.card,
+        EnableableFunctionsTypeEnum.BPD
+      )}
+      caption={`${FOUR_UNICODE_CIRCLES} ${card.blurredNumber ?? ""}`}
+    />
+  );
+};

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/CardBpdToggle.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/CardBpdToggle.tsx
@@ -1,18 +1,16 @@
 import * as React from "react";
 import { getCardIconFromBrandLogo } from "../../../../../components/wallet/card/Logo";
-import {
-  BancomatPaymentMethod,
-  CreditCardPaymentMethod,
-  EnableableFunctionsTypeEnum,
-  isCreditCard
-} from "../../../../../types/pagopa";
-import { HPan } from "../../store/actions/paymentMethods";
-import { hasFunctionEnabled } from "../../../../../utils/walletv2";
 import { getPaymentMethodHash } from "../../../../../store/reducers/wallet/wallets";
+import {
+  CreditCardPaymentMethod,
+  EnableableFunctionsTypeEnum
+} from "../../../../../types/pagopa";
+import { hasFunctionEnabled } from "../../../../../utils/walletv2";
+import { HPan } from "../../store/actions/paymentMethods";
 import PaymentMethodBpdToggle from "./base/PaymentMethodBpdToggle";
 
 type Props = {
-  card: CreditCardPaymentMethod | BancomatPaymentMethod;
+  card: CreditCardPaymentMethod;
 };
 
 const FOUR_UNICODE_CIRCLES = "●".repeat(4);
@@ -22,19 +20,14 @@ const FOUR_UNICODE_CIRCLES = "●".repeat(4);
  * @param props
  * @constructor
  */
-export const CardBpdToggle: React.FunctionComponent<Props> = props => {
-  const card = isCreditCard(props.card)
-    ? props.card.info.creditCard
-    : props.card.info.bancomat;
-  return (
-    <PaymentMethodBpdToggle
-      hPan={getPaymentMethodHash(props.card.info) as HPan}
-      icon={getCardIconFromBrandLogo(card)}
-      hasBpdCapability={hasFunctionEnabled(
-        props.card,
-        EnableableFunctionsTypeEnum.BPD
-      )}
-      caption={`${FOUR_UNICODE_CIRCLES} ${card.blurredNumber}`}
-    />
-  );
-};
+export const CardBpdToggle: React.FunctionComponent<Props> = props => (
+  <PaymentMethodBpdToggle
+    hPan={getPaymentMethodHash(props.card.info) as HPan}
+    icon={getCardIconFromBrandLogo(props.card)}
+    hasBpdCapability={hasFunctionEnabled(
+      props.card,
+      EnableableFunctionsTypeEnum.BPD
+    )}
+    caption={`${FOUR_UNICODE_CIRCLES} ${props.card.info.creditCard.blurredNumber}`}
+  />
+);

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/CardBpdToggle.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/CardBpdToggle.tsx
@@ -2,14 +2,15 @@ import * as React from "react";
 import { getCardIconFromBrandLogo } from "../../../../../components/wallet/card/Logo";
 import {
   EnableableFunctionsTypeEnum,
-  PatchedWalletV2
+  WalletV2WithInfo
 } from "../../../../../types/pagopa";
 import { HPan } from "../../store/actions/paymentMethods";
 import { hasFunctionEnabled } from "../../../../../utils/walletv2";
+import { CardInfo } from "../../../../../../definitions/pagopa/walletv2/CardInfo";
 import PaymentMethodBpdToggle from "./base/PaymentMethodBpdToggle";
 
 type Props = {
-  card: PatchedWalletV2;
+  card: WalletV2WithInfo<CardInfo>;
 };
 
 const FOUR_UNICODE_CIRCLES = "●".repeat(4);
@@ -24,9 +25,9 @@ export const CardBpdToggle: React.FunctionComponent<Props> = props => (
     hPan={props.card.info.hashPan as HPan}
     icon={getCardIconFromBrandLogo(props.card.info)}
     hasBpdCapability={hasFunctionEnabled(
-      props.card,
+      props.card.wallet,
       EnableableFunctionsTypeEnum.BPD
     )}
-    caption={`${FOUR_UNICODE_CIRCLES} ${props.card.info.blurredNumber}`}
+    caption={`${FOUR_UNICODE_CIRCLES} ${props.card.info.blurredNumber ?? ""}`}
   />
 );

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/__tests__/BancomatBpdToggle.test.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/__tests__/BancomatBpdToggle.test.tsx
@@ -16,9 +16,13 @@ import {
 } from "../../../../../../store/helpers/indexer";
 import { bancomat } from "../../../store/reducers/__mock__/bancomat";
 import I18n from "../../../../../../i18n";
-import { EnableableFunctionsTypeEnum } from "../../../../../../types/pagopa";
+import {
+  EnableableFunctionsTypeEnum,
+  WalletV2WithInfo
+} from "../../../../../../types/pagopa";
 import { BpdPotPaymentMethodActivation } from "../../../store/reducers/details/paymentMethods";
 import { HPan } from "../../../store/actions/paymentMethods";
+import { CardInfo } from "../../../../../../../definitions/pagopa/walletv2/CardInfo";
 jest.mock("../../../../../../utils/hooks/useOnFocus", () => ({
   useNavigationContext: () => ({ isFocused: () => true }),
   useActionOnFocus: () => (action: () => void) => action()
@@ -28,6 +32,10 @@ jest.mock("@gorhom/bottom-sheet", () => ({
   useBottomSheetModal: () => ({ present: jest.fn(), dismiss: jest.fn() })
 }));
 
+const walletWithInfo = {
+  wallet: bancomat,
+  info: bancomat.info
+} as WalletV2WithInfo<CardInfo>;
 const fallbackBankName = I18n.t("wallet.methods.bancomat.name");
 describe("BancomatBpdToggle UI states tests", () => {
   const mockStore = configureMockStore();
@@ -35,7 +43,7 @@ describe("BancomatBpdToggle UI states tests", () => {
     const store = mockStore(mockAbiStore(remoteUndefined));
     const component = render(
       <Provider store={store}>
-        <BancomatBpdToggle card={bancomat} />
+        <BancomatBpdToggle card={walletWithInfo} />
       </Provider>
     );
     expect(component).not.toBeNull();
@@ -53,8 +61,8 @@ describe("BancomatBpdToggle UI states tests", () => {
       <Provider store={store}>
         <BancomatBpdToggle
           card={{
-            ...bancomat,
-            info: { ...bancomat.info, issuerAbiCode: "12345" }
+            ...walletWithInfo,
+            info: { ...walletWithInfo.info, issuerAbiCode: "12345" }
           }}
         />
       </Provider>
@@ -74,8 +82,8 @@ describe("BancomatBpdToggle UI states tests", () => {
       <Provider store={store}>
         <BancomatBpdToggle
           card={{
-            ...bancomat,
-            info: { ...bancomat.info, issuerAbiCode: "1234" }
+            ...walletWithInfo,
+            info: { ...walletWithInfo.info, issuerAbiCode: "1234" }
           }}
         />
       </Provider>
@@ -90,8 +98,8 @@ describe("BancomatBpdToggle UI states tests", () => {
       mockAbiStore(
         remoteReady(getAbiIndexed([{ abi: "12345", name: "rightName" }])),
         {
-          [bancomat.info!.hashPan!]: pot.some({
-            hPan: bancomat.info!.hashPan! as HPan,
+          [walletWithInfo.info!.hashPan!]: pot.some({
+            hPan: walletWithInfo.info!.hashPan! as HPan,
             activationStatus: "active",
             activationDate: "2020-11-11"
           })
@@ -102,8 +110,11 @@ describe("BancomatBpdToggle UI states tests", () => {
       <Provider store={store}>
         <BancomatBpdToggle
           card={{
-            ...bancomat,
-            enableableFunctions: [EnableableFunctionsTypeEnum.BPD]
+            ...walletWithInfo,
+            wallet: {
+              ...bancomat,
+              enableableFunctions: [EnableableFunctionsTypeEnum.BPD]
+            }
           }}
         />
       </Provider>
@@ -120,8 +131,8 @@ describe("BancomatBpdToggle UI states tests", () => {
       mockAbiStore(
         remoteReady(getAbiIndexed([{ abi: "12345", name: "rightName" }])),
         {
-          [bancomat.info!.hashPan!]: pot.some({
-            hPan: bancomat.info!.hashPan! as HPan,
+          [walletWithInfo.info!.hashPan!]: pot.some({
+            hPan: walletWithInfo.info!.hashPan! as HPan,
             activationStatus: "inactive",
             activationDate: "2020-11-11"
           })
@@ -132,8 +143,11 @@ describe("BancomatBpdToggle UI states tests", () => {
       <Provider store={store}>
         <BancomatBpdToggle
           card={{
-            ...bancomat,
-            enableableFunctions: [EnableableFunctionsTypeEnum.BPD]
+            ...walletWithInfo,
+            wallet: {
+              ...bancomat,
+              enableableFunctions: [EnableableFunctionsTypeEnum.BPD]
+            }
           }}
         />
       </Provider>
@@ -150,8 +164,8 @@ describe("BancomatBpdToggle UI states tests", () => {
       mockAbiStore(
         remoteReady(getAbiIndexed([{ abi: "12345", name: "rightName" }])),
         {
-          [bancomat.info!.hashPan!]: pot.some({
-            hPan: bancomat.info!.hashPan! as HPan,
+          [walletWithInfo.info!.hashPan!]: pot.some({
+            hPan: walletWithInfo.info!.hashPan! as HPan,
             activationStatus: "active",
             activationDate: "2020-11-11"
           })
@@ -162,8 +176,11 @@ describe("BancomatBpdToggle UI states tests", () => {
       <Provider store={store}>
         <BancomatBpdToggle
           card={{
-            ...bancomat,
-            enableableFunctions: [EnableableFunctionsTypeEnum.FA]
+            ...walletWithInfo,
+            wallet: {
+              ...bancomat,
+              enableableFunctions: [EnableableFunctionsTypeEnum.FA]
+            }
           }}
         />
       </Provider>
@@ -178,8 +195,8 @@ describe("BancomatBpdToggle UI states tests", () => {
       mockAbiStore(
         remoteReady(getAbiIndexed([{ abi: "12345", name: "rightName" }])),
         {
-          [bancomat.info!.hashPan!]: pot.some({
-            hPan: bancomat.info!.hashPan! as HPan,
+          [walletWithInfo.info!.hashPan!]: pot.some({
+            hPan: walletWithInfo.info!.hashPan! as HPan,
             activationStatus: "notActivable"
           })
         }
@@ -189,8 +206,11 @@ describe("BancomatBpdToggle UI states tests", () => {
       <Provider store={store}>
         <BancomatBpdToggle
           card={{
-            ...bancomat,
-            enableableFunctions: [EnableableFunctionsTypeEnum.BPD]
+            ...walletWithInfo,
+            wallet: {
+              ...bancomat,
+              enableableFunctions: [EnableableFunctionsTypeEnum.BPD]
+            }
           }}
         />
       </Provider>

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/list/PaymentMethodGroupedList.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/list/PaymentMethodGroupedList.tsx
@@ -5,22 +5,22 @@ import { Body } from "../../../../../../components/core/typography/Body";
 import { H4 } from "../../../../../../components/core/typography/H4";
 import I18n from "../../../../../../i18n";
 import { EnableableFunctionsTypeEnum } from "../../../../../../types/pagopa";
-import { WalletV2WithActivation } from "../../../store/reducers/details/combiner";
+import { PaymentMethodWithActivation } from "../../../store/reducers/details/combiner";
 import { Link } from "../../../../../../components/core/typography/Link";
 import { hasFunctionEnabled } from "../../../../../../utils/walletv2";
 import { useOtherChannelInformationBottomSheet } from "../bottomsheet/OtherChannelInformation";
 import { PaymentMethodRawList } from "./PaymentMethodRawList";
 
-type Props = { paymentList: ReadonlyArray<WalletV2WithActivation> };
+type Props = { paymentList: ReadonlyArray<PaymentMethodWithActivation> };
 
 const styles = StyleSheet.create({
   row: { flexDirection: "row", justifyContent: "space-between" }
 });
 
-const isOtherChannel = (w: WalletV2WithActivation) =>
+const isOtherChannel = (w: PaymentMethodWithActivation) =>
   w.onboardingChannel === "EXT";
 
-const isNotActivable = (w: WalletV2WithActivation) =>
+const isNotActivable = (w: PaymentMethodWithActivation) =>
   w.activationStatus === "notActivable" ||
   !hasFunctionEnabled(w, EnableableFunctionsTypeEnum.BPD);
 
@@ -30,7 +30,7 @@ const isNotActivable = (w: WalletV2WithActivation) =>
  * @param paymentList
  */
 const clusterizePaymentMethods = (
-  paymentList: ReadonlyArray<WalletV2WithActivation>
+  paymentList: ReadonlyArray<PaymentMethodWithActivation>
 ) => ({
   otherChannels: paymentList.filter(isOtherChannel),
   notActivable: paymentList.filter(isNotActivable),
@@ -38,7 +38,7 @@ const clusterizePaymentMethods = (
 });
 
 const OtherChannelsSection = (props: {
-  paymentMethods: ReadonlyArray<WalletV2WithActivation>;
+  paymentMethods: ReadonlyArray<PaymentMethodWithActivation>;
 }) => {
   const { present } = useOtherChannelInformationBottomSheet();
 
@@ -67,7 +67,7 @@ const OtherChannelsSection = (props: {
 };
 
 const NotActivablesSection = (props: {
-  paymentMethods: ReadonlyArray<WalletV2WithActivation>;
+  paymentMethods: ReadonlyArray<PaymentMethodWithActivation>;
 }) => (
   <View>
     <View spacer={true} />

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/list/PaymentMethodRawList.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/list/PaymentMethodRawList.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
 import { View } from "react-native";
 import { IOStyles } from "../../../../../../components/core/variables/IOStyles";
-import { PatchedWalletV2 } from "../../../../../../types/pagopa";
 import { bpdToggleFactory } from "../BpdPaymentMethodToggleFactory";
+import { PaymentMethod } from "../../../../../../types/pagopa";
 
 type Props = {
-  paymentList: ReadonlyArray<PatchedWalletV2>;
+  paymentList: ReadonlyArray<PaymentMethod>;
 };
 
 /**

--- a/ts/features/bonus/bpd/saga/orchestration/insertIban.ts
+++ b/ts/features/bonus/bpd/saga/orchestration/insertIban.ts
@@ -5,7 +5,7 @@ import { call, put, select, take } from "redux-saga/effects";
 import { ActionType, getType, isActionOf } from "typesafe-actions";
 import { navigationHistoryPop } from "../../../../../store/actions/navigationHistory";
 import { navigationCurrentRouteSelector } from "../../../../../store/reducers/navigation";
-import { walletV2Selector } from "../../../../../store/reducers/wallet/wallets";
+import { paymentMethodsSelector } from "../../../../../store/reducers/wallet/wallets";
 import { EnableableFunctionsTypeEnum } from "../../../../../types/pagopa";
 import { hasFunctionEnabled } from "../../../../../utils/walletv2";
 import {
@@ -59,8 +59,8 @@ export function* bpdIbanInsertionWorker() {
     yield put(NavigationActions.back());
   } else {
     if (onboardingOngoing) {
-      const paymentMethods: ReturnType<typeof walletV2Selector> = yield select(
-        walletV2Selector
+      const paymentMethods: ReturnType<typeof paymentMethodsSelector> = yield select(
+        paymentMethodsSelector
       );
       const hasAtLeastOnePaymentMethodWithBpd = pot.getOrElse(
         pot.map(paymentMethods, pm =>

--- a/ts/features/bonus/bpd/screens/onboarding/EnrollPaymentMethodsScreen.tsx
+++ b/ts/features/bonus/bpd/screens/onboarding/EnrollPaymentMethodsScreen.tsx
@@ -12,10 +12,10 @@ import I18n from "../../../../../i18n";
 import { navigateToWalletHome } from "../../../../../store/actions/navigation";
 import { navigationHistoryPop } from "../../../../../store/actions/navigationHistory";
 import { GlobalState } from "../../../../../store/reducers/types";
-import { PatchedWalletV2 } from "../../../../../types/pagopa";
 import { FooterTwoButtons } from "../../../bonusVacanze/components/markdown/FooterTwoButtons";
 import { PaymentMethodGroupedList } from "../../components/paymentMethodActivationToggle/list/PaymentMethodGroupedList";
 import { walletV2WithActivationStatusSelector } from "../../store/reducers/details/combiner";
+import { PaymentMethod } from "../../../../../types/pagopa";
 
 const loadLocales = () => ({
   headerTitle: I18n.t("bonus.bpd.title"),
@@ -30,7 +30,7 @@ export type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
 
 const renderPaymentMethod = (
-  potWallets: pot.Pot<ReadonlyArray<PatchedWalletV2>, Error>
+  potWallets: pot.Pot<ReadonlyArray<PaymentMethod>, Error>
 ) =>
   pot.fold(
     potWallets,

--- a/ts/features/bonus/bpd/screens/test/TMPBpdScreen.tsx
+++ b/ts/features/bonus/bpd/screens/test/TMPBpdScreen.tsx
@@ -14,7 +14,6 @@ import BaseScreenComponent from "../../../../../components/screens/BaseScreenCom
 import FooterWithButtons from "../../../../../components/ui/FooterWithButtons";
 import { GlobalState } from "../../../../../store/reducers/types";
 import { paymentMethodsSelector } from "../../../../../store/reducers/wallet/wallets";
-import { PatchedWalletV2 } from "../../../../../types/pagopa";
 import { cancelButtonProps } from "../../../bonusVacanze/components/buttons/ButtonConfigurations";
 import { PaymentMethodRawList } from "../../components/paymentMethodActivationToggle/list/PaymentMethodRawList";
 import {
@@ -26,6 +25,7 @@ import {
 import { bpdLoadActivationStatus } from "../../store/actions/details";
 import { bpdDeleteUserFromProgram } from "../../store/actions/onboarding";
 import { bpdEnabledSelector } from "../../store/reducers/details/activation";
+import { PaymentMethod } from "../../../../../types/pagopa";
 
 export type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
@@ -44,10 +44,10 @@ const renderBpdActive = (value: RemoteValue<boolean, Error>) =>
   );
 
 const renderPaymentMethod = (
-  potWallets: pot.Pot<ReadonlyArray<PatchedWalletV2>, Error>
+  potPaymentMethod: pot.Pot<ReadonlyArray<PaymentMethod>, Error>
 ) =>
   pot.fold(
-    potWallets,
+    potPaymentMethod,
     // TODO: handle error, loading with spinner if needed
     () => (
       <LabelSmall color={"bluegrey"}>

--- a/ts/features/bonus/bpd/screens/test/TMPBpdScreen.tsx
+++ b/ts/features/bonus/bpd/screens/test/TMPBpdScreen.tsx
@@ -13,7 +13,7 @@ import { IOStyles } from "../../../../../components/core/variables/IOStyles";
 import BaseScreenComponent from "../../../../../components/screens/BaseScreenComponent";
 import FooterWithButtons from "../../../../../components/ui/FooterWithButtons";
 import { GlobalState } from "../../../../../store/reducers/types";
-import { walletV2Selector } from "../../../../../store/reducers/wallet/wallets";
+import { paymentMethodsSelector } from "../../../../../store/reducers/wallet/wallets";
 import { PatchedWalletV2 } from "../../../../../types/pagopa";
 import { cancelButtonProps } from "../../../bonusVacanze/components/buttons/ButtonConfigurations";
 import { PaymentMethodRawList } from "../../components/paymentMethodActivationToggle/list/PaymentMethodRawList";
@@ -129,7 +129,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 
 const mapStateToProps = (state: GlobalState) => ({
   bpdActive: bpdEnabledSelector(state),
-  potWallets: walletV2Selector(state)
+  potWallets: paymentMethodsSelector(state)
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(TmpBpdScreen);

--- a/ts/features/bonus/bpd/store/reducers/details/combiner.ts
+++ b/ts/features/bonus/bpd/store/reducers/details/combiner.ts
@@ -2,7 +2,6 @@ import { fromNullable, none, Option } from "fp-ts/lib/Option";
 import * as pot from "italia-ts-commons/lib/pot";
 import { createSelector } from "reselect";
 import { Abi } from "../../../../../../../definitions/pagopa/walletv2/Abi";
-import { WalletTypeEnum } from "../../../../../../../definitions/pagopa/walletv2/WalletV2";
 import pagoBancomatImage from "../../../../../../../img/wallet/cards-icons/pagobancomat.png";
 import {
   cardIcons,
@@ -20,7 +19,6 @@ import {
   CreditCardInfo,
   isBancomat,
   isCreditCard,
-  PatchedWalletV2,
   PaymentMethod
 } from "../../../../../../types/pagopa";
 import { abiListSelector } from "../../../../../wallet/onboarding/store/abi";
@@ -139,18 +137,17 @@ const pickPaymentMethodFromHashpan = (
   );
 
 /**
- * Choose an image to represent a {@link PatchedWalletV2}
- * @param w2
+ * Choose an image to represent a {@link PaymentMethod}
+ * @param paymentMethod
  */
-const getImageFromWallet = (w2: PatchedWalletV2) => {
-  switch (w2.walletType) {
-    case WalletTypeEnum.Card:
-      return getCardIconFromBrandLogo(w2.info);
-    case WalletTypeEnum.Bancomat:
-      return pagoBancomatImage;
-    default:
-      return cardIcons.UNKNOWN;
+const getImageFromPaymentMethod = (paymentMethod: PaymentMethod) => {
+  if (isCreditCard(paymentMethod)) {
+    return getCardIconFromBrandLogo(paymentMethod);
   }
+  if (isBancomat(paymentMethod)) {
+    return pagoBancomatImage;
+  }
+  return cardIcons.UNKNOWN;
 };
 
 // TODO: unify card representation (multiple part of the application use this)
@@ -158,7 +155,7 @@ const FOUR_UNICODE_CIRCLES = "●".repeat(4);
 
 /**
  * Choose a textual representation for a {@link PatchedWalletV2}
- * @param w2
+ * @param paymentMethod
  * @param abiList
  */
 const getTitleFromPaymentMethod = (
@@ -212,7 +209,7 @@ export const bpdDisplayTransactionsSelector = createSelector<
           ({
             ...t,
             image: pickPaymentMethodFromHashpan(t.hashPan, paymentMethod)
-              .map(getImageFromWallet)
+              .map(getImageFromPaymentMethod)
               .getOrElse(cardIcons.UNKNOWN),
             title: pickPaymentMethodFromHashpan(t.hashPan, paymentMethod)
               .map(w2 => getTitleFromPaymentMethod(w2, abiList))

--- a/ts/features/bonus/bpd/store/reducers/details/combiner.ts
+++ b/ts/features/bonus/bpd/store/reducers/details/combiner.ts
@@ -175,10 +175,12 @@ const getTitleFromCard = (creditCard: CreditCardInfo) =>
   `${FOUR_UNICODE_CIRCLES} ${creditCard.creditCard.blurredNumber}`;
 
 const getTitleFromBancomat = (
-  bancomat: BancomatInfo,
+  bancomatInfo: BancomatInfo,
   abiList: ReadonlyArray<Abi>
 ) =>
-  fromNullable(abiList.find(abi => abi.abi === bancomat.bancomat.issuerAbiCode))
+  fromNullable(
+    abiList.find(abi => abi.abi === bancomatInfo.bancomat.issuerAbiCode)
+  )
     .map(abi => abi.name)
     .getOrElse(I18n.t("wallet.methods.bancomat.name"));
 

--- a/ts/features/bonus/bpd/store/reducers/details/combiner.ts
+++ b/ts/features/bonus/bpd/store/reducers/details/combiner.ts
@@ -12,7 +12,7 @@ import I18n from "../../../../../../i18n";
 import { readPot } from "../../../../../../store/reducers/IndexedByIdPot";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import {
-  getWalletV2Haspan,
+  getWalletV2Hashpan,
   isBancomat,
   isCreditCard,
   walletV2Selector
@@ -130,7 +130,7 @@ const pickWalletFromHashpan = (
 ): Option<PatchedWalletV2> =>
   pot.getOrElse(
     pot.map(potWalletV2, walletV2 =>
-      fromNullable(walletV2.find(w => getWalletV2Haspan(w) === hashPan))
+      fromNullable(walletV2.find(w => getWalletV2Hashpan(w) === hashPan))
     ),
     none
   );
@@ -230,7 +230,7 @@ export const atLeastOnePaymentMethodHasBpdEnabledSelector = createSelector(
     pot.getOrElse(
       pot.map(walletV2Pot, walletv2 =>
         walletv2.some(w =>
-          fromNullable(getWalletV2Haspan(w))
+          fromNullable(getWalletV2Hashpan(w))
             .map(hpan => bpdActivations[hpan])
             .map(
               potActivation =>
@@ -258,7 +258,7 @@ export const walletV2WithActivationStatusSelector = createSelector(
     pot.map(walletV2Pot, walletv2 =>
       walletv2.map(pm => {
         // try to extract the activation status to enhance the wallet
-        const activationStatus = fromNullable(getWalletV2Haspan(pm))
+        const activationStatus = fromNullable(getWalletV2Hashpan(pm))
           .chain(hp => fromNullable(bpdActivations[hp]))
           .map(paymentMethodActivation =>
             pot.getOrElse(

--- a/ts/features/bonus/bpd/store/reducers/details/combiner.ts
+++ b/ts/features/bonus/bpd/store/reducers/details/combiner.ts
@@ -12,10 +12,10 @@ import I18n from "../../../../../../i18n";
 import { readPot } from "../../../../../../store/reducers/IndexedByIdPot";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import {
-  getWalletV2Hashpan,
-  isBancomat,
-  isCreditCard,
-  walletV2Selector
+  getPaymentMethodHash,
+  isBancomatInfo,
+  isCreditCardInfo,
+  paymentMethodsSelector
 } from "../../../../../../store/reducers/wallet/wallets";
 import {
   PatchedWalletV2,
@@ -130,7 +130,7 @@ const pickWalletFromHashpan = (
 ): Option<PatchedWalletV2> =>
   pot.getOrElse(
     pot.map(potWalletV2, walletV2 =>
-      fromNullable(walletV2.find(w => getWalletV2Hashpan(w) === hashPan))
+      fromNullable(walletV2.find(w => getPaymentMethodHash(w) === hashPan))
     ),
     none
   );
@@ -198,7 +198,7 @@ export const bpdDisplayTransactionsSelector = createSelector<
 >(
   [
     bpdTransactionsForSelectedPeriod,
-    walletV2Selector,
+    paymentMethodsSelector,
     abiListSelector,
     bpdSelectedPeriodSelector
   ],
@@ -225,12 +225,12 @@ export const bpdDisplayTransactionsSelector = createSelector<
  * There is at least one payment method with bpd enabled?
  */
 export const atLeastOnePaymentMethodHasBpdEnabledSelector = createSelector(
-  [walletV2Selector, bpdPaymentMethodActivationSelector],
+  [paymentMethodsSelector, bpdPaymentMethodActivationSelector],
   (walletV2Pot, bpdActivations): boolean =>
     pot.getOrElse(
       pot.map(walletV2Pot, walletv2 =>
         walletv2.some(w =>
-          fromNullable(getWalletV2Hashpan(w))
+          fromNullable(getPaymentMethodHash(w))
             .map(hpan => bpdActivations[hpan])
             .map(
               potActivation =>
@@ -253,12 +253,12 @@ export type WalletV2WithActivation = PatchedWalletV2 &
  * in order to group the elements "notActivable"
  */
 export const walletV2WithActivationStatusSelector = createSelector(
-  [walletV2Selector, bpdPaymentMethodActivationSelector],
+  [paymentMethodsSelector, bpdPaymentMethodActivationSelector],
   (walletV2Pot, bpdActivations) =>
     pot.map(walletV2Pot, walletv2 =>
       walletv2.map(pm => {
         // try to extract the activation status to enhance the wallet
-        const activationStatus = fromNullable(getWalletV2Hashpan(pm))
+        const activationStatus = fromNullable(getPaymentMethodHash(pm))
           .chain(hp => fromNullable(bpdActivations[hp]))
           .map(paymentMethodActivation =>
             pot.getOrElse(

--- a/ts/features/wallet/bancomat/component/bancomatCard/BancomatCard.tsx
+++ b/ts/features/wallet/bancomat/component/bancomatCard/BancomatCard.tsx
@@ -33,8 +33,8 @@ const BancomatCard: React.FunctionComponent<Props> = props => (
   <BaseBancomatCard
     abiLogo={props.bancomat.abiInfo?.logoUrl}
     expiringDate={getExpireDate(
-      props.bancomat.info.expireYear,
-      props.bancomat.info.expireMonth
+      props.bancomat.info.bancomat.expireYear,
+      props.bancomat.info.bancomat.expireMonth
     )}
     user={props.nameSurname ?? ""}
   />

--- a/ts/features/wallet/bancomat/component/bancomatCard/BancomatCard.tsx
+++ b/ts/features/wallet/bancomat/component/bancomatCard/BancomatCard.tsx
@@ -6,7 +6,7 @@ import { GlobalState } from "../../../../../store/reducers/types";
 import { EnhancedBancomat } from "../../../../../store/reducers/wallet/wallets";
 import BaseBancomatCard from "./BaseBancomatCard";
 
-type OwnProps = { bancomat: EnhancedBancomat };
+type OwnProps = { enhancedBancomat: EnhancedBancomat };
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps> &
@@ -31,10 +31,10 @@ const getExpireDate = (fullYear?: string, month?: string): Date | undefined => {
  */
 const BancomatCard: React.FunctionComponent<Props> = props => (
   <BaseBancomatCard
-    abiLogo={props.bancomat.abiInfo?.logoUrl}
+    abiLogo={props.enhancedBancomat.abiInfo?.logoUrl}
     expiringDate={getExpireDate(
-      props.bancomat.info.bancomat.expireYear,
-      props.bancomat.info.bancomat.expireMonth
+      props.enhancedBancomat.info.bancomat.expireYear,
+      props.enhancedBancomat.info.bancomat.expireMonth
     )}
     user={props.nameSurname ?? ""}
   />

--- a/ts/features/wallet/bancomat/screen/BancomatDetailScreen.tsx
+++ b/ts/features/wallet/bancomat/screen/BancomatDetailScreen.tsx
@@ -72,9 +72,7 @@ const BancomatDetailScreen: React.FunctionComponent<Props> = props => {
       hideHeader={true}
       footerContent={
         <UnsubscribeButton
-          onPress={() =>
-            present(() => props.deleteWallet(bancomat.wallet.idWallet))
-          }
+          onPress={() => present(() => props.deleteWallet(bancomat.idWallet))}
         />
       }
     >

--- a/ts/features/wallet/bancomat/screen/BancomatDetailScreen.tsx
+++ b/ts/features/wallet/bancomat/screen/BancomatDetailScreen.tsx
@@ -72,7 +72,9 @@ const BancomatDetailScreen: React.FunctionComponent<Props> = props => {
       hideHeader={true}
       footerContent={
         <UnsubscribeButton
-          onPress={() => present(() => props.deleteWallet(bancomat.idWallet))}
+          onPress={() =>
+            present(() => props.deleteWallet(bancomat.wallet.idWallet))
+          }
         />
       }
     >

--- a/ts/features/wallet/bancomat/screen/BancomatDetailScreen.tsx
+++ b/ts/features/wallet/bancomat/screen/BancomatDetailScreen.tsx
@@ -56,7 +56,7 @@ const UnsubscribeButton = (props: { onPress?: () => void }) => (
  * @constructor
  */
 const BancomatDetailScreen: React.FunctionComponent<Props> = props => {
-  const bancomat = props.navigation.getParam("bancomat");
+  const bancomat: EnhancedBancomat = props.navigation.getParam("bancomat");
   const { present } = useRemovePaymentMethodBottomSheet({
     icon: pagoBancomatImage,
     caption: bancomat.abiInfo?.name ?? I18n.t("wallet.methods.bancomat.name")
@@ -77,7 +77,7 @@ const BancomatDetailScreen: React.FunctionComponent<Props> = props => {
       }
     >
       <View style={styles.cardContainer}>
-        <BancomatCard bancomat={bancomat} />
+        <BancomatCard enhancedBancomat={bancomat} />
       </View>
       <View spacer={true} extralarge={true} />
       <View spacer={true} />

--- a/ts/features/wallet/component/WalletV2PreviewCards.tsx
+++ b/ts/features/wallet/component/WalletV2PreviewCards.tsx
@@ -18,10 +18,10 @@ type Props = ReturnType<typeof mapDispatchToProps> &
 const WalletV2PreviewCards: React.FunctionComponent<Props> = props => (
   <>
     {pot.getOrElse(
-      pot.map(props.bancomatList, walletv2 => (
+      pot.map(props.bancomatList, b => (
         <>
-          {walletv2.map(w2 => (
-            <BancomatWalletPreview key={w2.wallet.idWallet} bancomat={w2} />
+          {b.map(w2 => (
+            <BancomatWalletPreview key={w2.idWallet} bancomat={w2} />
           ))}
         </>
       )),

--- a/ts/features/wallet/component/WalletV2PreviewCards.tsx
+++ b/ts/features/wallet/component/WalletV2PreviewCards.tsx
@@ -21,7 +21,7 @@ const WalletV2PreviewCards: React.FunctionComponent<Props> = props => (
       pot.map(props.bancomatList, walletv2 => (
         <>
           {walletv2.map(w2 => (
-            <BancomatWalletPreview key={w2.idWallet} bancomat={w2} />
+            <BancomatWalletPreview key={w2.wallet.idWallet} bancomat={w2} />
           ))}
         </>
       )),

--- a/ts/features/wallet/component/WalletV2PreviewCards.tsx
+++ b/ts/features/wallet/component/WalletV2PreviewCards.tsx
@@ -20,8 +20,11 @@ const WalletV2PreviewCards: React.FunctionComponent<Props> = props => (
     {pot.getOrElse(
       pot.map(props.bancomatList, b => (
         <>
-          {b.map(w2 => (
-            <BancomatWalletPreview key={w2.idWallet} bancomat={w2} />
+          {b.map(enhancedBancomat => (
+            <BancomatWalletPreview
+              key={enhancedBancomat.idWallet}
+              bancomat={enhancedBancomat}
+            />
           ))}
         </>
       )),

--- a/ts/features/wallet/onboarding/bancomat/saga/networking/index.ts
+++ b/ts/features/wallet/onboarding/bancomat/saga/networking/index.ts
@@ -11,6 +11,7 @@ import {
   loadAbi,
   searchUserPans
 } from "../../store/actions";
+import { isCreditCard } from "../../../../../../store/reducers/wallet/wallets";
 
 // load all bancomat abi
 export function* handleLoadAbi(
@@ -119,7 +120,10 @@ export function* handleAddPan(
         const wallets = addPansWithRefreshResult.value.value.data ?? [];
         // search for the added bancomat.
         const maybeWallet = fromNullable(
-          wallets.find(w => w.info.hashPan === action.payload.hpan)
+          wallets.find(
+            w =>
+              isCreditCard(w, w.info) && w.info.hashPan === action.payload.hpan
+          )
         );
         if (maybeWallet.isSome()) {
           yield put(

--- a/ts/features/wallet/onboarding/bancomat/saga/networking/index.ts
+++ b/ts/features/wallet/onboarding/bancomat/saga/networking/index.ts
@@ -11,7 +11,8 @@ import {
   loadAbi,
   searchUserPans
 } from "../../store/actions";
-import { isCreditCard } from "../../../../../../store/reducers/wallet/wallets";
+import { getPaymentMethodHash } from "../../../../../../store/reducers/wallet/wallets";
+import { convertWalletV2toWalletV1 } from "../../../../../../utils/walletv2";
 
 // load all bancomat abi
 export function* handleLoadAbi(
@@ -122,7 +123,9 @@ export function* handleAddPan(
         const maybeWallet = fromNullable(
           wallets.find(
             w =>
-              isCreditCard(w, w.info) && w.info.hashPan === action.payload.hpan
+              getPaymentMethodHash(
+                convertWalletV2toWalletV1(w).paymentMethod
+              ) === action.payload.hpan
           )
         );
         if (maybeWallet.isSome()) {

--- a/ts/features/wallet/onboarding/bancomat/screens/bpd/ActivateBpdOnNewCreditCardScreen.tsx
+++ b/ts/features/wallet/onboarding/bancomat/screens/bpd/ActivateBpdOnNewCreditCardScreen.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { NavigationScreenProps } from "react-navigation";
-import { PatchedWalletV2 } from "../../../../../../types/pagopa";
+import { CreditCardPaymentMethod } from "../../../../../../types/pagopa";
 import ActivateBpdOnNewPaymentMethodScreen from "./ActivateBpdOnNewPaymentMethodScreen";
 
 type ActivateBpdOnNewCreditCardScreenNavigationParams = {
-  creditCards: ReadonlyArray<PatchedWalletV2>;
+  creditCards: ReadonlyArray<CreditCardPaymentMethod>;
 };
 type Props = NavigationScreenProps<
   ActivateBpdOnNewCreditCardScreenNavigationParams

--- a/ts/features/wallet/onboarding/bancomat/screens/bpd/ActivateBpdOnNewPaymentMethodScreen.tsx
+++ b/ts/features/wallet/onboarding/bancomat/screens/bpd/ActivateBpdOnNewPaymentMethodScreen.tsx
@@ -11,10 +11,10 @@ import BaseScreenComponent from "../../../../../../components/screens/BaseScreen
 import I18n from "../../../../../../i18n";
 import { FooterTwoButtons } from "../../../../../bonus/bonusVacanze/components/markdown/FooterTwoButtons";
 import { PaymentMethodRawList } from "../../../../../bonus/bpd/components/paymentMethodActivationToggle/list/PaymentMethodRawList";
-import { PatchedWalletV2 } from "../../../../../../types/pagopa";
+import { PaymentMethod } from "../../../../../../types/pagopa";
 
 type OwnProps = {
-  paymentMethods: ReadonlyArray<PatchedWalletV2>;
+  paymentMethods: ReadonlyArray<PaymentMethod>;
 };
 
 export type Props = ReturnType<typeof mapDispatchToProps> & OwnProps;

--- a/ts/features/wallet/onboarding/bancomat/store/actions/index.ts
+++ b/ts/features/wallet/onboarding/bancomat/store/actions/index.ts
@@ -5,7 +5,7 @@ import {
 } from "typesafe-actions";
 import { AbiListResponse } from "../../../../../../../definitions/pagopa/walletv2/AbiListResponse";
 import { Card } from "../../../../../../../definitions/pagopa/walletv2/Card";
-import { PatchedWalletV2 } from "../../../../../../types/pagopa";
+import { BancomatPaymentMethod } from "../../../../../../types/pagopa";
 import { LoadPansError } from "../../saga/networking";
 import { Message } from "../../../../../../../definitions/pagopa/walletv2/Message";
 
@@ -39,7 +39,7 @@ export const addBancomatToWallet = createAsyncAction(
   "WALLET_ONBOARDING_BANCOMAT_ADD_REQUEST",
   "WALLET_ONBOARDING_BANCOMAT_ADD_SUCCESS",
   "WALLET_ONBOARDING_BANCOMAT_ADD_FAILURE"
-)<Card, PatchedWalletV2, Error>();
+)<Card, BancomatPaymentMethod, Error>();
 
 /**
  * The user choose to start the workflow to add a new bancomat to the wallet

--- a/ts/features/wallet/onboarding/bancomat/store/reducers/addedPans.ts
+++ b/ts/features/wallet/onboarding/bancomat/store/reducers/addedPans.ts
@@ -1,13 +1,13 @@
 import { getType } from "typesafe-actions";
 import { Action } from "../../../../../../store/actions/types";
 import { GlobalState } from "../../../../../../store/reducers/types";
-import { PatchedWalletV2 } from "../../../../../../types/pagopa";
+import { BancomatPaymentMethod } from "../../../../../../types/pagopa";
 import { addBancomatToWallet, walletAddBancomatStart } from "../actions";
 
 const addedPansReducer = (
-  state: ReadonlyArray<PatchedWalletV2> = [],
+  state: ReadonlyArray<BancomatPaymentMethod> = [],
   action: Action
-): ReadonlyArray<PatchedWalletV2> => {
+): ReadonlyArray<BancomatPaymentMethod> => {
   switch (action.type) {
     // Register a new Bancomat added in the current onboarding session
     case getType(addBancomatToWallet.success):
@@ -21,6 +21,7 @@ const addedPansReducer = (
 
 export const onboardingBancomatAddedPansSelector = (
   state: GlobalState
-): ReadonlyArray<PatchedWalletV2> => state.wallet.onboarding.bancomat.addedPans;
+): ReadonlyArray<BancomatPaymentMethod> =>
+  state.wallet.onboarding.bancomat.addedPans;
 
 export default addedPansReducer;

--- a/ts/features/wallet/onboarding/bancomat/store/reducers/addingPans.ts
+++ b/ts/features/wallet/onboarding/bancomat/store/reducers/addingPans.ts
@@ -2,7 +2,7 @@ import { getType } from "typesafe-actions";
 import { Card } from "../../../../../../../definitions/pagopa/walletv2/Card";
 import { Action } from "../../../../../../store/actions/types";
 import { GlobalState } from "../../../../../../store/reducers/types";
-import { PatchedWalletV2 } from "../../../../../../types/pagopa";
+import { BancomatPaymentMethod } from "../../../../../../types/pagopa";
 import {
   remoteError,
   remoteLoading,
@@ -13,7 +13,7 @@ import {
 import { addBancomatToWallet } from "../actions";
 
 export type AddingPansState = {
-  addingResult: RemoteValue<PatchedWalletV2, Error>;
+  addingResult: RemoteValue<BancomatPaymentMethod, Error>;
   selectedPan?: Card;
 };
 
@@ -51,7 +51,7 @@ export const onboardingBancomatChosenPanSelector = (
 
 export const onboardingBancomatAddingResultSelector = (
   state: GlobalState
-): RemoteValue<PatchedWalletV2, Error> =>
+): RemoteValue<BancomatPaymentMethod, Error> =>
   state.wallet.onboarding.bancomat.addingPans.addingResult;
 
 export default addingPansReducer;

--- a/ts/features/wallet/onboarding/bancomat/store/reducers/index.ts
+++ b/ts/features/wallet/onboarding/bancomat/store/reducers/index.ts
@@ -1,5 +1,5 @@
 import { Action, combineReducers } from "redux";
-import { PatchedWalletV2 } from "../../../../../../types/pagopa";
+import { BancomatPaymentMethod } from "../../../../../../types/pagopa";
 import abiSelectedReducer, { AbiSelected } from "./abiSelected";
 import addedPansReducer from "./addedPans";
 import addingPansReducer, { AddingPansState } from "./addingPans";
@@ -8,7 +8,7 @@ import pansReducer, { Pans } from "./pans";
 export type BancomatState = {
   foundPans: Pans;
   addingPans: AddingPansState;
-  addedPans: ReadonlyArray<PatchedWalletV2>;
+  addedPans: ReadonlyArray<BancomatPaymentMethod>;
   abiSelected: AbiSelected;
 };
 

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -96,6 +96,7 @@ import { GlobalState } from "../store/reducers/types";
 
 import {
   EnableableFunctionsTypeEnum,
+  isCreditCard,
   NullableWallet,
   PaymentManagerToken,
   PayRequest
@@ -313,19 +314,22 @@ function* startOrResumeAddCreditCardSaga(
           bpdEnabledSelector
         );
         // check if the new method is compliant with bpd
-        if (bpdEnabled && maybeAddedWallet.v2) {
+        if (bpdEnabled) {
           const hasBpdFeature = hasFunctionEnabled(
-            maybeAddedWallet.v2,
+            maybeAddedWallet.paymentMethod,
             EnableableFunctionsTypeEnum.BPD
           );
           // if the method is bpd compliant check if we have info about bpd activation
           if (hasBpdFeature && isReady(bpdEnroll)) {
             // if bdp is active navigate to a screen where it asked to enroll that method in bpd
             // otherwise navigate to a screen where is asked to join bpd
-            if (bpdEnroll.value) {
+            if (
+              bpdEnroll.value &&
+              isCreditCard(maybeAddedWallet.paymentMethod)
+            ) {
               yield put(
                 navigateToActivateBpdOnNewCreditCard({
-                  creditCards: [maybeAddedWallet.v2]
+                  creditCards: [maybeAddedWallet.paymentMethod]
                 })
               );
             } else {

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -64,7 +64,7 @@ import {
   getTransactionsLoadedLength,
   latestTransactionsSelector
 } from "../../store/reducers/wallet/transactions";
-import { pagoPaCreditCardSelector } from "../../store/reducers/wallet/wallets";
+import { pagoPaCreditCardWalletV1Selector } from "../../store/reducers/wallet/wallets";
 import customVariables from "../../theme/variables";
 import variables from "../../theme/variables";
 import { Transaction, Wallet } from "../../types/pagopa";
@@ -558,7 +558,7 @@ const mapStateToProps = (state: GlobalState) => {
   return {
     allActiveBonus: allBonusActiveSelector(state),
     availableBonusesList: pot.getOrElse(potAvailableBonuses, []),
-    potWallets: pagoPaCreditCardSelector(state),
+    potWallets: pagoPaCreditCardWalletV1Selector(state),
     anyHistoryPayments: paymentsHistorySelector(state).length > 0,
     anyCreditCardAttempts: creditCardAttemptionsSelector(state).length > 0,
     potTransactions: latestTransactionsSelector(state),

--- a/ts/screens/wallet/WalletsScreen.tsx
+++ b/ts/screens/wallet/WalletsScreen.tsx
@@ -36,9 +36,9 @@ import {
 import { navSelector } from "../../store/reducers/navigationHistory";
 import { GlobalState } from "../../store/reducers/types";
 import {
-  creditCardSelector,
+  creditCardWalletV1Selector,
   getFavoriteWalletId,
-  pagoPaCreditCardSelector
+  pagoPaCreditCardWalletV1Selector
 } from "../../store/reducers/wallet/wallets";
 import variables from "../../theme/variables";
 import { Wallet } from "../../types/pagopa";
@@ -156,9 +156,9 @@ const WalletsScreen: React.FunctionComponent<Props> = (props: Props) => {
 };
 
 const mapStateToProps = (state: GlobalState) => {
-  const potWallets = pagoPaCreditCardSelector(state);
+  const potWallets = pagoPaCreditCardWalletV1Selector(state);
   return {
-    wallets: pot.getOrElse(creditCardSelector(state), []),
+    wallets: pot.getOrElse(creditCardWalletV1Selector(state), []),
     isLoading: pot.isLoading(potWallets),
     favoriteWallet: getFavoriteWalletId(state),
     nav: navSelector(state)

--- a/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
@@ -25,7 +25,7 @@ import {
 } from "../../../store/actions/navigation";
 import { Dispatch } from "../../../store/actions/types";
 import { GlobalState } from "../../../store/reducers/types";
-import { pagoPaCreditCardSelector } from "../../../store/reducers/wallet/wallets";
+import { pagoPaCreditCardWalletV1Selector } from "../../../store/reducers/wallet/wallets";
 import variables from "../../../theme/variables";
 import { Wallet } from "../../../types/pagopa";
 import { showToast } from "../../../utils/showToast";
@@ -127,7 +127,7 @@ class PickPaymentMethodScreen extends React.Component<Props> {
 }
 
 const mapStateToProps = (state: GlobalState) => {
-  const potWallets = pagoPaCreditCardSelector(state);
+  const potWallets = pagoPaCreditCardWalletV1Selector(state);
   const potPsps = state.wallet.payment.psps;
   const isLoading = pot.isLoading(potWallets) || pot.isLoading(potPsps);
   return {

--- a/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
@@ -38,7 +38,7 @@ import {
 import { GlobalState } from "../../../store/reducers/types";
 import {
   getFavoriteWallet,
-  pagoPaCreditCardSelector
+  pagoPaCreditCardWalletV1Selector
 } from "../../../store/reducers/wallet/wallets";
 import customVariables from "../../../theme/variables";
 import { PayloadForAction } from "../../../types/utils";
@@ -373,7 +373,7 @@ const mapStateToProps = (state: GlobalState) => {
     : I18n.t("wallet.firstTransactionSummary.loadingMessage.generic");
 
   const hasWallets =
-    pot.getOrElse(pagoPaCreditCardSelector(state), []).length !== 0;
+    pot.getOrElse(pagoPaCreditCardWalletV1Selector(state), []).length !== 0;
 
   return {
     error,

--- a/ts/store/reducers/wallet/__mocks__/wallets.ts
+++ b/ts/store/reducers/wallet/__mocks__/wallets.ts
@@ -128,3 +128,90 @@ export const walletsV2_2 = {
     }
   ]
 };
+
+// 1 bancomat, 1 bancomatPay, 1 satispay, 1 creditCard
+export const walletsV2_3 = {
+  data: [
+    {
+      walletType: "Bancomat",
+      createDate: "2021-10-22",
+      enableableFunctions: ["FA", "pagoPA", "BPD"],
+      favourite: false,
+      idWallet: 20341,
+      info: {
+        blurredNumber: "0003",
+        brand: "MASTERCARD",
+        brandLogo:
+          "https://wisp2.pagopa.gov.it/wallet/assets/img/creditcard/carta_mc.png",
+        expireMonth: "10",
+        expireYear: "2021",
+        hashPan:
+          "e105a87731025d54181d8e4c4c04ff344ce82e57d6a3d6c6911e8eadb0348d7b",
+        holder: "Maria Rossi",
+        htokenList: ["token1", "token2"],
+        issuerAbiCode: "00095",
+        type: "PP"
+      },
+      onboardingChannel: "I",
+      pagoPA: true,
+      updateDate: "2020-11-20"
+    },
+    {
+      walletType: "Card",
+      createDate: "2021-04-15",
+      enableableFunctions: ["FA", "pagoPA", "BPD"],
+      favourite: false,
+      idWallet: 21750,
+      info: {
+        blurredNumber: "0000",
+        brand: "DINERS",
+        brandLogo:
+          "https://wisp2.pagopa.gov.it/wallet/assets/img/creditcard/carta_diners.png",
+        expireMonth: "4",
+        expireYear: "2021",
+        hashPan:
+          "853afb770973eb48d5d275778bd124b28f60a684c20bcdf05dc8f0014c7ce871",
+        holder: "Maria Rossi",
+        htokenList: ["token1", "token2"],
+        issuerAbiCode: "00352",
+        type: "PP"
+      },
+      onboardingChannel: "I",
+      pagoPA: true,
+      updateDate: "2020-11-20"
+    },
+    {
+      walletType: "Satispay",
+      createDate: "2021-11-16",
+      enableableFunctions: ["FA", "pagoPA", "BPD"],
+      favourite: false,
+      idWallet: 25924,
+      info: {
+        brandLogo: "http://placeimg.com/640/480/technics",
+        uuid:
+          "2f969cf41246000a4f5a3b6e100e1826bd58205a0feba80f64c2a853fb8f4fa50000"
+      },
+      onboardingChannel: "I",
+      pagoPA: true,
+      updateDate: "2020-11-20"
+    },
+    {
+      walletType: "BPay",
+      createDate: "2021-07-08",
+      enableableFunctions: ["FA", "pagoPA", "BPD"],
+      favourite: false,
+      idWallet: 25572,
+      info: {
+        bankName: "Denti, Visintin and Galati",
+        instituteCode: "4",
+        numberObfuscated: "****0004",
+        paymentInstruments: [],
+        uidHash:
+          "d48a59cdfbe3da7e4fe25e28cbb47d5747720ecc6fc392c87f1636fe95db22f90004"
+      },
+      onboardingChannel: "I",
+      pagoPA: true,
+      updateDate: "2020-11-20"
+    }
+  ]
+};

--- a/ts/store/reducers/wallet/__mocks__/wallets.ts
+++ b/ts/store/reducers/wallet/__mocks__/wallets.ts
@@ -1,4 +1,5 @@
-export const walletV2List2Bancomat1PagoPACC = {
+// 2 bancomat, 1 credit card. All compliant with pagoPa
+export const walletsV2_1 = {
   data: [
     {
       walletType: "Bancomat",
@@ -74,8 +75,8 @@ export const walletV2List2Bancomat1PagoPACC = {
     }
   ]
 };
-
-export const walletV2List1Bancomat1CCNotPagoPA = {
+// 1 bancomat, 1 credit card. No compliant with pagoPa
+export const walletsV2_2 = {
   data: [
     {
       walletType: "Bancomat",
@@ -98,7 +99,7 @@ export const walletV2List1Bancomat1CCNotPagoPA = {
         type: "PP"
       },
       onboardingChannel: "I",
-      pagoPA: true,
+      pagoPA: false,
       updateDate: "2020-11-16"
     },
     {

--- a/ts/store/reducers/wallet/__tests__/wallets.test.ts
+++ b/ts/store/reducers/wallet/__tests__/wallets.test.ts
@@ -9,6 +9,7 @@ import { toIndexed } from "../../../helpers/indexer";
 import {
   bancomatSelector,
   creditCardWalletV1Selector,
+  getWalletV2Hashpan,
   isCreditCard,
   pagoPaCreditCardWalletV1Selector
 } from "../wallets";
@@ -45,11 +46,9 @@ describe("walletV2 selectors", () => {
       const wallet = maybeCC.value[0].v2;
       if (wallet) {
         expect(isCreditCard(wallet, wallet.info)).toBeTruthy();
-        if (isCreditCard(wallet, wallet.info)) {
-          expect(wallet.info.hashPan).toEqual(
-            "853afb770973eb48d5d275778bd124b28f60a684c20bcdf05dc8f0014c7ce871"
-          );
-        }
+        expect(getWalletV2Hashpan(wallet)).toEqual(
+          "853afb770973eb48d5d275778bd124b28f60a684c20bcdf05dc8f0014c7ce871"
+        );
       }
     }
   });
@@ -64,7 +63,9 @@ describe("walletV2 selectors", () => {
     if (pot.isSome(maybeBancomat)) {
       expect(maybeBancomat.value.length).toEqual(2);
       maybeBancomat.value.forEach(w => {
-        expect(hpans.find(h => h === w.info.hashPan)).toBeDefined();
+        expect(
+          hpans.find(h => h === getWalletV2Hashpan(w.wallet))
+        ).toBeDefined();
       });
     }
   });
@@ -77,11 +78,9 @@ describe("walletV2 selectors", () => {
       const wallet = maybePagoPaCC.value[0].v2;
       if (wallet) {
         expect(isCreditCard(wallet, wallet.info)).toBeTruthy();
-        if (isCreditCard(wallet, wallet.info)) {
-          expect(wallet.info.hashPan).toEqual(
-            "853afb770973eb48d5d275778bd124b28f60a684c20bcdf05dc8f0014c7ce871"
-          );
-        }
+        expect(getWalletV2Hashpan(wallet)).toEqual(
+          "853afb770973eb48d5d275778bd124b28f60a684c20bcdf05dc8f0014c7ce871"
+        );
       }
     }
   });

--- a/ts/store/reducers/wallet/__tests__/wallets.test.ts
+++ b/ts/store/reducers/wallet/__tests__/wallets.test.ts
@@ -8,8 +8,9 @@ import {
 import { toIndexed } from "../../../helpers/indexer";
 import {
   bancomatSelector,
-  creditCardSelector,
-  pagoPaCreditCardSelector
+  creditCardWalletV1Selector,
+  isCreditCard,
+  pagoPaCreditCardWalletV1Selector
 } from "../wallets";
 import { GlobalState } from "../../types";
 import { convertWalletV2toWalletV1 } from "../../../../utils/walletv2";
@@ -37,13 +38,19 @@ describe("walletV2 selectors", () => {
   });
 
   it("should return credit cards", () => {
-    const maybeCC = creditCardSelector(globalState);
+    const maybeCC = creditCardWalletV1Selector(globalState);
     expect(pot.isSome(maybeCC)).toBeTruthy();
     if (pot.isSome(maybeCC)) {
       expect(maybeCC.value.length).toEqual(1);
-      expect(maybeCC.value[0].v2!.info.hashPan).toEqual(
-        "853afb770973eb48d5d275778bd124b28f60a684c20bcdf05dc8f0014c7ce871"
-      );
+      const wallet = maybeCC.value[0].v2;
+      if (wallet) {
+        expect(isCreditCard(wallet, wallet.info)).toBeTruthy();
+        if (isCreditCard(wallet, wallet.info)) {
+          expect(wallet.info.hashPan).toEqual(
+            "853afb770973eb48d5d275778bd124b28f60a684c20bcdf05dc8f0014c7ce871"
+          );
+        }
+      }
     }
   });
 
@@ -63,13 +70,19 @@ describe("walletV2 selectors", () => {
   });
 
   it("should return credit card supporting pagoPa payments", () => {
-    const maybePagoPaCC = pagoPaCreditCardSelector(globalState);
+    const maybePagoPaCC = pagoPaCreditCardWalletV1Selector(globalState);
     expect(pot.isSome(maybePagoPaCC)).toBeTruthy();
     if (pot.isSome(maybePagoPaCC)) {
       expect(maybePagoPaCC.value.length).toEqual(1);
-      expect(maybePagoPaCC.value[0].v2!.info.hashPan).toEqual(
-        "853afb770973eb48d5d275778bd124b28f60a684c20bcdf05dc8f0014c7ce871"
-      );
+      const wallet = maybePagoPaCC.value[0].v2;
+      if (wallet) {
+        expect(isCreditCard(wallet, wallet.info)).toBeTruthy();
+        if (isCreditCard(wallet, wallet.info)) {
+          expect(wallet.info.hashPan).toEqual(
+            "853afb770973eb48d5d275778bd124b28f60a684c20bcdf05dc8f0014c7ce871"
+          );
+        }
+      }
     }
   });
 
@@ -90,7 +103,7 @@ describe("walletV2 selectors", () => {
         }
       }
     } as any) as GlobalState;
-    const maybePagoPaCC = pagoPaCreditCardSelector(globalState);
+    const maybePagoPaCC = pagoPaCreditCardWalletV1Selector(globalState);
     expect(pot.isSome(maybePagoPaCC)).toBeTruthy();
     if (pot.isSome(maybePagoPaCC)) {
       expect(maybePagoPaCC.value.length).toEqual(0);

--- a/ts/store/reducers/wallet/__tests__/wallets.test.ts
+++ b/ts/store/reducers/wallet/__tests__/wallets.test.ts
@@ -4,10 +4,7 @@ import {
   isCreditCard,
   PatchedWalletV2ListResponse
 } from "../../../../types/pagopa";
-import {
-  walletV2List1Bancomat1CCNotPagoPA,
-  walletV2List2Bancomat1PagoPACC
-} from "../__mocks__/wallets";
+import { walletV2_2, walletsV2_1 } from "../__mocks__/wallets";
 import { toIndexed } from "../../../helpers/indexer";
 import {
   bancomatSelector,
@@ -19,9 +16,7 @@ import { GlobalState } from "../../types";
 import { convertWalletV2toWalletV1 } from "../../../../utils/walletv2";
 
 describe("walletV2 selectors", () => {
-  const maybeWalletsV2 = PatchedWalletV2ListResponse.decode(
-    walletV2List2Bancomat1PagoPACC
-  );
+  const maybeWalletsV2 = PatchedWalletV2ListResponse.decode(walletsV2_1);
   const indexedWallets = toIndexed(
     (maybeWalletsV2.value as PatchedWalletV2ListResponse).data!.map(
       convertWalletV2toWalletV1
@@ -88,9 +83,7 @@ describe("walletV2 selectors", () => {
   });
 
   it("should return empty list since there is no method compliant with pagoPa", () => {
-    const maybeWallets = PatchedWalletV2ListResponse.decode(
-      walletV2List1Bancomat1CCNotPagoPA
-    );
+    const maybeWallets = PatchedWalletV2ListResponse.decode(walletV2_2);
     const indexedWallets = toIndexed(
       (maybeWallets.value as PatchedWalletV2ListResponse).data!.map(
         convertWalletV2toWalletV1

--- a/ts/store/reducers/wallet/__tests__/wallets.test.ts
+++ b/ts/store/reducers/wallet/__tests__/wallets.test.ts
@@ -1,6 +1,9 @@
 import * as pot from "italia-ts-commons/lib/pot";
 import { remoteUndefined } from "../../../../features/bonus/bpd/model/RemoteValue";
-import { PatchedWalletV2ListResponse } from "../../../../types/pagopa";
+import {
+  isCreditCard,
+  PatchedWalletV2ListResponse
+} from "../../../../types/pagopa";
 import {
   walletV2List1Bancomat1CCNotPagoPA,
   walletV2List2Bancomat1PagoPACC
@@ -10,7 +13,6 @@ import {
   bancomatSelector,
   creditCardWalletV1Selector,
   getPaymentMethodHash,
-  isCreditCardInfo,
   pagoPaCreditCardWalletV1Selector
 } from "../wallets";
 import { GlobalState } from "../../types";
@@ -43,10 +45,10 @@ describe("walletV2 selectors", () => {
     expect(pot.isSome(maybeCC)).toBeTruthy();
     if (pot.isSome(maybeCC)) {
       expect(maybeCC.value.length).toEqual(1);
-      const wallet = maybeCC.value[0].v2;
-      if (wallet) {
-        expect(isCreditCard(wallet, wallet.info)).toBeTruthy();
-        expect(getPaymentMethodHash(wallet)).toEqual(
+      const paymentMethod = maybeCC.value[0].paymentMethod;
+      if (paymentMethod) {
+        expect(isCreditCard(paymentMethod)).toBeTruthy();
+        expect(getPaymentMethodHash(paymentMethod.info)).toEqual(
           "853afb770973eb48d5d275778bd124b28f60a684c20bcdf05dc8f0014c7ce871"
         );
       }
@@ -64,7 +66,7 @@ describe("walletV2 selectors", () => {
       expect(maybeBancomat.value.length).toEqual(2);
       maybeBancomat.value.forEach(w => {
         expect(
-          hpans.find(h => h === getPaymentMethodHash(w.wallet))
+          hpans.find(h => h === getPaymentMethodHash(w.info))
         ).toBeDefined();
       });
     }
@@ -75,10 +77,10 @@ describe("walletV2 selectors", () => {
     expect(pot.isSome(maybePagoPaCC)).toBeTruthy();
     if (pot.isSome(maybePagoPaCC)) {
       expect(maybePagoPaCC.value.length).toEqual(1);
-      const wallet = maybePagoPaCC.value[0].v2;
-      if (wallet) {
-        expect(isCreditCard(wallet, wallet.info)).toBeTruthy();
-        expect(getPaymentMethodHash(wallet)).toEqual(
+      const paymentMethod = maybePagoPaCC.value[0].paymentMethod;
+      if (paymentMethod) {
+        expect(isCreditCard(paymentMethod)).toBeTruthy();
+        expect(getPaymentMethodHash(paymentMethod.info)).toEqual(
           "853afb770973eb48d5d275778bd124b28f60a684c20bcdf05dc8f0014c7ce871"
         );
       }

--- a/ts/store/reducers/wallet/__tests__/wallets.test.ts
+++ b/ts/store/reducers/wallet/__tests__/wallets.test.ts
@@ -9,8 +9,8 @@ import { toIndexed } from "../../../helpers/indexer";
 import {
   bancomatSelector,
   creditCardWalletV1Selector,
-  getWalletV2Hashpan,
-  isCreditCard,
+  getPaymentMethodHash,
+  isCreditCardInfo,
   pagoPaCreditCardWalletV1Selector
 } from "../wallets";
 import { GlobalState } from "../../types";
@@ -46,7 +46,7 @@ describe("walletV2 selectors", () => {
       const wallet = maybeCC.value[0].v2;
       if (wallet) {
         expect(isCreditCard(wallet, wallet.info)).toBeTruthy();
-        expect(getWalletV2Hashpan(wallet)).toEqual(
+        expect(getPaymentMethodHash(wallet)).toEqual(
           "853afb770973eb48d5d275778bd124b28f60a684c20bcdf05dc8f0014c7ce871"
         );
       }
@@ -64,7 +64,7 @@ describe("walletV2 selectors", () => {
       expect(maybeBancomat.value.length).toEqual(2);
       maybeBancomat.value.forEach(w => {
         expect(
-          hpans.find(h => h === getWalletV2Hashpan(w.wallet))
+          hpans.find(h => h === getPaymentMethodHash(w.wallet))
         ).toBeDefined();
       });
     }
@@ -78,7 +78,7 @@ describe("walletV2 selectors", () => {
       const wallet = maybePagoPaCC.value[0].v2;
       if (wallet) {
         expect(isCreditCard(wallet, wallet.info)).toBeTruthy();
-        expect(getWalletV2Hashpan(wallet)).toEqual(
+        expect(getPaymentMethodHash(wallet)).toEqual(
           "853afb770973eb48d5d275778bd124b28f60a684c20bcdf05dc8f0014c7ce871"
         );
       }

--- a/ts/store/reducers/wallet/__tests__/wallets.test.ts
+++ b/ts/store/reducers/wallet/__tests__/wallets.test.ts
@@ -4,7 +4,7 @@ import {
   isCreditCard,
   PatchedWalletV2ListResponse
 } from "../../../../types/pagopa";
-import { walletV2_2, walletsV2_1 } from "../__mocks__/wallets";
+import { walletsV2_2, walletsV2_1 } from "../__mocks__/wallets";
 import { toIndexed } from "../../../helpers/indexer";
 import {
   bancomatSelector,
@@ -83,7 +83,7 @@ describe("walletV2 selectors", () => {
   });
 
   it("should return empty list since there is no method compliant with pagoPa", () => {
-    const maybeWallets = PatchedWalletV2ListResponse.decode(walletV2_2);
+    const maybeWallets = PatchedWalletV2ListResponse.decode(walletsV2_2);
     const indexedWallets = toIndexed(
       (maybeWallets.value as PatchedWalletV2ListResponse).data!.map(
         convertWalletV2toWalletV1

--- a/ts/store/reducers/wallet/wallets.ts
+++ b/ts/store/reducers/wallet/wallets.ts
@@ -19,7 +19,9 @@ import {
   isBpayInfo,
   isBancomat,
   CreditCardPaymentMethod,
-  isCreditCard
+  isCreditCard,
+  PaymentMethodInfo,
+  BancomatPaymentMethod
 } from "../../../types/pagopa";
 
 import { PotFromActions } from "../../../types/utils";
@@ -135,24 +137,24 @@ export const paymentMethodsSelector = createSelector(
     )
 );
 
-export type EnhancedBancomat = PaymentMethod & {
+export type EnhancedBancomat = BancomatPaymentMethod & {
   abiInfo?: Abi;
 };
 
 export const getPaymentMethodHash = (
-  paymentMethod: PaymentMethod
+  paymentMethodInfo: PaymentMethodInfo
 ): string | undefined => {
-  if (isBancomatInfo(paymentMethod.info)) {
-    return paymentMethod.info.bancomat.hashPan;
+  if (isBancomatInfo(paymentMethodInfo)) {
+    return paymentMethodInfo.bancomat.hashPan;
   }
-  if (isCreditCardInfo(paymentMethod.info)) {
-    return paymentMethod.info.creditCard.hashPan;
+  if (isCreditCardInfo(paymentMethodInfo)) {
+    return paymentMethodInfo.creditCard.hashPan;
   }
-  if (isSatispayInfo(paymentMethod.info)) {
-    return paymentMethod.info.satispay.uuid;
+  if (isSatispayInfo(paymentMethodInfo)) {
+    return paymentMethodInfo.satispay.uuid;
   }
-  if (isBpayInfo(paymentMethod.info)) {
-    return paymentMethod.info.bPay.uidHash;
+  if (isBpayInfo(paymentMethodInfo)) {
+    return paymentMethodInfo.bPay.uidHash;
   }
   return undefined;
 };
@@ -195,7 +197,10 @@ export const creditCardWalletV1Selector = createSelector(
     potWallet: pot.Pot<ReadonlyArray<Wallet>, Error>
   ): pot.Pot<ReadonlyArray<Wallet>, Error> =>
     pot.map(potWallet, wallets =>
-      wallets.filter(w => w.paymentMethod.walletType === WalletTypeEnum.Card)
+      wallets.filter(
+        w =>
+          w.paymentMethod && w.paymentMethod.walletType === WalletTypeEnum.Card
+      )
     )
 );
 

--- a/ts/store/reducers/wallet/wallets.ts
+++ b/ts/store/reducers/wallet/wallets.ts
@@ -159,7 +159,7 @@ export const isCreditCard = (
 ): paymentMethodInfo is CardInfo =>
   paymentMethodInfo && wallet.walletType === WalletTypeEnum.Card;
 
-export const getWalletV2Haspan = (
+export const getWalletV2Hashpan = (
   wallet: PatchedWalletV2
 ): string | undefined => {
   if (isCard(wallet, wallet.info)) {

--- a/ts/types/pagopa.ts
+++ b/ts/types/pagopa.ts
@@ -164,12 +164,24 @@ export type BPayInfo = {
   type: WalletTypeEnum.BPay;
   bPay: BPayInfoPagoPa;
 };
+/**
+ * PaymentMethodInfo could be
+ * - credit card
+ * - bancomat
+ * - satispay
+ * - bancomat pay
+ * - unknown
+ */
 export type PaymentMethodInfo =
   | BancomatInfo
   | CreditCardInfo
   | SatispayInfo
   | BPayInfo
   | { type: "UNKNOWN" };
+/**
+ * PaymentMethod is a PatchedWalletV2 without info and walletType fields
+ * and with a new field info of type PaymentMethodInfo
+ */
 export type PaymentMethod = Exclude<PatchedWalletV2, "info" | "walletType"> & {
   info: PaymentMethodInfo;
 };
@@ -179,6 +191,7 @@ export type CreditCardPaymentMethod = PaymentMethod & { info: CreditCardInfo };
 export type BPayInfoMethod = PaymentMethod & { info: BPayInfo };
 export type SatispayInfoMethod = PaymentMethod & { info: SatispayInfo };
 
+// payment methods type guards
 export const isBancomat = (
   methodInfo: PaymentMethod | undefined
 ): methodInfo is BancomatPaymentMethod =>

--- a/ts/types/pagopa.ts
+++ b/ts/types/pagopa.ts
@@ -207,6 +207,11 @@ export const isCreditCard = (
 ): methodInfo is CreditCardPaymentMethod =>
   methodInfo === undefined ? false : isCreditCardInfo(methodInfo.info);
 
+export const isBPay = (
+  methodInfo: PaymentMethod | undefined
+): methodInfo is BancomatPaymentMethod =>
+  methodInfo === undefined ? false : isBpayInfo(methodInfo.info);
+
 export const isBancomatInfo = (
   methodInfo: PaymentMethodInfo | undefined
 ): methodInfo is BancomatInfo =>

--- a/ts/types/pagopa.ts
+++ b/ts/types/pagopa.ts
@@ -180,32 +180,43 @@ export type BPayInfoMethod = PaymentMethod & { info: BPayInfo };
 export type SatispayInfoMethod = PaymentMethod & { info: SatispayInfo };
 
 export const isBancomat = (
-  methodInfo: PaymentMethod
-): methodInfo is BancomatPaymentMethod => isBancomatInfo(methodInfo.info);
+  methodInfo: PaymentMethod | undefined
+): methodInfo is BancomatPaymentMethod =>
+  methodInfo === undefined ? false : isBancomatInfo(methodInfo.info);
 
 export const isSatispay = (
-  methodInfo: PaymentMethod
-): methodInfo is SatispayInfoMethod => isSatispayInfo(methodInfo.info);
+  methodInfo: PaymentMethod | undefined
+): methodInfo is SatispayInfoMethod =>
+  methodInfo === undefined ? false : isSatispayInfo(methodInfo.info);
 
 export const isCreditCard = (
-  methodInfo: PaymentMethod
-): methodInfo is CreditCardPaymentMethod => isCreditCardInfo(methodInfo.info);
+  methodInfo: PaymentMethod | undefined
+): methodInfo is CreditCardPaymentMethod =>
+  methodInfo === undefined ? false : isCreditCardInfo(methodInfo.info);
 
 export const isBancomatInfo = (
-  methodInfo: PaymentMethodInfo
-): methodInfo is BancomatInfo => methodInfo.type === WalletTypeEnum.Bancomat;
+  methodInfo: PaymentMethodInfo | undefined
+): methodInfo is BancomatInfo =>
+  methodInfo === undefined
+    ? false
+    : methodInfo.type === WalletTypeEnum.Bancomat;
 
 export const isCreditCardInfo = (
-  methodInfo: PaymentMethodInfo
-): methodInfo is CreditCardInfo => methodInfo.type === WalletTypeEnum.Card;
+  methodInfo: PaymentMethodInfo | undefined
+): methodInfo is CreditCardInfo =>
+  methodInfo === undefined ? false : methodInfo.type === WalletTypeEnum.Card;
 
 export const isSatispayInfo = (
-  methodInfo: PaymentMethodInfo
-): methodInfo is SatispayInfo => methodInfo.type === WalletTypeEnum.Satispay;
+  methodInfo: PaymentMethodInfo | undefined
+): methodInfo is SatispayInfo =>
+  methodInfo === undefined
+    ? false
+    : methodInfo.type === WalletTypeEnum.Satispay;
 
 export const isBpayInfo = (
-  methodInfo: PaymentMethodInfo
-): methodInfo is BPayInfo => methodInfo.type === WalletTypeEnum.BPay;
+  methodInfo: PaymentMethodInfo | undefined
+): methodInfo is BPayInfo =>
+  methodInfo === undefined ? false : methodInfo.type === WalletTypeEnum.BPay;
 
 /**
  * A refined Wallet
@@ -222,7 +233,7 @@ export const Wallet = repP(
 );
 
 export type Wallet = t.TypeOf<typeof Wallet> & {
-  paymentMethod: PaymentMethod;
+  paymentMethod?: PaymentMethod;
 };
 
 /**

--- a/ts/types/pagopa.ts
+++ b/ts/types/pagopa.ts
@@ -30,6 +30,8 @@ import {
   CreditCardPan
 } from "../utils/input";
 import { CardInfo } from "../../definitions/pagopa/walletv2/CardInfo";
+import { SatispayInfo } from "../../definitions/pagopa/walletv2/SatispayInfo";
+import { BPayInfo } from "../../definitions/pagopa/walletv2/BPayInfo";
 
 /**
  * Union of all possible credit card types
@@ -108,7 +110,8 @@ export enum EnableableFunctionsTypeEnum {
 }
 
 // required attributes
-
+const PaymentMethodInfo = t.union([CardInfo, SatispayInfo, BPayInfo]);
+export type PaymentMethodInfo = t.TypeOf<typeof PaymentMethodInfo>;
 const WalletV2O = t.partial({
   updateDate: t.string,
   createDate: t.string,
@@ -125,7 +128,7 @@ const WalletV2R = t.interface({
     ),
     "array of enableableFunctions"
   ),
-  info: CardInfo,
+  info: PaymentMethodInfo,
   idWallet: t.Integer,
   pagoPA: t.boolean,
   walletType: enumType<WalletTypeEnum>(WalletTypeEnum, "walletType")
@@ -137,6 +140,11 @@ export const PatchedWalletV2 = t.intersection(
 );
 
 export type PatchedWalletV2 = t.TypeOf<typeof PatchedWalletV2>;
+
+export type WalletV2WithInfo<T extends CardInfo | SatispayInfo | BPayInfo> = {
+  wallet: PatchedWalletV2;
+  info: T;
+};
 
 /**
  * A refined Wallet

--- a/ts/utils/__tests__/walletv2.ts
+++ b/ts/utils/__tests__/walletv2.ts
@@ -1,4 +1,10 @@
-import { isBancomat, isCreditCard, PatchedWalletV2 } from "../../types/pagopa";
+import {
+  isBancomat,
+  isBPay,
+  isCreditCard,
+  isSatispay,
+  PatchedWalletV2
+} from "../../types/pagopa";
 import {
   walletsV2_1,
   walletsV2_2,
@@ -41,12 +47,12 @@ describe("convert and recognize 1 bancomat and 1 credit card", () => {
   });
 });
 
-describe("convert and recognize 1 bancomat, 1 satispay, 1 bancomat pay", () => {
+describe("convert and recognize 1 bancomat, 1 satispay, 1 bancomat pay, 1 credit card", () => {
   const wallets = (walletsV2_3.data as ReadonlyArray<PatchedWalletV2>).map(
     convertWalletV2toWalletV1
   );
   it("should convert walletv2 to walletv1", () => {
-    expect(wallets.length).toEqual(2);
+    expect(wallets.length).toEqual(4);
   });
   // eslint-disable-next-line sonarjs/no-identical-functions
   it("should recognize credit card", () => {
@@ -56,5 +62,13 @@ describe("convert and recognize 1 bancomat, 1 satispay, 1 bancomat pay", () => {
   });
   it("should recognize bancomat", () => {
     expect(wallets.filter(w => isBancomat(w.paymentMethod)).length).toEqual(1);
+  });
+
+  it("should recognize bancomatpay", () => {
+    expect(wallets.filter(w => isBPay(w.paymentMethod)).length).toEqual(1);
+  });
+
+  it("should recognize satispay", () => {
+    expect(wallets.filter(w => isSatispay(w.paymentMethod)).length).toEqual(1);
   });
 });

--- a/ts/utils/__tests__/walletv2.ts
+++ b/ts/utils/__tests__/walletv2.ts
@@ -1,0 +1,60 @@
+import { isBancomat, isCreditCard, PatchedWalletV2 } from "../../types/pagopa";
+import {
+  walletsV2_1,
+  walletsV2_2,
+  walletsV2_3
+} from "../../store/reducers/wallet/__mocks__/wallets";
+import { convertWalletV2toWalletV1 } from "../walletv2";
+
+describe("convert and recognize 2 bancomat and 1 credit card", () => {
+  const wallets = (walletsV2_1.data as ReadonlyArray<PatchedWalletV2>).map(
+    convertWalletV2toWalletV1
+  );
+  it("should convert walletv2 to walletv1", () => {
+    expect(wallets.length).toEqual(3);
+  });
+  it("should recognize credit card", () => {
+    expect(wallets.filter(w => isCreditCard(w.paymentMethod)).length).toEqual(
+      1
+    );
+  });
+  it("should recognize bancomat", () => {
+    expect(wallets.filter(w => isBancomat(w.paymentMethod)).length).toEqual(2);
+  });
+});
+
+describe("convert and recognize 1 bancomat and 1 credit card", () => {
+  const wallets = (walletsV2_2.data as ReadonlyArray<PatchedWalletV2>).map(
+    convertWalletV2toWalletV1
+  );
+  it("should convert walletv2 to walletv1", () => {
+    expect(wallets.length).toEqual(2);
+  });
+  // eslint-disable-next-line sonarjs/no-identical-functions
+  it("should recognize credit card", () => {
+    expect(wallets.filter(w => isCreditCard(w.paymentMethod)).length).toEqual(
+      1
+    );
+  });
+  it("should recognize bancomat", () => {
+    expect(wallets.filter(w => isBancomat(w.paymentMethod)).length).toEqual(1);
+  });
+});
+
+describe("convert and recognize 1 bancomat, 1 satispay, 1 bancomat pay", () => {
+  const wallets = (walletsV2_3.data as ReadonlyArray<PatchedWalletV2>).map(
+    convertWalletV2toWalletV1
+  );
+  it("should convert walletv2 to walletv1", () => {
+    expect(wallets.length).toEqual(2);
+  });
+  // eslint-disable-next-line sonarjs/no-identical-functions
+  it("should recognize credit card", () => {
+    expect(wallets.filter(w => isCreditCard(w.paymentMethod)).length).toEqual(
+      1
+    );
+  });
+  it("should recognize bancomat", () => {
+    expect(wallets.filter(w => isBancomat(w.paymentMethod)).length).toEqual(1);
+  });
+});

--- a/ts/utils/walletv2.ts
+++ b/ts/utils/walletv2.ts
@@ -9,6 +9,7 @@ import {
 } from "../types/pagopa";
 import { TypeEnum as WalletTypeEnumV1 } from "../../definitions/pagopa/Wallet";
 import { WalletTypeEnum } from "../../definitions/pagopa/walletv2/WalletV2";
+import { isCreditCard } from "../store/reducers/wallet/wallets";
 import {
   CreditCardExpirationMonth,
   CreditCardExpirationYear,
@@ -33,6 +34,20 @@ export const convertWalletV2toWalletV1 = (
   walletV2: PatchedWalletV2
 ): Wallet => {
   const info = walletV2.info;
+  const cc = isCreditCard(walletV2, info)
+    ? {
+        id: undefined,
+        holder: info.holder ?? "",
+        pan: info.blurredNumber as CreditCardPan,
+        expireMonth: info.expireMonth as CreditCardExpirationMonth,
+        expireYear: info.expireYear as CreditCardExpirationYear,
+        brandLogo: info.brandLogo,
+        flag3dsVerified: true,
+        brand: info.brand,
+        onUs: true,
+        securityCode: undefined
+      }
+    : undefined;
   return {
     idWallet: walletV2.idWallet,
     type:
@@ -40,18 +55,7 @@ export const convertWalletV2toWalletV1 = (
         ? WalletTypeEnumV1.CREDIT_CARD
         : WalletTypeEnumV1.EXTERNAL_PS,
     favourite: walletV2.favourite,
-    creditCard: {
-      id: undefined,
-      holder: info.holder ?? "",
-      pan: info.blurredNumber as CreditCardPan,
-      expireMonth: info.expireMonth as CreditCardExpirationMonth,
-      expireYear: info.expireYear as CreditCardExpirationYear,
-      brandLogo: info.brandLogo,
-      flag3dsVerified: true,
-      brand: info.brand,
-      onUs: true,
-      securityCode: undefined
-    },
+    creditCard: cc,
     psp: undefined,
     idPsp: undefined,
     pspEditable: false,

--- a/ts/utils/walletv2.ts
+++ b/ts/utils/walletv2.ts
@@ -32,6 +32,7 @@ export const hasFunctionEnabled = (
   paymentMethod !== undefined &&
   paymentMethod.enableableFunctions.includes(walletFunction);
 
+// check if a PatchedWalletV2 has BPay as paymentInfo
 const isWalletV2BPay = (
   wallet: PatchedWalletV2,
   paymentMethodInfo: PatchedPaymentMethodInfo
@@ -39,18 +40,21 @@ const isWalletV2BPay = (
   (paymentMethodInfo && wallet.walletType === WalletTypeEnum.BPay) ||
   wallet.walletType === WalletTypeEnum.BPay;
 
+// check if a PatchedWalletV2 has Satispay as paymentInfo
 const isWalletV2Satispay = (
   wallet: PatchedWalletV2,
   paymentMethodInfo: PatchedPaymentMethodInfo
 ): paymentMethodInfo is SatispayInfo =>
   paymentMethodInfo && wallet.walletType === WalletTypeEnum.Satispay;
 
+// check if a PatchedWalletV2 has Bancomat as paymentInfo
 const isWalletV2Bancomat = (
   wallet: PatchedWalletV2,
   paymentMethodInfo: PatchedPaymentMethodInfo
 ): paymentMethodInfo is CardInfo =>
   paymentMethodInfo && wallet.walletType === WalletTypeEnum.Bancomat;
 
+// check if a PatchedWalletV2 has CreditCard  as paymentInfo
 const isWalletV2CreditCard = (
   wallet: PatchedWalletV2,
   paymentMethodInfo: PatchedPaymentMethodInfo
@@ -84,9 +88,9 @@ export const convertWalletV2toWalletV1 = (
   const card =
     paymentMethodInfo.type === WalletTypeEnum.Card
       ? paymentMethodInfo.creditCard
-      : paymentMethodInfo.type === WalletTypeEnum.Bancomat
-      ? paymentMethodInfo.bancomat
       : undefined;
+  // if the payment method is a credit card
+  // fill the creditCard field of Wallet
   const cc = card
     ? {
         id: undefined,


### PR DESCRIPTION
## Short description
This PR adds the ability to distinguish between wallets of type.
For that, it requires a mega refactoring.

Now code uses `PaymentMethod` instead of `PatchedWalletV2`
A PaymentMethod could be:
- `CreditCardPaymentMethod`
- `BancomatPaymentMethod`
- `SatispayPaymentMethod`
- `BPPaymentMethod`

### how to test
- make sure to have the last commit of io-dev-server
