### PR TITLE
fix: [#178070799] Allow the addition of Diners cards

### DIFF
--- a/ts/utils/__tests__/input.test.ts
+++ b/ts/utils/__tests__/input.test.ts
@@ -15,6 +15,7 @@ import { testableAddCardScreen } from "../../screens/wallet/AddCardScreen";
 
 describe("CreditCardPan", () => {
   const validPANs: ReadonlyArray<string> = [
+    "12341234123412",
     "123412341234123",
     "1234123412341234",
     "************1234",
@@ -34,7 +35,7 @@ describe("CreditCardPan", () => {
   const invalidPANs: ReadonlyArray<string> = [
     "1234 1234 1234 1234",
     "123412341234123_123",
-    "12341234123412",
+    "1234123412341",
     "12341234123412341234"
   ];
 

--- a/ts/utils/input.ts
+++ b/ts/utils/input.ts
@@ -4,7 +4,7 @@ import * as _ from "lodash";
 import { PatternString } from "italia-ts-commons/lib/strings";
 import { CreditCard } from "../types/pagopa";
 
-const MIN_PAN_DIGITS = 15;
+const MIN_PAN_DIGITS = 14;
 const MAX_PAN_DIGITS = 19;
 
 /**


### PR DESCRIPTION
## Short description
This PR update the lower limit for the number of digits allowed for the credit card.
This allow the user to insert a Diners credit card.  

## List of changes proposed in this pull request
- Update the lower limit to 14
- Update the tests case
<img src="https://user-images.githubusercontent.com/11773070/117827160-0b908000-b271-11eb-919d-8f6ce7ac5e13.png" width=300>
