### PR TITLE
fix(Bonus Pagamenti Digitali): [#176993827] In SuperCashbackRanking bottom sheet text is selectable

### DIFF
--- a/ts/components/ui/Markdown/index.tsx
+++ b/ts/components/ui/Markdown/index.tsx
@@ -199,7 +199,7 @@ type OwnProps = {
    * The code will be inserted in the html body between
    * <script> and </script> tags.
    */
-  avoidTextSelection?: boolean;
+  avoidTextSelection?: true;
   cssStyle?: string;
   webViewStyle?: StyleProp<ViewStyle>;
   letUserZoom?: boolean;

--- a/ts/features/bonus/bpd/components/superCashbackRanking/SuperCashbackRanking.tsx
+++ b/ts/features/bonus/bpd/components/superCashbackRanking/SuperCashbackRanking.tsx
@@ -90,7 +90,7 @@ const SuperCashbackBottomSheet: React.FunctionComponent<Props> = (
     <View spacer={true} />
     {props.selectedPeriod && (
       <>
-        <Markdown cssStyle={CSS_STYLE}>
+        <Markdown cssStyle={CSS_STYLE} avoidTextSelection>
           {I18n.t("bonus.bpd.details.superCashback.howItWorks.body", {
             citizens: formatIntegerNumber(props.selectedPeriod.minPosition),
             amount: formatNumberWithNoDigits(
@@ -104,7 +104,7 @@ const SuperCashbackBottomSheet: React.FunctionComponent<Props> = (
           props.selectedPeriod.endDate,
           props.selectedPeriod.gracePeriod
         ) ? (
-          <Markdown cssStyle={CSS_STYLE}>
+          <Markdown cssStyle={CSS_STYLE} avoidTextSelection>
             {I18n.t(
               "bonus.bpd.details.superCashback.howItWorks.status.active",
               {


### PR DESCRIPTION
## Short description
This PR fixes an annoying behavior that allows text selection in bottom sheet making a bad UX

<img src="https://user-images.githubusercontent.com/822471/109932167-20c5bd00-7cca-11eb-8cbf-d1b40905f857.jpg" height="600"/>