### PR TITLE
chore: [IA-126] Persisted store snapshot test

### DIFF
--- a/ts/boot/__tests__/__snapshots__/persistedStore.test.ts.snap
+++ b/ts/boot/__tests__/__snapshots__/persistedStore.test.ts.snap
@@ -1,0 +1,155 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Check the addition for new fields to the persisted store. If one of this test fails, check that exists the migration before updating the snapshot! Freeze 'authentication' state 1`] = `
+Object {
+  "kind": "LoggedOutWithoutIdp",
+  "reason": "NOT_LOGGED_IN",
+}
+`;
+
+exports[`Check the addition for new fields to the persisted store. If one of this test fails, check that exists the migration before updating the snapshot! Freeze 'content' state 1`] = `
+Object {
+  "contextualHelp": Object {
+    "kind": "PotNone",
+  },
+  "idps": Object {
+    "kind": "undefined",
+  },
+  "municipality": Object {
+    "codiceCatastale": Object {
+      "kind": "PotNone",
+    },
+    "data": Object {
+      "kind": "PotNone",
+    },
+  },
+  "servicesMetadata": Object {
+    "byId": Object {},
+  },
+}
+`;
+
+exports[`Check the addition for new fields to the persisted store. If one of this test fails, check that exists the migration before updating the snapshot! Freeze 'crossSessions' state 1`] = `
+Object {
+  "hashedFiscalCode": undefined,
+}
+`;
+
+exports[`Check the addition for new fields to the persisted store. If one of this test fails, check that exists the migration before updating the snapshot! Freeze 'debug' state 1`] = `
+Object {
+  "isDebugModeEnabled": false,
+}
+`;
+
+exports[`Check the addition for new fields to the persisted store. If one of this test fails, check that exists the migration before updating the snapshot! Freeze 'entities' state 1`] = `
+Object {
+  "calendarEvents": Object {
+    "byMessageId": Object {},
+  },
+  "messages": Object {
+    "allIds": Object {
+      "kind": "PotNone",
+    },
+    "byId": Object {},
+    "idsByServiceId": Object {},
+  },
+  "messagesStatus": Object {},
+  "organizations": Object {
+    "all": Array [],
+    "nameByFiscalCode": Object {},
+  },
+  "paymentByRptId": Object {},
+  "services": Object {
+    "byId": Object {},
+    "byOrgFiscalCode": Object {},
+    "currentSelectedService": null,
+    "firstLoading": Object {
+      "isFirstServicesLoadingCompleted": false,
+    },
+    "readState": Object {},
+    "servicePreference": Object {
+      "kind": "PotNone",
+    },
+    "visible": Object {
+      "kind": "PotNone",
+    },
+  },
+  "transactionsRead": Object {},
+}
+`;
+
+exports[`Check the addition for new fields to the persisted store. If one of this test fails, check that exists the migration before updating the snapshot! Freeze 'identification' state 1`] = `
+Object {
+  "fail": undefined,
+  "progress": Object {
+    "kind": "unidentified",
+  },
+}
+`;
+
+exports[`Check the addition for new fields to the persisted store. If one of this test fails, check that exists the migration before updating the snapshot! Freeze 'installation' state 1`] = `
+Object {
+  "isFirstRunAfterInstall": true,
+}
+`;
+
+exports[`Check the addition for new fields to the persisted store. If one of this test fails, check that exists the migration before updating the snapshot! Freeze 'notifications' state 1`] = `
+Object {
+  "installation": Object {
+    "id": "fakeInstallationId",
+    "token": undefined,
+  },
+  "pendingMessage": null,
+}
+`;
+
+exports[`Check the addition for new fields to the persisted store. If one of this test fails, check that exists the migration before updating the snapshot! Freeze 'onboarding' state 1`] = `
+Object {
+  "isFingerprintAcknowledged": false,
+}
+`;
+
+exports[`Check the addition for new fields to the persisted store. If one of this test fails, check that exists the migration before updating the snapshot! Freeze 'payments' state 1`] = `
+Object {
+  "creditCardInsertion": Array [],
+  "current": Object {
+    "kind": "UNSTARTED",
+  },
+  "history": Array [],
+  "lastDeleted": null,
+}
+`;
+
+exports[`Check the addition for new fields to the persisted store. If one of this test fails, check that exists the migration before updating the snapshot! Freeze 'persistedPreferences' state 1`] = `
+Object {
+  "continueWithRootOrJailbreak": false,
+  "isCustomEmailChannelEnabled": Object {
+    "kind": "PotNone",
+  },
+  "isExperimentalFeaturesEnabled": false,
+  "isFingerprintEnabled": undefined,
+  "isMixpanelEnabled": null,
+  "isPagoPATestEnabled": false,
+  "preferredCalendar": undefined,
+  "preferredLanguage": undefined,
+  "wasServiceAlertDisplayedOnce": false,
+}
+`;
+
+exports[`Check the addition for new fields to the persisted store. If one of this test fails, check that exists the migration before updating the snapshot! Freeze 'profile' state 1`] = `
+Object {
+  "kind": "PotNone",
+}
+`;
+
+exports[`Check the addition for new fields to the persisted store. If one of this test fails, check that exists the migration before updating the snapshot! Freeze 'userMetadata' state 1`] = `
+Object {
+  "kind": "PotNone",
+}
+`;
+
+exports[`Check the addition for new fields to the persisted store. If one of this test fails, check that exists the migration before updating the snapshot! Freeze 'wallet.wallets.walletById' state 1`] = `
+Object {
+  "kind": "PotNone",
+}
+`;

--- a/ts/boot/__tests__/persistedStore.test.ts
+++ b/ts/boot/__tests__/persistedStore.test.ts
@@ -1,0 +1,57 @@
+import { applicationChangeState } from "../../store/actions/application";
+import { appReducer } from "../../store/reducers";
+import { GlobalState } from "../../store/reducers/types";
+
+describe("Check the addition for new fields to the persisted store. If one of this test fails, check that exists the migration before updating the snapshot!", () => {
+  jest.useFakeTimers();
+  const globalState = appReducer(undefined, applicationChangeState("active"));
+  it("Freeze 'onboarding' state", () => {
+    expect(globalState.onboarding).toMatchSnapshot();
+  });
+  it("Freeze 'notifications' state", () => {
+    const notifications: GlobalState["notifications"] = {
+      ...globalState.notifications,
+      installation: {
+        ...globalState.notifications.installation,
+        id: "fakeInstallationId"
+      }
+    };
+    expect(notifications).toMatchSnapshot();
+  });
+  it("Freeze 'profile' state", () => {
+    expect(globalState.profile).toMatchSnapshot();
+  });
+  it("Freeze 'debug' state", () => {
+    expect(globalState.debug).toMatchSnapshot();
+  });
+  it("Freeze 'persistedPreferences' state", () => {
+    expect(globalState.persistedPreferences).toMatchSnapshot();
+  });
+  it("Freeze 'installation' state", () => {
+    expect(globalState.installation).toMatchSnapshot();
+  });
+  it("Freeze 'payments' state", () => {
+    expect(globalState.payments).toMatchSnapshot();
+  });
+  it("Freeze 'content' state", () => {
+    expect(globalState.content).toMatchSnapshot();
+  });
+  it("Freeze 'userMetadata' state", () => {
+    expect(globalState.userMetadata).toMatchSnapshot();
+  });
+  it("Freeze 'crossSessions' state", () => {
+    expect(globalState.crossSessions).toMatchSnapshot();
+  });
+  it("Freeze 'entities' state", () => {
+    expect(globalState.entities).toMatchSnapshot();
+  });
+  it("Freeze 'authentication' state", () => {
+    expect(globalState.authentication).toMatchSnapshot();
+  });
+  it("Freeze 'identification' state", () => {
+    expect(globalState.identification).toMatchSnapshot();
+  });
+  it("Freeze 'wallet.wallets.walletById' state", () => {
+    expect(globalState.wallet.wallets.walletById).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Short description
This pr adds the snapshot tests for the persisted store, in order to "freeze" the current layout of the persisted store and fails when a new fields is added. When this happens, it will serve as a reminder to write a migration, if it has not already been done.

## List of changes proposed in this pull request
- Added snapshot tests for all the persisted store sections.

## How to test
Run `ts/boot/__tests__/persistedStore.test.ts`
