### PR TITLE
Fix locales-en typo: aleady -> already

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1805,7 +1805,7 @@ bonus:
     earned: Collected Cashback
     onboarding:
       alert:
-        title: Cashback is aleady active
+        title: Cashback is already active
         body: You can find more details in your Wallet.
         cancel: Close
         confirm: Go back


### PR DESCRIPTION
## Short description
Fix a typo: aleady -> already

## List of changes proposed in this pull request
- Replace `aleady` with `already` 
