### PR TITLE
feat(Bonus Pagamenti Digitali): [#177144429] Add mixpanel tracking for privative workflow

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -3,7 +3,7 @@
 ENVIRONMENT=PROD
 API_URL_PREFIX='https://app-backend.io.italia.it'
 # pagoPA RESTful API
-PAGOPA_API_URL_PREFIX='https://acardste.vaservices.eu:443/pp-restapi-CD'
+PAGOPA_API_URL_PREFIX='https://wisp2.pagopa.gov.it/pp-restapi-CD'
 # pagoPA test/env RESTful API
 PAGOPA_API_URL_PREFIX_TEST='https://acardste.vaservices.eu:443/pp-restapi-CD'
 # endpoint to get backend status
@@ -43,10 +43,10 @@ MYPORTAL_ENABLED=NO
 PLAYGROUNDS_ENABLED=YES
 # BPD configuration
 BPD_ENABLED=YES
-BPD_TEST_OVERLAY=YES
-PRIVATIVE_ENABLED=YES
+BPD_TEST_OVERLAY=NO
+PRIVATIVE_ENABLED=NO
 # endpoint BPD API
-BPD_API_URL_PREFIX=https://test.cstar.pagopa.it
+BPD_API_URL_PREFIX=https://prod.cstar.pagopa.it
 BPD_API_SIT='https://bpd-dev.azure-api.net'
 BPD_API_UAT='https://test.cstar.pagopa.it'
 # CGN configuration

--- a/ts/features/bonus/bpd/analytics/index.ts
+++ b/ts/features/bonus/bpd/analytics/index.ts
@@ -30,7 +30,7 @@ import {
 // eslint-disable-next-line complexity
 const trackAction = (mp: NonNullable<typeof mixpanel>) => (
   action: Action
-): Promise<any> => {
+): Promise<void> => {
   switch (action.type) {
     // onboarding
     case getType(bpdEnrollUserToProgram.request):

--- a/ts/features/wallet/onboarding/bancomat/analytics/index.ts
+++ b/ts/features/wallet/onboarding/bancomat/analytics/index.ts
@@ -14,7 +14,7 @@ import { getNetworkErrorMessage } from "../../../../../utils/errors";
 
 const trackAction = (mp: NonNullable<typeof mixpanel>) => (
   action: Action
-): Promise<any> => {
+): Promise<void> => {
   switch (action.type) {
     case getType(walletAddBancomatStart):
     case getType(walletAddBancomatCompleted):

--- a/ts/features/wallet/onboarding/bancomatPay/analytics/index.ts
+++ b/ts/features/wallet/onboarding/bancomatPay/analytics/index.ts
@@ -16,7 +16,7 @@ import {
 
 export const trackBPayAction = (mp: NonNullable<typeof mixpanel>) => (
   action: Action
-): Promise<any> => {
+): Promise<void> => {
   switch (action.type) {
     case getType(walletAddBPayStart):
     case getType(walletAddBPayCompleted):

--- a/ts/features/wallet/onboarding/cobadge/analytics/index.ts
+++ b/ts/features/wallet/onboarding/cobadge/analytics/index.ts
@@ -17,7 +17,7 @@ import {
 
 export const trackCoBadgeAction = (mp: NonNullable<typeof mixpanel>) => (
   action: Action
-): Promise<any> => {
+): Promise<void> => {
   switch (action.type) {
     case getType(walletAddCoBadgeStart):
       return mp.track(action.type, {

--- a/ts/features/wallet/onboarding/privative/analytics/index.ts
+++ b/ts/features/wallet/onboarding/privative/analytics/index.ts
@@ -18,7 +18,7 @@ import {
 
 export const trackPrivativeAction = (mp: NonNullable<typeof mixpanel>) => (
   action: Action
-): Promise<any> => {
+): Promise<void> => {
   switch (action.type) {
     case getType(walletAddPrivativeStart):
     case getType(walletAddPrivativeCompleted):

--- a/ts/features/wallet/onboarding/privative/analytics/index.ts
+++ b/ts/features/wallet/onboarding/privative/analytics/index.ts
@@ -1,0 +1,60 @@
+import { getType } from "typesafe-actions";
+import { PrivativeServices } from "../../../../../../definitions/pagopa/privative/configuration/PrivativeServices";
+import { mixpanel } from "../../../../../mixpanel";
+import { Action } from "../../../../../store/actions/types";
+import { getNetworkErrorMessage } from "../../../../../utils/errors";
+import { trackCobadgeResponse } from "../../cobadge/analytics";
+import {
+  addPrivativeToWallet,
+  loadPrivativeIssuers,
+  searchUserPrivative,
+  walletAddPrivativeBack,
+  walletAddPrivativeCancel,
+  walletAddPrivativeCompleted,
+  walletAddPrivativeStart
+} from "../store/actions";
+
+export const trackCoBadgeAction = (mp: NonNullable<typeof mixpanel>) => (
+  action: Action
+): Promise<any> => {
+  switch (action.type) {
+    case getType(walletAddPrivativeStart):
+    case getType(walletAddPrivativeCompleted):
+    case getType(walletAddPrivativeCancel):
+    case getType(walletAddPrivativeBack):
+    case getType(addPrivativeToWallet.request):
+    case getType(loadPrivativeIssuers.request):
+      return mp.track(action.type);
+    case getType(searchUserPrivative.request):
+      return mp.track(action.type, { abi: action.payload });
+    case getType(loadPrivativeIssuers.success):
+      return mp.track(action.type, trackPrivativeIssuers(action.payload));
+    case getType(searchUserPrivative.success):
+      return mp.track(action.type, trackCobadgeResponse(action.payload));
+    case getType(addPrivativeToWallet.success):
+      return mp.track(action.type, {
+        abi: action.payload.info.issuerAbiCode
+      });
+    case getType(addPrivativeToWallet.failure):
+    case getType(loadPrivativeIssuers.failure):
+    case getType(searchUserPrivative.failure):
+      return mp.track(action.type, {
+        reason: getNetworkErrorMessage(action.payload)
+      });
+  }
+  return Promise.resolve();
+};
+
+/**
+ * Transform a {@link PrivativeServices} into a MixpanelPayload
+ * @param cobadgeSettings
+ */
+const trackPrivativeIssuers = (
+  cobadgeSettings: PrivativeServices
+): Record<string, unknown> =>
+  Object.keys(cobadgeSettings).reduce<Record<string, unknown>>(
+    (acc, val) => ({ ...acc, [`${val}service`]: cobadgeSettings[val].status }),
+    {
+      serviceProviders: Object.keys(cobadgeSettings)
+    }
+  );

--- a/ts/features/wallet/onboarding/privative/analytics/index.ts
+++ b/ts/features/wallet/onboarding/privative/analytics/index.ts
@@ -10,11 +10,13 @@ import {
   searchUserPrivative,
   walletAddPrivativeBack,
   walletAddPrivativeCancel,
+  walletAddPrivativeChooseIssuer,
   walletAddPrivativeCompleted,
+  walletAddPrivativeInsertCardNumber,
   walletAddPrivativeStart
 } from "../store/actions";
 
-export const trackCoBadgeAction = (mp: NonNullable<typeof mixpanel>) => (
+export const trackPrivativeAction = (mp: NonNullable<typeof mixpanel>) => (
   action: Action
 ): Promise<any> => {
   switch (action.type) {
@@ -24,16 +26,19 @@ export const trackCoBadgeAction = (mp: NonNullable<typeof mixpanel>) => (
     case getType(walletAddPrivativeBack):
     case getType(addPrivativeToWallet.request):
     case getType(loadPrivativeIssuers.request):
+    case getType(walletAddPrivativeInsertCardNumber):
       return mp.track(action.type);
+    case getType(walletAddPrivativeChooseIssuer):
+      return mp.track(action.type, { issuer: action.payload });
     case getType(searchUserPrivative.request):
-      return mp.track(action.type, { abi: action.payload });
+      return mp.track(action.type, { issuer: action.payload.id });
     case getType(loadPrivativeIssuers.success):
       return mp.track(action.type, trackPrivativeIssuers(action.payload));
     case getType(searchUserPrivative.success):
       return mp.track(action.type, trackCobadgeResponse(action.payload));
     case getType(addPrivativeToWallet.success):
       return mp.track(action.type, {
-        abi: action.payload.info.issuerAbiCode
+        issuer: action.payload.info.issuerAbiCode
       });
     case getType(addPrivativeToWallet.failure):
     case getType(loadPrivativeIssuers.failure):

--- a/ts/features/wallet/onboarding/privative/screens/search/LoadPrivativeSearch.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/LoadPrivativeSearch.tsx
@@ -37,7 +37,7 @@ const LoadPrivativeSearch = (props: Props): React.ReactElement | null => {
 
   if (privativeSelected === undefined) {
     showToast(I18n.t("global.genericError"), "danger");
-    void mixpanelTrack("PRIVATIVE_NO_QUERY_PARAMS_ERROR");
+    void mixpanelTrack("WALLET_ONBOARDING_PRIVATIVE_NO_QUERY_PARAMS_ERROR");
     props.cancel();
     return null;
   } else {

--- a/ts/features/wallet/onboarding/privative/screens/search/SearchPrivativeCardScreen.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/SearchPrivativeCardScreen.tsx
@@ -67,7 +67,7 @@ const SearchPrivativeCardScreen = (props: Props): React.ReactElement => {
     // TODO: add an error action to the workunit
     if (privativeSelected === undefined) {
       showToast(I18n.t("global.genericError"), "danger");
-      void mixpanelTrack("PRIVATIVE_NO_QUERY_PARAMS_ERROR");
+      void mixpanelTrack("WALLET_ONBOARDING_PRIVATIVE_NO_QUERY_PARAMS_ERROR");
       props.cancel();
     } else {
       props.search(privativeSelected);

--- a/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoTimeout.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoTimeout.tsx
@@ -54,7 +54,7 @@ const PrivativeKoTimeout = (props: Props): React.ReactElement | null => {
 
   if (privativeSelected === undefined) {
     showToast(I18n.t("global.genericError"), "danger");
-    void mixpanelTrack("PRIVATIVE_NO_QUERY_PARAMS_ERROR");
+    void mixpanelTrack("WALLET_ONBOARDING_PRIVATIVE_NO_QUERY_PARAMS_ERROR");
     props.cancel();
     return null;
   } else {

--- a/ts/features/wallet/onboarding/privative/store/actions/index.ts
+++ b/ts/features/wallet/onboarding/privative/store/actions/index.ts
@@ -42,9 +42,9 @@ export const addPrivativeToWallet = createAsyncAction(
  * Load the privative issuers configuration (the list of issuer that can issue a privative card )
  */
 export const loadPrivativeIssuers = createAsyncAction(
-  "WALLET_ONBOARDING_PRIVATIVE_LOAD_PRIVATIVE_ISSUERS_REQUEST",
-  "WALLET_ONBOARDING_PRIVATIVE_LOAD_PRIVATIVE_ISSUERS_SUCCESS",
-  "WALLET_ONBOARDING_PRIVATIVE_LOAD_PRIVATIVE_ISSUERS_FAILURE"
+  "WALLET_ONBOARDING_PRIVATIVE_LOAD_ISSUERS_REQUEST",
+  "WALLET_ONBOARDING_PRIVATIVE_LOAD_ISSUERS_SUCCESS",
+  "WALLET_ONBOARDING_PRIVATIVE_LOAD_ISSUERS_FAILURE"
 )<void, PrivativeServices, NetworkError>();
 
 /**

--- a/ts/features/wallet/satispay/analytics/index.ts
+++ b/ts/features/wallet/satispay/analytics/index.ts
@@ -13,7 +13,7 @@ import {
 
 const trackAction = (mp: NonNullable<typeof mixpanel>) => (
   action: Action
-): Promise<any> => {
+): Promise<void> => {
   switch (action.type) {
     case getType(searchUserSatispay.request):
     case getType(walletAddSatispayStart):

--- a/ts/store/middlewares/analytics.ts
+++ b/ts/store/middlewares/analytics.ts
@@ -137,7 +137,7 @@ import {
 // eslint-disable-next-line complexity
 const trackAction = (mp: NonNullable<typeof mixpanel>) => (
   action: Action
-): Promise<any> => {
+): Promise<void> => {
   // eslint-disable-next-line sonarjs/max-switch-cases
   switch (action.type) {
     //

--- a/ts/store/middlewares/analytics.ts
+++ b/ts/store/middlewares/analytics.ts
@@ -20,6 +20,7 @@ import {
 } from "../../features/bonus/bonusVacanze/utils/bonus";
 import { trackBPayAction } from "../../features/wallet/onboarding/bancomatPay/analytics";
 import { trackCoBadgeAction } from "../../features/wallet/onboarding/cobadge/analytics";
+import { trackPrivativeAction } from "../../features/wallet/onboarding/privative/analytics";
 import { mixpanel } from "../../mixpanel";
 import { getCurrentRouteName } from "../../utils/navigation";
 import {
@@ -462,6 +463,7 @@ export const actionTracking = (_: MiddlewareAPI) => (next: Dispatch) => (
     void trackSatispayAction(mixpanel)(action);
     void trackBPayAction(mixpanel)(action);
     void trackCoBadgeAction(mixpanel)(action);
+    void trackPrivativeAction(mixpanel)(action);
   }
   return next(action);
 };

--- a/ts/store/middlewares/analytics.ts
+++ b/ts/store/middlewares/analytics.ts
@@ -137,7 +137,7 @@ import {
 // eslint-disable-next-line complexity
 const trackAction = (mp: NonNullable<typeof mixpanel>) => (
   action: Action
-): Promise<void> => {
+): Promise<void | ReadonlyArray<null>> => {
   // eslint-disable-next-line sonarjs/max-switch-cases
   switch (action.type) {
     //


### PR DESCRIPTION
## Short description
This pr adds the mixpanel tracking for troubleshooting and alerting purpose.

[List of the new events](https://docs.google.com/spreadsheets/d/1bXNRcTDKU-5l2RqCcwSbT7Y1M9QQTWtS_f-3-AIqSYk/edit#gid=1909779257&range=A108:D108)

## List of changes proposed in this pull request
- Added tracking for relevant events
- Rename `PRIVATIVE_NO_QUERY_PARAMS_ERROR` to `WALLET_ONBOARDING_PRIVATIVE_NO_QUERY_PARAMS_ERROR` in order to have the same namespace
- Rename `WALLET_ONBOARDING_PRIVATIVE_LOAD_PRIVATIVE_ISSUERS_SUCCESS` to `WALLET_ONBOARDING_PRIVATIVE_LOAD_ISSUERS_SUCCESS`
