### PR TITLE
chore(Bonus Pagamenti Digitali): [#176116658] Hides the infobox on add bancomat bottom sheet

### DIFF
--- a/ts/features/wallet/bancomat/screen/BancomatInformation.tsx
+++ b/ts/features/wallet/bancomat/screen/BancomatInformation.tsx
@@ -19,7 +19,10 @@ import I18n from "../../../../i18n";
 import { navigateToWalletAddPaymentMethod } from "../../../../store/actions/navigation";
 import { GlobalState } from "../../../../store/reducers/types";
 
-type OwnProps = { onAddPaymentMethod?: () => void };
+type OwnProps = {
+  onAddPaymentMethod?: () => void;
+  hideInfobox?: boolean;
+};
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps> &
@@ -66,16 +69,20 @@ const BrandIconsBar = () => (
 
 const BancomatInformation: React.FunctionComponent<Props> = props => (
   <View>
-    <InfoBox iconColor={IOColors.black}>
-      <Body>
-        {I18n.t("wallet.bancomat.details.infobox.one")}
-        <H4>{I18n.t("wallet.bancomat.details.infobox.two")}</H4>
-        {I18n.t("wallet.bancomat.details.infobox.three")}
-      </Body>
-    </InfoBox>
-    <View spacer={true} large={true} />
-    <View spacer={true} small={true} />
-    <H4>{I18n.t("wallet.bancomat.details.debit.title")}</H4>
+    {!props.hideInfobox && (
+      <>
+        <InfoBox iconColor={IOColors.black}>
+          <Body>
+            {I18n.t("wallet.bancomat.details.infobox.one")}
+            <H4>{I18n.t("wallet.bancomat.details.infobox.two")}</H4>
+            {I18n.t("wallet.bancomat.details.infobox.three")}
+          </Body>
+        </InfoBox>
+        <View spacer={true} large={true} />
+        <View spacer={true} small={true} />
+        <H4>{I18n.t("wallet.bancomat.details.debit.title")}</H4>
+      </>
+    )}
     <View spacer={true} />
     <BrandIconsBar />
     <View spacer={true} />

--- a/ts/features/wallet/component/NewMethodAddedNotifier.tsx
+++ b/ts/features/wallet/component/NewMethodAddedNotifier.tsx
@@ -18,9 +18,9 @@ const newBancomatBottomSheet = () => {
 
   const openModalBox = async () => {
     const bottomSheetProps = await bottomSheetContent(
-      <BancomatInformation onAddPaymentMethod={dismiss} />,
+      <BancomatInformation onAddPaymentMethod={dismiss} hideInfobox={true} />,
       I18n.t("wallet.methods.pagobancomat.name"),
-      550,
+      385,
       dismiss
     );
     present(bottomSheetProps.content, {


### PR DESCRIPTION
## Short description
This PR removes the infobox on top of the bottom sheet notifier that appears when we add a bancomat to wallet, but keeps it visible on bancomat detail screen

<img src="https://user-images.githubusercontent.com/3959405/102203899-7196f800-3ec9-11eb-9110-4179da484215.png" height="550"/>