### PR TITLE
chore(Bonus Pagamenti Digitali): [#176203167] Satispay screens graphical refinements

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -808,7 +808,7 @@ wallet:
       headerTitle: "Add Satispay"
       start:
         title: "Do you want to add your Satispay account to IO?"
-        body: "We will check if there is a satispay account associated with your tax code"
+        body: "We will check if there is a Satispay account associated with your tax code."
         cta: "Information on the processing of personal data"
       loadingSearch:
         title: "We are verifying your Satispay account\n\nPlease wait a few seconds"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -828,7 +828,7 @@ wallet:
       headerTitle: "Aggiungi Satispay"
       start:
         title: "Vuoi aggiungere su IO il tuo account Satispay?"
-        body: "Verificheremo se esiste un account satispay associato al tuo codice fiscale"
+        body: "Verificheremo se esiste un account Satispay associato al tuo codice fiscale."
         cta: "Informativa sul trattamento dei dati personali"
       loadingSearch:
         title: "Stiamo verificando il tuo account Satispay\n\nAttendi qualche secondo"

--- a/ts/features/wallet/onboarding/DigitalMethodsList.tsx
+++ b/ts/features/wallet/onboarding/DigitalMethodsList.tsx
@@ -9,6 +9,9 @@ import {
 } from "react-native";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
+import { IOColors } from "../../../components/core/variables/IOColors";
+import { IOStyles } from "../../../components/core/variables/IOStyles";
+import IconFont from "../../../components/ui/IconFont";
 import I18n from "../../../i18n";
 import { H3 } from "../../../components/core/typography/H3";
 import { H5 } from "../../../components/core/typography/H5";
@@ -33,7 +36,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-between"
   },
-  logo: { width: 80, height: 40, resizeMode: "cover" }
+  logo: { width: 80, height: 40, resizeMode: "cover", marginRight: 16 }
 });
 
 const getMethods = (props: Props): ReadonlyArray<DigitalPaymentItem> => [
@@ -68,11 +71,12 @@ const DigitalMethodsList = (props: Props) => (
     renderItem={({ item }: ListRenderItemInfo<DigitalPaymentItem>) =>
       item.implemented && (
         <ListItem style={styles.listItem} onPress={item.onPress}>
-          <View>
+          <View style={IOStyles.flex}>
             <H3>{item.name}</H3>
             {item.subtitle && <H5 weight={"Regular"}>{item.subtitle}</H5>}
           </View>
           {item.logo && <Image source={item.logo} style={styles.logo} />}
+          <IconFont name={"io-right"} color={IOColors.blue} size={24} />
         </ListItem>
       )
     }

--- a/ts/features/wallet/onboarding/satispay/screens/StartSatispaySearchScreen.tsx
+++ b/ts/features/wallet/onboarding/satispay/screens/StartSatispaySearchScreen.tsx
@@ -1,9 +1,8 @@
 import { View } from "native-base";
 import * as React from "react";
-import { Image, SafeAreaView, ScrollView } from "react-native";
+import { SafeAreaView, ScrollView, StyleSheet } from "react-native";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
-import { StyleSheet } from "react-native";
 import { Body } from "../../../../../components/core/typography/Body";
 import { H1 } from "../../../../../components/core/typography/H1";
 import { Link } from "../../../../../components/core/typography/Link";
@@ -24,13 +23,12 @@ import {
   walletAddSatispayBack,
   walletAddSatispayCancel
 } from "../store/actions";
-import satispayLogo from "../../../../../../img/wallet/payment-methods/satispay-logo.png";
 
 export type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
 
 const styles = StyleSheet.create({
-  title: { flex: 1, paddingRight: 16, marginTop: -8 },
+  title: { flex: 1, paddingRight: 16 },
   image: { width: 100, height: 25 },
   row: { flexDirection: "row", flex: 1 }
 });
@@ -63,11 +61,6 @@ const StartSatispaySearchScreen: React.FunctionComponent<Props> = props => {
             <View spacer={true} large={true} />
             <View style={styles.row}>
               <H1 style={styles.title}>{title}</H1>
-              <Image
-                source={satispayLogo}
-                style={styles.image}
-                resizeMode={"contain"}
-              />
             </View>
             <View spacer={true} large={true} />
             <Body>{body}</Body>

--- a/ts/features/wallet/onboarding/satispay/screens/add/AddSatispayScreen.tsx
+++ b/ts/features/wallet/onboarding/satispay/screens/add/AddSatispayScreen.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { SafeAreaView, ScrollView } from "react-native";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
+import { StyleSheet } from "react-native";
 import { Satispay } from "../../../../../../../definitions/pagopa/walletv2/Satispay";
 import { H1 } from "../../../../../../components/core/typography/H1";
 import { IOStyles } from "../../../../../../components/core/variables/IOStyles";
@@ -33,6 +34,12 @@ import LoadAddSatispayComponent from "./LoadAddSatispayComponent";
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
 
+const styles = StyleSheet.create({
+  center: {
+    alignSelf: "center"
+  }
+});
+
 const loadLocales = () => ({
   headerTitle: I18n.t("wallet.onboarding.satispay.headerTitle"),
   title: I18n.t("wallet.onboarding.satispay.add.title")
@@ -52,7 +59,9 @@ const DisplayFoundSatispay = (props: Props) => {
             <View spacer={true} />
             <H1>{title}</H1>
             <View spacer={true} extralarge={true} />
-            <SatispayCard />
+            <View style={styles.center}>
+              <SatispayCard />
+            </View>
           </View>
         </ScrollView>
         <FooterWithButtons

--- a/ts/features/wallet/satispay/screen/SatispayDetailScreen.tsx
+++ b/ts/features/wallet/satispay/screen/SatispayDetailScreen.tsx
@@ -71,11 +71,6 @@ const SatispayDetailScreen: React.FunctionComponent<Props> = props => {
       allowGoBack={true}
       topContent={<View style={styles.headerSpacer} />}
       gradientHeader={true}
-      footerContent={
-        <UnsubscribeButton
-          onPress={() => present(() => props.deleteWallet(satispay.idWallet))}
-        />
-      }
       hideHeader={true}
     >
       <View style={styles.cardContainer}>
@@ -86,6 +81,10 @@ const SatispayDetailScreen: React.FunctionComponent<Props> = props => {
         <PaymentMethodCapabilities paymentMethod={satispay} />
         <View spacer={true} />
         <SatispayInformation />
+        <View spacer={true} large={true} />
+        <UnsubscribeButton
+          onPress={() => present(() => props.deleteWallet(satispay.idWallet))}
+        />
       </View>
       <View spacer={true} extralarge={true} />
     </DarkLayout>


### PR DESCRIPTION
## Short description
This pr changes the Satispay screens with some graphical refinements.

## List of changes proposed in this pull request
- Add right arrow to `DigitalMethodsList.tsx`
![Schermata 2020-12-17 alle 17 09 38](https://user-images.githubusercontent.com/26501317/102512730-a605e200-408a-11eb-9b8c-9089c385ce42.png)
- Remove Satispay logo from `StartSatispaySearchScreen.tsx`
<img src=https://user-images.githubusercontent.com/26501317/102512794-ba49df00-408a-11eb-84b5-2cb71bb9ce28.png width=300 />

- Center Satispay card in `AddSatispayScreen.tsx`
<img src=https://user-images.githubusercontent.com/26501317/102512946-e6656000-408a-11eb-9cc9-dca46e0b4792.png width=300 />

- Make the "Remove payment method" button not sticky in `SatispayDetailScreen`
<img src=https://user-images.githubusercontent.com/26501317/102513055-072db580-408b-11eb-849b-4bb2f2acfa8b.png width=300 />
