### PR TITLE
fix(EU Covid Certificate): [IAGP-56] Add overflow wrap for markdown component

### DIFF
--- a/ts/components/ui/Markdown/index.tsx
+++ b/ts/components/ui/Markdown/index.tsx
@@ -75,7 +75,6 @@ body {
   font-size: ${customVariables.fontSize1}px;
   font-family: 'Titillium Web';
   overflow-wrap: break-word;
-  word-wrap: break-word;
   hyphens: auto;
 }
 

--- a/ts/components/ui/Markdown/index.tsx
+++ b/ts/components/ui/Markdown/index.tsx
@@ -74,6 +74,9 @@ body {
   color: ${customVariables.textColor};
   font-size: ${customVariables.fontSize1}px;
   font-family: 'Titillium Web';
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  hyphens: auto;
 }
 
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
## Short description
This pr adds the overflow wrap for the `Markdown` component.

Before            |  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/26501317/121689114-86dd8f80-cac4-11eb-98ac-c7b01b28e342.png" width="300">|  <img src="https://user-images.githubusercontent.com/26501317/121689131-8e9d3400-cac4-11eb-96d0-e8647f766eb4.png" width="300">

Before            |  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/26501317/121689233-a83e7b80-cac4-11eb-9323-7844bd7c3c4b.png" width="300"> | <img src="https://user-images.githubusercontent.com/26501317/121689200-a07ed700-cac4-11eb-9eec-feba409684a4.png" width="300">

## List of changes proposed in this pull request
- Added `overflow-wrap` and `hyphens` to markdown body style.
