### PR TITLE
feat: [#176434157] Remove payment CTA and expired badge

### DIFF
--- a/ts/components/DetailedlistItemComponent.tsx
+++ b/ts/components/DetailedlistItemComponent.tsx
@@ -17,7 +17,6 @@ type OwnProps = Readonly<{
   text2: string;
   text3: string;
   isNew: boolean;
-  isExpired?: boolean;
   isPaid?: boolean;
   onPressItem: () => void;
   onLongPressItem?: () => void;
@@ -86,7 +85,7 @@ const styles = StyleSheet.create({
   },
   text3SubContainer: { width: `95%` },
   badgeInfo: {
-    borderWidth: 1, 
+    borderWidth: 1,
     borderStyle: "solid",
     width: 65,
     height: 25,
@@ -97,8 +96,8 @@ const styles = StyleSheet.create({
     borderColor: IOColors.red
   },
   badgeInfoPaid: {
-    borderColor: IOColors.aqua, 
-    backgroundColor: IOColors.aqua,
+    borderColor: IOColors.aqua,
+    backgroundColor: IOColors.aqua
   }
 });
 
@@ -149,11 +148,6 @@ export default class DetailedlistItemComponent extends React.PureComponent<
           </View>
 
           <View style={styles.icon}>
-            {this.props.isExpired && (
-              <Badge style={[styles.badgeInfo, styles.badgeInfoExpired]}>
-                <H5 color="red">{I18n.t("messages.badge.expired")}</H5>
-              </Badge>
-            )}
             {this.props.isPaid && (
               <Badge style={[styles.badgeInfo, styles.badgeInfoPaid]}>
                 <H5 color="bluegreyDark">{I18n.t("messages.badge.paid")}</H5>

--- a/ts/components/messages/MessageListCTABar.tsx
+++ b/ts/components/messages/MessageListCTABar.tsx
@@ -24,7 +24,6 @@ import {
 import ExtractedCTABar from "../cta/ExtractedCTABar";
 import CalendarEventButton from "./CalendarEventButton";
 import CalendarIconComponent from "./CalendarIconComponent";
-import PaymentButton from "./PaymentButton";
 
 type OwnProps = {
   message: CreatedMessageWithContent;
@@ -130,25 +129,6 @@ class MessageListCTABar extends React.PureComponent<Props> {
           message={this.props.message}
         />
       ));
-  // Render a button to display details of the payment related to the message
-  private renderPaymentButton() {
-    // The button is displayed if the payment has an expiration date in the future or if is valid also after due date.
-    return this.paymentExpirationInfo.fold(undefined, pei => {
-      const { message, service, disabled } = this.props;
-      const { paid } = this;
-      return (
-        <PaymentButton
-          paid={paid}
-          messagePaymentExpirationInfo={pei}
-          small={true}
-          disabled={disabled}
-          service={service}
-          message={message}
-          enableAlertStyle={false}
-        />
-      );
-    });
-  }
 
   public render() {
     const calendarIcon = this.renderCalendarIcon();
@@ -175,7 +155,6 @@ class MessageListCTABar extends React.PureComponent<Props> {
           {calendarIcon && <View hspacer={true} small={true} />}
           {calendarEventButton}
           {calendarEventButton && <View hspacer={true} small={true} />}
-          {this.renderPaymentButton()}
         </>
       ));
     return (

--- a/ts/components/messages/MessageListCTABar.tsx
+++ b/ts/components/messages/MessageListCTABar.tsx
@@ -149,7 +149,7 @@ class MessageListCTABar extends React.PureComponent<Props> {
       ) : null;
     const content =
       nestedCTA ||
-      (isPaymentStillValid && (
+      (isPaymentStillValid && (calendarIcon || calendarEventButton) && (
         <>
           {calendarIcon}
           {calendarIcon && <View hspacer={true} small={true} />}
@@ -157,15 +157,21 @@ class MessageListCTABar extends React.PureComponent<Props> {
           {calendarEventButton && <View hspacer={true} small={true} />}
         </>
       ));
+    if (!content) {
+      return null;
+    }
     return (
-      <View
-        style={[styles.topContainer, this.paid && styles.topContainerPaid]}
-        accessible={false}
-        accessibilityElementsHidden={true}
-        importantForAccessibility={"no-hide-descendants"}
-      >
-        {content}
-      </View>
+      <>
+        <View spacer={true} large={true} />
+        <View
+          style={[styles.topContainer, this.paid && styles.topContainerPaid]}
+          accessible={false}
+          accessibilityElementsHidden={true}
+          importantForAccessibility={"no-hide-descendants"}
+        >
+          {content}
+        </View>
+      </>
     );
   }
 }

--- a/ts/components/messages/MessageListItem.tsx
+++ b/ts/components/messages/MessageListItem.tsx
@@ -14,7 +14,6 @@ import {
 } from "../../utils/convertDateToWordDistance";
 import {
   hasPrescriptionData,
-  isExpired,
   messageNeedsCTABar,
   paymentExpirationInfo
 } from "../../utils/messages";
@@ -50,9 +49,7 @@ class MessageListItem extends React.PureComponent<Props> {
   get paid(): boolean {
     return this.props.payment !== undefined;
   }
-  get isPaymentExpired() {
-    return this.paymentExpirationInfo.fold(false, isExpired);
-  }
+
   private handlePress = () => {
     this.props.onPress(this.props.message.id);
   };
@@ -107,7 +104,6 @@ class MessageListItem extends React.PureComponent<Props> {
         isSelectionModeEnabled={isSelectionModeEnabled}
         isItemSelected={isSelected}
         isPaid={this.paid}
-        isExpired={this.isPaymentExpired && !this.paid}
         accessible={true}
         accessibilityLabel={this.announceMessage({
           isRead,

--- a/ts/components/messages/MessageListItem.tsx
+++ b/ts/components/messages/MessageListItem.tsx
@@ -2,7 +2,6 @@
  * A component to display the list item in the MessagesHomeScreen
  */
 import { fromNullable } from "fp-ts/lib/Option";
-import { Text, View } from "native-base";
 import React from "react";
 import { CreatedMessageWithContentAndAttachments } from "../../../definitions/backend/CreatedMessageWithContentAndAttachments";
 import { ServicePublic } from "../../../definitions/backend/ServicePublic";

--- a/ts/components/messages/MessageListItem.tsx
+++ b/ts/components/messages/MessageListItem.tsx
@@ -2,7 +2,7 @@
  * A component to display the list item in the MessagesHomeScreen
  */
 import { fromNullable } from "fp-ts/lib/Option";
-import { View } from "native-base";
+import { Text, View } from "native-base";
 import React from "react";
 import { CreatedMessageWithContentAndAttachments } from "../../../definitions/backend/CreatedMessageWithContentAndAttachments";
 import { ServicePublic } from "../../../definitions/backend/ServicePublic";
@@ -113,7 +113,6 @@ class MessageListItem extends React.PureComponent<Props> {
       >
         {!hasPrescriptionData(message) && messageNeedsCTABar(message) && (
           <React.Fragment>
-            <View spacer={true} large={true} />
             <MessageListCTABar
               message={message}
               service={service}


### PR DESCRIPTION
## Short description
This PR removes these elements from the message list item

- payment CTA
- expired (expired & not paid payment advice) badge

### bug fix
- due to a bad logic, a spacer was rendered despite the content is empty

| before  | now |
| ------------- | ------------- |
![before](https://user-images.githubusercontent.com/822471/105329957-07612980-5bd2-11eb-8cb3-14166a1eed55.png) | ![now](https://user-images.githubusercontent.com/822471/105329978-0f20ce00-5bd2-11eb-9c33-d2444772ec56.png)

