### PR TITLE
fix: [IA-125] Persisted store doesn't migrate

### DIFF
--- a/ts/boot/configureStoreAndPersistor.ts
+++ b/ts/boot/configureStoreAndPersistor.ts
@@ -37,7 +37,7 @@ import { configureReactotron } from "./configureRectotron";
 /**
  * Redux persist will migrate the store to the current version
  */
-const CURRENT_REDUX_STORE_VERSION = 15;
+const CURRENT_REDUX_STORE_VERSION = 16;
 
 // see redux-persist documentation:
 // https://github.com/rt2zz/redux-persist/blob/master/docs/migrations.md
@@ -232,6 +232,15 @@ const migrations: MigrationManifest = {
     return {
       ...state,
       persistedPreferences: { ...persistedPreferences, isMixpanelEnabled: null }
+    };
+  },
+  // Version 16
+  // default value for content.idps
+  "16": (state: PersistedState) => {
+    const content = (state as PersistedGlobalState).content;
+    return {
+      ...state,
+      content: { ...content, idps: remoteUndefined }
     };
   }
 };


### PR DESCRIPTION
## Short description
This PR adds a missing migration from version 15 to 16