### PR TITLE
fix(Bonus Pagamenti Digitali): [IAC-84] Wrong textual representation when superCashbackAmount === 0 for a period

### DIFF
--- a/ts/features/bonus/bpd/screens/details/components/summary/textualSummary/ClosedTextualSummary.tsx
+++ b/ts/features/bonus/bpd/screens/details/components/summary/textualSummary/ClosedTextualSummary.tsx
@@ -76,7 +76,10 @@ const endGracePeriod = (period: BpdPeriod) => {
  */
 const enhanceOkText = (props: Props): Option<string> => {
   // the user earned the super cashback
-  if (props.period.amount.totalCashback >= props.period.superCashbackAmount) {
+  if (
+    props.period.superCashbackAmount > 0 &&
+    props.period.amount.totalCashback >= props.period.superCashbackAmount
+  ) {
     return some(
       I18n.t(
         "bonus.bpd.details.components.transactionsCountOverview.closedPeriodSuperCashback",


### PR DESCRIPTION
## Short description
This pr fixes a wrong textual representation when a closed period have `superCashbackAmount === 0`

Before            |  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/26501317/123441331-0050a400-d5d4-11eb-8931-da5fbdf339a8.png" width="300">|  <img src="https://user-images.githubusercontent.com/26501317/123441262-ed3dd400-d5d3-11eb-8754-5cbfaba33044.png">

## List of changes proposed in this pull request
- Check if the period `props.period.superCashbackAmount > 0`

## How to test
- Wallet > Open a cashback card with `props.period.superCashbackAmount===0` 
