### PR TITLE
feat(Bonus Pagamenti Digitali): [#175165668,#175165677] IBAN code is now Monospace Bold and selectable on KO screens

### DIFF
--- a/ts/components/core/typography/Monospace.tsx
+++ b/ts/components/core/typography/Monospace.tsx
@@ -5,7 +5,7 @@ import { ExternalTypographyProps, TypographyProps } from "./common";
 import { typographyFactory } from "./Factory";
 
 type AllowedColors = Extract<IOColorType, "bluegrey">;
-type AllowedWeight = Extract<IOFontWeight, "Regular" | "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Regular" | "SemiBold" | "Bold">;
 
 type OwnProps = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>

--- a/ts/features/bonus/bpd/screens/iban/ko/IbanKoBody.tsx
+++ b/ts/features/bonus/bpd/screens/iban/ko/IbanKoBody.tsx
@@ -37,7 +37,7 @@ const IbanKoBody: React.FunctionComponent<Props> = props => {
         {props.text1}
       </H4>
       <View spacer={true} small={true} />
-      <Monospace style={styles.text} weight={"SemiBold"}>
+      <Monospace selectable style={styles.text} weight={"Bold"}>
         {iban}
       </Monospace>
       <View spacer={true} small={true} />

--- a/ts/features/bonus/bpd/screens/iban/ko/IbanKoBody.tsx
+++ b/ts/features/bonus/bpd/screens/iban/ko/IbanKoBody.tsx
@@ -37,7 +37,7 @@ const IbanKoBody: React.FunctionComponent<Props> = props => {
         {props.text1}
       </H4>
       <View spacer={true} small={true} />
-      <Monospace selectable style={styles.text} weight={"Bold"}>
+      <Monospace selectable={true} style={styles.text} weight={"Bold"}>
         {iban}
       </Monospace>
       <View spacer={true} small={true} />


### PR DESCRIPTION
## How to test

- Comment the `switch` in `MainIbanScreen.tsx` line 30, replace with `return <IbanKOWrong contextualHelp={emptyContextualHelp} />;`, `IbanKONotOwned` uses the same `IbanKoBody` component underneath
- Insert any IBAN code

## Changes

- IBAN should be bold
- Press on the IBAN code, you should be able to copy it in the clipboard

<img width="427" alt="Schermata 2020-12-09 alle 18 22 20" src="https://user-images.githubusercontent.com/26572302/101665868-d081ea80-3a4d-11eb-9b67-d85a94ae9fee.png">
