### PR TITLE
fix: [IA-63] CIE login continue button doesn't work with VoiceOver activated

### DIFF
--- a/ts/screens/authentication/cie/CiePinScreen.tsx
+++ b/ts/screens/authentication/cie/CiePinScreen.tsx
@@ -180,7 +180,6 @@ const CiePinScreen: React.FC<Props> = props => {
       </ScrollView>
       {pin.length === CIE_PIN_LENGTH && (
         <FooterWithButtons
-          accessible={true}
           ref={continueButtonRef}
           type={"SingleButton"}
           leftButton={{


### PR DESCRIPTION
## Short description
With VoiceOver activated, try to log in via CIE, immediately after entering the eight-digit PIN, you can't press the Continue button

## How to test
1. Enter the CIE login
2. Activate VoiceOver
3. Enter the 8-digit PIN
4. Tap Continue button, then double-tap to press it, you should be able to proceed to the next screen.

NOTE: Unfortunately I can't test it on a IOS physical device, the simulator does not allow me to simulate the double tap to press the Continue button. I need someone to test it for me.