### PR TITLE
fix(Bonus Pagamenti Digitali): [#176022289] remove wrong faq category in BpdDetailsScreen

### DIFF
--- a/ts/features/bonus/bpd/screens/details/BpdDetailsScreen.tsx
+++ b/ts/features/bonus/bpd/screens/details/BpdDetailsScreen.tsx
@@ -97,7 +97,6 @@ const BpdDetailsScreen: React.FunctionComponent<Props> = props => {
       <DarkLayout
         bounces={false}
         title={I18n.t("bonus.bpd.name")}
-        faqCategories={["bonus_detail"]}
         allowGoBack={true}
         topContent={<View style={styles.headerSpacer} />}
         gradientHeader={true}


### PR DESCRIPTION
## Short description
This PR remove the reference to the local Bonus Vacanze faq in BpdDetailsScreen

## List of changes proposed in this pull request
- removed the local faqs in the component

<img src="https://user-images.githubusercontent.com/11773070/101901711-c2e57580-3bb1-11eb-8457-700833f61b0f.png" width=300>

