### PR TITLE
fix(Bonus Pagamenti Digitali): [#176091299] Resize bancomat confirmation bottomsheet

### DIFF
--- a/ts/components/bottomSheet/BlurredBackgroundComponent.tsx
+++ b/ts/components/bottomSheet/BlurredBackgroundComponent.tsx
@@ -11,8 +11,6 @@ export const BlurredBackgroundComponent = (onPress: () => void) => (
     onPress={onPress}
     style={{
       ...StyleSheet.absoluteFillObject,
-      borderTopLeftRadius: 10,
-      borderTopRightRadius: 10,
       overflow: "hidden",
       backgroundColor: "rgba(0,0,0, 0.5)"
     }}

--- a/ts/features/wallet/component/NewMethodAddedNotifier.tsx
+++ b/ts/features/wallet/component/NewMethodAddedNotifier.tsx
@@ -20,7 +20,7 @@ const newBancomatBottomSheet = () => {
     const bottomSheetProps = await bottomSheetContent(
       <BancomatInformation onAddPaymentMethod={dismiss} />,
       I18n.t("wallet.methods.pagobancomat.name"),
-      500,
+      550,
       dismiss
     );
     present(bottomSheetProps.content, {

--- a/ts/utils/bottomSheet.ts
+++ b/ts/utils/bottomSheet.ts
@@ -1,6 +1,7 @@
 import { useBottomSheetModal } from "@gorhom/bottom-sheet";
 import { BottomSheetModalConfigs } from "@gorhom/bottom-sheet/lib/typescript/types";
 import * as React from "react";
+import { Dimensions } from "react-native";
 import { AccessibilityContent } from "../components/bottomSheet/AccessibilityContent";
 import { BlurredBackgroundComponent } from "../components/bottomSheet/BlurredBackgroundComponent";
 import { BottomSheetContent } from "../components/bottomSheet/BottomSheetContent";
@@ -38,7 +39,7 @@ export const bottomSheetContent = async (
   return {
     content: bottomSheetBody,
     config: {
-      snapPoints: [snapPoint],
+      snapPoints: [Math.min(snapPoint, Dimensions.get("window").height)],
       allowTouchThroughOverlay: false,
       dismissOnOverlayPress: true,
       dismissOnScrollDown: true,


### PR DESCRIPTION
## Short description
This pr increases the height for the `BancomatInformation` bottomsheet, in order to better display the content.

Before            |  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/26501317/101784825-4e9cca80-3afc-11eb-9040-ad2c5ff4abbf.png" width="300">|  <img src="https://user-images.githubusercontent.com/26501317/101784955-74c26a80-3afc-11eb-8f6c-fedb73fd8dc8.png" width="300">

