### PR TITLE
feat(EU Covid Certificate): [IAGP-23] Added generic error screen in case of networking errors, 500 error or other unmanaged response code 

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2454,8 +2454,8 @@ features:
       subtitle: "TMP"
     ko:
       genericError:
-        title: "TMP"
-        subtitle: "TMP"
+        title: "Your certificate data could not be retrieved: please try again"
+        subtitle: "This could be due to a temporary problem."
       notFound:
         title: "TMP"
         subtitle: "TMP"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2484,8 +2484,8 @@ features:
       subtitle: "TMP"
     ko:
       genericError:
-        title: "TMP"
-        subtitle: "TMP"
+        title: "Non è stato possibile recuperare i dati del tuo certificato: riprova"
+        subtitle: "Protrebbe essere dovuto ad un problema temporaneo."
       notFound:
         title: "TMP"
         subtitle: "TMP"

--- a/ts/features/euCovidCert/screens/ko/EuCovidCertGenericErrorKoScreen.tsx
+++ b/ts/features/euCovidCert/screens/ko/EuCovidCertGenericErrorKoScreen.tsx
@@ -1,22 +1,76 @@
+import { View } from "native-base";
 import * as React from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
-import { H1 } from "../../../../components/core/typography/H1";
+import image from "../../../../../img/servicesStatus/error-detail-icon.png";
+import { Body } from "../../../../components/core/typography/Body";
+import WorkunitGenericFailure from "../../../../components/error/WorkunitGenericFailure";
+import { renderInfoRasterImage } from "../../../../components/infoScreen/imageRendering";
+import { InfoScreenComponent } from "../../../../components/infoScreen/InfoScreenComponent";
+import FooterWithButtons from "../../../../components/ui/FooterWithButtons";
+import I18n from "../../../../i18n";
 import { GlobalState } from "../../../../store/reducers/types";
+import { confirmButtonProps } from "../../../bonus/bonusVacanze/components/buttons/ButtonConfigurations";
+import { euCovidCertificateGet } from "../../store/actions";
+import { euCovidCertCurrentSelector } from "../../store/reducers/current";
+import { EUCovidCertificateAuthCode } from "../../types/EUCovidCertificate";
 import { BaseEuCovidCertificateLayout } from "../BaseEuCovidCertificateLayout";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
 
-const EuCovidCertGenericErrorKoScreen = (_: Props): React.ReactElement => (
-  <BaseEuCovidCertificateLayout
-    testID={"EuCovidCertGenericErrorKoScreen"}
-    content={<H1>TMPEuCovidCertGenericErrorKoScreen</H1>}
+const EuCovidCertGenericErrorKoComponent = () => (
+  <>
+    <View spacer={true} extralarge={true} />
+    <View spacer={true} extralarge={true} />
+    <InfoScreenComponent
+      image={renderInfoRasterImage(image)}
+      title={I18n.t("features.euCovidCertificate.ko.genericError.title")}
+      body={
+        <Body style={{ textAlign: "center" }}>
+          {I18n.t("features.euCovidCertificate.ko.genericError.subtitle")}
+        </Body>
+      }
+    />
+  </>
+);
+
+type FooterProps = {
+  onPress: () => void;
+};
+
+const Footer = (props: FooterProps) => (
+  <FooterWithButtons
+    type={"SingleButton"}
+    leftButton={confirmButtonProps(
+      props.onPress,
+      I18n.t("global.buttons.retry")
+    )}
   />
 );
 
-const mapDispatchToProps = (_: Dispatch) => ({});
-const mapStateToProps = (_: GlobalState) => ({});
+const EuCovidCertGenericErrorKoScreen = (props: Props): React.ReactElement => {
+  const authCode = props.currentCertificate?.authCode;
+  const reloadCertificate = authCode ? () => props.reload(authCode) : undefined;
+
+  return reloadCertificate ? (
+    <BaseEuCovidCertificateLayout
+      testID={"EuCovidCertGenericErrorKoScreen"}
+      content={<EuCovidCertGenericErrorKoComponent />}
+      footer={<Footer onPress={reloadCertificate} />}
+    />
+  ) : (
+    <WorkunitGenericFailure />
+  );
+};
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  reload: (authCode: EUCovidCertificateAuthCode) =>
+    dispatch(euCovidCertificateGet.request(authCode))
+});
+const mapStateToProps = (state: GlobalState) => ({
+  currentCertificate: euCovidCertCurrentSelector(state)
+});
 
 export default connect(
   mapStateToProps,

--- a/ts/features/euCovidCert/screens/ko/EuCovidCertGenericErrorKoScreen.tsx
+++ b/ts/features/euCovidCert/screens/ko/EuCovidCertGenericErrorKoScreen.tsx
@@ -50,7 +50,7 @@ const Footer = (props: FooterProps) => (
 );
 
 const EuCovidCertGenericErrorKoScreen = (props: Props): React.ReactElement => {
-  // read from the store the authCode for the current certificate ad create the refresh callback
+  // read from the store the authCode for the current certificate and create the refresh callback
   const authCode = props.currentCertificate?.authCode;
   const reloadCertificate = authCode ? () => props.reload(authCode) : undefined;
 

--- a/ts/features/euCovidCert/screens/ko/EuCovidCertGenericErrorKoScreen.tsx
+++ b/ts/features/euCovidCert/screens/ko/EuCovidCertGenericErrorKoScreen.tsx
@@ -50,9 +50,11 @@ const Footer = (props: FooterProps) => (
 );
 
 const EuCovidCertGenericErrorKoScreen = (props: Props): React.ReactElement => {
+  // read from the store the authCode for the current certificate ad create the refresh callback
   const authCode = props.currentCertificate?.authCode;
   const reloadCertificate = authCode ? () => props.reload(authCode) : undefined;
 
+  // reloadCertificate === undefined should never happens, handled with WorkunitGenericFailure
   return reloadCertificate ? (
     <BaseEuCovidCertificateLayout
       testID={"EuCovidCertGenericErrorKoScreen"}

--- a/ts/features/euCovidCert/store/reducers/current.ts
+++ b/ts/features/euCovidCert/store/reducers/current.ts
@@ -1,5 +1,7 @@
 import { NavigationActions } from "react-navigation";
+import { createSelector } from "reselect";
 import { Action } from "../../../../store/actions/types";
+import { GlobalState } from "../../../../store/reducers/types";
 import EUCOVIDCERT_ROUTES from "../../navigation/routes";
 import { EUCovidCertificateAuthCode } from "../../types/EUCovidCertificate";
 
@@ -26,3 +28,12 @@ export const currentReducer = (
 
   return state;
 };
+
+/**
+ * currentAuthCode selector
+ */
+export const euCovidCertCurrentSelector = createSelector(
+  [(state: GlobalState) => state.features.euCovidCert.current],
+  (euCovidCertCurrent): EuCovidCertCurrentSelectedState | null =>
+    euCovidCertCurrent
+);


### PR DESCRIPTION
## Short description
This pr adds the generic error screen for the EU Covid certificate.

<img src=https://user-images.githubusercontent.com/26501317/120926659-1c9ca780-c6de-11eb-93da-a12160ceb8e3.png width=300 />


https://user-images.githubusercontent.com/26501317/120926692-39d17600-c6de-11eb-9fb6-b1975a62f000.mov

## List of changes proposed in this pull request
- Added graphical implementation for `EuCovidCertGenericErrorKoScreen`
- Picked `euCovidCertCurrentSelector` from https://github.com/pagopa/io-app/pull/3091 

## How to test
- Open a message with an EU Covid Certificate and return `500` with dev-server or disconnect the dev-server before the request.