### PR TITLE
fix: [IA-40] In "your data" screen, missing bottomsheet content when the screen reader is enabled

### DIFF
--- a/ts/screens/profile/components/ShareDataComponent.tsx
+++ b/ts/screens/profile/components/ShareDataComponent.tsx
@@ -6,23 +6,21 @@ import { H1 } from "../../../components/core/typography/H1";
 import { Label } from "../../../components/core/typography/Label";
 import { Link } from "../../../components/core/typography/Link";
 import Markdown from "../../../components/ui/Markdown";
+import { privacyUrl } from "../../../config";
 import I18n from "../../../i18n";
 import { ioSuppliersUrl } from "../../../urls";
 import { useIOBottomSheet } from "../../../utils/bottomSheet";
 import { openWebUrl } from "../../../utils/url";
-import { privacyUrl } from "../../../config";
 
 type MarkdownProps = {
   body: string;
 };
 
 const MarkdownBody = (props: MarkdownProps): React.ReactElement => (
-  <View>
+  <>
     <View spacer={true} />
-    <View style={{ flex: 1 }}>
-      <Markdown avoidTextSelection={true}>{props.body}</Markdown>
-    </View>
-  </View>
+    <Markdown avoidTextSelection={true}>{props.body}</Markdown>
+  </>
 );
 
 export const ShareDataComponent = (): React.ReactElement => {


### PR DESCRIPTION
## Short description
This pr fixes the wrong behaviour described in the pr title.

## List of changes proposed in this pull request
- Change the layout of `MarkdownBody`

<img src=https://user-images.githubusercontent.com/26501317/122371613-4a94ae00-cf60-11eb-9591-ead0c1bf7f34.png width=300 />

<img src=https://user-images.githubusercontent.com/26501317/122371707-5b452400-cf60-11eb-95f3-c4960ea868bf.png width=300 />




