### PR TITLE
chore: [IA-97] Add SectionStatusComponent to the favourite language screen

### DIFF
--- a/ts/screens/profile/LanguagesPreferencesScreen.tsx
+++ b/ts/screens/profile/LanguagesPreferencesScreen.tsx
@@ -155,7 +155,7 @@ class LanguagesPreferencesScreen extends React.PureComponent<Props, State> {
               })}
             </List>
           </ScreenContent>
-          <SectionStatusComponent sectionKey={"email_validation"} />
+          <SectionStatusComponent sectionKey={"favourite_language"} />
         </SafeAreaView>
       </TopScreenComponent>
     ));

--- a/ts/screens/profile/LanguagesPreferencesScreen.tsx
+++ b/ts/screens/profile/LanguagesPreferencesScreen.tsx
@@ -1,7 +1,7 @@
 import { List } from "native-base";
 import * as pot from "italia-ts-commons/lib/pot";
 import * as React from "react";
-import { Alert } from "react-native";
+import { Alert, SafeAreaView } from "react-native";
 import { connect } from "react-redux";
 import { fromNullable } from "fp-ts/lib/Option";
 import { Locales, TranslationKeys } from "../../../locales/locales";
@@ -25,6 +25,8 @@ import { profileUpsert } from "../../store/actions/profile";
 import { withLoadingSpinner } from "../../components/helpers/withLoadingSpinner";
 import { profileSelector } from "../../store/reducers/profile";
 import { showToast } from "../../utils/showToast";
+import { IOStyles } from "../../components/core/variables/IOStyles";
+import SectionStatusComponent from "../../components/SectionStatusComponent";
 
 type Props = LightModalContextInterface &
   ReturnType<typeof mapDispatchToProps> &
@@ -120,38 +122,41 @@ class LanguagesPreferencesScreen extends React.PureComponent<Props, State> {
         headerTitle={I18n.t("profile.preferences.title")}
         goBack={true}
       >
-        <ScreenContent
-          title={I18n.t("profile.preferences.list.preferred_language.title")}
-          subtitle={I18n.t(
-            "profile.preferences.list.preferred_language.subtitle"
-          )}
-        >
-          <List withContentLateralPadding={true}>
-            {availableTranslations.map((lang, index) => {
-              const isSelectedLanguage = this.isAlreadyPreferred(lang);
-              const languageTitle = I18n.t(`locales.${lang}`, {
-                defaultValue: lang
-              });
-              return (
-                <ListItemComponent
-                  key={index}
-                  title={languageTitle}
-                  hideIcon={!isSelectedLanguage}
-                  iconSize={iconSize}
-                  iconName={isSelectedLanguage ? "io-tick-big" : undefined}
-                  onPress={() => this.onLanguageSelected(lang)}
-                  accessible={true}
-                  accessibilityRole={"radio"}
-                  accessibilityLabel={`${languageTitle}, ${
-                    isSelectedLanguage
-                      ? I18n.t("global.accessibility.active")
-                      : I18n.t("global.accessibility.inactive")
-                  }`}
-                />
-              );
-            })}
-          </List>
-        </ScreenContent>
+        <SafeAreaView style={IOStyles.flex}>
+          <ScreenContent
+            title={I18n.t("profile.preferences.list.preferred_language.title")}
+            subtitle={I18n.t(
+              "profile.preferences.list.preferred_language.subtitle"
+            )}
+          >
+            <List withContentLateralPadding={true}>
+              {availableTranslations.map((lang, index) => {
+                const isSelectedLanguage = this.isAlreadyPreferred(lang);
+                const languageTitle = I18n.t(`locales.${lang}`, {
+                  defaultValue: lang
+                });
+                return (
+                  <ListItemComponent
+                    key={index}
+                    title={languageTitle}
+                    hideIcon={!isSelectedLanguage}
+                    iconSize={iconSize}
+                    iconName={isSelectedLanguage ? "io-tick-big" : undefined}
+                    onPress={() => this.onLanguageSelected(lang)}
+                    accessible={true}
+                    accessibilityRole={"radio"}
+                    accessibilityLabel={`${languageTitle}, ${
+                      isSelectedLanguage
+                        ? I18n.t("global.accessibility.active")
+                        : I18n.t("global.accessibility.inactive")
+                    }`}
+                  />
+                );
+              })}
+            </List>
+          </ScreenContent>
+          <SectionStatusComponent sectionKey={"email_validation"} />
+        </SafeAreaView>
       </TopScreenComponent>
     ));
     return <ContainerComponent isLoading={this.state.isLoading} />;

--- a/ts/store/reducers/__mock__/backendStatus.ts
+++ b/ts/store/reducers/__mock__/backendStatus.ts
@@ -159,6 +159,14 @@ export const baseRawBackendStatus: BackendStatus = {
         "it-IT": "euCovidCert banner test",
         "en-EN": "euCovidCert banner test"
       }
+    },
+    favourite_language: {
+      is_visible: false,
+      level: LevelEnum.warning,
+      message: {
+        "it-IT": "favourite_language banner test",
+        "en-EN": "favourite_language banner test"
+      }
     }
   },
   config: {


### PR DESCRIPTION
## Short description
This PR add `SectionStatusComponent` to the favourite language screen

## List of changes proposed in this pull request
- add the `SectionStatusComponent` to the `LanguagesPreferencesScreen` with key `email_validation`
<img src="https://user-images.githubusercontent.com/11773070/125756075-024dba87-6efe-4162-9251-ae8154ac5b2d.png" width=300>

## How to test
Checkout this branch: [IA-97-show-banner-language-section](https://github.com/pagopa/io-dev-api-server/tree/IA-97-show-banner-language-section) on the `io-dev-api-server` and set to `true` the field `is_visible` in the [favourite_language](https://github.com/pagopa/io-dev-api-server/blob/d01707890609e3def06bfccec0e9459125ec08cc/src/payloads/backend.ts#L168) section 
