### PR TITLE
fix: [#176068510] Removed status message in edit email screen

### DIFF
--- a/ts/screens/onboarding/EmailInsertScreen.tsx
+++ b/ts/screens/onboarding/EmailInsertScreen.tsx
@@ -37,7 +37,6 @@ import customVariables from "../../theme/variables";
 import { areStringsEqual } from "../../utils/options";
 import { showToast } from "../../utils/showToast";
 import { withKeyboard } from "../../utils/keyboard";
-import SectionStatusComponent from "../../components/SectionStatusComponent";
 
 type Props = ReduxProps &
   ReturnType<typeof mapDispatchToProps> &
@@ -302,7 +301,7 @@ class EmailInsertScreen extends React.PureComponent<Props, State> {
             </View>
           </Content>
         </View>
-        
+
         {withKeyboard(this.renderFooterButtons())}
       </BaseScreenComponent>
     );

--- a/ts/screens/onboarding/EmailInsertScreen.tsx
+++ b/ts/screens/onboarding/EmailInsertScreen.tsx
@@ -302,7 +302,7 @@ class EmailInsertScreen extends React.PureComponent<Props, State> {
             </View>
           </Content>
         </View>
-        <SectionStatusComponent sectionKey={"email_validation"} />
+        
         {withKeyboard(this.renderFooterButtons())}
       </BaseScreenComponent>
     );


### PR DESCRIPTION
## Short description
Message covered the input field.

## List of changes proposed in this pull request

Before:
<img width="429" alt="before" src="https://user-images.githubusercontent.com/26572302/103206827-0acc0280-48fd-11eb-8c9d-2b4f8b6e07b1.png">


After:
<img width="429" alt="after" src="https://user-images.githubusercontent.com/26572302/103206809-fe47aa00-48fc-11eb-8a4e-274698e3cead.png">





## How to test

1. Go to Profile -> Preferences -> Email Address -> Edit email
2. Focus the input field to expand the keyboard