### PR TITLE
fix: grammar error in locales/en/index.yml

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2194,7 +2194,7 @@ bonus:
               readMore: "Read more"
             calendarBlock:
               text1: "Please note that before you'll see the transaction on IO,"
-              text2: "it usually takes up 3 working days"
+              text2: "it usually takes up to 3 working days"
               text3: "."
             lastUpdated: "Latest valid transaction: "
             link: Anything missing?


### PR DESCRIPTION
## Short description
Fix grammar error in 'locales/en/index.yml'

## List of changes proposed in this pull request
- Change 'it usually takes up 3 working days' to 'it usually takes up to 3 working days'.

