### PR TITLE
fix(Bonus Pagamenti Digitali): [IAC-57] Privative displayed as incoming when adding a new payment method during a payment

### DIFF
--- a/ts/screens/wallet/AddPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/AddPaymentMethodScreen.tsx
@@ -86,7 +86,7 @@ const getpaymentMethods = (props: Props): ReadonlyArray<IPaymentMethod> => [
     onPress: props.startAddPrivative,
     status: props.navigation.getParam("inPayment").isNone()
       ? "implemented"
-      : "incoming"
+      : "notImplemented"
   },
   {
     name: I18n.t("wallet.methods.bonus.name"),


### PR DESCRIPTION
## Short description
This pr fixes the privative payment method displayed as "Incoming" when the user adds a new payment method, during a payment.

Before            |  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/26501317/118473759-a1615a80-b70a-11eb-8a23-f2ee5961aa6f.png" width="300">|  <img src="https://user-images.githubusercontent.com/26501317/118473429-416ab400-b70a-11eb-8d26-770d226c27f4.png" width="300">

## List of changes proposed in this pull request
- Changed the state from `incoming` to `notImplemented`.

## How to test
Add a payment method during a payment.
