### PR TITLE
chore(Redesign Servizi): [IARS-29] Add mixpanel track for newly integrated service preference API

### DIFF
--- a/ts/screens/onboarding/OnboardingServicesPreferenceScreen.tsx
+++ b/ts/screens/onboarding/OnboardingServicesPreferenceScreen.tsx
@@ -28,6 +28,7 @@ import { profileUpsert } from "../../store/actions/profile";
 import { withLoadingSpinner } from "../../components/helpers/withLoadingSpinner";
 import { showToast } from "../../utils/showToast";
 import { servicesOptinCompleted } from "../../store/actions/onboarding";
+import { mixpanelTrack } from "../../mixpanel";
 
 type NavigationProps = {
   isFirstOnboarding: boolean;
@@ -55,6 +56,9 @@ const OnboardingServicesPreferenceScreen = (
   React.useEffect(() => {
     // when the user made a choice (the profile is right updated), navigate to thank-you page
     if (isServicesPreferenceModeSet(props.profileServicePreferenceMode)) {
+      void mixpanelTrack("SERVICE_CONTACT_MODE_SET", {
+        mode: props.profileServicePreferenceMode
+      });
       props.onContinue(isFirstOnboarding);
       return;
     }

--- a/ts/screens/onboarding/OnboardingServicesPreferenceScreen.tsx
+++ b/ts/screens/onboarding/OnboardingServicesPreferenceScreen.tsx
@@ -54,7 +54,7 @@ const OnboardingServicesPreferenceScreen = (
     typeof props.potProfile
   >(props.potProfile);
   React.useEffect(() => {
-    // when the user made a choice (the profile is right updated), navigate to thank-you page
+    // when the user made a choice (the profile is right updated), continue to the next step
     if (isServicesPreferenceModeSet(props.profileServicePreferenceMode)) {
       void mixpanelTrack("SERVICE_CONTACT_MODE_SET", {
         mode: props.profileServicePreferenceMode

--- a/ts/screens/profile/EmailForwardingScreen.tsx
+++ b/ts/screens/profile/EmailForwardingScreen.tsx
@@ -34,6 +34,7 @@ import { GlobalState } from "../../store/reducers/types";
 import customVariables from "../../theme/variables";
 import { getProfileChannelsforServicesList } from "../../utils/profile";
 import { showToast } from "../../utils/showToast";
+import { servicesRedesignEnabled } from "../../config";
 
 type OwnProps = Readonly<{
   navigation: NavigationScreenProp<NavigationState>;
@@ -168,24 +169,26 @@ class EmailForwardingScreen extends React.Component<Props, State> {
               }
             )}
             {/* CASE BY CASE */}
-            {renderListItem(
-              I18n.t("send_email_messages.options.by_service.label"),
-              I18n.t("send_email_messages.options.by_service.info"),
-              this.props.isEmailEnabled &&
-                this.props.isCustomEmailChannelEnabled,
-              // Enable custom set of the email notification for each visible service
-              () => {
-                if (this.state.isLoading) {
-                  return;
-                }
-                this.setState(
-                  { isCustomChannelEnabledChoice: true, isLoading: true },
-                  () => {
-                    this.props.setEmailChannel(true);
+            {/* ByService option is disabled until it will be persisted on backend as a proper attribute */}
+            {!servicesRedesignEnabled &&
+              renderListItem(
+                I18n.t("send_email_messages.options.by_service.label"),
+                I18n.t("send_email_messages.options.by_service.info"),
+                this.props.isEmailEnabled &&
+                  this.props.isCustomEmailChannelEnabled,
+                // Enable custom set of the email notification for each visible service
+                () => {
+                  if (this.state.isLoading) {
+                    return;
                   }
-                );
-              }
-            )}
+                  this.setState(
+                    { isCustomChannelEnabledChoice: true, isLoading: true },
+                    () => {
+                      this.props.setEmailChannel(true);
+                    }
+                  );
+                }
+              )}
 
             <EdgeBorderComponent />
           </List>
@@ -210,10 +213,9 @@ const mapStateToProps = (state: GlobalState) => {
   const potIsCustomEmailChannelEnabled = isCustomEmailChannelEnabledSelector(
     state
   );
-  const isCustomEmailChannelEnabled = pot.getOrElse(
-    potIsCustomEmailChannelEnabled,
-    false
-  );
+  const isCustomEmailChannelEnabled = servicesRedesignEnabled
+    ? false
+    : pot.getOrElse(potIsCustomEmailChannelEnabled, false);
 
   const potUserEmail = profileEmailSelector(state);
   const userEmail = potUserEmail.fold(

--- a/ts/screens/profile/ServicesPreferenceScreen.tsx
+++ b/ts/screens/profile/ServicesPreferenceScreen.tsx
@@ -42,6 +42,7 @@ const ServicesPreferenceScreen = (props: Props): React.ReactElement => {
       showToast(I18n.t("global.genericError"));
     }
 
+    // when the user changes his/her preference, track the new preference
     if (
       isStrictSome(prevPotProfile) &&
       isStrictSome(props.potProfile) &&

--- a/ts/screens/profile/ServicesPreferenceScreen.tsx
+++ b/ts/screens/profile/ServicesPreferenceScreen.tsx
@@ -16,6 +16,8 @@ import {
 } from "../../store/reducers/profile";
 import { withLoadingSpinner } from "../../components/helpers/withLoadingSpinner";
 import { showToast } from "../../utils/showToast";
+import { isStrictSome } from "../../utils/pot";
+import { mixpanelTrack } from "../../mixpanel";
 import ServicesContactComponent from "./components/services/ServicesContactComponent";
 import { useManualConfigBottomSheet } from "./components/services/ManualConfigBottomSheet";
 
@@ -38,6 +40,17 @@ const ServicesPreferenceScreen = (props: Props): React.ReactElement => {
     // otherwise, if the profile is in error state, the toast will be shown immediately without any updates
     if (!pot.isError(prevPotProfile) && pot.isError(props.potProfile)) {
       showToast(I18n.t("global.genericError"));
+    }
+
+    if (
+      isStrictSome(prevPotProfile) &&
+      isStrictSome(props.potProfile) &&
+      prevPotProfile.value.service_preferences_settings !==
+        props.potProfile.value.service_preferences_settings
+    ) {
+      void mixpanelTrack("SERVICE_CONTACT_MODE_SET", {
+        mode: props.potProfile.value.service_preferences_settings
+      });
     }
     setPrevPotProfile(props.potProfile);
   }, [props.potProfile]);

--- a/ts/store/middlewares/analytics.ts
+++ b/ts/store/middlewares/analytics.ts
@@ -31,10 +31,7 @@ import {
   sessionInvalid
 } from "../actions/authentication";
 import { cieAuthenticationError } from "../actions/cie";
-import {
-  contentMunicipalityLoad,
-  loadServiceMetadata
-} from "../actions/content";
+import { contentMunicipalityLoad } from "../actions/content";
 import { instabugReportClosed, instabugReportOpened } from "../actions/debug";
 import {
   identificationCancel,
@@ -67,11 +64,6 @@ import {
   removeAccountMotivation
 } from "../actions/profile";
 import { profileEmailValidationChanged } from "../actions/profileEmailValidationChange";
-import {
-  loadServiceDetail,
-  loadServicesDetail,
-  loadVisibleServices
-} from "../actions/services";
 import { Action, Dispatch, MiddlewareAPI } from "../actions/types";
 import {
   deleteUserDataProcessing,
@@ -127,6 +119,7 @@ import {
 } from "../actions/wallet/outcomeCode";
 import { noAnalyticsRoutes } from "../../utils/analytics";
 import { trackContentAction } from "./contentAnalytics";
+import { trackServiceAction } from "./serviceAnalytics";
 
 // eslint-disable-next-line complexity
 const trackAction = (mp: NonNullable<typeof mixpanel>) => (
@@ -173,12 +166,6 @@ const trackAction = (mp: NonNullable<typeof mixpanel>) => (
       });
     // messages
     case getType(loadMessages.success):
-    //
-    // wallets success / services load requests
-    case getType(loadServicesDetail):
-      return mp.track(action.type, {
-        count: action.payload.length
-      });
     // end pay webview Payment (payment + onboarding credit card) actions (with properties)
     case getType(addCreditCardWebViewEnd):
     case getType(paymentWebViewEnd):
@@ -269,8 +256,6 @@ const trackAction = (mp: NonNullable<typeof mixpanel>) => (
     case getType(upsertUserDataProcessing.failure):
     case getType(loadMessage.failure):
     case getType(logoutFailure):
-    case getType(loadServiceDetail.failure):
-    case getType(loadServiceMetadata.failure):
       return mp.track(action.type, {
         reason: action.payload.error.message
       });
@@ -285,7 +270,6 @@ const trackAction = (mp: NonNullable<typeof mixpanel>) => (
     case getType(userMetadataLoad.failure):
     case getType(loginFailure):
     case getType(loadMessages.failure):
-    case getType(loadVisibleServices.failure):
     case getType(refreshPMTokenWhileAddCreditCard.failure):
     case getType(deleteWalletFailure):
     case getType(setFavouriteWalletFailure):
@@ -345,13 +329,6 @@ const trackAction = (mp: NonNullable<typeof mixpanel>) => (
     // messages
     case getType(loadMessages.request):
     case getType(loadMessagesCancel):
-    // services
-    case getType(loadVisibleServices.request):
-    case getType(loadVisibleServices.success):
-    case getType(loadServiceDetail.request):
-    case getType(loadServiceDetail.success):
-    case getType(loadServiceMetadata.request):
-    case getType(loadServiceMetadata.success):
     // wallet
     case getType(addWalletCreditCardInit):
     case getType(addWalletCreditCardRequest):
@@ -430,6 +407,7 @@ export const actionTracking = (_: MiddlewareAPI) => (next: Dispatch) => (
     void trackPrivativeAction(mixpanel)(action);
     void trackCgnAction(mixpanel)(action);
     void trackContentAction(mixpanel)(action);
+    void trackServiceAction(mixpanel)(action);
     void trackEuCovidCertificateActions(mixpanel)(action);
   }
   return next(action);

--- a/ts/store/middlewares/serviceAnalytics.ts
+++ b/ts/store/middlewares/serviceAnalytics.ts
@@ -44,12 +44,16 @@ export const trackServiceAction = (mp: NonNullable<typeof mixpanel>) => (
     case getType(loadServiceMetadata.request):
     case getType(loadServiceMetadata.success):
     case getType(loadServicePreference.request):
-    case getType(loadServicePreference.success):
       return mp.track(action.type);
     case getType(upsertServicePreference.request):
-    case getType(upsertServicePreference.success):
       return mp.track(action.type, {
         service_id: action.payload.id
+      });
+    case getType(loadServicePreference.success):
+    case getType(upsertServicePreference.success):
+      return mp.track(action.type, {
+        service_id: action.payload.id,
+        responseStatus: action.payload.kind
       });
   }
   return Promise.resolve();

--- a/ts/store/middlewares/serviceAnalytics.ts
+++ b/ts/store/middlewares/serviceAnalytics.ts
@@ -1,0 +1,55 @@
+import { getType } from "typesafe-actions";
+import { mixpanel } from "../../mixpanel";
+import { Action } from "../actions/types";
+import { loadServiceMetadata } from "../actions/content";
+import {
+  loadServiceDetail,
+  loadServicesDetail,
+  loadVisibleServices
+} from "../actions/services";
+import {
+  loadServicePreference,
+  upsertServicePreference
+} from "../actions/services/servicePreference";
+import { getNetworkErrorMessage } from "../../utils/errors";
+
+// Isolated tracker for services actions
+export const trackServiceAction = (mp: NonNullable<typeof mixpanel>) => (
+  action: Action
+): Promise<void> => {
+  switch (action.type) {
+    case getType(loadServicesDetail):
+      return mp.track(action.type, {
+        count: action.payload.length
+      });
+    case getType(loadServiceDetail.failure):
+    case getType(loadServiceMetadata.failure):
+      return mp.track(action.type, {
+        reason: action.payload.error.message
+      });
+    case getType(loadVisibleServices.failure):
+      return mp.track(action.type, {
+        reason: action.payload.message
+      });
+    case getType(loadServicePreference.failure):
+    case getType(upsertServicePreference.failure):
+      return mp.track(action.type, {
+        reason: getNetworkErrorMessage(action.payload)
+      });
+    case getType(loadVisibleServices.request):
+    case getType(loadVisibleServices.success):
+    case getType(loadServiceDetail.request):
+    case getType(loadServiceDetail.success):
+    case getType(loadServiceMetadata.request):
+    case getType(loadServiceMetadata.success):
+    case getType(loadServicePreference.request):
+    case getType(loadServicePreference.success):
+      return mp.track(action.type);
+    case getType(upsertServicePreference.request):
+    case getType(upsertServicePreference.success):
+      return mp.track(action.type, {
+        service_id: action.payload.id
+      });
+  }
+  return Promise.resolve();
+};

--- a/ts/store/middlewares/serviceAnalytics.ts
+++ b/ts/store/middlewares/serviceAnalytics.ts
@@ -34,6 +34,7 @@ export const trackServiceAction = (mp: NonNullable<typeof mixpanel>) => (
     case getType(loadServicePreference.failure):
     case getType(upsertServicePreference.failure):
       return mp.track(action.type, {
+        service_id: action.payload.id,
         reason: getNetworkErrorMessage(action.payload)
       });
     case getType(loadVisibleServices.request):


### PR DESCRIPTION
## THIS PR Depends on #3186 #3191 

## Short description
This PR introduces the tracking ability for the newly implemented APIs for setting single service contact preferences