### PR TITLE
chore: [IA-56] Upgrade react-native-cie

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -560,6 +560,7 @@ authentication:
     noDataTitle: To use IO you must authorize the sending of data
     authToSendData: !include cie/auth_to_send_data.md
     nfc:
+      apduNotSupported: "On this device the manufacturer, for this version of the operating system, has disabled the functionality necessary to read the CIE using NFC technology"
       retry: Retry
       noNfcConnectionTitle: Are you sure you put the card down?
       noNfcConnectionContent: !include cie/noNfcConnection.md

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -559,7 +559,7 @@ authentication:
     noDataTitle: To use IO you must authorize the sending of data
     authToSendData: !include cie/auth_to_send_data.md
     nfc:
-      apduNotSupported: "On this device the manufacturer, for this version of the operating system, has disabled the functionality necessary to read the CIE using NFC technology"
+      apduNotSupported: "The operating system doesn't support the reading of your CIE. For further details, please contact your device manufacturer."
       retry: Retry
       noNfcConnectionTitle: Are you sure you put the card down?
       noNfcConnectionContent: !include cie/noNfcConnection.md

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -567,7 +567,7 @@ authentication:
     noDataTitle: Per usare IO è necessario autorizzare l'invio dei dati
     authToSendData: !include cie/auth_to_send_data.md
     nfc:
-      apduNotSupported: "Su questo dispositivo il produttore, per questa versione di sistema operativo, ha disabilitato la funzionalità necessaria per leggere la CIE mediante la tecnologia NFC"
+      apduNotSupported: "Il sistema operativo non supporta la lettura della tua carta di identità elettronica. Per maggiori informazioni, contatta il produttore del tuo dispositivo."
       retry: Riprova
       noNfcConnectionTitle: Hai appoggiato la carta?
       noNfcConnectionContent: !include cie/noNfcConnection.md

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -568,7 +568,7 @@ authentication:
     noDataTitle: Per usare IO è necessario autorizzare l'invio dei dati
     authToSendData: !include cie/auth_to_send_data.md
     nfc:
-      apduNotSupported: "Su questo dispositivo il produttore, per questa versione di sistema operativo, ha disabilitato la funzionalità necessaria per leggere la CIE(Carta Identità Elettronica 3.0) mediante la tecnologia NFC"
+      apduNotSupported: "Su questo dispositivo il produttore, per questa versione di sistema operativo, ha disabilitato la funzionalità necessaria per leggere la CIE mediante la tecnologia NFC"
       retry: Riprova
       noNfcConnectionTitle: Hai appoggiato la carta?
       noNfcConnectionContent: !include cie/noNfcConnection.md

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -568,6 +568,7 @@ authentication:
     noDataTitle: Per usare IO è necessario autorizzare l'invio dei dati
     authToSendData: !include cie/auth_to_send_data.md
     nfc:
+      apduNotSupported: "Su questo dispositivo il produttore, per questa versione di sistema operativo, ha disabilitato la funzionalità necessaria per leggere la CIE(Carta Identità Elettronica 3.0) mediante la tecnologia NFC"
       retry: Riprova
       noNfcConnectionTitle: Hai appoggiato la carta?
       noNfcConnectionContent: !include cie/noNfcConnection.md

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@gorhom/bottom-sheet": "^1.4.1",
-    "@pagopa/react-native-cie": "^1.0.4",
+    "@pagopa/react-native-cie": "^1.0.5",
     "@pagopa/ts-commons": "^9.4.0",
     "@react-native-community/async-storage": "^1.6.1",
     "@react-native-community/cameraroll": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@gorhom/bottom-sheet": "^1.4.1",
-    "@pagopa/react-native-cie": "^1.0.5",
+    "@pagopa/react-native-cie": "^1.0.7",
     "@pagopa/ts-commons": "^9.4.0",
     "@react-native-community/async-storage": "^1.6.1",
     "@react-native-community/cameraroll": "^4.0.0",

--- a/ts/screens/authentication/cie/CieCardReaderScreen.tsx
+++ b/ts/screens/authentication/cie/CieCardReaderScreen.tsx
@@ -102,6 +102,10 @@ const analyticActions = new Map<CieAuthenticationErrorReason, string>([
   ["CERTIFICATE_REVOKED", I18n.t("authentication.cie.card.error.generic")],
   ["AUTHENTICATION_ERROR", I18n.t("authentication.cie.card.error.generic")],
   [
+    "EXTENDED_APDU_NOT_SUPPORTED",
+    I18n.t("authentication.cie.nfc.apduNotSupported")
+  ],
+  [
     "ON_NO_INTERNET_CONNECTION",
     I18n.t("authentication.cie.card.error.tryAgain")
   ],
@@ -194,13 +198,13 @@ class CieCardReaderScreen extends React.PureComponent<Props, State> {
           });
         }
         break;
-
       case "Transmission Error":
       case "ON_TAG_LOST":
       case "TAG_ERROR_NFC_NOT_SUPPORTED":
       case "ON_TAG_DISCOVERED_NOT_CIE":
       case "AUTHENTICATION_ERROR":
       case "ON_NO_INTERNET_CONNECTION":
+      case "EXTENDED_APDU_NOT_SUPPORTED":
         this.setError({ eventReason: event.event });
         break;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1937,10 +1937,10 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@pagopa/react-native-cie@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@pagopa/react-native-cie/-/react-native-cie-1.0.5.tgz#bf9eb9c502849f8227616b20cda109ef15d0688e"
-  integrity sha512-49xRqeiRQk4Us3idKOiAS3GVrK+hD4E3Kqsskg4YZEPBMThkiaulOTneIYVECBzxFrwIVoaxQ/nwYF83n0cJ5A==
+"@pagopa/react-native-cie@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@pagopa/react-native-cie/-/react-native-cie-1.0.7.tgz#ee2a3f28e56238d02767116920feede4cd9a3014"
+  integrity sha512-ysrIyDe0rxcRiQg0sdvHEVz+IYfZKeLfq94u7v/ecZsFFS2CQOIfveSrPLH0Sc0islEUKXrnt0BtJ6VxWq8bvQ==
 
 "@pagopa/ts-commons@^9.4.0":
   version "9.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1937,10 +1937,10 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@pagopa/react-native-cie@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@pagopa/react-native-cie/-/react-native-cie-1.0.4.tgz#d9901a6eae98d50d36cf9a905b0701b265f84dc6"
-  integrity sha512-+i7s0Fw5NmqB1I8DdFX0nN+ypCiLgc+JhBQglHOyreXhiNeGRKYhiqS+AGK23x6/qP00rMsqvZHtxN3g0xCGyg==
+"@pagopa/react-native-cie@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@pagopa/react-native-cie/-/react-native-cie-1.0.5.tgz#bf9eb9c502849f8227616b20cda109ef15d0688e"
+  integrity sha512-49xRqeiRQk4Us3idKOiAS3GVrK+hD4E3Kqsskg4YZEPBMThkiaulOTneIYVECBzxFrwIVoaxQ/nwYF83n0cJ5A==
 
 "@pagopa/ts-commons@^9.4.0":
   version "9.4.0"


### PR DESCRIPTION
## Short description
This PR upgrades `react-native-cie` to the last version
within version 1.0.7 `react-native-cie` includes two main changes proposed on the main [Android sdk repo ](https://github.com/italia/cieid-android-sdk)

1. italia/cieid-android-sdk#17
2. italia/cieid-android-sdk#19

these changes are included in this PR https://github.com/pagopa/io-cie-sdk/pull/34

1. IPZS (the CIE sdk Android mantainer) removed the certificates pinning: a security tech that restricts which certificates are considered valid for the communication client<->server
2. add a new error case: some Android devices (OPPO and Realme vendor) could not support a specific NFC feature required to read the CIE

### when point 2 happens
<img src="https://user-images.githubusercontent.com/822471/126478223-1fa0e383-7463-41f5-b6b8-26b1229dff4d.jpg" height="700"/>

