### PR TITLE
fix(Carta Giovani Nazionale): [#177455388] Footer text on CGN information screen shows the wrong text referring to Cashback

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2002,7 +2002,7 @@ bonus:
   active: Active
   failed: Failed
   redeemed: Consumed
-  termsAndConditionFooter: "By pressing \"Request cashback\" you declare that you have read and understood the [regulation]({{regulationLink}}) and the [information on the processing of personal data]({{tosUrl}}) of the service."
+  termsAndConditionFooter: "By pressing \"{{ctaText}}\" you declare that you have read and understood the [regulation]({{regulationLink}}) and the [information on the processing of personal data]({{tosUrl}}) of the service."
   tos:
     title: Information on the processing of personal data
     content: !include bonus/bonusVacanze/bonus_tos.md

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2032,7 +2032,7 @@ bonus:
   active: Attivo
   failed: Fallito
   redeemed: Utilizzato
-  termsAndConditionFooter: "Premendo \"Attiva il Cashback\" dichiari di aver letto e compreso la [guida]({{regulationLink}}) e l'[informativa sul trattamento dei dati personali]({{tosUrl}}) del servizio."
+  termsAndConditionFooter: "Premendo \"{{ctaText}}\" dichiari di aver letto e compreso la [guida]({{regulationLink}}) e l'[informativa sul trattamento dei dati personali]({{tosUrl}}) del servizio."
   tos:
     title: Informativa sul trattamento dei dati personali
     content: !include bonus/bonusVacanze/bonus_tos.md

--- a/ts/features/bonus/common/components/BonusInformationComponent.tsx
+++ b/ts/features/bonus/common/components/BonusInformationComponent.tsx
@@ -92,11 +92,11 @@ const loadingOpacity = 0.9;
 // for long content markdown computed height should be not enough
 const extraMarkdownBodyHeight = 20;
 
-// TODO get the tos footer from props
 const getTosFooter = (
   maybeBonusTos: Option<string>,
   maybeRegulationUrl: Option<{ url: string; name: string }>,
-  handleModalPress: (tos: string) => void
+  handleModalPress: (tos: string) => void,
+  ctaText: string
 ) =>
   maybeBonusTos.fold(null, bT =>
     maybeRegulationUrl.fold(
@@ -133,6 +133,7 @@ const getTosFooter = (
             extraBodyHeight={extraMarkdownBodyHeight}
           >
             {I18n.t("bonus.termsAndConditionFooter", {
+              ctaText,
               regulationLink: rU.url,
               tosUrl: bT
             })}
@@ -262,7 +263,12 @@ const BonusInformationComponent: React.FunctionComponent<Props> = props => {
           </Markdown>
           <View spacer={true} extralarge={true} />
           {isMarkdownLoaded && renderUrls()}
-          {getTosFooter(maybeBonusTos, maybeRegulationUrl, handleModalPress)}
+          {getTosFooter(
+            maybeBonusTos,
+            maybeRegulationUrl,
+            handleModalPress,
+            props.primaryCtaText
+          )}
           {isMarkdownLoaded && <EdgeBorderComponent />}
         </Content>
         {!isScreenReaderEnabled && isMarkdownLoaded && footerComponent}

--- a/ts/features/wallet/component/card/FeaturedCardCarousel.tsx
+++ b/ts/features/wallet/component/card/FeaturedCardCarousel.tsx
@@ -7,6 +7,7 @@ import { ScrollView, StyleSheet } from "react-native";
 import { connect } from "react-redux";
 import { BonusAvailable } from "../../../../../definitions/content/BonusAvailable";
 import cashbackLogo from "../../../../../img/bonus/bpd/logo_cashback_blue.png";
+import cgnLogo from "../../../../../img/bonus/cgn/cgn_logo.png";
 import { H3 } from "../../../../components/core/typography/H3";
 import { IOStyles } from "../../../../components/core/variables/IOStyles";
 import I18n from "../../../../i18n";
@@ -56,8 +57,7 @@ const FeaturedCardCarousel: React.FunctionComponent<Props> = (props: Props) => {
 
   if (cgnEnabled) {
     bonusMap.set(ID_CGN_TYPE, {
-      // FIXME Replace the logo when it has been approved
-      logo: cashbackLogo,
+      logo: cgnLogo,
       handler: _ => props.startCgnActivation()
     });
   }


### PR DESCRIPTION
## Short description
This PR fixes the footer text of the CGN information screen with the link to policy and guide

![image](https://user-images.githubusercontent.com/3959405/112142037-634a2d80-8bd6-11eb-87fa-5e7b0abcc099.png)
