### PR TITLE
[#177226606] Load local services in a embedded WebView

### DIFF
--- a/ts/components/services/LocalServicesWebView.tsx
+++ b/ts/components/services/LocalServicesWebView.tsx
@@ -1,10 +1,26 @@
 // a loading component rendered during the webview loading times
 import { StyleSheet, View } from "react-native";
 import React from "react";
+import * as pot from "italia-ts-commons/lib/pot";
 import WebView from "react-native-webview";
 import { WebViewNavigation } from "react-native-webview/lib/WebViewTypes";
+import URLParse from "url-parse";
+import { connect } from "react-redux";
+import { Dispatch } from "redux";
 import { fromNullable } from "fp-ts/lib/Option";
 import { RefreshIndicator } from "../ui/RefreshIndicator";
+import { ServicePublic } from "../../../definitions/backend/ServicePublic";
+import { withLightModalContext } from "../helpers/withLightModalContext";
+import { GlobalState } from "../../store/reducers/types";
+import { loadServiceDetail } from "../../store/actions/services";
+import { servicesByIdSelector } from "../../store/reducers/entities/services/servicesById";
+import { RTron } from "../../boot/configureStoreAndPersistor";
+import { isStrictSome } from "../../utils/pot";
+
+type Props = {
+  onServiceSelect: (service: ServicePublic) => void;
+} & ReturnType<typeof mapDispatchToProps> &
+  ReturnType<typeof mapStateToProps>;
 
 const styles = StyleSheet.create({
   refreshIndicatorContainer: {
@@ -13,6 +29,7 @@ const styles = StyleSheet.create({
     right: 0,
     top: 0,
     bottom: 0,
+    backgroundColor: "rgba(255,255,255,0.5)",
     justifyContent: "center",
     alignItems: "center",
     zIndex: 1000
@@ -23,24 +40,70 @@ const renderLoading = () => (
     <RefreshIndicator />
   </View>
 );
-const localServicesUri =
-  "https://604252d9556afc00079b0322--elated-archimedes-b3b6a6.netlify.app/app-content/enti-servizi.html";
-const handleOnShouldStartLoadWithRequest = (navState: WebViewNavigation) => {
-  if (navState.url) {
-  }
-  return true;
+const localServicesUri = "http://127.0.0.1:3000/services_web_view";
+const queryParam = "serviceId";
+
+const LocalServicesWebView = (props: Props) => {
+  const [serviceIdToLoad, setServiceIdToLoad] = React.useState<
+    string | undefined
+  >(undefined);
+
+  React.useEffect(() => {
+    fromNullable(serviceIdToLoad)
+      .mapNullable(sid => props.servicesById[sid])
+      .map(servicePot => {
+        if (isStrictSome(servicePot)) {
+          props.onServiceSelect(servicePot.value);
+        }
+      });
+  }, [props.servicesById]);
+
+  const handleOnShouldStartLoadWithRequest = (navState: WebViewNavigation) => {
+    if (navState.url) {
+      const urlParse = new URLParse(navState.url, true);
+      const maybeServiceId = urlParse.query[queryParam];
+      // click on service
+      if (maybeServiceId) {
+        setServiceIdToLoad(maybeServiceId);
+        // avoid webview load this url and load the service datail
+        props.loadService(maybeServiceId);
+        return false;
+      }
+      return true;
+    }
+    return true;
+  };
+  const isLoading = fromNullable(serviceIdToLoad)
+    .mapNullable(sid => props.servicesById[sid])
+    .fold(false, pot.isLoading);
+  return (
+    <>
+      {isLoading && renderLoading()}
+      <WebView
+        style={{ flex: 1 }}
+        textZoom={100}
+        source={{
+          uri: localServicesUri
+        }}
+        onShouldStartLoadWithRequest={handleOnShouldStartLoadWithRequest}
+        startInLoadingState={true}
+        renderLoading={renderLoading}
+        javaScriptEnabled={true}
+      />
+    </>
+  );
 };
 
-export const LocalServicesWebView = () => (
-  <WebView
-    style={{ flex: 1 }}
-    textZoom={100}
-    source={{
-      uri: localServicesUri
-    }}
-    onShouldStartLoadWithRequest={handleOnShouldStartLoadWithRequest}
-    startInLoadingState={true}
-    renderLoading={renderLoading}
-    javaScriptEnabled={true}
-  />
-);
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  loadService: (serviceId: string) =>
+    dispatch(loadServiceDetail.request(serviceId))
+});
+
+const mapStateToProps = (state: GlobalState) => ({
+  servicesById: servicesByIdSelector(state)
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(withLightModalContext(LocalServicesWebView));

--- a/ts/components/services/LocalServicesWebView.tsx
+++ b/ts/components/services/LocalServicesWebView.tsx
@@ -1,0 +1,46 @@
+// a loading component rendered during the webview loading times
+import { StyleSheet, View } from "react-native";
+import React from "react";
+import WebView from "react-native-webview";
+import { WebViewNavigation } from "react-native-webview/lib/WebViewTypes";
+import { fromNullable } from "fp-ts/lib/Option";
+import { RefreshIndicator } from "../ui/RefreshIndicator";
+
+const styles = StyleSheet.create({
+  refreshIndicatorContainer: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+    justifyContent: "center",
+    alignItems: "center",
+    zIndex: 1000
+  }
+});
+const renderLoading = () => (
+  <View style={styles.refreshIndicatorContainer}>
+    <RefreshIndicator />
+  </View>
+);
+const localServicesUri =
+  "https://604252d9556afc00079b0322--elated-archimedes-b3b6a6.netlify.app/app-content/enti-servizi.html";
+const handleOnShouldStartLoadWithRequest = (navState: WebViewNavigation) => {
+  if (navState.url) {
+  }
+  return true;
+};
+
+export const LocalServicesWebView = () => (
+  <WebView
+    style={{ flex: 1 }}
+    textZoom={100}
+    source={{
+      uri: localServicesUri
+    }}
+    onShouldStartLoadWithRequest={handleOnShouldStartLoadWithRequest}
+    startInLoadingState={true}
+    renderLoading={renderLoading}
+    javaScriptEnabled={true}
+  />
+);

--- a/ts/screens/services/ServicesHomeScreen.tsx
+++ b/ts/screens/services/ServicesHomeScreen.tsx
@@ -109,7 +109,7 @@ import { showToast } from "../../utils/showToast";
 import { setStatusBarColorAndBackground } from "../../utils/statusBar";
 import { IOStyles } from "../../components/core/variables/IOStyles";
 import SectionStatusComponent from "../../components/SectionStatusComponent";
-import { LocalServicesWebView } from "../../components/services/LocalServicesWebView";
+import LocalServicesWebView from "../../components/services/LocalServicesWebView";
 import ServiceDetailsScreen from "./ServiceDetailsScreen";
 
 type OwnProps = NavigationScreenProps;
@@ -708,7 +708,7 @@ class ServicesHomeScreen extends React.Component<Props, State> {
             textStyle={styles.textStyle}
             heading={I18n.t("services.tab.locals")}
           >
-            <LocalServicesWebView />
+            <LocalServicesWebView onServiceSelect={this.onServiceSelect} />
           </Tab>
           <Tab
             activeTextStyle={styles.activeTextStyle}

--- a/ts/screens/services/ServicesHomeScreen.tsx
+++ b/ts/screens/services/ServicesHomeScreen.tsx
@@ -109,6 +109,7 @@ import { showToast } from "../../utils/showToast";
 import { setStatusBarColorAndBackground } from "../../utils/statusBar";
 import { IOStyles } from "../../components/core/variables/IOStyles";
 import SectionStatusComponent from "../../components/SectionStatusComponent";
+import { LocalServicesWebView } from "../../components/services/LocalServicesWebView";
 import ServiceDetailsScreen from "./ServiceDetailsScreen";
 
 type OwnProps = NavigationScreenProps;
@@ -323,7 +324,6 @@ class ServicesHomeScreen extends React.Component<Props, State> {
   }
 
   private animatedTabScrollPositions: ReadonlyArray<Animated.Value> = [
-    new Animated.Value(0),
     new Animated.Value(0),
     new Animated.Value(0)
   ];
@@ -687,7 +687,6 @@ class ServicesHomeScreen extends React.Component<Props, State> {
     const {
       localTabSections,
       nationalTabSections,
-      allTabSections,
       potUserMetadata,
       isLoadingServices
     } = this.props;
@@ -709,28 +708,7 @@ class ServicesHomeScreen extends React.Component<Props, State> {
             textStyle={styles.textStyle}
             heading={I18n.t("services.tab.locals")}
           >
-            <ServicesTab
-              isLocal={true}
-              isAll={false}
-              sections={localTabSections}
-              isRefreshing={isRefreshing}
-              onRefresh={this.refreshScreenContent}
-              onServiceSelect={this.onServiceSelect}
-              handleOnLongPressItem={this.handleOnLongPressItem}
-              isLongPressEnabled={this.state.isLongPressEnabled}
-              updateOrganizationsOfInterestMetadata={
-                this.props.updateOrganizationsOfInterestMetadata
-              }
-              updateToast={() =>
-                this.setState({
-                  toastErrorMessage: I18n.t(
-                    "serviceDetail.onUpdateEnabledChannelsFailure"
-                  )
-                })
-              }
-              onItemSwitchValueChanged={this.onItemSwitchValueChanged}
-              tabScrollOffset={this.animatedTabScrollPositions[0]}
-            />
+            <LocalServicesWebView />
           </Tab>
           <Tab
             activeTextStyle={styles.activeTextStyle}
@@ -747,24 +725,6 @@ class ServicesHomeScreen extends React.Component<Props, State> {
               isLongPressEnabled={this.state.isLongPressEnabled}
               onItemSwitchValueChanged={this.onItemSwitchValueChanged}
               tabScrollOffset={this.animatedTabScrollPositions[1]}
-            />
-          </Tab>
-
-          <Tab
-            activeTextStyle={styles.activeTextStyle}
-            textStyle={styles.textStyle}
-            heading={I18n.t("services.tab.all")}
-          >
-            <ServicesTab
-              isAll={true}
-              sections={allTabSections}
-              isRefreshing={isRefreshing}
-              onRefresh={this.refreshScreenContent}
-              onServiceSelect={this.onServiceSelect}
-              handleOnLongPressItem={this.handleOnLongPressItem}
-              isLongPressEnabled={this.state.isLongPressEnabled}
-              onItemSwitchValueChanged={this.onItemSwitchValueChanged}
-              tabScrollOffset={this.animatedTabScrollPositions[2]}
             />
           </Tab>
         </AnimatedTabs>

--- a/ts/screens/services/ServicesHomeScreen.tsx
+++ b/ts/screens/services/ServicesHomeScreen.tsx
@@ -685,7 +685,6 @@ class ServicesHomeScreen extends React.Component<Props, State> {
    */
   private renderTabs = () => {
     const {
-      localTabSections,
       nationalTabSections,
       potUserMetadata,
       isLoadingServices


### PR DESCRIPTION
## Short description
This PR removes the `all` services tab and replaces the `local` tab with a webview.

The webview does the following:
It intercepts the loading request of a service and it does:
- block that request from loading
- extract the service id to load
- load the selected service (load and error are handled)


https://user-images.githubusercontent.com/822471/110304106-7a482780-7ffb-11eb-9c1c-86bc19bf1984.mp4

**Request error**
<img src="https://user-images.githubusercontent.com/822471/110304183-9055e800-7ffb-11eb-827c-4684a141dbfc.png" height="600" />