### PR TITLE
fix: [#176778241] On bug report can't share the screenshot

### DIFF
--- a/ts/components/screens/BaseScreenComponent.tsx
+++ b/ts/components/screens/BaseScreenComponent.tsx
@@ -171,7 +171,7 @@ class BaseScreenComponent extends React.PureComponent<Props, State> {
         const { reportAttachmentTypes } = this.props;
         const { shouldAttachScreenshotToIBRequest } = this.state;
 
-        // if reportAttachmentTypes is undefined use the default config
+        // if reportAttachmentTypes is undefined use the default attachment config
         const attachmentConfig: DefaultReportAttachmentTypeConfiguration = {
           ...(reportAttachmentTypes ?? defaultAttachmentTypeConfiguration),
           screenshot: shouldAttachScreenshotToIBRequest ?? true

--- a/ts/components/screens/BaseScreenComponent.tsx
+++ b/ts/components/screens/BaseScreenComponent.tsx
@@ -19,7 +19,8 @@ import {
   DefaultReportAttachmentTypeConfiguration,
   setInstabugSupportTokenAttribute,
   TypeLogs,
-  instabugLog
+  instabugLog,
+  defaultAttachmentTypeConfiguration
 } from "../../boot/configureInstabug";
 import I18n from "../../i18n";
 import customVariables from "../../theme/variables";
@@ -170,18 +171,10 @@ class BaseScreenComponent extends React.PureComponent<Props, State> {
         const { reportAttachmentTypes } = this.props;
         const { shouldAttachScreenshotToIBRequest } = this.state;
 
-        // Do not ignore reportAttachmentTypes, but overwrite
-        // the screenshot variable if the form featured the checkbox
-        const attachmentConfig = {
-          screenshot:
-            shouldAttachScreenshotToIBRequest !== undefined
-              ? shouldAttachScreenshotToIBRequest
-              : Boolean(reportAttachmentTypes?.screenshot),
-          ...(reportAttachmentTypes || {
-            extraScreenshot: false,
-            galleryImage: false,
-            screenRecording: false
-          })
+        // if reportAttachmentTypes is undefined use the default config
+        const attachmentConfig: DefaultReportAttachmentTypeConfiguration = {
+          ...(reportAttachmentTypes ?? defaultAttachmentTypeConfiguration),
+          screenshot: shouldAttachScreenshotToIBRequest ?? true
         };
 
         switch (type) {


### PR DESCRIPTION
## Short description
This PR restores the default behavior for which is possibile to share a screenshot within an Instabug support request.
At the moment only `AddCardScreen` specifies `shouldAskForScreenshotWithInitialValue=false`: the app asks to the user she wants to the screenshot


https://user-images.githubusercontent.com/822471/106718000-b9e8b180-6600-11eb-9234-7774388ab425.mp4

