### PR TITLE
fix(Carta Giovani Nazionale): [#177485208] Hardware back button doesn't work on CGN Detail screen

### DIFF
--- a/ts/features/bonus/cgn/components/detail/CgnCardComponent.tsx
+++ b/ts/features/bonus/cgn/components/detail/CgnCardComponent.tsx
@@ -25,15 +25,20 @@ type Props = {
 const styles = StyleSheet.create({
   cardContainer: {
     height: "100%",
-    width: widthPercentageToDP(90)
+    width: widthPercentageToDP(90),
+    maxWidth: 340
   },
   cgnCard: {
     position: "absolute",
-    width: "100%",
+    alignSelf: "center",
+    width: widthPercentageToDP(90),
+    maxWidth: 340,
     height: 192,
     top: 2
   },
   informationContainer: {
+    width: widthPercentageToDP(90),
+    maxWidth: 340,
     height: "100%",
     top: -190,
     zIndex: 9,
@@ -67,8 +72,9 @@ const styles = StyleSheet.create({
     resizeMode: "stretch",
     height: 215,
     width: widthPercentageToDP(95),
+    maxWidth: 360,
     top: -5,
-    left: -13,
+    left: -10,
     zIndex: 8
   }
 });
@@ -126,7 +132,7 @@ const CgnCardComponent: React.FunctionComponent<Props> = (props: Props) => {
   );
 
   return (
-    <View style={[IOStyles.horizontalContentPadding, styles.cgnCard]}>
+    <View style={[styles.cgnCard]}>
       <ImageBackground
         source={cardBg}
         imageStyle={[styles.imageFull]}

--- a/ts/features/bonus/cgn/screens/CgnDetailScreen.tsx
+++ b/ts/features/bonus/cgn/screens/CgnDetailScreen.tsx
@@ -43,6 +43,7 @@ import {
 import GenericErrorComponent from "../../../../components/screens/GenericErrorComponent";
 import { navigateBack } from "../../../../store/actions/navigation";
 import { isLoading, isReady } from "../../bpd/model/RemoteValue";
+import { useHardwareBackButton } from "../../bonusVacanze/components/hooks/useHardwareBackButton";
 
 type Props = ReturnType<typeof mapStateToProps> &
   ReturnType<typeof mapDispatchToProps>;
@@ -87,6 +88,11 @@ const CgnDetailScreen = (props: Props): React.ReactElement => {
   useActionOnFocus(loadCGN);
 
   const onCardLoadEnd = () => setCardLoading(false);
+
+  useHardwareBackButton(() => {
+    props.goBack();
+    return true;
+  });
 
   const canDisplayEycaDetails = canEycaCardBeShown(props.eycaDetails);
   return props.cgnDetails || props.isCgnInfoLoading ? (


### PR DESCRIPTION
## Short description
This PR Fixes the hardware back button not working on android phones when trying to exit from CGN Detail screen.

In addition, minor styles fixes has been implemented in CGN Card component