### PR TITLE
fix: [#177298671] On message pressed Service details is shown instead of Message details

### DIFF
--- a/ts/components/services/LocalServicesWebView.tsx
+++ b/ts/components/services/LocalServicesWebView.tsx
@@ -72,6 +72,7 @@ const LocalServicesWebView = (props: Props) => {
         // if service has been loaded
         if (isStrictSome(servicePot)) {
           props.onServiceSelect(servicePot.value);
+          setServiceIdToLoad(undefined);
           return;
         }
         if (pot.isError(servicePot)) {
@@ -90,7 +91,7 @@ const LocalServicesWebView = (props: Props) => {
   /**
    * 'listen' on web message
    * if a serviceId is sent: dispatch service loading request
-   * @param navState
+   * @param event
    */
   const handleWebviewMessage = (event: WebViewMessageEvent) => {
     ServiceId.decode(event.nativeEvent.data).map(sId => {


### PR DESCRIPTION
## Short description
This PR fixes a bug causing the navigation to service details screen instead of message detail screen when a message is tapped

### before  
https://user-images.githubusercontent.com/822471/110753472-ea96b900-8246-11eb-9369-ef1c387c1380.mov 

### now
https://user-images.githubusercontent.com/822471/110753524-f71b1180-8246-11eb-93b3-bdff22337c1d.mov



