### PR TITLE
chore: [#178106274] Remove legacy backend status endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,6 @@ API_URL_PREFIX='https://app-backend.io.italia.it'
 PAGOPA_API_URL_PREFIX='https://wisp2.pagopa.gov.it/pp-restapi-CD'
 # pagoPA test/env RESTful API
 PAGOPA_API_URL_PREFIX_TEST='https://acardste.vaservices.eu:443/pp-restapi-CD'
-# endpoint to get backend status
-BACKEND_STATUS_URL='https://iopstcdnassets.z6.web.core.windows.net/status'
 # If enabled the App shows an Alert with the push notification message details.
 DEBUG_REMOTE_PUSH_NOTIFICATION=NO
 # If set to "YES" an Alert is rendered when an error was received from the biometric identification

--- a/.env.local
+++ b/.env.local
@@ -6,8 +6,6 @@ API_URL_PREFIX='http://127.0.0.1:3000'
 PAGOPA_API_URL_PREFIX='http://127.0.0.1:3000/wallet'
 # pagoPA test/env RESTful API
 PAGOPA_API_URL_PREFIX_TEST='https://acardste.vaservices.eu:443/pp-restapi-CD'
-# endpoint to get backend status
-BACKEND_STATUS_URL='http://127.0.0.1:3000/status'
 # If enabled the App shows an Alert with the push notification message details.
 DEBUG_REMOTE_PUSH_NOTIFICATION=NO
 # If set to "YES" an Alert is rendered when an error was received from the biometric identification

--- a/.env.production
+++ b/.env.production
@@ -6,8 +6,6 @@ API_URL_PREFIX='https://app-backend.io.italia.it'
 PAGOPA_API_URL_PREFIX='https://wisp2.pagopa.gov.it/pp-restapi-CD'
 # pagoPA test/env RESTful API
 PAGOPA_API_URL_PREFIX_TEST='https://acardste.vaservices.eu:443/pp-restapi-CD'
-# endpoint to get backend status
-BACKEND_STATUS_URL='https://iopstcdnassets.z6.web.core.windows.net/status'
 # If enabled the App shows an Alert with the push notification message details.
 DEBUG_REMOTE_PUSH_NOTIFICATION=NO
 # If set to "YES" an Alert is rendered when an error was received from the biometric identification

--- a/ts/api/backendPublic.ts
+++ b/ts/api/backendPublic.ts
@@ -45,7 +45,7 @@ export function CdnBackendStatusClient(
   const getStatusT: GetStatusT = {
     method: "get",
     // to avoid response caching
-    url: () => `backend.json?ms=${new Date().getTime()}`,
+    url: () => `status/backend.json?ms=${new Date().getTime()}`,
     query: _ => ({}),
     headers: () => ({}),
     response_decoder: basicResponseDecoder(BackendStatus)

--- a/ts/config.ts
+++ b/ts/config.ts
@@ -36,7 +36,6 @@ export const environment: string = Config.ENVIRONMENT;
 export const apiUrlPrefix: string = Config.API_URL_PREFIX;
 export const pagoPaApiUrlPrefix: string = Config.PAGOPA_API_URL_PREFIX;
 export const pagoPaApiUrlPrefixTest: string = Config.PAGOPA_API_URL_PREFIX_TEST;
-export const backendStatusUrl: string = Config.BACKEND_STATUS_URL;
 export const mixpanelToken: string = Config.MIXPANEL_TOKEN;
 export const gcmSenderId: string = Config.GCM_SENDER_ID;
 export const debugRemotePushNotification =

--- a/ts/sagas/backendStatus.ts
+++ b/ts/sagas/backendStatus.ts
@@ -4,11 +4,11 @@
 import { Millisecond } from "italia-ts-commons/lib/units";
 import { call, Effect, fork, put, select } from "redux-saga/effects";
 import { CdnBackendStatusClient } from "../api/backendPublic";
-import { backendStatusUrl } from "../config";
 import { backendStatusLoadSuccess } from "../store/actions/backendStatus";
 import { backendServicesStatusSelector } from "../store/reducers/backendStatus";
 import { SagaCallReturnType } from "../types/utils";
 import { startTimer } from "../utils/timer";
+import { contentRepoUrl } from "../config";
 
 const BACKEND_SERVICES_STATUS_LOAD_INTERVAL = (60 * 1000) as Millisecond;
 const BACKEND_SERVICES_STATUS_FAILURE_INTERVAL = (10 * 1000) as Millisecond;
@@ -69,6 +69,6 @@ export function* backendStatusWatcherLoop(
 }
 
 export default function* root(): IterableIterator<Effect> {
-  const cdnBackendClient = CdnBackendStatusClient(backendStatusUrl);
+  const cdnBackendClient = CdnBackendStatusClient(contentRepoUrl);
   yield fork(backendStatusWatcherLoop, cdnBackendClient.getStatus);
 }


### PR DESCRIPTION
## Short description
This PR removes the usage of a legacy backend status endpoint
Now all status assets are hosted in IO CDN https://assets.cdn.io.italia.it/

### how to test
- **prod**: you are ready!
- **dev**: make sure to get the last commit from [master](https://github.com/pagopa/io-dev-api-server) 