### PR TITLE
feat(Bonus Pagamenti Digitali): [#176059090] Adds SectionStatusComponent to email and bpd details screen

### DIFF
--- a/ts/api/backendPublic.ts
+++ b/ts/api/backendPublic.ts
@@ -65,7 +65,7 @@ const Sections = t.interface({
   wallets: SectionStatus,
   login: SectionStatus,
   services: SectionStatus,
-  emailValidation: SectionStatus,
+  email_validation: SectionStatus,
   cashback: SectionStatus
 });
 export type Sections = t.TypeOf<typeof Sections>;

--- a/ts/api/backendPublic.ts
+++ b/ts/api/backendPublic.ts
@@ -64,7 +64,9 @@ const Sections = t.interface({
   messages: SectionStatus,
   wallets: SectionStatus,
   login: SectionStatus,
-  services: SectionStatus
+  services: SectionStatus,
+  emailValidation: SectionStatus,
+  cashback: SectionStatus
 });
 export type Sections = t.TypeOf<typeof Sections>;
 const BackendStatusO = t.partial({

--- a/ts/components/RemindEmailValidationOverlay.tsx
+++ b/ts/components/RemindEmailValidationOverlay.tsx
@@ -36,6 +36,7 @@ import { ContextualHelpPropsMarkdown } from "./screens/BaseScreenComponent";
 import TopScreenComponent, {
   TopScreenComponentProps
 } from "./screens/TopScreenComponent";
+import SectionStatusComponent from "./SectionStatusComponent";
 import TouchableDefaultOpacity from "./TouchableDefaultOpacity";
 import BlockButtons from "./ui/BlockButtons";
 import FooterWithButtons from "./ui/FooterWithButtons";
@@ -289,46 +290,49 @@ class RemindEmailValidationOverlay extends React.PureComponent<Props, State> {
     // show two buttons where the left one is a CTA
     // to edit again the email
     return (
-      <View footer={true}>
-        <BlockButtons
-          type={"SingleButton"}
-          leftButton={{
-            title: this.state.ctaSendEmailValidationText,
-            onPress: this.handleSendEmailValidationButton,
-            light: true,
-            bordered: true,
-            disabled:
-              this.state.isLoading ||
-              this.state.isCtaSentEmailValidationDisabled
-          }}
-        />
-        <View spacer={true} />
-        <BlockButtons
-          type={"TwoButtonsInlineThirdInverted"}
-          leftButton={{
-            block: true,
-            bordered: true,
-            disabled: this.state.isLoading,
-            onPress: () => {
-              if (!isOnboardingCompleted) {
-                this.props.closeModalAndNavigateToEmailInsertScreen();
-                return;
-              }
-              this.props.navigateToEmailInsertScreen();
-            },
-            title: I18n.t("email.edit.title")
-          }}
-          rightButton={{
-            block: true,
-            primary: true,
-            onPress: this.handleOnClose,
-            disabled: this.state.isLoading,
-            title: isOnboardingCompleted
-              ? I18n.t("global.buttons.ok")
-              : I18n.t("global.buttons.continue")
-          }}
-        />
-      </View>
+      <>
+        <SectionStatusComponent sectionKey={"emailValidation"} />
+        <View footer={true}>
+          <BlockButtons
+            type={"SingleButton"}
+            leftButton={{
+              title: this.state.ctaSendEmailValidationText,
+              onPress: this.handleSendEmailValidationButton,
+              light: true,
+              bordered: true,
+              disabled:
+                this.state.isLoading ||
+                this.state.isCtaSentEmailValidationDisabled
+            }}
+          />
+          <View spacer={true} />
+          <BlockButtons
+            type={"TwoButtonsInlineThirdInverted"}
+            leftButton={{
+              block: true,
+              bordered: true,
+              disabled: this.state.isLoading,
+              onPress: () => {
+                if (!isOnboardingCompleted) {
+                  this.props.closeModalAndNavigateToEmailInsertScreen();
+                  return;
+                }
+                this.props.navigateToEmailInsertScreen();
+              },
+              title: I18n.t("email.edit.title")
+            }}
+            rightButton={{
+              block: true,
+              primary: true,
+              onPress: this.handleOnClose,
+              disabled: this.state.isLoading,
+              title: isOnboardingCompleted
+                ? I18n.t("global.buttons.ok")
+                : I18n.t("global.buttons.continue")
+            }}
+          />
+        </View>
+      </>
     );
   };
 

--- a/ts/components/RemindEmailValidationOverlay.tsx
+++ b/ts/components/RemindEmailValidationOverlay.tsx
@@ -291,7 +291,7 @@ class RemindEmailValidationOverlay extends React.PureComponent<Props, State> {
     // to edit again the email
     return (
       <>
-        <SectionStatusComponent sectionKey={"emailValidation"} />
+        <SectionStatusComponent sectionKey={"email_validation"} />
         <View footer={true}>
           <BlockButtons
             type={"SingleButton"}

--- a/ts/features/bonus/bpd/screens/details/BpdDetailsScreen.tsx
+++ b/ts/features/bonus/bpd/screens/details/BpdDetailsScreen.tsx
@@ -24,6 +24,7 @@ import { navigateBack } from "../../../../../store/actions/navigation";
 import BpdPeriodSelector from "./BpdPeriodSelector";
 import BpdPeriodDetail from "./periods/BpdPeriodDetail";
 import GoToTransactions from "./transaction/GoToTransactions";
+import SectionStatusComponent from "../../../../../components/SectionStatusComponent";
 
 export type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
@@ -107,6 +108,7 @@ const BpdDetailsScreen: React.FunctionComponent<Props> = props => {
             <GoToTransactions goToTransactions={props.goToTransactions} />
           )
         }
+        footerFullWidth={<SectionStatusComponent sectionKey={"cashback"} />}
       >
         <View style={styles.selector}>
           <BpdPeriodSelector />

--- a/ts/features/bonus/bpd/screens/details/BpdDetailsScreen.tsx
+++ b/ts/features/bonus/bpd/screens/details/BpdDetailsScreen.tsx
@@ -21,10 +21,10 @@ import { navigateToBpdTransactions } from "../../navigation/actions";
 import { emptyContextualHelp } from "../../../../../utils/emptyContextualHelp";
 import { useHardwareBackButton } from "../../../bonusVacanze/components/hooks/useHardwareBackButton";
 import { navigateBack } from "../../../../../store/actions/navigation";
+import SectionStatusComponent from "../../../../../components/SectionStatusComponent";
 import BpdPeriodSelector from "./BpdPeriodSelector";
 import BpdPeriodDetail from "./periods/BpdPeriodDetail";
 import GoToTransactions from "./transaction/GoToTransactions";
-import SectionStatusComponent from "../../../../../components/SectionStatusComponent";
 
 export type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;

--- a/ts/screens/onboarding/EmailInsertScreen.tsx
+++ b/ts/screens/onboarding/EmailInsertScreen.tsx
@@ -37,6 +37,7 @@ import customVariables from "../../theme/variables";
 import { areStringsEqual } from "../../utils/options";
 import { showToast } from "../../utils/showToast";
 import { withKeyboard } from "../../utils/keyboard";
+import SectionStatusComponent from "../../components/SectionStatusComponent";
 
 type Props = ReduxProps &
   ReturnType<typeof mapDispatchToProps> &
@@ -301,6 +302,7 @@ class EmailInsertScreen extends React.PureComponent<Props, State> {
             </View>
           </Content>
         </View>
+        <SectionStatusComponent sectionKey={"emailValidation"} />
         {withKeyboard(this.renderFooterButtons())}
       </BaseScreenComponent>
     );

--- a/ts/screens/onboarding/EmailInsertScreen.tsx
+++ b/ts/screens/onboarding/EmailInsertScreen.tsx
@@ -302,7 +302,7 @@ class EmailInsertScreen extends React.PureComponent<Props, State> {
             </View>
           </Content>
         </View>
-        <SectionStatusComponent sectionKey={"emailValidation"} />
+        <SectionStatusComponent sectionKey={"email_validation"} />
         {withKeyboard(this.renderFooterButtons())}
       </BaseScreenComponent>
     );

--- a/ts/screens/onboarding/EmailReadScreen.tsx
+++ b/ts/screens/onboarding/EmailReadScreen.tsx
@@ -16,6 +16,7 @@ import { withValidatedEmail } from "../../components/helpers/withValidatedEmail"
 import { ContextualHelpPropsMarkdown } from "../../components/screens/BaseScreenComponent";
 import ScreenContent from "../../components/screens/ScreenContent";
 import TopScreenComponent from "../../components/screens/TopScreenComponent";
+import SectionStatusComponent from "../../components/SectionStatusComponent";
 import {
   SingleButton,
   TwoButtonsInlineHalf
@@ -179,6 +180,7 @@ export class EmailReadScreen extends React.PureComponent<Props> {
             </Text>
           </View>
         </ScreenContent>
+        <SectionStatusComponent sectionKey={"emailValidation"} />
         <FooterWithButtons
           {...(isFromProfileSection ? footerProps1 : footerProps2)}
         />

--- a/ts/screens/onboarding/EmailReadScreen.tsx
+++ b/ts/screens/onboarding/EmailReadScreen.tsx
@@ -180,7 +180,7 @@ export class EmailReadScreen extends React.PureComponent<Props> {
             </Text>
           </View>
         </ScreenContent>
-        <SectionStatusComponent sectionKey={"emailValidation"} />
+        <SectionStatusComponent sectionKey={"email_validation"} />
         <FooterWithButtons
           {...(isFromProfileSection ? footerProps1 : footerProps2)}
         />


### PR DESCRIPTION
## Short description
This PR supports 2 more sections status and adds the related component to Email Screens and BPD detail screen 

## How to test
Check the `io-dev-server` repo and set to true `emailValidation` and `cashback` sections `is_visible` attribute

<img src="https://user-images.githubusercontent.com/3959405/101523074-65baab80-3988-11eb-8a23-b194c3ff989c.png" height="550"/>

<img src="https://user-images.githubusercontent.com/3959405/101523130-779c4e80-3988-11eb-83ac-d8a9a4d59452.png" height="550"/>
