### PR TITLE
fix(Bonus Pagamenti Digitali): [#176551362] Not all the getWalletV2 call are tracked

### DIFF
--- a/ts/store/middlewares/analytics.ts
+++ b/ts/store/middlewares/analytics.ts
@@ -116,9 +116,6 @@ import {
   deleteWalletFailure,
   deleteWalletRequest,
   deleteWalletSuccess,
-  fetchWalletsFailure,
-  fetchWalletsRequest,
-  fetchWalletsSuccess,
   payCreditCardVerificationFailure,
   payCreditCardVerificationRequest,
   payCreditCardVerificationSuccess,
@@ -194,7 +191,6 @@ const trackAction = (mp: NonNullable<typeof mixpanel>) => (
     // wallets success / services load requests
     //
     case getType(loadServicesDetail):
-    case getType(fetchWalletsSuccess):
       return mp.track(action.type, {
         count: action.payload.length
       });
@@ -294,7 +290,6 @@ const trackAction = (mp: NonNullable<typeof mixpanel>) => (
     case getType(loginFailure):
     case getType(loadMessages.failure):
     case getType(loadVisibleServices.failure):
-    case getType(fetchWalletsFailure):
     case getType(payCreditCardVerificationFailure):
     case getType(deleteWalletFailure):
     case getType(setFavouriteWalletFailure):
@@ -365,7 +360,6 @@ const trackAction = (mp: NonNullable<typeof mixpanel>) => (
     case getType(loadServiceMetadata.request):
     case getType(loadServiceMetadata.success):
     // wallet
-    case getType(fetchWalletsRequest):
     case getType(addWalletCreditCardInit):
     case getType(addWalletCreditCardRequest):
     case getType(addWalletNewCreditCardSuccess):


### PR DESCRIPTION
## Short description
This pr changes the tracking for the `/v2/wallet` in order to track all the calls.
Atm, only the actions `fetchWalletsFailure`, `fetchWalletsRequest` and `fetchWalletsSuccess` are tracked, but the function `getWalletsV2` can be also called without using `fetchWalletsRequest`; this generates an incorrect and untrue subset of data.

## List of changes proposed in this pull request
- Removed from analytics `fetchWalletsFailure`, `fetchWalletsRequest` and `fetchWalletsSuccess`.
- Added custom track in `getWalletsV2` in order to track all the function invocation.
