### PR TITLE
feat(Payments): [#177548187] Add credit card / payment webview closing reason

### DIFF
--- a/ts/components/wallet/PayWebViewModal.tsx
+++ b/ts/components/wallet/PayWebViewModal.tsx
@@ -71,7 +71,7 @@ const crateAutoPostForm = (
 /**
  * return a 2-tuple
  * 0 element: boolean. true if the given {@param urlParse} contains the given {@param finishPathName} path name
- * 0 element: string | undefined. a string contains the value of {@param outcomeQueryparamName} in query string of {@param url}
+ * 1 element: string | undefined. a string contains the value of {@param outcomeQueryparamName} in query string of {@param url}
  * @param urlParse
  * @param finishPathName
  * @param outcomeQueryparamName

--- a/ts/components/wallet/PayWebViewModal.tsx
+++ b/ts/components/wallet/PayWebViewModal.tsx
@@ -70,9 +70,9 @@ const crateAutoPostForm = (
 
 /**
  * return a 2-tuple
- * 0 element: boolean. true if the given {@param url} contains the given {@param finishPathName} path name
+ * 0 element: boolean. true if the given {@param urlParse} contains the given {@param finishPathName} path name
  * 0 element: string | undefined. a string contains the value of {@param outcomeQueryparamName} in query string of {@param url}
- * @param url
+ * @param urlParse
  * @param finishPathName
  * @param outcomeQueryparamName
  */

--- a/ts/store/reducers/payments/history.ts
+++ b/ts/store/reducers/payments/history.ts
@@ -24,7 +24,9 @@ import {
   paymentCompletedSuccess,
   paymentIdPolling,
   paymentRedirectionUrls,
-  paymentVerifica
+  paymentVerifica,
+  paymentWebViewEnd,
+  PaymentWebViewEndReason
 } from "../../actions/wallet/payment";
 import { GlobalState } from "../types";
 import { paymentOutcomeCode } from "../../actions/wallet/outcomeCode";
@@ -42,6 +44,7 @@ export type PaymentHistory = {
   outcomeCode?: string;
   success?: true;
   payNavigationUrls?: ReadonlyArray<string>;
+  webViewCloseReason?: PaymentWebViewEndReason;
 };
 
 export type PaymentsHistoryState = ReadonlyArray<PaymentHistory>;
@@ -129,6 +132,11 @@ const reducer = (
         payNavigationUrls: action.payload
       };
       return replaceLastItem(state, navigationUrls);
+    case getType(paymentWebViewEnd):
+      return replaceLastItem(state, {
+        ...state[state.length - 1],
+        webViewCloseReason: action.payload
+      });
     case getType(clearCache): {
       return INITIAL_STATE;
     }

--- a/ts/store/reducers/wallet/creditCard.ts
+++ b/ts/store/reducers/wallet/creditCard.ts
@@ -9,7 +9,9 @@ import {
   addWalletCreditCardSuccess,
   addWalletNewCreditCardSuccess,
   creditCardPaymentNavigationUrls,
-  CreditCardFailure
+  CreditCardFailure,
+  addCreditCardWebViewEnd,
+  AddCreditCardWebViewEndReason
 } from "../../actions/wallet/wallets";
 import { Action } from "../../actions/types";
 import { clearCache } from "../../actions/profile";
@@ -27,6 +29,7 @@ export type CreditCardInsertion = {
     idCreditCard?: number;
     brand?: string;
   };
+  webViewCloseReason?: AddCreditCardWebViewEndReason;
   failureReason?: CreditCardFailure;
   payNavigationUrls?: ReadonlyArray<string>;
   onboardingComplete: boolean;
@@ -137,6 +140,11 @@ const reducer = (
       return updateStateHead(state, attempt => ({
         ...attempt,
         outcomeCode: action.payload.getOrElse("n/a")
+      }));
+    case getType(addCreditCardWebViewEnd):
+      return updateStateHead(state, attempt => ({
+        ...attempt,
+        webViewCloseReason: action.payload
       }));
     case getType(clearCache): {
       return INITIAL_STATE;

--- a/ts/utils/payment.ts
+++ b/ts/utils/payment.ts
@@ -184,6 +184,9 @@ export const getPaymentHistoryDetails = (
     new Date(payment.started_at)
   )}${separator}- payment data: ${JSON.stringify(payment.data, null, 4)}`;
   const codiceAvviso = `- codice avviso: ${getCodiceAvviso(payment.data)}`;
+  const webViewCloseReason = `- chiusura webview: ${
+    payment.webViewCloseReason ?? "n/a"
+  }`;
   const success = `- pagamento concluso con successo: ${
     payment.success === true ? "si" : "no"
   }`;
@@ -208,6 +211,8 @@ export const getPaymentHistoryDetails = (
     ccp,
     separator,
     success,
+    separator,
+    webViewCloseReason,
     separator,
     outcomeCode,
     separator,


### PR DESCRIPTION
## Short description
This PR adds the reason that causes the webview closing during a credit card on-boarding or a payment:

- `USER_ABORT` -> web view has been closed by the user (back press)
- `EXIT_PATH` -> web view has closed it self automatically by detecting the exit path in an url

This new data will be sent attached to the Instabug ticket

| payment  | credit card |
| ------------- | ------------- |
![payment](https://user-images.githubusercontent.com/822471/113326147-964c9980-9319-11eb-9dbd-9b343b37affb.png) | ![credit card](https://user-images.githubusercontent.com/822471/113326149-977dc680-9319-11eb-9a6a-e86e7a0286de.png)


