### PR TITLE
feat(Services): [#176919053] Remove services tab counter badge and item unread badge indicator

### DIFF
--- a/ts/components/ServiceTabIcon.tsx
+++ b/ts/components/ServiceTabIcon.tsx
@@ -11,8 +11,9 @@ type Props = {
 
 class ServiceTabIcon extends React.PureComponent<Props> {
   public render() {
-    const { color } = this.props;
-    return <TabIconComponent iconName={"io-servizi"} color={color} />;
+    return (
+      <TabIconComponent iconName={"io-servizi"} color={this.props.color} />
+    );
   }
 }
 

--- a/ts/components/ServiceTabIcon.tsx
+++ b/ts/components/ServiceTabIcon.tsx
@@ -1,38 +1,19 @@
 /**
  * Service tab icon with badge indicator
- * TODO: make badge displays the sum of unread service into the "Local" and the "National" tabs
- *        https://www.pivotaltracker.com/story/show/168169955
+ * Note: badge counter has been disabled for these reasons https://www.pivotaltracker.com/story/show/176919053
  */
 import React from "react";
-import { connect } from "react-redux";
-
-import { servicesBadgeValueSelector } from "../store/reducers/entities/services";
-import { GlobalState } from "../store/reducers/types";
 import TabIconComponent from "./ui/TabIconComponent";
 
-type OwnProps = {
+type Props = {
   color?: string;
 };
 
-type Props = OwnProps & ReturnType<typeof mapStateToProps>;
-
 class ServiceTabIcon extends React.PureComponent<Props> {
   public render() {
-    const { color, unreadServices } = this.props;
-    return (
-      <TabIconComponent
-        iconName={"io-servizi"}
-        badgeValue={unreadServices}
-        color={color}
-      />
-    );
+    const { color } = this.props;
+    return <TabIconComponent iconName={"io-servizi"} color={color} />;
   }
 }
 
-function mapStateToProps(state: GlobalState) {
-  return {
-    unreadServices: servicesBadgeValueSelector(state)
-  };
-}
-
-export default connect(mapStateToProps)(ServiceTabIcon);
+export default ServiceTabIcon;

--- a/ts/components/services/NewServiceListItem.tsx
+++ b/ts/components/services/NewServiceListItem.tsx
@@ -131,7 +131,7 @@ export default class NewServiceListItem extends React.PureComponent<
     return (
       <ListItemComponent
         title={serviceName}
-        hasBadge={!this.props.isRead}
+        hasBadge={false}
         onPress={onPress}
         onLongPress={this.props.onLongPress}
         hideSeparator={this.props.hideSeparator}

--- a/ts/components/services/NewServiceListItem.tsx
+++ b/ts/components/services/NewServiceListItem.tsx
@@ -131,7 +131,7 @@ export default class NewServiceListItem extends React.PureComponent<
     return (
       <ListItemComponent
         title={serviceName}
-        hasBadge={false}
+        hasBadge={false} // disabled for these reasons https://www.pivotaltracker.com/story/show/176919053
         onPress={onPress}
         onLongPress={this.props.onLongPress}
         hideSeparator={this.props.hideSeparator}


### PR DESCRIPTION
## Short description
This PR removes:

1. service tab counter badge indicator
2. service item unread badge indicator

| before  | after |
| ------------- | ------------- |
![before](https://user-images.githubusercontent.com/822471/107781537-48b7a580-6d48-11eb-951e-5951abcfcf8c.png) | ![after](https://user-images.githubusercontent.com/822471/107781570-4fdeb380-6d48-11eb-9d53-3af8fc3df4b0.png)
