### PR TITLE
feat(Bonus Pagamenti Digitali): [#175883670] Support adding Satispay to wallet

### DIFF
--- a/ts/api/pagopa.ts
+++ b/ts/api/pagopa.ts
@@ -69,7 +69,6 @@ import {
   PaymentManagerToken,
   PspListResponse,
   PspResponse,
-  SatispayPaymentMethod,
   SessionResponse,
   TransactionListResponse,
   TransactionResponse,

--- a/ts/features/wallet/onboarding/satispay/saga/networking/index.ts
+++ b/ts/features/wallet/onboarding/satispay/saga/networking/index.ts
@@ -1,14 +1,21 @@
 import { call, put } from "redux-saga/effects";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 import _ from "lodash";
+import { ActionType } from "typesafe-actions";
 import { PaymentManagerClient } from "../../../../../../api/pagopa";
 import { SessionManager } from "../../../../../../utils/SessionManager";
 import { PaymentManagerToken } from "../../../../../../types/pagopa";
 import { searchUserPans } from "../../../bancomat/store/actions";
 import { SagaCallReturnType } from "../../../../../../types/utils";
 import { searchUserSatispay } from "../../store/actions";
-import { getNetworkError } from "../../../../../../utils/errors";
+import { getError, getNetworkError } from "../../../../../../utils/errors";
+import { addSatispayToWallet as addSatispayToWalletAction } from "../../store/actions";
+import { convertWalletV2toWalletV1 } from "../../../../../../utils/walletv2";
+import { fetchWalletsSuccess } from "../../../../../../store/actions/wallet/wallets";
 
+/**
+ * search for user's satispay
+ */
 export function* handleSearchUserSatispay(
   searchSatispay: ReturnType<typeof PaymentManagerClient>["searchSatispay"],
   sessionManager: SessionManager<PaymentManagerToken>
@@ -55,5 +62,50 @@ export function* handleSearchUserSatispay(
     }
   } catch (e) {
     return yield put(searchUserPans.failure(getNetworkError(e)));
+  }
+}
+
+/**
+ * add the user's satispay to the wallet
+ */
+export function* handleAddUserSatispayToWallet(
+  addSatispayToWallet: ReturnType<
+    typeof PaymentManagerClient
+  >["addSatispayToWallet"],
+  sessionManager: SessionManager<PaymentManagerToken>,
+  action: ActionType<typeof addSatispayToWalletAction.request>
+) {
+  try {
+    const addSatispayToWalletWithRefresh = sessionManager.withRefresh(
+      addSatispayToWallet({ data: action.payload })
+    );
+
+    const addSatispayToWalletWithRefreshResult: SagaCallReturnType<typeof addSatispayToWalletWithRefresh> = yield call(
+      addSatispayToWalletWithRefresh
+    );
+    if (addSatispayToWalletWithRefreshResult.isRight()) {
+      const statusCode = addSatispayToWalletWithRefreshResult.value.status;
+      if (statusCode === 200) {
+        const wallets = (
+          addSatispayToWalletWithRefreshResult.value.value.data ?? []
+        ).map(convertWalletV2toWalletV1);
+        yield put(fetchWalletsSuccess(wallets));
+        yield put(addSatispayToWalletAction.success());
+      } else {
+        return yield put(
+          addSatispayToWalletAction.failure(
+            new Error(`response status ${statusCode}`)
+          )
+        );
+      }
+    } else {
+      return yield put(
+        addSatispayToWalletAction.failure(
+          new Error(readableReport(addSatispayToWalletWithRefreshResult.value))
+        )
+      );
+    }
+  } catch (e) {
+    return yield put(addSatispayToWalletAction.failure(getError(e)));
   }
 }

--- a/ts/features/wallet/onboarding/satispay/saga/networking/index.ts
+++ b/ts/features/wallet/onboarding/satispay/saga/networking/index.ts
@@ -10,8 +10,6 @@ import { SagaCallReturnType } from "../../../../../../types/utils";
 import { searchUserSatispay } from "../../store/actions";
 import { getError, getNetworkError } from "../../../../../../utils/errors";
 import { addSatispayToWallet as addSatispayToWalletAction } from "../../store/actions";
-import { convertWalletV2toWalletV1 } from "../../../../../../utils/walletv2";
-import { fetchWalletsSuccess } from "../../../../../../store/actions/wallet/wallets";
 
 /**
  * search for user's satispay
@@ -87,11 +85,6 @@ export function* handleAddUserSatispayToWallet(
       const statusCode = addSatispayToWalletWithRefreshResult.value.status;
       if (statusCode === 200) {
         // satispay has been added to the user wallet
-        // response is the list wallets, dispatch an action to update the sore
-        const wallets = (
-          addSatispayToWalletWithRefreshResult.value.value.data ?? []
-        ).map(convertWalletV2toWalletV1);
-        yield put(fetchWalletsSuccess(wallets));
         return yield put(addSatispayToWalletAction.success());
       } else {
         return yield put(

--- a/ts/features/wallet/onboarding/satispay/saga/networking/index.ts
+++ b/ts/features/wallet/onboarding/satispay/saga/networking/index.ts
@@ -86,11 +86,13 @@ export function* handleAddUserSatispayToWallet(
     if (addSatispayToWalletWithRefreshResult.isRight()) {
       const statusCode = addSatispayToWalletWithRefreshResult.value.status;
       if (statusCode === 200) {
+        // satispay has been added to the user wallet
+        // response is the list wallets, dispatch an action to update the sore
         const wallets = (
           addSatispayToWalletWithRefreshResult.value.value.data ?? []
         ).map(convertWalletV2toWalletV1);
         yield put(fetchWalletsSuccess(wallets));
-        yield put(addSatispayToWalletAction.success());
+        return yield put(addSatispayToWalletAction.success());
       } else {
         return yield put(
           addSatispayToWalletAction.failure(

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -43,7 +43,10 @@ import {
   searchUserPans,
   walletAddBancomatStart
 } from "../features/wallet/onboarding/bancomat/store/actions";
-import { handleSearchUserSatispay } from "../features/wallet/onboarding/satispay/saga/networking";
+import {
+  handleAddUserSatispayToWallet,
+  handleSearchUserSatispay
+} from "../features/wallet/onboarding/satispay/saga/networking";
 import ROUTES from "../navigation/routes";
 import { navigateBack } from "../store/actions/navigation";
 import { profileLoadSuccess, profileUpsert } from "../store/actions/profile";
@@ -139,7 +142,10 @@ import {
 } from "../features/wallet/onboarding/bancomat/navigation/action";
 import { navigationHistoryPop } from "../store/actions/navigationHistory";
 import { getTitleFromCard } from "../utils/paymentMethod";
-import { searchUserSatispay } from "../features/wallet/onboarding/satispay/store/actions";
+import {
+  addSatispayToWallet,
+  searchUserSatispay
+} from "../features/wallet/onboarding/satispay/store/actions";
 
 /**
  * Configure the max number of retries and delay between retries when polling
@@ -818,6 +824,14 @@ export function* watchWalletSaga(
       searchUserSatispay.request,
       handleSearchUserSatispay,
       paymentManagerClient.searchSatispay,
+      pmSessionManager
+    );
+
+    // watch for add satispay to the user's wallet
+    yield takeLatest(
+      addSatispayToWallet.request,
+      handleAddUserSatispayToWallet,
+      paymentManagerClient.addSatispayToWallet,
       pmSessionManager
     );
   }


### PR DESCRIPTION
## Short description
This PR implements the API to add satispay to the user's wallet

### how to test it
- make sure to have the last commit of `io-dev-server` (branch `support-bpd`)
- dispatch a fake action to add satispay to wallet

```typescript
addSatispayToWallet.request({
        hasMore: false,
        token:
          "3c469e9d6c5875d37a43f353d4f88e61fcf812c66eee3457465a40b0da4153e0",
        uidSatispay: "uidSatispay",
        uidSatispayHash:
          "d077188941373349f188e5475faeacd4aadc8e4bd6ce241de8d20f7bd66ef817"
      })
```