### PR TITLE
feat(Bonus Pagamenti Digitali): [#175718879] Show remote faqs 

### DIFF
--- a/ts/components/ContextualHelpModal.tsx
+++ b/ts/components/ContextualHelpModal.tsx
@@ -119,6 +119,7 @@ const ContextualHelpModal: React.FunctionComponent<Props> = (props: Props) => {
       const faqs = fromNullable(data.faqs)
         // ensure the array is defined and not empty
         .mapNullable(faqs => (faqs.length > 0 ? faqs : undefined))
+        // if remote faqs are not defined or empty, fallback to the local ones
         .fold(getFAQsFromCategories(props.faqCategories ?? []), fqs =>
           fqs.map(f => ({ title: f.title, content: f.body }))
         );

--- a/ts/components/ContextualHelpModal.tsx
+++ b/ts/components/ContextualHelpModal.tsx
@@ -116,10 +116,12 @@ const ContextualHelpModal: React.FunctionComponent<Props> = (props: Props) => {
           {data.content}
         </Markdown>
       );
-      const faqs = fromNullable(data.faqs).fold(
-        getFAQsFromCategories(props.faqCategories ?? []),
-        fqs => fqs.map(f => ({ title: f.title, content: f.body }))
-      );
+      const faqs = fromNullable(data.faqs)
+        // ensure the array is defined and not empty
+        .mapNullable(faqs => (faqs.length > 0 ? faqs : undefined))
+        .fold(getFAQsFromCategories(props.faqCategories ?? []), fqs =>
+          fqs.map(f => ({ title: f.title, content: f.body }))
+        );
       return { title: data.title, content, faqs };
     }
   );

--- a/ts/components/ContextualHelpModal.tsx
+++ b/ts/components/ContextualHelpModal.tsx
@@ -1,4 +1,4 @@
-import { none } from "fp-ts/lib/Option";
+import { fromNullable, none } from "fp-ts/lib/Option";
 import { BugReporting } from "instabug-reactnative";
 import * as pot from "italia-ts-commons/lib/pot";
 import { Container, Content, H3, Text, View } from "native-base";
@@ -17,7 +17,11 @@ import { Dispatch } from "../store/actions/types";
 import { screenContextualHelpDataSelector } from "../store/reducers/content";
 import { GlobalState } from "../store/reducers/types";
 import themeVariables from "../theme/variables";
-import { FAQsCategoriesType } from "../utils/faq";
+import {
+  FAQsCategoriesType,
+  FAQType,
+  getFAQsFromCategories
+} from "../utils/faq";
 import FAQComponent from "./FAQComponent";
 import InstabugAssistanceComponent from "./InstabugAssistanceComponent";
 import { BaseHeader } from "./screens/BaseHeader";
@@ -49,13 +53,19 @@ const styles = StyleSheet.create({
   }
 });
 
+type ContextualHelpData = {
+  title: string;
+  content: React.ReactNode;
+  faqs?: ReadonlyArray<FAQType>;
+};
+
 /**
  * A modal to show the contextual help reelated to a screen.
  * The contextual help is characterized by:
  * - a title
  * - a textual or a component containing the screen description
  * - [optional] if on SPID authentication once the user selected an idp, content to link the support desk of the selected identity provider
- * - a list of questions and aswers. They are selected by the component depending on the cathegories passed to the component
+ * - a list of questions and answers. They are selected by the component depending on the cathegories passed to the component
  *
  * Optionally, the title and the content are injected from the content presented in the related clinet response.
  */
@@ -92,17 +102,27 @@ const ContextualHelpModal: React.FunctionComponent<Props> = (props: Props) => {
 
   /**
    *  If contextualData (loaded from the content server) contains the route of the current screen,
-   *  title and content are read from it, otherwise they came from the locales sotred in app
+   *  title, content, faqs are read from it, otherwise they came from the locales stored in app
    */
-  const customizedTitle = props.maybeContextualData.fold(
-    props.title,
-    data => data.title
+  const contextualHelpData = props.maybeContextualData.fold<ContextualHelpData>(
+    {
+      title: props.title,
+      faqs: props.faqCategories && getFAQsFromCategories(props.faqCategories),
+      content
+    },
+    data => {
+      const content = (
+        <Markdown onLoadEnd={() => setContentLoaded(true)}>
+          {data.content}
+        </Markdown>
+      );
+      const faqs = fromNullable(data.faqs).fold(
+        props.faqCategories && getFAQsFromCategories(props.faqCategories),
+        fqs => fqs.map(f => ({ title: f.title, content: f.body }))
+      );
+      return { title: data.title, content, faqs };
+    }
   );
-
-  // content could be the one provided from props or the remote one
-  const customizedContent = props.maybeContextualData.fold(content, data => (
-    <Markdown onLoadEnd={() => setContentLoaded(true)}>{data.content}</Markdown>
-  ));
 
   // content is loaded is when:
   // - provided one from props is loaded or
@@ -136,24 +156,24 @@ const ContextualHelpModal: React.FunctionComponent<Props> = (props: Props) => {
           }}
         />
 
-        {!customizedContent && (
+        {!contextualHelpData.content && (
           <View centerJustified={true}>
             <ActivityIndicator color={themeVariables.brandPrimaryLight} />
           </View>
         )}
-        {customizedContent && (
+        {contextualHelpData.content && (
           <Content
             contentContainerStyle={styles.contentContainerStyle}
             noPadded={true}
           >
-            <H3 accessible={true}>{customizedTitle}</H3>
+            <H3 accessible={true}>{contextualHelpData.title}</H3>
             <View spacer={true} />
-            {customizedContent}
+            {contextualHelpData.content}
             <View spacer={true} />
-            {props.faqCategories && isContentLoaded && (
+            {contextualHelpData.faqs && isContentLoaded && (
               <FAQComponent
                 onLinkClicked={props.onLinkClicked}
-                faqCategories={props.faqCategories}
+                faqs={contextualHelpData.faqs}
               />
             )}
             {isContentLoaded && (

--- a/ts/components/ContextualHelpModal.tsx
+++ b/ts/components/ContextualHelpModal.tsx
@@ -107,7 +107,7 @@ const ContextualHelpModal: React.FunctionComponent<Props> = (props: Props) => {
   const contextualHelpData = props.maybeContextualData.fold<ContextualHelpData>(
     {
       title: props.title,
-      faqs: props.faqCategories && getFAQsFromCategories(props.faqCategories),
+      faqs: getFAQsFromCategories(props.faqCategories ?? []),
       content
     },
     data => {
@@ -117,7 +117,7 @@ const ContextualHelpModal: React.FunctionComponent<Props> = (props: Props) => {
         </Markdown>
       );
       const faqs = fromNullable(data.faqs).fold(
-        props.faqCategories && getFAQsFromCategories(props.faqCategories),
+        getFAQsFromCategories(props.faqCategories ?? []),
         fqs => fqs.map(f => ({ title: f.title, content: f.body }))
       );
       return { title: data.title, content, faqs };

--- a/ts/components/FAQComponent.tsx
+++ b/ts/components/FAQComponent.tsx
@@ -1,28 +1,22 @@
 import * as React from "react";
-import {
-  FAQsCategoriesType,
-  FAQType,
-  getFAQsFromCategories
-} from "../utils/faq";
+import { FAQType } from "../utils/faq";
 import Accordion from "./ui/Accordion";
 
 type Props = Readonly<{
-  faqCategories: ReadonlyArray<FAQsCategoriesType>;
+  faqs: ReadonlyArray<FAQType>;
   onLinkClicked?: (url: string) => void;
 }>;
 
 const FAQComponent: React.FunctionComponent<Props> = (props: Props) => (
   <>
-    {getFAQsFromCategories(props.faqCategories).map(
-      (faqType: FAQType, i: number) => (
-        <Accordion
-          key={i}
-          title={faqType.title}
-          content={faqType.content}
-          onLinkClicked={props.onLinkClicked}
-        />
-      )
-    )}
+    {props.faqs.map((faqType: FAQType, i: number) => (
+      <Accordion
+        key={i}
+        title={faqType.title}
+        content={faqType.content}
+        onLinkClicked={props.onLinkClicked}
+      />
+    ))}
   </>
 );
 


### PR DESCRIPTION
## Short description
This PR is based on this one https://github.com/pagopa/io-services-metadata/pull/154
Now the faqs showed in the Contextual Help could be _remote_ or _local_.
Remote ones, if defined, will be always displayed in place of local

<img src="https://user-images.githubusercontent.com/822471/100088507-86dfb000-2e50-11eb-8231-2fbb8ce65825.png" height="600"/>

### how to test
- get the last commit from `io-dev-api-server` branch `support-bpd`
- `io-dev-api-server` `yarn generate:all`
- app `yarn generate:all`