### PR TITLE
chore(Bonus Pagamenti Digitali): [#176498731] Add new bpd ranking config flag

### DIFF
--- a/ts/features/bonus/bpd/screens/details/components/summary/ranking/SuperCashbackRankingSummary.tsx
+++ b/ts/features/bonus/bpd/screens/details/components/summary/ranking/SuperCashbackRankingSummary.tsx
@@ -151,7 +151,7 @@ const SuperCashbackRankingSummary = (props: Props): React.ReactElement =>
 const mapDispatchToProps = (_: Dispatch) => ({});
 
 const mapStateToProps = (state: GlobalState) => ({
-  rankingRemoteEnabled: configSelector("bpd_ranking")(state)
+  rankingRemoteEnabled: configSelector("bpd_ranking_v2")(state)
 });
 
 export default connect(

--- a/ts/store/reducers/__mock__/backendStatus.ts
+++ b/ts/store/reducers/__mock__/backendStatus.ts
@@ -158,6 +158,6 @@ export const withBpdRankingConfig = (
   ...baseState,
   status: baseState.status.map(s => ({
     ...s,
-    config: { bpd_ranking: newConfig }
+    config: { bpd_ranking: newConfig, bpd_ranking_v2: newConfig }
   }))
 });

--- a/ts/store/reducers/__tests__/backendStatus.test.ts
+++ b/ts/store/reducers/__tests__/backendStatus.test.ts
@@ -234,27 +234,27 @@ describe("test selectors", () => {
   });
 
   it("should return undefined - configSelector", () => {
-    const config = configSelector("bpd_ranking")(noneStore);
+    const config = configSelector("bpd_ranking_v2")(noneStore);
     expect(config).toBeUndefined();
   });
 
   it("should return true - someStoreConfig", () => {
     const someStoreConfig = ({
       backendStatus: {
-        status: some({ ...status, config: { bpd_ranking: true } })
+        status: some({ ...status, config: { bpd_ranking_v2: true } })
       }
     } as any) as GlobalState;
-    const bpd_ranking = configSelector("bpd_ranking")(someStoreConfig);
+    const bpd_ranking = configSelector("bpd_ranking_v2")(someStoreConfig);
     expect(bpd_ranking).toBeTruthy();
   });
 
   it("should return false - someStoreConfig", () => {
     const someStoreConfig = ({
       backendStatus: {
-        status: some({ ...status, config: { bpd_ranking: false } })
+        status: some({ ...status, config: { bpd_ranking_v2: false } })
       }
     } as any) as GlobalState;
-    const bpd_ranking = configSelector("bpd_ranking")(someStoreConfig);
+    const bpd_ranking = configSelector("bpd_ranking_v2")(someStoreConfig);
     expect(bpd_ranking).toBeFalsy();
   });
 });

--- a/ts/types/backendStatus.ts
+++ b/ts/types/backendStatus.ts
@@ -53,7 +53,9 @@ export type Sections = t.TypeOf<typeof Sections>;
 
 // it represents a remote config to switch on/off a specific section,feature,module,etc
 const Config = t.interface({
-  bpd_ranking: t.boolean
+  // this flag is legacy, don't use it anymore see https://www.pivotaltracker.com/story/show/176498731
+  bpd_ranking: t.boolean,
+  bpd_ranking_v2: t.boolean
 });
 
 export type Config = t.TypeOf<typeof Config>;

--- a/ts/types/backendStatus.ts
+++ b/ts/types/backendStatus.ts
@@ -53,7 +53,7 @@ export type Sections = t.TypeOf<typeof Sections>;
 
 // it represents a remote config to switch on/off a specific section,feature,module,etc
 const Config = t.interface({
-  // this flag is legacy, don't use it anymore see https://www.pivotaltracker.com/story/show/176498731
+  // bpd_ranking is legacy, don't use it anymore see https://www.pivotaltracker.com/story/show/176498731
   bpd_ranking: t.boolean,
   bpd_ranking_v2: t.boolean
 });


### PR DESCRIPTION
## Short description
This PR introduces a new config flag about bdp ranking (super cashback)

### this PR is strictly related to https://github.com/pagopa/io-services-metadata/pull/214

#### how to test
- make sure to have last commit of io-dev-api-server (master branch)