### PR TITLE
feat(Bonus Pagamenti Digitali): [IAC-101] Display cashback capability for a payment method only if the cashback program is active

### DIFF
--- a/ts/features/bonus/bpd/components/BpdPaymentMethodCapability.tsx
+++ b/ts/features/bonus/bpd/components/BpdPaymentMethodCapability.tsx
@@ -89,7 +89,7 @@ const BpdPaymentMethodCapability: React.FunctionComponent<Props> = props => {
 
   return (
     <>
-      <View style={styles.row}>
+      <View style={styles.row} testID={"BpdPaymentMethodCapability"}>
         <View style={styles.left}>
           <H4 weight={"SemiBold"} color={"bluegreyDark"}>
             {I18n.t("bonus.bpd.title")}

--- a/ts/features/bonus/bpd/components/BpdPaymentMethodCapability.tsx
+++ b/ts/features/bonus/bpd/components/BpdPaymentMethodCapability.tsx
@@ -88,29 +88,27 @@ const BpdPaymentMethodCapability: React.FunctionComponent<Props> = props => {
   }).present;
 
   return (
-    <>
-      <View style={styles.row} testID={"BpdPaymentMethodCapability"}>
-        <View style={styles.left}>
-          <H4 weight={"SemiBold"} color={"bluegreyDark"}>
-            {I18n.t("bonus.bpd.title")}
-          </H4>
-          <H5 weight={"Regular"} color={"bluegrey"}>
-            {I18n.t("bonus.bpd.description")}
-          </H5>
-        </View>
-        <BpdToggle
-          graphicalValue={graphicalState}
-          onPress={() => showExplanation("NotActivable")}
-          onValueChanged={newVal =>
-            handleValueChanged(props, () =>
-              askConfirmation(newVal, () =>
-                props.updateValue(hash as HPan, newVal)
-              )
-            )
-          }
-        />
+    <View style={styles.row} testID={"BpdPaymentMethodCapability"}>
+      <View style={styles.left}>
+        <H4 weight={"SemiBold"} color={"bluegreyDark"}>
+          {I18n.t("bonus.bpd.title")}
+        </H4>
+        <H5 weight={"Regular"} color={"bluegrey"}>
+          {I18n.t("bonus.bpd.description")}
+        </H5>
       </View>
-    </>
+      <BpdToggle
+        graphicalValue={graphicalState}
+        onPress={() => showExplanation("NotActivable")}
+        onValueChanged={newVal =>
+          handleValueChanged(props, () =>
+            askConfirmation(newVal, () =>
+              props.updateValue(hash as HPan, newVal)
+            )
+          )
+        }
+      />
+    </View>
   );
 };
 

--- a/ts/features/bonus/bpd/components/BpdPaymentMethodCapability.tsx
+++ b/ts/features/bonus/bpd/components/BpdPaymentMethodCapability.tsx
@@ -40,6 +40,7 @@ type Props = ReturnType<typeof mapDispatchToProps> &
 
 const styles = StyleSheet.create({
   row: {
+    paddingVertical: 16,
     flexDirection: "row",
     justifyContent: "space-between"
   },
@@ -87,27 +88,29 @@ const BpdPaymentMethodCapability: React.FunctionComponent<Props> = props => {
   }).present;
 
   return (
-    <View style={styles.row}>
-      <View style={styles.left}>
-        <H4 weight={"SemiBold"} color={"bluegreyDark"}>
-          {I18n.t("bonus.bpd.title")}
-        </H4>
-        <H5 weight={"Regular"} color={"bluegrey"}>
-          {I18n.t("bonus.bpd.description")}
-        </H5>
-      </View>
-      <BpdToggle
-        graphicalValue={graphicalState}
-        onPress={() => showExplanation("NotActivable")}
-        onValueChanged={newVal =>
-          handleValueChanged(props, () =>
-            askConfirmation(newVal, () =>
-              props.updateValue(hash as HPan, newVal)
+    <>
+      <View style={styles.row}>
+        <View style={styles.left}>
+          <H4 weight={"SemiBold"} color={"bluegreyDark"}>
+            {I18n.t("bonus.bpd.title")}
+          </H4>
+          <H5 weight={"Regular"} color={"bluegrey"}>
+            {I18n.t("bonus.bpd.description")}
+          </H5>
+        </View>
+        <BpdToggle
+          graphicalValue={graphicalState}
+          onPress={() => showExplanation("NotActivable")}
+          onValueChanged={newVal =>
+            handleValueChanged(props, () =>
+              askConfirmation(newVal, () =>
+                props.updateValue(hash as HPan, newVal)
+              )
             )
-          )
-        }
-      />
-    </View>
+          }
+        />
+      </View>
+    </>
   );
 };
 

--- a/ts/features/wallet/bancomat/screen/BancomatDetailScreen.tsx
+++ b/ts/features/wallet/bancomat/screen/BancomatDetailScreen.tsx
@@ -121,7 +121,6 @@ const BancomatDetailScreen: React.FunctionComponent<Props> = props => {
         <ItemSeparatorComponent noPadded={true} />
         <View spacer={true} />
         <PaymentMethodCapabilities paymentMethod={bancomat} />
-        <View spacer={true} />
         <ItemSeparatorComponent noPadded={true} />
         <View spacer={true} />
         <UnsubscribeButton

--- a/ts/features/wallet/bancomatpay/screen/BPayDetailScreen.tsx
+++ b/ts/features/wallet/bancomatpay/screen/BPayDetailScreen.tsx
@@ -101,7 +101,6 @@ const BPayDetailScreen: React.FunctionComponent<Props> = props => {
       <View spacer={true} extralarge={true} />
       <View style={IOStyles.horizontalContentPadding}>
         <PaymentMethodCapabilities paymentMethod={bPay} />
-        <View spacer={true} />
         <View spacer={true} large={true} />
         <UnsubscribeButton
           onPress={() =>

--- a/ts/features/wallet/cobadge/screen/CobadgeDetailScreen.tsx
+++ b/ts/features/wallet/cobadge/screen/CobadgeDetailScreen.tsx
@@ -98,7 +98,6 @@ const CobadgeDetailScreen: React.FunctionComponent<Props> = props => {
       <View spacer={true} extralarge={true} />
       <View style={IOStyles.horizontalContentPadding}>
         <PaymentMethodCapabilities paymentMethod={cobadge} />
-        <View spacer={true} />
         <View spacer={true} large={true} />
         <UnsubscribeButton
           onPress={() =>

--- a/ts/features/wallet/component/PagoPaPaymentCapability.tsx
+++ b/ts/features/wallet/component/PagoPaPaymentCapability.tsx
@@ -19,6 +19,7 @@ import { openWebUrl } from "../../../utils/url";
 
 const styles = StyleSheet.create({
   row: {
+    paddingVertical: 16,
     flexDirection: "row",
     justifyContent: "space-between"
   },

--- a/ts/features/wallet/component/PaymentMethodCapabilities.tsx
+++ b/ts/features/wallet/component/PaymentMethodCapabilities.tsx
@@ -95,11 +95,7 @@ const PaymentMethodCapabilities: React.FunctionComponent<Props> = props => {
         <H3 color={"bluegrey"}>{I18n.t("wallet.capability.title")}</H3>
       </View>
       {capabilityItems}
-      {capabilityItems.length > 0 && (
-        <>
-          <ItemSeparatorComponent noPadded={true} />
-        </>
-      )}
+      {capabilityItems.length > 0 && <ItemSeparatorComponent noPadded={true} />}
       <PagoPaPaymentCapability paymentMethod={props.paymentMethod} />
     </>
   );

--- a/ts/features/wallet/component/PaymentMethodCapabilities.tsx
+++ b/ts/features/wallet/component/PaymentMethodCapabilities.tsx
@@ -3,12 +3,14 @@ import * as React from "react";
 import { StyleSheet } from "react-native";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
+import { BpdConfig } from "../../../../definitions/content/BpdConfig";
 import { H3 } from "../../../components/core/typography/H3";
 import { IOColors } from "../../../components/core/variables/IOColors";
 import ItemSeparatorComponent from "../../../components/ItemSeparatorComponent";
 import IconFont from "../../../components/ui/IconFont";
 import { bpdEnabled } from "../../../config";
 import I18n from "../../../i18n";
+import { bpdRemoteConfigSelector } from "../../../store/reducers/backendStatus";
 import { GlobalState } from "../../../store/reducers/types";
 import {
   EnableableFunctionsTypeEnum,
@@ -31,14 +33,15 @@ const styles = StyleSheet.create({
 const capabilityFactory = (
   paymentMethod: PaymentMethod,
   capability: EnableableFunctionsTypeEnum,
-  index: number
+  index: number,
+  bpdRemoteConfig?: BpdConfig
 ) => {
   switch (capability) {
     case EnableableFunctionsTypeEnum.FA:
     case EnableableFunctionsTypeEnum.pagoPA:
       return null;
     case EnableableFunctionsTypeEnum.BPD:
-      return bpdEnabled ? (
+      return bpdEnabled && bpdRemoteConfig?.program_active ? (
         <BpdPaymentMethodCapability
           paymentMethod={paymentMethod}
           key={`capability_item_${index}`}
@@ -47,11 +50,24 @@ const capabilityFactory = (
   }
 };
 
-const generateCapabilityItems = (paymentMethod: PaymentMethod) =>
+/** *
+ * Extracts the capabilities from a {@link PaymentMethod}, based on the enableableFunctions
+ * @param paymentMethod
+ * @param bpdRemoteConfig
+ */
+const generateCapabilityItems = (
+  paymentMethod: PaymentMethod,
+  bpdRemoteConfig?: BpdConfig
+) =>
   paymentMethod.enableableFunctions.reduce((acc, val, i): ReadonlyArray<
     React.ReactNode
   > => {
-    const handlerForCapability = capabilityFactory(paymentMethod, val, i);
+    const handlerForCapability = capabilityFactory(
+      paymentMethod,
+      val,
+      i,
+      bpdRemoteConfig
+    );
     return handlerForCapability === null ? acc : [...acc, handlerForCapability];
   }, [] as ReadonlyArray<React.ReactNode>);
 
@@ -61,7 +77,10 @@ const generateCapabilityItems = (paymentMethod: PaymentMethod) =>
  * @constructor
  */
 const PaymentMethodCapabilities: React.FunctionComponent<Props> = props => {
-  const capabilityItems = generateCapabilityItems(props.paymentMethod);
+  const capabilityItems = generateCapabilityItems(
+    props.paymentMethod,
+    props.bpdRemoteConfig
+  );
 
   return (
     <>
@@ -75,15 +94,12 @@ const PaymentMethodCapabilities: React.FunctionComponent<Props> = props => {
         <View hspacer={true} />
         <H3 color={"bluegrey"}>{I18n.t("wallet.capability.title")}</H3>
       </View>
-      <View spacer={true} />
       {capabilityItems}
       {capabilityItems.length > 0 && (
         <>
-          <View spacer={true} />
           <ItemSeparatorComponent noPadded={true} />
         </>
       )}
-      <View spacer={true} />
       <PagoPaPaymentCapability paymentMethod={props.paymentMethod} />
     </>
   );
@@ -91,7 +107,9 @@ const PaymentMethodCapabilities: React.FunctionComponent<Props> = props => {
 
 const mapDispatchToProps = (_: Dispatch) => ({});
 
-const mapStateToProps = (_: GlobalState) => ({});
+const mapStateToProps = (state: GlobalState) => ({
+  bpdRemoteConfig: bpdRemoteConfigSelector(state)
+});
 
 export default connect(
   mapStateToProps,

--- a/ts/features/wallet/component/PaymentMethodCapabilities.tsx
+++ b/ts/features/wallet/component/PaymentMethodCapabilities.tsx
@@ -42,10 +42,13 @@ const capabilityFactory = (
       return null;
     case EnableableFunctionsTypeEnum.BPD:
       return bpdEnabled && bpdRemoteConfig?.program_active ? (
-        <BpdPaymentMethodCapability
-          paymentMethod={paymentMethod}
-          key={`capability_item_${index}`}
-        />
+        <>
+          <BpdPaymentMethodCapability
+            paymentMethod={paymentMethod}
+            key={`capability_item_${index}`}
+          />
+          <ItemSeparatorComponent noPadded={true} />
+        </>
       ) : null;
   }
 };
@@ -58,7 +61,7 @@ const capabilityFactory = (
 const generateCapabilityItems = (
   paymentMethod: PaymentMethod,
   bpdRemoteConfig?: BpdConfig
-) =>
+): ReadonlyArray<React.ReactNode> =>
   paymentMethod.enableableFunctions.reduce((acc, val, i): ReadonlyArray<
     React.ReactNode
   > => {
@@ -95,7 +98,6 @@ const PaymentMethodCapabilities: React.FunctionComponent<Props> = props => {
         <H3 color={"bluegrey"}>{I18n.t("wallet.capability.title")}</H3>
       </View>
       {capabilityItems}
-      {capabilityItems.length > 0 && <ItemSeparatorComponent noPadded={true} />}
       <PagoPaPaymentCapability paymentMethod={props.paymentMethod} />
     </>
   );

--- a/ts/features/wallet/component/__test__/PaymentMethodCapability.test.tsx
+++ b/ts/features/wallet/component/__test__/PaymentMethodCapability.test.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+import { NavigationParams } from "react-navigation";
+import { createStore } from "redux";
+import { BackendStatus } from "../../../../../definitions/content/BackendStatus";
+import ROUTES from "../../../../navigation/routes";
+import { applicationChangeState } from "../../../../store/actions/application";
+import { backendStatusLoadSuccess } from "../../../../store/actions/backendStatus";
+import { appReducer } from "../../../../store/reducers";
+import { baseRawBackendStatus } from "../../../../store/reducers/__mock__/backendStatus";
+import { GlobalState } from "../../../../store/reducers/types";
+import { mockPrivativeCard } from "../../../../store/reducers/wallet/__mocks__/wallets";
+import { PaymentMethod } from "../../../../types/pagopa";
+import { renderScreenFakeNavRedux } from "../../../../utils/testWrapper";
+import PaymentMethodCapabilities from "../PaymentMethodCapabilities";
+
+jest.mock("@gorhom/bottom-sheet", () => ({
+  useBottomSheetModal: () => ({
+    present: jest.fn()
+  })
+}));
+
+jest.mock("../../../../config", () => ({ bpdEnabled: true }));
+
+describe("Test for PaymentMethodCapabilities", () => {
+  jest.useFakeTimers();
+  it("With undefined bpd remote configuration, the BpdPaymentMethodCapability will not be rendered", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+    const component = renderComponent(store.getState(), mockPrivativeCard);
+    expect(component.queryByTestId("BpdPaymentMethodCapability")).toBeNull();
+  });
+  it("With program_active===true in remote configuration, the BpdPaymentMethodCapability will be rendered", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+    store.dispatch(backendStatusLoadSuccess(baseRawBackendStatus));
+
+    const component = renderComponent(store.getState(), mockPrivativeCard);
+    expect(
+      component.queryByTestId("BpdPaymentMethodCapability")
+    ).not.toBeNull();
+  });
+  it("With program_active===true in remote configuration and a payment method without the bpd capabilities, the BpdPaymentMethodCapability will not be rendered", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+    store.dispatch(backendStatusLoadSuccess(baseRawBackendStatus));
+
+    const component = renderComponent(store.getState(), {
+      ...mockPrivativeCard,
+      enableableFunctions: ["FA", "pagoPA"]
+    } as PaymentMethod);
+    expect(component.queryByTestId("BpdPaymentMethodCapability")).toBeNull();
+  });
+  it("With program_active===false in remote configuration, the BpdPaymentMethodCapability will not be rendered", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+    store.dispatch(
+      backendStatusLoadSuccess({
+        ...baseRawBackendStatus,
+        config: {
+          ...baseRawBackendStatus.config,
+          bpd: {
+            ...baseRawBackendStatus.config.bpd,
+            program_active: false
+          }
+        }
+      } as BackendStatus)
+    );
+
+    const component = renderComponent(store.getState(), mockPrivativeCard);
+    expect(component.queryByTestId("BpdPaymentMethodCapability")).toBeNull();
+  });
+});
+
+const renderComponent = (state: GlobalState, paymentMethod: PaymentMethod) => {
+  const store = createStore(appReducer, state as any);
+
+  return renderScreenFakeNavRedux<GlobalState, NavigationParams>(
+    () => <PaymentMethodCapabilities paymentMethod={paymentMethod} />,
+    ROUTES.WALLET_BANCOMAT_DETAIL,
+    {},
+    store
+  );
+};

--- a/ts/features/wallet/privative/screen/PrivativeDetailScreen.tsx
+++ b/ts/features/wallet/privative/screen/PrivativeDetailScreen.tsx
@@ -100,7 +100,6 @@ const PrivativeDetailScreen: React.FunctionComponent<Props> = props => {
       <View spacer={true} extralarge={true} />
       <View style={IOStyles.horizontalContentPadding}>
         <PaymentMethodCapabilities paymentMethod={privative} />
-        <View spacer={true} />
         <View spacer={true} large={true} />
         <UnsubscribeButton
           onPress={() =>

--- a/ts/features/wallet/satispay/screen/SatispayDetailScreen.tsx
+++ b/ts/features/wallet/satispay/screen/SatispayDetailScreen.tsx
@@ -98,7 +98,6 @@ const SatispayDetailScreen: React.FunctionComponent<Props> = props => {
       <View spacer={true} extralarge={true} />
       <View style={IOStyles.horizontalContentPadding}>
         <PaymentMethodCapabilities paymentMethod={satispay} />
-        <View spacer={true} />
         <SatispayInformation />
         <View spacer={true} large={true} />
         <UnsubscribeButton

--- a/ts/screens/wallet/PaymentMethodDetailScreen.tsx
+++ b/ts/screens/wallet/PaymentMethodDetailScreen.tsx
@@ -193,7 +193,6 @@ const PaymentMethodDetailScreen: React.FC<Props> = (props: Props) => {
           <View style={IOStyles.horizontalContentPadding}>
             <View spacer={true} extralarge={true} />
             <PaymentMethodCapabilities paymentMethod={pm} />
-            <View spacer={true} />
             <ItemSeparatorComponent noPadded={true} />
             <View spacer={true} large={true} />
             <FavoritePaymentMethodSwitch

--- a/ts/store/reducers/backendStatus.ts
+++ b/ts/store/reducers/backendStatus.ts
@@ -5,12 +5,12 @@
 import { none, Option, some } from "fp-ts/lib/Option";
 import { createSelector } from "reselect";
 import { getType } from "typesafe-actions";
+import { BpdConfig } from "../../../definitions/content/BpdConfig";
 import { backendStatusLoadSuccess } from "../actions/backendStatus";
 import { Action } from "../actions/types";
 import { BackendStatus } from "../../../definitions/content/BackendStatus";
 import { Sections } from "../../../definitions/content/Sections";
 import { SectionStatus } from "../../../definitions/content/SectionStatus";
-import { BpdConfig } from "../../../definitions/content/BpdConfig";
 import { GlobalState } from "./types";
 
 export type SectionStatusKey = keyof Sections;


### PR DESCRIPTION
## Short description
This pr changes the payment methods detail screens in order to render the cashback capability only if the the cashback program is active, using the remote configuration `https://assets.cdn.io.italia.it/status/backend.json` `config.bpd.program_active`.

Following all the screen when `program_active: false`

Credit card            |  Bancomat   |  BancomatPAY
:-----------------:|:-------------:|:-------------------------:
<img width="300" alt="Schermata 2021-07-16 alle 17 46 56" src="https://user-images.githubusercontent.com/26501317/125974354-9e3523c6-48f3-47d9-95e0-810c6644d465.png"> |  <img width="300" alt="Schermata 2021-07-16 alle 17 47 16" src="https://user-images.githubusercontent.com/26501317/125974394-ee837dd8-ebb8-41b8-87e4-2db0b7583da5.png"> | <img width="300" alt="Schermata 2021-07-16 alle 17 47 38" src="https://user-images.githubusercontent.com/26501317/125974432-f9f38ab1-31c7-4731-87f1-89d54f8f449a.png">

Satispay           |  Cobadge   |  Privative
:-----------------:|:-------------:|:-------------------------:
<img width="418" alt="Schermata 2021-07-16 alle 17 48 39" src="https://user-images.githubusercontent.com/26501317/125974561-c2dd13ae-01fe-4bea-a0c2-ef0524142d1f.png"> |  <img width="409" alt="Schermata 2021-07-16 alle 17 49 02" src="https://user-images.githubusercontent.com/26501317/125974611-5fbdefde-199d-44c2-804b-45975ccafa77.png"> | <img width="406" alt="Schermata 2021-07-16 alle 17 49 16" src="https://user-images.githubusercontent.com/26501317/125974640-49f0ad3e-507b-4567-8a93-4c2cb7faa3b9.png">


## List of changes proposed in this pull request
- Refactoring for all the screens, removing `<View spacer={true} />` and including `paddingVertical: 16` for `BpdPaymentMethodCapability` and `PagoPaPaymentCapability`
- Changed `ts/features/wallet/component/PaymentMethodCapabilities.tsx` in order to use the remote configuration in `generateCapabilityItems` 

## How to test
- Change https://github.com/pagopa/io-dev-api-server/blob/a201910e5655f6ce521dfd89be00e10117a60f25/src/payloads/backend.ts#L179 in dev-server in order to test different configurations > open a payment method
- run `ts/features/wallet/component/__test__/PaymentMethodCapability.test.tsx`
