### PR TITLE
fix(Bonus Pagamenti Digitali): [#177357472] Wrong decode during the add of a new privative card to the wallet

### DIFF
--- a/ts/features/wallet/onboarding/cobadge/saga/networking/addCobadgeToWallet.ts
+++ b/ts/features/wallet/onboarding/cobadge/saga/networking/addCobadgeToWallet.ts
@@ -4,9 +4,8 @@ import { readableReport } from "italia-ts-commons/lib/reporters";
 import { PaymentInstrument } from "../../../../../../../definitions/pagopa/walletv2/PaymentInstrument";
 import { PaymentManagerClient } from "../../../../../../api/pagopa";
 import {
-  isRawCreditCard,
   PaymentManagerToken,
-  RawCreditCardPaymentMethod
+  RawPaymentMethod
 } from "../../../../../../types/pagopa";
 import {
   getGenericError,
@@ -29,7 +28,7 @@ export const addCobadgeToWallet = async (
   >["addCobadgeToWallet"],
   sessionManager: SessionManager<PaymentManagerToken>,
   paymentInstrument: PaymentInstrument
-): Promise<Either<NetworkError, RawCreditCardPaymentMethod>> => {
+): Promise<Either<NetworkError, RawPaymentMethod>> => {
   try {
     const addCobadgeToWalletWithRefresh = sessionManager.withRefresh(
       addCobadgeToWallet({
@@ -52,7 +51,7 @@ export const addCobadgeToWallet = async (
         );
         if (
           maybeWallet.isSome() &&
-          isRawCreditCard(maybeWallet.value.paymentMethod)
+          maybeWallet.value.paymentMethod !== undefined
         ) {
           return right(maybeWallet.value.paymentMethod);
         } else {

--- a/ts/features/wallet/onboarding/cobadge/saga/networking/index.ts
+++ b/ts/features/wallet/onboarding/cobadge/saga/networking/index.ts
@@ -1,11 +1,21 @@
+import { Either, left, right } from "fp-ts/lib/Either";
 import { select } from "redux-saga-test-plan/matchers";
 import { call, put } from "redux-saga/effects";
 import { ActionType } from "typesafe-actions";
 import { ContentClient } from "../../../../../../api/content";
 import { PaymentManagerClient } from "../../../../../../api/pagopa";
-import { PaymentManagerToken } from "../../../../../../types/pagopa";
+import {
+  isRawCreditCard,
+  PaymentManagerToken,
+  RawCreditCardPaymentMethod,
+  RawPaymentMethod
+} from "../../../../../../types/pagopa";
 import { SagaCallReturnType } from "../../../../../../types/utils";
-import { getNetworkError } from "../../../../../../utils/errors";
+import {
+  getGenericError,
+  getNetworkError,
+  NetworkError
+} from "../../../../../../utils/errors";
 import { readablePrivacyReport } from "../../../../../../utils/reporters";
 import { SessionManager } from "../../../../../../utils/SessionManager";
 import {
@@ -52,6 +62,17 @@ export function* handleSearchUserCoBadge(
   }
 }
 
+const toRawCreditCardPaymentMethod = (
+  rpm: RawPaymentMethod
+): Either<NetworkError, RawCreditCardPaymentMethod> =>
+  isRawCreditCard(rpm)
+    ? right(rpm)
+    : left(
+        getGenericError(
+          new Error("Cannot decode the payload as RawCreditCardPaymentMethod")
+        )
+      );
+
 /**
  * Add Cobadge to wallet
  */
@@ -69,11 +90,14 @@ export function* handleAddCoBadgeToWallet(
     sessionManager,
     action.payload
   );
+
+  const eitherRawCreditCard = result.chain(toRawCreditCardPaymentMethod);
+
   // dispatch the related action
-  if (result.isRight()) {
-    yield put(addCoBadgeToWallet.success(result.value));
+  if (eitherRawCreditCard.isRight()) {
+    yield put(addCoBadgeToWallet.success(eitherRawCreditCard.value));
   } else {
-    yield put(addCoBadgeToWallet.failure(result.value));
+    yield put(addCoBadgeToWallet.failure(eitherRawCreditCard.value));
   }
 }
 

--- a/ts/features/wallet/onboarding/privative/saga/networking/handleAddPrivativeToWallet.ts
+++ b/ts/features/wallet/onboarding/privative/saga/networking/handleAddPrivativeToWallet.ts
@@ -21,7 +21,7 @@ const toRawPrivativePaymentMethod = (
     ? right(rpm)
     : left(
         getGenericError(
-          new Error("Cannot decode the payload as RawCreditCardPaymentMethod")
+          new Error("Cannot decode the payload as RawPrivativePaymentMethod")
         )
       );
 

--- a/ts/features/wallet/onboarding/privative/saga/networking/handleAddPrivativeToWallet.ts
+++ b/ts/features/wallet/onboarding/privative/saga/networking/handleAddPrivativeToWallet.ts
@@ -1,11 +1,29 @@
+import { Either, left, right } from "fp-ts/lib/Either";
 import { call, put } from "redux-saga/effects";
 import { ActionType } from "typesafe-actions";
 import { PaymentManagerClient } from "../../../../../../api/pagopa";
-import { PaymentManagerToken } from "../../../../../../types/pagopa";
+import {
+  isRawPrivative,
+  PaymentManagerToken,
+  RawPaymentMethod,
+  RawPrivativePaymentMethod
+} from "../../../../../../types/pagopa";
 import { SagaCallReturnType } from "../../../../../../types/utils";
+import { getGenericError, NetworkError } from "../../../../../../utils/errors";
 import { SessionManager } from "../../../../../../utils/SessionManager";
 import { addCobadgeToWallet } from "../../../cobadge/saga/networking/addCobadgeToWallet";
 import { addPrivativeToWallet } from "../../store/actions";
+
+const toRawPrivativePaymentMethod = (
+  rpm: RawPaymentMethod
+): Either<NetworkError, RawPrivativePaymentMethod> =>
+  isRawPrivative(rpm)
+    ? right(rpm)
+    : left(
+        getGenericError(
+          new Error("Cannot decode the payload as RawCreditCardPaymentMethod")
+        )
+      );
 
 export function* handleAddPrivativeToWallet(
   addCobadgeToWalletClient: ReturnType<
@@ -21,10 +39,13 @@ export function* handleAddPrivativeToWallet(
     sessionManager,
     addAction.payload
   );
+
+  const eitherRawPrivative = result.chain(toRawPrivativePaymentMethod);
+
   // dispatch the related action
-  if (result.isRight()) {
-    yield put(addPrivativeToWallet.success(result.value));
+  if (eitherRawPrivative.isRight()) {
+    yield put(addPrivativeToWallet.success(eitherRawPrivative.value));
   } else {
-    yield put(addPrivativeToWallet.failure(result.value));
+    yield put(addPrivativeToWallet.failure(eitherRawPrivative.value));
   }
 }

--- a/ts/features/wallet/onboarding/privative/store/actions/index.ts
+++ b/ts/features/wallet/onboarding/privative/store/actions/index.ts
@@ -6,7 +6,7 @@ import {
 import { PrivativeServices } from "../../../../../../../definitions/pagopa/privative/configuration/PrivativeServices";
 import { PaymentInstrument } from "../../../../../../../definitions/pagopa/walletv2/PaymentInstrument";
 import { SearchRequestMetadata } from "../../../../../../../definitions/pagopa/walletv2/SearchRequestMetadata";
-import { RawCreditCardPaymentMethod } from "../../../../../../types/pagopa";
+import { RawPrivativePaymentMethod } from "../../../../../../types/pagopa";
 import { NetworkError } from "../../../../../../utils/errors";
 import {
   PrivativeIssuerId,
@@ -36,7 +36,7 @@ export const addPrivativeToWallet = createAsyncAction(
   "WALLET_ONBOARDING_PRIVATIVE_ADD_REQUEST",
   "WALLET_ONBOARDING_PRIVATIVE_ADD_SUCCESS",
   "WALLET_ONBOARDING_PRIVATIVE_ADD_FAILURE"
-)<PaymentInstrument, RawCreditCardPaymentMethod, NetworkError>();
+)<PaymentInstrument, RawPrivativePaymentMethod, NetworkError>();
 
 /**
  * Load the privative issuers configuration (the list of issuer that can issue a privative card )

--- a/ts/features/wallet/onboarding/privative/store/reducers/addedPrivative.ts
+++ b/ts/features/wallet/onboarding/privative/store/reducers/addedPrivative.ts
@@ -2,18 +2,18 @@ import { createSelector } from "reselect";
 import { getType } from "typesafe-actions";
 import { Action } from "../../../../../../store/actions/types";
 import {
-  CreditCardPaymentMethod,
-  RawCreditCardPaymentMethod
+  PrivativePaymentMethod,
+  RawPrivativePaymentMethod
 } from "../../../../../../types/pagopa";
-import { enhanceCreditCard } from "../../../../../../utils/paymentMethod";
+import { enhancePrivativeCard } from "../../../../../../utils/paymentMethod";
 import { getValueOrElse } from "../../../../../bonus/bpd/model/RemoteValue";
 import { abiSelector } from "../../../store/abi";
 import { addPrivativeToWallet, walletAddPrivativeStart } from "../actions";
 
 const addedPrivativeReducer = (
-  state: RawCreditCardPaymentMethod | null = null,
+  state: RawPrivativePaymentMethod | null = null,
   action: Action
-): RawCreditCardPaymentMethod | null => {
+): RawPrivativePaymentMethod | null => {
   switch (action.type) {
     // Register a new privative card added in the current onboarding session
     case getType(addPrivativeToWallet.success):
@@ -25,12 +25,11 @@ const addedPrivativeReducer = (
   return state;
 };
 
-// TODO: replace enhanceCreditCard with enhancePrivative to add the brand logo!
 export const onboardingPrivativeAddedSelector = createSelector(
   [state => state.wallet.onboarding.privative.addedPrivative, abiSelector],
-  (addedCoBadge, remoteAbi): CreditCardPaymentMethod | undefined =>
-    addedCoBadge
-      ? enhanceCreditCard(addedCoBadge, getValueOrElse(remoteAbi, {}))
+  (addedPrivative, remoteAbi): PrivativePaymentMethod | undefined =>
+    addedPrivative
+      ? enhancePrivativeCard(addedPrivative, getValueOrElse(remoteAbi, {}))
       : undefined
 );
 

--- a/ts/features/wallet/onboarding/privative/store/reducers/addingPrivative.ts
+++ b/ts/features/wallet/onboarding/privative/store/reducers/addingPrivative.ts
@@ -2,7 +2,7 @@ import { getType } from "typesafe-actions";
 import { PaymentInstrument } from "../../../../../../../definitions/pagopa/walletv2/PaymentInstrument";
 import { Action } from "../../../../../../store/actions/types";
 import { GlobalState } from "../../../../../../store/reducers/types";
-import { RawCreditCardPaymentMethod } from "../../../../../../types/pagopa";
+import { RawPrivativePaymentMethod } from "../../../../../../types/pagopa";
 import { NetworkError } from "../../../../../../utils/errors";
 import {
   remoteError,
@@ -14,7 +14,7 @@ import {
 import { addPrivativeToWallet, walletAddPrivativeStart } from "../actions";
 
 export type AddingPrivativeState = {
-  addingResult: RemoteValue<RawCreditCardPaymentMethod, NetworkError>;
+  addingResult: RemoteValue<RawPrivativePaymentMethod, NetworkError>;
   selectedPrivative?: PaymentInstrument;
 };
 
@@ -55,7 +55,7 @@ export const onboardingPrivativeChosenSelector = (
 
 export const onboardingPrivativeAddingResultSelector = (
   state: GlobalState
-): RemoteValue<RawCreditCardPaymentMethod, NetworkError> =>
+): RemoteValue<RawPrivativePaymentMethod, NetworkError> =>
   state.wallet.onboarding.privative.addingPrivative.addingResult;
 
 export default addingPrivativeReducer;

--- a/ts/features/wallet/onboarding/privative/store/reducers/index.ts
+++ b/ts/features/wallet/onboarding/privative/store/reducers/index.ts
@@ -1,5 +1,5 @@
 import { Action, combineReducers } from "redux";
-import { RawCreditCardPaymentMethod } from "../../../../../../types/pagopa";
+import { RawPrivativePaymentMethod } from "../../../../../../types/pagopa";
 import addedPrivativeReducer from "./addedPrivative";
 import addingPrivativeReducer, {
   AddingPrivativeState
@@ -19,7 +19,7 @@ import searchPrivativeRequestIdReducer, {
 export type OnboardingPrivativeState = {
   foundPrivative: RemotePrivative;
   addingPrivative: AddingPrivativeState;
-  addedPrivative: RawCreditCardPaymentMethod | null;
+  addedPrivative: RawPrivativePaymentMethod | null;
   searchedPrivative: SearchedPrivativeData;
   privativeIssuers: PrivativeIssuersState;
   searchPrivativeRequestId: SearchPrivativeRequestIdState;

--- a/ts/utils/paymentMethod.ts
+++ b/ts/utils/paymentMethod.ts
@@ -185,16 +185,16 @@ export const enhanceCreditCard = (
 });
 
 export const enhancePrivativeCard = (
-  rawCreditCard: RawPrivativePaymentMethod,
+  rawPrivative: RawPrivativePaymentMethod,
   abiList: IndexedById<Abi>
 ): PrivativePaymentMethod => ({
-  ...rawCreditCard,
-  caption: getTitleFromPaymentMethod(rawCreditCard, abiList),
-  icon: rawCreditCard.info.issuerAbiCode
-    ? getPrivativeLoyaltyLogoUrl(rawCreditCard.info.issuerAbiCode)
+  ...rawPrivative,
+  caption: getTitleFromPaymentMethod(rawPrivative, abiList),
+  icon: rawPrivative.info.issuerAbiCode
+    ? getPrivativeLoyaltyLogoUrl(rawPrivative.info.issuerAbiCode)
     : cardIcons.UNKNOWN,
-  gdoLogo: rawCreditCard.info.issuerAbiCode
-    ? getPrivativeGdoLogoUrl(rawCreditCard.info.issuerAbiCode)
+  gdoLogo: rawPrivative.info.issuerAbiCode
+    ? getPrivativeGdoLogoUrl(rawPrivative.info.issuerAbiCode)
     : undefined
 });
 


### PR DESCRIPTION
## Short description
This pr fixes the wrong decode of the `/cobadge/add-wallets` response when adding a new `PrivativePaymentMethod`.

## List of changes proposed in this pull request
- Changed `addCobadgeToWallet` in order to return a `RawPaymentMethod` instead of `RawCreditCardPaymentMethod`
- Changed `handleAddCoBadgeToWallet` in order to check the `CreditCardPaymentMethod` type
- Changed `handleAddPrivativeToWallet` in order to check the `RawPrivativePaymentMethod` type
- Changed the type for `addPrivativeToWallet`, `addedPrivativeReducer`, `onboardingPrivativeAddedSelector`, `onboardingPrivativeAddingResultSelector`