### PR TITLE
fix: [IA-140] Remove Instubug unused property

### DIFF
--- a/ts/boot/configureInstabug.ts
+++ b/ts/boot/configureInstabug.ts
@@ -19,7 +19,6 @@ type InstabugLocales = { [k in Locales]: Instabug.locale };
 type InstabugUserAttributeKeys =
   | "backendVersion"
   | "activeScreen"
-  | "fiscalcode"
   | "identityProvider"
   | "lastSeenMessageID"
   | "appVersion"


### PR DESCRIPTION
## Short description
This PR updates `InstabugUserAttributeKeys` type definition since one of the element of union type is not used anymore
