### PR TITLE
fix: [#176038688] Fixed en locale typo

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -750,7 +750,7 @@ wallet:
     header: Add PagoBANCOMAT
     title: Search for your PagoBANCOMAT cards
     description:
-      text1: "IO will search for all PagoBANCOMAT cards associated with you.\nBy continuing you accept the"
+      text1: "IO will search for all PagoBANCOMAT cards associated with you.\nBy continuing you accept the "
       text2: information on the processing of personal data.
       text3: "If you prefer, you can choose the bank on which you have an active PagoBANCOMAT card "
       text4: by searching among those available


### PR DESCRIPTION
## Short description
Try to add a new Bancomat, you should now see the space in place of "theinformation". 

<img width="294" alt="Schermata 2020-12-15 alle 16 19 54" src="https://user-images.githubusercontent.com/26572302/102235968-36a9ba00-3ef3-11eb-9380-2cabc0301282.png">

