### PR TITLE
fix(Redesign Servizi): [IARS-36] Android doesn't show activity indicator on service preference switches

### DIFF
--- a/ts/components/services/ContactPreferencesToggles/PreferenceToggleRow.tsx
+++ b/ts/components/services/ContactPreferencesToggles/PreferenceToggleRow.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { View, StyleSheet, ActivityIndicator } from "react-native";
+import { View, StyleSheet } from "react-native";
 import Switch from "../../ui/Switch";
 import { H4 } from "../../core/typography/H4";
 import { IOStyles } from "../../core/variables/IOStyles";
@@ -8,6 +8,7 @@ import { IOColors } from "../../core/variables/IOColors";
 import TouchableDefaultOpacity from "../../TouchableDefaultOpacity";
 import I18n from "../../../i18n";
 import { WithTestID } from "../../../types/WithTestID";
+import ActivityIndicator from "../../ui/ActivityIndicator";
 
 type Props = WithTestID<{
   label: string;
@@ -41,6 +42,7 @@ const PreferenceToggleRow = ({
       case "loading":
         return (
           <ActivityIndicator
+            size={"small"}
             testID={`${testID}-loading`}
             accessibilityLabel={I18n.t("global.remoteStates.loading")}
           />

--- a/ts/components/services/ContactPreferencesToggles/__test__/ContactPreferencesToggles.test.tsx
+++ b/ts/components/services/ContactPreferencesToggles/__test__/ContactPreferencesToggles.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import configureMockStore from "redux-mock-store";
 import { render } from "@testing-library/react-native";
 import { Provider } from "react-redux";
+import { Store } from "redux";
 import { NotificationChannelEnum } from "../../../../../definitions/backend/NotificationChannel";
 import { applicationChangeState } from "../../../../store/actions/application";
 import { GlobalState } from "../../../../store/reducers/types";
@@ -88,6 +89,66 @@ describe("ContactPreferencesToggles component", () => {
       // ).toBeDefined();
     });
   });
+
+  describe("when channels are loading", () => {
+    it("should render activity indicator on inbox", () => {
+      const initialState = appReducer(
+        undefined,
+        loadServicePreference.success({
+          id: "some_id" as ServiceId,
+          kind: "success",
+          value: { inbox: true, email: true, push: true, settings_version: 0 }
+        })
+      );
+      // the store will be in someLoading
+      const state = appReducer(
+        initialState,
+        loadServicePreference.request("aServiceID" as ServiceId)
+      );
+      const mockStore = configureMockStore<GlobalState>();
+      const store = mockStore({
+        ...state
+      } as GlobalState);
+      const component = renderComponent(store, {
+        channels: [
+          NotificationChannelEnum.EMAIL,
+          NotificationChannelEnum.WEBHOOK
+        ]
+      });
+      expect(
+        component.getByTestId("contact-preferences-inbox-switch-loading")
+      ).toBeDefined();
+      expect(
+        component.getByTestId("contact-preferences-webhook-switch-loading")
+      ).toBeDefined();
+    });
+  });
+
+  describe("when channels are loading", () => {
+    it("should render activity indicator on inbox and webhook", () => {
+      const initialState = appReducer(
+        undefined,
+        applicationChangeState("active")
+      );
+      const state = appReducer(
+        initialState,
+        loadServicePreference.request("aServiceID" as ServiceId)
+      );
+      const mockStore = configureMockStore<GlobalState>();
+      const store = mockStore({
+        ...state
+      } as GlobalState);
+      const component = renderComponent(store, {
+        channels: [
+          NotificationChannelEnum.EMAIL,
+          NotificationChannelEnum.WEBHOOK
+        ]
+      });
+      expect(
+        component.getByTestId("contact-preferences-inbox-switch-loading")
+      ).toBeDefined();
+    });
+  });
 });
 
 const mockState = (servicePreference: ServicePreferenceResponse) => {
@@ -103,7 +164,7 @@ const mockState = (servicePreference: ServicePreferenceResponse) => {
 };
 
 const renderComponent = (
-  store: any,
+  store: Store<unknown>,
   options: {
     channels?: ReadonlyArray<NotificationChannelEnum>;
   }

--- a/ts/components/services/ContactPreferencesToggles/__test__/ContactPreferencesToggles.test.tsx
+++ b/ts/components/services/ContactPreferencesToggles/__test__/ContactPreferencesToggles.test.tsx
@@ -122,9 +122,7 @@ describe("ContactPreferencesToggles component", () => {
         component.getByTestId("contact-preferences-webhook-switch-loading")
       ).toBeDefined();
     });
-  });
 
-  describe("when channels are loading", () => {
     it("should render activity indicator on inbox and webhook", () => {
       const initialState = appReducer(
         undefined,

--- a/ts/components/ui/ActivityIndicator.tsx
+++ b/ts/components/ui/ActivityIndicator.tsx
@@ -1,17 +1,24 @@
 import * as React from "react";
-import { ActivityIndicator as RNActivityIndicator } from "react-native";
+import {
+  ActivityIndicator as RNActivityIndicator,
+  ActivityIndicatorProps
+} from "react-native";
 
 import variables from "../../theme/variables";
+import { WithTestID } from "../../types/WithTestID";
 
-interface Props {
+type Props = WithTestID<{
   color?: string;
-}
+  accessibilityLabel?: string;
+  size?: ActivityIndicatorProps["size"];
+}>;
 
-const ActivityIndicator: React.SFC<Props> = ({ color }) => (
+const ActivityIndicator = (props: Props) => (
   <RNActivityIndicator
-    size="large"
-    color={color || variables.brandPrimary}
-    testID="rn-activity-indicator"
+    size={props.size ?? "large"}
+    accessibilityLabel={props.accessibilityLabel}
+    color={props.color || variables.brandPrimary}
+    testID={props.testID ?? "rn-activity-indicator"}
   />
 );
 

--- a/ts/components/ui/ActivityIndicator.tsx
+++ b/ts/components/ui/ActivityIndicator.tsx
@@ -5,15 +5,8 @@ import {
 } from "react-native";
 
 import variables from "../../theme/variables";
-import { WithTestID } from "../../types/WithTestID";
 
-type Props = WithTestID<{
-  color?: string;
-  accessibilityLabel?: string;
-  size?: ActivityIndicatorProps["size"];
-}>;
-
-const ActivityIndicator = (props: Props) => (
+const ActivityIndicator = (props: ActivityIndicatorProps) => (
   <RNActivityIndicator
     size={props.size ?? "large"}
     accessibilityLabel={props.accessibilityLabel}

--- a/ts/components/ui/__test__/ActivityIndicator.test.tsx
+++ b/ts/components/ui/__test__/ActivityIndicator.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import ActivityIndicator from "../ActivityIndicator";
 
 describe("ActivityIndicator", () => {
-  it("Freeze 'ActivityIndicator' state", () => {
+  it("should match the snapshot with default props", () => {
     expect(TestRenderer.create(<ActivityIndicator />)).toMatchSnapshot();
   });
 });

--- a/ts/components/ui/__test__/ActivityIndicator.test.tsx
+++ b/ts/components/ui/__test__/ActivityIndicator.test.tsx
@@ -1,0 +1,9 @@
+import TestRenderer from "react-test-renderer";
+import React from "react";
+import ActivityIndicator from "../ActivityIndicator";
+
+describe("ActivityIndicator", () => {
+  it("Freeze 'ActivityIndicator' state", () => {
+    expect(TestRenderer.create(<ActivityIndicator />)).toMatchSnapshot();
+  });
+});

--- a/ts/components/ui/__test__/__snapshots__/ActivityIndicator.test.tsx.snap
+++ b/ts/components/ui/__test__/__snapshots__/ActivityIndicator.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`des Freeze 'onboarding' state 1`] = `
+<ActivityIndicator
+  animating={true}
+  color="#0066CC"
+  hidesWhenStopped={true}
+  size="large"
+  testID="rn-activity-indicator"
+/>
+`;

--- a/ts/components/ui/__test__/__snapshots__/ActivityIndicator.test.tsx.snap
+++ b/ts/components/ui/__test__/__snapshots__/ActivityIndicator.test.tsx.snap
@@ -9,13 +9,3 @@ exports[`ActivityIndicator Freeze 'ActivityIndicator' state 1`] = `
   testID="rn-activity-indicator"
 />
 `;
-
-exports[`des Freeze 'onboarding' state 1`] = `
-<ActivityIndicator
-  animating={true}
-  color="#0066CC"
-  hidesWhenStopped={true}
-  size="large"
-  testID="rn-activity-indicator"
-/>
-`;

--- a/ts/components/ui/__test__/__snapshots__/ActivityIndicator.test.tsx.snap
+++ b/ts/components/ui/__test__/__snapshots__/ActivityIndicator.test.tsx.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ActivityIndicator Freeze 'ActivityIndicator' state 1`] = `
+<ActivityIndicator
+  animating={true}
+  color="#0066CC"
+  hidesWhenStopped={true}
+  size="large"
+  testID="rn-activity-indicator"
+/>
+`;
+
 exports[`des Freeze 'onboarding' state 1`] = `
 <ActivityIndicator
   animating={true}

--- a/ts/components/ui/__test__/__snapshots__/ActivityIndicator.test.tsx.snap
+++ b/ts/components/ui/__test__/__snapshots__/ActivityIndicator.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ActivityIndicator Freeze 'ActivityIndicator' state 1`] = `
+exports[`ActivityIndicator should match the snapshot with default props 1`] = `
 <ActivityIndicator
   animating={true}
   color="#0066CC"

--- a/ts/features/bonus/bpd/saga/orchestration/__tests__/activateBpdOnNewPaymentMethods.test.ts
+++ b/ts/features/bonus/bpd/saga/orchestration/__tests__/activateBpdOnNewPaymentMethods.test.ts
@@ -15,11 +15,13 @@ import { isBpdEnabled } from "../onboarding/startOnboarding";
 import { BpdConfig } from "../../../../../../../definitions/content/BpdConfig";
 
 const enrollAfterAddTrue: BpdConfig = {
-  enroll_bpd_after_add_payment_method: true
+  enroll_bpd_after_add_payment_method: true,
+  program_active: true
 };
 
 const enrollAfterAddFalse: BpdConfig = {
-  enroll_bpd_after_add_payment_method: false
+  enroll_bpd_after_add_payment_method: false,
+  program_active: true
 };
 
 describe("Test activateBpdOnNewPaymentMethods behaviour", () => {

--- a/ts/store/reducers/__mock__/backendStatus.ts
+++ b/ts/store/reducers/__mock__/backendStatus.ts
@@ -171,7 +171,8 @@ export const baseRawBackendStatus: BackendStatus = {
   },
   config: {
     bpd: {
-      enroll_bpd_after_add_payment_method: false
+      enroll_bpd_after_add_payment_method: false,
+      program_active: true
     },
     bpd_ranking: true,
     bpd_ranking_v2: true,

--- a/ts/store/reducers/__mock__/backendStatus.ts
+++ b/ts/store/reducers/__mock__/backendStatus.ts
@@ -188,7 +188,8 @@ export const baseBackendState: BackendStatusState = {
 
 export const baseBackendConfig: Config = {
   bpd: {
-    enroll_bpd_after_add_payment_method: false
+    enroll_bpd_after_add_payment_method: false,
+    program_active: true
   },
   bpd_ranking: true,
   bpd_ranking_v2: true,


### PR DESCRIPTION
## Short description
This PR fixes a bug that doesn't show activity indicator on Android when the user makes some changes on his/her services preferences

### before iOS
https://user-images.githubusercontent.com/822471/125633856-5a2d4340-013c-400d-a0d0-f7655143d11b.mov

### now iOS
https://user-images.githubusercontent.com/822471/125633858-7c344dfc-f120-45a8-9ec3-65b8012e1841.mov

### before Android
https://user-images.githubusercontent.com/822471/125633838-95732da9-a877-4a77-9cf1-197de759c6e7.mp4

### now Android
https://user-images.githubusercontent.com/822471/125633847-f76c742e-c6d5-49e3-9e28-1c15c252f0ac.mp4









