### PR TITLE
fix(Carta Giovani Nazionale): [#177490914] Discount bottom sheet title doesn't break line

### DIFF
--- a/ts/features/bonus/cgn/components/merchants/CgnDiscountDetail.tsx
+++ b/ts/features/bonus/cgn/components/merchants/CgnDiscountDetail.tsx
@@ -128,7 +128,7 @@ const CgnDiscountDetailHeader = ({ discount }: Props) => (
   <View style={[IOStyles.row, { alignItems: "center" }]}>
     <CgnDiscountValueBox value={discount.value} small />
     <View hspacer />
-    <H3>{discount.title}</H3>
+    <H3 style={IOStyles.flex}>{discount.title}</H3>
   </View>
 );
 


### PR DESCRIPTION
## Short description
This PR fixes a minor UI Bug where the bottom sheet title overflows the BS close button

<img src="https://user-images.githubusercontent.com/3959405/113277683-46ea7700-92e1-11eb-99ef-74e4932a5244.png" height="550"/>


