### PR TITLE
feat(Bonus Pagamenti Digitali): [IAC-96] Remove cashback item from FeaturedCardCarousel in wallet

### DIFF
--- a/ts/features/wallet/component/__test__/FeaturedCardCarousel.test.tsx
+++ b/ts/features/wallet/component/__test__/FeaturedCardCarousel.test.tsx
@@ -120,48 +120,6 @@ describe("FeaturedCardCarousel", () => {
     expect(bpdItem).toBeNull();
   });
 
-  it("BPD should be displayed (FF enabled and BPD not enrolled and visibility visible)", () => {
-    jest
-      .spyOn(availableBonusSelectors, "mapBonusIdFeatureFlag")
-      .mockImplementation(
-        // eslint-disable-next-line sonarjs/no-identical-functions
-        () =>
-          new Map<number, boolean>([
-            [ID_BONUS_VACANZE_TYPE, false],
-            [ID_BPD_TYPE, true],
-            [ID_CGN_TYPE, false]
-          ])
-      );
-    const mockStore = configureMockStore<GlobalState>();
-    const withBpdEnabled: GlobalState = appReducer(
-      undefined,
-      bpdLoadActivationStatus.success({
-        enabled: false,
-        payoffInstr: undefined
-      })
-    );
-    const bpdBonus = availableBonuses[1];
-    const updatedAvailableBonuses = availableBonuses.filter(
-      b => b.id_type !== ID_BPD_TYPE
-    );
-    const withBonusAvailable = appReducer(
-      withBpdEnabled,
-      loadAvailableBonuses.success([
-        ...updatedAvailableBonuses,
-        { ...bpdBonus, visibility: BonusVisibilityEnum.visible }
-      ])
-    );
-
-    const component = getComponent(mockStore(withBonusAvailable));
-    expect(component).toBeDefined();
-    const featuredCardCarousel = component.queryByTestId(
-      "FeaturedCardCarousel"
-    );
-    expect(featuredCardCarousel).toBeTruthy();
-    const bpdItem = component.queryByTestId("FeaturedCardBPDTestID");
-    expect(bpdItem).toBeTruthy();
-  });
-
   it("BPD should not be displayed (FF enabled and BPD enrolled loading and visibility visible)", () => {
     jest
       .spyOn(availableBonusSelectors, "mapBonusIdFeatureFlag")
@@ -199,48 +157,6 @@ describe("FeaturedCardCarousel", () => {
     expect(featuredCardCarousel).toBeNull();
     const bpdItem = component.queryByTestId("FeaturedCardBPDTestID");
     expect(bpdItem).toBeNull();
-  });
-
-  it("BPD should be displayed (FF enabled and BPD not enrolled and visibility experimental)", () => {
-    jest
-      .spyOn(availableBonusSelectors, "mapBonusIdFeatureFlag")
-      .mockImplementation(
-        // eslint-disable-next-line sonarjs/no-identical-functions
-        () =>
-          new Map<number, boolean>([
-            [ID_BONUS_VACANZE_TYPE, false],
-            [ID_BPD_TYPE, true],
-            [ID_CGN_TYPE, false]
-          ])
-      );
-    const mockStore = configureMockStore<GlobalState>();
-    const withBpdEnabled: GlobalState = appReducer(
-      undefined,
-      bpdLoadActivationStatus.success({
-        enabled: false,
-        payoffInstr: undefined
-      })
-    );
-    const bpdBonus = availableBonuses[1];
-    const updatedAvailableBonuses = availableBonuses.filter(
-      b => b.id_type !== ID_BPD_TYPE
-    );
-    const withBonusAvailable = appReducer(
-      withBpdEnabled,
-      loadAvailableBonuses.success([
-        ...updatedAvailableBonuses,
-        { ...bpdBonus, visibility: BonusVisibilityEnum.experimental }
-      ])
-    );
-
-    const component = getComponent(mockStore(withBonusAvailable));
-    expect(component).toBeDefined();
-    const featuredCardCarousel = component.queryByTestId(
-      "FeaturedCardCarousel"
-    );
-    expect(featuredCardCarousel).toBeTruthy();
-    const bpdItem = component.queryByTestId("FeaturedCardBPDTestID");
-    expect(bpdItem).toBeTruthy();
   });
 
   it("BPD and CGN should be not displayed (FF off, BPD not enrolled, CGN not enrolled)", () => {

--- a/ts/features/wallet/component/card/FeaturedCardCarousel.tsx
+++ b/ts/features/wallet/component/card/FeaturedCardCarousel.tsx
@@ -10,21 +10,17 @@ import cashbackLogo from "../../../../../img/bonus/bpd/logo_cashback_blue.png";
 import cgnLogo from "../../../../../img/bonus/cgn/cgn_logo.png";
 import { H3 } from "../../../../components/core/typography/H3";
 import { IOStyles } from "../../../../components/core/variables/IOStyles";
+import { cgnEnabled } from "../../../../config";
 import I18n from "../../../../i18n";
 import { Dispatch } from "../../../../store/actions/types";
 import { GlobalState } from "../../../../store/reducers/types";
-import {
-  ID_BPD_TYPE,
-  ID_CGN_TYPE
-} from "../../../bonus/bonusVacanze/utils/bonus";
+import { getLocalePrimaryWithFallback } from "../../../../utils/locale";
+import { supportedAvailableBonusSelector } from "../../../bonus/bonusVacanze/store/reducers/availableBonusesTypes";
+import { ID_CGN_TYPE } from "../../../bonus/bonusVacanze/utils/bonus";
 import { bpdOnboardingStart } from "../../../bonus/bpd/store/actions/onboarding";
 import { bpdEnabledSelector } from "../../../bonus/bpd/store/reducers/details/activation";
-import { getLocalePrimaryWithFallback } from "../../../../utils/locale";
 import { cgnActivationStart } from "../../../bonus/cgn/store/actions/activation";
-import { bpdEnabled, cgnEnabled } from "../../../../config";
-import { isStrictSome } from "../../../../utils/pot";
 import { isCgnEnrolledSelector } from "../../../bonus/cgn/store/reducers/details";
-import { supportedAvailableBonusSelector } from "../../../bonus/bonusVacanze/store/reducers/availableBonusesTypes";
 import FeaturedCard from "./FeaturedCard";
 
 type Props = ReturnType<typeof mapStateToProps> &
@@ -48,13 +44,6 @@ const styles = StyleSheet.create({
 const FeaturedCardCarousel: React.FunctionComponent<Props> = (props: Props) => {
   const bonusMap: Map<number, BonusUtils> = new Map<number, BonusUtils>([]);
 
-  if (bpdEnabled) {
-    bonusMap.set(ID_BPD_TYPE, {
-      logo: cashbackLogo,
-      handler: _ => props.startBpdOnboarding()
-    });
-  }
-
   if (cgnEnabled) {
     bonusMap.set(ID_CGN_TYPE, {
       logo: cgnLogo,
@@ -62,13 +51,8 @@ const FeaturedCardCarousel: React.FunctionComponent<Props> = (props: Props) => {
     });
   }
 
-  const hasBpdActive: boolean | undefined = isStrictSome(props.bpdActiveBonus)
-    ? props.bpdActiveBonus.value
-    : undefined;
-
   // are there any bonus to activate?
-  const anyBonusNotActive =
-    hasBpdActive === false || props.cgnActiveBonus === false;
+  const anyBonusNotActive = props.cgnActiveBonus === false;
   return props.availableBonusesList.length > 0 && anyBonusNotActive ? (
     <View style={styles.container} testID={"FeaturedCardCarousel"}>
       <View style={[IOStyles.horizontalContentPadding]}>
@@ -94,19 +78,6 @@ const FeaturedCardCarousel: React.FunctionComponent<Props> = (props: Props) => {
           const currentLocale = getLocalePrimaryWithFallback();
 
           switch (b.id_type) {
-            case ID_BPD_TYPE:
-              return (
-                hasBpdActive === false && (
-                  <FeaturedCard
-                    testID={"FeaturedCardBPDTestID"}
-                    key={`featured_bonus_${i}`}
-                    title={I18n.t("bonus.bpd.name")}
-                    image={logo}
-                    isNew={true}
-                    onPress={() => handler(b)}
-                  />
-                )
-              );
             case ID_CGN_TYPE:
               return (
                 props.cgnActiveBonus === false && (


### PR DESCRIPTION
## Short description
This pr removes the cashback item from the `FeaturedCardCarousel` in wallet.

Before            |  After
:-------------------------:|:-------------------------:
<img width="300" alt="Schermata 2021-07-05 alle 12 02 35" src="https://user-images.githubusercontent.com/26501317/124455327-bdd45780-dd89-11eb-8bc1-9a0fc15f5292.png"> |  <img width="300" alt="Schermata 2021-07-05 alle 12 09 16" src="https://user-images.githubusercontent.com/26501317/124455383-d2b0eb00-dd89-11eb-8c08-a0556e067a63.png">

## List of changes proposed in this pull request
- Removed the cashback item

## How to test
Navigate to wallet home without being enrolled in cashback  > the `FeaturedCardCarousel` is not displayed (with `CGN_ENABLED` === false)
