### PR TITLE
fix(Bonus Pagamenti Digitali): [#177368806] Wrong align for the bottom-left text of the privative & cobadge cards

### DIFF
--- a/ts/features/wallet/cobadge/component/BaseCoBadgeCard.tsx
+++ b/ts/features/wallet/cobadge/component/BaseCoBadgeCard.tsx
@@ -122,7 +122,7 @@ const BaseCoBadgeCard: React.FunctionComponent<Props> = (props: Props) => {
         </>
       }
       bottomLeftCorner={
-        <View>
+        <>
           {props.caption && (
             <>
               <View style={{ flexDirection: "row" }}>
@@ -133,7 +133,7 @@ const BaseCoBadgeCard: React.FunctionComponent<Props> = (props: Props) => {
               <View spacer small />
             </>
           )}
-        </View>
+        </>
       }
       bottomRightCorner={
         <View style={{ justifyContent: "flex-end", flexDirection: "column" }}>

--- a/ts/features/wallet/privative/component/card/BasePrivativeCard.tsx
+++ b/ts/features/wallet/privative/component/card/BasePrivativeCard.tsx
@@ -126,7 +126,7 @@ const BasePrivativeCard: React.FunctionComponent<Props> = (props: Props) => {
         </>
       }
       bottomLeftCorner={
-        <View>
+        <>
           {props.caption && (
             <>
               <View style={{ flexDirection: "row" }}>
@@ -137,7 +137,7 @@ const BasePrivativeCard: React.FunctionComponent<Props> = (props: Props) => {
               <View spacer small />
             </>
           )}
-        </View>
+        </>
       }
       bottomRightCorner={loyaltyLogo}
     />


### PR DESCRIPTION
## Short description
This pr fixes the align for the bottom-left text in the privative and cobadge cards.

Before            |  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/26501317/111477241-33f77480-872f-11eb-90ac-76f9b2bc8262.png" width="300"> | <img src="https://user-images.githubusercontent.com/26501317/111477252-378afb80-872f-11eb-87ac-d6d771750a94.png" width="300">

