### PR TITLE
fix: [#178155677] Local scheduled notification aren't canceled after login with SPID / CIE

### DIFF
--- a/ts/boot/scheduleLocalNotifications.ts
+++ b/ts/boot/scheduleLocalNotifications.ts
@@ -44,7 +44,7 @@ export const scheduleLocalNotificationsAccessSpid = () => {
  */
 export const removeScheduledNotificationAccessSpid = () => {
   /**
-   * With the current library version seems that cancelLocalNotifications doesn't work.
+   * With the current library version (7.3.1) seems that cancelLocalNotifications doesn't work.
    *
    * eg. example code that doesn't work:
    *
@@ -59,7 +59,7 @@ export const removeScheduledNotificationAccessSpid = () => {
    * );
    *
    * At the moment the "first access spid" is the only kind of scheduled notification and for this reason
-   * is safe to use PushNotification.cancelAllLocalNotifications();
+   * it is safe to use PushNotification.cancelAllLocalNotifications();
    * If we add more scheduled notifications, we need to investigate why cancelLocalNotifications doesn't work
    */
   PushNotification.cancelAllLocalNotifications();

--- a/ts/boot/scheduleLocalNotifications.ts
+++ b/ts/boot/scheduleLocalNotifications.ts
@@ -28,7 +28,6 @@ export const scheduleLocalNotificationsAccessSpid = () => {
     twoMonthsFromPrev,
     sixMonthsFromPrev
   ];
-
   localNotificationDates.forEach((scheduledDate: Date) =>
     PushNotification.localNotificationSchedule({
       title: I18n.t("global.localNotifications.spidLogin.title"),
@@ -44,7 +43,24 @@ export const scheduleLocalNotificationsAccessSpid = () => {
  * Remove all the local notifications relating to authentication with spid
  */
 export const removeScheduledNotificationAccessSpid = () => {
-  PushNotification.cancelLocalNotifications({
-    id: FIRST_ACCESS_SPID_TAG
-  });
+  /**
+   * With the current library version seems that cancelLocalNotifications doesn't work.
+   *
+   * eg. example code that doesn't work:
+   *
+   *   PushNotification.getScheduledLocalNotifications(x =>
+   * x
+   * .filter(notification => notification.data.tag === FIRST_ACCESS_SPID_TAG)
+   * .forEach(firstAccessNotification => {
+   *      PushNotification.cancelLocalNotifications({
+   *        id: firstAccessNotification.id.toString()
+   *      });
+   *    })
+   * );
+   *
+   * At the moment the "first access spid" is the only kind of scheduled notification and for this reason
+   * is safe to use PushNotification.cancelAllLocalNotifications();
+   * If we add more scheduled notifications, we need to investigate why cancelLocalNotifications doesn't work
+   */
+  PushNotification.cancelAllLocalNotifications();
 };


### PR DESCRIPTION
## Short description
This pr fixes a bug that doesn't clearing scheduled notifications correctly after the SPID / CIE login.

## List of changes proposed in this pull request
- Removed `PushNotification.cancelLocalNotifications`
- Added `PushNotification.cancelAllLocalNotifications`

## How to test
It's possible to see the currently scheduled notification with `PushNotification.getScheduledLocalNotifications`
