### PR TITLE
fix(Redesign Servizi): [IARS-37] Fix disabled webhook flag when reactivating service communication

### DIFF
--- a/ts/sagas/services/servicePreference/handleUpsertServicePreferenceSaga.ts
+++ b/ts/sagas/services/servicePreference/handleUpsertServicePreferenceSaga.ts
@@ -63,7 +63,7 @@ export function* handleUpsertServicePreference(
     servicePreferenceSelector
   );
 
-  const updatingPreference = calulateUpdatingPreference(
+  const updatingPreference = calculateUpdatingPreference(
     currentPreferences,
     action
   );

--- a/ts/sagas/services/servicePreference/handleUpsertServicePreferenceSaga.ts
+++ b/ts/sagas/services/servicePreference/handleUpsertServicePreferenceSaga.ts
@@ -21,7 +21,7 @@ import { mapKinds } from "./handleGetServicePreferenceSaga";
  * @param currentServicePreferenceState
  * @param action
  */
-const calulateUpdatingPreference = (
+const calculateUpdatingPreference = (
   currentServicePreferenceState: ServicePreferenceState,
   action: ActionType<typeof upsertServicePreference.request>
 ): ServicePreference => {

--- a/ts/sagas/services/servicePreference/handleUpsertServicePreferenceSaga.ts
+++ b/ts/sagas/services/servicePreference/handleUpsertServicePreferenceSaga.ts
@@ -17,7 +17,7 @@ import { mapKinds } from "./handleGetServicePreferenceSaga";
 /**
  * Generates the payload for the updating preferences request, if a users disables the inbox flag than the other flags
  * are disabled.
- * If a user activate a disabled inbox flag than webhook is enabled too.
+ * If a user activates a disabled inbox flag than webhook is enabled too.
  * @param currentServicePreferenceState
  * @param action
  */


### PR DESCRIPTION
## Short description
This PR fixes an issues that wouldn't reactivate notification channel if user reactivates the service communication

https://user-images.githubusercontent.com/3959405/124942626-174bb900-e00c-11eb-995e-705139b67309.mp4

