### PR TITLE
fix(Carta Giovani Nazionale): [#177367873] Transactions header in wallet home shows before the required scroll position if CGN informations are available

### DIFF
--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -83,7 +83,10 @@ import { showToast } from "../../utils/showToast";
 import { setStatusBarColorAndBackground } from "../../utils/statusBar";
 import { cgnDetails } from "../../features/bonus/cgn/store/actions/details";
 import CgnCardInWalletContainer from "../../features/bonus/cgn/components/CgnCardInWalletComponent";
-import { cgnDetailSelector } from "../../features/bonus/cgn/store/reducers/details";
+import {
+  cgnDetailSelector,
+  isCgnInformationAvailableSelector
+} from "../../features/bonus/cgn/store/reducers/details";
 
 type NavigationParams = Readonly<{
   newMethodAdded: boolean;
@@ -580,6 +583,7 @@ class WalletHomeScreen extends React.PureComponent<Props, State> {
       (bpdEnabled
         ? pot.getOrElse(this.props.periodsWithAmount, []).length * 88
         : 0) +
+      (cgnEnabled && this.props.isCgnInfoAvailable ? 88 : 0) +
       this.getCreditCards().length * 56
     );
   }
@@ -605,7 +609,8 @@ const mapStateToProps = (state: GlobalState) => {
     nav: navSelector(state),
     isPagoPaVersionSupported,
     bpdLoadState: bpdLastUpdateSelector(state),
-    cgnDetails: cgnDetailSelector(state)
+    cgnDetails: cgnDetailSelector(state),
+    isCgnInfoAvailable: isCgnInformationAvailableSelector(state)
   };
 };
 


### PR DESCRIPTION
## Short description
This PR fixes the Wallet transaction dynamic sub header showing before the related position when a CGN is active
