### PR TITLE
fix: [#176173361] Wallets store doesn't use persist transform

### DIFF
--- a/ts/mixpanel.ts
+++ b/ts/mixpanel.ts
@@ -38,10 +38,10 @@ const setupMixpanel = async (mp: MixpanelInstance) => {
 export const setMixpanelPushNotificationToken = (token: string) => {
   if (mixpanel) {
     return Platform.select({
-      android: mixpanel.setPushRegistrationId(token),
-      ios: mixpanel.addPushDeviceToken(token),
-      default: Promise.resolve()
-    });
+      android: () => mixpanel?.setPushRegistrationId(token),
+      ios: () => mixpanel?.addPushDeviceToken(token),
+      default: () => Promise.resolve()
+    })();
   }
   return Promise.resolve();
 };

--- a/ts/mixpanel.ts
+++ b/ts/mixpanel.ts
@@ -1,5 +1,6 @@
 import DeviceInfo from "react-native-device-info";
 import { MixpanelInstance } from "react-native-mixpanel";
+import { Platform } from "react-native";
 import { mixpanelToken } from "./config";
 import { isScreenReaderEnabled } from "./utils/accessibility";
 import { getAppVersion } from "./utils/appVersion";
@@ -36,7 +37,11 @@ const setupMixpanel = async (mp: MixpanelInstance) => {
 
 export const setMixpanelPushNotificationToken = (token: string) => {
   if (mixpanel) {
-    return mixpanel.setPushRegistrationId(token);
+    return Platform.select({
+      android: mixpanel.setPushRegistrationId(token),
+      ios: mixpanel.addPushDeviceToken(token),
+      default: Promise.resolve()
+    });
   }
   return Promise.resolve();
 };

--- a/ts/mixpanel.ts
+++ b/ts/mixpanel.ts
@@ -37,11 +37,12 @@ const setupMixpanel = async (mp: MixpanelInstance) => {
 
 export const setMixpanelPushNotificationToken = (token: string) => {
   if (mixpanel) {
-    return Platform.select({
-      android: () => mixpanel?.setPushRegistrationId(token),
-      ios: () => mixpanel?.addPushDeviceToken(token),
-      default: () => Promise.resolve()
-    })();
+    if (Platform.OS === "ios") {
+      return mixpanel.addPushDeviceToken(token);
+    }
+    if (Platform.OS === "android") {
+      return mixpanel.setPushRegistrationId(token);
+    }
   }
   return Promise.resolve();
 };

--- a/ts/store/reducers/wallet/index.ts
+++ b/ts/store/reducers/wallet/index.ts
@@ -12,6 +12,7 @@ import abiReducer, {
   AbiState
 } from "../../../features/wallet/onboarding/store/abi";
 import { DateISO8601Transform } from "../../transforms/dateISO8601Tranform";
+import { PotTransform } from "../../transforms/potTransform";
 import paymentReducer, { PaymentState } from "./payment";
 import pspsByIdReducer, { PspStateById } from "./pspsById";
 import transactionsReducer, { TransactionsState } from "./transactions";
@@ -37,7 +38,7 @@ export const walletsPersistConfig: PersistConfig = {
   key: "wallets",
   storage: AsyncStorage,
   whitelist: ["walletById"],
-  transforms: [DateISO8601Transform]
+  transforms: [DateISO8601Transform, PotTransform]
 };
 
 const reducer = combineReducers<WalletState, Action>({


### PR DESCRIPTION
## Short description
This PR fixes a bug that could happen if app persists wallet store while it is loading state
It also fixes a critical bug that happens when try to send PN token to mixpanel (only for internal tests)
