### PR TITLE
fix(Bonus Pagamenti Digitali): [#177511360] Wrong rendering of privative loyalty logo in cashback transaction detail bottomsheet

### DIFF
--- a/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionDetailComponent.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionDetailComponent.tsx
@@ -162,7 +162,11 @@ export const BpdTransactionDetailComponent: React.FunctionComponent<Props> = pro
       <Body>{paymentMethod}</Body>
       <View spacer={true} />
       <View style={[IOStyles.flex, IOStyles.row]}>
-        <Image source={props.transaction.image} style={styles.image} />
+        <Image
+          source={props.transaction.image}
+          style={styles.image}
+          resizeMode={"contain"}
+        />
         <View hspacer={true} small={true} />
         <H4>{props.transaction.title}</H4>
       </View>


### PR DESCRIPTION
## Short description
This pr fixes the wrong privative loyalty logo rendering in the cashback transaction detail bottomsheet

Before            |  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/26501317/112998501-61501380-916e-11eb-8e44-e66d9cf88952.png" width="300">|  <img src="https://user-images.githubusercontent.com/26501317/112998528-68772180-916e-11eb-90a7-efb79bddfbfc.png" width="300">

