### PR TITLE
feat(Bonus Pagamenti Digitali): [#177244740] In the "co-badge add card to wallet" screen, the disclaimer bold text now does not always wrap 

### DIFF
--- a/ts/features/wallet/onboarding/cobadge/screens/add-account/AddCobadgeComponent.tsx
+++ b/ts/features/wallet/onboarding/cobadge/screens/add-account/AddCobadgeComponent.tsx
@@ -102,8 +102,9 @@ const AddCobadgeComponent: React.FunctionComponent<Props> = (props: Props) => {
               </InfoBox>
             ) : (
               <InfoBox>
-                <Body>{warning1}</Body>
-                <Label color={"bluegrey"}>{warning2}</Label>
+                <Body>
+                  {warning1} <Label color={"bluegrey"}>{warning2}</Label>
+                </Body>
               </InfoBox>
             )}
           </View>


### PR DESCRIPTION
## Short description
This pr changes the behaviour of the disclaimer bold text, in order to avoid to always wrap.

Before            |  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/26501317/111478918-cba99280-8730-11eb-931d-d37f1f47d493.png" width="300">|  <img src="https://user-images.githubusercontent.com/26501317/111478950-d2d0a080-8730-11eb-8866-3a98118a6f64.png" width="300">
