### PR TITLE
fix: [#178243533] Fix cards not visible during payment

### DIFF
--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -631,6 +631,9 @@ const mapStateToProps = (state: GlobalState) => {
     periodsWithAmount: bpdPeriodsAmountWalletVisibleSelector(state),
     allActiveBonus: allBonusActiveSelector(state),
     availableBonusesList: supportedAvailableBonusSelector(state),
+    // TODO: This selector (pagoPaCreditCardWalletV1Selector) should return the credit cards
+    //  available for display in the wallet, so the cards added with the APP or with the WISP.
+    //  But it leverage on the assumption that the meaning of pagoPA === true is the same of onboardingChannel !== "EXT"
     potWallets: pagoPaCreditCardWalletV1Selector(state),
     anyHistoryPayments: paymentsHistorySelector(state).length > 0,
     anyCreditCardAttempts: creditCardAttemptsSelector(state).length > 0,

--- a/ts/screens/wallet/payment/__tests__/PickPaymentMethodScreen.test.tsx
+++ b/ts/screens/wallet/payment/__tests__/PickPaymentMethodScreen.test.tsx
@@ -203,6 +203,33 @@ describe("PickPaymentMethodScreen", () => {
 
     expect(availablePaymentMethodList).not.toBeNull();
   });
+
+  it("should show a credit card if the field onboardingChannel is undefined", () => {
+    const indexedWalletById = toIndexed(
+      [{ ...aCreditCard, onboardingChannel: undefined }].map(
+        convertWalletV2toWalletV1
+      ),
+      pm => pm.idWallet
+    );
+
+    store = mockStore({
+      ...globalState,
+      wallet: {
+        ...globalState.wallet,
+        wallets: {
+          ...globalState.wallet.wallets,
+          walletById: pot.some(indexedWalletById)
+        }
+      }
+    });
+
+    const component = renderPickPaymentMethodScreen(store);
+    const availablePaymentMethodList = component.queryByTestId(
+      "availablePaymentMethodList"
+    );
+
+    expect(availablePaymentMethodList).not.toBeNull();
+  });
 });
 
 const renderPickPaymentMethodScreen = (store: Store<GlobalState, Action>) =>

--- a/ts/store/reducers/wallet/wallets.ts
+++ b/ts/store/reducers/wallet/wallets.ts
@@ -215,11 +215,18 @@ export const bPayListSelector = createSelector(
 
 /**
  * return true if the payment method is visible in the wallet (the onboardingChannel
- * is IO or WISP)
+ * is IO or WISP) or if the onboardingChannel is undefined.
+ * We choose to show cards with onboardingChannel undefined to ensure backward compatibility
+ * with cards inserted before the field was added.
+ * Explicitly handling the undefined is a conservative choice, as the field should be an enum (IO, WISP, EXT)
+ * but it is a string and therefore we cannot be sure that incorrect data will not arrive.
+ *
  * @param pm
  */
 export const isVisibleInWallet = (pm: PaymentMethod) =>
-  pm.onboardingChannel === "IO" || pm.onboardingChannel === "WISP";
+  pm.onboardingChannel === "IO" ||
+  pm.onboardingChannel === "WISP" ||
+  pm.onboardingChannel === undefined;
 
 /**
  * Return a credit card list visible in the wallet

--- a/ts/store/reducers/wallet/wallets.ts
+++ b/ts/store/reducers/wallet/wallets.ts
@@ -223,10 +223,11 @@ export const bPayListSelector = createSelector(
  *
  * @param pm
  */
-export const isVisibleInWallet = (pm: PaymentMethod) =>
-  pm.onboardingChannel === "IO" ||
-  pm.onboardingChannel === "WISP" ||
-  pm.onboardingChannel === undefined;
+const visibleOnboardingChannels = ["IO", "WISP", undefined];
+export const isVisibleInWallet = (pm: PaymentMethod): boolean =>
+  visibleOnboardingChannels.some(
+    oc => oc === pm.onboardingChannel?.toUpperCase().trim()
+  );
 
 /**
  * Return a credit card list visible in the wallet


### PR DESCRIPTION
## Short description
This PR corrects a bug due to the receipt of incomplete data: in fact, the onboardingChannel field was added after the creation of some wallets and for these it has not been evaluated.
This resulted in the user seeing all his payment methods in the wallet section but not when he changed payment method during a payment.

## List of changes proposed in this pull request
- Added the undefined check to the `isVisibleInWallet` utils

## How to test

- **Dev mode:** remove the field `onboardingChannel` from the card (_src/payloads/wallet_v2.ts_). 
- **Prod**: if you have an added card without the field `onboardingChannel`
In both the cases you should see the card in the `PAYMENT_PICK_PAYMENT_METHOD` screen.
- Added a test case in `PickPaymentMethodScreen.test.tsx`
