### PR TITLE
feat(Bonus Pagamenti Digitali): [#175971953] No retries and increased timeout for PM requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@ FETCH_PAGOPA_TIMEOUT_MS=60000
 # default timeout of fetch (in ms)
 FETCH_TIMEOUT_MS=5000
 # default timeout of fetch for calling certain pagoPA Payment Manager APIs
-FETCH_PAYMENT_MANAGER_TIMEOUT_MS=10000
+FETCH_PAYMENT_MANAGER_TIMEOUT_MS=16000
 # default max retries for fetch
 FETCH_MAX_RETRIES=3
 # number of workers to fetch message

--- a/.env.local
+++ b/.env.local
@@ -21,7 +21,7 @@ FETCH_PAGOPA_TIMEOUT_MS=60000
 # default timeout of fetch (in ms)
 FETCH_TIMEOUT_MS=5000
 # default timeout of fetch for calling certain pagoPA Payment Manager APIs
-FETCH_PAYMENT_MANAGER_TIMEOUT_MS=10000
+FETCH_PAYMENT_MANAGER_TIMEOUT_MS=16000
 # default max retries for fetch
 FETCH_MAX_RETRIES=3
 # number of workers to fetch message

--- a/.env.production
+++ b/.env.production
@@ -21,7 +21,7 @@ FETCH_PAGOPA_TIMEOUT_MS=60000
 # default timeout of fetch (in ms)
 FETCH_TIMEOUT_MS=8000
 # default timeout of fetch for calling certain pagoPA Payment Manager APIs
-FETCH_PAYMENT_MANAGER_TIMEOUT_MS=10000
+FETCH_PAYMENT_MANAGER_TIMEOUT_MS=16000
 # default max retries for fetch
 FETCH_MAX_RETRIES=3
 # number of workers to fetch message

--- a/ts/features/bonus/bpd/api/backendBpdClient.ts
+++ b/ts/features/bonus/bpd/api/backendBpdClient.ts
@@ -39,6 +39,7 @@ import {
   CitizenPatchDTO,
   PayoffInstrTypeEnum
 } from "../../../../../definitions/bpd/citizen/CitizenPatchDTO";
+import { fetchPaymentManagerLongTimeout } from "../../../../config";
 import { PatchedCitizenResource } from "./patchedTypes";
 
 const headersProducers = <
@@ -254,7 +255,10 @@ type Options = {
 export function BackendBpdClient(
   baseUrl: string,
   token: string,
-  fetchApi: typeof fetch = defaultRetryingFetch()
+  fetchApi: typeof fetch = defaultRetryingFetch(
+    fetchPaymentManagerLongTimeout,
+    0
+  )
 ) {
   const options: Options = {
     baseUrl,

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/base/PaymentMethodBpdToggle.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/base/PaymentMethodBpdToggle.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef } from "react";
 import { ImageSourcePropType, StyleSheet } from "react-native";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
+import { fetchPaymentManagerLongTimeout } from "../../../../../../config";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import { useNavigationContext } from "../../../../../../utils/hooks/useOnFocus";
 import {
@@ -60,7 +61,6 @@ const styles = StyleSheet.create({
   leftSection: { flexDirection: "row", flex: 1 }
 });
 
-const retryTimeout = 10000 as Millisecond;
 /**
  * This custom hook handles the load of the initial state and the retry in case of error.
  * TODO: refactor with  {@link useLoadPotValue}
@@ -97,7 +97,7 @@ const useInitialValue = (props: Props) => {
     ) {
       // If the pot is NoneError, the navigation focus is on the element
       // and no other retry are scheduled
-      timerRetry.current = setTimeout(retry, retryTimeout);
+      timerRetry.current = setTimeout(retry, fetchPaymentManagerLongTimeout);
     }
   }, [props.bpdPotActivation, timerRetry.current, navigation.isFocused()]);
 

--- a/ts/features/bonus/bpd/components/paymentMethodActivationToggle/base/PaymentMethodBpdToggle.tsx
+++ b/ts/features/bonus/bpd/components/paymentMethodActivationToggle/base/PaymentMethodBpdToggle.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable functional/immutable-data */
 import * as pot from "italia-ts-commons/lib/pot";
-import { Millisecond } from "italia-ts-commons/lib/units";
 import { View } from "native-base";
 import * as React from "react";
 import { useEffect, useRef } from "react";

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -584,7 +584,8 @@ export function* watchWalletSaga(
   const paymentManagerClient: PaymentManagerClient = PaymentManagerClient(
     paymentManagerUrlPrefix,
     walletToken,
-    defaultRetryingFetch(),
+    // despite both fetch have same configuration, keeping both ensures possible modding
+    defaultRetryingFetch(fetchPaymentManagerLongTimeout, 0),
     defaultRetryingFetch(fetchPaymentManagerLongTimeout, 0)
   );
 

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -481,11 +481,12 @@ class WalletHomeScreen extends React.PureComponent<Props> {
       anyCreditCardAttempts
     } = this.props;
 
-    const headerContent = pot.isLoading(potWallets)
-      ? this.loadingWalletsHeader()
-      : pot.isError(potWallets)
-      ? this.errorWalletsHeader()
-      : this.cardPreview();
+    const headerContent =
+      pot.isLoading(potWallets) || pot.isNone(potWallets)
+        ? this.loadingWalletsHeader()
+        : pot.isError(potWallets)
+        ? this.errorWalletsHeader()
+        : this.cardPreview();
 
     const transactionContent = pot.isError(potTransactions)
       ? this.transactionError()

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -481,12 +481,17 @@ class WalletHomeScreen extends React.PureComponent<Props> {
       anyCreditCardAttempts
     } = this.props;
 
-    const headerContent =
-      pot.isLoading(potWallets) || pot.isNone(potWallets)
-        ? this.loadingWalletsHeader()
-        : pot.isError(potWallets)
-        ? this.errorWalletsHeader()
-        : this.cardPreview();
+    const headerContent = pot.fold(
+      potWallets,
+      () => this.loadingWalletsHeader(),
+      () => this.loadingWalletsHeader(),
+      _ => this.loadingWalletsHeader(),
+      _ => this.errorWalletsHeader(),
+      _ => this.cardPreview(),
+      _ => this.loadingWalletsHeader(),
+      _ => this.cardPreview(),
+      _ => this.errorWalletsHeader()
+    );
 
     const transactionContent = pot.isError(potTransactions)
       ? this.transactionError()


### PR DESCRIPTION
## Short description
This PR changes the fetch configuration for all requests to Payment Manager
Furthermore this PR fixes a double render in WalletHomeScreen
### before
- timeout 10sec
- retries 0/3 (for some requests 0, 3 for others)

### now
- timeout 16sec
- retries 0
