### PR TITLE
feat(Bonus Pagamenti Digitali): [#176578587] Update the co-badge in app payment badge

### DIFF
--- a/ts/features/wallet/component/PagoPaPaymentCapability.tsx
+++ b/ts/features/wallet/component/PagoPaPaymentCapability.tsx
@@ -9,6 +9,7 @@ import { IOColors } from "../../../components/core/variables/IOColors";
 import { IOStyles } from "../../../components/core/variables/IOStyles";
 import TouchableDefaultOpacity from "../../../components/TouchableDefaultOpacity";
 import Markdown from "../../../components/ui/Markdown";
+import Switch from "../../../components/ui/Switch";
 import I18n from "../../../i18n";
 import { PaymentMethod } from "../../../types/pagopa";
 import { PaymentSupportStatus } from "../../../types/paymentMethodCapabilities";
@@ -85,16 +86,19 @@ const availabilityBadge = (badgeType: PaymentSupportStatus) => {
           <H5 color="blue">{incompatible}</H5>
         </Badge>
       );
+    case "onboardableNotImplemented":
+      return <Switch testID={"switchOnboardCard"} disabled={true} />;
   }
 };
 
 /**
  * Represent the capability to pay in PagoPa of a payment method.
  *
- * We have 3 possible different cases:
+ * We have 4 possible different cases:
  *   - The card can pay on IO -> pagoPa === true and if is a credit card must be different from MAESTRO
  *   - The card in the future can pay on IO -> Satispay, MAESTRO
  *   - The card is not abilitated to pay on IO
+ *   - The card can onboard another card that can pay on IO -> co-badge credit card
  * @param props
  */
 const PagoPaPaymentCapability: React.FC<Props> = props => {

--- a/ts/features/wallet/component/__test__/PagoPaPaymentCapability.test.tsx
+++ b/ts/features/wallet/component/__test__/PagoPaPaymentCapability.test.tsx
@@ -87,4 +87,22 @@ describe("PagoPaPaymentCapability", () => {
 
     expect(component.getByText("Incompatible")).toBeTruthy();
   });
+
+  it("should render a disabled switch if passed a co-badge, payment method of kind CreditCard with issuerAbiCode and PagoPa = false", () => {
+    const aNonMaestroCreditCard = {
+      info: {
+        brand: CreditCardType.decode("VISA").value,
+        issuerAbiCode: "123"
+      }
+    } as CreditCardPaymentMethod;
+    const aPaymentMethod = {
+      ...aNonMaestroCreditCard,
+      kind: "CreditCard",
+      pagoPA: false
+    } as PaymentMethod;
+
+    const component = renderTestTarget(aPaymentMethod);
+    const disabledSwitch = component.queryByTestId("switchOnboardCard");
+    expect(disabledSwitch).not.toBeNull();
+  });
 });

--- a/ts/types/paymentMethodCapabilities.ts
+++ b/ts/types/paymentMethodCapabilities.ts
@@ -1,4 +1,8 @@
 /**
  * Union of all possible status of a supporting payment method
  */
-export type PaymentSupportStatus = "available" | "arriving" | "not_available";
+export type PaymentSupportStatus =
+  | "available"
+  | "arriving"
+  | "not_available"
+  | "onboardableNotImplemented";

--- a/ts/utils/__tests__/paymentMethodCapabilities.test.ts
+++ b/ts/utils/__tests__/paymentMethodCapabilities.test.ts
@@ -96,7 +96,7 @@ describe("isPaymentMethodSupported", () => {
 
     expect(isPaymentMethodSupported(aPaymentMethod)).toEqual("arriving");
   });
-  it("should return not_available if is a cobadge card, pagoPa is false", () => {
+  it("should return not_available if is a credit card and pagoPa is false", () => {
     const aMaestroCreditCard = {
       kind: "CreditCard",
       info: {
@@ -110,6 +110,24 @@ describe("isPaymentMethodSupported", () => {
     } as PaymentMethod;
 
     expect(isPaymentMethodSupported(aPaymentMethod)).toEqual("not_available");
+  });
+  it("should return onboardableNotImplemented if is a cobadge card", () => {
+    const aCreditCard = {
+      kind: "CreditCard",
+      info: {
+        brand: "MAESTRO",
+        issuerAbiCode: "123"
+      }
+    } as CreditCardPaymentMethod;
+    const aPaymentMethod = {
+      ...aCreditCard,
+      kind: "CreditCard",
+      pagoPA: false
+    } as PaymentMethod;
+
+    expect(isPaymentMethodSupported(aPaymentMethod)).toEqual(
+      "onboardableNotImplemented"
+    );
   });
 
   it("should return arriving if the payment method is of kind Satispay", () => {

--- a/ts/utils/paymentMethodCapabilities.ts
+++ b/ts/utils/paymentMethodCapabilities.ts
@@ -27,6 +27,7 @@ export const canMethodPay = (paymentMethod: PaymentMethod): boolean => {
  * "available" -> can pay
  * "arriving" -> will pay
  * "not_available" -> can't pay
+ * "onboardableNotImplemented" -> can onboard a card that can pay but is not yet implemented
  */
 export const isPaymentMethodSupported = (
   paymentMethod: PaymentMethod
@@ -39,6 +40,8 @@ export const isPaymentMethodSupported = (
             ? canMethodPay(pM)
               ? "available"
               : "arriving"
+            : pM.info?.issuerAbiCode
+            ? "onboardableNotImplemented"
             : "not_available";
         case "Satispay":
         case "BPay":


### PR DESCRIPTION
## Short description
This PR substitute the in app payment badge with a disabled switch

## List of changes proposed in this pull request
- Added the `onboardableNotImplemented` case in the `isPaymentMethodSupported` utils
- Added the `onboardableNotImplemented` case in the `PagoPaPaymentCapability` component

<img src="https://user-images.githubusercontent.com/11773070/107241892-b6ec2780-6a2b-11eb-9907-12c4ea75df01.png" width=300>


