### PR TITLE
chore: [#177137637] Show services status banner in any rendering state

### DIFF
--- a/ts/screens/services/ServicesHomeScreen.tsx
+++ b/ts/screens/services/ServicesHomeScreen.tsx
@@ -618,6 +618,7 @@ class ServicesHomeScreen extends React.Component<Props, State> {
             )}
           </TopScreenComponent>
         </View>
+        <SectionStatusComponent sectionKey={"services"} />
       </KeyboardAvoidingView>
     );
   }
@@ -727,7 +728,6 @@ class ServicesHomeScreen extends React.Component<Props, State> {
             <LocalServicesWebView onServiceSelect={this.onServiceSelect} />
           </Tab>
         </AnimatedTabs>
-        <SectionStatusComponent sectionKey={"services"} />
       </View>
     );
   };


### PR DESCRIPTION
## Short description
This PR shows the services status banner, if available, even when the services section is in loading state

| list  | loading |
| ------------- | ------------- |
![Preferences](https://user-images.githubusercontent.com/822471/112032468-b374b180-8b3c-11eb-803f-2a962d964780.png) | ![Privacy](https://user-images.githubusercontent.com/822471/112032487-bb345600-8b3c-11eb-8233-746a67510ee8.png) 
