### PR TITLE
chore: [#178065380] Replaced failed identification text

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -122,6 +122,7 @@ global:
   genericThanks: Thank you
   genericShare: Share
   genericSave: Save
+  genericRetry: Try again
   jserror:
     title: Unexpected error occurred
     message: We have reported this to our team! Please close the app and start again!
@@ -1581,7 +1582,6 @@ identification:
   subtitleCodeFingerprint: use the fingerprint or the unlock code
   subtitleCodeFaceId: use the Face ID or enter the unlock code
   biometric:
-    failure: Identification failed
     fingerprintType: Fingerprint
     title: Biometric identification
     popup:
@@ -1591,7 +1591,6 @@ identification:
       sensorErrorDescription: Fingerprint not recognized. Touch the sensor again.
       fallbackLabel: Use the unlock code
   fail:
-    wrongCode: Try again
     remainingAttempts: You have {{attempts}} attempts left.
     remainingAttemptSingle: You have {{attempts}} attempt left.
     tooManyAttempts: Too many attempts.

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -122,6 +122,7 @@ global:
   genericThanks: Grazie
   genericShare: Condividi
   genericSave: Salva
+  genericRetry: Riprova
   jserror:
     title: Si è verificato un errore imprevisto
     message: Abbiamo segnalato questo al nostro team! Si prega di chiudere l'app e ricominciare!
@@ -1611,7 +1612,6 @@ identification:
   subtitleCodeFingerprint: "usa l'impronta o il codice di sblocco"
   subtitleCodeFaceId: "usa Face ID o il codice di sblocco"
   biometric:
-    failure: Identificazione fallita
     fingerprintType: Impronta digitale
     title: Identificazione Biometrica
     popup:
@@ -1621,7 +1621,6 @@ identification:
       sensorErrorDescription: Impronta non riconosciuta. Tocca nuovamente il sensore.
       fallbackLabel: Usa il codice di sblocco
   fail:
-    wrongCode: Riprova
     remainingAttempts: Ti rimangono {{attempts}} tentativi.
     remainingAttemptSingle: Ti rimane {{attempts}} tentativo.
     tooManyAttempts: Troppi tentativi di inserimento errati.

--- a/ts/screens/modal/IdentificationLockModal.tsx
+++ b/ts/screens/modal/IdentificationLockModal.tsx
@@ -30,7 +30,7 @@ const styles = StyleSheet.create({
   }
 });
 
-const wrongCodeText = I18n.t("identification.fail.wrongCode");
+const wrongCodeText = I18n.t("global.genericRetry");
 const waitMessageText = I18n.t("identification.fail.waitMessage");
 const tooManyAttemptsText = I18n.t("identification.fail.tooManyAttempts");
 

--- a/ts/screens/modal/IdentificationModal.tsx
+++ b/ts/screens/modal/IdentificationModal.tsx
@@ -11,8 +11,6 @@ import Pinpad from "../../components/Pinpad";
 import BaseScreenComponent, {
   ContextualHelpPropsMarkdown
 } from "../../components/screens/BaseScreenComponent";
-import IconFont from "../../components/ui/IconFont";
-import TextWithIcon from "../../components/ui/TextWithIcon";
 import { isDebugBiometricIdentificationEnabled } from "../../config";
 import I18n from "../../i18n";
 import { getFingerprintSettings } from "../../sagas/startup/checkAcknowledgedFingerprintSaga";
@@ -74,24 +72,6 @@ const checkPinInterval = 100 as Millisecond;
 // the threshold of attempts after which it is necessary to activate the timer check
 const checkTimerThreshold = maxAttempts - freeAttempts;
 
-const renderIdentificationByBiometryState = (
-  identificationByBiometryState: IdentificationByPinState
-) => {
-  if (identificationByBiometryState === "failure") {
-    return (
-      <React.Fragment>
-        <View spacer={true} extralarge={true} />
-        <TextWithIcon danger={true}>
-          <IconFont name={"io-close"} color={"white"} />
-          <Text white={true}>{I18n.t("identification.biometric.failure")}</Text>
-        </TextWithIcon>
-      </React.Fragment>
-    );
-  }
-
-  return null;
-};
-
 const onRequestCloseHandler = () => undefined;
 
 const styles = StyleSheet.create({
@@ -125,7 +105,7 @@ class IdentificationModal extends React.PureComponent<Props, State> {
 
     this.state = {
       identificationByPinState: "unstarted",
-      identificationByBiometryState: "unstarted",
+      identificationByBiometryState: "failure",
       biometryAuthAvailable: true,
       canInsertPinTooManyAttempts: this.props.identificationFailState.isNone()
     };
@@ -379,8 +359,40 @@ class IdentificationModal extends React.PureComponent<Props, State> {
     );
   };
 
+  private getErrorText = () => {
+    const textTryAgain = I18n.t("global.genericRetry");
+
+    if (this.state.identificationByPinState === "failure") {
+      this.setState({
+        identificationByBiometryState: "unstarted"
+      });
+      return this.props.identificationFailState
+        .filter(fs => fs.remainingAttempts <= maxAttempts - freeAttempts)
+        .map(
+          // here if the user finished his free attempts
+          fd =>
+            `${textTryAgain}. ${I18n.t(
+              fd.remainingAttempts > 1
+                ? "identification.fail.remainingAttempts"
+                : "identification.fail.remainingAttemptSingle",
+              { attempts: fd.remainingAttempts }
+            )}`
+        )
+        .getOrElse(textTryAgain);
+    }
+
+    if (this.state.identificationByBiometryState === "failure") {
+      this.setState({
+        identificationByPinState: "unstarted"
+      });
+      return textTryAgain;
+    }
+
+    return undefined;
+  };
+
   private renderErrorDescription = () =>
-    maybeNotNullyString(this.getCodeInsertionStatus()).fold(undefined, des => (
+    maybeNotNullyString(this.getErrorText()).fold(undefined, des => (
       <Text
         alignCenter={true}
         bold={true}
@@ -392,27 +404,6 @@ class IdentificationModal extends React.PureComponent<Props, State> {
         {des}
       </Text>
     ));
-
-  private getCodeInsertionStatus = () => {
-    if (this.state.identificationByPinState === "unstarted") {
-      return undefined;
-    }
-
-    const wrongCodeString = I18n.t("identification.fail.wrongCode");
-    return this.props.identificationFailState
-      .filter(fs => fs.remainingAttempts <= maxAttempts - freeAttempts)
-      .map(
-        // here if the user finished his free attempts
-        fd =>
-          `${wrongCodeString}. ${I18n.t(
-            fd.remainingAttempts > 1
-              ? "identification.fail.remainingAttempts"
-              : "identification.fail.remainingAttemptSingle",
-            { attempts: fd.remainingAttempts }
-          )}`
-      )
-      .getOrElse(wrongCodeString);
-  };
 
   public render() {
     const { identificationProgressState, isFingerprintEnabled } = this.props;
@@ -429,11 +420,7 @@ class IdentificationModal extends React.PureComponent<Props, State> {
       shufflePad
     } = identificationProgressState;
 
-    const {
-      identificationByBiometryState,
-      biometryType,
-      countdown
-    } = this.state;
+    const { biometryType, countdown } = this.state;
 
     const canInsertPin =
       !this.state.biometryAuthAvailable &&
@@ -548,8 +535,6 @@ class IdentificationModal extends React.PureComponent<Props, State> {
               }
               remainingAttempts={displayRemainingAttempts}
             />
-            {renderIdentificationByBiometryState(identificationByBiometryState)}
-
             <View spacer={true} large={true} />
             {!isValidatingTask && (
               <View style={styles.bottomContainer}>

--- a/ts/screens/modal/IdentificationModal.tsx
+++ b/ts/screens/modal/IdentificationModal.tsx
@@ -105,7 +105,7 @@ class IdentificationModal extends React.PureComponent<Props, State> {
 
     this.state = {
       identificationByPinState: "unstarted",
-      identificationByBiometryState: "failure",
+      identificationByBiometryState: "unstarted",
       biometryAuthAvailable: true,
       canInsertPinTooManyAttempts: this.props.identificationFailState.isNone()
     };

--- a/ts/screens/modal/IdentificationModal.tsx
+++ b/ts/screens/modal/IdentificationModal.tsx
@@ -359,6 +359,11 @@ class IdentificationModal extends React.PureComponent<Props, State> {
     );
   };
 
+  // The generic "Try again" message appears if you make a mistake
+  // in entering the unlock code or in case of failed biometric authentication.
+  // If you fail to write the unlock code more than 4 times you should see
+  // "Try again. Number of remaining attempts". In case of failed biometric identification
+  // the message is displayed when you open the app by holding the "wrong finger" on the biometric iPhone sensor.
   private getErrorText = () => {
     const textTryAgain = I18n.t("global.genericRetry");
 


### PR DESCRIPTION
## Short description
Replaced "Identification failed" text that shows if you fail the biometric identification and wrong code error text.
Now you will see a generic "Try again" for both errors.
It seems that "Try again" text of biometric identification fail comes out only when you put the "wrong finger" in the biometric sensor and then open the app from the iPhone

## How to test
Try to unlock the app, in the identification modal component, if biometry state is in failure state or if you fail to write the unlock code you should see "Try again" text.
If you fail to write the unlock code more than 4-5 times you should see "Try again. Number of remaining attempts" text.

**Before:**
<img width="300" alt="Screenshot 2021-05-14 at 10 31 21" src="https://user-images.githubusercontent.com/61834253/118245499-2ea17680-b4a1-11eb-8f28-ab29fee497e9.png">

**After:**
<img width="300" alt="Screenshot 2021-05-14 at 10 45 15" src="https://user-images.githubusercontent.com/61834253/118245861-92c43a80-b4a1-11eb-8b5b-707f8e6b720f.png">

