### PR TITLE
chore(linter): Add "react-hooks/rules-of-hooks" rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
     project: "tsconfig.json",
     sourceType: "module"
   },
-  plugins: ["@typescript-eslint", "react", "import", "functional", "sonarjs"],
+  plugins: ["@typescript-eslint", "react", "react-hooks", "import", "functional", "sonarjs"],
   rules: {
     "no-case-declarations": "off",
     "no-inner-declarations": "off",
@@ -80,6 +80,7 @@ module.exports = {
     "react/display-name": "off",
     "react/jsx-key": "error",
     "react/jsx-no-bind": ["error", { allowArrowFunctions: true }],
+    "react-hooks/rules-of-hooks": "error",
     "functional/no-let": "error",
     "functional/immutable-data": "error",
     "sonarjs/no-small-switch": "off",

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "eslint": "^6.5.1",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-react": "^7.20.6",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "fs-extra": "^7.0.0",
     "italia-utils": "^4.1.1",
     "jest": "^25.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4679,6 +4679,11 @@ eslint-plugin-react-hooks@^3.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-3.0.0.tgz#9e80c71846eb68dd29c3b21d832728aa66e5bd35"
   integrity sha512-EjxTHxjLKIBWFgDJdhKKzLh5q+vjTFrqNZX36uIxWS4OfyXe5DawqPj3U5qeJ1ngLwatjzQnmR0Lz0J0YH3kxw==
 
+eslint-plugin-react-hooks@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
+  integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
+
 eslint-plugin-react-native-globals@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-native-globals/-/eslint-plugin-react-native-globals-0.1.2.tgz#ee1348bc2ceb912303ce6bdbd22e2f045ea86ea2"


### PR DESCRIPTION
## Short description
Add a rule to avoid messing up with React hooks.

As stated in React official docs (https://en.reactjs.org/docs/hooks-rules.html), using hooks has a few rules to respect. If the code doesn't follow those rules, some strange behavior can happen and some subtle bugs can appear.
This PR adds a new linter rule and the linter breaks, so I suggest taking an eye on the few points where the rules are not respected.

## List of changes proposed in this pull request
- Add `react-hooks/rules-of-hooks` linter rule

## How to test
`yarn lint` breaks the CI, highlighting some bugs (or if not proper bugs, at least some code smells) in the codebase