### PR TITLE
fix(Carta Giovani Nazionale): [#177303103] First tap on merchants list item fails

### DIFF
--- a/ts/features/bonus/cgn/screens/merchants/CgnMerchantsListScreen.tsx
+++ b/ts/features/bonus/cgn/screens/merchants/CgnMerchantsListScreen.tsx
@@ -1,6 +1,11 @@
 import * as React from "react";
 import { connect } from "react-redux";
-import { FlatList, ListRenderItemInfo, SafeAreaView } from "react-native";
+import {
+  FlatList,
+  Keyboard,
+  ListRenderItemInfo,
+  SafeAreaView
+} from "react-native";
 import { Input, Item, View } from "native-base";
 import { debounce } from "lodash";
 import { Millisecond } from "italia-ts-commons/lib/units";
@@ -65,6 +70,7 @@ const CgnMerchantsListScreen: React.FunctionComponent<Props> = (
   const onItemPress = () => {
     // TODO Add the dispatch of merchant selected when the complete workflow is available
     props.navigateToMerchantDetail();
+    Keyboard.dismiss();
   };
 
   const renderListItem = (listItem: ListRenderItemInfo<TmpMerchantType>) => (
@@ -104,6 +110,7 @@ const CgnMerchantsListScreen: React.FunctionComponent<Props> = (
             )}
             renderItem={renderListItem}
             keyExtractor={c => `${c.name}-${c.category}`}
+            keyboardShouldPersistTaps={"handled"}
             ListFooterComponent={
               merchantList.length > 0 && <EdgeBorderComponent />
             }


### PR DESCRIPTION
## Short description
This PR Fixes the double tap needed to navigate from list item to merchant detail

## How to test
Navigate to CGN detail, navigate to merchants list and tap on any item even if the focus is yet on input box

https://user-images.githubusercontent.com/3959405/110931407-82210800-832a-11eb-94f8-e7c5f189acf8.mov

