### PR TITLE
[#177306957] Add ko service error screen

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -926,6 +926,9 @@ wallet:
           body: "Try entering the number again or, alternatively, ask your supermarket customer service for help."
           cta:
             modifyCardNumber: "Change card number"
+        koServiceError:
+          title: "Sorry, we're unable to retrieve your card"
+          body: "Please try again later."
   alert:
     supportedCardPageLinkError: An error occurred while opening the supported cards page.
     msgErrorUpdateApp: "An error occurred while opening the app store"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -946,6 +946,9 @@ wallet:
           body: "Prova ad inserire nuovamente il numero oppure, in alternativa, chiedi aiuto al servizio clienti del tuo supermercato."
           cta:
             modifyCardNumber: "Modifica numero carta"
+        koServiceError:
+          title: "Al momento è impossibile recuperare la tua carta"
+          body: "Riprova più tardi per favore"
   alert:
     supportedCardPageLinkError: Si è verificato un errore durante l'apertura della pagina di riferimento per le carte supportate.
     msgErrorUpdateApp: "Si è verificato un errore durante l'apertura dello store delle app"

--- a/ts/features/wallet/onboarding/privative/screens/add/AddPrivativeCardScreen.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/add/AddPrivativeCardScreen.tsx
@@ -68,10 +68,7 @@ const AddPrivativeCardScreen = (props: Props): React.ReactElement => {
       headerTitle={I18n.t("wallet.onboarding.privative.headerTitle")}
       contextualHelp={emptyContextualHelp}
     >
-      <SafeAreaView
-        style={IOStyles.flex}
-        testID={"ChoosePrivativeIssuerComponent"}
-      >
+      <SafeAreaView style={IOStyles.flex} testID={"AddPrivativeCardScreen"}>
         {/* TODO: Complete the component, this is a draft version for test purpose only */}
         <View style={[IOStyles.horizontalContentPadding, IOStyles.flex]}>
           <AddPrivativeBody {...props} />

--- a/ts/features/wallet/onboarding/privative/screens/search/LoadPrivativeSearch.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/LoadPrivativeSearch.tsx
@@ -2,10 +2,8 @@ import * as React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import I18n from "../../../../../../i18n";
-import { mixpanelTrack } from "../../../../../../mixpanel";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import { WithTestID } from "../../../../../../types/WithTestID";
-import { showToast } from "../../../../../../utils/showToast";
 import { useHardwareBackButton } from "../../../../../bonus/bonusVacanze/components/hooks/useHardwareBackButton";
 import { LoadingErrorComponent } from "../../../../../bonus/bonusVacanze/components/loadingErrorScreen/LoadingErrorComponent";
 import {
@@ -36,9 +34,6 @@ const LoadPrivativeSearch = (props: Props): React.ReactElement | null => {
   const { privativeSelected } = props;
 
   if (privativeSelected === undefined) {
-    showToast(I18n.t("global.genericError"), "danger");
-    void mixpanelTrack("PRIVATIVE_NO_QUERY_PARAMS_ERROR");
-    props.cancel();
     return null;
   } else {
     return (

--- a/ts/features/wallet/onboarding/privative/screens/search/SearchPrivativeCardScreen.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/SearchPrivativeCardScreen.tsx
@@ -24,6 +24,7 @@ import AddPrivativeCardScreen from "../add/AddPrivativeCardScreen";
 import PrivativeKoNotFound from "./ko/PrivativeKoNotFound";
 import PrivativeKoTimeout from "./ko/PrivativeKoTimeout";
 import LoadPrivativeSearch from "./LoadPrivativeSearch";
+import PrivativeKoServiceError from "./ko/PrivativeKoServiceError";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
@@ -43,8 +44,13 @@ const PrivativeReady = (p: {
 
   // with a pending request or if not all the services replied with success we show the timeout screen and the user
   // will retry
-  if (anyPendingRequest || anyServiceError) {
+  if (anyPendingRequest) {
     return <PrivativeKoTimeout contextualHelp={emptyContextualHelp} />;
+  }
+
+  // if not all the services replied with success we show the specific error
+  if (anyServiceError) {
+    return <PrivativeKoServiceError contextualHelp={emptyContextualHelp} />;
   }
 
   const noPrivativeFound = privative.paymentInstrument === null;

--- a/ts/features/wallet/onboarding/privative/screens/search/__tests__/SearchPrivativeCardScreen.test.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/__tests__/SearchPrivativeCardScreen.test.tsx
@@ -1,0 +1,200 @@
+import { fireEvent, RenderAPI } from "@testing-library/react-native";
+import * as React from "react";
+import { NavigationParams } from "react-navigation";
+import { Action, createStore, Store } from "redux";
+import * as showToast from "../../../../../../../utils/showToast";
+import {
+  PaymentInstrument,
+  PaymentNetworkEnum,
+  ProductTypeEnum,
+  ValidityStatusEnum
+} from "../../../../../../../../definitions/pagopa/walletv2/PaymentInstrument";
+import {
+  ExecutionStatusEnum,
+  SearchRequestMetadata
+} from "../../../../../../../../definitions/pagopa/walletv2/SearchRequestMetadata";
+import I18n from "../../../../../../../i18n";
+import { applicationChangeState } from "../../../../../../../store/actions/application";
+import { appReducer } from "../../../../../../../store/reducers";
+import { GlobalState } from "../../../../../../../store/reducers/types";
+import { getTimeoutError } from "../../../../../../../utils/errors";
+import { renderScreenFakeNavRedux } from "../../../../../../../utils/testWrapper";
+import { PrivativeResponse } from "../../../store/actions";
+import SearchPrivativeCardScreen from "../SearchPrivativeCardScreen";
+import WALLET_ONBOARDING_PRIVATIVE_ROUTES from "../../../navigation/routes";
+import configureMockStore from "redux-mock-store";
+import {
+  searchUserPrivative,
+  walletAddPrivativeCancel,
+  walletAddPrivativeChooseIssuer,
+  walletAddPrivativeInsertCardNumber,
+  walletAddPrivativeStart
+} from "../../../store/actions";
+import { PrivativeIssuerId } from "../../../store/reducers/searchedPrivative";
+
+const cardTestId = "9876";
+const timeoutError = getTimeoutError();
+
+const noCardResponse: PrivativeResponse = {
+  paymentInstrument: null,
+  searchRequestId: "aSearchRequestId",
+  searchRequestMetadata: []
+};
+const paymentInstrument: PaymentInstrument = {
+  validityStatus: ValidityStatusEnum.VALID,
+  paymentNetwork: PaymentNetworkEnum.MAESTRO,
+  expiringDate: new Date("2025-11-09"),
+  abiCode: cardTestId,
+  productType: ProductTypeEnum.CREDIT,
+  hpan: "hpan",
+  panCode: "panCode",
+  panPartialNumber: "panPartialNumber",
+  tokenMac: "tokenMac"
+};
+
+const oneCardResponse: PrivativeResponse = {
+  paymentInstrument: paymentInstrument,
+  searchRequestId: "aSearchRequestId",
+  searchRequestMetadata: []
+};
+
+const searchRequestMetaOK: SearchRequestMetadata = {
+  executionStatus: ExecutionStatusEnum.OK,
+  retrievedInstrumentsCount: 0,
+  serviceProviderName: "ServiceNameHere"
+};
+
+const searchRequestMetaKO: SearchRequestMetadata = {
+  executionStatus: ExecutionStatusEnum.KO,
+  retrievedInstrumentsCount: 0,
+  serviceProviderName: "ServiceNameHere"
+};
+
+const searchRequestMetaPending: SearchRequestMetadata = {
+  executionStatus: ExecutionStatusEnum.PENDING,
+  retrievedInstrumentsCount: 0,
+  serviceProviderName: "ServiceNameHere"
+};
+const withSearchRequestMetadata = (
+  metadataList: ReadonlyArray<SearchRequestMetadata>
+) => (response: PrivativeResponse) => ({
+  ...response,
+  searchRequestMetadata: [...metadataList]
+});
+describe("SearchPrivativeCardScreen", () => {
+  jest.useFakeTimers();
+  it("if privativeQuery is undefined a cancel action is dispatched and a toast is shown", () => {
+    const mySpy = jest.spyOn(showToast, "showToast").mockReturnValue();
+    const mockStore = configureMockStore<GlobalState>();
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = mockStore(globalState);
+    renderSearchPrivativeCardScreen(store);
+
+    expect(store.getActions()).toEqual([walletAddPrivativeCancel()]);
+    expect(mySpy).toBeCalled();
+  });
+  it("With timeout error should render PrivativeKoTimeout and pressing on retry should request a reload", () => {
+    const { store, testComponent } = getSearchPrivativeCardScreen();
+
+    expect(isLoadingScreen(testComponent)).toBe(true);
+
+    store.dispatch(searchUserPrivative.failure(timeoutError));
+    expect(isPrivativeKoTimeoutScreen(testComponent)).toBe(true);
+
+    const retryButton = testComponent.queryByText(
+      I18n.t("global.buttons.retry")
+    );
+    expect(retryButton).toBeTruthy();
+
+    if (retryButton !== null) {
+      fireEvent.press(retryButton);
+      expect(isLoadingScreen(testComponent)).toBe(true);
+    }
+  });
+  it("With no card found, single abi, should render PrivativeKoNotFound", () => {
+    const { store, testComponent } = getSearchPrivativeCardScreen();
+    store.dispatch(searchUserPrivative.success(noCardResponse));
+    expect(isPrivativeKoNotFoundScreen(testComponent)).toBe(true);
+  });
+
+  describe("Search request metadata error behaviour", () => {
+    it(`With at least one error in search metadata request, , should render CoBadgeKoServiceError`, () => {
+      const { store, testComponent } = getSearchPrivativeCardScreen();
+      store.dispatch(
+        searchUserPrivative.success(
+          withSearchRequestMetadata([searchRequestMetaKO])(noCardResponse)
+        )
+      );
+      expect(isPrivativeKoServiceErrorScreen(testComponent)).toBe(true);
+      store.dispatch(
+        searchUserPrivative.success(
+          withSearchRequestMetadata([searchRequestMetaPending])(noCardResponse)
+        )
+      );
+      expect(isPrivativeKoTimeoutScreen(testComponent)).toBe(true);
+      store.dispatch(
+        searchUserPrivative.success(
+          withSearchRequestMetadata([searchRequestMetaOK, searchRequestMetaKO])(
+            noCardResponse
+          )
+        )
+      );
+      expect(isPrivativeKoServiceErrorScreen(testComponent)).toBe(true);
+    });
+  });
+  describe("Payment methods found", () => {
+    it(`With at least one payment method found and all search metadata request ok, should render AddCoBadgeScreen`, () => {
+      const { store, testComponent } = getSearchPrivativeCardScreen();
+      store.dispatch(
+        searchUserPrivative.success(
+          withSearchRequestMetadata([searchRequestMetaOK])(oneCardResponse)
+        )
+      );
+      expect(isAddPrivativeScreen(testComponent)).toBe(true);
+    });
+  });
+});
+
+const getSearchPrivativeCardScreen = () => {
+  const anIssuerId = "1" as PrivativeIssuerId;
+  const aCardNumber = "123456789";
+  const globalState = appReducer(undefined, applicationChangeState("active"));
+  const store = createStore(appReducer, globalState as any);
+  store.dispatch(walletAddPrivativeStart());
+  store.dispatch(walletAddPrivativeChooseIssuer(anIssuerId));
+  store.dispatch(walletAddPrivativeInsertCardNumber(aCardNumber));
+  const testComponent = renderSearchPrivativeCardScreen(store);
+  return { store, testComponent };
+};
+
+const renderSearchPrivativeCardScreen = (store: Store<GlobalState, Action>) =>
+  renderScreenFakeNavRedux<GlobalState, NavigationParams>(
+    () => <SearchPrivativeCardScreen />,
+    WALLET_ONBOARDING_PRIVATIVE_ROUTES.SEARCH_AVAILABLE,
+    {},
+    store
+  );
+
+const isLoadingScreen = (component: RenderAPI) =>
+  component.queryByTestId("LoadPrivativeSearch") !== null;
+
+const isPrivativeKoTimeoutScreen = (component: RenderAPI) =>
+  component.queryByTestId("PrivativeKoTimeout") !== null &&
+  component.queryByText(
+    I18n.t("wallet.onboarding.privative.search.koTimeout.body")
+  ) !== null;
+
+const isPrivativeKoNotFoundScreen = (component: RenderAPI) =>
+  component.queryByTestId("PrivativeKoNotFound") !== null &&
+  component.queryByText(
+    I18n.t("wallet.onboarding.privative.search.koNotFound.body")
+  ) !== null;
+
+const isPrivativeKoServiceErrorScreen = (component: RenderAPI) =>
+  component.queryByTestId("PrivativeKoServiceError") !== null &&
+  component.queryByText(
+    I18n.t("wallet.onboarding.privative.search.koServiceError.body")
+  ) !== null;
+
+const isAddPrivativeScreen = (component: RenderAPI) =>
+  component.queryByTestId("AddPrivativeCardScreen") !== null;

--- a/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoNotFound.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoNotFound.tsx
@@ -49,7 +49,7 @@ const PrivativeKoNotFound = (props: Props): React.ReactElement => {
       headerTitle={headerTitle}
       contextualHelp={emptyContextualHelp}
     >
-      <SafeAreaView style={IOStyles.flex} testID={"CoBadgeKoTimeout"}>
+      <SafeAreaView style={IOStyles.flex} testID={"PrivativeKoNotFound"}>
         <InfoScreenComponent
           image={renderInfoRasterImage(image)}
           title={title}

--- a/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoServiceError.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoServiceError.tsx
@@ -1,0 +1,74 @@
+import { View } from "native-base";
+import * as React from "react";
+import { connect } from "react-redux";
+import { Dispatch } from "redux";
+import { SafeAreaView } from "react-native";
+import I18n from "../../../../../../../i18n";
+import { GlobalState } from "../../../../../../../store/reducers/types";
+import BaseScreenComponent from "../../../../../../../components/screens/BaseScreenComponent";
+import { useHardwareBackButton } from "../../../../../../bonus/bonusVacanze/components/hooks/useHardwareBackButton";
+import { InfoScreenComponent } from "../../../../../../../components/infoScreen/InfoScreenComponent";
+import image from "../../../../../../../../img/wallet/errors/payment-unavailable-icon.png";
+import { emptyContextualHelp } from "../../../../../../../utils/emptyContextualHelp";
+import { IOStyles } from "../../../../../../../components/core/variables/IOStyles";
+import { renderInfoRasterImage } from "../../../../../../../components/infoScreen/imageRendering";
+import { walletAddPrivativeCancel } from "../../../store/actions";
+import { cancelButtonProps } from "../../../../../../bonus/bonusVacanze/components/buttons/ButtonConfigurations";
+import FooterWithButtons from "../../../../../../../components/ui/FooterWithButtons";
+
+type Props = ReturnType<typeof mapDispatchToProps> &
+  ReturnType<typeof mapStateToProps> &
+  Pick<React.ComponentProps<typeof BaseScreenComponent>, "contextualHelp">;
+
+const loadLocales = () => ({
+  headerTitle: I18n.t("wallet.onboarding.privative.headerTitle"),
+  title: I18n.t("wallet.onboarding.privative.search.koServiceError.title"),
+  body: I18n.t("wallet.onboarding.privative.search.koServiceError.body"),
+  close: I18n.t("global.buttons.close")
+});
+
+/**
+ * This screen informs the user that no privative card in his name was found because at least one service
+ * reply with a fail.
+ * @param props
+ * @constructor
+ */
+const PrivativeKoServiceError = (props: Props): React.ReactElement => {
+  const { headerTitle, title, body, close } = loadLocales();
+
+  useHardwareBackButton(() => {
+    props.cancel();
+    return true;
+  });
+  return (
+    <BaseScreenComponent
+      goBack={false}
+      customGoBack={<View />}
+      headerTitle={headerTitle}
+      contextualHelp={emptyContextualHelp}
+    >
+      <SafeAreaView style={IOStyles.flex} testID={"CoBadgeKoServiceError"}>
+        <InfoScreenComponent
+          image={renderInfoRasterImage(image)}
+          title={title}
+          body={body}
+        />
+        <FooterWithButtons
+          type={"SingleButton"}
+          leftButton={cancelButtonProps(props.cancel, close)}
+        />
+      </SafeAreaView>
+    </BaseScreenComponent>
+  );
+};
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  cancel: () => dispatch(walletAddPrivativeCancel())
+});
+
+const mapStateToProps = (_: GlobalState) => ({});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(PrivativeKoServiceError);

--- a/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoServiceError.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoServiceError.tsx
@@ -47,7 +47,7 @@ const PrivativeKoServiceError = (props: Props): React.ReactElement => {
       headerTitle={headerTitle}
       contextualHelp={emptyContextualHelp}
     >
-      <SafeAreaView style={IOStyles.flex} testID={"CoBadgeKoServiceError"}>
+      <SafeAreaView style={IOStyles.flex} testID={"PrivativeKoServiceError"}>
         <InfoScreenComponent
           image={renderInfoRasterImage(image)}
           title={title}

--- a/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoTimeout.tsx
+++ b/ts/features/wallet/onboarding/privative/screens/search/ko/PrivativeKoTimeout.tsx
@@ -65,7 +65,7 @@ const PrivativeKoTimeout = (props: Props): React.ReactElement | null => {
         headerTitle={headerTitle}
         contextualHelp={emptyContextualHelp}
       >
-        <SafeAreaView style={IOStyles.flex} testID={"CoBadgeKoTimeout"}>
+        <SafeAreaView style={IOStyles.flex} testID={"PrivativeKoTimeout"}>
           <InfoScreenComponent
             image={renderInfoRasterImage(image)}
             title={title}


### PR DESCRIPTION
## Short description
This PR show the ko service error screen if there is at least one KO in the `searchRequestMetadata` field of the privative card research response.

## List of changes proposed in this pull request
- Add `PrivativeKoServiceError` screen
- Add `SearchPrivativeCardScreen` tests

<img src="https://user-images.githubusercontent.com/11773070/111326603-f6caae00-866c-11eb-947c-73c478493436.png" width=300>

