### PR TITLE
feat(Bonus Pagamenti Digitali): [#175876837] Show disclaimer when activate bpd on a payment method

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1826,6 +1826,7 @@ bonus:
           title: "Method activation"
           body: "Activate cashback on this payment method?
                  This will start **tomorrow**, so the transactions performed today will not be valid for cashback purposes. "
+          disclaimer: "By clicking on Activate, you declare that you are the owner of this payment method."
         deactivate:
           title: "Method deactivation"
           body: "Are you sure you want to disable the cashback on this payment method? By continuing,from now on this method will no longer contribute to the collection of transactions.

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1826,7 +1826,7 @@ bonus:
           title: "Method activation"
           body: "Activate cashback on this payment method?
                  This will start **tomorrow**, so the transactions performed today will not be valid for cashback purposes. "
-          disclaimer: "By clicking on Activate, you declare that you are the owner of this payment method."
+          disclaimer: "Choosing {{activate}}, you declare that you are the owner of this payment method."
         deactivate:
           title: "Method deactivation"
           body: "Are you sure you want to disable the cashback on this payment method? By continuing,from now on this method will no longer contribute to the collection of transactions.

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1858,6 +1858,7 @@ bonus:
           title: "Attivazione metodo"
           body: "Confermi di voler attivare il cashback su questo metodo di pagamento?
                  L’attivazione sarà operativa **da domani**, quindi non saranno valide ai fini del cashback le transazioni che farai nella giornata di oggi."
+          disclaimer: "Cliccando su Attiva, dichiari di essere il titolare di questo metodo di pagamento."
         deactivate:
           title: "Disattivazione metodo"
           body: "Vuoi davvero disattivare il cashback su questo metodo di pagamento?

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1858,7 +1858,7 @@ bonus:
           title: "Attivazione metodo"
           body: "Confermi di voler attivare il cashback su questo metodo di pagamento?
                  L’attivazione sarà operativa **da domani**, quindi non saranno valide ai fini del cashback le transazioni che farai nella giornata di oggi."
-          disclaimer: "Cliccando su Attiva, dichiari di essere il titolare di questo metodo di pagamento."
+          disclaimer: "Scegliendo {{activate}}, dichiari di essere il titolare di questo metodo di pagamento."
         deactivate:
           title: "Disattivazione metodo"
           body: "Vuoi davvero disattivare il cashback su questo metodo di pagamento?

--- a/ts/components/CopyButtonComponent.tsx
+++ b/ts/components/CopyButtonComponent.tsx
@@ -67,7 +67,7 @@ const CopyButtonComponent: React.FunctionComponent<Props> = (props: Props) => {
         small={true}
       >
         {isTap
-          ? I18n.t("clipboard.copyFeedbackButtona")
+          ? I18n.t("clipboard.copyFeedbackButton")
           : I18n.t("clipboard.copyText")}
       </Text>
     </ButtonDefaultOpacity>

--- a/ts/components/CopyButtonComponent.tsx
+++ b/ts/components/CopyButtonComponent.tsx
@@ -67,7 +67,7 @@ const CopyButtonComponent: React.FunctionComponent<Props> = (props: Props) => {
         small={true}
       >
         {isTap
-          ? I18n.t("clipboard.copyFeedbackButton")
+          ? I18n.t("clipboard.copyFeedbackButtona")
           : I18n.t("clipboard.copyText")}
       </Text>
     </ButtonDefaultOpacity>

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/bottomsheet/BpdChangeActivationConfirmationScreen.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/bottomsheet/BpdChangeActivationConfirmationScreen.tsx
@@ -2,6 +2,8 @@ import { useBottomSheetModal } from "@gorhom/bottom-sheet";
 import { View } from "native-base";
 import * as React from "react";
 import { BottomSheetContent } from "../../../../../../components/bottomSheet/BottomSheetContent";
+import { InfoBox } from "../../../../../../components/box/InfoBox";
+import { Body } from "../../../../../../components/core/typography/Body";
 import FooterWithButtons from "../../../../../../components/ui/FooterWithButtons";
 import Markdown from "../../../../../../components/ui/Markdown";
 import I18n from "../../../../../../i18n";
@@ -62,6 +64,16 @@ export const BpdChangeActivationConfirmationScreen: React.FunctionComponent<Prop
         <PaymentMethodRepresentationComponent {...props.representation} />
         <View spacer={true} />
         <Markdown>{body}</Markdown>
+        {props.type === "Activation" && (
+          <>
+            <View spacer={true} large={true} />
+            <InfoBox>
+              <Body>
+                {I18n.t("bonus.bpd.details.paymentMethods.activate.disclaimer")}
+              </Body>
+            </InfoBox>
+          </>
+        )}
       </View>
     </BottomSheetContent>
   );

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/bottomsheet/BpdChangeActivationConfirmationScreen.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/bottomsheet/BpdChangeActivationConfirmationScreen.tsx
@@ -69,7 +69,10 @@ export const BpdChangeActivationConfirmationScreen: React.FunctionComponent<Prop
             <View spacer={true} large={true} />
             <InfoBox>
               <Body>
-                {I18n.t("bonus.bpd.details.paymentMethods.activate.disclaimer")}
+                {I18n.t(
+                  "bonus.bpd.details.paymentMethods.activate.disclaimer",
+                  { activate: I18n.t("global.buttons.activate") }
+                )}
               </Body>
             </InfoBox>
           </>


### PR DESCRIPTION
## Short description
This pr adds a disclaimer that informs the user that the cashback can only be activated by a payment method that belongs to him.

<img src=https://user-images.githubusercontent.com/26501317/100370127-1b3f4380-3006-11eb-8b16-2172567ad550.png width=300 />

## List of changes proposed in this pull request
- Modified `BpdChangeActivationConfirmationScreen.tsx `

## How to test
Activate bpd on a payment method from any entrypoint (bpd details, pm details, new bancomat added, new card added)