### PR TITLE
feat(Bonus Pagamenti Digitali): [#176053275] BPDDetailScreen

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -136,6 +136,8 @@ global:
     info: "Info"
     activate: "Activate"
     deactivate: "Deactivate"
+    show: "Show"
+    update: "Update"
   navigator:
     messages: messages
     wallet: wallet
@@ -1924,6 +1926,7 @@ bonus:
           canceled: "Refund"
       paymentMethods:
         add:
+          cta: "Add a method to cashback"
           alertBody: "The payment method you are adding will be saved in the IO app wallet and, if compatible, can also be used for any payments within the app."
         noPaymentMethods: "You must add at least one payment method to start collecting valid transactions"
         noActiveMethod: "You must have activated at least one payment method to collect valid transactions"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -136,6 +136,8 @@ global:
     info: "Info"
     activate: "Attiva"
     deactivate: "Disattiva"
+    show: "Mostra"
+    update: "Aggiorna"
   navigator:
     messages: messaggi
     wallet: portafoglio
@@ -1956,6 +1958,7 @@ bonus:
           canceled: "Storno"
       paymentMethods:
         add:
+          cta: "Aggiungi un metodo al cashback"
           alertBody: "Il metodo di pagamento che stai aggiungendo sarà salvato nel wallet dell'app IO e, se compatibile, potrà essere usato anche per eventuali pagamenti all'interno dell'app."
         noPaymentMethods: "Devi aggiungere almeno un metodo di pagamento per iniziare a collezionare transazioni valide"
         noActiveMethod: "Devi aver attivato almeno un metodo di pagamento per collezionare transazioni valide"

--- a/ts/features/bonus/bpd/screens/details/components/paymentMethod/WalletPaymentMethodBpdList.tsx
+++ b/ts/features/bonus/bpd/screens/details/components/paymentMethod/WalletPaymentMethodBpdList.tsx
@@ -50,6 +50,11 @@ const UpdateLabel = (props: Props & { caption: string }) =>
     <Link onPress={props.loadWallets}>{props.caption}</Link>
   );
 
+/**
+ * Start the onboarding of a new payment method
+ * @param props
+ * @constructor
+ */
 const AddPaymentMethodButton = (props: { onPress: () => void }) => (
   <Button style={styles.addButton} onPress={props.onPress} bordered={true}>
     <Label color={"blue"}>
@@ -58,6 +63,10 @@ const AddPaymentMethodButton = (props: { onPress: () => void }) => (
   </Button>
 );
 
+/**
+ * No payment methods are active
+ * @constructor
+ */
 const NoPaymentMethodAreActiveWarning = () => (
   <View>
     <InfoBox>
@@ -67,6 +76,10 @@ const NoPaymentMethodAreActiveWarning = () => (
   </View>
 );
 
+/**
+ * No payment methods are found
+ * @constructor
+ */
 const NoPaymentMethodFound = () => (
   <View>
     <InfoBox>
@@ -75,6 +88,11 @@ const NoPaymentMethodFound = () => (
   </View>
 );
 
+/**
+ * The wallet is none
+ * @param props
+ * @constructor
+ */
 const PaymentMethodNone = (props: Props) => (
   <>
     <View style={styles.row}>
@@ -92,6 +110,11 @@ const PaymentMethodNone = (props: Props) => (
   </>
 );
 
+/**
+ * The wallet is error
+ * @param props
+ * @constructor
+ */
 const PaymentMethodError = (props: Props) => (
   <>
     <View style={styles.row}>
@@ -110,6 +133,11 @@ const PaymentMethodError = (props: Props) => (
   </>
 );
 
+/**
+ * The wallet is some
+ * @param props
+ * @constructor
+ */
 const PaymentMethodSome = (props: Props) =>
   pot.isSome(props.potWallets) ? (
     <View>
@@ -154,7 +182,6 @@ const addPaymentMethod = (action: () => void) =>
 
 /**
  * Render all the wallet v2 as bpd toggle
- * TODO: temp implementation, raw list without loading and error state
  * @param props
  * @constructor
  */

--- a/ts/features/bonus/bpd/screens/details/components/paymentMethod/WalletPaymentMethodBpdList.tsx
+++ b/ts/features/bonus/bpd/screens/details/components/paymentMethod/WalletPaymentMethodBpdList.tsx
@@ -1,6 +1,7 @@
 import { none } from "fp-ts/lib/Option";
 import * as pot from "italia-ts-commons/lib/pot";
 import { Button, View } from "native-base";
+import { useEffect, useState } from "react";
 import * as React from "react";
 import { ActivityIndicator, Alert, StyleSheet } from "react-native";
 import { connect } from "react-redux";
@@ -15,6 +16,7 @@ import I18n from "../../../../../../../i18n";
 import { navigateToWalletAddPaymentMethod } from "../../../../../../../store/actions/navigation";
 import { fetchWalletsRequest } from "../../../../../../../store/actions/wallet/wallets";
 import { GlobalState } from "../../../../../../../store/reducers/types";
+import { showToast } from "../../../../../../../utils/showToast";
 import { PaymentMethodGroupedList } from "../../../../components/paymentMethodActivationToggle/list/PaymentMethodGroupedList";
 import {
   atLeastOnePaymentMethodHasBpdEnabledSelector,
@@ -185,8 +187,19 @@ const addPaymentMethod = (action: () => void) =>
  * @param props
  * @constructor
  */
-const WalletPaymentMethodBpdList: React.FunctionComponent<Props> = props =>
-  pot.fold(
+const WalletPaymentMethodBpdList: React.FunctionComponent<Props> = props => {
+  const [potState, setPotCurrentState] = useState(props.potWallets.kind);
+
+  useEffect(() => {
+    if (props.potWallets.kind !== potState) {
+      setPotCurrentState(props.potWallets.kind);
+      if (pot.isError(props.potWallets)) {
+        showToast(I18n.t("global.genericError"), "danger");
+      }
+    }
+  }, [props.potWallets.kind]);
+
+  return pot.fold(
     props.potWallets,
     () => <PaymentMethodNone {...props} />,
     () => <PaymentMethodNone {...props} />,
@@ -197,6 +210,7 @@ const WalletPaymentMethodBpdList: React.FunctionComponent<Props> = props =>
     _ => <PaymentMethodSome {...props} />,
     _ => <PaymentMethodSome {...props} />
   );
+};
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   addPaymentMethod: () => {

--- a/ts/features/bonus/bpd/screens/details/components/paymentMethod/WalletPaymentMethodBpdList.tsx
+++ b/ts/features/bonus/bpd/screens/details/components/paymentMethod/WalletPaymentMethodBpdList.tsx
@@ -34,6 +34,22 @@ const styles = StyleSheet.create({
   }
 });
 
+const Spinner = () => (
+  <ActivityIndicator
+    color={"black"}
+    accessible={false}
+    importantForAccessibility={"no-hide-descendants"}
+    accessibilityElementsHidden={true}
+  />
+);
+
+const UpdateLabel = (props: Props & { caption: string }) =>
+  pot.isLoading(props.potWallets) ? (
+    <Spinner />
+  ) : (
+    <Link onPress={props.loadWallets}>{props.caption}</Link>
+  );
+
 const AddPaymentMethodButton = (props: { onPress: () => void }) => (
   <Button style={styles.addButton} onPress={props.onPress} bordered={true}>
     <Label color={"blue"}>
@@ -51,13 +67,11 @@ const NoPaymentMethodAreActiveWarning = () => (
   </View>
 );
 
-const NoPaymentMethodFound = (props: Props) => (
+const NoPaymentMethodFound = () => (
   <View>
     <InfoBox>
       <Body>{I18n.t("bonus.bpd.details.paymentMethods.noPaymentMethods")}</Body>
     </InfoBox>
-    <View spacer={true} />
-    <AddPaymentMethodButton onPress={props.addPaymentMethod} />
   </View>
 );
 
@@ -65,9 +79,10 @@ const PaymentMethodNone = (props: Props) => (
   <>
     <View style={styles.row}>
       <H4>{I18n.t("wallet.paymentMethods")}</H4>
-      <Link onPress={props.loadWallets}>
-        {I18n.t("global.buttons.show").toLowerCase()}
-      </Link>
+      <UpdateLabel
+        {...props}
+        caption={I18n.t("global.buttons.show").toLowerCase()}
+      />
     </View>
 
     <View spacer={true} large={true} />
@@ -79,19 +94,19 @@ const PaymentMethodNone = (props: Props) => (
 
 const PaymentMethodError = (props: Props) => (
   <>
-    <H4>{I18n.t("wallet.paymentMethods")}</H4>
+    <View style={styles.row}>
+      <H4>{I18n.t("wallet.paymentMethods")}</H4>
+      <UpdateLabel
+        {...props}
+        caption={I18n.t("global.buttons.update").toLowerCase()}
+      />
+    </View>
     <View spacer={true} />
     <InfoBox iconColor={IOColors.red}>
       <Body>{I18n.t("bonus.bpd.details.paymentMethods.error")}</Body>
     </InfoBox>
-    <View spacer={true} />
-    <Button
-      style={styles.addButton}
-      onPress={props.loadWallets}
-      bordered={true}
-    >
-      <Label color={"blue"}>{I18n.t("global.buttons.retry")}</Label>
-    </Button>
+    <View spacer={true} large={true} />
+    <AddPaymentMethodButton onPress={props.addPaymentMethod} />
   </>
 );
 
@@ -100,11 +115,10 @@ const PaymentMethodSome = (props: Props) =>
     <View>
       <View style={styles.row}>
         <H4>{I18n.t("wallet.paymentMethods")}</H4>
-        {props.potWallets.value.length > 0 && (
-          <Link onPress={props.addPaymentMethod}>
-            {I18n.t("global.buttons.add").toLowerCase()}
-          </Link>
-        )}
+        <UpdateLabel
+          {...props}
+          caption={I18n.t("global.buttons.update").toLowerCase()}
+        />
       </View>
       <View spacer={true} />
       {!props.atLeastOnePaymentMethodActive &&
@@ -115,8 +129,10 @@ const PaymentMethodSome = (props: Props) =>
       {props.potWallets.value.length > 0 ? (
         <PaymentMethodGroupedList paymentList={props.potWallets.value} />
       ) : (
-        <NoPaymentMethodFound {...props} />
+        <NoPaymentMethodFound />
       )}
+      <View spacer={true} />
+      <AddPaymentMethodButton onPress={props.addPaymentMethod} />
     </View>
   ) : null;
 
@@ -146,18 +162,7 @@ const WalletPaymentMethodBpdList: React.FunctionComponent<Props> = props =>
   pot.fold(
     props.potWallets,
     () => <PaymentMethodNone {...props} />,
-    () => (
-      <>
-        <View spacer={true} />
-        <ActivityIndicator
-          color={"black"}
-          accessible={false}
-          importantForAccessibility={"no-hide-descendants"}
-          accessibilityElementsHidden={true}
-        />
-        <View spacer={true} />
-      </>
-    ),
+    () => <PaymentMethodNone {...props} />,
     _ => <PaymentMethodNone {...props} />,
     _ => <PaymentMethodError {...props} />,
     _ => <PaymentMethodSome {...props} />,

--- a/ts/features/bonus/bpd/screens/details/components/paymentMethod/WalletPaymentMethodBpdList.tsx
+++ b/ts/features/bonus/bpd/screens/details/components/paymentMethod/WalletPaymentMethodBpdList.tsx
@@ -34,6 +34,14 @@ const styles = StyleSheet.create({
   }
 });
 
+const AddPaymentMethodButton = (props: { onPress: () => void }) => (
+  <Button style={styles.addButton} onPress={props.onPress} bordered={true}>
+    <Label color={"blue"}>
+      {I18n.t("bonus.bpd.details.paymentMethods.add.cta")}
+    </Label>
+  </Button>
+);
+
 const NoPaymentMethodAreActiveWarning = () => (
   <View>
     <InfoBox>
@@ -49,10 +57,24 @@ const NoPaymentMethodFound = (props: Props) => (
       <Body>{I18n.t("bonus.bpd.details.paymentMethods.noPaymentMethods")}</Body>
     </InfoBox>
     <View spacer={true} />
-    <Button style={styles.addButton} onPress={props.addPaymentMethod}>
-      <Label color={"white"}>{I18n.t("wallet.addPaymentMethodTitle")}</Label>
-    </Button>
+    <AddPaymentMethodButton onPress={props.addPaymentMethod} />
   </View>
+);
+
+const PaymentMethodNone = (props: Props) => (
+  <>
+    <View style={styles.row}>
+      <H4>{I18n.t("wallet.paymentMethods")}</H4>
+      <Link onPress={props.loadWallets}>
+        {I18n.t("global.buttons.show").toLowerCase()}
+      </Link>
+    </View>
+
+    <View spacer={true} large={true} />
+    <View spacer={true} small={true} />
+    <AddPaymentMethodButton onPress={props.addPaymentMethod} />
+    <View spacer={true} small={true} />
+  </>
 );
 
 const PaymentMethodError = (props: Props) => (
@@ -73,13 +95,13 @@ const PaymentMethodError = (props: Props) => (
   </>
 );
 
-const PaymentMethodSome = (props: Props & { onAddPress: () => void }) =>
+const PaymentMethodSome = (props: Props) =>
   pot.isSome(props.potWallets) ? (
     <View>
       <View style={styles.row}>
         <H4>{I18n.t("wallet.paymentMethods")}</H4>
         {props.potWallets.value.length > 0 && (
-          <Link onPress={props.onAddPress}>
+          <Link onPress={props.addPaymentMethod}>
             {I18n.t("global.buttons.add").toLowerCase()}
           </Link>
         )}
@@ -98,32 +120,32 @@ const PaymentMethodSome = (props: Props & { onAddPress: () => void }) =>
     </View>
   ) : null;
 
+const addPaymentMethod = (action: () => void) =>
+  Alert.alert(
+    I18n.t("global.genericAlert"),
+    I18n.t("bonus.bpd.details.paymentMethods.add.alertBody"),
+    [
+      {
+        text: I18n.t("global.buttons.continue"),
+        onPress: action
+      },
+      {
+        text: I18n.t("global.buttons.cancel"),
+        style: "cancel"
+      }
+    ]
+  );
+
 /**
  * Render all the wallet v2 as bpd toggle
  * TODO: temp implementation, raw list without loading and error state
  * @param props
  * @constructor
  */
-const WalletPaymentMethodBpdList: React.FunctionComponent<Props> = props => {
-  const onAddPress = () =>
-    Alert.alert(
-      I18n.t("global.genericAlert"),
-      I18n.t("bonus.bpd.details.paymentMethods.add.alertBody"),
-      [
-        {
-          text: I18n.t("global.buttons.continue"),
-          onPress: props.addPaymentMethod
-        },
-        {
-          text: I18n.t("global.buttons.cancel"),
-          style: "cancel"
-        }
-      ]
-    );
-
-  return pot.fold(
+const WalletPaymentMethodBpdList: React.FunctionComponent<Props> = props =>
+  pot.fold(
     props.potWallets,
-    () => null,
+    () => <PaymentMethodNone {...props} />,
     () => (
       <>
         <View spacer={true} />
@@ -136,18 +158,19 @@ const WalletPaymentMethodBpdList: React.FunctionComponent<Props> = props => {
         <View spacer={true} />
       </>
     ),
-    _ => null,
+    _ => <PaymentMethodNone {...props} />,
     _ => <PaymentMethodError {...props} />,
-    _ => <PaymentMethodSome {...props} onAddPress={onAddPress} />,
-    _ => <PaymentMethodSome {...props} onAddPress={onAddPress} />,
-    _ => <PaymentMethodSome {...props} onAddPress={onAddPress} />,
-    _ => <PaymentMethodSome {...props} onAddPress={onAddPress} />
+    _ => <PaymentMethodSome {...props} />,
+    _ => <PaymentMethodSome {...props} />,
+    _ => <PaymentMethodSome {...props} />,
+    _ => <PaymentMethodSome {...props} />
   );
-};
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   addPaymentMethod: () => {
-    dispatch(navigateToWalletAddPaymentMethod({ inPayment: none }));
+    addPaymentMethod(() =>
+      dispatch(navigateToWalletAddPaymentMethod({ inPayment: none }))
+    );
   },
   loadWallets: () => dispatch(fetchWalletsRequest())
 });

--- a/ts/features/bonus/bpd/screens/details/components/summary/BpdSummaryComponent.tsx
+++ b/ts/features/bonus/bpd/screens/details/components/summary/BpdSummaryComponent.tsx
@@ -22,15 +22,25 @@ type SummaryData = {
   name: string | undefined;
 };
 
+/**
+ * The graphical summary is visible only when the period is closed or when the period is Active
+ * and transactionNumber > 0
+ * @param period
+ * @param amount
+ */
+const isGraphicalSummaryVisible = (period: BpdPeriod, amount: BpdAmount) =>
+  period.status === "Closed" ||
+  (period.status === "Active" && amount.transactionNumber > 0);
+
 const Content = (sd: SummaryData) => (
   <View testID={"bpdSummaryComponent"}>
-    {sd.period.status === "Inactive" ? null : (
+    {isGraphicalSummaryVisible(sd.period, sd.amount) ? (
       <TransactionsGraphicalSummary
         transactions={sd.amount.transactionNumber}
         minTransactions={sd.period.minTransactionNumber}
         period={sd.period}
       />
-    )}
+    ) : null}
     <View spacer={true} />
     <TextualSummary {...sd} />
   </View>

--- a/ts/features/bonus/bpd/screens/details/components/summary/TextualSummary.tsx
+++ b/ts/features/bonus/bpd/screens/details/components/summary/TextualSummary.tsx
@@ -138,7 +138,9 @@ const chooseTextualInfoBox = (props: Props) => {
       // active period but still not enough transaction
       if (
         props.amount.transactionNumber < props.period.minTransactionNumber &&
-        props.amount.totalCashback > 0
+        props.amount.totalCashback > 0 &&
+        // hide with transactionNumber === 0
+        props.amount.transactionNumber > 0
       ) {
         return <CurrentPeriodWarning period={props.period} />;
       }

--- a/ts/features/bonus/bpd/screens/details/components/summary/__test__/bpdSummaryComponent.test.tsx
+++ b/ts/features/bonus/bpd/screens/details/components/summary/__test__/bpdSummaryComponent.test.tsx
@@ -64,8 +64,6 @@ describe("Bpd Summary Component graphical test for different states", () => {
       </Provider>
     );
 
-    activePeriodNotEnoughTransaction(component, zeroAmount);
-
     // When the period is "Active" and transactionNumber<minTransactionNumber,
     // TextualSummary should be null if totalCashback == 0
     expect(component.queryByTestId("currentPeriodWarning")).toBeNull();


### PR DESCRIPTION
## Short description
This pr changes the representation of different states for the payment method section.

None            |  Error | Some
:-------------------------:|:-----------:|:--------------------:
<img src="https://user-images.githubusercontent.com/26501317/101495801-43656580-3969-11eb-8298-770361c1423b.png" width="300">|  <img src="https://user-images.githubusercontent.com/26501317/101519080-09a15880-3983-11eb-80c0-77669ecc179a.png" width="300"> | <img src="https://user-images.githubusercontent.com/26501317/101519247-40776e80-3983-11eb-93cc-2120fd0e2619.png" width="300"> 

## List of changes proposed in this pull request
- Changed representation for `WalletPaymentMethodBpdList.tsx`
- Hide `BpdSummaryComponent.tsx` if period === current and numTransaction === 0


## How to test
- Test the BpdDetail screen with different potValues
