### PR TITLE
feat: [IA-72] Add contextual help and tracking to UpdateAppModal

### DIFF
--- a/ts/screens/modal/RootModal.tsx
+++ b/ts/screens/modal/RootModal.tsx
@@ -1,6 +1,7 @@
 import { fromNullable } from "fp-ts/lib/Option";
 import * as React from "react";
 import { connect } from "react-redux";
+import { mixpanelTrack } from "../../mixpanel";
 import { serverInfoDataSelector } from "../../store/reducers/backendInfo";
 import { isBackendServicesStatusOffSelector } from "../../store/reducers/backendStatus";
 import { GlobalState } from "../../store/reducers/types";
@@ -27,6 +28,10 @@ export const RootModal: React.FunctionComponent<Props> = (props: Props) => {
     .getOrElse(false);
   // if the app is out of date, force a screen to update it
   if (isAppOutOfDate) {
+    void mixpanelTrack("UPDATE_APP_MODAL", {
+      minVersioniOS: props.backendInfo?.min_app_version.ios,
+      minVersionAndroid: props.backendInfo?.min_app_version.android
+    });
     return <UpdateAppModal />;
   }
   return <IdentificationModal />;

--- a/ts/screens/modal/UpdateAppModal.tsx
+++ b/ts/screens/modal/UpdateAppModal.tsx
@@ -19,10 +19,12 @@ import {
 import BaseScreenComponent from "../../components/screens/BaseScreenComponent";
 import FooterWithButtons from "../../components/ui/FooterWithButtons";
 import I18n from "../../i18n";
+import { mixpanelTrack } from "../../mixpanel";
 import customVariables from "../../theme/variables";
 import { storeUrl, webStoreURL } from "../../utils/appVersion";
 import { useHardwareBackButton } from "../../features/bonus/bonusVacanze/components/hooks/useHardwareBackButton";
 import updateIcon from "../../../img/icons/update-icon.png";
+import { emptyContextualHelp } from "../../utils/emptyContextualHelp";
 import { openWebUrl } from "../../utils/url";
 
 const ERROR_MESSAGE_TIMEOUT: Millisecond = 5000 as Millisecond;
@@ -121,6 +123,7 @@ const UpdateAppModal: React.FC = () => {
         appLogo={true}
         goBack={false}
         accessibilityEvents={{ avoidNavigationEventsUsage: true }}
+        contextualHelp={emptyContextualHelp}
       >
         <Container>
           <View style={styles.container}>

--- a/ts/screens/modal/UpdateAppModal.tsx
+++ b/ts/screens/modal/UpdateAppModal.tsx
@@ -3,10 +3,9 @@
  *
  */
 
-import React, { FC, useCallback, useEffect, useState } from "react";
-
 import { Millisecond } from "italia-ts-commons/lib/units";
 import { Button, Container, H2, Text, View } from "native-base";
+import React, { FC, useCallback, useEffect, useState } from "react";
 import {
   BackHandler,
   Image,
@@ -15,15 +14,14 @@ import {
   Platform,
   StyleSheet
 } from "react-native";
+import updateIcon from "../../../img/icons/update-icon.png";
 
 import BaseScreenComponent from "../../components/screens/BaseScreenComponent";
 import FooterWithButtons from "../../components/ui/FooterWithButtons";
+import { useHardwareBackButton } from "../../features/bonus/bonusVacanze/components/hooks/useHardwareBackButton";
 import I18n from "../../i18n";
-import { mixpanelTrack } from "../../mixpanel";
 import customVariables from "../../theme/variables";
 import { storeUrl, webStoreURL } from "../../utils/appVersion";
-import { useHardwareBackButton } from "../../features/bonus/bonusVacanze/components/hooks/useHardwareBackButton";
-import updateIcon from "../../../img/icons/update-icon.png";
 import { emptyContextualHelp } from "../../utils/emptyContextualHelp";
 import { openWebUrl } from "../../utils/url";
 


### PR DESCRIPTION
## Short description
This pr add remote placeholder and tracking for the `UpdateAppModal`.

<img src=https://user-images.githubusercontent.com/26501317/123675114-a73a7780-d842-11eb-9b80-ce2a91fba032.png width=300 />

## List of changes proposed in this pull request
- Added contextual help
- Added `UPDATE_APP_MODAL` event

## How to test
1. In dev-server, change the payload https://github.com/pagopa/io-dev-api-server/blob/c516e6751d279875d7cd0a410b0fc85e12527ba5/src/payloads/backend.ts#L4 in order to return a app version > of the current (eg: `2.0.0`)
2. Open the app and check the `UpdateAppModal`.
