### PR TITLE
fix: [#175879918] Add missing ca bancomat success code

### DIFF
--- a/ts/features/wallet/onboarding/bancomat/screens/searchBancomat/SearchAvailableUserBancomatScreen.tsx
+++ b/ts/features/wallet/onboarding/bancomat/screens/searchBancomat/SearchAvailableUserBancomatScreen.tsx
@@ -49,8 +49,11 @@ const SearchAvailableUserBancomatScreen: React.FunctionComponent<Props> = props 
         m => m.code && servicesSuccessCodes.includes(m.code)
       )
     ) {
+      // The user doesn't have a bancomat
       return <BancomatKoNotFound />;
     }
+    // One of the ca returned with error, the user could have a bancomat
+    // and he should try to search for a single bank
     return <BancomatKoServicesError />;
   }
   if (isError(pans) && pans.error.kind === "timeout") {

--- a/ts/features/wallet/onboarding/bancomat/screens/searchBancomat/SearchAvailableUserBancomatScreen.tsx
+++ b/ts/features/wallet/onboarding/bancomat/screens/searchBancomat/SearchAvailableUserBancomatScreen.tsx
@@ -20,6 +20,14 @@ export type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
 
 const bancomatServiceSuccessCode = 0;
+const bancomatServiceCustomerNotFound = 21;
+const bancomatServiceCardNotFound = 23;
+
+const servicesSuccessCodes = [
+  bancomatServiceSuccessCode,
+  bancomatServiceCardNotFound,
+  bancomatServiceCustomerNotFound
+];
 
 /**
  * This screen handle the errors and loading for the user bancomat.
@@ -37,7 +45,9 @@ const SearchAvailableUserBancomatScreen: React.FunctionComponent<Props> = props 
     // check if all services response successfully
     if (
       isReady(pans) &&
-      pans.value.messages.every(m => m.code === bancomatServiceSuccessCode)
+      pans.value.messages.every(
+        m => m.code && servicesSuccessCodes.includes(m.code)
+      )
     ) {
       return <BancomatKoNotFound />;
     }

--- a/ts/features/wallet/onboarding/bancomat/screens/searchBancomat/SearchAvailableUserBancomatScreen.tsx
+++ b/ts/features/wallet/onboarding/bancomat/screens/searchBancomat/SearchAvailableUserBancomatScreen.tsx
@@ -42,7 +42,7 @@ const SearchAvailableUserBancomatScreen: React.FunctionComponent<Props> = props 
     return <BancomatKoSingleBankNotFound />;
   }
   if (noBancomatFound) {
-    // check if all services response successfully
+    // check if all services respond without error (success or not found)
     if (
       isReady(pans) &&
       pans.value.messages.every(


### PR DESCRIPTION
## Short description
This pr allows to handle also the ca bancomat return code `CUSTOMER_NOT_FOUND(21)` and `CARDS_NOT_FOUND(23)`.
With this pr the user will receive the right feedback screen when all the ca return without error (success or not found).
