### PR TITLE
feat: [#176222893] increased delay between user profile activation retries

### DIFF
--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -6,6 +6,7 @@ import { NavigationActions, NavigationState } from "react-navigation";
 import {
   call,
   cancel,
+  delay,
   Effect,
   fork,
   put,
@@ -58,7 +59,6 @@ import { profileSelector } from "../store/reducers/profile";
 import { PinString } from "../types/PinString";
 import { SagaCallReturnType } from "../types/utils";
 import { deletePin, getPin } from "../utils/keychain";
-import { startTimer } from "../utils/timer";
 import { watchBonusBpdSaga } from "../features/bonus/bpd/saga";
 import I18n from "../i18n";
 import {
@@ -99,7 +99,7 @@ import {
 import { watchWalletSaga } from "./wallet";
 import { watchProfileEmailValidationChangedSaga } from "./watchProfileEmailValidationChangedSaga";
 
-const WAIT_INITIALIZE_SAGA = 3000 as Millisecond;
+const WAIT_INITIALIZE_SAGA = 5000 as Millisecond;
 /**
  * Handles the application startup and the main application logic loop
  */
@@ -214,7 +214,7 @@ export function* initializeApplicationSaga(): Generator<Effect, void, any> {
 
   if (isNone(maybeUserProfile)) {
     // Start again if we can't load the profile but wait a while
-    yield call(startTimer, WAIT_INITIALIZE_SAGA);
+    yield delay(WAIT_INITIALIZE_SAGA);
     yield put(startApplicationInitialization());
     return;
   }


### PR DESCRIPTION
## Short description
As of now, If profile activation fails, the operation is retried after 3 seconds.

## List of changes proposed in this pull request
- Delay is increased to 5 seconds
- No need to use `startTimer`, we'd better use `redux-saga`'s `delay` helper

## How to test
- Run the app, login
- Stop the dev server
- Reload the app from the simulator
- In Reactotron you should see the target actions being dispatched 5 seconds apart, see the two groups:

<img width="636" alt="Schermata 2020-12-31 alle 17 36 38" src="https://user-images.githubusercontent.com/26572302/103418867-d1abc080-4b90-11eb-8516-a3c893528ec4.png">



