### PR TITLE
fix(Bonus Pagamenti Digitali): [#175922831] CTA text is wrong in bonus vacanze details screen

### DIFF
--- a/ts/features/bonus/bonusVacanze/screens/BonusInformationScreen.tsx
+++ b/ts/features/bonus/bonusVacanze/screens/BonusInformationScreen.tsx
@@ -47,6 +47,7 @@ const BonusInformationScreen: React.FunctionComponent<Props> = props => {
       : props.requestBonusActivation();
   return (
     <BonusInformationComponent
+      primaryCtaText={I18n.t("bonus.bonusVacanze.cta.requestBonus")}
       bonus={bonusType}
       onCancel={props.navigateBack}
       onConfirm={handleBonusRequestOnPress}

--- a/ts/features/bonus/bpd/screens/onboarding/BpdInformationScreen.tsx
+++ b/ts/features/bonus/bpd/screens/onboarding/BpdInformationScreen.tsx
@@ -37,6 +37,7 @@ const BpdInformationScreen: React.FunctionComponent<Props> = (props: Props) => {
     <>
       {props.bonus ? (
         <BonusInformationComponent
+          primaryCtaText={I18n.t("bonus.bpd.cta.activeBonus")}
           bonus={props.bonus}
           onConfirm={onConfirm}
           onCancel={props.onCancel}

--- a/ts/features/bonus/common/components/BonusInformationComponent.tsx
+++ b/ts/features/bonus/common/components/BonusInformationComponent.tsx
@@ -29,6 +29,7 @@ type OwnProps = {
   bonus: BonusAvailable;
   onConfirm?: () => void;
   onCancel?: () => void;
+  primaryCtaText: string;
 };
 
 type Props = OwnProps &
@@ -111,7 +112,7 @@ const BonusInformationComponent: React.FunctionComponent<Props> = props => {
     block: true,
     primary: true,
     onPress: props.onConfirm,
-    title: I18n.t("bonus.bpd.cta.activeBonus")
+    title: props.primaryCtaText
   };
 
   const onMarkdownLoaded = () => {


### PR DESCRIPTION
## Short description
This PR fixes the wrong text shown in bonus vacanze details screen primary CTA

### bonus details fixex
<img src="https://user-images.githubusercontent.com/822471/100498317-b8fb5580-3161-11eb-9923-2fd60b8024e5.gif" height="600"/>

