### PR TITLE
178036707 feature capitalize profile name

### DIFF
--- a/ts/store/reducers/profile.ts
+++ b/ts/store/reducers/profile.ts
@@ -10,6 +10,7 @@ import { createSelector } from "reselect";
 import { getType } from "typesafe-actions";
 import { EmailAddress } from "../../../definitions/backend/EmailAddress";
 import { InitializedProfile } from "../../../definitions/backend/InitializedProfile";
+import { capitalize } from "../../utils/strings";
 import {
   profileLoadFailure,
   profileLoadRequest,
@@ -71,7 +72,7 @@ export const profileNameSelector = createSelector(
   profileSelector,
   (profile: ProfileState): string | undefined =>
     pot.getOrElse(
-      pot.map(profile, p => p.name),
+      pot.map(profile, p => capitalize(p.name)),
       undefined
     )
 );

--- a/ts/store/reducers/profile.ts
+++ b/ts/store/reducers/profile.ts
@@ -84,7 +84,7 @@ export const profileNameSurnameSelector = createSelector(
   profileSelector,
   (profile: ProfileState): string | undefined =>
     pot.getOrElse(
-      pot.map(profile, p => `${p.name} ${p.family_name}`),
+      pot.map(profile, p => capitalize(`${p.name} ${p.family_name}`)),
       undefined
     )
 );


### PR DESCRIPTION
## Short description
Added capitalization to profile name or profile name + profile surname.

Examples:
<img width="200" alt="Screenshot 2021-05-07 at 12 57 44" src="https://user-images.githubusercontent.com/61834253/117440130-f1366980-af33-11eb-8995-63489859789b.png">
<img width="300" alt="Screenshot 2021-05-07 at 12 56 50" src="https://user-images.githubusercontent.com/61834253/117440177-fe535880-af33-11eb-906e-a22bd77b5c50.png">

## How to test
If your name is written in lowercase or uppercase you can try, for example, to see if on identification modal your name has been formatted correctly.
You can also change the string passed to capitalize function in profileNameSelector or profileNameSurnameSelector