### PR TITLE
chore: [#178065366] Copy change

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1591,7 +1591,7 @@ identification:
       sensorErrorDescription: Fingerprint not recognized. Touch the sensor again.
       fallbackLabel: Use the unlock code
   fail:
-    wrongCode: Wrong code
+    wrongCode: Try again
     remainingAttempts: You have {{attempts}} attempts left.
     remainingAttemptSingle: You have {{attempts}} attempt left.
     tooManyAttempts: Too many attempts.

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1621,7 +1621,7 @@ identification:
       sensorErrorDescription: Impronta non riconosciuta. Tocca nuovamente il sensore.
       fallbackLabel: Usa il codice di sblocco
   fail:
-    wrongCode: Codice errato
+    wrongCode: Riprova
     remainingAttempts: Ti rimangono {{attempts}} tentativi.
     remainingAttemptSingle: Ti rimane {{attempts}} tentativo.
     tooManyAttempts: Troppi tentativi di inserimento errati.


### PR DESCRIPTION
This PR changes the error which appears when the authentication fails: "Wrong code" is now a simpler "Try again", to support all use cases.
