### PR TITLE
feat(Bonus Pagamenti Digitali): [#177243713,#177144863,#177144964] Manages privative search loading and ko.

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -924,6 +924,8 @@ wallet:
         koNotFound:
           title: "Sorry, this card is not in your name"
           body: "Try entering the number again or, alternatively, ask your supermarket customer service for help."
+          cta:
+            modifyCardNumber: "Change card number"
   alert:
     supportedCardPageLinkError: An error occurred while opening the supported cards page.
     msgErrorUpdateApp: "An error occurred while opening the app store"

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -916,6 +916,8 @@ wallet:
         koUnavailable:
           title: "We're unable to contact the server"
           body: "We are working to solve the problem."
+      search:
+        loading: "We are verifying your card\n\nPlease wait"
   alert:
     supportedCardPageLinkError: An error occurred while opening the supported cards page.
     msgErrorUpdateApp: "An error occurred while opening the app store"

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -918,6 +918,12 @@ wallet:
           body: "We are working to solve the problem."
       search:
         loading: "We are verifying your card\n\nPlease wait"
+        koTimeout:
+          title: "It is currently impossible to verify your card"
+          body: "Please try again"
+        koNotFound:
+          title: "Sorry, this card is not in your name"
+          body: "Try entering the number again or, alternatively, ask your supermarket customer service for help."
   alert:
     supportedCardPageLinkError: An error occurred while opening the supported cards page.
     msgErrorUpdateApp: "An error occurred while opening the app store"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -944,6 +944,8 @@ wallet:
         koNotFound:
           title: "Spiacenti, questa carta non risulta intestata a te"
           body: "Prova ad inserire nuovamente il numero oppure, in alternativa, chiedi aiuto al servizio clienti del tuo supermercato."
+          cta:
+            modifyCardNumber: "Modifica numero carta"
   alert:
     supportedCardPageLinkError: Si è verificato un errore durante l'apertura della pagina di riferimento per le carte supportate. 
     msgErrorUpdateApp: "Si è verificato un errore durante l'apertura dello store delle app"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -938,6 +938,12 @@ wallet:
           body: "Siamo al lavoro per risolvere il problema."
       search:
         loading: "Stiamo verificando la tua carta\n\nAttendi qualche secondo"
+        koTimeout:
+          title: "Al momento è impossibile verificare la tua carta"
+          body: "Riprova per favore"
+        koNotFound:
+          title: "Spiacenti, questa carta non risulta intestata a te"
+          body: "Prova ad inserire nuovamente il numero oppure, in alternativa, chiedi aiuto al servizio clienti del tuo supermercato."
   alert:
     supportedCardPageLinkError: Si è verificato un errore durante l'apertura della pagina di riferimento per le carte supportate. 
     msgErrorUpdateApp: "Si è verificato un errore durante l'apertura dello store delle app"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -936,6 +936,8 @@ wallet:
         koUnavailable:
           title: "Non riusciamo a contattare il server"
           body: "Siamo al lavoro per risolvere il problema."
+      search:
+        loading: "Stiamo verificando la tua carta\n\nAttendi qualche secondo"
   alert:
     supportedCardPageLinkError: Si è verificato un errore durante l'apertura della pagina di riferimento per le carte supportate. 
     msgErrorUpdateApp: "Si è verificato un errore durante l'apertura dello store delle app"

--- a/ts/features/wallet/onboarding/privative/screens/add/AddPrivativeCardScreen.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/add/AddPrivativeCardScreen.tsx
@@ -3,9 +3,11 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { GlobalState } from "../../../../../../store/reducers/types";
+import BaseScreenComponent from "../../../../../../components/screens/BaseScreenComponent";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
-  ReturnType<typeof mapStateToProps>;
+  ReturnType<typeof mapStateToProps> &
+  Pick<React.ComponentProps<typeof BaseScreenComponent>, "contextualHelp">;;
 
 /**
  * This screen shows the user the private card found and allows him to add it to the wallet

--- a/ts/features/wallet/onboarding/privative/screens/search/LoadPrivativeSearch.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/LoadPrivativeSearch.tsx
@@ -1,46 +1,69 @@
 import * as React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
+import { isNone } from "fp-ts/lib/Option";
 import I18n from "../../../../../../i18n";
 import { GlobalState } from "../../../../../../store/reducers/types";
-import { walletAddPrivativeCancel } from "../../store/actions";
-import { onboardingSearchedPrivativeSelector } from "../../store/reducers/searchedPrivative";
+import {
+  searchUserPrivative,
+  walletAddPrivativeCancel
+} from "../../store/actions";
+import {
+  onboardingSearchedPrivativeSelector,
+  SearchedPrivativeData
+} from "../../store/reducers/searchedPrivative";
 import { onboardingPrivativeFoundIsError } from "../../store/reducers/foundPrivative";
 import { useHardwareBackButton } from "../../../../../bonus/bonusVacanze/components/hooks/useHardwareBackButton";
 import { LoadingErrorComponent } from "../../../../../bonus/bonusVacanze/components/loadingErrorScreen/LoadingErrorComponent";
+import { WithTestID } from "../../../../../../types/WithTestID";
+import { showToast } from "../../../../../../utils/showToast";
+import { mixpanelTrack } from "../../../../../../mixpanel";
+import { toPrivativeQuery } from "./SearchPrivativeCardScreen";
 
-type Props = ReturnType<typeof mapDispatchToProps> &
-  ReturnType<typeof mapStateToProps>;
+type Props = WithTestID<
+  ReturnType<typeof mapDispatchToProps> & ReturnType<typeof mapStateToProps>
+>;
 
 /**
  * Loading screen while search the privative card
  * @param props
  * @constructor
  */
-const LoadPrivativeSearch = (props: Props): React.ReactElement => {
+const LoadPrivativeSearch = (props: Props): React.ReactElement | null => {
   useHardwareBackButton(() => {
     if (!props.isLoading) {
       props.cancel();
     }
     return true;
   });
-  return (
-    <LoadingErrorComponent
-      {...props}
-      loadingCaption={I18n.t("wallet.onboarding.coBadge.search.loading")}
-      onAbort={props.cancel}
-      onRetry={() => props.retry(props.abiSelected)}
-    />
-  );
+
+  const privativeQueryParam = toPrivativeQuery(props.privativeSelected);
+  if (isNone(privativeQueryParam)) {
+    showToast(I18n.t("global.genericError"), "danger");
+    void mixpanelTrack("PRIVATIVE_NO_QUERY_PARAMS_ERROR");
+    props.cancel();
+    return null;
+  } else {
+    return (
+      <LoadingErrorComponent
+        {...props}
+        loadingCaption={I18n.t("wallet.onboarding.privative.search.loading")}
+        onAbort={props.cancel}
+        onRetry={() => props.retry(privativeQueryParam.value)}
+      />
+    );
+  }
 };
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  cancel: () => dispatch(walletAddPrivativeCancel())
+  cancel: () => dispatch(walletAddPrivativeCancel()),
+  retry: (searchedPrivativeData: Required<SearchedPrivativeData>) =>
+    dispatch(searchUserPrivative.request(searchedPrivativeData))
 });
 
 const mapStateToProps = (state: GlobalState) => ({
   privativeSelected: onboardingSearchedPrivativeSelector(state),
-  isLoading: onboardingPrivativeFoundIsError(state)
+  isLoading: !onboardingPrivativeFoundIsError(state)
 });
 
 export default connect(

--- a/ts/features/wallet/onboarding/privative/screens/search/LoadPrivativeSearch.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/LoadPrivativeSearch.tsx
@@ -1,8 +1,13 @@
-import { View } from "native-base";
 import * as React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
+import I18n from "../../../../../../i18n";
 import { GlobalState } from "../../../../../../store/reducers/types";
+import { walletAddPrivativeCancel } from "../../store/actions";
+import { onboardingSearchedPrivativeSelector } from "../../store/reducers/searchedPrivative";
+import { onboardingPrivativeFoundIsError } from "../../store/reducers/foundPrivative";
+import { useHardwareBackButton } from "../../../../../bonus/bonusVacanze/components/hooks/useHardwareBackButton";
+import { LoadingErrorComponent } from "../../../../../bonus/bonusVacanze/components/loadingErrorScreen/LoadingErrorComponent";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
@@ -12,11 +17,31 @@ type Props = ReturnType<typeof mapDispatchToProps> &
  * @param props
  * @constructor
  */
-const LoadPrivativeSearch = (_: Props): React.ReactElement => <View />;
+const LoadPrivativeSearch = (props: Props): React.ReactElement => {
+  useHardwareBackButton(() => {
+    if (!props.isLoading) {
+      props.cancel();
+    }
+    return true;
+  });
+  return (
+    <LoadingErrorComponent
+      {...props}
+      loadingCaption={I18n.t("wallet.onboarding.coBadge.search.loading")}
+      onAbort={props.cancel}
+      onRetry={() => props.retry(props.abiSelected)}
+    />
+  );
+};
 
-const mapDispatchToProps = (_: Dispatch) => ({});
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  cancel: () => dispatch(walletAddPrivativeCancel())
+});
 
-const mapStateToProps = (_: GlobalState) => ({});
+const mapStateToProps = (state: GlobalState) => ({
+  privativeSelected: onboardingSearchedPrivativeSelector(state),
+  isLoading: onboardingPrivativeFoundIsError(state)
+});
 
 export default connect(
   mapStateToProps,

--- a/ts/features/wallet/onboarding/privative/screens/search/SearchPrivativeCardScreen.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/SearchPrivativeCardScreen.tsx
@@ -110,7 +110,6 @@ const SearchPrivativeCardScreen = (props: Props): React.ReactElement => {
   }, []);
 
   const privativeFound = props.privativeFound;
-
   if (isReady(privativeFound)) {
     const payload = decodePayload(privativeFound.value);
     return payload.fold(
@@ -122,6 +121,7 @@ const SearchPrivativeCardScreen = (props: Props): React.ReactElement => {
   if (isError(privativeFound) && isTimeoutError(privativeFound.error)) {
     return <PrivativeKoTimeout contextualHelp={emptyContextualHelp} />;
   }
+
   return <LoadPrivativeSearch testID={"LoadPrivativeSearch"} />;
 };
 

--- a/ts/features/wallet/onboarding/privative/screens/search/SearchPrivativeCardScreen.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/SearchPrivativeCardScreen.tsx
@@ -3,6 +3,8 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { GlobalState } from "../../../../../../store/reducers/types";
+import { searchUserPrivative } from "../../store/actions";
+import { SearchedPrivativeData } from "../../store/reducers/searchedPrivative";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
@@ -14,7 +16,10 @@ type Props = ReturnType<typeof mapDispatchToProps> &
  */
 const SearchPrivativeCardScreen = (_: Props): React.ReactElement => <View />;
 
-const mapDispatchToProps = (_: Dispatch) => ({});
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  search: (searchedPrivativeData: Required<SearchedPrivativeData>) =>
+    dispatch(searchUserPrivative.request(searchedPrivativeData))
+});
 
 const mapStateToProps = (_: GlobalState) => ({});
 

--- a/ts/features/wallet/onboarding/privative/screens/search/SearchPrivativeCardScreen.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/SearchPrivativeCardScreen.tsx
@@ -1,27 +1,69 @@
+import * as t from "io-ts";
+import { useEffect } from "react";
 import { View } from "native-base";
 import * as React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
+import {fromNullable} from "fp-ts/lib/Option";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import { searchUserPrivative } from "../../store/actions";
 import {
   SearchedPrivativeData,
   onboardingSearchedPrivativeSelector
 } from "../../store/reducers/searchedPrivative";
-import {
-  onboardingPrivativeFoundIsError,
-  onboardingPrivativeFoundSelector
-} from "../../store/reducers/foundPrivative";
+import { onboardingPrivativeFoundSelector } from "../../store/reducers/foundPrivative";
+import { PaymentInstrument } from "../../../../../../../definitions/pagopa/walletv2/PaymentInstrument";
+import { SearchRequestMetadata } from "../../../../../../../definitions/pagopa/walletv2/SearchRequestMetadata";
+import { CobadgeResponse } from "../../../../../../../definitions/pagopa/walletv2/CobadgeResponse";
+
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
 
+const PrivativePayload = t.type({
+  paymentInstruments: t.readonlyArray(
+    PaymentInstrument,
+    "array of PaymentInstrument"
+  ),
+  searchRequestMetadata: t.readonlyArray(
+    SearchRequestMetadata,
+    "array of SearchRequestMetadata"
+  )
+});
+
+type PrivativePayload = t.TypeOf<typeof PrivativePayload>;
+
+const decodePayload = (privative: CobadgeResponse) =>
+  PrivativePayload.decode(privative.payload);
+
+
+const toPrivativeQuery = (
+  searched: SearchedPrivativeData
+): Option<PrivativeQuery> => {
+  const { id, cardNumber } = searched;
+  return id !== undefined && cardNumber !== undefined
+    ? some({ id, cardNumber })
+    : none;
+};
 /**
  * This screen orchestrates (loading, kos, success) the search of a privative card
  * @param props
  * @constructor
  */
-const SearchPrivativeCardScreen = (_: Props): React.ReactElement => <View />;
+const SearchPrivativeCardScreen = (props: Props): React.ReactElement => {
+  useEffect(() => {
+    const issuerId = fromNullable(props.privativeSelected.id);
+    const cardNumber = fromNullable(props.privativeSelected.cardNumber);
+
+    // Is not expected that the user can arrive in this screen without the issuerId and the cardNumber.
+    // If this happens, an event will be send to mixpanel and the cancel action will be dispatched.
+    // TODO: add an error action to the workunit
+
+
+  }, []);
+
+  return <View />;
+};
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   search: (searchedPrivativeData: Required<SearchedPrivativeData>) =>
@@ -29,9 +71,8 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 });
 
 const mapStateToProps = (state: GlobalState) => ({
-  searchedPrivative: onboardingSearchedPrivativeSelector(state),
-  foundPrivative: onboardingPrivativeFoundSelector(state),
-  foundError: onboardingPrivativeFoundIsError(state)
+  privativeSelected: onboardingSearchedPrivativeSelector(state),
+  foundPrivative: onboardingPrivativeFoundSelector(state)
 });
 
 export default connect(

--- a/ts/features/wallet/onboarding/privative/screens/search/SearchPrivativeCardScreen.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/SearchPrivativeCardScreen.tsx
@@ -4,7 +4,14 @@ import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import { searchUserPrivative } from "../../store/actions";
-import { SearchedPrivativeData } from "../../store/reducers/searchedPrivative";
+import {
+  SearchedPrivativeData,
+  onboardingSearchedPrivativeSelector
+} from "../../store/reducers/searchedPrivative";
+import {
+  onboardingPrivativeFoundIsError,
+  onboardingPrivativeFoundSelector
+} from "../../store/reducers/foundPrivative";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
@@ -21,7 +28,11 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     dispatch(searchUserPrivative.request(searchedPrivativeData))
 });
 
-const mapStateToProps = (_: GlobalState) => ({});
+const mapStateToProps = (state: GlobalState) => ({
+  searchedPrivative: onboardingSearchedPrivativeSelector(state),
+  foundPrivative: onboardingPrivativeFoundSelector(state),
+  foundError: onboardingPrivativeFoundIsError(state)
+});
 
 export default connect(
   mapStateToProps,

--- a/ts/features/wallet/onboarding/privative/screens/search/SearchPrivativeCardScreen.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/SearchPrivativeCardScreen.tsx
@@ -27,10 +27,10 @@ import { mixpanelTrack } from "../../../../../../mixpanel";
 import { isError, isReady } from "../../../../../bonus/bpd/model/RemoteValue";
 import { emptyContextualHelp } from "../../../../../../utils/emptyContextualHelp";
 import { isTimeoutError } from "../../../../../../utils/errors";
+import AddPrivativeCardScreen from "../add/AddPrivativeCardScreen";
 import LoadPrivativeSearch from "./LoadPrivativeSearch";
 import PrivativeKoTimeout from "./ko/PrivativeKoTimeout";
 import PrivativeKoNotFound from "./ko/PrivativeKoNotFound";
-import AddPrivativeCardScreen from "../add/AddPrivativeCardScreen";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;

--- a/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoNotFound.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoNotFound.tsx
@@ -3,10 +3,11 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { GlobalState } from "../../../../../../../store/reducers/types";
+import BaseScreenComponent from "../../../../../../../components/screens/BaseScreenComponent";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
-  ReturnType<typeof mapStateToProps>;
-
+  ReturnType<typeof mapStateToProps> &
+  Pick<React.ComponentProps<typeof BaseScreenComponent>, "contextualHelp">;
 /**
  * This screen informs the user that the private card indicated was not found
  * @param props

--- a/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoNotFound.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoNotFound.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { SafeAreaView } from "react-native";
+import { NavigationActions } from "react-navigation";
 import I18n from "../../../../../../../i18n";
 import { GlobalState } from "../../../../../../../store/reducers/types";
 import BaseScreenComponent from "../../../../../../../components/screens/BaseScreenComponent";
@@ -14,7 +15,6 @@ import { emptyContextualHelp } from "../../../../../../../utils/emptyContextualH
 import { IOStyles } from "../../../../../../../components/core/variables/IOStyles";
 import { renderInfoRasterImage } from "../../../../../../../components/infoScreen/imageRendering";
 import { walletAddPrivativeCancel } from "../../../store/actions";
-import { NavigationActions } from "react-navigation";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps> &

--- a/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoNotFound.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoNotFound.tsx
@@ -2,20 +2,75 @@ import { View } from "native-base";
 import * as React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
+import { SafeAreaView } from "react-native";
+import I18n from "../../../../../../../i18n";
 import { GlobalState } from "../../../../../../../store/reducers/types";
 import BaseScreenComponent from "../../../../../../../components/screens/BaseScreenComponent";
+import { useHardwareBackButton } from "../../../../../../bonus/bonusVacanze/components/hooks/useHardwareBackButton";
+import { InfoScreenComponent } from "../../../../../../../components/infoScreen/InfoScreenComponent";
+import image from "../../../../../../../../img/servicesStatus/error-detail-icon.png";
+import { FooterTwoButtons } from "../../../../../../bonus/bonusVacanze/components/markdown/FooterTwoButtons";
+import { emptyContextualHelp } from "../../../../../../../utils/emptyContextualHelp";
+import { IOStyles } from "../../../../../../../components/core/variables/IOStyles";
+import { renderInfoRasterImage } from "../../../../../../../components/infoScreen/imageRendering";
+import { walletAddPrivativeCancel } from "../../../store/actions";
+import { NavigationActions } from "react-navigation";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps> &
   Pick<React.ComponentProps<typeof BaseScreenComponent>, "contextualHelp">;
+
+const loadLocales = () => ({
+  headerTitle: I18n.t("wallet.onboarding.privative.headerTitle"),
+  title: I18n.t("wallet.onboarding.privative.search.koNotFound.title"),
+  body: I18n.t("wallet.onboarding.privative.search.koNotFound.body"),
+  cancel: I18n.t("global.buttons.cancel"),
+  modifyCardNumber: I18n.t(
+    "wallet.onboarding.privative.search.koNotFound.cta.modifyCardNumber"
+  )
+});
+
 /**
  * This screen informs the user that the private card indicated was not found
  * @param props
  * @constructor
  */
-const PrivativeKoNotFound = (_: Props): React.ReactElement => <View />;
+const PrivativeKoNotFound = (props: Props): React.ReactElement => {
+  const { headerTitle, title, body, cancel, modifyCardNumber } = loadLocales();
 
-const mapDispatchToProps = (_: Dispatch) => ({});
+  useHardwareBackButton(() => {
+    props.cancel();
+    return true;
+  });
+  return (
+    <BaseScreenComponent
+      goBack={false}
+      customGoBack={<View />}
+      headerTitle={headerTitle}
+      contextualHelp={emptyContextualHelp}
+    >
+      <SafeAreaView style={IOStyles.flex} testID={"CoBadgeKoTimeout"}>
+        <InfoScreenComponent
+          image={renderInfoRasterImage(image)}
+          title={title}
+          body={body}
+        />
+        <FooterTwoButtons
+          type={"TwoButtonsInlineThird"}
+          onRight={props.goToModifyCardNumber}
+          onCancel={props.cancel}
+          rightText={modifyCardNumber}
+          leftText={cancel}
+        />
+      </SafeAreaView>
+    </BaseScreenComponent>
+  );
+};
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  cancel: () => dispatch(walletAddPrivativeCancel()),
+  goToModifyCardNumber: () => dispatch(NavigationActions.back())
+});
 
 const mapStateToProps = (_: GlobalState) => ({});
 

--- a/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoTimeout.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoTimeout.tsx
@@ -3,9 +3,11 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { GlobalState } from "../../../../../../../store/reducers/types";
+import BaseScreenComponent from "../../../../../../../components/screens/BaseScreenComponent";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
-  ReturnType<typeof mapStateToProps>;
+  ReturnType<typeof mapStateToProps> &
+  Pick<React.ComponentProps<typeof BaseScreenComponent>, "contextualHelp">;
 
 /**
  * This screen informs the user that a timeout is occurred while searching the indicated privative card.

--- a/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoTimeout.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoTimeout.tsx
@@ -1,13 +1,42 @@
 import { View } from "native-base";
 import * as React from "react";
+import { SafeAreaView } from "react-native";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
+import { isNone } from "fp-ts/lib/Option";
+import I18n from "../../../../../../../i18n";
+import { InfoScreenComponent } from "../../../../../../../components/infoScreen/InfoScreenComponent";
 import { GlobalState } from "../../../../../../../store/reducers/types";
+import { FooterTwoButtons } from "../../../../../../bonus/bonusVacanze/components/markdown/FooterTwoButtons";
 import BaseScreenComponent from "../../../../../../../components/screens/BaseScreenComponent";
+import { useHardwareBackButton } from "../../../../../../bonus/bonusVacanze/components/hooks/useHardwareBackButton";
+import { emptyContextualHelp } from "../../../../../../../utils/emptyContextualHelp";
+import { IOStyles } from "../../../../../../../components/core/variables/IOStyles";
+import image from "../../../../../../../../img/servicesStatus/error-detail-icon.png";
+import { renderInfoRasterImage } from "../../../../../../../components/infoScreen/imageRendering";
+import {
+  searchUserPrivative,
+  walletAddPrivativeCancel
+} from "../../../store/actions";
+import {
+  onboardingSearchedPrivativeSelector,
+  SearchedPrivativeData
+} from "../../../store/reducers/searchedPrivative";
+import { toPrivativeQuery } from "../SearchPrivativeCardScreen";
+import { showToast } from "../../../../../../../utils/showToast";
+import { mixpanelTrack } from "../../../../../../../mixpanel";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps> &
   Pick<React.ComponentProps<typeof BaseScreenComponent>, "contextualHelp">;
+
+const loadLocales = () => ({
+  headerTitle: I18n.t("wallet.onboarding.privative.headerTitle"),
+  title: I18n.t("wallet.onboarding.privative.search.koTimeout.title"),
+  body: I18n.t("wallet.onboarding.privative.search.koTimeout.body"),
+  cancel: I18n.t("global.buttons.cancel"),
+  retry: I18n.t("global.buttons.retry")
+});
 
 /**
  * This screen informs the user that a timeout is occurred while searching the indicated privative card.
@@ -17,10 +46,55 @@ type Props = ReturnType<typeof mapDispatchToProps> &
  * @param props
  * @constructor
  */
-const PrivativeKoTimeout = (_: Props): React.ReactElement => <View />;
+const PrivativeKoTimeout = (props: Props): React.ReactElement | null => {
+  const { headerTitle, title, body, cancel, retry } = loadLocales();
 
-const mapDispatchToProps = (_: Dispatch) => ({});
+  useHardwareBackButton(() => {
+    props.cancel();
+    return true;
+  });
 
-const mapStateToProps = (_: GlobalState) => ({});
+  const privativeQueryParam = toPrivativeQuery(props.privativeSelected);
+  if (isNone(privativeQueryParam)) {
+    showToast(I18n.t("global.genericError"), "danger");
+    void mixpanelTrack("PRIVATIVE_NO_QUERY_PARAMS_ERROR");
+    props.cancel();
+    return null;
+  } else {
+    return (
+      <BaseScreenComponent
+        goBack={false}
+        customGoBack={<View />}
+        headerTitle={headerTitle}
+        contextualHelp={emptyContextualHelp}
+      >
+        <SafeAreaView style={IOStyles.flex} testID={"CoBadgeKoTimeout"}>
+          <InfoScreenComponent
+            image={renderInfoRasterImage(image)}
+            title={title}
+            body={body}
+          />
+          <FooterTwoButtons
+            type={"TwoButtonsInlineThird"}
+            onRight={() => props.retry(privativeQueryParam.value)}
+            onCancel={props.cancel}
+            rightText={retry}
+            leftText={cancel}
+          />
+        </SafeAreaView>
+      </BaseScreenComponent>
+    );
+  }
+};
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  cancel: () => dispatch(walletAddPrivativeCancel()),
+  retry: (searchedPrivativeData: Required<SearchedPrivativeData>) =>
+    dispatch(searchUserPrivative.request(searchedPrivativeData))
+});
+
+const mapStateToProps = (state: GlobalState) => ({
+  privativeSelected: onboardingSearchedPrivativeSelector(state)
+});
 
 export default connect(mapStateToProps, mapDispatchToProps)(PrivativeKoTimeout);


### PR DESCRIPTION
## Short description
This PR manages the search privative card step.
If the status is loading it shows the `LoadPrivativeSearch` screen, while if the status is ko it shows the `PrivativeKoTimeout` screen or if there isn't any card the `PrivativeKoNotFound`.
Finally if the card is found the `AddPrivativeCardScreen` is shown.

## List of changes proposed in this pull request
- Manage the search results in `SearchPrivativeCardScreen`
- Fill the `LoadPrivativeSearch` screen
- Fill the `PrivativeKoTimeout` screen 
- Fill the `PrivativeKoNotFound` screen

| LoadPrivativeSearch Loading  | LoadPrivativeSearch Error  |
| ------------- | ------------- |
![LoadPrivativeSearch Loading](https://user-images.githubusercontent.com/11773070/110930640-a6c8b000-8329-11eb-8af8-1b684c74185c.png) | ![LoadPrivativeSearch Error](https://user-images.githubusercontent.com/11773070/110930688-b516cc00-8329-11eb-8804-7bebd5182cdf.png)

| PrivativeKoTimeout  | PrivativeKoNotFound  |
| ------------- | ------------- |
![PrivativeKoTimeout](https://user-images.githubusercontent.com/11773070/110930814-db3c6c00-8329-11eb-8bde-cc1a5e24eada.png) | ![PrivativeKoNotFound](https://user-images.githubusercontent.com/11773070/110930846-e1cae380-8329-11eb-86f4-1ddb1e9c67b6.png)
