### PR TITLE
feat(Payments): [#176176928] Add a switch to set payment method as favorite

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -948,7 +948,7 @@ wallet:
     titlePagoPaUpdateApp: Update required
     messagePagoPaUpdateApp: "IO often introduces small improvements and new features: to continue using the wallet you need to update the app to the latest version."
     btnUpdateApp: Update the IO app
-    favourite: To change this option, select another method from your Wallet and set it as favorite.
+    favorite: To change this option, select another method from your Wallet and set it as favorite.
     amex: Payments with American Express cards, for amounts above €1000, are currently not possible.
   contextualHelpTitle: About this section
   contextualHelpContent: !include wallet/wallet_home.md
@@ -1326,8 +1326,8 @@ cardComponent:
   expiresOn: Expires on
   expiredCard: CARD EXPIRED ON
   actions: Actions
-  setFavourite: Set as favourite
-  unsetFavourite: Remove from favourites
+  setFavorite: Set as favourite
+  unsetFavorite: Remove from favourites
   deleteTitle: Delete this payment method?
   deleteMsg: This payment method will be removed. Any related feature, such as Cashback, will be disabled within 24 hours.
   neverUsed: Never used

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -751,6 +751,9 @@ payment:
 wallet:
   wallet: Wallet
   refreshWallet: Refresh the Wallet
+  favourite:
+    setFavoriteTitle: Use as favorite
+    setFavoriteSubtitle: When you pay in-app, IO will automatically show this payment method
   incoming:
     title: "Upcoming"
     message: "This payment method will be available in a future release"
@@ -945,7 +948,7 @@ wallet:
     titlePagoPaUpdateApp: Update required
     messagePagoPaUpdateApp: "IO often introduces small improvements and new features: to continue using the wallet you need to update the app to the latest version."
     btnUpdateApp: Update the IO app
-    favourite: This method is already set as favourite. To change this, please set another method as favourite.
+    favourite: To change this option, select another method from your Wallet and set it as favorite.
     amex: Payments with American Express cards, for amounts above €1000, are currently not possible.
   contextualHelpTitle: About this section
   contextualHelpContent: !include wallet/wallet_home.md

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -771,6 +771,9 @@ payment:
 wallet:
   wallet: Portafoglio
   refreshWallet: Aggiorna il Portafoglio
+  favourite:
+    setFavoriteTitle: Usa come preferito
+    setFavoriteSubtitle: Quando paghi in app, IO mostra in automatico questo metodo di pagamento
   incoming:
     title: "In arrivo"
     message: "Una prossima versione di IO renderà disponibile anche questo metodo di pagamento"
@@ -965,7 +968,7 @@ wallet:
     titlePagoPaUpdateApp: Aggiornamento richiesto
     messagePagoPaUpdateApp: "IO introduce spesso piccole migliorie e nuove funzioni: per continuare ad usare il portafoglio è necessario aggiornare l'applicazione all'ultima versione."
     btnUpdateApp: Aggiorna l'app IO
-    favourite: Questo metodo di pagamento è già contrassegnato come il tuo preferito, se vuoi cambiarlo devi selezionarne un altro
+    favourite: Per modificare quest'opzione, seleziona un altro metodo dal tuo Portafoglio e impostalo come preferito.
     amex: I pagamenti con carte American Express, per importi superiori a €1000, non sono al momento possibili
   contextualHelpTitle: Cosa puoi fare nel tuo Portafoglio
   contextualHelpContent: !include wallet/wallet_home.md

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -968,7 +968,7 @@ wallet:
     titlePagoPaUpdateApp: Aggiornamento richiesto
     messagePagoPaUpdateApp: "IO introduce spesso piccole migliorie e nuove funzioni: per continuare ad usare il portafoglio è necessario aggiornare l'applicazione all'ultima versione."
     btnUpdateApp: Aggiorna l'app IO
-    favourite: Per modificare quest'opzione, seleziona un altro metodo dal tuo Portafoglio e impostalo come preferito.
+    favorite: Per modificare quest'opzione, seleziona un altro metodo dal tuo Portafoglio e impostalo come preferito.
     amex: I pagamenti con carte American Express, per importi superiori a €1000, non sono al momento possibili
   contextualHelpTitle: Cosa puoi fare nel tuo Portafoglio
   contextualHelpContent: !include wallet/wallet_home.md
@@ -1353,8 +1353,8 @@ cardComponent:
   expiresOn: Scade il
   expiredCard: CARTA SCADUTA IL
   actions: Azioni
-  setFavourite: Imposta come preferita
-  unsetFavourite: Rimuovi dai preferiti
+  setFavorite: Imposta come preferita
+  unsetFavorite: Rimuovi dai preferiti
   deleteTitle: Vuoi eliminare questo metodo?
   deleteMsg: Questo metodo di pagamento verrà rimosso. Eventuali funzioni collegate, come il Cashback, verranno disattivate entro 24h.
   neverUsed: Mai utilizzata

--- a/ts/components/wallet/FavoriteMethodSwitch.tsx
+++ b/ts/components/wallet/FavoriteMethodSwitch.tsx
@@ -23,7 +23,8 @@ const styles = StyleSheet.create({
     paddingRight: 8
   },
   right: {
-    justifyContent: "flex-start"
+    justifyContent: "flex-start",
+    minWidth: 50
   }
 });
 

--- a/ts/components/wallet/FavoriteMethodSwitch.tsx
+++ b/ts/components/wallet/FavoriteMethodSwitch.tsx
@@ -27,7 +27,7 @@ const styles = StyleSheet.create({
   }
 });
 
-export const FavouritePaymentMethodSwitch = (props: Props) => (
+export const FavoritePaymentMethodSwitch = (props: Props) => (
   <View style={styles.row}>
     <View style={styles.left}>
       <H4 weight={"SemiBold"} color={"bluegreyDark"}>

--- a/ts/components/wallet/FavoriteMethodSwitch.tsx
+++ b/ts/components/wallet/FavoriteMethodSwitch.tsx
@@ -27,6 +27,7 @@ const styles = StyleSheet.create({
   }
 });
 
+// this component represents the payment status as favorite and handle the user request to change it
 export const FavoritePaymentMethodSwitch = (props: Props) => (
   <View style={styles.row}>
     <View style={styles.left}>

--- a/ts/components/wallet/FavoriteMethodSwitch.tsx
+++ b/ts/components/wallet/FavoriteMethodSwitch.tsx
@@ -39,15 +39,14 @@ export const FavoritePaymentMethodSwitch = (props: Props) => (
       </H5>
     </View>
     <View style={styles.right}>
-      {props.isLoading && (
+      {props.isLoading ? (
         <ActivityIndicator
           color={"black"}
           accessible={false}
           importantForAccessibility={"no-hide-descendants"}
           accessibilityElementsHidden={true}
         />
-      )}
-      {!props.isLoading && (
+      ) : (
         <Switch
           onValueChange={v => props.onValueChange?.(v)}
           value={props.switchValue}

--- a/ts/components/wallet/FavouriteMethodSwitch.tsx
+++ b/ts/components/wallet/FavouriteMethodSwitch.tsx
@@ -1,0 +1,57 @@
+import { View } from "native-base";
+import * as React from "react";
+import { ActivityIndicator, StyleSheet } from "react-native";
+import { H4 } from "../core/typography/H4";
+import I18n from "../../i18n";
+import { H5 } from "../core/typography/H5";
+import { IOStyles } from "../core/variables/IOStyles";
+import Switch from "../ui/Switch";
+
+type Props = {
+  isLoading?: boolean;
+  onValueChange?: (value: boolean) => void;
+  switchValue: boolean;
+};
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between"
+  },
+  left: {
+    ...IOStyles.flex,
+    paddingRight: 8
+  },
+  right: {
+    justifyContent: "flex-start"
+  }
+});
+
+export const FavouritePaymentMethodSwitch = (props: Props) => (
+  <View style={styles.row}>
+    <View style={styles.left}>
+      <H4 weight={"SemiBold"} color={"bluegreyDark"}>
+        {I18n.t("wallet.favourite.setFavoriteTitle")}
+      </H4>
+      <H5 weight={"Regular"} color={"bluegrey"}>
+        {I18n.t("wallet.favourite.setFavoriteSubtitle")}
+      </H5>
+    </View>
+    <View style={styles.right}>
+      {props.isLoading && (
+        <ActivityIndicator
+          color={"black"}
+          accessible={false}
+          importantForAccessibility={"no-hide-descendants"}
+          accessibilityElementsHidden={true}
+        />
+      )}
+      {!props.isLoading && (
+        <Switch
+          onValueChange={v => props.onValueChange?.(v)}
+          value={props.switchValue}
+        />
+      )}
+    </View>
+  </View>
+);

--- a/ts/components/wallet/card/CardComponent.tsx
+++ b/ts/components/wallet/card/CardComponent.tsx
@@ -161,8 +161,8 @@ export default class CardComponent extends React.Component<Props> {
                     <Text bold={true} style={styles.blueText}>
                       {I18n.t(
                         pot.getOrElseWithUpdating(isFavorite, false) === true
-                          ? "cardComponent.unsetFavourite"
-                          : "cardComponent.setFavourite"
+                          ? "cardComponent.unsetFavorite"
+                          : "cardComponent.setFavorite"
                       )}
                     </Text>
                   </MenuOption>

--- a/ts/screens/wallet/TransactionsScreen.tsx
+++ b/ts/screens/wallet/TransactionsScreen.tsx
@@ -25,6 +25,7 @@ import {
 } from "../../store/actions/wallet/wallets";
 import { GlobalState } from "../../store/reducers/types";
 import {
+  favouriteWalletIdSelector,
   getFavoriteWalletId,
   paymentMethodsSelector
 } from "../../store/reducers/wallet/wallets";
@@ -39,6 +40,7 @@ import { getTitleFromCard } from "../../utils/paymentMethod";
 import { Label } from "../../components/core/typography/Label";
 import { IOColors } from "../../components/core/variables/IOColors";
 import ButtonDefaultOpacity from "../../components/ButtonDefaultOpacity";
+import { FavouritePaymentMethodSwitch } from "../../components/wallet/FavouriteMethodSwitch";
 
 type NavigationParams = Readonly<{
   selectedWallet: Wallet;
@@ -128,7 +130,7 @@ const TransactionsScreen: React.FC<Props> = (props: Props) => {
   const selectedWallet = props.navigation.getParam("selectedWallet");
 
   const isFavorite = pot.map(
-    props.favoriteWallet,
+    props.favoriteWalletId,
     _ => _ === selectedWallet.idWallet
   );
 
@@ -183,6 +185,21 @@ const TransactionsScreen: React.FC<Props> = (props: Props) => {
             <View spacer={true} />
             <ItemSeparatorComponent noPadded={true} />
             <View spacer={true} large={true} />
+            <FavouritePaymentMethodSwitch
+              isLoading={
+                pot.isLoading(props.favouriteWallet) ||
+                pot.isUpdating(props.favouriteWallet)
+              }
+              switchValue={pot.getOrElse(isFavorite, false)}
+              onValueChange={v =>
+                handleSetFavourite(v, () =>
+                  props.setFavoriteWallet(pm.idWallet)
+                )
+              }
+            />
+            <View spacer={true} />
+            <ItemSeparatorComponent noPadded={true} />
+            <View spacer={true} large={true} />
             <DeletePaymentMethodButton
               onPress={() =>
                 present(() => props.deleteWallet(selectedWallet.idWallet))
@@ -197,7 +214,8 @@ const TransactionsScreen: React.FC<Props> = (props: Props) => {
 };
 
 const mapStateToProps = (state: GlobalState) => ({
-  favoriteWallet: getFavoriteWalletId(state),
+  favouriteWallet: favouriteWalletIdSelector(state),
+  favoriteWalletId: getFavoriteWalletId(state),
   paymentMethods: paymentMethodsSelector(state)
 });
 

--- a/ts/screens/wallet/TransactionsScreen.tsx
+++ b/ts/screens/wallet/TransactionsScreen.tsx
@@ -25,7 +25,7 @@ import {
 } from "../../store/actions/wallet/wallets";
 import { GlobalState } from "../../store/reducers/types";
 import {
-  favouriteWalletIdSelector,
+  favoriteWalletIdSelector,
   getFavoriteWalletId,
   paymentMethodsSelector
 } from "../../store/reducers/wallet/wallets";
@@ -40,7 +40,7 @@ import { getTitleFromCard } from "../../utils/paymentMethod";
 import { Label } from "../../components/core/typography/Label";
 import { IOColors } from "../../components/core/variables/IOColors";
 import ButtonDefaultOpacity from "../../components/ButtonDefaultOpacity";
-import { FavouritePaymentMethodSwitch } from "../../components/wallet/FavouriteMethodSwitch";
+import { FavoritePaymentMethodSwitch } from "../../components/wallet/FavoriteMethodSwitch";
 
 type NavigationParams = Readonly<{
   selectedWallet: Wallet;
@@ -185,7 +185,7 @@ const TransactionsScreen: React.FC<Props> = (props: Props) => {
             <View spacer={true} />
             <ItemSeparatorComponent noPadded={true} />
             <View spacer={true} large={true} />
-            <FavouritePaymentMethodSwitch
+            <FavoritePaymentMethodSwitch
               isLoading={
                 pot.isLoading(props.favouriteWallet) ||
                 pot.isUpdating(props.favouriteWallet)
@@ -214,7 +214,7 @@ const TransactionsScreen: React.FC<Props> = (props: Props) => {
 };
 
 const mapStateToProps = (state: GlobalState) => ({
-  favouriteWallet: favouriteWalletIdSelector(state),
+  favouriteWallet: favoriteWalletIdSelector(state),
   favoriteWalletId: getFavoriteWalletId(state),
   paymentMethods: paymentMethodsSelector(state)
 });

--- a/ts/screens/wallet/TransactionsScreen.tsx
+++ b/ts/screens/wallet/TransactionsScreen.tsx
@@ -187,8 +187,8 @@ const TransactionsScreen: React.FC<Props> = (props: Props) => {
             <View spacer={true} large={true} />
             <FavoritePaymentMethodSwitch
               isLoading={
-                pot.isLoading(props.favouriteWalletRequestStatus) ||
-                pot.isUpdating(props.favouriteWalletRequestStatus)
+                pot.isLoading(props.favoriteWalletRequestStatus) ||
+                pot.isUpdating(props.favoriteWalletRequestStatus)
               }
               switchValue={pot.getOrElse(isFavorite, false)}
               onValueChange={v =>
@@ -214,7 +214,7 @@ const TransactionsScreen: React.FC<Props> = (props: Props) => {
 };
 
 const mapStateToProps = (state: GlobalState) => ({
-  favouriteWalletRequestStatus: favoriteWalletIdSelector(state),
+  favoriteWalletRequestStatus: favoriteWalletIdSelector(state),
   favoriteWalletId: getFavoriteWalletId(state),
   paymentMethods: paymentMethodsSelector(state)
 });

--- a/ts/screens/wallet/TransactionsScreen.tsx
+++ b/ts/screens/wallet/TransactionsScreen.tsx
@@ -187,8 +187,8 @@ const TransactionsScreen: React.FC<Props> = (props: Props) => {
             <View spacer={true} large={true} />
             <FavoritePaymentMethodSwitch
               isLoading={
-                pot.isLoading(props.favouriteWallet) ||
-                pot.isUpdating(props.favouriteWallet)
+                pot.isLoading(props.favouriteWalletRequestStatus) ||
+                pot.isUpdating(props.favouriteWalletRequestStatus)
               }
               switchValue={pot.getOrElse(isFavorite, false)}
               onValueChange={v =>
@@ -214,7 +214,7 @@ const TransactionsScreen: React.FC<Props> = (props: Props) => {
 };
 
 const mapStateToProps = (state: GlobalState) => ({
-  favouriteWallet: favoriteWalletIdSelector(state),
+  favouriteWalletRequestStatus: favoriteWalletIdSelector(state),
   favoriteWalletId: getFavoriteWalletId(state),
   paymentMethods: paymentMethodsSelector(state)
 });

--- a/ts/store/reducers/wallet/wallets.ts
+++ b/ts/store/reducers/wallet/wallets.ts
@@ -97,6 +97,10 @@ export const getFavoriteWalletId = createSelector(
     )
 );
 
+// return the pot representing the updating request of a favourite payment method
+export const favouriteWalletIdSelector = (state: GlobalState) =>
+  state.wallet.wallets.favoriteWalletId;
+
 export const getFavoriteWallet = createSelector(
   [getFavoriteWalletId, getWalletsById],
   (

--- a/ts/store/reducers/wallet/wallets.ts
+++ b/ts/store/reducers/wallet/wallets.ts
@@ -98,7 +98,7 @@ export const getFavoriteWalletId = createSelector(
 );
 
 // return the pot representing the updating request of a favourite payment method
-export const favouriteWalletIdSelector = (state: GlobalState) =>
+export const favoriteWalletIdSelector = (state: GlobalState) =>
   state.wallet.wallets.favoriteWalletId;
 
 export const getFavoriteWallet = createSelector(

--- a/ts/utils/wallet.ts
+++ b/ts/utils/wallet.ts
@@ -72,5 +72,5 @@ export const handleSetFavourite = (
     ? callback()
     : Alert.alert(
         I18n.t("global.genericAlert"),
-        I18n.t("wallet.alert.favourite")
+        I18n.t("wallet.alert.favorite")
       );


### PR DESCRIPTION
## Short description
This PR adds a switch to handle the user request to set that payment method as favorite.
The switch is replaced by a loader when the setting is in progress

https://user-images.githubusercontent.com/822471/112162908-c9da4600-8bec-11eb-9dce-551c180a4cff.mov

