### PR TITLE
fix(Carta Giovani Nazionale): [#177490938] Success Screen pictogram results cut on the bottom

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2002,7 +2002,7 @@ bonus:
   requestLabel: Bonuses and discounts
   requestTitle: Request
   validity_interval: from {{from}} until {{to}}
-  active: Active\
+  active: Active
   failed: Failed
   redeemed: Consumed
   termsAndConditionFooter: "By pressing \"{{ctaText}}\" you declare that you have read and understood the [regulation]({{regulationLink}}) and the [information on the processing of personal data]({{tosUrl}}) of the service."

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2002,7 +2002,7 @@ bonus:
   requestLabel: Bonuses and discounts
   requestTitle: Request
   validity_interval: from {{from}} until {{to}}
-  active: Active
+  active: Active\
   failed: Failed
   redeemed: Consumed
   termsAndConditionFooter: "By pressing \"{{ctaText}}\" you declare that you have read and understood the [regulation]({{regulationLink}}) and the [information on the processing of personal data]({{tosUrl}}) of the service."
@@ -2283,7 +2283,7 @@ bonus:
         eycaPending: "We're linking your Carta Giovani Nazionale to a EYCA Number."
         eycaError: "We had some issues with EYCA's systems."
         eycaBottomSheetTitle: "EYCA card number"
-        eycaDescription: "Until the Until you turn 31, **your National Youth Card is a member of the EYCA circuit** (European Youth Card Association).\n\nBy entering your EYCA card number on e-commerce or showing your card at participating merchants, you will be able to get discounts and benefits on cultural activities, shopping, transportation, dining and lodging in the 38 European countries participating in the circuit."
+        eycaDescription: "Until the Until you turn 31, **your National Youth Card is a member of the EYCA circuit** (European Youth Card Association).\n\nBy entering your EYCA card number on e&#8209;commerce or showing your card at participating merchants, you will be able to get discounts and benefits on cultural activities, shopping, transportation, dining and lodging in the 38 European countries participating in the circuit."
         eycaNumber: Card number
         badge:
           active: Active

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2314,7 +2314,7 @@ bonus:
         eycaPending: "Stiamo associando la tua Carta Giovani Nazionale a un Numero EYCA."
         eycaError: "Abbiamo riscontrato problemi con i sistemi EYCA."
         eycaBottomSheetTitle: "Numero di carta EYCA"
-        eycaDescription: "Fino al compimento dei 31 anni, **la tua Carta Giovani Nazionale aderisce al circuito EYCA** (European Youth Card Association).\n\nInserendo il numero di carta EYCA sugli e-commerce o mostrando la carta presso gli esercenti aderenti, potrai ottenere sconti e agevolazioni su attività culturali, negozi, trasporti, ristorazione e alloggio anche nei 38 paesi europei aderenti al circuito."
+        eycaDescription: "Fino al compimento dei 31 anni, **la tua Carta Giovani Nazionale aderisce al circuito EYCA** (European Youth Card Association).\n\nInserendo il numero di carta EYCA sugli e&#8209;commerce o mostrando la carta presso gli esercenti aderenti, potrai ottenere sconti e agevolazioni su attività culturali, negozi, trasporti, ristorazione e alloggio anche nei 38 paesi europei aderenti al circuito."
         badge:
           active: Attiva
           revoked: Annullata

--- a/ts/features/bonus/cgn/screens/activation/CgnActivationCompletedScreen.tsx
+++ b/ts/features/bonus/cgn/screens/activation/CgnActivationCompletedScreen.tsx
@@ -7,11 +7,11 @@ import { InfoScreenComponent } from "../../../../../components/infoScreen/InfoSc
 import { FooterStackButton } from "../../../bonusVacanze/components/buttons/FooterStackButtons";
 import { confirmButtonProps } from "../../../bonusVacanze/components/buttons/ButtonConfigurations";
 import { IOStyles } from "../../../../../components/core/variables/IOStyles";
-import IconFont from "../../../../../components/ui/IconFont";
 import { cgnActivationComplete } from "../../store/actions/activation";
 import { navigateToCgnDetails } from "../../navigation/actions";
 import I18n from "../../../../../i18n";
-import { IOColors } from "../../../../../components/core/variables/IOColors";
+import paymentCompleted from "../../../../../../img/pictograms/payment-completed.png";
+import { renderInfoRasterImage } from "../../../../../components/infoScreen/imageRendering";
 
 type Props = ReturnType<typeof mapStateToProps> &
   ReturnType<typeof mapDispatchToProps>;
@@ -23,7 +23,7 @@ type Props = ReturnType<typeof mapStateToProps> &
 const CgnActivationCompletedScreen = (props: Props): React.ReactElement => (
   <SafeAreaView style={IOStyles.flex}>
     <InfoScreenComponent
-      image={<IconFont name={"io-complete"} size={104} color={IOColors.aqua} />}
+      image={renderInfoRasterImage(paymentCompleted)}
       title={I18n.t("bonus.cgn.activation.success.title")}
       body={I18n.t("bonus.cgn.activation.success.body")}
     />


### PR DESCRIPTION
## Short description
This PR fixes 2 typos on CGN Eyca Description BottomSheet and changes the pictogram inside CgnActivationCompletedScreen.

### Before
<img src="https://user-images.githubusercontent.com/3959405/112470967-983bb900-8d6b-11eb-9309-7737f0b11556.png" height="550"/>

### After
<img src="https://user-images.githubusercontent.com/3959405/112470774-5a3e9500-8d6b-11eb-96e1-017049f00e9d.png" height="550"/>
