### PR TITLE
feat(Payments): [#176364017] Use /v1/psps/selected instead of deprecated /v1/psps

### DIFF
--- a/ts/api/pagopa.ts
+++ b/ts/api/pagopa.ts
@@ -49,6 +49,7 @@ import {
   GetPspListUsingGETT,
   getPspUsingGETDecoder,
   GetPspUsingGETT,
+  getSelectedPspUsingGETDecoder,
   getTransactionsUsingGETDecoder,
   getTransactionUsingGETDecoder,
   GetTransactionUsingGETT,
@@ -270,6 +271,33 @@ const getPspList: GetPspListUsingGETTExtra = {
         },
   headers: ParamAuthorizationBearerHeader,
   response_decoder: getPspListUsingGETDecoder(PspListResponse)
+};
+
+export type GetSelectedPspUsingGETTExtra = r.IGetApiRequestType<
+  {
+    readonly Bearer: string;
+    readonly idWallet: string;
+    readonly idPayment: string;
+    readonly language: string;
+  },
+  "Authorization",
+  never,
+  | r.IResponseType<200, PspListResponse>
+  | r.IResponseType<401, undefined>
+  | r.IResponseType<403, undefined>
+  | r.IResponseType<404, undefined>
+>;
+
+const getPspSelected: GetSelectedPspUsingGETTExtra = {
+  method: "get",
+  url: () => "/v1/psps/selected",
+  query: ({ idPayment, idWallet, language }) => ({
+    idPayment,
+    idWallet,
+    language
+  }),
+  headers: ParamAuthorizationBearerHeader,
+  response_decoder: getSelectedPspUsingGETDecoder(PspListResponse)
 };
 
 type GetAllPspListUsingGETTExtra = MapResponseType<
@@ -534,6 +562,19 @@ export function PaymentManagerClient(
       flip(
         withPaymentManagerToken(
           createFetchRequestForApi(getAllPspList, options)
+        )
+      )({
+        idPayment,
+        idWallet,
+        language: getLocalePrimaryWithFallback()
+      }),
+    getPspSelected: (
+      idPayment: TypeofApiParams<GetAllPspsUsingGETT>["idPayment"],
+      idWallet: TypeofApiParams<GetAllPspsUsingGETT>["idWallet"]
+    ) =>
+      flip(
+        withPaymentManagerToken(
+          createFetchRequestForApi(getPspSelected, options)
         )
       )({
         idPayment,

--- a/ts/api/pagopa.ts
+++ b/ts/api/pagopa.ts
@@ -273,13 +273,14 @@ const getPspList: GetPspListUsingGETTExtra = {
   response_decoder: getPspListUsingGETDecoder(PspListResponse)
 };
 
+type PspParams = {
+  readonly Bearer: string;
+  readonly idWallet: string;
+  readonly idPayment: string;
+  readonly language: string;
+};
 export type GetSelectedPspUsingGETTExtra = r.IGetApiRequestType<
-  {
-    readonly Bearer: string;
-    readonly idWallet: string;
-    readonly idPayment: string;
-    readonly language: string;
-  },
+  PspParams,
   "Authorization",
   never,
   | r.IResponseType<200, PspListResponse>
@@ -287,15 +288,18 @@ export type GetSelectedPspUsingGETTExtra = r.IGetApiRequestType<
   | r.IResponseType<403, undefined>
   | r.IResponseType<404, undefined>
 >;
-
-const getPspSelected: GetSelectedPspUsingGETTExtra = {
-  method: "get",
-  url: () => "/v1/psps/selected",
-  query: ({ idPayment, idWallet, language }) => ({
+const getPspQuery = (params: PspParams) => {
+  const { idPayment, idWallet, language } = params;
+  return {
     idPayment,
     idWallet,
     language
-  }),
+  };
+};
+const getPspSelected: GetSelectedPspUsingGETTExtra = {
+  method: "get",
+  url: () => "/v1/psps/selected",
+  query: getPspQuery,
   headers: ParamAuthorizationBearerHeader,
   response_decoder: getSelectedPspUsingGETDecoder(PspListResponse)
 };
@@ -309,11 +313,7 @@ type GetAllPspListUsingGETTExtra = MapResponseType<
 const getAllPspList: GetAllPspListUsingGETTExtra = {
   method: "get",
   url: () => "/v1/psps/all",
-  query: ({ idPayment, idWallet, language }) => ({
-    idPayment,
-    idWallet,
-    language
-  }),
+  query: getPspQuery,
   headers: ParamAuthorizationBearerHeader,
   response_decoder: getPspListUsingGETDecoder(PspListResponse)
 };

--- a/ts/sagas/wallet/pagopaApis.ts
+++ b/ts/sagas/wallet/pagopaApis.ts
@@ -435,14 +435,16 @@ export function* paymentFetchPspsForWalletRequestHandler(
   pmSessionManager: SessionManager<PaymentManagerToken>,
   action: ActionType<typeof paymentFetchPspsForPaymentId["request"]>
 ) {
-  const apiGetPspList = pagoPaClient.getPspList(
+  const apiGetPspSelected = pagoPaClient.getPspSelected(
     action.payload.idPayment,
-    action.payload.idWallet
+    action.payload.idWallet.toString()
   );
-  const getPspListWithRefresh = pmSessionManager.withRefresh(apiGetPspList);
+  const apiGetPspSelectedWithRefresh = pmSessionManager.withRefresh(
+    apiGetPspSelected
+  );
   try {
-    const response: SagaCallReturnType<typeof getPspListWithRefresh> = yield call(
-      getPspListWithRefresh
+    const response: SagaCallReturnType<typeof apiGetPspSelectedWithRefresh> = yield call(
+      apiGetPspSelectedWithRefresh
     );
     if (response.isRight()) {
       if (response.value.status === 200) {

--- a/ts/screens/wallet/payment/common.ts
+++ b/ts/screens/wallet/payment/common.ts
@@ -85,8 +85,6 @@ export const dispatchPickPspOrConfirm = (dispatch: Dispatch) => (
     dispatch(
       paymentFetchPspsForPaymentId.request({
         idPayment,
-        // provide the idWallet to the getPsps request only if the wallet has
-        // a preferred PSP
         idWallet: selectedWallet.idWallet,
         onFailure: () => onFailure("FETCH_PSPS_FAILURE"),
         onSuccess: successAction => {

--- a/ts/screens/wallet/payment/common.ts
+++ b/ts/screens/wallet/payment/common.ts
@@ -87,7 +87,7 @@ export const dispatchPickPspOrConfirm = (dispatch: Dispatch) => (
         idPayment,
         // provide the idWallet to the getPsps request only if the wallet has
         // a preferred PSP
-        idWallet: selectedWallet.psp ? selectedWallet.idWallet : undefined,
+        idWallet: selectedWallet.idWallet,
         onFailure: () => onFailure("FETCH_PSPS_FAILURE"),
         onSuccess: successAction => {
           // filter PSPs for the current locale only (the list will contain

--- a/ts/store/actions/wallet/payment.ts
+++ b/ts/store/actions/wallet/payment.ts
@@ -109,7 +109,7 @@ export const paymentCheck = createAsyncAction(
 
 type PaymentFetchPspsForPaymentIdRequestPayload = Readonly<{
   idPayment: string;
-  idWallet?: number;
+  idWallet: number;
   onSuccess?: (
     action: ActionType<typeof paymentFetchPspsForPaymentId["success"]>
   ) => void;


### PR DESCRIPTION
## Short description
This PR introduces the usage of `/v1/psps/selected` API in place of the deprecated one `/v1/psps` when the app asks for the `psp` during a payment flow
The behavior is pretty the same but the new one wants `idWallet` as required param
