### PR TITLE
fix(Carta Giovani Nazionale): [#177385897] CGN Details doesn't load automatically when activation is completed

### DIFF
--- a/ts/features/bonus/cgn/screens/CgnDetailScreen.tsx
+++ b/ts/features/bonus/cgn/screens/CgnDetailScreen.tsx
@@ -27,6 +27,8 @@ import { availableBonusTypesSelectorFromId } from "../../bonusVacanze/store/redu
 import { ID_CGN_TYPE } from "../../bonusVacanze/utils/bonus";
 import { navigateToCgnMerchantsList } from "../navigation/actions";
 import CgnCardComponent from "../components/detail/CgnCardComponent";
+import { useActionOnFocus } from "../../../../utils/hooks/useOnFocus";
+import { cgnDetails } from "../store/actions/details";
 
 type Props = ReturnType<typeof mapStateToProps> &
   ReturnType<typeof mapDispatchToProps>;
@@ -39,6 +41,8 @@ const CgnDetailScreen = (props: Props): React.ReactElement => {
   useEffect(() => {
     setStatusBarColorAndBackground("dark-content", IOColors.yellowGradientTop);
   }, []);
+
+  useActionOnFocus(props.loadCgnDetails);
 
   return (
     <BaseScreenComponent
@@ -107,6 +111,7 @@ const mapStateToProps = (state: GlobalState) => ({
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
+  loadCgnDetails: () => dispatch(cgnDetails.request()),
   navigateToMerchants: () => dispatch(navigateToCgnMerchantsList())
 });
 


### PR DESCRIPTION
## Short description
This PR fixes a bug where CGN details doesn't load when activation flow is completed
