### PR TITLE
fix(Bonus Pagamenti Digitali): [#176338423] Wrong cashback detail by selecting card preview

### DIFF
--- a/ts/features/bonus/bpd/screens/details/BpdPeriodSelector.tsx
+++ b/ts/features/bonus/bpd/screens/details/BpdPeriodSelector.tsx
@@ -63,7 +63,7 @@ const BpdPeriodSelector: React.FunctionComponent<Props> = props => {
 
   const indexOfSelectedPeriod = findIndex(
     periodWithAmountList,
-    elem => elem === props.selectedPeriod
+    elem => elem.awardPeriodId === props.selectedPeriod?.awardPeriodId
   ).getOrElse(0);
 
   return (


### PR DESCRIPTION
## Short description
This PR fixes a bug that shows the wrong detail on selecting cashback period

### how to reproduce the bug
- load the cashback periods (at least 2 periods)
- open both periods from wallet (now it works as expected)
- load bonus from wallet (refresh)
- the bug is on: by selecting the preview always the 0-indexed period will be shown
