### PR TITLE
feat(Bonus Pagamenti Digitali): [#176050060] Wallets home rework

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -821,6 +821,7 @@ wallet:
     text2: Consult the help at the top right of this page.
   transactionsLoadMore: Load previous
   transacionsLoadingMore: Loading previous...
+  transactionsShow: Show transactions
   pickPaymentMethod:
     unavailable:
       title: This payment method is not available at this time
@@ -838,6 +839,8 @@ wallet:
     alert: 'The payment method used for payment of the transaction has been removed from the wallet'
   newPaymentMethod:
     add: add
+    show: show
+    refresh: refresh
     addButton: Add a new method
     addDescription: Add a payment method to pay from IO in seconds, or request activation of a bonus or discount card.
     walletAlert: "Your wallet includes payment methods but no one is supported by IO yet"
@@ -1073,6 +1076,7 @@ wallet:
     PAYMENT_ONGOING_CANCELLED: The previous attempt to pay this notice is being canceled, you can retry paying this notice after {{remainingMinutes}} minutes.
     PAYMENT_ONGOING_CANCELLED_TIMEOUT: The cancellation of this payment has beed requested more than 15 minutes ago but it is still blocked. Use the button below to send us a report.
     sendReport: Send report
+    loadingData: loading failure, try again.
   walletList:
     contextualHelpTitle: Your payment methods
     contextualHelpContent: !include wallet/wallet_list.md

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -842,6 +842,7 @@ wallet:
     text2: Consulta l’help in alto a destra su questa pagina.
   transactionsLoadMore: Carica precedenti
   transacionsLoadingMore: Carico precedenti...
+  transactionsShow: Mostra operazioni
   pickPaymentMethod:
     unavailable:
       title: Questo metodo di pagamento non è ancora disponibile
@@ -859,6 +860,8 @@ wallet:
     alert: "Il metodo di pagamento usato per la transazione non è più presente nel portafoglio"
   newPaymentMethod:
     add: aggiungi
+    show: mostra
+    refresh: aggiorna
     addButton: Aggiungi un metodo
     addDescription: Aggiungi un metodo di pagamento per pagare da IO in pochi secondi, oppure richiedi l’attivazione di un bonus o di una carta sconto.
     walletAlert: "Nel tuo portafoglio sono registrati dei metodi di pagamento ma nessuno di questi è compatibile con IO"
@@ -1100,6 +1103,7 @@ wallet:
     PAYMENT_ONGOING_CANCELLED: È in corso l'annullamento del tuo tentativo di pagamento precedente, potrai riprovare a pagare l'avviso tra {{remainingMinutes}} minuti.
     PAYMENT_ONGOING_CANCELLED_TIMEOUT: L'annullamento di questo pagamento è stato richiesto più di 15 minuti fa ma risulta ancora bloccato. Utilizza il pulsante qui sotto per inviarci una segnalazione.
     sendReport: Invia segnalazione
+    loadingData: errore durante il caricamento, riprova.
   walletList:
     contextualHelpTitle: I tuoi metodi di pagamento
     contextualHelpContent: !include wallet/wallet_list.md

--- a/ts/components/wallet/card/SectionCardComponent.tsx
+++ b/ts/components/wallet/card/SectionCardComponent.tsx
@@ -1,14 +1,21 @@
 import { Badge, Text, View } from "native-base";
 import * as React from "react";
-import { Platform, StyleSheet, ViewStyle } from "react-native";
+import {
+  ActivityIndicator,
+  Platform,
+  StyleSheet,
+  ViewStyle
+} from "react-native";
 import IconFont from "../../../components/ui/IconFont";
 import I18n from "../../../i18n";
 import customVariables from "../../../theme/variables";
 import TouchableDefaultOpacity from "../../TouchableDefaultOpacity";
 
+export type SectionCardStatus = "add" | "refresh" | "loading" | "show";
 type Props = {
   onPress: () => void;
   label: string;
+  status?: SectionCardStatus;
   isError?: boolean;
   isNew?: boolean;
   cardStyle?: ViewStyle;
@@ -18,6 +25,9 @@ const styles = StyleSheet.create({
   flexRow: {
     flexDirection: "row",
     alignItems: "center"
+  },
+  row: {
+    flexDirection: "row"
   },
   topSpacing: {
     marginTop: 2
@@ -103,6 +113,77 @@ const styles = StyleSheet.create({
 
 const SectionCardComponent: React.FunctionComponent<Props> = (props: Props) => {
   const { label, onPress, isNew, isError, cardStyle } = props;
+  const rightLabel = () => {
+    switch (props.status) {
+      case undefined:
+      case "add":
+        return (
+          <>
+            <IconFont
+              name="io-plus"
+              color={customVariables.colorWhite}
+              size={customVariables.fontSize2}
+            />
+            <Text
+              bold={true}
+              style={[
+                styles.labelButton,
+                { fontSize: customVariables.fontSize1 + 1 }
+              ]}
+            >
+              {I18n.t("wallet.newPaymentMethod.add").toUpperCase()}
+            </Text>
+          </>
+        );
+      case "loading":
+        return <ActivityIndicator size={24} color={"white"} />;
+      case "refresh":
+        return (
+          <View style={styles.row}>
+            <Text
+              bold={true}
+              style={[
+                styles.labelButton,
+                { fontSize: customVariables.fontSize1 + 1 }
+              ]}
+            >
+              {I18n.t("wallet.newPaymentMethod.refresh").toUpperCase()}
+            </Text>
+            <Text
+              style={{
+                fontSize: customVariables.fontSize1 + 16,
+                height: 22,
+                paddingTop: 8,
+                color: "white"
+              }}
+            >
+              {" ⟳"}
+            </Text>
+          </View>
+        );
+      case "show":
+        return (
+          <View style={styles.row}>
+            <Text
+              bold={true}
+              style={[
+                styles.labelButton,
+                { fontSize: customVariables.fontSize1 + 1 }
+              ]}
+            >
+              {I18n.t("wallet.newPaymentMethod.show").toUpperCase()}
+            </Text>
+            <IconFont
+              style={{ marginTop: 1, marginLeft: 2 }}
+              name={"io-right"}
+              color={customVariables.colorWhite}
+              size={20}
+            />
+          </View>
+        );
+    }
+  };
+
   return (
     <>
       {Platform.OS === "android" && <View style={styles.shadowBox} />}
@@ -141,22 +222,7 @@ const SectionCardComponent: React.FunctionComponent<Props> = (props: Props) => {
                   )}
                 </View>
                 {!isError && (
-                  <View style={[styles.button]}>
-                    <IconFont
-                      name="io-plus"
-                      color={customVariables.colorWhite}
-                      size={customVariables.fontSize2}
-                    />
-                    <Text
-                      bold={true}
-                      style={[
-                        styles.labelButton,
-                        { fontSize: customVariables.fontSize1 + 1 }
-                      ]}
-                    >
-                      {I18n.t("wallet.newPaymentMethod.add").toUpperCase()}
-                    </Text>
-                  </View>
+                  <View style={[styles.button]}>{rightLabel()}</View>
                 )}
               </View>
             </View>

--- a/ts/components/wallet/card/SectionCardComponent.tsx
+++ b/ts/components/wallet/card/SectionCardComponent.tsx
@@ -136,7 +136,15 @@ const SectionCardComponent: React.FunctionComponent<Props> = (props: Props) => {
           </>
         );
       case "loading":
-        return <ActivityIndicator size={24} color={"white"} />;
+        return (
+          <ActivityIndicator
+            size={24}
+            color={"white"}
+            accessible={false}
+            importantForAccessibility={"no-hide-descendants"}
+            accessibilityElementsHidden={true}
+          />
+        );
       case "refresh":
         return (
           <View style={styles.row}>

--- a/ts/features/bonus/bonusVacanze/components/RequestBonus.tsx
+++ b/ts/features/bonus/bonusVacanze/components/RequestBonus.tsx
@@ -9,7 +9,6 @@ import SectionCardComponent, {
   SectionCardStatus
 } from "../../../../components/wallet/card/SectionCardComponent";
 import I18n from "../../../../i18n";
-import customVariables from "../../../../theme/variables";
 import { ID_BONUS_VACANZE_TYPE } from "../utils/bonus";
 import BonusCardComponent from "./BonusCardComponent";
 

--- a/ts/features/bonus/bonusVacanze/components/RequestBonus.tsx
+++ b/ts/features/bonus/bonusVacanze/components/RequestBonus.tsx
@@ -23,7 +23,6 @@ type OwnProps = {
   ) => void;
   activeBonuses: ReadonlyArray<pot.Pot<BonusActivationWithQrCode, Error>>;
   availableBonusesList: BonusesAvailable;
-  noMethod: boolean;
 };
 
 const styles = StyleSheet.create({
@@ -51,8 +50,7 @@ const RequestBonus: React.FunctionComponent<OwnProps> = (props: OwnProps) => {
     onButtonPress,
     activeBonuses,
     onBonusPress,
-    availableBonusesList,
-    noMethod
+    availableBonusesList
   } = props;
   const maybeBonusVacanzeCategory = fromNullable(
     availableBonusesList.find(bi => bi.id_type === ID_BONUS_VACANZE_TYPE)
@@ -69,11 +67,6 @@ const RequestBonus: React.FunctionComponent<OwnProps> = (props: OwnProps) => {
         status={props.status}
         label={I18n.t("bonus.requestLabel")}
         onPress={onButtonPress}
-        cardStyle={
-          noMethod
-            ? { backgroundColor: customVariables.brandPrimary }
-            : undefined
-        }
       />
       {activeBonuses.length > 0 ? (
         activeBonuses.map(

--- a/ts/features/bonus/bonusVacanze/components/RequestBonus.tsx
+++ b/ts/features/bonus/bonusVacanze/components/RequestBonus.tsx
@@ -5,7 +5,9 @@ import * as React from "react";
 import { StyleSheet } from "react-native";
 import { BonusActivationWithQrCode } from "../../../../../definitions/bonus_vacanze/BonusActivationWithQrCode";
 import { BonusesAvailable } from "../../../../../definitions/content/BonusesAvailable";
-import SectionCardComponent from "../../../../components/wallet/card/SectionCardComponent";
+import SectionCardComponent, {
+  SectionCardStatus
+} from "../../../../components/wallet/card/SectionCardComponent";
 import I18n from "../../../../i18n";
 import customVariables from "../../../../theme/variables";
 import { ID_BONUS_VACANZE_TYPE } from "../utils/bonus";
@@ -13,6 +15,7 @@ import BonusCardComponent from "./BonusCardComponent";
 
 type OwnProps = {
   onButtonPress: () => void;
+  status?: SectionCardStatus;
   onBonusPress: (
     bonus: BonusActivationWithQrCode,
     validFrom?: Date,
@@ -63,6 +66,7 @@ const RequestBonus: React.FunctionComponent<OwnProps> = (props: OwnProps) => {
   return (
     <React.Fragment>
       <SectionCardComponent
+        status={props.status}
         label={I18n.t("bonus.requestLabel")}
         onPress={onButtonPress}
         cardStyle={

--- a/ts/features/bonus/bpd/saga/networking/prefetctBpdDetails.ts
+++ b/ts/features/bonus/bpd/saga/networking/prefetctBpdDetails.ts
@@ -24,7 +24,7 @@ export function* prefetchBpdData() {
   const abiList: ReturnType<typeof abiSelector> = yield select(abiSelector);
 
   // The volatility of the bank list is extremely low.
-  // There is no need to refresher it every time.
+  // There is no need to refresh it every time.
   // A further refinement could be to insert an expiring cache
   if (!isReady(abiList)) {
     yield put(loadAbi.request());

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -549,14 +549,6 @@ class WalletHomeScreen extends React.PureComponent<Props, State> {
         ? this.footerButton(potWallets)
         : undefined;
 
-    const walletRefreshControl = (
-      <RefreshControl
-        onRefresh={undefined}
-        refreshing={false}
-        tintColor={"transparent"} // iOS
-      />
-    );
-
     return (
       <WalletLayout
         accessibilityLabel={I18n.t("wallet.wallet")}
@@ -568,7 +560,6 @@ class WalletHomeScreen extends React.PureComponent<Props, State> {
         hasDynamicSubHeader={true}
         topContent={headerContent}
         footerContent={footerContent}
-        refreshControl={walletRefreshControl}
         contextualHelpMarkdown={contextualHelpMarkdown}
         faqCategories={["wallet", "wallet_methods"]}
         gradientHeader={true}

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -507,7 +507,12 @@ class WalletHomeScreen extends React.PureComponent<Props> {
       anyCreditCardAttempts
     } = this.props;
 
-    const headerContent = this.cardPreview();
+    const headerContent = (
+      <>
+        <WalletHomeHeader />
+        {this.cardPreview()}
+      </>
+    );
     const transactionContent =
       pot.isError(potTransactions) ||
       (pot.isNone(potTransactions) &&
@@ -518,29 +523,6 @@ class WalletHomeScreen extends React.PureComponent<Props> {
             potTransactions,
             anyHistoryPayments || anyCreditCardAttempts
           );
-    const headerContent = (
-      <>
-        <WalletHomeHeader />
-        {pot.fold(
-          potWallets,
-          () => this.loadingWalletsHeader(),
-          () => this.loadingWalletsHeader(),
-          _ => this.loadingWalletsHeader(),
-          _ => this.errorWalletsHeader(),
-          _ => this.cardPreview(),
-          _ => this.loadingWalletsHeader(),
-          _ => this.cardPreview(),
-          _ => this.errorWalletsHeader()
-        )}
-      </>
-    );
-
-    const transactionContent = pot.isError(potTransactions)
-      ? this.transactionError()
-      : this.transactionList(
-          potTransactions,
-          anyHistoryPayments || anyCreditCardAttempts
-        );
 
     const footerContent =
       pot.isSome(potWallets) && !this.newMethodAdded

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -2,7 +2,7 @@ import { fromNullable, fromPredicate, none } from "fp-ts/lib/Option";
 import * as pot from "italia-ts-commons/lib/pot";
 import { Content, Text, View } from "native-base";
 import * as React from "react";
-import { BackHandler, Image, RefreshControl, StyleSheet } from "react-native";
+import { BackHandler, Image, StyleSheet } from "react-native";
 import {
   NavigationEvents,
   NavigationEventSubscription,

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -77,7 +77,6 @@ import { isUpdateNeeded } from "../../utils/appVersion";
 import { setStatusBarColorAndBackground } from "../../utils/statusBar";
 import { bpdEnabledSelector } from "../../features/bonus/bpd/store/reducers/details/activation";
 import {
-  getValue,
   isLoading,
   isReady,
   isError as isRemoteValueError
@@ -285,7 +284,7 @@ class WalletHomeScreen extends React.PureComponent<Props, State> {
     }
   }
 
-  private cardHeader(isError: boolean = false, isBlue: boolean = false) {
+  private cardHeader(isError: boolean = false) {
     const sectionCardStatus: SectionCardStatus = pot.fold(
       this.props.potWallets,
       () => "show",
@@ -307,9 +306,6 @@ class WalletHomeScreen extends React.PureComponent<Props, State> {
           }
         }}
         isError={isError}
-        cardStyle={
-          isBlue ? { backgroundColor: customVariables.brandPrimary } : undefined
-        }
       />
     );
   }
@@ -346,26 +342,11 @@ class WalletHomeScreen extends React.PureComponent<Props, State> {
     const wallets = this.getCreditCards();
     // we have to render only wallets of credit card type
     const validWallets = wallets.filter(w => w.type === TypeEnum.CREDIT_CARD);
-    const noMethod =
-      // say that there are no method if we have a valid data about wallets
-      pot.isSome(this.props.potWallets) &&
-      validWallets.length === 0 &&
-      this.props.allActiveBonus.length === 0 &&
-      getValue(this.props.bpdActiveBonus) === false;
     const bonusLoadingStatus = this.getBonusLoadingStatus();
     return (
       <View>
         <View spacer={true} />
-        {noMethod && (
-          <React.Fragment>
-            <Text white={true} style={styles.addDescription}>
-              {I18n.t("wallet.newPaymentMethod.addDescription")}
-            </Text>
-            <View spacer={true} large={true} />
-            <View spacer={true} small={true} />
-          </React.Fragment>
-        )}
-        {this.cardHeader(false, noMethod)}
+        {this.cardHeader(false)}
 
         {validWallets.length > 0 ? (
           <RotatedCards
@@ -387,7 +368,6 @@ class WalletHomeScreen extends React.PureComponent<Props, State> {
               }
             }}
             activeBonuses={this.props.allActiveBonus}
-            noMethod={noMethod}
             availableBonusesList={this.props.availableBonusesList}
             onBonusPress={this.props.navigateToBonusDetail}
           />

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -552,7 +552,10 @@ class WalletHomeScreen extends React.PureComponent<Props> {
       _ => this.errorWalletsHeader()
     );
     const transactionContent =
-      pot.isError(potTransactions) || pot.isNone(potTransactions)
+      pot.isError(potTransactions) ||
+      (pot.isNone(potTransactions) &&
+        !pot.isLoading(potTransactions) &&
+        !pot.isUpdating(potTransactions))
         ? this.transactionError(anyHistoryPayments || anyCreditCardAttempts)
         : this.transactionList(
             potTransactions,
@@ -593,7 +596,7 @@ class WalletHomeScreen extends React.PureComponent<Props> {
           this.newMethodAddedContent
         ) : (
           <>
-            {bpdEnabled && !pot.isLoading(potTransactions) && (
+            {bpdEnabled && (
               <FeaturedCardCarousel
                 bvActive={this.props.allActiveBonus.length > 0}
               />

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -251,13 +251,13 @@ class WalletHomeScreen extends React.PureComponent<Props> {
       this.props.dispatchAllTransactionLoaded(this.props.potTransactions.value);
     }
     if (
-      // error on bpd bonus loading
+      // error loading: bpd bonus
       (!isRemoteValueError(prevProps.bpdActiveBonus) &&
         isRemoteValueError(this.props.bpdActiveBonus)) ||
-      // error on bonus vacanze loading
+      // error loading: bonus vacanze
       (prevProps.allActiveBonus.some(ab => !pot.isError(ab)) &&
         this.props.allActiveBonus.some(ab => pot.isError(ab))) ||
-      // error on load wallets loading
+      // error loading: wallet
       (!pot.isError(prevProps.potWallets) && pot.isError(this.props.potWallets))
     ) {
       showToast(I18n.t("wallet.errors.loadingData"));

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -280,7 +280,11 @@ class WalletHomeScreen extends React.PureComponent<Props> {
       <SectionCardComponent
         status={sectionCardStatus}
         label={I18n.t("wallet.paymentMethods")}
-        onPress={this.props.loadWallets}
+        onPress={() => {
+          if (sectionCardStatus !== "loading") {
+            this.props.loadWallets();
+          }
+        }}
         isError={isError}
         cardStyle={
           isBlue ? { backgroundColor: customVariables.brandPrimary } : undefined
@@ -494,15 +498,6 @@ class WalletHomeScreen extends React.PureComponent<Props> {
     );
   }
 
-  // triggered on pull to refresh
-  private handleOnRefresh = () => {
-    this.loadBonusVacanze();
-    this.loadBonusBpd();
-    // FIXME restore loadWallets and refreshTransactions see https://www.pivotaltracker.com/story/show/176051000
-    // this.props.refreshTransactions();
-    // this.props.loadWallets();
-  };
-
   public render(): React.ReactNode {
     const {
       potWallets,
@@ -530,7 +525,7 @@ class WalletHomeScreen extends React.PureComponent<Props> {
 
     const walletRefreshControl = (
       <RefreshControl
-        onRefresh={this.handleOnRefresh}
+        onRefresh={undefined}
         refreshing={false}
         tintColor={"transparent"} // iOS
       />

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -288,7 +288,7 @@ class WalletHomeScreen extends React.PureComponent<Props> {
       .getOrElse(this.props.potWallets, [])
       .filter(w => w.type === TypeEnum.CREDIT_CARD);
 
-  private getBonusPreviewStatus = (): SectionCardStatus => {
+  private getBonusLoadingStatus = (): SectionCardStatus => {
     // if any bonus is loading or updating
     // note: in the BPD case, we are watching for loading on one of several steps
     // so this loading state is very weak
@@ -321,7 +321,7 @@ class WalletHomeScreen extends React.PureComponent<Props> {
       validWallets.length === 0 &&
       this.props.allActiveBonus.length === 0 &&
       getValue(this.props.bpdActiveBonus) === false;
-    const bonusPreviewStatus = this.getBonusPreviewStatus();
+    const bonusLoadingStatus = this.getBonusLoadingStatus();
     return (
       <View>
         <View spacer={true} />
@@ -348,9 +348,9 @@ class WalletHomeScreen extends React.PureComponent<Props> {
         {/* Display this item only if the flag is enabled */}
         {(bonusVacanzeEnabled || bpdEnabled) && (
           <RequestBonus
-            status={bonusPreviewStatus}
+            status={bonusLoadingStatus}
             onButtonPress={() => {
-              if (bonusPreviewStatus !== "loading") {
+              if (bonusLoadingStatus !== "loading") {
                 this.loadBonusVacanze();
                 this.loadBonusBpd();
               }


### PR DESCRIPTION
## Short description
Changes proposed

- only one `/start-session` can be executed at the same time. All other requests will be rejected as an Error

**WalletsHome**
- disable pull to refresh
-  remove _wallets_ & _transactions_ automatically load
-  pull to refresh load only bonus (vacanze + bpd, no wallets&transactions)
-  _wallets_ & _transaction_ can be loaded manually