### PR TITLE
feat(Bonus Pagamenti Digitali): [#175777655] Display bank fallback if logo is not available in bancomat card

### DIFF
--- a/ts/components/ContextualHelpModal.tsx
+++ b/ts/components/ContextualHelpModal.tsx
@@ -83,8 +83,6 @@ const ContextualHelpModal: React.FunctionComponent<Props> = (props: Props) => {
     ) {
       props.loadContextualHelpData();
     }
-    // refresh / load support token
-    props.loadSupportToken();
   }, [
     pot.isNone(props.potContextualData) || pot.isError(props.potContextualData)
   ]);
@@ -147,6 +145,9 @@ const ContextualHelpModal: React.FunctionComponent<Props> = (props: Props) => {
    */
   const handleOnRequestAssistance = (reportType: BugReporting.reportType) => {
     if (props.isAuthenticated) {
+      // refresh / load support token
+      props.loadSupportToken();
+
       setShowSendPersonalInfo(true);
       setSupportType(reportType);
       return;

--- a/ts/features/wallet/bancomat/component/bancomatCard/BancomatCard.tsx
+++ b/ts/features/wallet/bancomat/component/bancomatCard/BancomatCard.tsx
@@ -31,6 +31,7 @@ const getExpireDate = (fullYear?: string, month?: string): Date | undefined => {
  */
 const BancomatCard: React.FunctionComponent<Props> = props => (
   <BaseBancomatCard
+    abiName={props.enhancedBancomat.abiInfo?.name}
     abiLogo={props.enhancedBancomat.abiInfo?.logoUrl}
     expiringDate={getExpireDate(
       props.enhancedBancomat.info.expireYear,

--- a/ts/features/wallet/bancomat/component/bancomatCard/BancomatCard.tsx
+++ b/ts/features/wallet/bancomat/component/bancomatCard/BancomatCard.tsx
@@ -31,8 +31,7 @@ const getExpireDate = (fullYear?: string, month?: string): Date | undefined => {
  */
 const BancomatCard: React.FunctionComponent<Props> = props => (
   <BaseBancomatCard
-    abiName={props.enhancedBancomat.abiInfo?.name}
-    abiLogo={props.enhancedBancomat.abiInfo?.logoUrl}
+    abi={props.enhancedBancomat.abiInfo ?? {}}
     expiringDate={getExpireDate(
       props.enhancedBancomat.info.expireYear,
       props.enhancedBancomat.info.expireMonth

--- a/ts/features/wallet/bancomat/component/bancomatCard/BaseBancomatCard.tsx
+++ b/ts/features/wallet/bancomat/component/bancomatCard/BaseBancomatCard.tsx
@@ -15,9 +15,10 @@ import I18n from "../../../../../i18n";
 import customVariables from "../../../../../theme/variables";
 import { localeDateFormat } from "../../../../../utils/locale";
 import { useImageResize } from "../../../onboarding/bancomat/screens/hooks/useImageResize";
+import { Abi } from "../../../../../../definitions/pagopa/walletv2/Abi";
 
 type Props = {
-  abiLogo?: string;
+  abi: Abi;
   expiringDate?: Date;
   user: string;
 };
@@ -74,7 +75,11 @@ const BASE_IMG_H = 40;
  * @constructor
  */
 const BaseBancomatCard: React.FunctionComponent<Props> = (props: Props) => {
-  const imgDimensions = useImageResize(BASE_IMG_W, BASE_IMG_H, props.abiLogo);
+  const imgDimensions = useImageResize(
+    BASE_IMG_W,
+    BASE_IMG_H,
+    props.abi?.logoUrl
+  );
 
   const imageStyle: StyleProp<ImageStyle> | undefined = imgDimensions.fold(
     undefined,
@@ -90,7 +95,7 @@ const BaseBancomatCard: React.FunctionComponent<Props> = (props: Props) => {
       {Platform.OS === "android" && <View style={styles.shadowBox} />}
       <View style={styles.cardBox}>
         <View>
-          <Image style={imageStyle} source={{ uri: props.abiLogo }} />
+          <Image style={imageStyle} source={{ uri: props.abi?.logoUrl }} />
           <View spacer={true} />
           {props.expiringDate && (
             <H5 color={"bluegrey"} weight={"Regular"}>{`${I18n.t(

--- a/ts/features/wallet/bancomat/component/bancomatCard/PreviewBancomatCard.tsx
+++ b/ts/features/wallet/bancomat/component/bancomatCard/PreviewBancomatCard.tsx
@@ -4,9 +4,10 @@ import { Dispatch } from "redux";
 import { Card } from "../../../../../../definitions/pagopa/walletv2/Card";
 import { profileNameSurnameSelector } from "../../../../../store/reducers/profile";
 import { GlobalState } from "../../../../../store/reducers/types";
+import { Abi } from "../../../../../../definitions/pagopa/walletv2/Abi";
 import BaseBancomatCard from "./BaseBancomatCard";
 
-type OnboardingData = { bancomat: Card; logoUrl?: string };
+type OnboardingData = { bancomat: Card; abi?: Abi };
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps> &
@@ -18,7 +19,8 @@ type Props = ReturnType<typeof mapDispatchToProps> &
  */
 const PreviewBancomatCard: React.FunctionComponent<Props> = props => (
   <BaseBancomatCard
-    abiLogo={props.logoUrl}
+    abiLogo={props.abi?.logoUrl}
+    abiName={props.abi?.name}
     expiringDate={props.bancomat.expiringDate}
     user={props.nameSurname ?? ""}
   />

--- a/ts/features/wallet/bancomat/component/bancomatCard/PreviewBancomatCard.tsx
+++ b/ts/features/wallet/bancomat/component/bancomatCard/PreviewBancomatCard.tsx
@@ -7,7 +7,7 @@ import { GlobalState } from "../../../../../store/reducers/types";
 import { Abi } from "../../../../../../definitions/pagopa/walletv2/Abi";
 import BaseBancomatCard from "./BaseBancomatCard";
 
-type OnboardingData = { bancomat: Card; abi?: Abi };
+type OnboardingData = { bancomat: Card; abi: Abi };
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps> &
@@ -19,8 +19,7 @@ type Props = ReturnType<typeof mapDispatchToProps> &
  */
 const PreviewBancomatCard: React.FunctionComponent<Props> = props => (
   <BaseBancomatCard
-    abiLogo={props.abi?.logoUrl}
-    abiName={props.abi?.name}
+    abi={props.abi}
     expiringDate={props.bancomat.expiringDate}
     user={props.nameSurname ?? ""}
   />

--- a/ts/features/wallet/onboarding/bancomat/screens/add-pans/AddBancomatComponent.tsx
+++ b/ts/features/wallet/onboarding/bancomat/screens/add-pans/AddBancomatComponent.tsx
@@ -1,4 +1,3 @@
-import { fromNullable } from "fp-ts/lib/Option";
 import { View } from "native-base";
 import * as React from "react";
 import { SafeAreaView, StyleSheet } from "react-native";
@@ -21,6 +20,7 @@ import {
 } from "../../../../../bonus/bonusVacanze/components/buttons/ButtonConfigurations";
 import PreviewBancomatCard from "../../../../bancomat/component/bancomatCard/PreviewBancomatCard";
 import { abiListSelector } from "../../../store/abi";
+import { Abi } from "../../../../../../../definitions/pagopa/walletv2/Abi";
 
 type Props = {
   pan: Card;
@@ -39,11 +39,13 @@ const styles = StyleSheet.create({
   flexStart: { alignSelf: "flex-start" }
 });
 const AddBancomatComponent: React.FunctionComponent<Props> = (props: Props) => {
-  const [abiLogo, setAbiLogo] = React.useState<string | undefined>();
+  const [abiInfo, setAbiInfo] = React.useState<Abi | undefined>(undefined);
 
   React.useEffect(() => {
-    const abi = props.abiList.find(elem => elem.abi === props.pan.abi);
-    setAbiLogo(fromNullable(abi).fold(undefined, a => a.logoUrl));
+    const abi: Abi | undefined = props.abiList.find(
+      elem => elem.abi === props.pan.abi
+    );
+    setAbiInfo(abi ?? undefined);
   }, [props.currentIndex]);
 
   return (
@@ -77,7 +79,7 @@ const AddBancomatComponent: React.FunctionComponent<Props> = (props: Props) => {
               })}
             </H4>
             <View spacer={true} large={true} />
-            <PreviewBancomatCard bancomat={props.pan} logoUrl={abiLogo} />
+            <PreviewBancomatCard bancomat={props.pan} abi={abiInfo} />
             <View spacer={true} large={true} />
             <InfoBox>
               <Body>{I18n.t("wallet.onboarding.bancomat.add.warning")}</Body>

--- a/ts/features/wallet/onboarding/bancomat/screens/add-pans/AddBancomatComponent.tsx
+++ b/ts/features/wallet/onboarding/bancomat/screens/add-pans/AddBancomatComponent.tsx
@@ -39,13 +39,13 @@ const styles = StyleSheet.create({
   flexStart: { alignSelf: "flex-start" }
 });
 const AddBancomatComponent: React.FunctionComponent<Props> = (props: Props) => {
-  const [abiInfo, setAbiInfo] = React.useState<Abi | undefined>(undefined);
+  const [abiInfo, setAbiInfo] = React.useState<Abi>({});
 
   React.useEffect(() => {
     const abi: Abi | undefined = props.abiList.find(
       elem => elem.abi === props.pan.abi
     );
-    setAbiInfo(abi ?? undefined);
+    setAbiInfo(abi ?? {});
   }, [props.currentIndex]);
 
   return (


### PR DESCRIPTION
## Short description
This pr allows to display the bank name if the bank logo is not available.

## List of changes proposed in this pull request
- Update the `BaseBancomatCard` behaviour
- Update `loadSupportToken` when the user open a report.
