### PR TITLE
chore(Payments): [#175845944] Dispatch action to MixPanel on credit card addition failure

### DIFF
--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -83,6 +83,7 @@ import {
   addWalletCreditCardRequest,
   addWalletCreditCardSuccess,
   addWalletNewCreditCardSuccess,
+  addWalletNewCreditCardFailure,
   creditCardCheckout3dsRequest,
   creditCardCheckout3dsSuccess,
   deleteWalletRequest,
@@ -371,6 +372,8 @@ function* startOrResumeAddCreditCardSaga(
           action.payload.onSuccess(maybeAddedWallet);
         }
       } else {
+        yield put(addWalletNewCreditCardFailure());
+
         if (action.payload.onFailure) {
           action.payload.onFailure();
         }

--- a/ts/store/actions/wallet/wallets.ts
+++ b/ts/store/actions/wallet/wallets.ts
@@ -45,6 +45,10 @@ export const addWalletNewCreditCardSuccess = createStandardAction(
   "WALLET_ADD_NEW_CREDITCARD_SUCCESS"
 )();
 
+export const addWalletNewCreditCardFailure = createStandardAction(
+  "WALLET_ADD_NEW_CREDITCARD_FAILURE"
+)();
+
 export type CreditCardFailure =
   | {
       kind: "GENERIC_ERROR";
@@ -154,6 +158,7 @@ export type WalletsActions =
   | ActionType<typeof addWalletCreditCardSuccess>
   | ActionType<typeof addWalletCreditCardFailure>
   | ActionType<typeof addWalletNewCreditCardSuccess>
+  | ActionType<typeof addWalletNewCreditCardFailure>
   | ActionType<typeof payCreditCardVerificationRequest>
   | ActionType<typeof payCreditCardVerificationSuccess>
   | ActionType<typeof payCreditCardVerificationFailure>

--- a/ts/store/middlewares/analytics.ts
+++ b/ts/store/middlewares/analytics.ts
@@ -99,6 +99,7 @@ import {
   addWalletCreditCardFailure,
   addWalletCreditCardInit,
   addWalletCreditCardRequest,
+  addWalletNewCreditCardFailure,
   addWalletNewCreditCardSuccess,
   creditCardCheckout3dsRequest,
   creditCardCheckout3dsSuccess,
@@ -221,6 +222,9 @@ const trackAction = (mp: NonNullable<typeof mixpanel>) => (
             ? action.payload.reason
             : "n/a"
       });
+    case getType(addWalletNewCreditCardFailure):
+      return mp.track(action.type);
+
     case getType(paymentAttiva.failure):
     case getType(paymentVerifica.failure):
     case getType(paymentIdPolling.failure):


### PR DESCRIPTION
## Short description
See title.

## How to test

1. Comment line 124 of `src/routers/wallet.ts` inside the dev server to always trigger a failure case
2. Try to add a card.