### PR TITLE
Remove obsolete events

### DIFF
--- a/ts/features/euCovidCert/analytics/index.ts
+++ b/ts/features/euCovidCert/analytics/index.ts
@@ -35,8 +35,7 @@ const trackEuCovidCertificateGetSuccessResponse = (
     return {
       containsInfo: false,
       containsDetails: false,
-      qrCodeLength: undefined,
-      responseType: response.kind
+      qrCodeLength: undefined
     };
   }
   const containsInfo = response.value.markdownInfo !== undefined;
@@ -48,12 +47,10 @@ const trackEuCovidCertificateGetSuccessResponse = (
     response.value.kind === "valid"
       ? response.value.qrCode.content.length
       : undefined;
-  const responseType = response.value.kind;
   return {
     containsInfo,
     containsDetails,
-    qrCodeLength,
-    responseType
+    qrCodeLength
   };
 };
 

--- a/ts/store/middlewares/analytics.ts
+++ b/ts/store/middlewares/analytics.ts
@@ -7,17 +7,10 @@ import { NavigationActions } from "react-navigation";
 import { getType } from "typesafe-actions";
 import { setInstabugUserAttribute } from "../../boot/configureInstabug";
 import {
-  activateBonusVacanze,
-  cancelBonusVacanzeRequest,
-  checkBonusVacanzeEligibility,
   loadAllBonusActivations,
-  loadAvailableBonuses,
-  storeEligibilityRequestId
+  loadAvailableBonuses
 } from "../../features/bonus/bonusVacanze/store/actions/bonusVacanze";
-import {
-  isActivationResponseTrackable,
-  isEligibilityResponseTrackable
-} from "../../features/bonus/bonusVacanze/utils/bonus";
+import { isActivationResponseTrackable } from "../../features/bonus/bonusVacanze/utils/bonus";
 import { trackBPayAction } from "../../features/wallet/onboarding/bancomatPay/analytics";
 import { trackCoBadgeAction } from "../../features/wallet/onboarding/cobadge/analytics";
 import { trackPrivativeAction } from "../../features/wallet/onboarding/privative/analytics";
@@ -324,8 +317,6 @@ const trackAction = (mp: NonNullable<typeof mixpanel>) => (
     //  Bonus vacanze
     case getType(loadAllBonusActivations.failure):
     case getType(loadAvailableBonuses.failure):
-    case getType(checkBonusVacanzeEligibility.failure):
-    case getType(activateBonusVacanze.failure):
       return mp.track(action.type, {
         reason: action.payload.message
       });
@@ -418,9 +409,6 @@ const trackAction = (mp: NonNullable<typeof mixpanel>) => (
     case getType(loadAllBonusActivations.success):
     case getType(loadAvailableBonuses.success):
     case getType(loadAvailableBonuses.request):
-    case getType(checkBonusVacanzeEligibility.request):
-    case getType(cancelBonusVacanzeRequest):
-    case getType(storeEligibilityRequestId):
       return mp.track(action.type);
 
     case getType(loadMessage.success):
@@ -428,21 +416,6 @@ const trackAction = (mp: NonNullable<typeof mixpanel>) => (
         ecc: action.payload.content.eu_covid_cert !== undefined
       });
 
-    // bonus vacanze
-    case getType(checkBonusVacanzeEligibility.success):
-      if (isEligibilityResponseTrackable(action.payload)) {
-        return mp.track(action.type, {
-          status: action.payload.status
-        });
-      }
-      break;
-    case getType(activateBonusVacanze.success):
-      if (isActivationResponseTrackable(action.payload)) {
-        return mp.track(action.type, {
-          status: action.payload.status
-        });
-      }
-      break;
     case getType(deleteUserDataProcessing.request):
       return mp.track(action.type, { choice: action.payload });
     case getType(removeAccountMotivation):

--- a/ts/store/middlewares/analytics.ts
+++ b/ts/store/middlewares/analytics.ts
@@ -10,7 +10,6 @@ import {
   loadAllBonusActivations,
   loadAvailableBonuses
 } from "../../features/bonus/bonusVacanze/store/actions/bonusVacanze";
-import { isActivationResponseTrackable } from "../../features/bonus/bonusVacanze/utils/bonus";
 import { trackBPayAction } from "../../features/wallet/onboarding/bancomatPay/analytics";
 import { trackCoBadgeAction } from "../../features/wallet/onboarding/cobadge/analytics";
 import { trackPrivativeAction } from "../../features/wallet/onboarding/privative/analytics";
@@ -403,6 +402,7 @@ const trackAction = (mp: NonNullable<typeof mixpanel>) => (
     //  profile First time Login
     case getType(profileFirstLogin):
     // other
+    case getType(loadMessage.success):
     case getType(updateNotificationsInstallationToken):
     // bonus vacanze
     case getType(loadAllBonusActivations.request):
@@ -410,11 +410,6 @@ const trackAction = (mp: NonNullable<typeof mixpanel>) => (
     case getType(loadAvailableBonuses.success):
     case getType(loadAvailableBonuses.request):
       return mp.track(action.type);
-
-    case getType(loadMessage.success):
-      return mp.track(action.type, {
-        ecc: action.payload.content.eu_covid_cert !== undefined
-      });
 
     case getType(deleteUserDataProcessing.request):
       return mp.track(action.type, { choice: action.payload });


### PR DESCRIPTION
## Short description
This PR removes some obsolete events no longer user by the app (e.g bonus vacanze eligibility & activation)
It also removes some properties that are no useful for stats or troubleshooting assistance
