### PR TITLE
fix(Bonus Pagamenti Digitali): [#175717757,#175876304] Empty footer cuts screen content on BPD Detail

### DIFF
--- a/ts/features/bonus/bpd/components/BaseDailyTransactionHeader.tsx
+++ b/ts/features/bonus/bpd/components/BaseDailyTransactionHeader.tsx
@@ -28,7 +28,7 @@ const styles = StyleSheet.create({
 const BaseDailyTransactionHeader: React.FunctionComponent<Props> = (
   props: Props
 ) => (
-  <View style={[styles.whiteBg, { paddingHorizontal: 8 }]}>
+  <View style={[styles.whiteBg, { paddingHorizontal: 24 }]}>
     <H3 weight={"Bold"} color={"black"}>
       {props.date}
     </H3>

--- a/ts/features/bonus/bpd/components/transactionItem/BaseBpdTransactionItem.tsx
+++ b/ts/features/bonus/bpd/components/transactionItem/BaseBpdTransactionItem.tsx
@@ -44,7 +44,10 @@ const styles = StyleSheet.create({
  * @constructor
  */
 export const BaseBpdTransactionItem: React.FunctionComponent<Props> = props => (
-  <TouchableOpacity style={{ marginVertical: 4 }} onPress={props.onPress}>
+  <TouchableOpacity
+    style={{ marginVertical: 4, paddingHorizontal: 16 }}
+    onPress={props.onPress}
+  >
     <ShadowBox>
       <View style={[styles.body, styles.row]}>
         <View style={[styles.row]}>

--- a/ts/features/bonus/bpd/screens/details/BpdDetailsScreen.tsx
+++ b/ts/features/bonus/bpd/screens/details/BpdDetailsScreen.tsx
@@ -4,6 +4,8 @@ import { StyleSheet, View } from "react-native";
 import { NavigationActions } from "react-navigation";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
+import { fromNullable } from "fp-ts/lib/Option";
+import * as pot from "italia-ts-commons/lib/pot";
 import LoadingSpinnerOverlay from "../../../../../components/LoadingSpinnerOverlay";
 import DarkLayout from "../../../../../components/screens/DarkLayout";
 import I18n from "../../../../../i18n";
@@ -13,14 +15,12 @@ import { isError, isLoading, isReady } from "../../model/RemoteValue";
 import { bpdDetailsLoadAll } from "../../store/actions/details";
 import { bpdUnsubscribeCompleted } from "../../store/actions/onboarding";
 import { bpdUnsubscriptionSelector } from "../../store/reducers/details/activation";
-import BpdPeriodSelector from "./BpdPeriodSelector";
-import BpdPeriodDetail from "./periods/BpdPeriodDetail";
-import GoToTransactions from "./transaction/GoToTransactions";
-import { fromNullable } from "fp-ts/lib/Option";
-import * as pot from "italia-ts-commons/lib/pot";
 import { bpdTransactionsForSelectedPeriod } from "../../store/reducers/details/transactions";
 import { bpdSelectedPeriodSelector } from "../../store/reducers/details/selectedPeriod";
 import { navigateToBpdTransactions } from "../../navigation/actions";
+import BpdPeriodSelector from "./BpdPeriodSelector";
+import BpdPeriodDetail from "./periods/BpdPeriodDetail";
+import GoToTransactions from "./transaction/GoToTransactions";
 
 export type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;

--- a/ts/features/bonus/bpd/screens/details/transaction/BpdTransactionsScreen.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/BpdTransactionsScreen.tsx
@@ -159,14 +159,12 @@ const getTransactionsByDaySections = (
 const renderSectionHeader = (info: {
   section: SectionListData<EnhancedBpdTransaction | TotalCashbackPerDate>;
 }): React.ReactNode => (
-  <View style={{ paddingHorizontal: 16 }}>
-    <BaseDailyTransactionHeader
-      date={info.section.title}
-      transactionsNumber={
-        [...info.section.data].filter(i => !isTotalCashback(i)).length
-      }
-    />
-  </View>
+  <BaseDailyTransactionHeader
+    date={info.section.title}
+    transactionsNumber={
+      [...info.section.data].filter(i => !isTotalCashback(i)).length
+    }
+  />
 );
 
 /**
@@ -196,11 +194,7 @@ const BpdTransactionsScreen: React.FunctionComponent<Props> = props => {
         />
       );
     }
-    return (
-      <View style={{ paddingHorizontal: 16 }}>
-        <BpdTransactionItem transaction={info.item} />
-      </View>
-    );
+    return <BpdTransactionItem transaction={info.item} />;
   };
 
   return (

--- a/ts/features/bonus/bpd/screens/details/transaction/GoToTransactions.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/GoToTransactions.tsx
@@ -1,21 +1,10 @@
-import { fromNullable } from "fp-ts/lib/Option";
-import * as pot from "italia-ts-commons/lib/pot";
 import * as React from "react";
-import { connect } from "react-redux";
-import { Dispatch } from "redux";
 import ButtonDefaultOpacity from "../../../../../../components/ButtonDefaultOpacity";
 import { Label } from "../../../../../../components/core/typography/Label";
 import IconFont from "../../../../../../components/ui/IconFont";
 import I18n from "../../../../../../i18n";
-import { GlobalState } from "../../../../../../store/reducers/types";
-import { navigateToBpdTransactions } from "../../../navigation/actions";
-import { AwardPeriodId } from "../../../store/actions/periods";
-import { bpdTransactionsLoad } from "../../../store/actions/transactions";
-import { bpdSelectedPeriodSelector } from "../../../store/reducers/details/selectedPeriod";
-import { bpdTransactionsForSelectedPeriod } from "../../../store/reducers/details/transactions";
 
-type Props = ReturnType<typeof mapDispatchToProps> &
-  ReturnType<typeof mapStateToProps>;
+type Props = { goToTransactions: () => void };
 
 /**
  * Display the transactions button when:
@@ -25,45 +14,18 @@ type Props = ReturnType<typeof mapDispatchToProps> &
  * @param props
  * @constructor
  */
-const GoToTransactions: React.FunctionComponent<Props> = props => {
-  const canRenderButton = fromNullable(props.selectedPeriod).fold(false, sp => {
-    switch (sp.status) {
-      case "Closed":
-        return pot.getOrElse(
-          pot.map(props.transactions, val => val.length > 0),
-          false
-        );
-      case "Inactive":
-        return false;
-      default:
-        return true;
-    }
-  });
+const GoToTransactions: React.FunctionComponent<Props> = props => (
+  <ButtonDefaultOpacity
+    block={true}
+    onPress={props.goToTransactions}
+    activeOpacity={1}
+    style={{ marginBottom: 23 }}
+  >
+    <IconFont name="io-transactions" size={24} color={"white"} />
+    <Label color={"white"}>
+      {I18n.t("bonus.bpd.details.transaction.goToButton")}
+    </Label>
+  </ButtonDefaultOpacity>
+);
 
-  return canRenderButton ? (
-    <ButtonDefaultOpacity
-      block={true}
-      onPress={props.goToTransactions}
-      activeOpacity={1}
-      style={{ marginBottom: 23 }}
-    >
-      <IconFont name="io-transactions" size={24} color={"white"} />
-      <Label color={"white"}>
-        {I18n.t("bonus.bpd.details.transaction.goToButton")}
-      </Label>
-    </ButtonDefaultOpacity>
-  ) : null;
-};
-
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  goToTransactions: () => dispatch(navigateToBpdTransactions()),
-  loadTransactionsByPeriod: (periodId: AwardPeriodId) =>
-    dispatch(bpdTransactionsLoad.request(periodId))
-});
-
-const mapStateToProps = (state: GlobalState) => ({
-  transactions: bpdTransactionsForSelectedPeriod(state),
-  selectedPeriod: bpdSelectedPeriodSelector(state)
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(GoToTransactions);
+export default GoToTransactions;


### PR DESCRIPTION
## Short description
This PR fixes the cut content by footer on BPD detail screen.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/3959405/100133825-91696c00-2e87-11eb-978c-4297e8b8dd79.png) | ![image](https://user-images.githubusercontent.com/3959405/100133926-b1992b00-2e87-11eb-887e-cc2434bf188a.png) |

This PR includes some minor fixes on transactions list items and header for content padding.
