### PR TITLE
fix: [#176166635] removes border from the paid badge

### DIFF
--- a/ts/components/DetailedlistItemComponent.tsx
+++ b/ts/components/DetailedlistItemComponent.tsx
@@ -86,7 +86,7 @@ const styles = StyleSheet.create({
   },
   text3SubContainer: { width: `95%` },
   badgeInfo: {
-    borderWidth: 1,
+    borderWidth: 1, 
     borderStyle: "solid",
     width: 65,
     height: 25,
@@ -97,7 +97,8 @@ const styles = StyleSheet.create({
     borderColor: IOColors.red
   },
   badgeInfoPaid: {
-    backgroundColor: IOColors.aqua
+    borderColor: IOColors.aqua, 
+    backgroundColor: IOColors.aqua,
   }
 });
 


### PR DESCRIPTION
## Short description
it removes the border on the paid badge
![Screenshot 2020-12-16 at 15 54 54](https://user-images.githubusercontent.com/8376065/102364789-23602280-3fb7-11eb-9dee-110cc7fe8aa9.png)

## List of changes proposed in this pull request
- the border's now got the same colour as the background (IOColors.aqua)

