### PR TITLE
fix: [IA-9] Remove extra space context help

### DIFF
--- a/ts/components/ContextualHelpComponent.tsx
+++ b/ts/components/ContextualHelpComponent.tsx
@@ -33,50 +33,85 @@ const ContextualHelpComponent: React.FunctionComponent<Props> = ({
   isContentLoaded,
   onLinkClicked,
   onRequestAssistance
-}) => (
-  <>
-    <BaseHeader
-      accessibilityEvents={{
-        avoidNavigationEventsUsage: true
-      }}
-      headerTitle={I18n.t("contextualHelp.title")}
-      customRightIcon={{
-        iconName: "io-close",
-        onPress: onClose,
-        accessibilityLabel: I18n.t("global.accessibility.contextualHelp.close")
-      }}
-    />
+}) => {
+  // Being content a ReactNode we can rely on `null` to represent no-content
+  const showLoader = contextualHelpData.content === undefined;
 
-    {!contextualHelpData.content && (
-      <View centerJustified={true}>
-        <ActivityIndicator color={themeVariables.brandPrimaryLight} />
-      </View>
-    )}
-    {contextualHelpData.content && (
-      <Content contentContainerStyle={styles.contentContainer} noPadded={true}>
-        <H3 accessible={true}>{contextualHelpData.title}</H3>
-        <View spacer={true} />
-        {contextualHelpData.content}
-        <View spacer={true} />
-        {contextualHelpData.faqs && isContentLoaded && (
-          <FAQComponent
-            onLinkClicked={onLinkClicked}
-            faqs={contextualHelpData.faqs}
-          />
-        )}
-        {isContentLoaded && (
-          <>
-            <View spacer={true} extralarge={true} />
-            <InstabugAssistanceComponent
-              requestAssistance={onRequestAssistance}
+  return (
+    <>
+      <BaseHeader
+        accessibilityEvents={{
+          avoidNavigationEventsUsage: true
+        }}
+        headerTitle={I18n.t("contextualHelp.title")}
+        customRightIcon={{
+          iconName: "io-close",
+          onPress: onClose,
+          accessibilityLabel: I18n.t(
+            "global.accessibility.contextualHelp.close"
+          )
+        }}
+      />
+      {showLoader && (
+        <View centerJustified={true}>
+          <ActivityIndicator color={themeVariables.brandPrimaryLight} />
+        </View>
+      )}
+      {!showLoader && (
+        <Content
+          contentContainerStyle={styles.contentContainer}
+          noPadded={true}
+        >
+          {renderTitleIfPresent(contextualHelpData.title)}
+          {renderContentIfPresent(contextualHelpData.content)}
+
+          {contextualHelpData.faqs && isContentLoaded && (
+            <FAQComponent
+              onLinkClicked={onLinkClicked}
+              faqs={contextualHelpData.faqs}
             />
-          </>
-        )}
-        {isContentLoaded && <EdgeBorderComponent />}
-      </Content>
-    )}
-    <BetaBannerComponent />
-  </>
-);
+          )}
+          {isContentLoaded && (
+            <>
+              {contextualHelpData.content !== null && (
+                <View spacer={true} extralarge={true} />
+              )}
+              <InstabugAssistanceComponent
+                requestAssistance={onRequestAssistance}
+              />
+            </>
+          )}
+          {isContentLoaded && <EdgeBorderComponent />}
+        </Content>
+      )}
+      <BetaBannerComponent />
+    </>
+  );
+};
+
+function renderTitleIfPresent(title: string) {
+  if (title) {
+    return (
+      <>
+        <H3 accessible={true}>{title}</H3>
+        <View spacer={true} />
+      </>
+    );
+  }
+  return null;
+}
+
+function renderContentIfPresent(content: React.ReactNode) {
+  if (content === null) {
+    return null;
+  }
+
+  return (
+    <>
+      {content}
+      <View spacer={true} />
+    </>
+  );
+}
 
 export default ContextualHelpComponent;

--- a/ts/components/ContextualHelpComponent.tsx
+++ b/ts/components/ContextualHelpComponent.tsx
@@ -3,6 +3,7 @@ import { Content, View } from "native-base";
 import * as React from "react";
 import { StyleSheet } from "react-native";
 import I18n from "../i18n";
+import { isStringNullyOrEmpty } from "../utils/strings";
 import themeVariables from "../theme/variables";
 import { ContextualHelpData } from "./ContextualHelpModal";
 import { H3 } from "./core/typography/H3";
@@ -35,7 +36,7 @@ const ContextualHelpComponent: React.FunctionComponent<Props> = ({
   onRequestAssistance
 }) => {
   // Being content a ReactNode we can rely on `null` to represent no-content
-  const showLoader = contextualHelpData.content === undefined;
+  const isContentReady = contextualHelpData.content === undefined;
 
   return (
     <>
@@ -52,18 +53,29 @@ const ContextualHelpComponent: React.FunctionComponent<Props> = ({
           )
         }}
       />
-      {showLoader && (
+      {isContentReady && (
         <View centerJustified={true}>
           <ActivityIndicator color={themeVariables.brandPrimaryLight} />
         </View>
       )}
-      {!showLoader && (
+      {!isContentReady && (
         <Content
           contentContainerStyle={styles.contentContainer}
           noPadded={true}
         >
-          {renderTitleIfPresent(contextualHelpData.title)}
-          {renderContentIfPresent(contextualHelpData.content)}
+          {!isStringNullyOrEmpty(contextualHelpData.title) && (
+            <>
+              <H3 accessible={true}>{contextualHelpData.title}</H3>
+              <View spacer={true} />
+            </>
+          )}
+
+          {contextualHelpData.content && (
+            <>
+              {contextualHelpData.content}
+              <View spacer={true} />
+            </>
+          )}
 
           {contextualHelpData.faqs && isContentLoaded && (
             <FAQComponent
@@ -88,30 +100,5 @@ const ContextualHelpComponent: React.FunctionComponent<Props> = ({
     </>
   );
 };
-
-function renderTitleIfPresent(title: string) {
-  if (title) {
-    return (
-      <>
-        <H3 accessible={true}>{title}</H3>
-        <View spacer={true} />
-      </>
-    );
-  }
-  return null;
-}
-
-function renderContentIfPresent(content: React.ReactNode) {
-  if (content === null) {
-    return null;
-  }
-
-  return (
-    <>
-      {content}
-      <View spacer={true} />
-    </>
-  );
-}
 
 export default ContextualHelpComponent;

--- a/ts/components/__tests__/ContextualHelp.test.tsx
+++ b/ts/components/__tests__/ContextualHelp.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { NavigationParams } from "react-navigation";
+import { BackHandler, Text } from "react-native";
+import { createStore } from "redux";
+import { fireEvent, RenderAPI } from "@testing-library/react-native";
+
+import { applicationChangeState } from "../../store/actions/application";
+import { GlobalState } from "../../store/reducers/types";
+import { renderScreenFakeNavRedux } from "../../utils/testWrapper";
+import ROUTES from "../../navigation/routes";
+import { appReducer } from "../../store/reducers";
+import { ContextualHelp } from "../ContextualHelp";
+
+jest.useFakeTimers();
+
+const options = {
+  title: "a title",
+  body: jest.fn(),
+  onClose: jest.fn()
+};
+
+/**
+ * Finds the first button with iconName as a child.
+ * Behaves as getAll*
+ *
+ * TODO: this helper is a stub for further development around an a11y-oriented
+ * library that can be shared across projects.
+ */
+function buttonByIconName(iconName: string, renderAPI: RenderAPI) {
+  return renderAPI.getAllByRole("button").find(
+    button =>
+      !!button.children.find(child => {
+        if (typeof child !== "string") {
+          return child.props.name === iconName;
+        }
+        return false;
+      })
+  );
+}
+
+describe("ContextualHelp component", () => {
+  it("should render a button with the 'io-close' icon", () => {
+    const component = renderComponent(options);
+    // ensure that the close icon is inside an accessible button
+    expect(buttonByIconName("io-close", component)).toBeDefined();
+  });
+
+  describe("when the close button is pressed", () => {
+    it("should call `onClose`", () => {
+      const onClose = jest.fn();
+      const component = renderComponent({ ...options, onClose });
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const closeButton = buttonByIconName("io-close", component)!;
+      fireEvent(closeButton, "onPress");
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("should render the body", () => {
+    const body = jest.fn(() => <Text>{"a very small body"}</Text>);
+    const component = renderComponent({ ...options, body });
+    expect(body).toHaveBeenCalledTimes(1);
+    expect(component.getByText("a very small body")).toBeDefined();
+  });
+
+  it("should render the title", () => {
+    const component = renderComponent(options);
+    expect(component.getByText(options.title)).toBeDefined();
+  });
+
+  it("should listen for the `hardwareBackPress` event and clean it up on unmount", () => {
+    const addEventSpy = jest.spyOn(BackHandler, "addEventListener");
+    const removeEventSpy = jest.spyOn(BackHandler, "removeEventListener");
+    const component = renderComponent(options);
+    expect(addEventSpy).toHaveBeenLastCalledWith(
+      "hardwareBackPress",
+      expect.any(Function)
+    );
+    component.unmount();
+    expect(removeEventSpy).toHaveBeenLastCalledWith(
+      "hardwareBackPress",
+      expect.any(Function)
+    );
+  });
+});
+
+function renderComponent(props: React.ComponentProps<typeof ContextualHelp>) {
+  const globalState = appReducer(undefined, applicationChangeState("active"));
+  return renderScreenFakeNavRedux<GlobalState, NavigationParams>(
+    () => <ContextualHelp {...props} />,
+    ROUTES.WALLET_CHECKOUT_3DS_SCREEN,
+    {},
+    createStore(appReducer, globalState as any)
+  );
+}

--- a/ts/components/__tests__/ContextualHelpComponent.test.tsx
+++ b/ts/components/__tests__/ContextualHelpComponent.test.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { NavigationParams } from "react-navigation";
+import { Text } from "react-native";
+import { createStore } from "redux";
+
+import { applicationChangeState } from "../../store/actions/application";
+// import I18n from "../../i18n";
+import { GlobalState } from "../../store/reducers/types";
+import { renderScreenFakeNavRedux } from "../../utils/testWrapper";
+import ROUTES from "../../navigation/routes";
+import { appReducer } from "../../store/reducers";
+import ContextualHelpComponent from "../ContextualHelpComponent";
+import { ContextualHelpData } from "../ContextualHelpModal";
+
+jest.useFakeTimers();
+
+const options = {
+  contextualHelpData: {
+    title: "a title",
+    content: null
+  },
+  onClose: jest.fn(),
+  isContentLoaded: true,
+  onRequestAssistance: jest.fn()
+};
+
+describe("ContextualHelpComponent", () => {
+  it("should render the title", () => {
+    expect(
+      renderComponent(options).getByText(options.contextualHelpData.title)
+    ).toBeDefined();
+  });
+
+  describe("when the title is an empty string", () => {
+    const contextualHelpData: ContextualHelpData = {
+      ...options.contextualHelpData,
+      title: ""
+    };
+    it("should not render the title", () => {
+      expect(
+        renderComponent({ ...options, contextualHelpData }).queryByText(
+          options.contextualHelpData.title
+        )
+      ).toBeNull();
+    });
+  });
+
+  describe("when the content is defined and not null", () => {
+    const contextualHelpData: ContextualHelpData = {
+      title: "THIS VERY TITLE",
+      content: <Text>{"the content"}</Text>
+    };
+
+    it("should render the content", () => {
+      expect(
+        renderComponent({ ...options, contextualHelpData }).getByText(
+          "the content"
+        )
+      ).toBeDefined();
+    });
+
+    it("should render the title", () => {
+      expect(
+        renderComponent({ ...options, contextualHelpData }).getByText(
+          contextualHelpData.title
+        )
+      ).toBeDefined();
+    });
+  });
+
+  describe("when the content is not defined", () => {
+    const contextualHelpData: ContextualHelpData = {
+      title: "MUST NEVER SHOW",
+      content: undefined
+    };
+
+    it("should render the loader", () => {
+      expect(
+        renderComponent({
+          ...options,
+          contextualHelpData
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        }).getByTestId("rn-activity-indicator")
+      ).toBeDefined();
+    });
+  });
+
+  describe("when the faqs are defined", () => {
+    const contextualHelpData: ContextualHelpData = {
+      ...options.contextualHelpData,
+      faqs: [{ title: "FAQ", content: "U" }]
+    };
+    it("should render the FAQs", () => {
+      expect(
+        renderComponent({
+          ...options,
+          contextualHelpData
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        }).getByText(contextualHelpData.faqs![0].title)
+      ).toBeDefined();
+    });
+  });
+});
+
+function renderComponent(
+  props: React.ComponentProps<typeof ContextualHelpComponent>
+) {
+  const globalState = appReducer(undefined, applicationChangeState("active"));
+  return renderScreenFakeNavRedux<GlobalState, NavigationParams>(
+    () => <ContextualHelpComponent {...props} />,
+    ROUTES.WALLET_CHECKOUT_3DS_SCREEN,
+    {},
+    createStore(appReducer, globalState as any)
+  );
+}

--- a/ts/components/ui/ActivityIndicator.tsx
+++ b/ts/components/ui/ActivityIndicator.tsx
@@ -8,7 +8,11 @@ interface Props {
 }
 
 const ActivityIndicator: React.SFC<Props> = ({ color }) => (
-  <RNActivityIndicator size="large" color={color || variables.brandPrimary} />
+  <RNActivityIndicator
+    size="large"
+    color={color || variables.brandPrimary}
+    testID="rn-activity-indicator"
+  />
 );
 
 export default ActivityIndicator;

--- a/ts/utils/emptyContextualHelp.tsx
+++ b/ts/utils/emptyContextualHelp.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-import { View } from "native-base";
 import { ContextualHelpProps } from "../components/screens/BaseScreenComponent";
 
 /**
@@ -9,5 +7,5 @@ import { ContextualHelpProps } from "../components/screens/BaseScreenComponent";
  */
 export const emptyContextualHelp: ContextualHelpProps = {
   title: "",
-  body: () => <View />
+  body: () => null
 };


### PR DESCRIPTION
## Short description
This was expect to be a short fix but led to a major refactoring due to the component's internal structure.
I decided to (perhaps) overdo the testing side because the lack of it made this task much more difficult than it should have been.

## List of changes proposed in this pull request
- the major change is that the body of [emptyContextualHelp](https://github.com/pagopa/io-app/compare/IA-9-remove-extra-space-context-help?expand=1#diff-5964beb965ba64ac8c59e200cef71c4ae29d9d759f5193414ec729905ccc3d08R10) now defaults to `null`
- updated the structure of [ContextualHelpComponent](ts/components/ContextualHelpComponent.tsx) to accommodate the new logic and avoid extra spacers be rendered
- add two new test files to ensure that my major change is reasonably safe and that future updates on the same component will be easier
- I've realized that we may need [some helpers like this one](https://github.com/pagopa/io-app/compare/IA-9-remove-extra-space-context-help?expand=1#diff-e7fa8fb828e920c395f22500f2ee38c01323dc0d8b8eea8c8d9207e4d48aff72R30) for testing. I don't want to broaden the scope of this PR and that's why I only added a TODO.

## How to test
* running the dev server, open a Covid Green Pass message
* click on `?` top right
* compare the title's alignement with the existing one

| before  | after |
| ------------- | ------------- |
|<img width="444" alt="Screenshot 2021-07-08 at 15 39 10" src="https://user-images.githubusercontent.com/2094604/124931604-ad7ae180-e002-11eb-8183-b8e88b6f1dc9.png">|<img width="443" alt="Screenshot 2021-07-08 at 15 38 47" src="https://user-images.githubusercontent.com/2094604/124931809-d9966280-e002-11eb-96a9-2f331487c5f7.png">|

