### PR TITLE
feat(Bonus Pagamenti Digitali): [#175883590] Satispay and Bancomatpay selector

### DIFF
--- a/scripts/changelog/ts/__tests__/changelog.test.ts
+++ b/scripts/changelog/ts/__tests__/changelog.test.ts
@@ -75,9 +75,12 @@ describe("Test pivotal Utility", () => {
     const eitherScope = getStoryChangelogScope(clashScopeLabelStory);
     expect(eitherScope.isLeft()).toBeTruthy();
   });
-  it("getStoryChangelogScope on a story with scope label not allowed should return Left,Error", () => {
+  it("getStoryChangelogScope on a story with scope label not allowed should return Right,none", () => {
     const eitherScope = getStoryChangelogScope(scopeLabelNotAllowedStory);
-    expect(eitherScope.isLeft()).toBeTruthy();
+    expect(eitherScope.isRight()).toBeTruthy();
+    if (eitherScope.isRight()) {
+      expect(eitherScope.value).toBe(none);
+    }
   });
   it("getStoryChangelogScope on a story with a scope labels and belonging to a project that assigns a scope should return Left,Error", () => {
     const eitherScope = getStoryChangelogScope(bonusVacanzeStoryWithScopeLabel);

--- a/scripts/changelog/ts/changelog.ts
+++ b/scripts/changelog/ts/changelog.ts
@@ -116,8 +116,7 @@ export const getStoryChangelogScope = (
   // search for scope labels associated with the story
   const maybeChangelogScopeTag = story.labels
     .filter(l => l.name.match(regex))
-    .map(l => l.name.match(regex)!.pop())
-    .filter(tag => tag && allowedScope.has(tag));
+    .map(l => l.name.match(regex)!.pop());
 
   // multiple scope labels found on the story
   if (maybeChangelogScopeTag.length > 1) {

--- a/scripts/changelog/ts/changelog.ts
+++ b/scripts/changelog/ts/changelog.ts
@@ -116,7 +116,8 @@ export const getStoryChangelogScope = (
   // search for scope labels associated with the story
   const maybeChangelogScopeTag = story.labels
     .filter(l => l.name.match(regex))
-    .map(l => l.name.match(regex)!.pop());
+    .map(l => l.name.match(regex)!.pop())
+    .filter(tag => tag && allowedScope.has(tag));
 
   // multiple scope labels found on the story
   if (maybeChangelogScopeTag.length > 1) {

--- a/ts/features/wallet/component/WalletV2PreviewCards.tsx
+++ b/ts/features/wallet/component/WalletV2PreviewCards.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { GlobalState } from "../../../store/reducers/types";
-import { bancomatSelector } from "../../../store/reducers/wallet/wallets";
+import { bancomatListSelector } from "../../../store/reducers/wallet/wallets";
 import BancomatWalletPreview from "../bancomat/component/BancomatWalletPreview";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
@@ -36,7 +36,7 @@ const WalletV2PreviewCards: React.FunctionComponent<Props> = props => (
 const mapDispatchToProps = (_: Dispatch) => ({});
 
 const mapStateToProps = (state: GlobalState) => ({
-  bancomatList: bancomatSelector(state)
+  bancomatList: bancomatListSelector(state)
 });
 
 export default connect(

--- a/ts/features/wallet/onboarding/bancomat/store/reducers/addedPans.ts
+++ b/ts/features/wallet/onboarding/bancomat/store/reducers/addedPans.ts
@@ -3,9 +3,9 @@ import { getType } from "typesafe-actions";
 import { Action } from "../../../../../../store/actions/types";
 import {
   BancomatPaymentMethod,
-  enhanceBancomat,
   RawBancomatPaymentMethod
 } from "../../../../../../types/pagopa";
+import { enhanceBancomat } from "../../../../../../utils/paymentMethod";
 import { getValueOrElse } from "../../../../../bonus/bpd/model/RemoteValue";
 import { abiSelector } from "../../../store/abi";
 import { addBancomatToWallet, walletAddBancomatStart } from "../actions";

--- a/ts/store/reducers/wallet/__tests__/wallets.test.ts
+++ b/ts/store/reducers/wallet/__tests__/wallets.test.ts
@@ -7,7 +7,7 @@ import {
 import { walletsV2_2, walletsV2_1 } from "../__mocks__/wallets";
 import { toIndexed } from "../../../helpers/indexer";
 import {
-  bancomatSelector,
+  bancomatListSelector,
   creditCardWalletV1Selector,
   pagoPaCreditCardWalletV1Selector
 } from "../wallets";
@@ -51,7 +51,7 @@ describe("walletV2 selectors", () => {
   });
 
   it("should return bancomat", () => {
-    const maybeBancomat = bancomatSelector(globalState);
+    const maybeBancomat = bancomatListSelector(globalState);
     expect(pot.isSome(maybeBancomat)).toBeTruthy();
     const hpans = [
       "a591ab131bd9492e6df0357f1ac52785a96ddc8e772baddbb02e2169af9474f4",

--- a/ts/store/reducers/wallet/wallets.ts
+++ b/ts/store/reducers/wallet/wallets.ts
@@ -148,9 +148,6 @@ export const paymentMethodsSelector = createSelector(
     )
 );
 
-/**
- * Return the
- */
 export const rawCreditCardListSelector = createSelector(
   [paymentMethodsSelector],
   (
@@ -163,7 +160,7 @@ export const rawCreditCardListSelector = createSelector(
 );
 
 /**
- * Return a bancomat list enhanced with the additional abi information
+ * Return a bancomat list enhanced with the additional abi information in the wallet
  */
 export const bancomatListSelector = createSelector(
   [paymentMethodsSelector],
@@ -172,7 +169,7 @@ export const bancomatListSelector = createSelector(
 );
 
 /**
- * Return a credit card list
+ * Return a credit card list in the wallet
  */
 export const creditCardListSelector = createSelector(
   [paymentMethodsSelector],
@@ -183,7 +180,7 @@ export const creditCardListSelector = createSelector(
 );
 
 /**
- * Return a satispay list
+ * Return a satispay list in the wallet
  */
 export const satispayListSelector = createSelector(
   [paymentMethodsSelector],
@@ -192,7 +189,7 @@ export const satispayListSelector = createSelector(
 );
 
 /**
- * Return a BPay list
+ * Return a BPay list in the wallet
  */
 export const bPayListSelector = createSelector(
   [paymentMethodsSelector],

--- a/ts/store/reducers/wallet/wallets.ts
+++ b/ts/store/reducers/wallet/wallets.ts
@@ -10,17 +10,23 @@ import { getValueOrElse } from "../../../features/bonus/bpd/model/RemoteValue";
 import { abiSelector } from "../../../features/wallet/onboarding/store/abi";
 import {
   BancomatPaymentMethod,
-  enhancePaymentMethod,
+  BPayPaymentMethod,
+  CreditCardPaymentMethod,
   isBancomat,
+  isBPay,
+  isCreditCard,
   isRawCreditCard,
+  isSatispay,
   PaymentMethod,
   RawCreditCardPaymentMethod,
   RawPaymentMethod,
+  SatispayPaymentMethod,
   Wallet
 } from "../../../types/pagopa";
 
 import { PotFromActions } from "../../../types/utils";
 import { isDefined } from "../../../utils/guards";
+import { enhancePaymentMethod } from "../../../utils/paymentMethod";
 import { Action } from "../../actions/types";
 import { paymentUpdateWalletPsp } from "../../actions/wallet/payment";
 import {
@@ -95,7 +101,7 @@ export const getFavoriteWallet = (state: GlobalState) =>
 /**
  * @deprecated Using API v2 this selector is deprecated
  * If you are searching for credit card or bancomat use {@link creditCardWalletV1Selector}
- * - {@link pagoPaCreditCardWalletV1Selector} {@link bancomatSelector} instead
+ * - {@link pagoPaCreditCardWalletV1Selector} {@link bancomatListSelector} instead
  */
 export const walletsSelector = createSelector(
   getWallets,
@@ -143,12 +149,55 @@ export const paymentMethodsSelector = createSelector(
 );
 
 /**
+ * Return the
+ */
+export const rawCreditCardListSelector = createSelector(
+  [paymentMethodsSelector],
+  (
+    paymentMethods: pot.Pot<ReadonlyArray<RawPaymentMethod>, Error>
+  ): ReadonlyArray<RawCreditCardPaymentMethod> =>
+    pot.getOrElse(
+      pot.map(paymentMethods, w => w.filter(isRawCreditCard)),
+      []
+    )
+);
+
+/**
  * Return a bancomat list enhanced with the additional abi information
  */
-export const bancomatSelector = createSelector(
+export const bancomatListSelector = createSelector(
   [paymentMethodsSelector],
   (paymentMethodPot): pot.Pot<ReadonlyArray<BancomatPaymentMethod>, Error> =>
     pot.map(paymentMethodPot, paymentMethod => paymentMethod.filter(isBancomat))
+);
+
+/**
+ * Return a credit card list
+ */
+export const creditCardListSelector = createSelector(
+  [paymentMethodsSelector],
+  (paymentMethodPot): pot.Pot<ReadonlyArray<CreditCardPaymentMethod>, Error> =>
+    pot.map(paymentMethodPot, paymentMethod =>
+      paymentMethod.filter(isCreditCard)
+    )
+);
+
+/**
+ * Return a satispay list
+ */
+export const satispayListSelector = createSelector(
+  [paymentMethodsSelector],
+  (paymentMethodPot): pot.Pot<ReadonlyArray<SatispayPaymentMethod>, Error> =>
+    pot.map(paymentMethodPot, paymentMethod => paymentMethod.filter(isSatispay))
+);
+
+/**
+ * Return a BPay list
+ */
+export const bPayListSelector = createSelector(
+  [paymentMethodsSelector],
+  (paymentMethodPot): pot.Pot<ReadonlyArray<BPayPaymentMethod>, Error> =>
+    pot.map(paymentMethodPot, paymentMethod => paymentMethod.filter(isBPay))
 );
 
 /**
@@ -164,17 +213,6 @@ export const creditCardWalletV1Selector = createSelector(
         w =>
           w.paymentMethod && w.paymentMethod.walletType === WalletTypeEnum.Card
       )
-    )
-);
-
-export const creditCardSelector = createSelector(
-  [paymentMethodsSelector],
-  (
-    paymentMethods: pot.Pot<ReadonlyArray<RawPaymentMethod>, Error>
-  ): ReadonlyArray<RawCreditCardPaymentMethod> =>
-    pot.getOrElse(
-      pot.map(paymentMethods, w => w.filter(isRawCreditCard)),
-      []
     )
 );
 

--- a/ts/types/pagopa.ts
+++ b/ts/types/pagopa.ts
@@ -28,18 +28,12 @@ import { BPayInfo as BPayInfoPagoPa } from "../../definitions/pagopa/walletv2/BP
 import { CardInfo } from "../../definitions/pagopa/walletv2/CardInfo";
 import { SatispayInfo as SatispayInfoPagoPa } from "../../definitions/pagopa/walletv2/SatispayInfo";
 import { WalletTypeEnum } from "../../definitions/pagopa/walletv2/WalletV2";
-import { IndexedById } from "../store/helpers/indexer";
 import {
   CreditCardCVC,
   CreditCardExpirationMonth,
   CreditCardExpirationYear,
   CreditCardPan
 } from "../utils/input";
-import {
-  getImageFromPaymentMethod,
-  getTitleFromBancomat,
-  getTitleFromPaymentMethod
-} from "../utils/paymentMethod";
 
 /**
  * Union of all possible credit card types
@@ -255,37 +249,6 @@ export const isCreditCard = (
 export const isBPay = (
   pm: PaymentMethod | undefined
 ): pm is BPayPaymentMethod => (pm === undefined ? false : pm.kind === "BPay");
-
-export const enhanceBancomat = (
-  bancomat: RawBancomatPaymentMethod,
-  abiList: IndexedById<Abi>
-): BancomatPaymentMethod => ({
-  ...bancomat,
-  abiInfo: bancomat.info.issuerAbiCode
-    ? abiList[bancomat.info.issuerAbiCode]
-    : undefined,
-  caption: getTitleFromBancomat(bancomat, abiList),
-  icon: getImageFromPaymentMethod(bancomat)
-});
-
-export const enhancePaymentMethod = (
-  pm: RawPaymentMethod,
-  abiList: IndexedById<Abi>
-): PaymentMethod => {
-  switch (pm.kind) {
-    // bancomat need a special handling, we need to include the abi
-    case "Bancomat":
-      return enhanceBancomat(pm, abiList);
-    case "CreditCard":
-    case "BPay":
-    case "Satispay":
-      return {
-        ...pm,
-        caption: getTitleFromPaymentMethod(pm, abiList),
-        icon: getImageFromPaymentMethod(pm)
-      };
-  }
-};
 
 /**
  * A refined Wallet


### PR DESCRIPTION
## Short description
This pr adds the selector fo BPay and BancomatPay.

## List of changes proposed in this pull request
- Added `creditCardListSelector`, `satispayListSelector` and `bPayListSelector`.
- Moved `enhanceBancomat` and `enhancePaymentMethod` to utils.
- Added fix for changelog scope generation.

## How to test
Run `ts/store/reducers/wallet/__tests__/wallets.test.ts`
