### PR TITLE
chore: [IA-32] Open ToS links in external browser

### DIFF
--- a/ts/components/TosWebviewComponent.tsx
+++ b/ts/components/TosWebviewComponent.tsx
@@ -4,6 +4,7 @@ import WebView from "react-native-webview";
 import I18n from "../i18n";
 import { AVOID_ZOOM_JS, closeInjectedScript } from "../utils/webview";
 import FooterWithButtons from "./ui/FooterWithButtons";
+import { NOTIFY_LINK_CLICK_SCRIPT } from "./ui/Markdown/script";
 
 type Props = {
   shouldFooterRender: boolean;
@@ -25,7 +26,9 @@ const TosWebviewComponent: React.FunctionComponent<Props> = (props: Props) => (
         onError={props.handleError}
         source={{ uri: props.url }}
         onMessage={props.handleWebViewMessage}
-        injectedJavaScript={closeInjectedScript(AVOID_ZOOM_JS)}
+        injectedJavaScript={closeInjectedScript(
+          AVOID_ZOOM_JS + NOTIFY_LINK_CLICK_SCRIPT
+        )}
       />
     </View>
     {props.shouldFooterRender && (

--- a/ts/screens/onboarding/TosScreen.tsx
+++ b/ts/screens/onboarding/TosScreen.tsx
@@ -39,7 +39,6 @@ type Props = ReduxProps & OwnProps & ReturnType<typeof mapStateToProps>;
 type State = {
   isLoading: boolean;
   hasError: boolean;
-  scrollEnd: boolean;
 };
 
 import brokenLinkImage from "../../../img/broken-link.png";
@@ -109,7 +108,7 @@ class TosScreen extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
     // it start with loading webview
-    this.state = { isLoading: true, hasError: false, scrollEnd: false };
+    this.state = { isLoading: true, hasError: false };
   }
 
   public componentDidUpdate() {

--- a/ts/screens/onboarding/TosScreen.tsx
+++ b/ts/screens/onboarding/TosScreen.tsx
@@ -43,6 +43,7 @@ type State = {
 };
 
 import brokenLinkImage from "../../../img/broken-link.png";
+import { openWebUrl } from "../../utils/url";
 
 const styles = StyleSheet.create({
   alert: {
@@ -126,7 +127,7 @@ class TosScreen extends React.PureComponent<Props, State> {
   };
 
   private renderError = () => {
-    if (this.state.hasError === false) {
+    if (!this.state.hasError) {
       return null;
     }
     return (
@@ -153,22 +154,12 @@ class TosScreen extends React.PureComponent<Props, State> {
   };
 
   // A function that handles message sent by the WebView component
-  private handleWebViewMessage = (event: WebViewMessageEvent) => {
-    if (this.state.scrollEnd) {
-      return;
-    }
-
-    // We validate the format of the message with a dedicated codec
-    const messageOrErrors = WebViewMessage.decode(
-      JSON.parse(event.nativeEvent.data)
-    );
-
-    messageOrErrors.map(message => {
-      if (message.type === "SCROLL_END_MESSAGE") {
-        this.setState({ scrollEnd: true });
+  private handleWebViewMessage = (event: WebViewMessageEvent) =>
+    WebViewMessage.decode(JSON.parse(event.nativeEvent.data)).map(m => {
+      if (m.type === "LINK_MESSAGE") {
+        void openWebUrl(m.payload.href);
       }
     });
-  };
 
   public render() {
     const { dispatch } = this.props;


### PR DESCRIPTION
## Short description
This PR allows to open links, contained in the Terms of Service web page, in the device browser.
It injects a JS into the webview to intercept the clicked links and it command to open them in the system default browser.

This PR also fixes a navigation bug for which if the user opens an internal link he/she can't go back in the previous web page.

### changes
- add the `link clicked` handling
- remove the `end of scroll` handling since it is never sent by the webview (no script added)

### before
https://user-images.githubusercontent.com/822471/122024995-3d918680-cdc9-11eb-98d4-e32f2fa414e3.mov

### now

https://user-images.githubusercontent.com/822471/122025040-4aae7580-cdc9-11eb-90a5-28934d52afd8.mov

