### PR TITLE
fix(Bonus Pagamenti Digitali): [#176023285] Wrong tracking for the event bpdLoadActivationStatus.failure

### DIFF
--- a/ts/features/bonus/bpd/saga/networking/index.ts
+++ b/ts/features/bonus/bpd/saga/networking/index.ts
@@ -46,7 +46,7 @@ export function* executeAndDispatch(
       throw new Error(readableReport(enrollCitizenIOResult.value));
     }
   } catch (e) {
-    yield put(bpdEnrollUserToProgram.failure(e));
+    yield put(action.failure(e));
   }
 }
 


### PR DESCRIPTION
## Short description
This pr fixes the wrong failure event sent to mixpanel.