### PR TITLE
fix: [IA-164] Unable to navigate to an internal route using a CTA in service details 

### DIFF
--- a/ts/screens/services/ServiceDetailsScreen.tsx
+++ b/ts/screens/services/ServiceDetailsScreen.tsx
@@ -13,7 +13,7 @@ import BaseScreenComponent, {
 import { EdgeBorderComponent } from "../../components/screens/EdgeBorderComponent";
 import Markdown from "../../components/ui/Markdown";
 import I18n from "../../i18n";
-import { Dispatch, ReduxProps } from "../../store/actions/types";
+import { Dispatch } from "../../store/actions/types";
 import {
   contentSelector,
   ServiceMetadataState
@@ -49,7 +49,6 @@ type NavigationParams = Readonly<{
 
 type Props = ReturnType<typeof mapStateToProps> &
   ReturnType<typeof mapDispatchToProps> &
-  ReduxProps &
   NavigationInjectedProps<NavigationParams>;
 
 type State = {
@@ -307,7 +306,9 @@ const mapStateToProps = (state: GlobalState) => {
   };
 };
 
-const mapDispatchToProps = (_: Dispatch) => ({});
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  dispatch
+});
 
 export default connect(
   mapStateToProps,


### PR DESCRIPTION
## Short description
This PR fix an error in the `ServiceDetailsScreen` component.
With this error the user was unable to navigate to an internal route using a CTA sended through the `/services/:service_id` API.

## List of changes proposed in this pull request
- Added the `dispatch` prop

## How to test
In the dev server simulate a service with a CTA that navigate to an internal route.
Go to the service detail screen and press the CTA.
