### PR TITLE
feat: [#176299898] Amex warning (transaction >1000 EUR)

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -835,6 +835,7 @@ wallet:
     messagePagoPaUpdateApp: "IO often introduces small improvements and new features: to continue using the wallet you need to update the app to the latest version."
     btnUpdateApp: Update the IO app
     favourite: This method is already set as favourite. To change this, please set another method as favourite.
+    amex: Payments with American Express cards, for amounts above €1000, are currently not possible.
   contextualHelpTitle: About this section
   contextualHelpContent: !include wallet/wallet_home.md
   creditcards: Credit Cards

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -855,6 +855,7 @@ wallet:
     messagePagoPaUpdateApp: "IO introduce spesso piccole migliorie e nuove funzioni: per continuare ad usare il portafoglio è necessario aggiornare l'applicazione all'ultima versione."
     btnUpdateApp: Aggiorna l'app IO
     favourite: Questo metodo di pagamento è già contrassegnato come il tuo preferito, se vuoi cambiarlo devi selezionarne un altro
+    amex: I pagamenti con carte American Express, per importi superiori a €1000, non sono al momento possibili
   contextualHelpTitle: Cosa puoi fare nel tuo Portafoglio
   contextualHelpContent: !include wallet/wallet_home.md
   creditcards: Carte di Credito

--- a/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
@@ -20,6 +20,7 @@ import CardComponent from "../../../components/wallet/card/CardComponent";
 import PaymentBannerComponent from "../../../components/wallet/PaymentBannerComponent";
 import { InfoBox } from "../../../components/box/InfoBox";
 import { IOColors } from "../../../components/core/variables/IOColors";
+import { Label } from "../../../components/core/typography/Label";
 
 import I18n from "../../../i18n";
 import {
@@ -54,8 +55,7 @@ const styles = StyleSheet.create({
   },
   infoBoxContainer: { padding: 20, backgroundColor: IOColors.orange },
   infoBoxMessage: {
-    color: IOColors.white,
-    backgroundColor: IOColors.orange
+    color: IOColors.white
   }
 });
 
@@ -63,6 +63,8 @@ const contextualHelpMarkdown: ContextualHelpPropsMarkdown = {
   title: "wallet.payWith.contextualHelpTitle",
   body: "wallet.payWith.contextualHelpContent"
 };
+
+const amexPaymentWarningTreshold = 100000; // Eurocents
 
 class PickPaymentMethodScreen extends React.Component<Props> {
   public render(): React.ReactNode {
@@ -125,12 +127,12 @@ class PickPaymentMethodScreen extends React.Component<Props> {
         <View spacer={true} />
 
         {wallets.some(myWallet => myWallet.creditCard?.brand === "AMEX") &&
-          verifica.importoSingoloVersamento >= 100000 && (
+          verifica.importoSingoloVersamento >= amexPaymentWarningTreshold && (
             <View style={styles.infoBoxContainer}>
               <InfoBox alignedCentral={true} iconColor={IOColors.white}>
-                <Text style={styles.infoBoxMessage}>
+                <Label weight={"Regular"} color="white">
                   {I18n.t("wallet.alert.amex")}
-                </Text>
+                </Label>
               </InfoBox>
             </View>
           )}

--- a/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
@@ -51,6 +51,11 @@ const styles = StyleSheet.create({
   paddedLR: {
     paddingLeft: variables.contentPadding,
     paddingRight: variables.contentPadding
+  },
+  infoBoxContainer: { padding: 20, backgroundColor: IOColors.orange },
+  infoBoxMessage: {
+    color: IOColors.white,
+    backgroundColor: IOColors.orange
   }
 });
 
@@ -120,15 +125,10 @@ class PickPaymentMethodScreen extends React.Component<Props> {
         <View spacer={true} />
 
         {wallets.some(myWallet => myWallet.creditCard?.brand === "AMEX") &&
-          verifica.importoSingoloVersamento >= 1000 && (
-            <View style={{ padding: 20, backgroundColor: IOColors.orange }}>
+          verifica.importoSingoloVersamento >= 100000 && (
+            <View style={styles.infoBoxContainer}>
               <InfoBox alignedCentral={true} iconColor={IOColors.white}>
-                <Text
-                  style={{
-                    color: IOColors.white,
-                    backgroundColor: IOColors.orange
-                  }}
-                >
+                <Text style={styles.infoBoxMessage}>
                   {I18n.t("wallet.alert.amex")}
                 </Text>
               </InfoBox>

--- a/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
@@ -127,7 +127,7 @@ class PickPaymentMethodScreen extends React.Component<Props> {
                 backgroundColor: IOColors.orange
               }}
             >
-              {I18n.t("bonus.bpd.details.components.iban.noIbanBody")}
+              {I18n.t("wallet.alert.amex")}
             </Text>
           </InfoBox>
         </View>

--- a/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
@@ -53,10 +53,7 @@ const styles = StyleSheet.create({
     paddingLeft: variables.contentPadding,
     paddingRight: variables.contentPadding
   },
-  infoBoxContainer: { padding: 20, backgroundColor: IOColors.orange },
-  infoBoxMessage: {
-    color: IOColors.white
-  }
+  infoBoxContainer: { padding: 20, backgroundColor: IOColors.orange }
 });
 
 const contextualHelpMarkdown: ContextualHelpPropsMarkdown = {

--- a/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
@@ -119,19 +119,21 @@ class PickPaymentMethodScreen extends React.Component<Props> {
 
         <View spacer={true} />
 
-        <View style={{ padding: 20, backgroundColor: IOColors.orange }}>
-          <InfoBox alignedCentral={true} iconColor={IOColors.white}>
-            <Text
-              style={{
-                color: IOColors.white,
-                backgroundColor: IOColors.orange
-              }}
-            >
-              {I18n.t("wallet.alert.amex")}
-            </Text>
-          </InfoBox>
-        </View>
-
+        {wallets.some(myWallet => myWallet.creditCard?.brand === "AMEX") &&
+          verifica.importoSingoloVersamento >= 1000 && (
+            <View style={{ padding: 20, backgroundColor: IOColors.orange }}>
+              <InfoBox alignedCentral={true} iconColor={IOColors.white}>
+                <Text
+                  style={{
+                    color: IOColors.white,
+                    backgroundColor: IOColors.orange
+                  }}
+                >
+                  {I18n.t("wallet.alert.amex")}
+                </Text>
+              </InfoBox>
+            </View>
+          )}
         <FooterWithButtons
           type="TwoButtonsInlineThird"
           leftButton={secondaryButtonProps}

--- a/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/PickPaymentMethodScreen.tsx
@@ -18,6 +18,9 @@ import { EdgeBorderComponent } from "../../../components/screens/EdgeBorderCompo
 import FooterWithButtons from "../../../components/ui/FooterWithButtons";
 import CardComponent from "../../../components/wallet/card/CardComponent";
 import PaymentBannerComponent from "../../../components/wallet/PaymentBannerComponent";
+import { InfoBox } from "../../../components/box/InfoBox";
+import { IOColors } from "../../../components/core/variables/IOColors";
+
 import I18n from "../../../i18n";
 import {
   navigateToPaymentTransactionSummaryScreen,
@@ -115,6 +118,19 @@ class PickPaymentMethodScreen extends React.Component<Props> {
         </Content>
 
         <View spacer={true} />
+
+        <View style={{ padding: 20, backgroundColor: IOColors.orange }}>
+          <InfoBox alignedCentral={true} iconColor={IOColors.white}>
+            <Text
+              style={{
+                color: IOColors.white,
+                backgroundColor: IOColors.orange
+              }}
+            >
+              {I18n.t("bonus.bpd.details.components.iban.noIbanBody")}
+            </Text>
+          </InfoBox>
+        </View>
 
         <FooterWithButtons
           type="TwoButtonsInlineThird"


### PR DESCRIPTION
## Short description
This PR adds an InfoBox in PickPaymentMethod Screen to warn AMEX users of limits affecting their transactions 

## List of changes proposed in this pull request
- Added an `InfoBox `in `PickPaymentMethodScreen`

## How to test
Visual Test: please see the attached images
Before delivery, a test in production with a real card and real payment is needed

- Test 1: No AMEX, Amount > 1000 EUR
<img src="https://user-images.githubusercontent.com/8901084/103596176-9812e680-4efd-11eb-858d-d9428f69bbb6.png" width=300/>
- Test 2: No AMEX, Amount < 1000 EUR
<img src="https://user-images.githubusercontent.com/8901084/103596279-dad4be80-4efd-11eb-9b04-9a268cce5d3c.png" width=300 />
- Test 3: Si AMEX, Amount < 1000 EUR
<img src="https://user-images.githubusercontent.com/8901084/103596702-ccd36d80-4efe-11eb-9b80-862ff4e61d80.png" width=300 />
- Test 4: Si AMEX, Amount > 1000 EUR
<img src="https://user-images.githubusercontent.com/8901084/103596774-fa201b80-4efe-11eb-953a-08d3fcc5bf34.png" width=300 />





