### PR TITLE
fix(Bonus Pagamenti Digitali): [#176940152] The BANCOMAT detail icons is (!) instead of (i)

### DIFF
--- a/ts/features/wallet/bancomat/screen/BancomatInformation.tsx
+++ b/ts/features/wallet/bancomat/screen/BancomatInformation.tsx
@@ -46,7 +46,7 @@ const BancomatInformation: React.FunctionComponent<Props> = props => {
       <View style={styles.titleContainer}>
         <H3>{I18n.t("wallet.bancomat.details.debit.title")}</H3>
         <IconFont
-          name={"io-notice"}
+          name={"io-info"}
           size={24}
           color={IOColors.blue}
           onPress={present}


### PR DESCRIPTION
## Short description
This pr changes the BANCOMAT detail icon from (!) to (i)

![Schermata 2021-02-15 alle 12 11 58](https://user-images.githubusercontent.com/26501317/107939552-30819980-6f87-11eb-8f70-d0e76b339fa9.png)

