### PR TITLE
feat: [#176980827] Don't allow user to add a credit card when insert a cardholder with accented characters

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1145,7 +1145,7 @@ wallet:
   dummyCard:
     labels:
       holder: 
-        label: Cardholder
+        label: Card holder
         description:
           base: "Enter as shown on the card"
           error: "Enter exactly as shown on the card"

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1144,7 +1144,7 @@ wallet:
   addCardTitle: Card details
   dummyCard:
     labels:
-      holder: Card holder
+      holder: Cardholder
       pan: Card number
       expirationDate: Expiration date
       securityCode: Card security code

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1144,7 +1144,11 @@ wallet:
   addCardTitle: Card details
   dummyCard:
     labels:
-      holder: Cardholder
+      holder: 
+        label: Cardholder
+        description:
+          base: "Enter as shown on the card"
+          error: "Enter exactly as shown on the card"
       pan: Card number
       expirationDate: Expiration date
       securityCode: Card security code

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1170,7 +1170,7 @@ wallet:
   addCardTitle: Dati carta
   dummyCard:
     labels:
-      holder: Titolare
+      holder: Intestatario della carta
       pan: Numero della carta
       expirationDate: Data di scadenza
       securityCode: Codice di sicurezza

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1170,8 +1170,12 @@ wallet:
   addCardTitle: Dati carta
   dummyCard:
     labels:
-      holder: Intestatario della carta
-      pan: Numero della carta
+      holder:
+        label: Intestatario carta
+        description:
+          base: "Inserisci come riportato sulla carta"
+          error: "Inserisci esattamente come riportato sulla carta"
+      pan: Numero carta
       expirationDate: Data di scadenza
       securityCode: Codice di sicurezza
       securityCode4D: CID (4 cifre)

--- a/ts/components/LabelledItem.tsx
+++ b/ts/components/LabelledItem.tsx
@@ -23,6 +23,8 @@ import {
 import { TextInputMaskProps } from "react-native-masked-text";
 import { IconProps } from "react-native-vector-icons/Icon";
 import variables from "../theme/variables";
+import { H4 } from "./core/typography/H4";
+import { H5 } from "./core/typography/H5";
 import IconFont from "./ui/IconFont";
 import TextInputMask from "./ui/MaskedInput";
 
@@ -44,6 +46,7 @@ type CommonProp = Readonly<{
   isValid?: boolean;
   iconStyle?: StyleType;
   focusBorderColor?: string;
+  description?: string;
 }>;
 
 type State = {
@@ -172,6 +175,19 @@ export class LabelledItem extends React.Component<Props, State> {
             />
           )}
         </Item>
+        {this.props.description && (
+          <Item style={styles.noBottomLine}>
+            <H5
+              color={
+                this.props.isValid === undefined || this.props.isValid === true
+                  ? "bluegreyDark"
+                  : "red"
+              }
+            >
+              {this.props.label}
+            </H5>
+          </Item>
+        )}
       </View>
     );
   }

--- a/ts/components/LabelledItem.tsx
+++ b/ts/components/LabelledItem.tsx
@@ -11,7 +11,7 @@
  */
 import color from "color";
 import { isString } from "lodash";
-import { Input, Item, Text, View } from "native-base";
+import { Input, Item, View } from "native-base";
 import * as React from "react";
 import {
   StyleSheet,
@@ -23,7 +23,6 @@ import {
 import { TextInputMaskProps } from "react-native-masked-text";
 import { IconProps } from "react-native-vector-icons/Icon";
 import variables from "../theme/variables";
-import { H4 } from "./core/typography/H4";
 import { H5 } from "./core/typography/H5";
 import IconFont from "./ui/IconFont";
 import TextInputMask from "./ui/MaskedInput";

--- a/ts/components/LabelledItem.tsx
+++ b/ts/components/LabelledItem.tsx
@@ -23,6 +23,7 @@ import {
 import { TextInputMaskProps } from "react-native-masked-text";
 import { IconProps } from "react-native-vector-icons/Icon";
 import variables from "../theme/variables";
+import { WithTestID } from "../types/WithTestID";
 import { H5 } from "./core/typography/H5";
 import IconFont from "./ui/IconFont";
 import TextInputMask from "./ui/MaskedInput";
@@ -53,7 +54,7 @@ type State = {
   hasFocus: boolean;
 };
 
-type Props = CommonProp &
+type Props = WithTestID<CommonProp> &
   (
     | Readonly<{
         type: "masked";
@@ -160,6 +161,7 @@ export class LabelledItem extends React.Component<Props, State> {
               onChangeText={this.handleOnMaskedChangeText}
               onFocus={this.handleOnFocus}
               onBlur={this.handleOnBlur}
+              testID={`${this.props.testID}InputMask`}
             />
           ) : (
             <Input
@@ -171,6 +173,7 @@ export class LabelledItem extends React.Component<Props, State> {
               onChangeText={this.handleOnChangeText}
               onFocus={this.handleOnFocus}
               onBlur={this.handleOnBlur}
+              testID={`${this.props.testID}Input`}
             />
           )}
         </Item>

--- a/ts/components/LabelledItem.tsx
+++ b/ts/components/LabelledItem.tsx
@@ -124,7 +124,7 @@ export class LabelledItem extends React.Component<Props, State> {
     return (
       <View>
         <Item style={styles.noBottomLine}>
-          <Text>{this.props.label}</Text>
+          <H5>{this.props.label}</H5>
         </Item>
         <Item
           style={{
@@ -178,13 +178,14 @@ export class LabelledItem extends React.Component<Props, State> {
         {this.props.description && (
           <Item style={styles.noBottomLine}>
             <H5
+              weight={"Regular"}
               color={
                 this.props.isValid === undefined || this.props.isValid === true
                   ? "bluegreyDark"
                   : "red"
               }
             >
-              {this.props.label}
+              {this.props.description}
             </H5>
           </Item>
         )}

--- a/ts/components/LabelledItem.tsx
+++ b/ts/components/LabelledItem.tsx
@@ -181,11 +181,7 @@ export class LabelledItem extends React.Component<Props, State> {
           <Item style={styles.noBottomLine}>
             <H5
               weight={"Regular"}
-              color={
-                this.props.isValid === undefined || this.props.isValid === true
-                  ? "bluegreyDark"
-                  : "red"
-              }
+              color={this.props.isValid === false ? "red" : "bluegreyDark"}
             >
               {this.props.description}
             </H5>

--- a/ts/components/core/typography/H5.tsx
+++ b/ts/components/core/typography/H5.tsx
@@ -14,7 +14,7 @@ type AllowedSemiBoldColors = Extract<
 // when the weight is bold, only the white color is allowed
 type AllowedRegularColors = Extract<
   IOColorType,
-  "bluegreyDark" | "bluegrey" | "blue" | "white"
+  "bluegreyDark" | "bluegrey" | "blue" | "white" | "red"
 >;
 
 // all the possible colors

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -13,7 +13,7 @@ import {
 import { Content, View } from "native-base";
 import { Col, Grid } from "react-native-easy-grid";
 
-import { fromNullable, Option } from "fp-ts/lib/Option";
+import { fromNullable, none, Option } from "fp-ts/lib/Option";
 
 import { AmountInEuroCents, RptId } from "italia-pagopa-commons/lib/pagopa";
 import { PaymentRequestsGetResponse } from "../../../definitions/backend/PaymentRequestsGetResponse";
@@ -150,11 +150,12 @@ const AddCardScreen: React.FC<Props> = props => {
     creditCard.pan
   );
 
-  const updateState = (key: CreditCardStateKeys, value: string) =>
+  const updateState = (key: CreditCardStateKeys, value: string) => {
     setCreditCard({
       ...creditCard,
-      [key]: fromNullable(value)
+      [key]: value.length > 0 ? fromNullable(value) : none
     });
+  };
 
   const secondaryButtonProps = {
     block: true,
@@ -179,7 +180,7 @@ const AddCardScreen: React.FC<Props> = props => {
         <Content scrollEnabled={false}>
           <LabelledItem
             type={"text"}
-            label={I18n.t("wallet.dummyCard.labels.holder")}
+            label={I18n.t("wallet.dummyCard.labels.holder.label")}
             icon="io-titolare"
             isValid={creditCard.holder.getOrElse("") === "" ? undefined : true}
             inputProps={{
@@ -295,7 +296,7 @@ const AddCardScreen: React.FC<Props> = props => {
   );
 };
 
-const mapStateToProps = (state: GlobalState) => ({});
+const mapStateToProps = (_: GlobalState) => ({});
 
 const mapDispatchToProps = (dispatch: Dispatch, props: OwnProps) => ({
   addWalletCreditCardInit: () => dispatch(addWalletCreditCardInit()),

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -13,7 +13,7 @@ import {
 import { Content, View } from "native-base";
 import { Col, Grid } from "react-native-easy-grid";
 
-import { fromNullable, isNone, none, Option } from "fp-ts/lib/Option";
+import { isNone, Option, fromPredicate } from "fp-ts/lib/Option";
 
 import { AmountInEuroCents, RptId } from "italia-pagopa-commons/lib/pagopa";
 import { PaymentRequestsGetResponse } from "../../../definitions/backend/PaymentRequestsGetResponse";
@@ -52,7 +52,6 @@ import { useIOBottomSheet } from "../../utils/bottomSheet";
 import { Body } from "../../components/core/typography/Body";
 import { CreditCard } from "../../types/pagopa";
 import { BlockButtonProps } from "../../components/ui/BlockButtons";
-import { fromPredicate } from "fp-ts/lib/Option";
 
 export type NavigationParams = Readonly<{
   inPayment: Option<{

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -52,6 +52,7 @@ import { useIOBottomSheet } from "../../utils/bottomSheet";
 import { Body } from "../../components/core/typography/Body";
 import { CreditCard } from "../../types/pagopa";
 import { BlockButtonProps } from "../../components/ui/BlockButtons";
+import { fromPredicate } from "fp-ts/lib/Option";
 
 export type NavigationParams = Readonly<{
   inPayment: Option<{
@@ -154,7 +155,7 @@ const AddCardScreen: React.FC<Props> = props => {
   const updateState = (key: CreditCardStateKeys, value: string) => {
     setCreditCard({
       ...creditCard,
-      [key]: value.length > 0 ? fromNullable(value) : none
+      [key]: fromPredicate((value: string) => value.length > 0)(value)
     });
   };
 

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -43,7 +43,6 @@ import {
 
 import { CreditCardDetector, SupportedBrand } from "../../utils/creditCard";
 import { GlobalState } from "../../store/reducers/types";
-import { profileNameSurnameSelector } from "../../store/reducers/profile";
 import { Link } from "../../components/core/typography/Link";
 import SectionStatusComponent from "../../components/SectionStatusComponent";
 import { openWebUrl } from "../../utils/url";
@@ -137,10 +136,9 @@ const primaryButtonPropsFromState = (
 };
 
 const AddCardScreen: React.FC<Props> = props => {
-  const [creditCard, setCreditCard] = useState<CreditCardState>({
-    ...INITIAL_CARD_FORM_STATE,
-    holder: fromNullable(props.profileNameSurname)
-  });
+  const [creditCard, setCreditCard] = useState<CreditCardState>(
+    INITIAL_CARD_FORM_STATE
+  );
 
   const { present } = useIOBottomSheet(
     <Body>{I18n.t("wallet.missingDataText")}</Body>,
@@ -297,9 +295,7 @@ const AddCardScreen: React.FC<Props> = props => {
   );
 };
 
-const mapStateToProps = (state: GlobalState) => ({
-  profileNameSurname: profileNameSurnameSelector(state)
-});
+const mapStateToProps = (state: GlobalState) => ({});
 
 const mapDispatchToProps = (dispatch: Dispatch, props: OwnProps) => ({
   addWalletCreditCardInit: () => dispatch(addWalletCreditCardInit()),

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -201,6 +201,7 @@ const AddCardScreen: React.FC<Props> = props => {
               returnKeyType: "done",
               onChangeText: (value: string) => updateState("holder", value)
             }}
+            testID={"cardHolder"}
           />
 
           <View spacer={true} />
@@ -229,6 +230,7 @@ const AddCardScreen: React.FC<Props> = props => {
                 }
               }
             }}
+            testID={"pan"}
           />
 
           <View spacer={true} />
@@ -249,6 +251,7 @@ const AddCardScreen: React.FC<Props> = props => {
                   includeRawValueInChangeText: true,
                   onChangeText: value => updateState("expirationDate", value)
                 }}
+                testID={"expirationDate"}
               />
             </Col>
             <Col style={styles.verticalSpacing} />
@@ -278,6 +281,7 @@ const AddCardScreen: React.FC<Props> = props => {
                   includeRawValueInChangeText: true,
                   onChangeText: value => updateState("securityCode", value)
                 }}
+                testID={"securityCode"}
               />
             </Col>
           </Grid>

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -53,7 +53,7 @@ import { Body } from "../../components/core/typography/Body";
 import { CreditCard } from "../../types/pagopa";
 import { BlockButtonProps } from "../../components/ui/BlockButtons";
 
-export type NavigationParams = Readonly<{
+type NavigationParams = Readonly<{
   inPayment: Option<{
     rptId: RptId;
     initialAmount: AmountInEuroCents;

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -13,7 +13,7 @@ import {
 import { Content, View } from "native-base";
 import { Col, Grid } from "react-native-easy-grid";
 
-import { fromNullable, none, Option } from "fp-ts/lib/Option";
+import { fromNullable, isNone, none, Option } from "fp-ts/lib/Option";
 
 import { AmountInEuroCents, RptId } from "italia-pagopa-commons/lib/pagopa";
 import { PaymentRequestsGetResponse } from "../../../definitions/backend/PaymentRequestsGetResponse";
@@ -38,7 +38,8 @@ import {
   CreditCardState,
   getCreditCardFromState,
   INITIAL_CARD_FORM_STATE,
-  CreditCardStateKeys
+  CreditCardStateKeys,
+  isValidCardHolder
 } from "../../utils/input";
 
 import { CreditCardDetector, SupportedBrand } from "../../utils/creditCard";
@@ -52,7 +53,7 @@ import { Body } from "../../components/core/typography/Body";
 import { CreditCard } from "../../types/pagopa";
 import { BlockButtonProps } from "../../components/ui/BlockButtons";
 
-type NavigationParams = Readonly<{
+export type NavigationParams = Readonly<{
   inPayment: Option<{
     rptId: RptId;
     initialAmount: AmountInEuroCents;
@@ -181,8 +182,17 @@ const AddCardScreen: React.FC<Props> = props => {
           <LabelledItem
             type={"text"}
             label={I18n.t("wallet.dummyCard.labels.holder.label")}
+            description={
+              isNone(creditCard.holder) || isValidCardHolder(creditCard.holder)
+                ? I18n.t("wallet.dummyCard.labels.holder.description.base")
+                : I18n.t("wallet.dummyCard.labels.holder.description.error")
+            }
             icon="io-titolare"
-            isValid={creditCard.holder.getOrElse("") === "" ? undefined : true}
+            isValid={
+              isNone(creditCard.holder)
+                ? undefined
+                : isValidCardHolder(creditCard.holder)
+            }
             inputProps={{
               value: creditCard.holder.getOrElse(""),
               placeholder: I18n.t("wallet.dummyCard.values.holder"),

--- a/ts/screens/wallet/__tests__/AddCardScreen.test.tsx
+++ b/ts/screens/wallet/__tests__/AddCardScreen.test.tsx
@@ -1,6 +1,7 @@
-import { none } from "fp-ts/lib/Option";
+import { none, some } from "fp-ts/lib/Option";
 import * as React from "react";
 import { createStore } from "redux";
+import { fireEvent } from "@testing-library/react-native";
 import I18n from "../../../i18n";
 import ROUTES from "../../../navigation/routes";
 import { applicationChangeState } from "../../../store/actions/application";
@@ -8,6 +9,7 @@ import { appReducer } from "../../../store/reducers";
 import { GlobalState } from "../../../store/reducers/types";
 import { renderScreenFakeNavRedux } from "../../../utils/testWrapper";
 import AddCardScreen, { NavigationParams } from "../AddCardScreen";
+import { isValidCardHolder } from "../../../utils/input";
 
 const mockPresentFn = jest.fn();
 jest.mock("../../../utils/bottomSheet", () => ({
@@ -20,6 +22,12 @@ jest.mock("react-native-share", () => ({
   open: jest.fn()
 }));
 
+const aValidCardHolder = "Mario Rossi";
+const aValidPan = "1234 5678 9123 4568";
+const aValidExpirationDate = "12/99";
+const aValidSecurityCode = "123";
+
+const anInvalidCardHolder = "Màriò Ròssì";
 describe("AddCardScreen", () => {
   beforeEach(() => jest.useFakeTimers());
   it("should show the continue button blocked if the aren't data", () => {
@@ -28,6 +36,70 @@ describe("AddCardScreen", () => {
       I18n.t("global.buttons.continue")
     );
     expect(continueButton).not.toBeNull();
+    expect(continueButton).toBeDisabled();
+  });
+
+  it("should show the continue button active if all the field are filled correctly", () => {
+    const component = getComponent();
+    const cardHolderInput = component.queryByTestId("cardHolderInput");
+    const panInputMask = component.queryByTestId("panInputMask");
+    const expirationDateInput = component.queryByTestId(
+      "expirationDateInputMask"
+    );
+    const securityCodeInput = component.queryByTestId("securityCodeInputMask");
+    const continueButton = component.queryByText(
+      I18n.t("global.buttons.continue")
+    );
+
+    expect(cardHolderInput).not.toBeNull();
+    expect(panInputMask).not.toBeNull();
+    expect(expirationDateInput).not.toBeNull();
+    expect(securityCodeInput).not.toBeNull();
+
+    if (
+      cardHolderInput &&
+      panInputMask &&
+      expirationDateInput &&
+      securityCodeInput
+    ) {
+      fireEvent.changeText(panInputMask, aValidPan);
+      fireEvent.changeText(expirationDateInput, aValidExpirationDate);
+      fireEvent.changeText(securityCodeInput, aValidSecurityCode);
+      fireEvent.changeText(cardHolderInput, aValidCardHolder);
+    }
+
+    expect(continueButton).not.toBeDisabled();
+  });
+  it("should show the continue button blocked if all the cardHolder is invalid", () => {
+    const component = getComponent();
+    const cardHolderInput = component.queryByTestId("cardHolderInput");
+    const panInputMask = component.queryByTestId("panInputMask");
+    const expirationDateInput = component.queryByTestId(
+      "expirationDateInputMask"
+    );
+    const securityCodeInput = component.queryByTestId("securityCodeInputMask");
+    const continueButton = component.queryByText(
+      I18n.t("global.buttons.continue")
+    );
+
+    if (
+      cardHolderInput &&
+      panInputMask &&
+      expirationDateInput &&
+      securityCodeInput
+    ) {
+      fireEvent.changeText(panInputMask, aValidPan);
+      fireEvent.changeText(expirationDateInput, aValidExpirationDate);
+      fireEvent.changeText(securityCodeInput, aValidSecurityCode);
+      fireEvent.changeText(cardHolderInput, anInvalidCardHolder);
+    }
+
+    const errorMessage = component.queryByText(
+      I18n.t("wallet.dummyCard.labels.holder.description.error")
+    );
+
+    expect(isValidCardHolder(some(anInvalidCardHolder))).toBeFalsy();
+    expect(errorMessage).not.toBeNull();
     expect(continueButton).toBeDisabled();
   });
 });

--- a/ts/screens/wallet/__tests__/AddCardScreen.test.tsx
+++ b/ts/screens/wallet/__tests__/AddCardScreen.test.tsx
@@ -30,7 +30,7 @@ const aValidSecurityCode = "123";
 const anInvalidCardHolder = "Màriò Ròssì";
 describe("AddCardScreen", () => {
   beforeEach(() => jest.useFakeTimers());
-  it("should show the continue button blocked if the aren't data", () => {
+  it("should show the continue button disabled if there aren't data", () => {
     const component = getComponent();
     const continueButton = component.queryByText(
       I18n.t("global.buttons.continue")
@@ -39,7 +39,7 @@ describe("AddCardScreen", () => {
     expect(continueButton).toBeDisabled();
   });
 
-  it("should show the continue button active if all the field are filled correctly", () => {
+  it("should show the continue button active if all fields are correctly filled", () => {
     const component = getComponent();
     const cardHolderInput = component.queryByTestId("cardHolderInput");
     const panInputMask = component.queryByTestId("panInputMask");
@@ -70,7 +70,7 @@ describe("AddCardScreen", () => {
 
     expect(continueButton).not.toBeDisabled();
   });
-  it("should show the continue button blocked if all the cardHolder is invalid", () => {
+  it("should show the continue button disabled if the cardHolder is invalid", () => {
     const component = getComponent();
     const cardHolderInput = component.queryByTestId("cardHolderInput");
     const panInputMask = component.queryByTestId("panInputMask");

--- a/ts/screens/wallet/__tests__/AddCardScreen.test.tsx
+++ b/ts/screens/wallet/__tests__/AddCardScreen.test.tsx
@@ -1,0 +1,54 @@
+import { none } from "fp-ts/lib/Option";
+import * as React from "react";
+import { createStore } from "redux";
+import I18n from "../../../i18n";
+import ROUTES from "../../../navigation/routes";
+import { applicationChangeState } from "../../../store/actions/application";
+import { appReducer } from "../../../store/reducers";
+import { GlobalState } from "../../../store/reducers/types";
+import { renderScreenFakeNavRedux } from "../../../utils/testWrapper";
+import AddCardScreen, { NavigationParams } from "../AddCardScreen";
+
+const mockPresentFn = jest.fn();
+jest.mock("../../../utils/bottomSheet", () => ({
+  __esModule: true,
+  useIOBottomSheet: () => ({ present: mockPresentFn })
+}));
+
+jest.unmock("react-navigation");
+jest.mock("react-native-share", () => ({
+  open: jest.fn()
+}));
+
+describe("AddCardScreen", () => {
+  beforeEach(() => jest.useFakeTimers());
+  it("should show the continue button blocked if the aren't data", () => {
+    const component = getComponent();
+    const continueButton = component.queryByText(
+      I18n.t("global.buttons.continue")
+    );
+    expect(continueButton).not.toBeNull();
+    expect(continueButton).toBeDisabled();
+  });
+});
+
+const getComponent = () => {
+  const params: NavigationParams = {
+    inPayment: none
+  } as NavigationParams;
+
+  const ToBeTested: React.FunctionComponent<React.ComponentProps<
+    typeof AddCardScreen
+  >> = (props: React.ComponentProps<typeof AddCardScreen>) => (
+    <AddCardScreen {...props} />
+  );
+
+  const globalState = appReducer(undefined, applicationChangeState("active"));
+  const store = createStore(appReducer, globalState as any);
+  return renderScreenFakeNavRedux<GlobalState, NavigationParams>(
+    ToBeTested,
+    ROUTES.WALLET_ADD_CARD,
+    params,
+    store
+  );
+};

--- a/ts/screens/wallet/__tests__/AddCardScreen.test.tsx
+++ b/ts/screens/wallet/__tests__/AddCardScreen.test.tsx
@@ -8,8 +8,9 @@ import { applicationChangeState } from "../../../store/actions/application";
 import { appReducer } from "../../../store/reducers";
 import { GlobalState } from "../../../store/reducers/types";
 import { renderScreenFakeNavRedux } from "../../../utils/testWrapper";
-import AddCardScreen, { NavigationParams } from "../AddCardScreen";
+import AddCardScreen from "../AddCardScreen";
 import { isValidCardHolder } from "../../../utils/input";
+import { InferNavigationParams } from "../../../types/react";
 
 const mockPresentFn = jest.fn();
 jest.mock("../../../utils/bottomSheet", () => ({
@@ -105,6 +106,7 @@ describe("AddCardScreen", () => {
 });
 
 const getComponent = () => {
+  type NavigationParams = InferNavigationParams<typeof AddCardScreen>;
   const params: NavigationParams = {
     inPayment: none
   } as NavigationParams;

--- a/ts/utils/__tests__/input.test.ts
+++ b/ts/utils/__tests__/input.test.ts
@@ -4,6 +4,7 @@ import {
   CreditCardExpirationMonth,
   CreditCardExpirationYear,
   CreditCardPan,
+  isValidCardHolder,
   isValidExpirationDate,
   isValidPan,
   isValidSecurityCode
@@ -130,4 +131,44 @@ describe("CreditCardCVC", () => {
   it("should reject invalid CVCs, round 2", () => {
     invalidCVCs.forEach(d => expect(isValidSecurityCode(some(d))).toBeFalsy());
   });
+});
+
+describe("isValidCardHolder", () => {
+  [
+    "á",
+    "à",
+    "ã",
+    "â",
+    "é",
+    "è",
+    "ê",
+    "í",
+    "ì",
+    "î",
+    "õ",
+    "ó",
+    "ò",
+    "ô",
+    "ú",
+    "ù",
+    "û"
+  ].map(accentedCardHolder =>
+    it(`should return false if the input string contains the accented character ${accentedCardHolder}`, () => {
+      expect(isValidCardHolder(some(accentedCardHolder))).toBeFalsy();
+    })
+  );
+
+  it("should return false if the input string is none", () => {
+    expect(isValidCardHolder(none)).toBeFalsy();
+  });
+
+  [
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    "0123456789",
+    "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+  ].map(notAccentedCardHolder =>
+    it(`should return true if the input string is composed by character different from accented character: ${notAccentedCardHolder}`, () => {
+      expect(isValidCardHolder(some(notAccentedCardHolder))).toBeTruthy();
+    })
+  );
 });

--- a/ts/utils/__tests__/input.test.ts
+++ b/ts/utils/__tests__/input.test.ts
@@ -1,9 +1,11 @@
-import { fromNullable, none, some } from "fp-ts/lib/Option";
+import { fromNullable, isSome, none, some } from "fp-ts/lib/Option";
 import {
   CreditCardCVC,
   CreditCardExpirationMonth,
   CreditCardExpirationYear,
   CreditCardPan,
+  CreditCardState,
+  getCreditCardFromState,
   isValidCardHolder,
   isValidExpirationDate,
   isValidPan,
@@ -171,4 +173,63 @@ describe("isValidCardHolder", () => {
       expect(isValidCardHolder(some(notAccentedCardHolder))).toBeTruthy();
     })
   );
+});
+
+describe("getCreditCardFromState", () => {
+  const aValidCardHolder = "Mario Rossi";
+  const anInvalidCardHolder = "Mariò Rossi";
+  const aValidPan = "1234567891234568";
+  const anInvalidPan = "1234 5678 9123";
+  const aValidExpirationDate = "12/99";
+  const anInvalidExpirationDate = "99/9";
+  const aValidSecurityCode = "123";
+  const anInvalidSecurityCode = "1";
+  it.each`
+    pan                   | expirationDate                   | securityCode                   | holder
+    ${none}               | ${some(aValidExpirationDate)}    | ${some(aValidSecurityCode)}    | ${some(aValidCardHolder)}
+    ${some(aValidPan)}    | ${none}                          | ${some(aValidSecurityCode)}    | ${some(aValidCardHolder)}
+    ${some(aValidPan)}    | ${some(aValidExpirationDate)}    | ${none}                        | ${some(aValidCardHolder)}
+    ${some(aValidPan)}    | ${some(aValidExpirationDate)}    | ${some(aValidSecurityCode)}    | ${none}
+    ${some(anInvalidPan)} | ${some(aValidExpirationDate)}    | ${some(aValidSecurityCode)}    | ${some(aValidCardHolder)}
+    ${some(aValidPan)}    | ${some(anInvalidExpirationDate)} | ${some(aValidSecurityCode)}    | ${some(aValidCardHolder)}
+    ${some(aValidPan)}    | ${some(aValidExpirationDate)}    | ${some(anInvalidSecurityCode)} | ${some(aValidCardHolder)}
+    ${some(aValidPan)}    | ${some(aValidExpirationDate)}    | ${some(aValidSecurityCode)}    | ${some(anInvalidCardHolder)}
+  `(
+    "should return none if at least one field of the credit card is none or is invalid",
+    async ({ pan, expirationDate, securityCode, holder }) => {
+      const cardState: CreditCardState = {
+        pan,
+        expirationDate,
+        securityCode,
+        holder
+      };
+      expect(getCreditCardFromState(cardState)).toBe(none);
+    }
+  );
+
+  it("should return a credit card if all the field are correctly filled ", () => {
+    const cardState: CreditCardState = {
+      pan: some(aValidPan),
+      expirationDate: some(aValidExpirationDate),
+      securityCode: some(aValidSecurityCode),
+      holder: some(aValidCardHolder)
+    };
+
+    if (isSome(cardState.expirationDate)) {
+      const [expireMonth, expireYear] = cardState.expirationDate.value.split(
+        "/"
+      );
+
+      const expectedCreditCard = {
+        pan: aValidPan,
+        expireMonth,
+        expireYear,
+        securityCode: aValidSecurityCode,
+        holder: aValidCardHolder
+      };
+      expect(getCreditCardFromState(cardState)).toStrictEqual(
+        some(expectedCreditCard)
+      );
+    }
+  });
 });

--- a/ts/utils/input.ts
+++ b/ts/utils/input.ts
@@ -138,14 +138,10 @@ export function getCreditCardFromState(
  * This function checks if the cardholder charset is ammitted.
  * We consider not a valid character an accented character.
  *
- * This function return 3 possible state:
- *  - undefined -> the cardHolder is none
- *  - true -> the card doesn't contain accented characters
- *  - false -> the card contain accented characters.
  * @param cardHolder
  */
 export const isValidCardHolder = (cardHolder: Option<string>) =>
-  cardHolder.fold(undefined, cH => {
+  cardHolder.fold(false, cH => {
     const cardHolderWithoutDiacriticalMarks = _.deburr(cH);
     return _.isEqual(cH, cardHolderWithoutDiacriticalMarks);
   });

--- a/ts/utils/input.ts
+++ b/ts/utils/input.ts
@@ -1,5 +1,6 @@
 import { Option, none, some } from "fp-ts/lib/Option";
 import * as t from "io-ts";
+import * as _ from "lodash";
 import { PatternString } from "italia-ts-commons/lib/strings";
 import { CreditCard } from "../types/pagopa";
 import { isExpired } from "./dates";
@@ -118,6 +119,10 @@ export function getCreditCardFromState(
     return none;
   }
 
+  if (!isValidCardHolder(holder)) {
+    return none;
+  }
+
   const card: CreditCard = {
     pan: pan.value,
     holder: holder.value,
@@ -128,3 +133,19 @@ export function getCreditCardFromState(
 
   return some(card);
 }
+
+/**
+ * This function checks if the cardholder charset is ammitted.
+ * We consider not a valid character an accented character.
+ *
+ * This function return 3 possible state:
+ *  - undefined -> the cardHolder is none
+ *  - true -> the card doesn't contain accented characters
+ *  - false -> the card contain accented characters.
+ * @param cardHolder
+ */
+export const isValidCardHolder = (cardHolder: Option<string>) =>
+  cardHolder.fold(undefined, cH => {
+    const cardHolderWithoutDiacriticalMarks = _.deburr(cH);
+    return _.isEqual(cH, cardHolderWithoutDiacriticalMarks);
+  });

--- a/ts/utils/input.ts
+++ b/ts/utils/input.ts
@@ -143,5 +143,5 @@ export function getCreditCardFromState(
 export const isValidCardHolder = (cardHolder: Option<string>): boolean =>
   cardHolder.fold(false, cH => {
     const cardHolderWithoutDiacriticalMarks = _.deburr(cH);
-    return _.isEqual(cH, cardHolderWithoutDiacriticalMarks);
+    return cH === cardHolderWithoutDiacriticalMarks;
   });

--- a/ts/utils/input.ts
+++ b/ts/utils/input.ts
@@ -135,7 +135,7 @@ export function getCreditCardFromState(
 }
 
 /**
- * This function checks if the cardholder charset is ammitted.
+ * This function checks if the cardholder charset is admitted.
  * We consider not a valid character an accented character.
  *
  * @param cardHolder

--- a/ts/utils/input.ts
+++ b/ts/utils/input.ts
@@ -140,7 +140,7 @@ export function getCreditCardFromState(
  *
  * @param cardHolder
  */
-export const isValidCardHolder = (cardHolder: Option<string>) =>
+export const isValidCardHolder = (cardHolder: Option<string>): boolean =>
   cardHolder.fold(false, cH => {
     const cardHolderWithoutDiacriticalMarks = _.deburr(cH);
     return _.isEqual(cH, cardHolderWithoutDiacriticalMarks);


### PR DESCRIPTION
## Short description
This PR block the add credit card workflow if the user insert in the cardholder a string with accented characters.

## List of changes proposed in this pull request
- Added the diacritical marks check in the `AddCardScreen`
- Removed pre-filled cardholder
- Fixed error that allow the user to add a card without cardholder
- Added the optional description in the `LabelledItem` component
- Aligned `LabelledItem` label style with invision design

## How to test
- Added `AddCardScreen` tests
- Added `isValidCardHolder` tests in `input.test.ts`
- Added `getCreditCardFromState` tests in `input.test.ts`


https://user-images.githubusercontent.com/11773070/108376588-6df25b00-7203-11eb-9b50-417bf8ebcfc9.mov

