### PR TITLE
fix:[176632919] removes psp and logo from transaction details

### DIFF
--- a/ts/screens/wallet/TransactionDetailsScreen.tsx
+++ b/ts/screens/wallet/TransactionDetailsScreen.tsx
@@ -304,8 +304,6 @@ class TransactionDetailsScreen extends React.Component<Props, State> {
             <View spacer={true} />
           )}
 
-          <View spacer={true} large={true} />
-
           {/** Transaction id */}
           <View>
             <Text>

--- a/ts/screens/wallet/TransactionDetailsScreen.tsx
+++ b/ts/screens/wallet/TransactionDetailsScreen.tsx
@@ -304,20 +304,6 @@ class TransactionDetailsScreen extends React.Component<Props, State> {
             <View spacer={true} />
           )}
 
-          {/** psp logo */}
-          {psp && (
-            <View style={[styles.row, styles.centered]}>
-              <Text>{I18n.t("wallet.psp")}</Text>
-              {psp.logoPSP && psp.logoPSP.length > 0 ? (
-                <Image style={styles.pspLogo} source={{ uri: psp.logoPSP }} />
-              ) : psp.businessName ? (
-                <Text>{psp.businessName}</Text>
-              ) : undefined}
-            </View>
-          )}
-
-          <View spacer={true} large={true} />
-          <ItemSeparatorComponent noPadded={true} />
           <View spacer={true} large={true} />
 
           {/** Transaction id */}


### PR DESCRIPTION
## Short description
removes psp and provider s logo 
![Screenshot 2021-02-03 at 14 48 36](https://user-images.githubusercontent.com/8376065/106755846-e7e4ea80-662e-11eb-9151-d399c64b88ff.png)
