### PR TITLE
fix(Bonus Pagamenti Digitali): [#175990175] fix double click on bancomat search

### DIFF
--- a/ts/features/wallet/onboarding/bancomat/screens/search/SearchBankComponent.tsx
+++ b/ts/features/wallet/onboarding/bancomat/screens/search/SearchBankComponent.tsx
@@ -1,6 +1,11 @@
 import { Input, Item, View } from "native-base";
 import * as React from "react";
-import { FlatList, ListRenderItemInfo, ActivityIndicator } from "react-native";
+import {
+  FlatList,
+  ListRenderItemInfo,
+  ActivityIndicator,
+  Keyboard
+} from "react-native";
 import { debounce } from "lodash";
 import I18n from "../../../../../../i18n";
 import { Label } from "../../../../../../components/core/typography/Label";
@@ -58,6 +63,7 @@ export const SearchBankComponent: React.FunctionComponent<Props> = (
       onPress={(abi: string) => {
         props.onItemPress(abi);
         setSearchText("");
+        Keyboard.dismiss();
       }}
     />
   );
@@ -97,7 +103,7 @@ export const SearchBankComponent: React.FunctionComponent<Props> = (
           data={filteredList}
           renderItem={renderListItem(true)}
           keyExtractor={keyExtractor}
-          keyboardShouldPersistTaps={"always"}
+          keyboardShouldPersistTaps={"handled"}
         />
       )}
     </>

--- a/ts/features/wallet/onboarding/bancomat/screens/search/SearchBankComponent.tsx
+++ b/ts/features/wallet/onboarding/bancomat/screens/search/SearchBankComponent.tsx
@@ -97,6 +97,7 @@ export const SearchBankComponent: React.FunctionComponent<Props> = (
           data={filteredList}
           renderItem={renderListItem(true)}
           keyExtractor={keyExtractor}
+          keyboardShouldPersistTaps={"always"}
         />
       )}
     </>


### PR DESCRIPTION
## Short description
This PR solves the behavior of the Flatlist in SearchBankComponent which required 2 clicks to select the bank from the list.

## List of changes proposed in this pull request
- Set keyboardShouldPersistTaps prop to the Flatlist component
<img src="https://user-images.githubusercontent.com/11773070/102103417-42cb4400-3e2d-11eb-93b3-214faeb7264f.gif" width=300>

