### PR TITLE
feat(Bonus Pagamenti Digitali): [IAC-109] Disable cashback onboarding and edit IBAN from message CTA if the initiative is completed

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2241,6 +2241,7 @@ bonus:
       body2: "If you prefer, you can activate cashback on these methods later as well."
       skip: "Maybe later"
     iban:
+      bpdCompletedMessage: "This initiative has ended and it is no longer possible to change the IBAN"
       cta:
         bpdNotActiveTitle: "attention"
         bpdNotActiveMessage: "you are not registered for cashback, sign up and try again."

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2269,6 +2269,7 @@ bonus:
       body2: "Se preferisci, puoi attivare il Cashback su questi metodi anche in un secondo momento."
       skip: "Non ora"
     iban:
+      bpdCompletedMessage: "Questa iniziativa è terminata e non è più possibile modificare l'IBAN"
       cta:
         bpdNotActiveTitle: "attenzione"
         bpdNotActiveMessage: "non sei iscritto al cashback, iscriviti e riprova."

--- a/ts/features/bonus/bpd/screens/iban/IbanCTAEditScreen.tsx
+++ b/ts/features/bonus/bpd/screens/iban/IbanCTAEditScreen.tsx
@@ -42,12 +42,12 @@ const loadLocales = () => ({
  * Landing screen from the CTA message that asks to review user's IBAN insertion
  */
 const IbanCTAEditScreen: React.FC<Props> = (props: Props) => {
+  const navigation = useNavigationContext();
   if (!props.bpdRemoteConfig?.program_active) {
     Alert.alert(
       I18n.t("bonus.bpd.title"),
       I18n.t("bonus.bpd.iban.bpdCompletedMessage")
     );
-    const navigation = useNavigationContext();
     navigation.goBack();
     return null;
   }

--- a/ts/features/bonus/bpd/screens/iban/IbanCTAEditScreen.tsx
+++ b/ts/features/bonus/bpd/screens/iban/IbanCTAEditScreen.tsx
@@ -3,6 +3,7 @@ import * as pot from "italia-ts-commons/lib/pot";
 import { connect } from "react-redux";
 import * as React from "react";
 import { Alert } from "react-native";
+import { bpdRemoteConfigSelector } from "../../../../../store/reducers/backendStatus";
 import { GlobalState } from "../../../../../store/reducers/types";
 import BaseScreenComponent from "../../../../../components/screens/BaseScreenComponent";
 import I18n from "../../../../../i18n";
@@ -18,7 +19,10 @@ import {
   BpdPeriodWithInfo
 } from "../../store/reducers/details/periods";
 import { navigationHistoryPop } from "../../../../../store/actions/navigationHistory";
-import { useActionOnFocus } from "../../../../../utils/hooks/useOnFocus";
+import {
+  useActionOnFocus,
+  useNavigationContext
+} from "../../../../../utils/hooks/useOnFocus";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
@@ -38,6 +42,15 @@ const loadLocales = () => ({
  * Landing screen from the CTA message that asks to review user's IBAN insertion
  */
 const IbanCTAEditScreen: React.FC<Props> = (props: Props) => {
+  if (!props.bpdRemoteConfig?.program_active) {
+    Alert.alert(
+      I18n.t("bonus.bpd.title"),
+      I18n.t("bonus.bpd.iban.bpdCompletedMessage")
+    );
+    const navigation = useNavigationContext();
+    navigation.goBack();
+    return null;
+  }
   useActionOnFocus(props.load);
   // keep track if loading has been completed or not
   // to avoid to handle not update data coming from the store
@@ -113,7 +126,8 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 const mapStateToProps = (state: GlobalState) => ({
   bpdLoadState: bpdLastUpdateSelector(state),
   bpdPeriods: bpdPeriodsSelector(state),
-  bpdEnabled: bpdEnabledSelector(state)
+  bpdEnabled: bpdEnabledSelector(state),
+  bpdRemoteConfig: bpdRemoteConfigSelector(state)
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(IbanCTAEditScreen);

--- a/ts/features/bonus/bpd/screens/onboarding/BpdCTAStartOnboardingScreen.tsx
+++ b/ts/features/bonus/bpd/screens/onboarding/BpdCTAStartOnboardingScreen.tsx
@@ -26,12 +26,12 @@ const loadingCaption = () => I18n.t("global.remoteStates.loading");
  * this is a dummy screen reachable only from a message CTA
  */
 const BpdCTAStartOnboardingScreen: React.FC<Props> = (props: Props) => {
+  const navigation = useNavigationContext();
   if (!props.bpdRemoteConfig?.program_active) {
     Alert.alert(
       I18n.t("bonus.bpd.title"),
       I18n.t("bonus.state.completed.description")
     );
-    const navigation = useNavigationContext();
     navigation.goBack();
     return null;
   }

--- a/ts/features/bonus/bpd/screens/onboarding/BpdCTAStartOnboardingScreen.tsx
+++ b/ts/features/bonus/bpd/screens/onboarding/BpdCTAStartOnboardingScreen.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
+import { Alert } from "react-native";
 import { Dispatch } from "redux";
 import { connect } from "react-redux";
+import { bpdRemoteConfigSelector } from "../../../../../store/reducers/backendStatus";
 import { bpdOnboardingStart } from "../../store/actions/onboarding";
 import { LoadingErrorComponent } from "../../../bonusVacanze/components/loadingErrorScreen/LoadingErrorComponent";
 import I18n from "../../../../../i18n";
@@ -10,7 +12,10 @@ import {
   isAvailableBonusErrorSelector,
   supportedAvailableBonusSelector
 } from "../../../bonusVacanze/store/reducers/availableBonusesTypes";
-import { useActionOnFocus } from "../../../../../utils/hooks/useOnFocus";
+import {
+  useActionOnFocus,
+  useNavigationContext
+} from "../../../../../utils/hooks/useOnFocus";
 import BaseScreenComponent from "../../../../../components/screens/BaseScreenComponent";
 
 export type Props = ReturnType<typeof mapDispatchToProps> &
@@ -21,6 +26,15 @@ const loadingCaption = () => I18n.t("global.remoteStates.loading");
  * this is a dummy screen reachable only from a message CTA
  */
 const BpdCTAStartOnboardingScreen: React.FC<Props> = (props: Props) => {
+  if (!props.bpdRemoteConfig?.program_active) {
+    Alert.alert(
+      I18n.t("bonus.bpd.title"),
+      I18n.t("bonus.state.completed.description")
+    );
+    const navigation = useNavigationContext();
+    navigation.goBack();
+    return null;
+  }
   // load available bonus when component is focused
   useActionOnFocus(props.loadAvailableBonus);
 
@@ -51,6 +65,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 
 const mapStateToProps = (globalState: GlobalState) => ({
   availableBonus: supportedAvailableBonusSelector(globalState),
+  bpdRemoteConfig: bpdRemoteConfigSelector(globalState),
   hasError: isAvailableBonusErrorSelector(globalState)
 });
 


### PR DESCRIPTION
## Short description
This pr changes the behaviour of the "Onboard to cashback" and "Edit IBAN" message CTA if the initiative is completed (`program_active: false` in https://assets.cdn.io.italia.it/status/backend.json)

When `program_active: false`:

https://user-images.githubusercontent.com/26501317/126528224-9228a6a9-a50b-47f1-ac17-956ba5d45589.mov

## List of changes proposed in this pull request
- Changed `ts/features/bonus/bpd/screens/iban/IbanCTAEditScreen.tsx` and `ts/features/bonus/bpd/screens/onboarding/BpdCTAStartOnboardingScreen.tsx` in order to add the new logic related to the remote config.

## How to test
- Use the messages
<img width="381" alt="Schermata 2021-07-21 alle 18 51 36" src="https://user-images.githubusercontent.com/26501317/126527938-139ab7bd-4547-455f-86cd-7904fd2109dc.png">
provided by the dev-server to test the CTA behaviour, changing the https://github.com/pagopa/io-dev-api-server/blob/a201910e5655f6ce521dfd89be00e10117a60f25/src/payloads/backend.ts#L179 value.