### PR TITLE
fix: [IA-73] Can't login with spid due to wrong navigation route

### DIFF
--- a/ts/screens/authentication/IdpSelectionScreen.tsx
+++ b/ts/screens/authentication/IdpSelectionScreen.tsx
@@ -56,10 +56,11 @@ const IdpSelectionScreen = (props: Props): React.ReactElement => {
     if (idp.isTestIdp === true && counter < TAPS_TO_OPEN_TESTIDP) {
       const newValue = (counter + 1) % (TAPS_TO_OPEN_TESTIDP + 1);
       setCounter(newValue);
+    } else {
+      props.setSelectedIdp(idp);
+      instabugLog(`IDP selected: ${idp.id}`, TypeLogs.DEBUG, "login");
+      props.navigateToIdpSelection();
     }
-    props.setSelectedIdp(idp);
-    instabugLog(`IDP selected: ${idp.id}`, TypeLogs.DEBUG, "login");
-    props.navigateToIdpSelection();
   };
 
   useEffect(() => {

--- a/ts/store/actions/navigation.ts
+++ b/ts/store/actions/navigation.ts
@@ -426,5 +426,5 @@ export const navigateToSPIDTestIDP = () =>
 
 export const navigateToSPIDLogin = () =>
   NavigationActions.navigate({
-    routeName: ROUTES.AUTHENTICATION_IDP_SELECTION
+    routeName: ROUTES.AUTHENTICATION_IDP_LOGIN
   });


### PR DESCRIPTION
## Short description
This PR fix a bug from #3136.
It doesn't allow the user authentication due to a wrong navigation route.

## List of changes proposed in this pull request
- Modified the route associated to `navigateToSPIDLogin` from `AUTHENTICATION_IDP_SELECTION` to `ROUTES.AUTHENTICATION_IDP_LOGIN`

## How to test
Try to login both in dev and prod mode.
