### PR TITLE
chore(EU Covid Certificate): [IAGP-46] Prevent the Covid CERT CTA if FF is disabled

### DIFF
--- a/ts/components/messages/MessageListCTABar.tsx
+++ b/ts/components/messages/MessageListCTABar.tsx
@@ -23,6 +23,7 @@ import {
 } from "../../utils/messages";
 import ExtractedCTABar from "../cta/ExtractedCTABar";
 import { ViewEUCovidButton } from "../../features/euCovidCert/components/ViewEUCovidButton";
+import { euCovidCertificateEnabled } from "../../config";
 import CalendarEventButton from "./CalendarEventButton";
 import CalendarIconComponent from "./CalendarIconComponent";
 
@@ -98,6 +99,7 @@ class MessageListCTABar extends React.PureComponent<Props> {
 
   private renderEUCovidViewCTA() {
     return (
+      euCovidCertificateEnabled &&
       this.props.message.content.eu_covid_cert && (
         <ViewEUCovidButton onPress={this.props.onEUCovidCTAPress} />
       )


### PR DESCRIPTION
## Short description
Protects the message CTA by chacking the Feature Flag.

## How to test
Disable the Feature flag on `.env` file and check if the CTA is displayed on the message item for covid certificates information.

### `EU_COVID_CERT_ENABLED` set to YES
<img src="https://user-images.githubusercontent.com/3959405/121023639-c1cd8380-c7a3-11eb-8d9c-1e6084389b6c.png" height="550"/>

### `EU_COVID_CERT_ENABLED` set to NO
<img src="https://user-images.githubusercontent.com/3959405/121023816-f17c8b80-c7a3-11eb-8b36-ca8f925d5ce6.png" height="550"/>