### PR TITLE
chore: [IA-41] Expose the unique device ID and let the developer copy it to the clipboard

### DIFF
--- a/ts/screens/profile/ProfileMainScreen.tsx
+++ b/ts/screens/profile/ProfileMainScreen.tsx
@@ -382,7 +382,7 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
 
             {isDevEnv &&
               this.debugListItem(
-                `Notification ID ${notificationId.slice(0, 6)}`,
+                `Notification ID ${notificationId}`,
                 () => clipboardSetStringWithFeedback(notificationId),
                 false
               )}
@@ -390,7 +390,7 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
             {isDevEnv &&
               notificationToken &&
               this.debugListItem(
-                `Notification token ${notificationToken.slice(0, 6)}`,
+                `Notification token ${notificationToken}`,
                 () => clipboardSetStringWithFeedback(notificationToken),
                 false
               )}

--- a/ts/screens/profile/ProfileMainScreen.tsx
+++ b/ts/screens/profile/ProfileMainScreen.tsx
@@ -48,6 +48,7 @@ import { clipboardSetStringWithFeedback } from "../../utils/clipboard";
 import { isDevEnv } from "../../utils/environment";
 import { setStatusBarColorAndBackground } from "../../utils/statusBar";
 import { navigateToLogout } from "../../store/actions/navigation";
+import DeviceInfo from "react-native-device-info";
 
 type OwnProps = Readonly<{
   navigation: NavigationScreenProp<NavigationState>;
@@ -60,6 +61,7 @@ type Props = OwnProps &
 
 type State = {
   tapsOnAppVersion: number;
+  deviceUniqueId: string;
 };
 
 const styles = StyleSheet.create({
@@ -111,7 +113,8 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      tapsOnAppVersion: 0
+      tapsOnAppVersion: 0,
+      deviceUniqueId: DeviceInfo.getUniqueId()
     };
     this.handleClearCachePress = this.handleClearCachePress.bind(this);
   }
@@ -310,6 +313,8 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
       notificationId
     } = this.props;
 
+    const { deviceUniqueId } = this.state;
+
     const showInformationModal = (
       title: TranslationKeys,
       body: TranslationKeys
@@ -459,6 +464,13 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
                     this.debugListItem(
                       `Notification token ${notificationToken.slice(0, 6)}`,
                       () => clipboardSetStringWithFeedback(notificationToken),
+                      false
+                    )}
+
+                  {isDevEnv &&
+                    this.debugListItem(
+                      `Device unique ID ${deviceUniqueId}`,
+                      () => clipboardSetStringWithFeedback(deviceUniqueId),
                       false
                     )}
 

--- a/ts/screens/profile/ProfileMainScreen.tsx
+++ b/ts/screens/profile/ProfileMainScreen.tsx
@@ -2,6 +2,7 @@ import { Millisecond } from "italia-ts-commons/lib/units";
 import { List, ListItem, Text, Toast, View } from "native-base";
 import * as React from "react";
 import { Alert, ScrollView, StyleSheet } from "react-native";
+import DeviceInfo from "react-native-device-info";
 import {
   NavigationEvents,
   NavigationEventSubscription,
@@ -48,7 +49,6 @@ import { clipboardSetStringWithFeedback } from "../../utils/clipboard";
 import { isDevEnv } from "../../utils/environment";
 import { setStatusBarColorAndBackground } from "../../utils/statusBar";
 import { navigateToLogout } from "../../store/actions/navigation";
-import DeviceInfo from "react-native-device-info";
 
 type OwnProps = Readonly<{
   navigation: NavigationScreenProp<NavigationState>;
@@ -126,7 +126,7 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
         "light-content",
         customVariables.brandDarkGray
       );
-    }); // eslint-disable-line
+    });
   }
 
   public componentWillUnmount() {
@@ -278,7 +278,7 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
       this.setState({ tapsOnAppVersion: 0 });
       Toast.show({ text: I18n.t("profile.main.developerModeOn") });
     } else {
-      // eslint-disable-next-line
+      // eslint-disable-next-line functional/immutable-data
       this.idResetTap = setInterval(
         this.resetAppTapCounter,
         RESET_COUNTER_TIMEOUT
@@ -302,7 +302,6 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
     }
   };
 
-  // eslint-disable-next-line
   public render() {
     const {
       navigation,
@@ -328,7 +327,6 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
       );
     };
 
-    // eslint-disable
     const screenContent = () => (
       <ScrollView ref={this.ServiceListRef} style={styles.whiteBg}>
         <NavigationEvents onWillFocus={this.scrollToTop} />

--- a/ts/screens/profile/ProfileMainScreen.tsx
+++ b/ts/screens/profile/ProfileMainScreen.tsx
@@ -263,7 +263,7 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
 
   private idResetTap?: number;
 
-  // When tapped 5 time activate the debug mode of the application.
+  // When tapped 5 times activate the debug mode of the application.
   // If more than two seconds pass between taps, the counter is reset
   private onTapAppVersion = () => {
     if (this.idResetTap) {
@@ -302,17 +302,125 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
     }
   };
 
-  public render() {
+  private renderDeveloperSection() {
     const {
-      navigation,
       backendInfo,
+      dispatchSessionExpired,
+      isDebugModeEnabled,
+      isPagoPATestEnabled,
+      navigation,
+      notificationId,
+      notificationToken,
       sessionToken,
       walletToken,
-      notificationToken,
-      notificationId
+      setDebugModeEnabled
     } = this.props;
-
     const { deviceUniqueId } = this.state;
+
+    return (
+      <React.Fragment>
+        <SectionHeaderComponent
+          sectionHeader={I18n.t("profile.main.developersSectionHeader")}
+        />
+        {isPlaygroundsEnabled && (
+          <>
+            <ListItemComponent
+              title={"MyPortal Web Playground"}
+              onPress={() => navigation.navigate(ROUTES.WEB_PLAYGROUND)}
+            />
+            <ListItemComponent
+              title={"Markdown Playground"}
+              onPress={() => navigation.navigate(ROUTES.MARKDOWN_PLAYGROUND)}
+            />
+          </>
+        )}
+
+        {/* Showroom */}
+        <ListItemComponent
+          title={I18n.t("profile.main.showroom")}
+          onPress={() => navigation.navigate(ROUTES.SHOWROOM)}
+          isFirstItem={true}
+        />
+
+        {this.developerListItem(
+          I18n.t("profile.main.pagoPaEnvironment.pagoPaEnv"),
+          isPagoPATestEnabled,
+          this.onPagoPAEnvironmentToggle,
+          I18n.t("profile.main.pagoPaEnvironment.pagoPAEnvAlert")
+        )}
+        {this.developerListItem(
+          I18n.t("profile.main.debugMode"),
+          isDebugModeEnabled,
+          setDebugModeEnabled
+        )}
+        {isDebugModeEnabled && (
+          <React.Fragment>
+            {backendInfo &&
+              this.debugListItem(
+                `${I18n.t("profile.main.backendVersion")} ${
+                  backendInfo.version
+                }`,
+                () => clipboardSetStringWithFeedback(backendInfo.version),
+                false
+              )}
+
+            {isDevEnv &&
+              sessionToken &&
+              this.debugListItem(
+                `Session Token ${sessionToken}`,
+                () => clipboardSetStringWithFeedback(sessionToken),
+                false
+              )}
+
+            {isDevEnv &&
+              walletToken &&
+              this.debugListItem(
+                `Wallet token ${walletToken}`,
+                () => clipboardSetStringWithFeedback(walletToken),
+                false
+              )}
+
+            {isDevEnv &&
+              this.debugListItem(
+                `Notification ID ${notificationId.slice(0, 6)}`,
+                () => clipboardSetStringWithFeedback(notificationId),
+                false
+              )}
+
+            {isDevEnv &&
+              notificationToken &&
+              this.debugListItem(
+                `Notification token ${notificationToken.slice(0, 6)}`,
+                () => clipboardSetStringWithFeedback(notificationToken),
+                false
+              )}
+
+            {isDevEnv &&
+              this.debugListItem(
+                `Device unique ID ${deviceUniqueId}`,
+                () => clipboardSetStringWithFeedback(deviceUniqueId),
+                false
+              )}
+
+            {this.debugListItem(
+              I18n.t("profile.main.cache.clear"),
+              this.handleClearCachePress,
+              true
+            )}
+
+            {isDevEnv &&
+              this.debugListItem(
+                I18n.t("profile.main.forgetCurrentSession"),
+                dispatchSessionExpired,
+                true
+              )}
+          </React.Fragment>
+        )}
+      </React.Fragment>
+    );
+  }
+  public render() {
+    const { navigation } = this.props;
 
     const showInformationModal = (
       title: TranslationKeys,
@@ -387,107 +495,8 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
           )}
 
           {/* Developers Section */}
-          {(this.props.isDebugModeEnabled || isDevEnv) && (
-            <React.Fragment>
-              <SectionHeaderComponent
-                sectionHeader={I18n.t("profile.main.developersSectionHeader")}
-              />
-              {isPlaygroundsEnabled && (
-                <>
-                  <ListItemComponent
-                    title={"MyPortal Web Playground"}
-                    onPress={() => navigation.navigate(ROUTES.WEB_PLAYGROUND)}
-                  />
-                  <ListItemComponent
-                    title={"Markdown Playground"}
-                    onPress={() =>
-                      navigation.navigate(ROUTES.MARKDOWN_PLAYGROUND)
-                    }
-                  />
-                </>
-              )}
-              {/* Showroom */}
-              <ListItemComponent
-                title={I18n.t("profile.main.showroom")}
-                onPress={() => navigation.navigate(ROUTES.SHOWROOM)}
-                isFirstItem={true}
-              />
-              {this.developerListItem(
-                I18n.t("profile.main.pagoPaEnvironment.pagoPaEnv"),
-                this.props.isPagoPATestEnabled,
-                this.onPagoPAEnvironmentToggle,
-                I18n.t("profile.main.pagoPaEnvironment.pagoPAEnvAlert")
-              )}
-              {this.developerListItem(
-                I18n.t("profile.main.debugMode"),
-                this.props.isDebugModeEnabled,
-                this.props.setDebugModeEnabled
-              )}
-              {this.props.isDebugModeEnabled && (
-                <React.Fragment>
-                  {backendInfo &&
-                    this.debugListItem(
-                      `${I18n.t("profile.main.backendVersion")} ${
-                        backendInfo.version
-                      }`,
-                      () => clipboardSetStringWithFeedback(backendInfo.version),
-                      false
-                    )}
-
-                  {isDevEnv &&
-                    sessionToken &&
-                    this.debugListItem(
-                      `Session Token ${sessionToken}`,
-                      () => clipboardSetStringWithFeedback(sessionToken),
-                      false
-                    )}
-
-                  {isDevEnv &&
-                    walletToken &&
-                    this.debugListItem(
-                      `Wallet token ${walletToken}`,
-                      () => clipboardSetStringWithFeedback(walletToken),
-                      false
-                    )}
-
-                  {isDevEnv &&
-                    this.debugListItem(
-                      `Notification ID ${notificationId.slice(0, 6)}`,
-                      () => clipboardSetStringWithFeedback(notificationId),
-                      false
-                    )}
-
-                  {isDevEnv &&
-                    notificationToken &&
-                    this.debugListItem(
-                      `Notification token ${notificationToken.slice(0, 6)}`,
-                      () => clipboardSetStringWithFeedback(notificationToken),
-                      false
-                    )}
-
-                  {isDevEnv &&
-                    this.debugListItem(
-                      `Device unique ID ${deviceUniqueId}`,
-                      () => clipboardSetStringWithFeedback(deviceUniqueId),
-                      false
-                    )}
-
-                  {this.debugListItem(
-                    I18n.t("profile.main.cache.clear"),
-                    this.handleClearCachePress,
-                    true
-                  )}
-
-                  {isDevEnv &&
-                    this.debugListItem(
-                      I18n.t("profile.main.forgetCurrentSession"),
-                      this.props.dispatchSessionExpired,
-                      true
-                    )}
-                </React.Fragment>
-              )}
-            </React.Fragment>
-          )}
+          {(this.props.isDebugModeEnabled || isDevEnv) &&
+            this.renderDeveloperSection()}
 
           {/* end list */}
           <EdgeBorderComponent />


### PR DESCRIPTION
## Short description
Expose the unique device ID and let the developer copy it to the clipboard.
Please note that the UUID is longer than the available space and will be cut most of the time using ellipsis. This was discussed on the relevant ticket and is not deemed an issue.

## List of changes proposed in this pull request
* add a new item in the _Profile_ screen to show the device unique ID and copy it
* separate rendering of developer's items to improve readability

## How to test

1. open _Profile_ tab
2. activate _debug mode_ (either via 5 taps or using the toggle)
3. the last blue item containst the device UUID
4. tap on the item to copy the UUID to the clipboard

See the recording below for a full walk-through:


https://user-images.githubusercontent.com/2094604/122768194-a7b39b00-d2a3-11eb-98ae-598cc0e16476.mov





