### PR TITLE
[#172097711,#172935224] On some iOS devices a white screen is shown after biometric authentication 

### DIFF
--- a/ios/ItaliaApp/AppDelegate.m
+++ b/ios/ItaliaApp/AppDelegate.m
@@ -126,37 +126,4 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
   completionHandler(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge);
 }
 
-
-// Code used to replace the main view with a blank one when application is in background.
-// Taken from @https://pinkstone.co.uk/how-to-control-the-preview-screenshot-in-the-ios-multitasking-switcher/
-- (void)applicationWillResignActive:(UIApplication *)application {
-
-     // Fill screen with our own colour
-    UIView *colourView = [[UIView alloc]initWithFrame:self.window.frame];
-    colourView.backgroundColor = [UIColor whiteColor];
-    colourView.tag = 1234;
-    colourView.alpha = 0;
-    [self.window addSubview:colourView];
-    [self.window bringSubviewToFront:colourView];
-
-     // Fade in the view
-    [UIView animateWithDuration:0.5 animations:^{
-        colourView.alpha = 1;
-    }];
-}
-
-- (void)applicationDidBecomeActive:(UIApplication *)application {
-
-     // Grab a reference to our coloured view
-    UIView *colourView = [self.window viewWithTag:1234];
-
-     // Fade away colour view from main view
-    [UIView animateWithDuration:0.5 animations:^{
-        colourView.alpha = 0;
-    } completion:^(BOOL finished) {
-        // Remove when finished fading
-        [colourView removeFromSuperview];
-    }];
-}
-
 @end


### PR DESCRIPTION
## Short description
This PR fixes the "white screen" bug that often happens on iPhone 7/8

### what causes the bug
On iOS there is an animation that make the screen totally white when the app goes in background and brings it back transparent when it goes to active
- app is going to be `inactive` -> make the screen totally white
- app is going to be `active` -> make the screen transparent (the below content is visible)

### how the fix works
All these animation (transparent -> white / white -> transparent) are been removed since in certain conditions and on some device could happen that the app state change in a wrong way.
In example this is the state changes on iOS 14.4.1 iPhone 7

- open the app
- authenticate with touch ID
- move to cashback detail screen
- leave the app to go in standby
- resume the app by pressing home (touchID too)

these are the state changes

`inactive -> active -> active -> inactive -> inactive`

and the screen remains totally white

### iPhone 7
| before  | now |
| ------------- | ------------- |
![before](https://user-images.githubusercontent.com/822471/112486340-11430c80-8d7c-11eb-95ce-791bd662edcb.png) | ![now](https://user-images.githubusercontent.com/822471/112486380-199b4780-8d7c-11eb-9ac0-c9d04ab7e140.png)



