### PR TITLE
chore(Bonus Pagamenti Digitali): [#176737219] milestone copy

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2038,8 +2038,8 @@ bonus:
               text4: "and collected "
               text5: "a cashback of "
             milestone:
-              title: "Congratulation, you earned {{cashbackValue}}"
-              body: "You have reached the maximum refund for this phase. Keep collecting valid transactions to climb the ranking!"
+              title: "Congratulation, you reached {{cashbackValue}}"
+              body: "You have reached the maximum amount for this phase. Keep collecting valid transactions to climb the ranking!"
           title: "Transaction details"
           paymentCircuit: "Payment circuit"
           transactionAmount: "Transaction amount"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2069,8 +2069,8 @@ bonus:
               text4: "e accumulato "
               text5: "un Cashback di "
             milestone:
-              title: "Complimenti, hai ottenuto {{cashbackValue}}"
-              body: "Hai raggiunto il rimborso massimo previsto in questo periodo. Continua ad accumulare transazioni valide per salire in classifica!"
+              title: "Complimenti, hai raggiunto {{cashbackValue}}"
+              body: "Hai raggiunto l'importo massimo previsto in questo periodo. Continua ad accumulare transazioni valide per salire in classifica!"
           title: "Dettaglio della transazione"
           paymentCircuit: "Circuito di pagamento"
           transactionAmount: "Importo transazione"


### PR DESCRIPTION
Changed text from "earned" to "reached", because reaching the €150 milestone doesn't necessarily mean earning the money (users still have to collect at least 50 transactions).