### PR TITLE
chore: [#178393697] Changed LabelledItem input disabled colours

### DIFF
--- a/ts/components/LabelledItem.tsx
+++ b/ts/components/LabelledItem.tsx
@@ -210,7 +210,7 @@ export const LabelledItem: React.FC<Props> = (props: Props) => {
               placeholderTextColor={
                 props.type === "text" && props.inputProps.disabled
                   ? color(IOColors.bluegreyLight).string()
-                  : color(variables.brandDarkGray).darken(0.2).string()
+                  : color(variables.brandGray).darken(0.2).string()
               }
               underlineColorAndroid="transparent"
               {...props.inputProps}

--- a/ts/components/LabelledItem.tsx
+++ b/ts/components/LabelledItem.tsx
@@ -28,6 +28,7 @@ import variables from "../theme/variables";
 import { WithTestID } from "../types/WithTestID";
 import { makeFontStyleObject } from "./core/fonts";
 import { H5 } from "./core/typography/H5";
+import { IOColors } from "./core/variables/IOColors";
 import IconFont from "./ui/IconFont";
 import TextInputMask from "./ui/MaskedInput";
 
@@ -57,6 +58,10 @@ type CommonProp = Readonly<{
   accessibilityHint?: string;
 }>;
 
+interface InputProps extends TextInputProps {
+  disabled?: boolean;
+}
+
 type Props = WithTestID<CommonProp> &
   (
     | Readonly<{
@@ -66,7 +71,7 @@ type Props = WithTestID<CommonProp> &
       }>
     | Readonly<{
         type: "text";
-        inputProps: TextInputProps;
+        inputProps: InputProps;
       }>
   );
 
@@ -117,12 +122,24 @@ export const LabelledItem: React.FC<Props> = (props: Props) => {
     setHasFocus(false);
   };
 
-  const descriptionColor = props.isValid === false ? "red" : "bluegreyDark";
+  const onSetInputBorderColor = () => {
+    if (props.type === "text" && props.inputProps.disabled) {
+      return IOColors.greyLight;
+    }
+    if (hasFocus && isEmpty) {
+      return variables.itemBorderDefaultColor;
+    }
+
+    return props.focusBorderColor;
+  };
+
+  const descriptionColor =
+    props.type === "text" && props.inputProps.disabled
+      ? "bluegreyLight"
+      : props.isValid === false
+      ? "red"
+      : "bluegreyDark";
   const accessibilityLabel = props.accessibilityLabel ?? "";
-  const inputBorderColor =
-    hasFocus && isEmpty
-      ? variables.itemBorderDefaultColor
-      : props.focusBorderColor;
   const isValid = props.isValid === undefined ? false : props.isValid;
   const isNotValid = props.isValid === undefined ? false : !props.isValid;
   return (
@@ -132,7 +149,15 @@ export const LabelledItem: React.FC<Props> = (props: Props) => {
         accessibilityElementsHidden={true}
       >
         <Item style={styles.noBottomLine}>
-          <H5>{props.label}</H5>
+          <H5
+            color={
+              props.type === "text" && props.inputProps.disabled
+                ? "bluegreyLight"
+                : "bluegreyDark"
+            }
+          >
+            {props.label}
+          </H5>
         </Item>
       </View>
 
@@ -146,7 +171,7 @@ export const LabelledItem: React.FC<Props> = (props: Props) => {
         <Item
           style={{
             ...styles.bottomLine,
-            borderColor: inputBorderColor
+            borderColor: onSetInputBorderColor()
           }}
           error={isNotValid}
           success={isValid}
@@ -155,7 +180,11 @@ export const LabelledItem: React.FC<Props> = (props: Props) => {
             (isString(props.icon) ? (
               <IconFont
                 size={variables.iconSize3}
-                color={variables.brandDarkGray}
+                color={
+                  props.type === "text" && props.inputProps.disabled
+                    ? IOColors.bluegreyLight
+                    : variables.brandDarkGray
+                }
                 name={props.icon}
                 style={props.iconStyle}
               />
@@ -178,15 +207,18 @@ export const LabelledItem: React.FC<Props> = (props: Props) => {
             />
           ) : (
             <Input
-              placeholderTextColor={color(variables.brandGray)
-                .darken(0.2)
-                .string()}
+              placeholderTextColor={
+                props.type === "text" && props.inputProps.disabled
+                  ? color(IOColors.bluegreyLight).string()
+                  : color(variables.brandDarkGray).darken(0.2).string()
+              }
               underlineColorAndroid="transparent"
               {...props.inputProps}
               onChangeText={handleOnChangeText}
               onFocus={handleOnFocus}
               onBlur={handleOnBlur}
               testID={`${props.testID}Input`}
+              disabled={props.inputProps.disabled}
             />
           )}
         </Item>

--- a/ts/components/core/typography/H5.tsx
+++ b/ts/components/core/typography/H5.tsx
@@ -8,13 +8,19 @@ import { typographyFactory } from "./Factory";
 type AllowedSemiBoldColors = Extract<
   IOColorType,
   // tslint:disable-next-line:max-union-size
-  "bluegreyDark" | "bluegrey" | "blue" | "white" | "red"
+  "bluegreyDark" | "bluegrey" | "bluegreyLight" | "blue" | "white" | "red"
 >;
 
 // when the weight is bold, only the white color is allowed
 type AllowedRegularColors = Extract<
   IOColorType,
-  "bluegreyDark" | "bluegrey" | "blue" | "white" | "red" | "grey"
+  | "bluegreyDark"
+  | "bluegrey"
+  | "bluegreyLight"
+  | "blue"
+  | "white"
+  | "red"
+  | "grey"
 >;
 
 // all the possible colors

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -313,7 +313,8 @@ const AddCardScreen: React.FC<Props> = props => {
               autoCapitalize: "words",
               keyboardType: "default",
               returnKeyType: "done",
-              onChangeText: (value: string) => updateState("holder", value)
+              onChangeText: (value: string) => updateState("holder", value),
+              disabled: true
             }}
             testID={"cardHolder"}
           />

--- a/ts/screens/wallet/AddCardScreen.tsx
+++ b/ts/screens/wallet/AddCardScreen.tsx
@@ -313,8 +313,7 @@ const AddCardScreen: React.FC<Props> = props => {
               autoCapitalize: "words",
               keyboardType: "default",
               returnKeyType: "done",
-              onChangeText: (value: string) => updateState("holder", value),
-              disabled: true
+              onChangeText: (value: string) => updateState("holder", value)
             }}
             testID={"cardHolder"}
           />


### PR DESCRIPTION
## Short description
Changed input colours in disabled state to pass accessibility test.
It would seem temporarily there aren't many inputs in the app in a disabled state, this PR includes changes that can be used in the future.

## List of changes proposed in this pull request
- Use a single input generic component throughout the app. In the current state, multiple input components imported from react-native, native-base or LabelledItem component are used.

## How to test
You can try to force disabled boolean value to true on any LabelledItem component to see the colours changes.
Test if colours are equal to Figma [Click here](https://www.figma.com/file/GBRk8f5WGyaX29lahpT5fM/IO-Library?node-id=446%3A77)

## Example
**Before:**
<img width="300" alt="Screenshot 2021-06-07 at 19 09 11" src="https://user-images.githubusercontent.com/61834253/121061244-e2a5d100-c7c3-11eb-8b87-bc76667e3152.png">

**After:**
<img width="300" alt="Screenshot 2021-06-07 at 18 51 04" src="https://user-images.githubusercontent.com/61834253/121061124-c1dd7b80-c7c3-11eb-8d95-b4437b974a6d.png">
