### PR TITLE
fix: [#178157694] No transactions done even if there are

### DIFF
--- a/ts/components/wallet/TransactionsList.tsx
+++ b/ts/components/wallet/TransactionsList.tsx
@@ -141,36 +141,35 @@ export default class TransactionsList extends React.Component<Props, State> {
     }
 
     return (
-      <ButtonDefaultOpacity
-        style={styles.moreButton}
-        bordered={true}
-        disabled={this.state.loadingMore}
-        onPress={() => {
-          this.setState({ loadingMore: true }, () =>
-            this.props.onLoadMoreTransactions()
-          );
-        }}
-      >
-        <Text>
-          {I18n.t(
-            // change the button text if we are loading another slice of transactions
-            this.state.loadingMore
-              ? "wallet.transacionsLoadingMore"
-              : "wallet.transactionsLoadMore"
-          )}
-        </Text>
-      </ButtonDefaultOpacity>
+      <View>
+        <ButtonDefaultOpacity
+          style={styles.moreButton}
+          bordered={true}
+          disabled={this.state.loadingMore}
+          onPress={() => {
+            this.setState({ loadingMore: true }, () =>
+              this.props.onLoadMoreTransactions()
+            );
+          }}
+        >
+          <Text>
+            {I18n.t(
+              // change the button text if we are loading another slice of transactions
+              this.state.loadingMore
+                ? "wallet.transacionsLoadingMore"
+                : "wallet.transactionsLoadMore"
+            )}
+          </Text>
+        </ButtonDefaultOpacity>
+        <EdgeBorderComponent />
+      </View>
     );
   };
 
   public render(): React.ReactNode {
     const { ListEmptyComponent } = this.props;
-
     // first loading
-    if (
-      this.state.loadingMore === false &&
-      pot.isLoading(this.props.transactions)
-    ) {
+    if (!this.state.loadingMore && pot.isLoading(this.props.transactions)) {
       return (
         <BoxedRefreshIndicator
           white={true}
@@ -182,7 +181,9 @@ export default class TransactionsList extends React.Component<Props, State> {
       this.props.transactions,
       []
     );
-    return transactions.length === 0 && ListEmptyComponent ? (
+    return transactions.length === 0 &&
+      !this.props.areMoreTransactionsAvailable &&
+      ListEmptyComponent ? (
       ListEmptyComponent
     ) : (
       <Content scrollEnabled={false} style={styles.whiteContent}>

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -457,6 +457,7 @@ class WalletHomeScreen extends React.PureComponent<Props, State> {
           <Text primary={true}>{I18n.t("wallet.transactionsShow")}</Text>
         </ButtonDefaultOpacity>
         <EdgeBorderComponent />
+        <View spacer={true} />
       </Content>
     );
   }
@@ -473,6 +474,7 @@ class WalletHomeScreen extends React.PureComponent<Props, State> {
             source={require("../../../img/messages/empty-transaction-list-icon.png")}
           />
         </View>
+        <EdgeBorderComponent />
       </Content>
     );
   }


### PR DESCRIPTION
## Short description
At the moment if the first page (transaction API is paginated) has [no valid transactions](https://github.com/pagopa/io-app/blob/ac6e9ef811711a60d8f6cc5733051bb5c2b07788/ts/types/pagopa.ts#L352), the app shows the user she has no transactions. 
This PR also adds the `<EdgeBorderComponent />` to have a better info displaying

### 🐞 
https://user-images.githubusercontent.com/822471/118269859-84851700-b4bf-11eb-9643-28d2a782ad00.mp4

this happens when the first page of transactions contains all invalid transactions, even if in the other pages there are valid ones

### now
https://user-images.githubusercontent.com/822471/118270062-bd24f080-b4bf-11eb-92d5-08d79bf71cd5.mp4



## How to test
- take the last commit of dev-server
- create a set of mixed transactions here 
    replace this line 
https://github.com/pagopa/io-dev-api-server/blob/b8f91c84bb24bcf7d66dccd8680e4e5dd7173426/src/routers/wallet.ts#L51
with this code (15 transaction valid + 15 invalid -> 3 pages)
```typescript
export const transactions: ReadonlyArray<Transaction> = [
  ...getTransactions(15, false, true, wallets.data),
  ...getTransactions(15, true, true, wallets.data)
];
```
