### PR TITLE
fix: [#177314796] Starting blank space on link "update your preferences"

### DIFF
--- a/ts/screens/services/ServiceDetailsScreen.tsx
+++ b/ts/screens/services/ServiceDetailsScreen.tsx
@@ -634,9 +634,9 @@ class ServiceDetailsScreen extends React.Component<Props, State> {
           !this.props.isEmailValidated) && (
           <Row style={styles.info}>
             <Text>
-              {emailForwardingDescription}
+              {`${emailForwardingDescription} `}
               <Text link={true} onPress={this.navigateToEmailPreferences}>
-                {` ${emailForwardingLink}`}
+                {emailForwardingLink}
               </Text>
             </Text>
           </Row>

--- a/ts/screens/services/ServiceDetailsScreen.tsx
+++ b/ts/screens/services/ServiceDetailsScreen.tsx
@@ -92,7 +92,6 @@ const styles = StyleSheet.create({
     paddingVertical: 12
   },
   otherSwitchRow: {
-    paddingLeft: 8,
     borderTopColor: customVariables.itemSeparator,
     borderTopWidth: 1 / 3
   },


### PR DESCRIPTION
## Short description
Removed switch row and edit link useless spacing in service details screen

**Before changes:**
<img width="300" alt="before-changes" src="https://user-images.githubusercontent.com/61834253/113693323-c3f56200-96ce-11eb-840c-b795be340d63.jpg">

**After changes:**
<img width="300" alt="after-changes" src="https://user-images.githubusercontent.com/61834253/113894616-79581080-97c8-11eb-83fb-1c5bea6a6bee.png">

## How to test
Move in service details screen and see if there is an useless padding left in the rows with the switch button and an useless space after edit link