### PR TITLE
fix: [#176607041] Hashed CF is reset on logout

### DIFF
--- a/ts/store/reducers/index.ts
+++ b/ts/store/reducers/index.ts
@@ -170,7 +170,8 @@ export function createRootReducer(
                 transactionsRead: state.entities.transactionsRead
               },
               // backend status must be kept
-              backendStatus: state.backendStatus
+              backendStatus: state.backendStatus,
+              crossSessions: state.crossSessions
             } as GlobalState)
           : state;
     }


### PR DESCRIPTION
## Short description
This PR keeps stored the hashed fiscal code on logout (hard logout)