### PR TITLE
fix: [#177960813] Changelog may contains noise suffixes

### DIFF
--- a/scripts/changelog/add_pivotal_stories.js
+++ b/scripts/changelog/add_pivotal_stories.js
@@ -58,7 +58,7 @@ async function cleanCloses(content) {
 
 async function addTasksUrls() {
   // read changelog
-  const rawChangelog = fs.readFileSync("../../CHANGELOG.md").toString("utf8");
+  const rawChangelog = fs.readFileSync("CHANGELOG.md").toString("utf8");
 
   const updatedContent = await [
     // Add pivotal stories url
@@ -72,7 +72,7 @@ async function addTasksUrls() {
     Promise.resolve(rawChangelog)
   );
   // write the new modified changelog
-  fs.writeFileSync("../../CHANGELOG.md", updatedContent);
+  fs.writeFileSync("CHANGELOG.md", updatedContent);
 }
 
 async function replacePivotalStories(content) {

--- a/scripts/changelog/add_pivotal_stories.js
+++ b/scripts/changelog/add_pivotal_stories.js
@@ -60,7 +60,7 @@ async function addTasksUrls() {
   // read changelog
   const rawChangelog = fs.readFileSync("CHANGELOG.md").toString("utf8");
 
-  const updatedContent = await [
+  const updatedChangelog = await [
     // Add pivotal stories url
     replacePivotalStories,
     // Add jira ticket url
@@ -72,7 +72,7 @@ async function addTasksUrls() {
     Promise.resolve(rawChangelog)
   );
   // write the new modified changelog
-  fs.writeFileSync("CHANGELOG.md", updatedContent);
+  fs.writeFileSync("CHANGELOG.md", updatedChangelog);
 }
 
 async function replacePivotalStories(content) {


### PR DESCRIPTION
## Short description
This PR introduces another step in the `postchangelog` phase to fix these scenarios
![Schermata 2021-04-29 alle 10 26 16](https://user-images.githubusercontent.com/822471/116522346-63280680-a8d5-11eb-8c06-94296f8943bf.png)


`cleanCloses` detectes the noise pattern and removes it from CHANGELOG

![Schermata 2021-04-29 alle 10 05 50](https://user-images.githubusercontent.com/822471/116522137-1f350180-a8d5-11eb-9497-15827376859d.png)
