### PR TITLE
feat: [#178230437] Changed valid until color

### DIFF
--- a/ts/components/wallet/card/CardComponent.tsx
+++ b/ts/components/wallet/card/CardComponent.tsx
@@ -215,7 +215,10 @@ export default class CardComponent extends React.Component<Props> {
     return (
       <View style={[styles.columns, styles.paddedTop]}>
         <View>
-          <H5 color={isCardExpired ? "red" : "bluegrey"} weight={"SemiBold"}>
+          <H5
+            color={isCardExpired ? "red" : "bluegreyDark"}
+            weight={"SemiBold"}
+          >
             {`${I18n.t("cardComponent.validUntil")} ${expirationDate}`}
           </H5>
           <Text style={[CreditCardStyles.textStyle, styles.marginTop]}>

--- a/ts/features/wallet/bancomat/component/bancomatCard/BaseBancomatCard.tsx
+++ b/ts/features/wallet/bancomat/component/bancomatCard/BaseBancomatCard.tsx
@@ -141,7 +141,7 @@ const BaseBancomatCard: React.FunctionComponent<Props> = (props: Props) => {
           <View spacer={true} />
           {props.expiringDate && (
             <H5
-              color={props.isExpired ? "red" : "bluegrey"}
+              color={props.isExpired ? "red" : "bluegreyDark"}
               weight={"SemiBold"}
             >{`${I18n.t("cardComponent.validUntil")} ${localeDateFormat(
               props.expiringDate,

--- a/ts/features/wallet/cobadge/component/BaseCoBadgeCard.tsx
+++ b/ts/features/wallet/cobadge/component/BaseCoBadgeCard.tsx
@@ -108,7 +108,7 @@ const BaseCoBadgeCard: React.FunctionComponent<Props> = (props: Props) => {
               <View spacer={true} />
               <H5
                 weight={props.isExpired ? "SemiBold" : "Regular"}
-                color={props.isExpired ? "red" : "bluegrey"}
+                color={props.isExpired ? "red" : "bluegreyDark"}
                 testID={"expirationDate"}
               >
                 {I18n.t("wallet.cobadge.details.card.validUntil", {


### PR DESCRIPTION
## Short description
Changed "Valid until" label color on credit card

## How to test
You can see the changes in these points:

- Credit card detail (from wallet)
- During checkout step (when you pay a notice)
- When you add PagoBANCOMAT or Co-badge card

**Before:**
<img width="300" alt="Screenshot 2021-05-20 at 15 44 54" src="https://user-images.githubusercontent.com/61834253/118989912-b47e5f80-b982-11eb-913b-bb067a6543b0.png">

**After:**
<img width="300" alt="Screenshot 2021-05-20 at 15 44 35" src="https://user-images.githubusercontent.com/61834253/118989847-a6c8da00-b982-11eb-8438-bc28aeb1d19a.png">
