### PR TITLE
feat: [#174034081] Unlock code is persisted across logins if citizen doesn't change (2nd attempt)

### DIFF
--- a/ts/__mocks__/react-native-keychain.ts
+++ b/ts/__mocks__/react-native-keychain.ts
@@ -38,9 +38,11 @@ module.exports = {
     }
   ),
 
-  resetGenericPassword: jest.fn((options: Options) => {
-    // eslint-disable-next-line
-    delete keychainDB[options.service];
+  resetGenericPassword: jest.fn((options: Options | undefined) => {
+    if (options) {
+      // eslint-disable-next-line
+      delete keychainDB[options.service];
+    }
     return Promise.resolve(true);
   })
 };

--- a/ts/sagas/installation.ts
+++ b/ts/sagas/installation.ts
@@ -9,7 +9,6 @@ import {
 } from "../boot/scheduleLocalNotifications";
 import { sessionInvalid } from "../store/actions/authentication";
 import { isFirstRunAfterInstallSelector } from "../store/reducers/installation";
-import { deletePin } from "../utils/keychain";
 
 /**
  * This generator function removes user data from previous application
@@ -25,9 +24,6 @@ export function* previousInstallationDataDeleteSaga(): Generator<
   );
 
   if (isFirstRunAfterInstall) {
-    // Delete the current unlock code from the Keychain
-    // eslint-disable-next-line
-    yield call(deletePin);
     // invalidate the session
     yield put(sessionInvalid());
     // Remove all the notification already set

--- a/ts/sagas/profile.ts
+++ b/ts/sagas/profile.ts
@@ -52,6 +52,7 @@ import {
 } from "../store/actions/crossSessions";
 import { isDifferentFiscalCodeSelector } from "../store/reducers/crossSessions";
 import { isTestEnv } from "../utils/environment";
+import { deletePin } from "../utils/keychain";
 
 // A saga to load the Profile.
 export function* loadProfile(
@@ -330,6 +331,7 @@ function* checkStoreHashedFiscalCode(
   );
   // the current logged user has a different fiscal code from the stored hashed one
   if (checkIsDifferentFiscalCode === true) {
+    yield call(deletePin);
     yield put(differentProfileLoggedIn());
   }
   yield put(

--- a/ts/sagas/profile.ts
+++ b/ts/sagas/profile.ts
@@ -331,6 +331,7 @@ function* checkStoreHashedFiscalCode(
   );
   // the current logged user has a different fiscal code from the stored hashed one
   if (checkIsDifferentFiscalCode === true) {
+    // delete current store pin
     yield call(deletePin);
     yield put(differentProfileLoggedIn());
   }

--- a/ts/sagas/startup/watchSessionExpiredSaga.ts
+++ b/ts/sagas/startup/watchSessionExpiredSaga.ts
@@ -1,8 +1,7 @@
-import { call, Effect, put, takeLatest } from "redux-saga/effects";
+import { Effect, put, takeLatest } from "redux-saga/effects";
 import { getType } from "typesafe-actions";
 import { startApplicationInitialization } from "../../store/actions/application";
 import { sessionExpired } from "../../store/actions/authentication";
-import { deletePin } from "../../utils/keychain";
 import { clearCache } from "../../store/actions/profile";
 
 /**
@@ -11,7 +10,6 @@ import { clearCache } from "../../store/actions/profile";
 export function* watchSessionExpiredSaga(): IterableIterator<Effect> {
   yield takeLatest(getType(sessionExpired), function* () {
     // delete saved pin
-    yield call(deletePin);
     yield put(clearCache());
     // start again the application
     yield put(startApplicationInitialization());

--- a/ts/sagas/startup/watchSessionExpiredSaga.ts
+++ b/ts/sagas/startup/watchSessionExpiredSaga.ts
@@ -9,7 +9,6 @@ import { clearCache } from "../../store/actions/profile";
  */
 export function* watchSessionExpiredSaga(): IterableIterator<Effect> {
   yield takeLatest(getType(sessionExpired), function* () {
-    // delete saved pin
     yield put(clearCache());
     // start again the application
     yield put(startApplicationInitialization());


### PR DESCRIPTION
## Short description
It is now possible to log-out and log back in without resetting the unlock code, unless the SPID user is different.

## How to test
- Log-in and set an unlock code
- Log-out
- Log back in, no unlock code reset should be asked
- Log-out
- In `mock-server/src/global.ts` change the fiscal code and restart the mock server
- Log back in, you should be prompted to set a new unlock code
