### PR TITLE
fix(Bonus Pagamenti Digitali): [#176496182] SuggestBpdActivationScreen displays always a "pagoBANCOMAT" title

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -810,18 +810,6 @@ wallet:
         loading: "We are adding your PagoBANCOMAT card\n\nPlease hold on..."
         warning: "If you don't find all the cards of your own, you can try to add the missing one at a later time by selecting the Bank where you have your personal account."
         blocked: "This card is blocked and can't be activated for Cashback. Please, contact the card issuer."
-      bpd:
-        suggestActivation:
-          title: "Do you want to activate Cashback?"
-          body: "You have added payment methods compatible with Cashback, the initiative promoted by the Presidency of the Council of Ministers and the Ministry of Economy and Finance, to promote the use of electronic money in Italy.\n\n
-                 You can get a money refund when you shop using your cards and apps."
-          skip: "No, thanks"
-          confirm: "Info and activation"
-        activateNew:
-          title: "Do you want to activate Cashback?"
-          body1: "Turn on your methods saved into your wallet and start collecting cashback on your valid transactions."
-          body2: "If you prefer, you can activate cashback on these methods later as well."
-          skip: "Maybe later"
     bPay:
       headerTitle: "Add BANCOMAT Pay"
       loadingSearch: "We are recovering your BANCOMAT Pay data\n\nPlease wait"
@@ -1923,6 +1911,17 @@ bonus:
         title: "Almost there, activate Cashback on your payment methods!"
         body: "Enable Cashback on methods already in your wallet or add new ones."
         cta: "Activate payment methods"
+    suggestActivation:
+      title: "Do you want to activate Cashback?"
+      body: "You have added payment methods compatible with Cashback, the initiative promoted by the Presidency of the Council of Ministers and the Ministry of Economy and Finance, to promote the use of electronic money in Italy.\n\n
+             You can get a money refund when you shop using your cards and apps."
+      skip: "No, thanks"
+      confirm: "Info and activation"
+    activateOnNewMethods:
+      title: "Do you want to activate Cashback?"
+      body1: "Turn on your methods saved into your wallet and start collecting cashback on your valid transactions."
+      body2: "If you prefer, you can activate cashback on these methods later as well."
+      skip: "Maybe later"
     iban:
       cta:
         bpdNotActiveTitle: "attention"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -830,18 +830,6 @@ wallet:
         loading: "Stiamo aggiungendo la tua carta PagoBANCOMAT\n\nAttendi qualche secondo..."
         warning: "Se non trovi tutte le carte che possiedi, prova ad aggiungere quella mancante in un secondo momento, selezionando la Banca presso cui hai il tuo conto corrente."
         blocked: "Questa carta risulta bloccata e pertanto non può essere attivata ai fini del Cashback. Contatta la tua banca."
-      bpd:
-        suggestActivation:
-          title: "Vuoi attivare il Cashback?"
-          body: "Hai aggiunto dei metodi di pagamento compatibili con il Cashback, l’iniziativa promossa dalla Presidenza del Consiglio dei Ministri e dal Ministero dell’Economia e delle Finanze, allo scopo di incentivare un maggiore utilizzo di moneta elettronica nel Paese.\n\n
-                 Puoi ricevere un rimborso sugli acquisti effettuati con carte, bancomat e app di pagamento.\n\n"
-          skip: "No, grazie"
-          confirm: "Info e attivazione"
-        activateNew:
-          title: "Vuoi attivare il Cashback?"
-          body1: "Attiva il Cashback sui metodi salvati nel tuo portafoglio per iniziare a collezionare le transazioni valide."
-          body2: "Se preferisci, puoi attivare il Cashback su questi metodi anche in un secondo momento."
-          skip: "Non ora"
     bPay:
       headerTitle: "Aggiungi BANCOMAT Pay"
       loadingSearch: "Stiamo recuperando i tuoi dati BANCOMAT Pay\n\nAttendi qualche secondo"
@@ -1954,6 +1942,17 @@ bonus:
         title: "Ci siamo quasi, attiva il Cashback sui tuoi metodi di pagamento!"
         body: "Abilita il Cashback sui metodi già presenti nel tuo portafoglio o aggiungine di nuovi."
         cta: "Attiva i metodi di pagamento"
+    suggestActivation:
+      title: "Vuoi attivare il Cashback?"
+      body: "Hai aggiunto dei metodi di pagamento compatibili con il Cashback, l’iniziativa promossa dalla Presidenza del Consiglio dei Ministri e dal Ministero dell’Economia e delle Finanze, allo scopo di incentivare un maggiore utilizzo di moneta elettronica nel Paese.\n\n
+             Puoi ricevere un rimborso sugli acquisti effettuati con carte, bancomat e app di pagamento.\n\n"
+      skip: "No, grazie"
+      confirm: "Info e attivazione"
+    activateOnNewMethods:
+      title: "Vuoi attivare il Cashback?"
+      body1: "Attiva il Cashback sui metodi salvati nel tuo portafoglio per iniziare a collezionare le transazioni valide."
+      body2: "Se preferisci, puoi attivare il Cashback su questi metodi anche in un secondo momento."
+      skip: "Non ora"
     iban:
       cta:
         bpdNotActiveTitle: "attenzione"

--- a/ts/features/wallet/onboarding/common/screens/bpd/ActivateBpdOnNewPaymentMethodScreen.tsx
+++ b/ts/features/wallet/onboarding/common/screens/bpd/ActivateBpdOnNewPaymentMethodScreen.tsx
@@ -26,10 +26,10 @@ export type Props = ReturnType<typeof mapDispatchToProps> &
   Pick<React.ComponentProps<typeof BaseScreenComponent>, "contextualHelp">;
 
 const loadLocales = () => ({
-  title: I18n.t("wallet.onboarding.bancomat.bpd.activateNew.title"),
-  body1: I18n.t("wallet.onboarding.bancomat.bpd.activateNew.body1"),
-  body2: I18n.t("wallet.onboarding.bancomat.bpd.activateNew.body2"),
-  skip: I18n.t("wallet.onboarding.bancomat.bpd.activateNew.skip"),
+  title: I18n.t("bonus.bpd.activateOnNewMethods.title"),
+  body1: I18n.t("bonus.bpd.activateOnNewMethods.body1"),
+  body2: I18n.t("bonus.bpd.activateOnNewMethods.body2"),
+  skip: I18n.t("bonus.bpd.activateOnNewMethods.skip"),
   continueStr: I18n.t("global.buttons.continue")
 });
 

--- a/ts/features/wallet/onboarding/common/screens/bpd/SuggestBpdActivationScreen.tsx
+++ b/ts/features/wallet/onboarding/common/screens/bpd/SuggestBpdActivationScreen.tsx
@@ -18,11 +18,11 @@ export type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
 
 const loadLocales = () => ({
-  headerTitle: I18n.t("wallet.onboarding.bancomat.headerTitle"),
-  title: I18n.t("wallet.onboarding.bancomat.bpd.suggestActivation.title"),
-  body: I18n.t("wallet.onboarding.bancomat.bpd.suggestActivation.body"),
-  skip: I18n.t("wallet.onboarding.bancomat.bpd.suggestActivation.skip"),
-  confirm: I18n.t("wallet.onboarding.bancomat.bpd.suggestActivation.confirm")
+  headerTitle: I18n.t("bonus.bpd.title"),
+  title: I18n.t("bonus.bpd.suggestActivation.title"),
+  body: I18n.t("bonus.bpd.suggestActivation.body"),
+  skip: I18n.t("bonus.bpd.suggestActivation.skip"),
+  confirm: I18n.t("bonus.bpd.suggestActivation.confirm")
 });
 
 /**


### PR DESCRIPTION
## Short description
This pr fixes the wrong title for `SuggestBpdActivationScreen`.

Before            |  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/26501317/104586472-cca54180-5665-11eb-9da3-058836d0911c.png" width="300">|  <img src="https://user-images.githubusercontent.com/26501317/104586543-e3e42f00-5665-11eb-8927-cb5c12b5690e.png" width="300">

## List of changes proposed in this pull request
- Moved locales from`wallet.onboarding.bancomat.bpd.suggestActivation` to `bonus.bpd.suggestActivation`
- Moved locales from `wallet.onboarding.bancomat.bpd.activateNew` to `bonus.bpd.activateOnNewMethods`
- Changed the screen title from `wallet.onboarding.bancomat.headerTitle` to `bonus.bpd.title`
