### PR TITLE
feat(Bonus Pagamenti Digitali): [IAC-97] Remote configuration for cashback enroll after add payment method

### DIFF
--- a/ts/features/bonus/bpd/saga/orchestration/__tests__/activateBpdOnNewPaymentMethods.test.ts
+++ b/ts/features/bonus/bpd/saga/orchestration/__tests__/activateBpdOnNewPaymentMethods.test.ts
@@ -1,0 +1,155 @@
+import { left, right } from "fp-ts/lib/Either";
+import { createStore } from "redux";
+import { expectSaga } from "redux-saga-test-plan";
+import * as matchers from "redux-saga-test-plan/matchers";
+import { applicationChangeState } from "../../../../../../store/actions/application";
+import { navigateToWalletHome } from "../../../../../../store/actions/navigation";
+import { appReducer } from "../../../../../../store/reducers";
+import { bpdRemoteConfigSelector } from "../../../../../../store/reducers/backendStatus";
+import { mockPrivativeCard } from "../../../../../../store/reducers/wallet/__mocks__/wallets";
+import { BpdConfig } from "../../../../../../types/backendStatus";
+import { EnableableFunctionsTypeEnum } from "../../../../../../types/pagopa";
+import { navigateToSuggestBpdActivation } from "../../../../../wallet/onboarding/bancomat/navigation/action";
+import { navigateToActivateBpdOnNewPrivative } from "../../../../../wallet/onboarding/privative/navigation/action";
+import { activateBpdOnNewPaymentMethods } from "../activateBpdOnNewAddedPaymentMethods";
+import { isBpdEnabled } from "../onboarding/startOnboarding";
+
+const enrollAfterAddTrue: BpdConfig = {
+  enroll_bpd_after_add_payment_method: true
+};
+
+const enrollAfterAddFalse: BpdConfig = {
+  enroll_bpd_after_add_payment_method: false
+};
+
+describe("Test activateBpdOnNewPaymentMethods behaviour", () => {
+  jest.useFakeTimers();
+  it("With default state and no payment methods, should navigate to wallet home", async () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+
+    await expectSaga(
+      activateBpdOnNewPaymentMethods,
+      [],
+      navigateToActivateBpdOnNewPrivative()
+    )
+      .withState(store.getState())
+      .put(navigateToWalletHome())
+      .not.call(isBpdEnabled)
+      .not.select(bpdRemoteConfigSelector)
+      .not.put(navigateToActivateBpdOnNewPrivative())
+      .not.put(navigateToSuggestBpdActivation())
+      .run();
+  });
+
+  it("With at least one payment method with bpd capability and an error to retrieve the bpd enrolling, should navigate to wallet home", async () => {
+    await expectSaga(
+      activateBpdOnNewPaymentMethods,
+      [mockPrivativeCard],
+      navigateToActivateBpdOnNewPrivative()
+    )
+      .provide([
+        [matchers.call(isBpdEnabled), left(new Error("An error"))],
+        [matchers.select(bpdRemoteConfigSelector), enrollAfterAddFalse]
+      ])
+      .call(isBpdEnabled)
+      .put(navigateToWalletHome())
+      .select(bpdRemoteConfigSelector)
+      .not.put(navigateToActivateBpdOnNewPrivative())
+      .not.put(navigateToSuggestBpdActivation())
+      .run();
+  });
+
+  it("With all payment methods without bpd capability, should navigate to navigateToWalletHome", async () => {
+    await expectSaga(
+      activateBpdOnNewPaymentMethods,
+      [
+        {
+          ...mockPrivativeCard,
+          enableableFunctions: [
+            EnableableFunctionsTypeEnum.FA,
+            EnableableFunctionsTypeEnum.pagoPA
+          ]
+        }
+      ],
+      navigateToActivateBpdOnNewPrivative()
+    )
+      .provide([
+        [matchers.call(isBpdEnabled), right(true)],
+        [matchers.select(bpdRemoteConfigSelector), enrollAfterAddFalse]
+      ])
+      .put(navigateToWalletHome())
+      .not.call(isBpdEnabled)
+      .not.select(bpdRemoteConfigSelector)
+      .not.put(navigateToActivateBpdOnNewPrivative())
+      .not.put(navigateToSuggestBpdActivation())
+      .run();
+  });
+
+  it("With at least one payment method with bpd capability and bpd enrolled, should navigate to navigateToActivateBpdOnNewPrivative", async () => {
+    await expectSaga(
+      activateBpdOnNewPaymentMethods,
+      [mockPrivativeCard],
+      navigateToActivateBpdOnNewPrivative()
+    )
+      .provide([
+        [matchers.call(isBpdEnabled), right(true)],
+        [matchers.select(bpdRemoteConfigSelector), enrollAfterAddFalse]
+      ])
+      .not.put(navigateToWalletHome())
+      .call(isBpdEnabled)
+      .select(bpdRemoteConfigSelector)
+      .put(navigateToActivateBpdOnNewPrivative())
+      .not.put(navigateToSuggestBpdActivation())
+      .run();
+  });
+
+  it("With at least one payment method with bpd capability, bpd not enrolled and remote configuration false or undefined should navigate to navigateToWalletHome", async () => {
+    await expectSaga(
+      activateBpdOnNewPaymentMethods,
+      [mockPrivativeCard],
+      navigateToActivateBpdOnNewPrivative()
+    )
+      .provide([
+        [matchers.call(isBpdEnabled), right(false)],
+        [matchers.select(bpdRemoteConfigSelector), enrollAfterAddFalse]
+      ])
+      .call(isBpdEnabled)
+      .select(bpdRemoteConfigSelector)
+      .not.put(navigateToActivateBpdOnNewPrivative())
+      .not.put(navigateToSuggestBpdActivation())
+      .run();
+
+    await expectSaga(
+      activateBpdOnNewPaymentMethods,
+      [mockPrivativeCard],
+      navigateToActivateBpdOnNewPrivative()
+    )
+      .provide([
+        [matchers.call(isBpdEnabled), right(false)],
+        [matchers.select(bpdRemoteConfigSelector), undefined]
+      ])
+      .call(isBpdEnabled)
+      .select(bpdRemoteConfigSelector)
+      .not.put(navigateToActivateBpdOnNewPrivative())
+      .not.put(navigateToSuggestBpdActivation())
+      .run();
+  });
+
+  it("With at least one payment method with bpd capability, bpd not enrolled and remote configuration true, should navigate to navigateToWalletHome", async () => {
+    await expectSaga(
+      activateBpdOnNewPaymentMethods,
+      [mockPrivativeCard],
+      navigateToActivateBpdOnNewPrivative()
+    )
+      .provide([
+        [matchers.call(isBpdEnabled), right(false)],
+        [matchers.select(bpdRemoteConfigSelector), enrollAfterAddTrue]
+      ])
+      .call(isBpdEnabled)
+      .select(bpdRemoteConfigSelector)
+      .not.put(navigateToActivateBpdOnNewPrivative())
+      .put(navigateToSuggestBpdActivation())
+      .run();
+  });
+});

--- a/ts/features/bonus/bpd/screens/details/components/summary/__test__/bpdSummaryComponent.test.tsx
+++ b/ts/features/bonus/bpd/screens/details/components/summary/__test__/bpdSummaryComponent.test.tsx
@@ -7,6 +7,7 @@ import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";
 import I18n from "../../../../../../../../i18n";
 import {
+  baseBackendConfig,
   baseBackendState,
   withBpdRankingConfig
 } from "../../../../../../../../store/reducers/__mock__/backendStatus";
@@ -447,7 +448,10 @@ export const mockBpdState = (
   backendStatus:
     bpdRankingRemoteConfig === undefined
       ? baseBackendState
-      : withBpdRankingConfig(baseBackendState, bpdRankingRemoteConfig),
+      : withBpdRankingConfig(baseBackendState, {
+          ...baseBackendConfig,
+          bpd_ranking_v2: bpdRankingRemoteConfig
+        }),
   profile: pot.none
 });
 

--- a/ts/features/bonus/bpd/screens/details/components/summary/ranking/SuperCashbackRankingSummary.tsx
+++ b/ts/features/bonus/bpd/screens/details/components/summary/ranking/SuperCashbackRankingSummary.tsx
@@ -9,7 +9,7 @@ import { IOColors } from "../../../../../../../../components/core/variables/IOCo
 import { IOStyles } from "../../../../../../../../components/core/variables/IOStyles";
 import IconFont from "../../../../../../../../components/ui/IconFont";
 import I18n from "../../../../../../../../i18n";
-import { configSelector } from "../../../../../../../../store/reducers/backendStatus";
+import { bpdRankingEnabledSelector } from "../../../../../../../../store/reducers/backendStatus";
 import { GlobalState } from "../../../../../../../../store/reducers/types";
 import { formatIntegerNumber } from "../../../../../../../../utils/stringBuilder";
 import { useSuperCashbackRankingBottomSheet } from "../../../../../components/superCashbackRanking/SuperCashbackRanking";
@@ -151,7 +151,7 @@ const SuperCashbackRankingSummary = (props: Props): React.ReactElement =>
 const mapDispatchToProps = (_: Dispatch) => ({});
 
 const mapStateToProps = (state: GlobalState) => ({
-  rankingRemoteEnabled: configSelector("bpd_ranking_v2")(state)
+  rankingRemoteEnabled: bpdRankingEnabledSelector(state)
 });
 
 export default connect(

--- a/ts/features/bonus/cgn/screens/CgnDetailScreen.tsx
+++ b/ts/features/bonus/cgn/screens/CgnDetailScreen.tsx
@@ -3,6 +3,7 @@ import { connect } from "react-redux";
 import { View } from "native-base";
 import LinearGradient from "react-native-linear-gradient";
 import { SafeAreaView, ScrollView } from "react-native";
+import { cgnMerchantVersionSelector } from "../../../../store/reducers/backendStatus";
 import { GlobalState } from "../../../../store/reducers/types";
 import { Dispatch } from "../../../../store/actions/types";
 import I18n from "../../../../i18n";
@@ -41,7 +42,6 @@ import GenericErrorComponent from "../../../../components/screens/GenericErrorCo
 import { navigateBack } from "../../../../store/actions/navigation";
 import { useHardwareBackButton } from "../../bonusVacanze/components/hooks/useHardwareBackButton";
 import { canEycaCardBeShown } from "../utils/eyca";
-import { configSelector } from "../../../../store/reducers/backendStatus";
 
 type Props = ReturnType<typeof mapStateToProps> &
   ReturnType<typeof mapDispatchToProps>;
@@ -154,7 +154,7 @@ const CgnDetailScreen = (props: Props): React.ReactElement => {
 const mapStateToProps = (state: GlobalState) => ({
   cgnDetails: cgnDetailsInformationSelector(state),
   isCgnInfoLoading: isCgnDetailsLoading(state),
-  isMerchantV2Enabled: configSelector("cgn_merchants_v2")(state),
+  isMerchantV2Enabled: cgnMerchantVersionSelector(state),
   cgnBonusInfo: availableBonusTypesSelectorFromId(ID_CGN_TYPE)(state),
   eycaDetails: eycaDetailSelector(state)
 });

--- a/ts/features/wallet/privative/component/__tests__/PrivativeWalletPreview.test.tsx
+++ b/ts/features/wallet/privative/component/__tests__/PrivativeWalletPreview.test.tsx
@@ -4,50 +4,24 @@ import { Provider } from "react-redux";
 import configureMockStore from "redux-mock-store";
 import { none, some } from "fp-ts/lib/Option";
 import { NavigationActions } from "react-navigation";
+import { mockPrivativeCard } from "../../../../../store/reducers/wallet/__mocks__/wallets";
 import { PrivativePaymentMethod } from "../../../../../types/pagopa";
 import PrivativeWalletPreview from "../PrivativeWalletPreview";
 import * as hooks from "../../../onboarding/bancomat/screens/hooks/useImageResize";
 import ROUTES from "../../../../../navigation/routes";
 
 describe("PrivativeWalletPreview", () => {
-  const aPrivativeCard: PrivativePaymentMethod = {
-    walletType: "Card",
-    createDate: "2021-07-08",
-    enableableFunctions: ["FA", "pagoPA", "BPD"],
-    favourite: false,
-    idWallet: 25572,
-    info: {
-      blurredNumber: "0001",
-      brand: "Maestro",
-      brandLogo:
-        "https://wisp2.pagopa.gov.it/wallet/assets/img/creditcard/carta_maestro.png",
-      expireMonth: "11",
-      expireYear: "2021",
-      hashPan:
-        "d48a59cdfbe3da7e4fe25e28cbb47d5747720ecc6fc392c87f1636fe95db22f90004",
-      holder: "Maria Rossi",
-      htokenList: ["token1", "token2"],
-      issuerAbiCode: "CONAD",
-      type: "PRV"
-    },
-    onboardingChannel: "IO",
-    pagoPA: false,
-    updateDate: "2020-11-20",
-    kind: "Privative",
-    caption: "●●●●0001",
-    icon: 37
-  } as PrivativePaymentMethod;
   it("should show the caption", () => {
     jest.spyOn(hooks, "useImageResize").mockReturnValue(none);
-    const { component } = getComponent(aPrivativeCard);
+    const { component } = getComponent(mockPrivativeCard);
     const caption = component.queryByTestId("caption");
 
     expect(caption).not.toBeNull();
-    expect(caption).toHaveTextContent(aPrivativeCard.caption);
+    expect(caption).toHaveTextContent(mockPrivativeCard.caption);
   });
   it("should show the fallback gdo logo if useImageResize returns a size but there isn't the cardLogo", () => {
     jest.spyOn(hooks, "useImageResize").mockReturnValue(some([15, 15]));
-    const { component } = getComponent(aPrivativeCard);
+    const { component } = getComponent(mockPrivativeCard);
     const cardLogo = component.queryByTestId("loyaltyLogo");
     const cardLogoFallback = component.queryByTestId("unknownLoyaltyLogo");
 
@@ -57,7 +31,7 @@ describe("PrivativeWalletPreview", () => {
   it("should show the gdo logo if useImageResize return a size", () => {
     jest.spyOn(hooks, "useImageResize").mockReturnValue(some([15, 15]));
     const { component } = getComponent({
-      ...aPrivativeCard,
+      ...mockPrivativeCard,
       icon: { uri: "aCardLogoUrl" }
     });
     const cardLogo = component.queryByTestId("loyaltyLogo");
@@ -68,12 +42,12 @@ describe("PrivativeWalletPreview", () => {
   });
   it("should call navigateToPrivativeDetailScreen when it is pressed", () => {
     jest.spyOn(hooks, "useImageResize").mockReturnValue(none);
-    const { component, store } = getComponent(aPrivativeCard);
+    const { component, store } = getComponent(mockPrivativeCard);
     const cardComponent = component.queryByTestId("cardPreview");
     const expectedPayload = {
       type: NavigationActions.NAVIGATE,
       routeName: ROUTES.WALLET_PRIVATIVE_DETAIL,
-      params: { privative: aPrivativeCard }
+      params: { privative: mockPrivativeCard }
     };
     if (cardComponent) {
       fireEvent.press(cardComponent);

--- a/ts/sagas/wallet.ts
+++ b/ts/sagas/wallet.ts
@@ -145,6 +145,7 @@ import {
   setFavouriteWalletRequest,
   setWalletSessionEnabled
 } from "../store/actions/wallet/wallets";
+import { bpdRemoteConfigSelector } from "../store/reducers/backendStatus";
 import { getTransactionsRead } from "../store/reducers/entities/readTransactions";
 import { isProfileEmailValidatedSelector } from "../store/reducers/profile";
 import { GlobalState } from "../store/reducers/types";
@@ -341,6 +342,9 @@ function* startOrResumeAddCreditCardSaga(
                   );
                   // if the method is bpd compliant check if we have info about bpd activation
                   if (hasBpdFeature && pot.isSome(bpdEnroll)) {
+                    const bpdRemoteConfig: ReturnType<typeof bpdRemoteConfigSelector> = yield select(
+                      bpdRemoteConfigSelector
+                    );
                     // if bdp is active navigate to a screen where it asked to enroll that method in bpd
                     // otherwise navigate to a screen where is asked to join bpd
                     if (
@@ -362,8 +366,12 @@ function* startOrResumeAddCreditCardSaga(
                           ]
                         })
                       );
-                    } else {
+                    } else if (
+                      bpdRemoteConfig?.enroll_bpd_after_add_payment_method
+                    ) {
                       yield put(navigateToSuggestBpdActivation());
+                    } else {
+                      yield call(waitAndNavigateToWalletHome);
                     }
                     // remove these screens from the navigation stack: method choice, credit card form, credit card resume and outcome code message
                     // this pop could be easily break when this flow is entered by other points

--- a/ts/store/reducers/__mock__/backendStatus.ts
+++ b/ts/store/reducers/__mock__/backendStatus.ts
@@ -1,5 +1,5 @@
 import { some } from "fp-ts/lib/Option";
-import { BackendStatus } from "../../../types/backendStatus";
+import { BackendStatus, Config } from "../../../types/backendStatus";
 import { BackendStatusState } from "../backendStatus";
 
 export const baseRawBackendStatus: BackendStatus = {
@@ -167,20 +167,22 @@ export const baseBackendState: BackendStatusState = {
   deadsCounter: 0
 };
 
+export const baseBackendConfig: Config = {
+  bpd: {
+    enroll_bpd_after_add_payment_method: false
+  },
+  bpd_ranking: true,
+  bpd_ranking_v2: true,
+  cgn_merchants_v2: true
+};
+
 export const withBpdRankingConfig = (
   baseState: BackendStatusState,
-  newConfig: boolean
+  newConfig: Config
 ): BackendStatusState => ({
   ...baseState,
   status: baseState.status.map(s => ({
     ...s,
-    config: {
-      bpd: {
-        enroll_bpd_after_add_payment_method: false
-      },
-      bpd_ranking: newConfig,
-      bpd_ranking_v2: newConfig,
-      cgn_merchants_v2: newConfig
-    }
+    config: { ...newConfig }
   }))
 });

--- a/ts/store/reducers/__mock__/backendStatus.ts
+++ b/ts/store/reducers/__mock__/backendStatus.ts
@@ -175,6 +175,9 @@ export const withBpdRankingConfig = (
   status: baseState.status.map(s => ({
     ...s,
     config: {
+      bpd: {
+        enroll_bpd_after_add_payment_method: false
+      },
       bpd_ranking: newConfig,
       bpd_ranking_v2: newConfig,
       cgn_merchants_v2: newConfig

--- a/ts/store/reducers/__tests__/backendStatus.test.ts
+++ b/ts/store/reducers/__tests__/backendStatus.test.ts
@@ -2,7 +2,7 @@ import { none, some } from "fp-ts/lib/Option";
 import {
   areSystemsDeadReducer,
   BackendStatusState,
-  configSelector,
+  bpdRankingEnabledSelector,
   sectionStatusSelector
 } from "../backendStatus";
 import { BackendStatus } from "../../../types/backendStatus";
@@ -234,7 +234,7 @@ describe("test selectors", () => {
   });
 
   it("should return undefined - configSelector", () => {
-    const config = configSelector("bpd_ranking_v2")(noneStore);
+    const config = bpdRankingEnabledSelector(noneStore);
     expect(config).toBeUndefined();
   });
 
@@ -244,7 +244,7 @@ describe("test selectors", () => {
         status: some({ ...status, config: { bpd_ranking_v2: true } })
       }
     } as any) as GlobalState;
-    const bpd_ranking = configSelector("bpd_ranking_v2")(someStoreConfig);
+    const bpd_ranking = bpdRankingEnabledSelector(someStoreConfig);
     expect(bpd_ranking).toBeTruthy();
   });
 
@@ -254,7 +254,7 @@ describe("test selectors", () => {
         status: some({ ...status, config: { bpd_ranking_v2: false } })
       }
     } as any) as GlobalState;
-    const bpd_ranking = configSelector("bpd_ranking_v2")(someStoreConfig);
+    const bpd_ranking = bpdRankingEnabledSelector(someStoreConfig);
     expect(bpd_ranking).toBeFalsy();
   });
 });

--- a/ts/store/reducers/backendStatus.ts
+++ b/ts/store/reducers/backendStatus.ts
@@ -5,14 +5,14 @@
 import { none, Option, some } from "fp-ts/lib/Option";
 import { createSelector } from "reselect";
 import { getType } from "typesafe-actions";
-import { backendStatusLoadSuccess } from "../actions/backendStatus";
-import { Action } from "../actions/types";
 import {
   BackendStatus,
-  ConfigStatusKey,
+  BpdConfig,
   SectionStatus,
   SectionStatusKey
 } from "../../types/backendStatus";
+import { backendStatusLoadSuccess } from "../actions/backendStatus";
+import { Action } from "../actions/types";
 import { GlobalState } from "./types";
 
 /** note that this state is not persisted so Option type is accepted
@@ -48,13 +48,32 @@ export const sectionStatusSelector = (sectionStatusKey: SectionStatusKey) =>
       .fold(undefined, s => s[sectionStatusKey])
   );
 
-// return the config status for the given key. if it is not present, returns undefined
-export const configSelector = (configStatusKey: ConfigStatusKey) =>
-  createSelector(backendStatusSelector, (backendStatus): boolean | undefined =>
+export const bpdRankingEnabledSelector = createSelector(
+  backendStatusSelector,
+  (backendStatus): boolean | undefined =>
     backendStatus
       .mapNullable(bs => bs.config)
-      .fold(undefined, c => c[configStatusKey])
-  );
+      .mapNullable(config => config.bpd_ranking_v2)
+      .toUndefined()
+);
+
+export const bpdRemoteConfigSelector = createSelector(
+  backendStatusSelector,
+  (backendStatus): BpdConfig | undefined =>
+    backendStatus
+      .mapNullable(bs => bs.config)
+      .mapNullable(config => config.bpd)
+      .toUndefined()
+);
+
+export const cgnMerchantVersionSelector = createSelector(
+  backendStatusSelector,
+  (backendStatus): boolean | undefined =>
+    backendStatus
+      .mapNullable(bs => bs.config)
+      .mapNullable(config => config.cgn_merchants_v2)
+      .toUndefined()
+);
 
 // systems could be consider dead when we have no updates for at least DEAD_COUNTER_THRESHOLD times
 export const DEAD_COUNTER_THRESHOLD = 2;

--- a/ts/store/reducers/wallet/__mocks__/wallets.ts
+++ b/ts/store/reducers/wallet/__mocks__/wallets.ts
@@ -2,6 +2,7 @@
 import { WalletTypeEnum } from "../../../../../definitions/pagopa/WalletV2";
 import {
   EnableableFunctionsTypeEnum,
+  PrivativePaymentMethod,
   RawBPayPaymentMethod
 } from "../../../../types/pagopa";
 
@@ -245,3 +246,31 @@ export const rawBPay: RawBPayPaymentMethod = {
   updateDate: "2020-11-20",
   kind: "BPay"
 };
+
+export const mockPrivativeCard: PrivativePaymentMethod = {
+  walletType: "Card",
+  createDate: "2021-07-08",
+  enableableFunctions: ["FA", "pagoPA", "BPD"],
+  favourite: false,
+  idWallet: 25572,
+  info: {
+    blurredNumber: "0001",
+    brand: "Maestro",
+    brandLogo:
+      "https://wisp2.pagopa.gov.it/wallet/assets/img/creditcard/carta_maestro.png",
+    expireMonth: "11",
+    expireYear: "2021",
+    hashPan:
+      "d48a59cdfbe3da7e4fe25e28cbb47d5747720ecc6fc392c87f1636fe95db22f90004",
+    holder: "Maria Rossi",
+    htokenList: ["token1", "token2"],
+    issuerAbiCode: "CONAD",
+    type: "PRV"
+  },
+  onboardingChannel: "IO",
+  pagoPA: false,
+  updateDate: "2020-11-20",
+  kind: "Privative",
+  caption: "●●●●0001",
+  icon: 37
+} as PrivativePaymentMethod;

--- a/ts/types/backendStatus.ts
+++ b/ts/types/backendStatus.ts
@@ -53,8 +53,20 @@ const Sections = t.interface({
 });
 export type Sections = t.TypeOf<typeof Sections>;
 
+/**
+ * Bpd configuration
+ * enroll_cashback_after_add_payment_method: if true and the user is not enrolled to the cashback, when he adds
+ * a payment method he is suggested to register for cashback
+ */
+const BpdConfig = t.interface({
+  enroll_bpd_after_add_payment_method: t.boolean
+});
+
+export type BpdConfig = t.TypeOf<typeof BpdConfig>;
+
 // it represents a remote config to switch on/off a specific section,feature,module,etc
 const Config = t.interface({
+  bpd: BpdConfig,
   // bpd_ranking is legacy, don't use it anymore see https://www.pivotaltracker.com/story/show/176498731
   bpd_ranking: t.boolean,
   bpd_ranking_v2: t.boolean,


### PR DESCRIPTION
## Short description
This pr integrates the remote configuration for the cashback enroll suggestion after a payment method has been added.
The current configuration is `enroll_bpd_after_add_payment_method: false` -> the user is not invited to activate the cashback after adding a payment method.

https://user-images.githubusercontent.com/26501317/124494770-7b297400-ddb7-11eb-97ab-a2cd4fdcfa08.mov

## List of changes proposed in this pull request
- Integrated `enroll_bpd_after_add_payment_method` condition in `activateBpdOnNewPaymentMethods` (used for all payment methods except credit cards )
- Integrated `enroll_bpd_after_add_payment_method` condition in `startOrResumeAddCreditCardSaga`.
- Removed `configSelector` (not all the config should be boolean)
- Added new specific selectors `bpdRankingEnabledSelector`, `bpdRemoteConfigSelector` and `cgnMerchantVersionSelector`.
- Extended the remote `BackendStatus` adding the new section `BpdConfig` (see https://github.com/pagopa/io-services-metadata/pull/396)

## How to test
- Reboot dev server to lose the cashback activation (if any) > change https://github.com/pagopa/io-dev-api-server/blob/665be4f77494f3c0fbe685d8d4b993a2763e9c57/src/payloads/backend.ts#L170 in order to obtain the desired behavior  > try to add a credit card or any other payment method.
- run `ts/features/bonus/bpd/saga/orchestration/__tests__/activateBpdOnNewPaymentMethods.test.ts` 
