### PR TITLE
feat: [#177097833] Add card detail screen on onboarding new card flow

### DIFF
--- a/ts/components/wallet/WalletLayout.tsx
+++ b/ts/components/wallet/WalletLayout.tsx
@@ -39,6 +39,7 @@ type Props = Readonly<{
   gradientHeader?: boolean;
   headerPaddingMin?: boolean;
   footerFullWidth?: React.ReactNode;
+  customGoBack?: React.ReactNode;
 }>;
 
 const styles = StyleSheet.create({
@@ -130,6 +131,7 @@ export default class WalletLayout extends React.Component<Props> {
         faqCategories={this.props.faqCategories}
         gradientHeader={this.props.gradientHeader}
         headerPaddingMin={this.props.headerPaddingMin}
+        customGoBack={this.props.customGoBack}
       >
         {this.props.children}
       </DarkLayout>

--- a/ts/screens/wallet/TransactionsScreen.tsx
+++ b/ts/screens/wallet/TransactionsScreen.tsx
@@ -25,6 +25,7 @@ import {
 } from "../../store/actions/wallet/wallets";
 import { GlobalState } from "../../store/reducers/types";
 import {
+  creditCardWalletV1Selector,
   favoriteWalletIdSelector,
   getFavoriteWalletId,
   getWalletsById,
@@ -43,6 +44,7 @@ import { IOColors } from "../../components/core/variables/IOColors";
 import ButtonDefaultOpacity from "../../components/ButtonDefaultOpacity";
 import { FavoritePaymentMethodSwitch } from "../../components/wallet/FavoriteMethodSwitch";
 import LoadingSpinnerOverlay from "../../components/LoadingSpinnerOverlay";
+import GoBackButton from "../../components/GoBackButton";
 
 type NavigationParams = Readonly<{
   selectedWallet: Wallet;
@@ -145,6 +147,7 @@ const TransactionsScreen: React.FC<Props> = (props: Props) => {
     ),
     undefined
   );
+
   const { present } = useRemovePaymentMethodBottomSheet({
     icon: selectedWallet.creditCard
       ? getCardIconFromBrandLogo(selectedWallet.creditCard)
@@ -161,6 +164,10 @@ const TransactionsScreen: React.FC<Props> = (props: Props) => {
       setIsLoadingDelete(false);
     }
   }, [props.hasErrorDelete]);
+
+  const customGoBack = selectedWallet.navigateToWalletHome
+    ? selectedWallet.navigateToWalletHome
+    : false;
 
   const DeletePaymentMethodButton = (props: { onPress?: () => void }) => (
     <ButtonDefaultOpacity
@@ -192,6 +199,9 @@ const TransactionsScreen: React.FC<Props> = (props: Props) => {
       topContentHeight={HEADER_HEIGHT}
       contextualHelpMarkdown={contextualHelpMarkdown}
       faqCategories={["wallet_transaction"]}
+      customGoBack={
+        <GoBackButton testID={"back-button"} onPress={customGoBack} white />
+      }
     >
       {pm && (
         <>
@@ -236,7 +246,8 @@ const mapStateToProps = (state: GlobalState) => ({
   favoriteWalletRequestStatus: favoriteWalletIdSelector(state),
   favoriteWalletId: getFavoriteWalletId(state),
   paymentMethods: paymentMethodsSelector(state),
-  hasErrorDelete: pot.isError(getWalletsById(state))
+  hasErrorDelete: pot.isError(getWalletsById(state)),
+  wallets: pot.getOrElse(creditCardWalletV1Selector(state), [])
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({


### PR DESCRIPTION
## DESCRIPTION
Added card detail view at the end of the new card insertion flow.
Previously, after you finished adding a card, you landed in the wallet home screen.

## CASHBACK SERVICE NOT ACTIVED
**If the cashback service is not yet active, it must land on the home screen wallet**

https://user-images.githubusercontent.com/53444973/119350986-41395e00-bca0-11eb-82e7-256ec154dd7d.mov

## CASHBACK ACTIVED
**If the cashback service is already activated, as a last step you must land in the detail of a card**


https://user-images.githubusercontent.com/53444973/119351879-49de6400-bca1-11eb-9d49-a6a3534ea22a.mov

## WARNING 
**In the preview, the data appear to be distorted because everything was developed with the mocked data of the server locally, but the Wallet ID relating to the correct card matches and is correctly passed**



