### PR TITLE
feat(EU Covid Certificate): [IAGP-2] Introduces the SectionStatusComponent on BaseEuCovidCertificateLayout component

### DIFF
--- a/ts/features/euCovidCert/screens/BaseEuCovidCertificateLayout.tsx
+++ b/ts/features/euCovidCert/screens/BaseEuCovidCertificateLayout.tsx
@@ -12,6 +12,7 @@ import I18n from "../../../i18n";
 import { WithTestID } from "../../../types/WithTestID";
 import { setAccessibilityFocus } from "../../../utils/accessibility";
 import { emptyContextualHelp } from "../../../utils/emptyContextualHelp";
+import SectionStatusComponent from "../../../components/SectionStatusComponent";
 
 type Props = WithTestID<{
   content: React.ReactElement;
@@ -61,6 +62,7 @@ export const BaseEuCovidCertificateLayout = (props: Props) => {
           <Header />
           {props.content}
         </ScrollView>
+        <SectionStatusComponent sectionKey={"euCovidCert"} />
         {props.footer}
       </SafeAreaView>
     </BaseScreenComponent>


### PR DESCRIPTION
## Short description
This PR introduces the SectionStatus message on the EuCovidCertificate screen component.

## How to test
Set to `true` the visibility of the `euCovidCert` section on `io-dev-api-server` and check the visibility of the app

<img src="https://user-images.githubusercontent.com/3959405/121026044-0fe38680-c7a6-11eb-840d-ce3d1bfab979.png" height="550"/>