### PR TITLE
fix(Bonus Pagamenti Digitali): [IAC-66] Wrong normalization of cashback amount when the pivot transaction is in a different day but in the same page

### DIFF
--- a/ts/features/bonus/bpd/store/reducers/details/transactionsv2/entities.ts
+++ b/ts/features/bonus/bpd/store/reducers/details/transactionsv2/entities.ts
@@ -127,7 +127,7 @@ const updateTransactions = (
     const transactionsNormalized = normalizeCashback(
       val.transactions,
       pivot,
-      state.foundPivot
+      foundPivot
     );
     // update the foundPivot
     if (!foundPivot && transactionsNormalized.found) {


### PR DESCRIPTION
## Short description
This pr fixes the wrong normalization when the pivot transaction is in the same page but in a different day.

Before

https://user-images.githubusercontent.com/26501317/119334416-62438400-bc8b-11eb-8bba-b41af6bd5429.mov

After


https://user-images.githubusercontent.com/26501317/119334497-7b4c3500-bc8b-11eb-91ff-1fdbfb4f437e.mov



## List of changes proposed in this pull request
- changed the use of the initial state instead of the accumulator `foundPivot` in `updateTransactions`

## How to test
- run `ts/features/bonus/bpd/store/reducers/details/transactionsv2/__test__/normalization.test.ts`
