### PR TITLE
chore: [IA-19] When copy id message is missing service name

### DIFF
--- a/ts/components/messages/MessageDetailData.tsx
+++ b/ts/components/messages/MessageDetailData.tsx
@@ -86,9 +86,10 @@ class MessageDetailData extends React.PureComponent<Props> {
   };
 
   public render() {
-    const serviceName = pot.getOrElse(this.props.serviceDetail, undefined)
-      ?.service_name;
-    const textToCopy = `${serviceName} - ${this.props.message.id}`;
+    const textToCopy: string = pot
+      .toOption(this.props.serviceDetail)
+      .map(({ service_name }) => `${service_name} - ${this.props.message.id}`)
+      .getOrElse(this.props.message.id);
 
     return (
       <View style={styles.container}>

--- a/ts/components/messages/MessageDetailData.tsx
+++ b/ts/components/messages/MessageDetailData.tsx
@@ -86,6 +86,10 @@ class MessageDetailData extends React.PureComponent<Props> {
   };
 
   public render() {
+    const serviceName = pot.getOrElse(this.props.serviceDetail, undefined)
+      ?.service_name;
+    const textToCopy = `${serviceName} - ${this.props.message.id}`;
+
     return (
       <View style={styles.container}>
         <Text>
@@ -127,7 +131,7 @@ class MessageDetailData extends React.PureComponent<Props> {
                 <Text style={styles.flex}>{`${I18n.t("messageDetails.id")} ${
                   this.props.message.id
                 }`}</Text>
-                <CopyButtonComponent textToCopy={this.props.message.id} />
+                <CopyButtonComponent textToCopy={textToCopy} />
               </View>
               <View spacer={true} />
             </React.Fragment>


### PR DESCRIPTION
## Short description
Based on the multiple requests from the institutions to make the logic of copying the id of a message clearer, I have implemented a step that, in addition to copying the message, also copies the service name.
**The format will then be: service_name - 000000000001**

## AFTER:
https://user-images.githubusercontent.com/53444973/122354418-444b0580-cf51-11eb-9647-040062ddb91b.mov

## BEFORE:
https://user-images.githubusercontent.com/53444973/122354279-21205600-cf51-11eb-80a5-168d33970f13.mov

