### PR TITLE
fix(Bonus Pagamenti Digitali): [#177378257] When viewing the details of a bpd transaction with a cashback value equal to 0, the warning on the maximum value reached is displayed 

### DIFF
--- a/ts/features/bonus/bpd/components/transactionItem/BpdTransactionItem.tsx
+++ b/ts/features/bonus/bpd/components/transactionItem/BpdTransactionItem.tsx
@@ -4,7 +4,10 @@ import I18n from "../../../../../i18n";
 import { useIOBottomSheet } from "../../../../../utils/bottomSheet";
 import { localeDateFormat } from "../../../../../utils/locale";
 import { formatNumberAmount } from "../../../../../utils/stringBuilder";
-import { BpdTransactionDetailComponent } from "../../screens/details/transaction/detail/BpdTransactionDetailComponent";
+import {
+  BpdTransactionDetailComponent,
+  BpdTransactionDetailRepresentation
+} from "../../screens/details/transaction/detail/BpdTransactionDetailComponent";
 import { BpdTransaction } from "../../store/actions/transactions";
 import { BaseBpdTransactionItem } from "./BaseBpdTransactionItem";
 
@@ -16,7 +19,7 @@ export type EnhancedBpdTransaction = {
 } & BpdTransaction;
 
 type Props = {
-  transaction: EnhancedBpdTransaction;
+  transaction: BpdTransactionDetailRepresentation;
 };
 
 /**

--- a/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionDetailComponent.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionDetailComponent.tsx
@@ -14,7 +14,13 @@ import { formatNumberAmount } from "../../../../../../../utils/stringBuilder";
 import { EnhancedBpdTransaction } from "../../../../components/transactionItem/BpdTransactionItem";
 import { BpdTransactionWarning } from "./BpdTransactionWarning";
 
-type Props = { transaction: EnhancedBpdTransaction };
+export type BpdTransactionDetailRepresentation = EnhancedBpdTransaction & {
+  // false if the transaction is not valid for the cashback (eg: the user has
+  // already reached the maximum cashback value for the period )
+  validForCashback: boolean;
+};
+
+type Props = { transaction: BpdTransactionDetailRepresentation };
 
 const styles = StyleSheet.create({
   image: { width: 48, height: 30 },

--- a/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionWarning.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionWarning.tsx
@@ -1,11 +1,20 @@
-import * as React from "react";
 import { View } from "native-base";
+import * as React from "react";
 import { InfoBox } from "../../../../../../../components/box/InfoBox";
 import { Body } from "../../../../../../../components/core/typography/Body";
 import I18n from "../../../../../../../i18n";
-import { EnhancedBpdTransaction } from "../../../../components/transactionItem/BpdTransactionItem";
+import { BpdTransactionDetailRepresentation } from "./BpdTransactionDetailComponent";
 
-type Props = { transaction: EnhancedBpdTransaction };
+type Props = { transaction: BpdTransactionDetailRepresentation };
+
+const TransactionWarning = (props: { text: string }) => (
+  <>
+    <View spacer={true} />
+    <InfoBox>
+      <Body>{props.text}</Body>
+    </InfoBox>
+  </>
+);
 
 /**
  * Displays a warning when certain conditions occur
@@ -13,37 +22,41 @@ type Props = { transaction: EnhancedBpdTransaction };
  * @constructor
  */
 export const BpdTransactionWarning: React.FunctionComponent<Props> = props => {
+  // max cashback for a single transaction reached
   if (
     props.transaction.maxCashbackForTransactionAmount ===
     props.transaction.cashback
   ) {
     return (
-      <>
-        <View spacer={true} />
-        <InfoBox>
-          <Body>
-            {I18n.t("bonus.bpd.details.transaction.detail.maxCashbackWarning", {
-              amount: props.transaction.maxCashbackForTransactionAmount
-            })}
-          </Body>
-        </InfoBox>
-      </>
+      <TransactionWarning
+        text={I18n.t(
+          "bonus.bpd.details.transaction.detail.maxCashbackWarning",
+          {
+            amount: props.transaction.maxCashbackForTransactionAmount
+          }
+        )}
+      />
     );
   }
-  if (props.transaction.cashback <= 0) {
+  // transaction canceled (negative amount)
+  if (props.transaction.cashback < 0) {
     return (
-      <>
-        <View spacer={true} />
-        <InfoBox>
-          <Body>
-            {I18n.t(
-              props.transaction.cashback < 0
-                ? "bonus.bpd.details.transaction.detail.canceledOperationWarning"
-                : "bonus.bpd.details.transaction.detail.maxCashbackForPeriodWarning"
-            )}
-          </Body>
-        </InfoBox>
-      </>
+      <TransactionWarning
+        text={I18n.t(
+          "bonus.bpd.details.transaction.detail.canceledOperationWarning"
+        )}
+      />
+    );
+  }
+  // transaction not valid for cashback (eg: the user has already reached
+  // the maximum cashback value for the period
+  if (!props.transaction.validForCashback) {
+    return (
+      <TransactionWarning
+        text={I18n.t(
+          "bonus.bpd.details.transaction.detail.maxCashbackForPeriodWarning"
+        )}
+      />
     );
   }
   return null;

--- a/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionWarning.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionWarning.tsx
@@ -22,6 +22,17 @@ const TransactionWarning = (props: { text: string }) => (
  * @constructor
  */
 export const BpdTransactionWarning: React.FunctionComponent<Props> = props => {
+  // transaction not valid for cashback (eg: the user has already reached
+  // the maximum cashback value for the period
+  if (!props.transaction.validForCashback) {
+    return (
+      <TransactionWarning
+        text={I18n.t(
+          "bonus.bpd.details.transaction.detail.maxCashbackForPeriodWarning"
+        )}
+      />
+    );
+  }
   // max cashback for a single transaction reached
   if (
     props.transaction.maxCashbackForTransactionAmount ===
@@ -44,17 +55,6 @@ export const BpdTransactionWarning: React.FunctionComponent<Props> = props => {
       <TransactionWarning
         text={I18n.t(
           "bonus.bpd.details.transaction.detail.canceledOperationWarning"
-        )}
-      />
-    );
-  }
-  // transaction not valid for cashback (eg: the user has already reached
-  // the maximum cashback value for the period
-  if (!props.transaction.validForCashback) {
-    return (
-      <TransactionWarning
-        text={I18n.t(
-          "bonus.bpd.details.transaction.detail.maxCashbackForPeriodWarning"
         )}
       />
     );

--- a/ts/features/bonus/bpd/screens/details/transaction/detail/__test__/BdpTransactionDetailComponent.test.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/detail/__test__/BdpTransactionDetailComponent.test.tsx
@@ -1,12 +1,29 @@
 // import { debug } from "console";
 import { render } from "@testing-library/react-native";
 import * as React from "react";
+import I18n from "../../../../../../../../i18n";
 import { HPan } from "../../../../../store/actions/paymentMethods";
 import { AwardPeriodId } from "../../../../../store/actions/periods";
 import {
   BpdTransactionDetailComponent,
   BpdTransactionDetailRepresentation
 } from "../BpdTransactionDetailComponent";
+
+const baseTransaction: BpdTransactionDetailRepresentation = {
+  hashPan: "0d4194712c5d820fcbbb2e7ba199e15f73cfd43f8fe49f0aa62e7901253506df" as HPan,
+  idTrxAcquirer: "10126487773E",
+  idTrxIssuer: "R64692",
+  amount: 87.79,
+  awardPeriodId: 2 as AwardPeriodId,
+  image: 29,
+  maxCashbackForTransactionAmount: 15,
+  title: "xxxxxxx",
+  trxDate: new Date("2100-12-17T00:00"),
+  keyId: "xxxxxxxxx",
+  cashback: 8.779,
+  circuitType: "Mastercard",
+  validForCashback: true
+};
 
 describe("Test Transaction Timestamp", () => {
   it("It should render label 'Date' and a value without hours and minutes when the transaction has a timestamp 00:00", () => {
@@ -64,5 +81,180 @@ describe("Test Transaction Timestamp", () => {
 
     expect(dateLabel.children[0]).toMatch(/Date and time/);
     expect(dateValue.children[0]).toMatch(/17 Dec 2100, 01:00/);
+  });
+});
+
+describe("Test BpdTransactionDetailComponent warnings", () => {
+  describe("It should render warning 'max cashback for transaction' when maxCashbackForTransactionAmount === cashback", () => {
+    const maxAmount = 15.01;
+    const testCases: ReadonlyArray<BpdTransactionDetailRepresentation> = [
+      {
+        ...baseTransaction,
+        cashback: maxAmount,
+        maxCashbackForTransactionAmount: maxAmount,
+        validForCashback: true
+      },
+      {
+        ...baseTransaction,
+        cashback: maxAmount,
+        maxCashbackForTransactionAmount: maxAmount,
+        validForCashback: false
+      }
+    ];
+
+    test.each(testCases)("Test case: %p", transaction => {
+      const component = render(
+        <BpdTransactionDetailComponent transaction={transaction} />
+      );
+
+      const warningTest = component.queryByText(
+        I18n.t("bonus.bpd.details.transaction.detail.maxCashbackWarning", {
+          amount: maxAmount
+        })
+      );
+      expect(warningTest).not.toBeNull();
+    });
+  });
+
+  describe("It shouldn't render warning 'max cashback for transaction' when maxCashbackForTransactionAmount !== cashback", () => {
+    const maxAmount = 15.01;
+    const testCases: ReadonlyArray<BpdTransactionDetailRepresentation> = [
+      {
+        ...baseTransaction,
+        cashback: maxAmount,
+        maxCashbackForTransactionAmount: maxAmount - 0.01,
+        validForCashback: true
+      },
+      {
+        ...baseTransaction,
+        cashback: maxAmount,
+        maxCashbackForTransactionAmount: 0,
+        validForCashback: false
+      }
+    ];
+
+    test.each(testCases)("Test case: %p", transaction => {
+      const component = render(
+        <BpdTransactionDetailComponent transaction={transaction} />
+      );
+
+      const warningTest = component.queryByText(
+        I18n.t("bonus.bpd.details.transaction.detail.maxCashbackWarning", {
+          amount: maxAmount
+        })
+      );
+      expect(warningTest).toBeNull();
+    });
+  });
+
+  describe("It should render warning 'canceledOperationWarning' when cashback value < 0", () => {
+    const testCases: ReadonlyArray<BpdTransactionDetailRepresentation> = [
+      {
+        ...baseTransaction,
+        cashback: -0.01,
+        validForCashback: true
+      },
+      {
+        ...baseTransaction,
+        cashback: -5,
+        validForCashback: false
+      }
+    ];
+
+    test.each(testCases)("Test case: %p", transaction => {
+      const component = render(
+        <BpdTransactionDetailComponent transaction={transaction} />
+      );
+
+      const warningTest = component.queryByText(
+        I18n.t("bonus.bpd.details.transaction.detail.canceledOperationWarning")
+      );
+      expect(warningTest).not.toBeNull();
+    });
+  });
+  describe("It shouldn't render warning 'canceledOperationWarning' when cashback value >= 0", () => {
+    const testCases: ReadonlyArray<BpdTransactionDetailRepresentation> = [
+      {
+        ...baseTransaction,
+        cashback: 0,
+        validForCashback: true
+      },
+      {
+        ...baseTransaction,
+        cashback: 5,
+        validForCashback: false
+      }
+    ];
+
+    test.each(testCases)("Test case: %p", transaction => {
+      const component = render(
+        <BpdTransactionDetailComponent transaction={transaction} />
+      );
+
+      const warningTest = component.queryByText(
+        I18n.t("bonus.bpd.details.transaction.detail.canceledOperationWarning")
+      );
+      expect(warningTest).toBeNull();
+    });
+  });
+  describe("It should render warning 'maxCashbackForPeriodWarning' when validForCashback === false", () => {
+    const testCases: ReadonlyArray<BpdTransactionDetailRepresentation> = [
+      {
+        ...baseTransaction,
+        cashback: 0,
+        validForCashback: false
+      },
+      {
+        ...baseTransaction,
+        cashback: 10.5,
+        validForCashback: false
+      }
+    ];
+
+    test.each(testCases)("Test case: %p", transaction => {
+      const component = render(
+        <BpdTransactionDetailComponent transaction={transaction} />
+      );
+
+      const warningTest = component.queryByText(
+        I18n.t(
+          "bonus.bpd.details.transaction.detail.maxCashbackForPeriodWarning"
+        )
+      );
+      expect(warningTest).not.toBeNull();
+    });
+  });
+  describe("It shouldn't render warning 'maxCashbackForPeriodWarning'", () => {
+    const testCases: ReadonlyArray<BpdTransactionDetailRepresentation> = [
+      {
+        ...baseTransaction,
+        cashback: 0,
+        validForCashback: true
+      },
+      {
+        ...baseTransaction,
+        cashback: -10.5,
+        validForCashback: false
+      },
+      {
+        ...baseTransaction,
+        cashback: 15,
+        maxCashbackForTransactionAmount: 15,
+        validForCashback: false
+      }
+    ];
+
+    test.each(testCases)("Test case: %p", transaction => {
+      const component = render(
+        <BpdTransactionDetailComponent transaction={transaction} />
+      );
+
+      const warningTest = component.queryByText(
+        I18n.t(
+          "bonus.bpd.details.transaction.detail.maxCashbackForPeriodWarning"
+        )
+      );
+      expect(warningTest).toBeNull();
+    });
   });
 });

--- a/ts/features/bonus/bpd/screens/details/transaction/detail/__test__/BdpTransactionDetailComponent.test.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/detail/__test__/BdpTransactionDetailComponent.test.tsx
@@ -55,7 +55,7 @@ describe("Test Transaction Timestamp", () => {
     expect(dateValue.children[0]).toMatch(/17 Dec 2100/);
   });
 
-  it("It should render label 'Date and time' and a vale woth hours and minutes when the transaction has a timestamp different from 00:00 ", () => {
+  it("It should render label 'Date and time' and a value with hours and minutes when the transaction has a timestamp different from 00:00 ", () => {
     const myTransaction: BpdTransactionDetailRepresentation = {
       hashPan: "0d4194712c5d820fcbbb2e7ba199e15f73cfd43f8fe49f0aa62e7901253506df" as HPan,
       idTrxAcquirer: "10126487773E",

--- a/ts/features/bonus/bpd/screens/details/transaction/detail/__test__/BdpTransactionDetailComponent.test.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/detail/__test__/BdpTransactionDetailComponent.test.tsx
@@ -93,12 +93,6 @@ describe("Test BpdTransactionDetailComponent warnings", () => {
         cashback: maxAmount,
         maxCashbackForTransactionAmount: maxAmount,
         validForCashback: true
-      },
-      {
-        ...baseTransaction,
-        cashback: maxAmount,
-        maxCashbackForTransactionAmount: maxAmount,
-        validForCashback: false
       }
     ];
 
@@ -130,6 +124,12 @@ describe("Test BpdTransactionDetailComponent warnings", () => {
         cashback: maxAmount,
         maxCashbackForTransactionAmount: 0,
         validForCashback: false
+      },
+      {
+        ...baseTransaction,
+        cashback: maxAmount,
+        maxCashbackForTransactionAmount: maxAmount,
+        validForCashback: false
       }
     ];
 
@@ -153,11 +153,6 @@ describe("Test BpdTransactionDetailComponent warnings", () => {
         ...baseTransaction,
         cashback: -0.01,
         validForCashback: true
-      },
-      {
-        ...baseTransaction,
-        cashback: -5,
-        validForCashback: false
       }
     ];
 
@@ -182,6 +177,11 @@ describe("Test BpdTransactionDetailComponent warnings", () => {
       {
         ...baseTransaction,
         cashback: 5,
+        validForCashback: false
+      },
+      {
+        ...baseTransaction,
+        cashback: -5,
         validForCashback: false
       }
     ];
@@ -208,6 +208,17 @@ describe("Test BpdTransactionDetailComponent warnings", () => {
         ...baseTransaction,
         cashback: 10.5,
         validForCashback: false
+      },
+      {
+        ...baseTransaction,
+        cashback: -10.5,
+        validForCashback: false
+      },
+      {
+        ...baseTransaction,
+        cashback: 15,
+        maxCashbackForTransactionAmount: 15,
+        validForCashback: false
       }
     ];
 
@@ -230,17 +241,6 @@ describe("Test BpdTransactionDetailComponent warnings", () => {
         ...baseTransaction,
         cashback: 0,
         validForCashback: true
-      },
-      {
-        ...baseTransaction,
-        cashback: -10.5,
-        validForCashback: false
-      },
-      {
-        ...baseTransaction,
-        cashback: 15,
-        maxCashbackForTransactionAmount: 15,
-        validForCashback: false
       }
     ];
 

--- a/ts/features/bonus/bpd/screens/details/transaction/detail/__test__/BdpTransactionDetailComponent.test.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/detail/__test__/BdpTransactionDetailComponent.test.tsx
@@ -1,14 +1,16 @@
 // import { debug } from "console";
-import * as React from "react";
 import { render } from "@testing-library/react-native";
-import { BpdTransactionDetailComponent } from "../BpdTransactionDetailComponent";
-import { EnhancedBpdTransaction } from "../../../../../components/transactionItem/BpdTransactionItem";
+import * as React from "react";
 import { HPan } from "../../../../../store/actions/paymentMethods";
 import { AwardPeriodId } from "../../../../../store/actions/periods";
+import {
+  BpdTransactionDetailComponent,
+  BpdTransactionDetailRepresentation
+} from "../BpdTransactionDetailComponent";
 
 describe("Test Transaction Timestamp", () => {
   it("It should render label 'Date' and a value without hours and minutes when the transaction has a timestamp 00:00", () => {
-    const myTransaction: EnhancedBpdTransaction = {
+    const myTransaction: BpdTransactionDetailRepresentation = {
       hashPan: "0d4194712c5d820fcbbb2e7ba199e15f73cfd43f8fe49f0aa62e7901253506df" as HPan,
       idTrxAcquirer: "10126487773E",
       idTrxIssuer: "R64692",
@@ -20,7 +22,8 @@ describe("Test Transaction Timestamp", () => {
       trxDate: new Date("2100-12-17T00:00"),
       keyId: "xxxxxxxxx",
       cashback: 8.779,
-      circuitType: "Mastercard"
+      circuitType: "Mastercard",
+      validForCashback: true
     };
 
     // cut : Component Under Test
@@ -36,7 +39,7 @@ describe("Test Transaction Timestamp", () => {
   });
 
   it("It should render label 'Date and time' and a vale woth hours and minutes when the transaction has a timestamp different from 00:00 ", () => {
-    const myTransaction: EnhancedBpdTransaction = {
+    const myTransaction: BpdTransactionDetailRepresentation = {
       hashPan: "0d4194712c5d820fcbbb2e7ba199e15f73cfd43f8fe49f0aa62e7901253506df" as HPan,
       idTrxAcquirer: "10126487773E",
       idTrxIssuer: "R64692",
@@ -48,7 +51,8 @@ describe("Test Transaction Timestamp", () => {
       trxDate: new Date("2100-12-17T01:00"),
       keyId: "xxxxxxxxx",
       cashback: 8.779,
-      circuitType: "Mastercard"
+      circuitType: "Mastercard",
+      validForCashback: true
     };
 
     // cut : Component Under Test


### PR DESCRIPTION
## Short description
This pr fixes a bug that displayed an alert on the maximum cashback value reached, when opening a detail of a transaction with cashback value equals too `0.00`.
Now the warning is correcly displayed only for the transaction only for transactions subsequent to the one that resulted in the maximum cashback value being reached .

<img src=https://user-images.githubusercontent.com/26501317/111499171-f3095b00-8742-11eb-8900-f06739c6ab0f.png width=300 />



## List of changes proposed in this pull request
- Added a new type `BpdTransactionDetailRepresentation` (accepted by all the component that should represent a transaction) that adds a new field `validForCashback` used explicitly to determine which transactions are not valid for cashback (instead of implicitly using the value)  
- Refactor of `getTransactionsByDaySections`, in order to explicitly set the `validForCashback` value
- Refactoring and fix for `BpdTransactionWarning`

## How to test
- run `ts/features/bonus/bpd/screens/details/transaction/detail/__test__/BdpTransactionDetailComponent.test.tsx`
