### PR TITLE
fix(Bonus Pagamenti Digitali): [#176023332] If the unsubscription to bpd fails, exiting and re-entering the detail screen, the error toast is displayed again

### DIFF
--- a/ts/features/bonus/bpd/screens/details/BpdDetailsScreen.tsx
+++ b/ts/features/bonus/bpd/screens/details/BpdDetailsScreen.tsx
@@ -1,28 +1,31 @@
-import { useEffect } from "react";
+import { fromNullable } from "fp-ts/lib/Option";
+import * as pot from "italia-ts-commons/lib/pot";
 import * as React from "react";
+import { useEffect } from "react";
 import { StyleSheet, View } from "react-native";
 import { NavigationActions } from "react-navigation";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
-import { fromNullable } from "fp-ts/lib/Option";
-import * as pot from "italia-ts-commons/lib/pot";
 import LoadingSpinnerOverlay from "../../../../../components/LoadingSpinnerOverlay";
 import DarkLayout from "../../../../../components/screens/DarkLayout";
-import I18n from "../../../../../i18n";
-import { GlobalState } from "../../../../../store/reducers/types";
-import { showToast } from "../../../../../utils/showToast";
-import { isError, isLoading, isReady } from "../../model/RemoteValue";
-import { bpdAllData } from "../../store/actions/details";
-import { bpdUnsubscribeCompleted } from "../../store/actions/onboarding";
-import { bpdUnsubscriptionSelector } from "../../store/reducers/details/activation";
-import { bpdTransactionsForSelectedPeriod } from "../../store/reducers/details/transactions";
-import { bpdSelectedPeriodSelector } from "../../store/reducers/details/selectedPeriod";
-import { navigateToBpdTransactions } from "../../navigation/actions";
-import { emptyContextualHelp } from "../../../../../utils/emptyContextualHelp";
-import { useHardwareBackButton } from "../../../bonusVacanze/components/hooks/useHardwareBackButton";
-import { navigateBack } from "../../../../../store/actions/navigation";
 import SectionStatusComponent from "../../../../../components/SectionStatusComponent";
+import I18n from "../../../../../i18n";
+import { navigateBack } from "../../../../../store/actions/navigation";
+import { GlobalState } from "../../../../../store/reducers/types";
+import { emptyContextualHelp } from "../../../../../utils/emptyContextualHelp";
+import { showToast } from "../../../../../utils/showToast";
+import { useHardwareBackButton } from "../../../bonusVacanze/components/hooks/useHardwareBackButton";
 import BpdLastUpdateComponent from "../../components/BpdLastUpdateComponent";
+import { isError, isLoading, isReady } from "../../model/RemoteValue";
+import { navigateToBpdTransactions } from "../../navigation/actions";
+import { bpdAllData } from "../../store/actions/details";
+import {
+  bpdUnsubscribeCompleted,
+  bpdUnsubscribeFailure
+} from "../../store/actions/onboarding";
+import { bpdUnsubscriptionSelector } from "../../store/reducers/details/activation";
+import { bpdSelectedPeriodSelector } from "../../store/reducers/details/selectedPeriod";
+import { bpdTransactionsForSelectedPeriod } from "../../store/reducers/details/transactions";
 import BpdPeriodSelector from "./BpdPeriodSelector";
 import BpdPeriodDetail from "./periods/BpdPeriodDetail";
 import GoToTransactions from "./transaction/GoToTransactions";
@@ -58,9 +61,10 @@ const BpdDetailsScreen: React.FunctionComponent<Props> = props => {
   useEffect(() => {
     if (isError(props.unsubscription)) {
       showToast(I18n.t("bonus.bpd.unsubscribe.failure"), "danger");
+      props.completeUnsubscriptionFailure();
     } else if (isReady(props.unsubscription)) {
       showToast(I18n.t("bonus.bpd.unsubscribe.success"), "success");
-      props.completeUnsubscription();
+      props.completeUnsubscriptionSuccess();
     }
   }, [props.unsubscription]);
 
@@ -121,13 +125,14 @@ const BpdDetailsScreen: React.FunctionComponent<Props> = props => {
 };
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  completeUnsubscription: () => {
+  completeUnsubscriptionSuccess: () => {
     dispatch(bpdAllData.request());
     dispatch(bpdUnsubscribeCompleted());
     dispatch(NavigationActions.back());
   },
   goToTransactions: () => dispatch(navigateToBpdTransactions()),
-  goBack: () => dispatch(navigateBack())
+  goBack: () => dispatch(navigateBack()),
+  completeUnsubscriptionFailure: () => dispatch(bpdUnsubscribeFailure())
 });
 
 const mapStateToProps = (state: GlobalState) => ({

--- a/ts/features/bonus/bpd/store/actions/onboarding.ts
+++ b/ts/features/bonus/bpd/store/actions/onboarding.ts
@@ -32,6 +32,13 @@ export const bpdUnsubscribeCompleted = createStandardAction(
 )<void>();
 
 /**
+ * The user complete the unsubscribe workflow with a failure
+ */
+export const bpdUnsubscribeFailure = createStandardAction(
+  "BPD_UNSUBSCRIBE_COMPLETED_WITH_FAILURE"
+)<void>();
+
+/**
  * Start the onboarding workflow
  */
 export const bpdOnboardingStart = createStandardAction("BPD_ONBOARDING_START")<
@@ -74,4 +81,5 @@ export type BpdOnboardingActions =
   | ActionType<typeof bpdOnboardingCancel>
   | ActionType<typeof bpdOnboardingCompleted>
   | ActionType<typeof bpdDeleteUserFromProgram>
-  | ActionType<typeof bpdUnsubscribeCompleted>;
+  | ActionType<typeof bpdUnsubscribeCompleted>
+  | ActionType<typeof bpdUnsubscribeFailure>;

--- a/ts/features/bonus/bpd/store/reducers/details/activation/index.ts
+++ b/ts/features/bonus/bpd/store/reducers/details/activation/index.ts
@@ -1,8 +1,8 @@
 import { fromNullable } from "fp-ts/lib/Option";
+import * as pot from "italia-ts-commons/lib/pot";
 import { combineReducers } from "redux";
 import { createSelector } from "reselect";
 import { getType } from "typesafe-actions";
-import * as pot from "italia-ts-commons/lib/pot";
 import { Action } from "../../../../../../../store/actions/types";
 import { GlobalState } from "../../../../../../../store/reducers/types";
 import {
@@ -17,7 +17,8 @@ import { bpdLoadActivationStatus } from "../../../actions/details";
 import {
   bpdDeleteUserFromProgram,
   bpdEnrollUserToProgram,
-  bpdUnsubscribeCompleted
+  bpdUnsubscribeCompleted,
+  bpdUnsubscribeFailure
 } from "../../../actions/onboarding";
 import paymentInstrumentReducer, {
   bpdUpsertIbanSelector,
@@ -78,6 +79,7 @@ const unsubscriptionReducer = (
       return remoteError(action.payload);
     // reset the state when return to wallet
     case getType(bpdUnsubscribeCompleted):
+    case getType(bpdUnsubscribeFailure):
       return remoteUndefined;
   }
   return state;


### PR DESCRIPTION
## Short description
This pr fixes a bug that occurs when the unsubscription to bpd fails and the user exit and re-enter in the bpd details screen, displaying again the error toast.

### Before:

https://user-images.githubusercontent.com/26501317/107780663-456fea00-6d47-11eb-9fa5-276bc815e9fa.mov

### After:

https://user-images.githubusercontent.com/26501317/107780681-4acd3480-6d47-11eb-9d5b-89e47e6b8417.mov



## List of changes proposed in this pull request
- Added `bpdUnsubscribeFailure` action, in order to update the store.

## How to test
- Unsubscribe from BPD with a failure
- A error toast is displayed
- Return to wallet
- Return to BPD detail screen
- No toast should be displayed
