### PR TITLE
feat(EU Covid Certificate): [IAGP-36] Add euCovidCert as new section status

### DIFF
--- a/scripts/ts/common/ticket/jira/types.ts
+++ b/scripts/ts/common/ticket/jira/types.ts
@@ -5,6 +5,7 @@ const JiraIssueType = t.keyof({
   Story: null,
   Task: null,
   Sottotask: null,
+  "Sub-task": null,
   Bug: null
 });
 

--- a/scripts/ts/common/ticket/types.ts
+++ b/scripts/ts/common/ticket/types.ts
@@ -33,6 +33,7 @@ const convertJiraTypeToGeneric = (
       return "fix";
     case "Epic":
       return "feat";
+    case "Sub-task":
     case "Sottotask":
       return "chore";
     case "Story":

--- a/ts/store/reducers/__mock__/backendStatus.ts
+++ b/ts/store/reducers/__mock__/backendStatus.ts
@@ -149,6 +149,14 @@ export const baseRawBackendStatus: BackendStatus = {
         "it-IT": "cobadge",
         "en-EN": "cobadge"
       }
+    },
+    euCovidCert: {
+      is_visible: false,
+      level: "warning",
+      message: {
+        "it-IT": "euCovidCert banner test",
+        "en-EN": "euCovidCert banner test"
+      }
     }
   }
 };

--- a/ts/types/backendStatus.ts
+++ b/ts/types/backendStatus.ts
@@ -48,7 +48,8 @@ const Sections = t.interface({
   satispay: SectionStatus,
   services: SectionStatus,
   wallets: SectionStatus,
-  cobadge: SectionStatus
+  cobadge: SectionStatus,
+  euCovidCert: SectionStatus
 });
 export type Sections = t.TypeOf<typeof Sections>;
 


### PR DESCRIPTION
## ⚠️ This PR is related to https://github.com/pagopa/io-services-metadata/pull/338

## Short description
This PR allows to have a dedicated status banner about eu covid certificate

![Schermata 2021-05-31 alle 12 56 23](https://user-images.githubusercontent.com/822471/120183166-a1378380-c20f-11eb-885f-a010d2d956be.png)

### how to test
- include this component wherever you want
`<SectionStatusComponent sectionKey={"messages"} />`
- get the last commit from io-dev-server
    - edit the `euCovidCert` block in [backend.ts](https://github.com/pagopa/io-dev-api-server/blob/c516e6751d279875d7cd0a410b0fc85e12527ba5/src/payloads/backend.ts#L158)
    
```json
euCovidCert: {
      is_visible: true,
      level: "warning",
      message: {
        "it-IT": "euCovidCert banner test",
        "en-EN": "euCovidCert banner test"
      }
    }
```
- reload the app