### PR TITLE
fix: [IA-58] VoiceOver doesn't read the FAQ's content

### DIFF
--- a/ts/components/ui/Accordion.tsx
+++ b/ts/components/ui/Accordion.tsx
@@ -72,7 +72,7 @@ const Accordion: React.FunctionComponent<Props> = (props: Props) => {
   );
 
   const renderContent = (content: string) => (
-    <View style={styles.pad} accessible={expanded}>
+    <View style={styles.pad}>
       <Markdown
         onLinkClicked={(url: string) => {
           fromNullable(props.onLinkClicked).map(s => s(url));


### PR DESCRIPTION
## Short description
VoiceOver doesn't work correctly, if you try to read FAQ's accordion content, it will say "Horizontal scroll bar, 1 page, vertical scroll bar ..."

## How to test
Move into a FAQ, open an accordion and try to listen its content with the VoiceOver

**Before:**

https://user-images.githubusercontent.com/61834253/123981132-62d5e580-d9c2-11eb-9de5-05d237272af0.mp4

**After:**

https://user-images.githubusercontent.com/61834253/123981198-71bc9800-d9c2-11eb-9026-e30fd998a45e.mp4

