### PR TITLE
fix: [IA-3] Error swallowing on upsert email API fault code

### DIFF
--- a/ts/sagas/profile.ts
+++ b/ts/sagas/profile.ts
@@ -103,7 +103,7 @@ function* createOrUpdateProfileSaga(
   );
 
   if (pot.isNone(profileState)) {
-    // somewhing's wrong, we don't even have an AuthenticatedProfile meaning
+    // something's wrong, we don't even have an AuthenticatedProfile meaning
     // the user didn't yet authenticated: ignore this upsert request.
     return;
   }

--- a/ts/screens/onboarding/EmailInsertScreen.tsx
+++ b/ts/screens/onboarding/EmailInsertScreen.tsx
@@ -185,7 +185,10 @@ class EmailInsertScreen extends React.PureComponent<Props, State> {
   }
 
   public componentDidUpdate(prevProps: Props) {
-    if (!this.state.isMounted) {
+    const isPrevCurrentSameState =
+      prevProps.profile.kind === this.props.profile.kind;
+    // do nothing if prev profile is in the same state of the current
+    if (!this.state.isMounted || isPrevCurrentSameState) {
       return;
     }
     // if we were updating the profile


### PR DESCRIPTION
## Short description
This PR fixes a bug with error management during the email update.

## how to reproduce
- change the API status response with 500 [on dev-server ](https://github.com/pagopa/io-dev-api-server/blob/efa0d9261bf6b9ce92bf8fe08e845986f2382638/src/routers/profile.ts#L52)
- update the user email (from profile/preferences section or from onboarding phase - first login)
- press continue
- 🐛 

## before
https://user-images.githubusercontent.com/822471/121391187-625fa700-c94e-11eb-8659-5541d87a60ed.mov

## after
https://user-images.githubusercontent.com/822471/121390833-0d239580-c94e-11eb-8304-7caaed0798c2.mov



