### PR TITLE
fix: [#177606620] Buttons inside BottomSheets are not pressable on Android

### DIFF
--- a/ts/components/ButtonDefaultOpacity.tsx
+++ b/ts/components/ButtonDefaultOpacity.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-native-gesture-handler";
 import customVariables from "../theme/variables";
 import { isIos } from "../utils/platform";
+import { useScreenReaderEnabled } from "../utils/accessibility";
 import { calculateSlop } from "./core/accessibility";
 
 const defaultActiveOpacity = 1.0;
@@ -58,8 +59,11 @@ const getSlopForCurrentButton = (props: Props): Insets => {
  */
 const ButtonDefaultOpacity = (props: Props) => {
   const hitSlop = getSlopForCurrentButton(props);
+  const isScreenReaderEnabled = useScreenReaderEnabled();
+
   // use the alternative handling only if is request by props AND is android
-  const tapGestureRequired = props.onPressWithGestureHandler && !isIos;
+  const tapGestureRequired =
+    props.onPressWithGestureHandler && !isIos && !isScreenReaderEnabled;
 
   const button = (
     <Button

--- a/ts/components/ButtonDefaultOpacity.tsx
+++ b/ts/components/ButtonDefaultOpacity.tsx
@@ -62,6 +62,7 @@ const ButtonDefaultOpacity = (props: Props) => {
   const isScreenReaderEnabled = useScreenReaderEnabled();
 
   // use the alternative handling only if is request by props AND is android
+  // if the screenReader is active render common button or the button would not be pressable
   const tapGestureRequired =
     props.onPressWithGestureHandler && !isIos && !isScreenReaderEnabled;
 

--- a/ts/components/bottomSheet/AccessibilityContent.tsx
+++ b/ts/components/bottomSheet/AccessibilityContent.tsx
@@ -1,6 +1,7 @@
 import { View } from "native-base";
 import * as React from "react";
 import { Modal } from "react-native";
+import { IOStyles } from "../core/variables/IOStyles";
 
 /**
  * Accessibility version of a BottomSheet including a header and it's content
@@ -14,6 +15,6 @@ export const AccessibilityContent = (
   <Modal>
     <View spacer={true} extralarge={true} />
     {header}
-    {content}
+    <View style={IOStyles.horizontalContentPadding}>{content}</View>
   </Modal>
 );

--- a/ts/components/wallet/WalletHomeHeader.tsx
+++ b/ts/components/wallet/WalletHomeHeader.tsx
@@ -131,6 +131,8 @@ const WalletHomeHeader: React.FC<Props> = (props: Props) => {
           alignItems: "center"
         }}
         onPress={openBS}
+        accessible={true}
+        accessibilityRole={"button"}
       >
         <IconFont
           name="io-plus"


### PR DESCRIPTION
## Short description
This PR Fixes a bug where any button inside a bottom sheet on android would not be pressable