### PR TITLE
fix(Bonus Pagamenti Digitali): [#175973442] Periods with different ids were not removed from the store following an update

### DIFF
--- a/ts/features/bonus/bpd/store/reducers/details/periods.ts
+++ b/ts/features/bonus/bpd/store/reducers/details/periods.ts
@@ -30,7 +30,7 @@ export const bpdPeriodsReducer = (
             ...acc,
             [curr.awardPeriodId]: curr
           }),
-          pot.getOrElse(state, {})
+          {}
         )
       );
     case getType(bpdPeriodsLoad.failure):


### PR DESCRIPTION
## Short description
This pr fixes the wrong behaviour that periods with different ids were not removed from the store following an update.

## List of changes proposed in this pull request
- With the action `bpdPeriodsLoad.success` the store is cleaned and the new entry are the periods from the action.payload 
