### PR TITLE
fix(Bonus Pagamenti Digitali): [#175697866] Shows an inline feedback to copy button

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -114,7 +114,7 @@ locales:
 clipboard:
   copyFeedback: Copied to clipboard
   copyText: copy
-  copyFeedbackButton: Copied
+  copyFeedbackButton: copied
 betaBanner:
   title: 'The IO app is in beta version.'
   description: Your reports help us to improve day after day.

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -114,6 +114,7 @@ locales:
 clipboard:
   copyFeedback: Copied to clipboard
   copyText: copy
+  copyFeedbackButton: Copied
 betaBanner:
   title: 'The IO app is in beta version.'
   description: Your reports help us to improve day after day.

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -114,7 +114,7 @@ locales:
 clipboard:
   copyFeedback: Copiato negli appunti
   copyText: copia
-  copyFeedbackButton: Copiato
+  copyFeedbackButton: copiato
 betaBanner:
   title: "L’app IO è in versione beta."
   description: Le tue segnalazioni ci aiutano a migliorare giorno dopo giorno.

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -114,6 +114,7 @@ locales:
 clipboard:
   copyFeedback: Copiato negli appunti
   copyText: copia
+  copyFeedbackButton: Copiato
 betaBanner:
   title: "L’app IO è in versione beta."
   description: Le tue segnalazioni ci aiutano a migliorare giorno dopo giorno.

--- a/ts/components/CopyButtonComponent.tsx
+++ b/ts/components/CopyButtonComponent.tsx
@@ -1,3 +1,4 @@
+import { Millisecond } from "italia-ts-commons/lib/units";
 import { Text } from "native-base";
 import * as React from "react";
 import { Platform, StyleSheet } from "react-native";
@@ -34,13 +35,24 @@ const styles = StyleSheet.create({
   }
 });
 
+const FEEDBACK_MS = 4000 as Millisecond;
+
 const CopyButtonComponent: React.FunctionComponent<Props> = (props: Props) => {
   const [isTap, setIsTap] = React.useState(false);
+  const timerRetry = React.useRef<number | undefined>(undefined);
+
+  React.useEffect(
+    () => () => {
+      clearTimeout(timerRetry.current);
+    },
+    []
+  );
 
   const handlePress = () => {
     setIsTap(true);
     clipboardSetStringWithFeedback(props.textToCopy);
-    setTimeout(() => setIsTap(false), 4000);
+    // eslint-disable-next-line functional/immutable-data
+    timerRetry.current = setTimeout(() => setIsTap(false), FEEDBACK_MS);
   };
 
   return (

--- a/ts/components/CopyButtonComponent.tsx
+++ b/ts/components/CopyButtonComponent.tsx
@@ -1,11 +1,12 @@
-import I18n from "i18n-js";
 import { Text } from "native-base";
 import * as React from "react";
 import { Platform, StyleSheet } from "react-native";
+import I18n from "../i18n";
 import { makeFontStyleObject } from "../theme/fonts";
 import customVariables from "../theme/variables";
 import { clipboardSetStringWithFeedback } from "../utils/clipboard";
 import ButtonDefaultOpacity from "./ButtonDefaultOpacity";
+import { IOColors } from "./core/variables/IOColors";
 
 type Props = Readonly<{
   textToCopy: string;
@@ -22,22 +23,43 @@ const styles = StyleSheet.create({
   },
   text: {
     ...makeFontStyleObject(Platform.select, customVariables.textNormalWeight),
-    color: customVariables.brandPrimary,
     paddingLeft: 0,
     paddingRight: 0
+  },
+  colorBlue: {
+    color: IOColors.blue
+  },
+  colorWhite: {
+    color: IOColors.white
   }
 });
 
-export default function CopyButtonComponent(props: Props) {
+const CopyButtonComponent: React.FunctionComponent<Props> = (props: Props) => {
+  const [isTap, setIsTap] = React.useState(false);
+
+  const handlePress = () => {
+    setIsTap(true);
+    clipboardSetStringWithFeedback(props.textToCopy);
+    setTimeout(() => setIsTap(false), 4000);
+  };
+
   return (
     <ButtonDefaultOpacity
-      onPress={() => clipboardSetStringWithFeedback(props.textToCopy)}
+      onPress={handlePress}
       style={styles.button}
-      bordered={true}
+      bordered={!isTap}
+      primary={isTap}
     >
-      <Text style={styles.text} small={true}>
-        {I18n.t("clipboard.copyText")}
+      <Text
+        style={[styles.text, isTap ? styles.colorWhite : styles.colorBlue]}
+        small={true}
+      >
+        {isTap
+          ? I18n.t("clipboard.copyFeedbackButton")
+          : I18n.t("clipboard.copyText")}
       </Text>
     </ButtonDefaultOpacity>
   );
-}
+};
+
+export default CopyButtonComponent;


### PR DESCRIPTION
## Short description
This PR adds an in-button feedback on copy button component to prevent toast hiding bug.

<img src="https://user-images.githubusercontent.com/3959405/100137417-bad8c680-2e8c-11eb-84c2-c613f1a34485.gif" height="550"/>
