### PR TITLE
chore: [#176900759] Extend urls checking to *.ts source files

### DIFF
--- a/scripts/check_urls/check_urls.py
+++ b/scripts/check_urls/check_urls.py
@@ -44,7 +44,7 @@ class IOUrl(object):
         self.has_error = True
 
 
-def scan_directory(path, black_list, exts={'*.ts'}):
+def scan_directory(path, black_list, urls_black_list, exts={'*.ts'}):
     """
       Scan the chosen directory, and the sub-directories and returns the execution of readFile from the found collection of files
       :param path: directory to scan
@@ -63,7 +63,7 @@ def scan_directory(path, black_list, exts={'*.ts'}):
             to_remove.append(f)
     for tr in to_remove:
         files.remove(tr)
-    return readFile(files)
+    return readFile(files,urls_black_list)
 
 
 def extract_uris(text):
@@ -73,7 +73,7 @@ def extract_uris(text):
     return urls
 
 
-def readFile(files):
+def readFile(files, urls_black_list):
     """
     Reads the collection of files passed as parameter and returns the set of uris found inside all the files
     :param files: an iterable of file paths
@@ -84,6 +84,7 @@ def readFile(files):
         with open(path, 'r') as f:
             content = f.read()
             uris = extract_uris(content)
+            uris = list(filter(lambda f: f not in urls_black_list,uris))
             uri_set = uri_set.union(uris)
     return uri_set
 
@@ -201,10 +202,11 @@ if not run_test and __name__ == '__main__':
     manager = Manager()
     print("scanning local folders...")
     all_uris = []
+    urls_black_list = ["https://assets.cdn.io.italia.it"]
     locales = (abspath(join(dirname(__file__), "../..", "locales")),[])
     ts_dir = (abspath(join(dirname(__file__), "../..", "ts")),["testFaker.ts"])
     for directory,black_list in [locales,ts_dir]:
-      all_uris.extend(list(map(lambda u: IOUrl(u, basename(directory)), scan_directory(directory,black_list))))
+      all_uris.extend(list(map(lambda u: IOUrl(u, basename(directory)), scan_directory(directory,black_list,urls_black_list))))
     print("scanning remote resources...")
     for ru in remote_content_uri:
         c = load_remote_content(ru)

--- a/scripts/check_urls/check_urls.py
+++ b/scripts/check_urls/check_urls.py
@@ -44,7 +44,7 @@ class IOUrl(object):
         self.has_error = True
 
 
-def scan_directory(path, black_list, urls_black_list, exts={'*.ts'}):
+def scan_directory(path, file_black_list, urls_black_list, exts={'*.ts'}):
     """
       Scan the chosen directory, and the sub-directories and returns the execution of readFile from the found collection of files
       :param path: directory to scan
@@ -59,7 +59,7 @@ def scan_directory(path, black_list, urls_black_list, exts={'*.ts'}):
     # exclude test files
     for f in files:
         name = basename(f)
-        if name.endswith("test.ts") or name in black_list:
+        if name.endswith("test.ts") or name in file_black_list:
             to_remove.append(f)
     for tr in to_remove:
         files.remove(tr)
@@ -202,7 +202,9 @@ if not run_test and __name__ == '__main__':
     manager = Manager()
     print("scanning local folders...")
     all_uris = []
-    urls_black_list = ["https://assets.cdn.io.italia.it"]
+    urls_black_list = ["https://assets.cdn.io.italia.it",
+                       "https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf",
+                       "https://www.trusttechnologies.it/contatti/#form"]
     locales = (abspath(join(dirname(__file__), "../..", "locales")),[])
     ts_dir = (abspath(join(dirname(__file__), "../..", "ts")),["testFaker.ts"])
     for directory,black_list in [locales,ts_dir]:

--- a/ts/@types/react-native-pull.d.ts
+++ b/ts/@types/react-native-pull.d.ts
@@ -1,5 +1,5 @@
 /**
- * See {@link https://github.com/greatbsky/react-native-pull}
+ * See {@link https://github.com/greatbsky/react-native-pull }
  * This module exposes 3 component to implements scrollable view with a custom pull-to-refresh animation,
  * it's possible create a custom refresh-control with a view instead the default progress-indicator.
  *

--- a/ts/@types/react-native-vector-icons.d.ts
+++ b/ts/@types/react-native-vector-icons.d.ts
@@ -13,7 +13,7 @@ declare module "react-native-vector-icons/Icon" {
      * Name of the icon to show
      *
      * See Icon Explorer app
-     * {@link https://github.com/oblador/react-native-vector-icons/tree/master/Examples/IconExplorer}
+     * {@link https://github.com/oblador/react-native-vector-icons/tree/master/Examples/IconExplorer }
      */
     name: string;
 

--- a/ts/api/pagopa.ts
+++ b/ts/api/pagopa.ts
@@ -371,7 +371,6 @@ const favouriteWallet: FavouriteWalletUsingPOSTTExtra = {
 };
 
 // Remove this patch once SIA has fixed the spec.
-// @see https://www.pivotaltracker.com/story/show/161113136
 type AddWalletCreditCardUsingPOSTTExtra = MapResponseType<
   AddResponseType<AddWalletCreditCardUsingPOSTT, 422, PagoPAErrorResponse>,
   200,

--- a/ts/components/ui/Markdown/handlers/link.ts
+++ b/ts/components/ui/Markdown/handlers/link.ts
@@ -30,7 +30,7 @@ export function handleLinkMessage(dispatch: Dispatch, href: string) {
   }
 }
 
-// remove protocol from a link ex: http://www.site.com -> www.site.com
+// remove protocol from a link
 export const removeProtocol = (link: string): string =>
   link.replace(new RegExp(/https?:\/\//gi), "");
 

--- a/ts/config.ts
+++ b/ts/config.ts
@@ -7,7 +7,7 @@ import { Millisecond, Second } from "italia-ts-commons/lib/units";
 import Config from "react-native-config";
 
 // default repository for fetching app content (e.g. services metadata)
-const DEFAULT_CONTENT_REPO_URL = "https://raw.githubusercontent.com/pagopa/io-services-metadata/master" as NonEmptyString;
+const DEFAULT_CONTENT_REPO_URL = "https://assets.cdn.io.italia.it" as NonEmptyString;
 
 // default timeout of fetch (in ms)
 const DEFAULT_FETCH_TIMEOUT_MS = 8000;

--- a/ts/features/bonus/bpd/api/backendBpdClient.ts
+++ b/ts/features/bonus/bpd/api/backendBpdClient.ts
@@ -93,7 +93,6 @@ const deleteResponseDecoders = r.composeResponseDecoders(
 );
 
 // these responses code/codec are built from api usage and not from API spec
-// see https://bpd-dev.portal.azure-api.net/docs/services/bpd-ms-citizen/operations/deleteUsingDELETE
 type DeleteUsingDELETETExtra = r.IDeleteApiRequestType<
   {
     readonly Authorization: string;

--- a/ts/sagas/services/watchLoadServicesSaga.ts
+++ b/ts/sagas/services/watchLoadServicesSaga.ts
@@ -39,7 +39,6 @@ export function* watchLoadServicesSaga(
 
   // TODO: it could be implemented in a forked saga being canceled as soon as
   // isFirstServiceLoadCOmpleted is true (https://redux-saga.js.org/docs/advanced/TaskCancellation.html)
-  // https://www.pivotaltracker.com/story/show/170770471
   yield takeEvery(
     [
       getType(loadServiceDetail.success),

--- a/ts/store/middlewares/analytics.ts
+++ b/ts/store/middlewares/analytics.ts
@@ -459,7 +459,7 @@ export const actionTracking = (_: MiddlewareAPI) => (next: Dispatch) => (
 
 /*
   The middleware acts as a general hook in order to track any meaningful navigation action
-  https://reactnavigation.org/docs/guides/screen-tracking#Screen-tracking-with-Redux
+  https://reactnavigation.org/docs/1.x/screen-tracking/#screen-tracking-with-redux
 */
 export function screenTracking(
   store: MiddlewareAPI

--- a/ts/store/reducers/profile.ts
+++ b/ts/store/reducers/profile.ts
@@ -163,7 +163,6 @@ const reducer = (
     //
 
     case getType(profileUpsert.request):
-      // TODO: remove the cast after: https://www.pivotaltracker.com/story/show/160924538 (https://www.pivotaltracker.com/story/show/170819398)
       // eslint-disable-next-line
       return pot.toUpdating(state, action.payload as any);
 

--- a/ts/utils/bottomSheet.ts
+++ b/ts/utils/bottomSheet.ts
@@ -16,7 +16,7 @@ export type BottomSheetProps = {
 
 /**
  * Utility function to build a BottomSheet considering accessibility. This will create a common BottomSheet object to be used in the `present` function
- * that is available only in component context since it uses the context api made available from https://github.com/gorhom/react-native-bottom-sheet/blob/master/docs/modal.md#present
+ * that is available only in component context since it uses the context api made available from https://gorhom.github.io/react-native-bottom-sheet/modal/methods
  * @param content
  * @param title
  * @param snapPoint

--- a/ts/utils/number.ts
+++ b/ts/utils/number.ts
@@ -1,7 +1,7 @@
 import * as t from "io-ts";
 
 /*
- * this code is a copy from gcanti repository https://github.com/gcanti/io-ts-types/blob/master/src/number/NumberFromString.ts
+ * this code is a copy from gcanti repository https://gcanti.github.io/io-ts-types/modules/NumberFromString.ts.html
  * this because to avoid node modules conflicts given from using io-ts-types
  * NumberFromStringType is a codec to encode (number -> string) and decode (string -> number)
  */

--- a/ts/utils/share.ts
+++ b/ts/utils/share.ts
@@ -5,7 +5,7 @@ import Share from "react-native-share";
 import { hasAndroidPermission } from "./permission";
 
 /**
- * share an url see https://react-native-community.github.io/react-native-share/docs/share-open#supported-options
+ * share an url see https://react-native-share.github.io/react-native-share/docs/share-open#supported-options
  * @param url
  * @param message option string to attach as a text with shared file
  */


### PR DESCRIPTION
## Short description
This PR extends the url checking to *.ts source files
This to ensure we are always using valid urls
It also adds [backend status](https://raw.githubusercontent.com/pagopa/io-services-metadata/master/status/backend.json) to the remote monitored resources and remove [services.xml](https://assets.cdn.io.italia.it/services.yml) from monitoring since it is not longer used 

This is the current outcome
----
found 7 errors
[ts][status code 404] -> https://reactnavigation.org/docs/guides/screen-tracking#Screen-tracking-with-Redux
[ts][status code 404] -> https://react-native-community.github.io/react-native-share/docs/share-open#supported-options
[ts][status code 404] -> https://github.com/gorhom/react-native-bottom-sheet/blob/master/docs/modal.md#present
[ts][status code 404] -> https://github.com/gcanti/io-ts-types/blob/master/src/number/NumberFromString.ts
[ts][status code 404] -> https://www.pivotaltracker.com/story/show/161113136
[ts][status code 404] -> https://www.pivotaltracker.com/story/show/170770471
[ts][status code 404] -> https://www.pivotaltracker.com/story/show/160924538

----
### how to test
- go to the folder `/scripts/check_urls/check_urls.py`
- run `python check_urls.py` (python3.8 needed)