### PR TITLE
chore: [#177755852] Disable CI CIE iOS button check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -576,4 +576,4 @@ workflows:
     jobs:
       - pagopa_specs_diff
       - io_check_uris
-      - io_check_cie_button_exists_ios
+      # - io_check_cie_button_exists_ios


### PR DESCRIPTION
## Short description
This PR temporary disables the check on iOS button existence - CIE authentication flow - since it seems have stopped working
