### PR TITLE
feat(Sicilia Vola): [IASV-23] Select beneficiary category screen

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2561,7 +2561,13 @@ bonus:
       checkResidence:
         title: "CheckResidenceComponent"
       selectBeneficiaryCategory:
-        title: "SelectBeneficiaryCategory"
+        title: "I declare to be"
+        categories:
+          student: "Off-site student"
+          disabled: "Severely disabled"
+          worker: "Employee with a workplace outside Sicily"
+          sick: "Patient in need of treatment outside the Sicily region"
+          other: "None of the above"
       student:
         selectDestination:
           title: "StudentSelectDestinationScreen"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2589,7 +2589,13 @@ bonus:
       checkResidence:
         title: "CheckResidenceComponent"
       selectBeneficiaryCategory:
-        title: "SelectBeneficiaryCategory"
+        title: "Dichiaro di essere"
+        categories:
+          student: "Studente fuori sede"
+          disabled: "Disabile grave"
+          worker: "Lavoratore dipendente con sede lavorativa al di fuori della Sicilia"
+          sick: "Paziente con necessità di cure al di fuori della regione Sicilia"
+          other: "Nessuno dei precedenti"
       student:
         selectDestination:
           title: "StudentSelectDestinationScreen"

--- a/ts/components/core/selection/RadioButtonList.tsx
+++ b/ts/components/core/selection/RadioButtonList.tsx
@@ -5,7 +5,7 @@ import { IOStyles } from "../variables/IOStyles";
 import IconFont from "./../../ui/IconFont";
 import themeVariables from "./../../../theme/variables";
 
-type RadioItem<T> = {
+export type RadioItem<T> = {
   label: string;
   id: T;
 };

--- a/ts/features/bonus/siciliaVola/saga/orchestration/voucherGeneration.ts
+++ b/ts/features/bonus/siciliaVola/saga/orchestration/voucherGeneration.ts
@@ -1,4 +1,4 @@
-import { call } from "redux-saga/effects";
+import { call, put, select } from "redux-saga/effects";
 import { SagaIterator } from "redux-saga";
 import {
   executeWorkUnit,
@@ -13,6 +13,10 @@ import {
 } from "../../store/actions/voucherGeneration";
 import SV_ROUTES from "../../navigation/routes";
 import { navigateToSvCheckStatusRouterScreen } from "../../navigation/actions";
+import { navigateBack } from "../../../../../store/actions/navigation";
+import { navigationCurrentRouteSelector } from "../../../../../store/reducers/navigation";
+import CGN_ROUTES from "../../../cgn/navigation/routes";
+import BONUSVACANZE_ROUTES from "../../../bonusVacanze/navigation/routes";
 
 /**
  * Define the workflow that allows the user to generate a new voucher.
@@ -41,4 +45,15 @@ export function* handleSvVoucherGenerationStartActivationSaga(): SagaIterator {
       withResetNavigationStack(svVoucherGenerationWorkUnit)
     );
   yield call(sagaExecution);
+
+  const currentRoute: ReturnType<typeof navigationCurrentRouteSelector> = yield select(
+    navigationCurrentRouteSelector
+  );
+  const route = currentRoute.toUndefined();
+  if (
+    // if the activation started from the CTA -> go back
+    route === SV_ROUTES.VOUCHER_GENERATION.CHECK_STATUS
+  ) {
+    yield put(navigateBack());
+  }
 }

--- a/ts/features/bonus/siciliaVola/saga/orchestration/voucherGeneration.ts
+++ b/ts/features/bonus/siciliaVola/saga/orchestration/voucherGeneration.ts
@@ -15,8 +15,6 @@ import SV_ROUTES from "../../navigation/routes";
 import { navigateToSvCheckStatusRouterScreen } from "../../navigation/actions";
 import { navigateBack } from "../../../../../store/actions/navigation";
 import { navigationCurrentRouteSelector } from "../../../../../store/reducers/navigation";
-import CGN_ROUTES from "../../../cgn/navigation/routes";
-import BONUSVACANZE_ROUTES from "../../../bonusVacanze/navigation/routes";
 
 /**
  * Define the workflow that allows the user to generate a new voucher.

--- a/ts/features/bonus/siciliaVola/screens/voucherGeneration/CheckStatusRouterScreen.tsx
+++ b/ts/features/bonus/siciliaVola/screens/voucherGeneration/CheckStatusRouterScreen.tsx
@@ -4,7 +4,8 @@ import { Dispatch } from "redux";
 import { GlobalState } from "../../../../../store/reducers/types";
 import {
   svGenerateVoucherBack,
-  svGenerateVoucherCancel
+  svGenerateVoucherCancel,
+  svGenerateVoucherStart
 } from "../../store/actions/voucherGeneration";
 import {
   isAliveSelector,
@@ -25,6 +26,7 @@ const manageTosResponse = (tosAccepted: boolean): React.ReactElement =>
 
 const CheckStatusRouterScreen = (props: Props): React.ReactElement => {
   React.useEffect(() => {
+    props.start();
     props.checkServiceAvailable();
     props.checkTosAccepted();
   }, []);
@@ -57,6 +59,7 @@ const CheckStatusRouterScreen = (props: Props): React.ReactElement => {
   );
 };
 const mapDispatchToProps = (dispatch: Dispatch) => ({
+  start: () => dispatch(svGenerateVoucherStart()),
   back: () => dispatch(svGenerateVoucherBack()),
   cancel: () => dispatch(svGenerateVoucherCancel()),
   checkServiceAvailable: () => dispatch(svServiceAlive.request()),

--- a/ts/features/bonus/siciliaVola/screens/voucherGeneration/SelectBeneficiaryCategoryScreen.tsx
+++ b/ts/features/bonus/siciliaVola/screens/voucherGeneration/SelectBeneficiaryCategoryScreen.tsx
@@ -3,6 +3,7 @@ import { useRef, useState } from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { SafeAreaView, ScrollView } from "react-native";
+import { View } from "native-base";
 import BaseScreenComponent from "../../../../../components/screens/BaseScreenComponent";
 import { emptyContextualHelp } from "../../../../../utils/emptyContextualHelp";
 import { IOStyles } from "../../../../../components/core/variables/IOStyles";
@@ -25,7 +26,6 @@ import {
 } from "../../navigation/actions";
 import I18n from "../../../../../i18n";
 import { RadioButtonList } from "../../../../../components/core/selection/RadioButtonList";
-import { View } from "native-base";
 
 type BeneficiaryCategory = SvBeneficiaryCategory | "other";
 

--- a/ts/features/bonus/siciliaVola/screens/voucherGeneration/SelectBeneficiaryCategoryScreen.tsx
+++ b/ts/features/bonus/siciliaVola/screens/voucherGeneration/SelectBeneficiaryCategoryScreen.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useRef, useState } from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
-import { SafeAreaView, ScrollView, Text } from "react-native";
+import { SafeAreaView, ScrollView } from "react-native";
 import BaseScreenComponent from "../../../../../components/screens/BaseScreenComponent";
 import { emptyContextualHelp } from "../../../../../utils/emptyContextualHelp";
 import { IOStyles } from "../../../../../components/core/variables/IOStyles";
@@ -14,7 +14,6 @@ import {
   svGenerateVoucherSelectCategory
 } from "../../store/actions/voucherGeneration";
 import FooterWithButtons from "../../../../../components/ui/FooterWithButtons";
-import ButtonDefaultOpacity from "../../../../../components/ButtonDefaultOpacity";
 import { SvBeneficiaryCategory } from "../../types/SvVoucherRequest";
 import { selectedBeneficiaryCategorySelector } from "../../store/reducers/voucherRequest";
 import {
@@ -24,15 +23,55 @@ import {
   navigateToSvWorkerCheckIncomeThresholdScreen
 } from "../../navigation/actions";
 import I18n from "../../../../../i18n";
+import { RadioButtonList } from "../../../../../components/core/selection/RadioButtonList";
+import { View } from "native-base";
+
+type BeneficiaryCategory = SvBeneficiaryCategory | "other";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
+
+const getCategoryBeneficiaryItems = (): ReadonlyArray<{
+  label: string;
+  id: BeneficiaryCategory;
+}> => [
+  {
+    label: I18n.t(
+      "bonus.sv.voucherGeneration.selectBeneficiaryCategory.categories.student"
+    ),
+    id: "student"
+  },
+  {
+    label: I18n.t(
+      "bonus.sv.voucherGeneration.selectBeneficiaryCategory.categories.disabled"
+    ),
+    id: "disabled"
+  },
+  {
+    label: I18n.t(
+      "bonus.sv.voucherGeneration.selectBeneficiaryCategory.categories.worker"
+    ),
+    id: "worker"
+  },
+  {
+    label: I18n.t(
+      "bonus.sv.voucherGeneration.selectBeneficiaryCategory.categories.sick"
+    ),
+    id: "sick"
+  },
+  {
+    label: I18n.t(
+      "bonus.sv.voucherGeneration.selectBeneficiaryCategory.categories.other"
+    ),
+    id: "other"
+  }
+];
 
 const SelectBeneficiaryCategoryScreen = (props: Props): React.ReactElement => {
   const elementRef = useRef(null);
 
   const [categoryBeneficiary, setCategoryBeneficiary] = useState<
-    SvBeneficiaryCategory | "other" | undefined
+    BeneficiaryCategory | undefined
   >(undefined);
 
   const routeNextScreen = () => {
@@ -63,13 +102,13 @@ const SelectBeneficiaryCategoryScreen = (props: Props): React.ReactElement => {
     primary: false,
     bordered: true,
     onPress: props.back,
-    title: "Back"
+    title: I18n.t("global.buttons.cancel")
   };
   const continueButtonProps = {
     primary: false,
-    bordered: true,
+    bordered: false,
     onPress: routeNextScreen,
-    title: "Continue",
+    title: I18n.t("global.buttons.continue"),
     disabled: categoryBeneficiary === undefined
   };
 
@@ -91,27 +130,13 @@ const SelectBeneficiaryCategoryScreen = (props: Props): React.ReactElement => {
             )}
           </H1>
 
-          <ButtonDefaultOpacity
-            onPress={() => setCategoryBeneficiary("student")}
-          >
-            <Text>Student</Text>
-          </ButtonDefaultOpacity>
-
-          <ButtonDefaultOpacity
-            onPress={() => setCategoryBeneficiary("disabled")}
-          >
-            <Text>Disabled</Text>
-          </ButtonDefaultOpacity>
-
-          <ButtonDefaultOpacity
-            onPress={() => setCategoryBeneficiary("worker")}
-          >
-            <Text>Worker</Text>
-          </ButtonDefaultOpacity>
-
-          <ButtonDefaultOpacity onPress={() => setCategoryBeneficiary("sick")}>
-            <Text>Sick</Text>
-          </ButtonDefaultOpacity>
+          <View spacer={true} />
+          <RadioButtonList<BeneficiaryCategory>
+            key="delete_reason"
+            items={getCategoryBeneficiaryItems()}
+            selectedItem={categoryBeneficiary}
+            onPress={setCategoryBeneficiary}
+          />
         </ScrollView>
         <FooterWithButtons
           type={"TwoButtonsInlineHalf"}

--- a/ts/features/bonus/siciliaVola/screens/voucherGeneration/SelectBeneficiaryCategoryScreen.tsx
+++ b/ts/features/bonus/siciliaVola/screens/voucherGeneration/SelectBeneficiaryCategoryScreen.tsx
@@ -25,17 +25,19 @@ import {
   navigateToSvWorkerCheckIncomeThresholdScreen
 } from "../../navigation/actions";
 import I18n from "../../../../../i18n";
-import { RadioButtonList } from "../../../../../components/core/selection/RadioButtonList";
+import {
+  RadioButtonList,
+  RadioItem
+} from "../../../../../components/core/selection/RadioButtonList";
 
 type BeneficiaryCategory = SvBeneficiaryCategory | "other";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
 
-const getCategoryBeneficiaryItems = (): ReadonlyArray<{
-  label: string;
-  id: BeneficiaryCategory;
-}> => [
+const getCategoryBeneficiaryItems = (): ReadonlyArray<
+  RadioItem<BeneficiaryCategory>
+> => [
   {
     label: I18n.t(
       "bonus.sv.voucherGeneration.selectBeneficiaryCategory.categories.student"

--- a/ts/features/bonus/siciliaVola/screens/voucherGeneration/SelectBeneficiaryCategoryScreen.tsx
+++ b/ts/features/bonus/siciliaVola/screens/voucherGeneration/SelectBeneficiaryCategoryScreen.tsx
@@ -18,6 +18,7 @@ import { SvBeneficiaryCategory } from "../../types/SvVoucherRequest";
 import { selectedBeneficiaryCategorySelector } from "../../store/reducers/voucherRequest";
 import {
   navigateToSvDisabledAdditionalInfoScreen,
+  navigateToSvKoSelectBeneficiaryCategoryScreen,
   navigateToSvSickCheckIncomeThresholdScreen,
   navigateToSvStudentSelectDestinationScreen,
   navigateToSvWorkerCheckIncomeThresholdScreen
@@ -93,7 +94,7 @@ const SelectBeneficiaryCategoryScreen = (props: Props): React.ReactElement => {
         props.navigateToSvSickCheckIncomeThreshold();
         return;
       case "other":
-        // TODO: go to ko screen
+        props.navigateToSvKoSelectBeneficiaryCategory();
         return;
     }
   };
@@ -159,7 +160,9 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   navigateToSvWorkerCheckIncomeThreshold: () =>
     dispatch(navigateToSvWorkerCheckIncomeThresholdScreen()),
   navigateToSvSickCheckIncomeThreshold: () =>
-    dispatch(navigateToSvSickCheckIncomeThresholdScreen())
+    dispatch(navigateToSvSickCheckIncomeThresholdScreen()),
+  navigateToSvKoSelectBeneficiaryCategory: () =>
+    dispatch(navigateToSvKoSelectBeneficiaryCategoryScreen())
 });
 const mapStateToProps = (state: GlobalState) => ({
   selectedBeneficiaryCategory: selectedBeneficiaryCategorySelector(state)

--- a/ts/features/bonus/siciliaVola/screens/voucherGeneration/ko/SvCheckIncomeKoScreen.tsx
+++ b/ts/features/bonus/siciliaVola/screens/voucherGeneration/ko/SvCheckIncomeKoScreen.tsx
@@ -1,31 +1,40 @@
 import * as React from "react";
 import { Dispatch } from "redux";
 import { connect } from "react-redux";
-import { View } from "native-base";
+import { SafeAreaView } from "react-native";
 import { InfoScreenComponent } from "../../../../../../components/infoScreen/InfoScreenComponent";
 import { renderInfoRasterImage } from "../../../../../../components/infoScreen/imageRendering";
 import image from "../../../../../../../img/servicesStatus/error-detail-icon.png";
 import I18n from "../../../../../../i18n";
-import { Body } from "../../../../../../components/core/typography/Body";
 import { GlobalState } from "../../../../../../store/reducers/types";
+import { cancelButtonProps } from "../../../../bonusVacanze/components/buttons/ButtonConfigurations";
+import FooterWithButtons from "../../../../../../components/ui/FooterWithButtons";
+import { IOStyles } from "../../../../../../components/core/variables/IOStyles";
+import { svGenerateVoucherCancel } from "../../../store/actions/voucherGeneration";
 
-const SvCheckIncomeKoScreen = () => (
-  <>
-    <View spacer={true} extralarge={true} />
-    <View spacer={true} extralarge={true} />
+type Props = ReturnType<typeof mapDispatchToProps> &
+  ReturnType<typeof mapStateToProps>;
+
+const SvCheckIncomeKoScreen: React.FC<Props> = (props: Props) => (
+  <SafeAreaView style={IOStyles.flex}>
     <InfoScreenComponent
       image={renderInfoRasterImage(image)}
       title={I18n.t("bonus.sv.voucherGeneration.ko.checkIncome.title")}
-      body={
-        <Body style={{ textAlign: "center" }}>
-          {I18n.t("bonus.sv.voucherGeneration.ko.checkIncome.body")}
-        </Body>
-      }
+      body={I18n.t("bonus.sv.voucherGeneration.ko.checkIncome.body")}
     />
-  </>
+    <FooterWithButtons
+      type="SingleButton"
+      leftButton={cancelButtonProps(
+        props.onExit,
+        I18n.t("global.buttons.exit")
+      )}
+    />
+  </SafeAreaView>
 );
 
-const mapDispatchToProps = (_: Dispatch) => ({});
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  onExit: () => dispatch(svGenerateVoucherCancel())
+});
 const mapStateToProps = (_: GlobalState) => ({});
 
 export default connect(

--- a/ts/features/bonus/siciliaVola/screens/voucherGeneration/ko/SvCheckResidenceKoScreen.tsx
+++ b/ts/features/bonus/siciliaVola/screens/voucherGeneration/ko/SvCheckResidenceKoScreen.tsx
@@ -9,7 +9,7 @@ import I18n from "../../../../../../i18n";
 import { Body } from "../../../../../../components/core/typography/Body";
 import { GlobalState } from "../../../../../../store/reducers/types";
 
-const SvCheckIncomeKoScreen = () => (
+const SvCheckResidenceKoScreen = () => (
   <>
     <View spacer={true} extralarge={true} />
     <View spacer={true} extralarge={true} />
@@ -31,4 +31,4 @@ const mapStateToProps = (_: GlobalState) => ({});
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(SvCheckIncomeKoScreen);
+)(SvCheckResidenceKoScreen);

--- a/ts/features/bonus/siciliaVola/screens/voucherGeneration/ko/SvCheckResidenceKoScreen.tsx
+++ b/ts/features/bonus/siciliaVola/screens/voucherGeneration/ko/SvCheckResidenceKoScreen.tsx
@@ -1,31 +1,40 @@
 import * as React from "react";
 import { Dispatch } from "redux";
 import { connect } from "react-redux";
-import { View } from "native-base";
+import { SafeAreaView } from "react-native";
 import { InfoScreenComponent } from "../../../../../../components/infoScreen/InfoScreenComponent";
 import { renderInfoRasterImage } from "../../../../../../components/infoScreen/imageRendering";
 import image from "../../../../../../../img/servicesStatus/error-detail-icon.png";
 import I18n from "../../../../../../i18n";
-import { Body } from "../../../../../../components/core/typography/Body";
 import { GlobalState } from "../../../../../../store/reducers/types";
+import { IOStyles } from "../../../../../../components/core/variables/IOStyles";
+import { cancelButtonProps } from "../../../../bonusVacanze/components/buttons/ButtonConfigurations";
+import FooterWithButtons from "../../../../../../components/ui/FooterWithButtons";
+import { svGenerateVoucherCancel } from "../../../store/actions/voucherGeneration";
 
-const SvCheckResidenceKoScreen = () => (
-  <>
-    <View spacer={true} extralarge={true} />
-    <View spacer={true} extralarge={true} />
+type Props = ReturnType<typeof mapDispatchToProps> &
+  ReturnType<typeof mapStateToProps>;
+
+const SvCheckResidenceKoScreen: React.FC<Props> = (props: Props) => (
+  <SafeAreaView style={IOStyles.flex}>
     <InfoScreenComponent
       image={renderInfoRasterImage(image)}
       title={I18n.t("bonus.sv.voucherGeneration.ko.checkResidence.title")}
-      body={
-        <Body style={{ textAlign: "center" }}>
-          {I18n.t("bonus.sv.voucherGeneration.ko.checkResidence.body")}
-        </Body>
-      }
+      body={I18n.t("bonus.sv.voucherGeneration.ko.checkResidence.body")}
     />
-  </>
+    <FooterWithButtons
+      type="SingleButton"
+      leftButton={cancelButtonProps(
+        props.onExit,
+        I18n.t("global.buttons.exit")
+      )}
+    />
+  </SafeAreaView>
 );
 
-const mapDispatchToProps = (_: Dispatch) => ({});
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  onExit: () => dispatch(svGenerateVoucherCancel())
+});
 const mapStateToProps = (_: GlobalState) => ({});
 
 export default connect(

--- a/ts/features/bonus/siciliaVola/screens/voucherGeneration/ko/SvGeneratedVoucherTimeoutScreen.tsx
+++ b/ts/features/bonus/siciliaVola/screens/voucherGeneration/ko/SvGeneratedVoucherTimeoutScreen.tsx
@@ -9,7 +9,7 @@ import I18n from "../../../../../../i18n";
 import { Body } from "../../../../../../components/core/typography/Body";
 import { GlobalState } from "../../../../../../store/reducers/types";
 
-const SvCheckIncomeKoScreen = () => (
+const SvGeneratedVoucherTimeoutScreen = () => (
   <>
     <View spacer={true} extralarge={true} />
     <View spacer={true} extralarge={true} />
@@ -31,4 +31,4 @@ const mapStateToProps = (_: GlobalState) => ({});
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(SvCheckIncomeKoScreen);
+)(SvGeneratedVoucherTimeoutScreen);

--- a/ts/features/bonus/siciliaVola/screens/voucherGeneration/ko/SvGeneratedVoucherTimeoutScreen.tsx
+++ b/ts/features/bonus/siciliaVola/screens/voucherGeneration/ko/SvGeneratedVoucherTimeoutScreen.tsx
@@ -1,31 +1,40 @@
 import * as React from "react";
 import { Dispatch } from "redux";
 import { connect } from "react-redux";
-import { View } from "native-base";
+import { SafeAreaView } from "react-native";
 import { InfoScreenComponent } from "../../../../../../components/infoScreen/InfoScreenComponent";
 import { renderInfoRasterImage } from "../../../../../../components/infoScreen/imageRendering";
 import image from "../../../../../../../img/servicesStatus/error-detail-icon.png";
 import I18n from "../../../../../../i18n";
-import { Body } from "../../../../../../components/core/typography/Body";
 import { GlobalState } from "../../../../../../store/reducers/types";
+import { svGenerateVoucherCancel } from "../../../store/actions/voucherGeneration";
+import { IOStyles } from "../../../../../../components/core/variables/IOStyles";
+import { cancelButtonProps } from "../../../../bonusVacanze/components/buttons/ButtonConfigurations";
+import FooterWithButtons from "../../../../../../components/ui/FooterWithButtons";
 
-const SvGeneratedVoucherTimeoutScreen = () => (
-  <>
-    <View spacer={true} extralarge={true} />
-    <View spacer={true} extralarge={true} />
+type Props = ReturnType<typeof mapDispatchToProps> &
+  ReturnType<typeof mapStateToProps>;
+
+const SvGeneratedVoucherTimeoutScreen: React.FC<Props> = (props: Props) => (
+  <SafeAreaView style={IOStyles.flex}>
     <InfoScreenComponent
       image={renderInfoRasterImage(image)}
       title={I18n.t("bonus.sv.voucherGeneration.ko.timeout.title")}
-      body={
-        <Body style={{ textAlign: "center" }}>
-          {I18n.t("bonus.sv.voucherGeneration.ko.timeout.body")}
-        </Body>
-      }
+      body={I18n.t("bonus.sv.voucherGeneration.ko.timeout.body")}
     />
-  </>
+    <FooterWithButtons
+      type="SingleButton"
+      leftButton={cancelButtonProps(
+        props.onExit,
+        I18n.t("global.buttons.exit")
+      )}
+    />
+  </SafeAreaView>
 );
 
-const mapDispatchToProps = (_: Dispatch) => ({});
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  onExit: () => dispatch(svGenerateVoucherCancel())
+});
 const mapStateToProps = (_: GlobalState) => ({});
 
 export default connect(

--- a/ts/features/bonus/siciliaVola/screens/voucherGeneration/ko/SvSelectBeneficiaryCategoryKoScreen.tsx
+++ b/ts/features/bonus/siciliaVola/screens/voucherGeneration/ko/SvSelectBeneficiaryCategoryKoScreen.tsx
@@ -1,35 +1,44 @@
 import * as React from "react";
 import { Dispatch } from "redux";
 import { connect } from "react-redux";
-import { View } from "native-base";
+import { SafeAreaView } from "react-native";
 import { InfoScreenComponent } from "../../../../../../components/infoScreen/InfoScreenComponent";
 import { renderInfoRasterImage } from "../../../../../../components/infoScreen/imageRendering";
 import image from "../../../../../../../img/servicesStatus/error-detail-icon.png";
 import I18n from "../../../../../../i18n";
-import { Body } from "../../../../../../components/core/typography/Body";
 import { GlobalState } from "../../../../../../store/reducers/types";
+import { IOStyles } from "../../../../../../components/core/variables/IOStyles";
+import { cancelButtonProps } from "../../../../bonusVacanze/components/buttons/ButtonConfigurations";
+import FooterWithButtons from "../../../../../../components/ui/FooterWithButtons";
+import { svGenerateVoucherCancel } from "../../../store/actions/voucherGeneration";
 
-const SvCheckIncomeKoScreen = () => (
-  <>
-    <View spacer={true} extralarge={true} />
-    <View spacer={true} extralarge={true} />
+type Props = ReturnType<typeof mapDispatchToProps> &
+  ReturnType<typeof mapStateToProps>;
+
+const SvCheckIncomeKoScreen: React.FC<Props> = (props: Props) => (
+  <SafeAreaView style={IOStyles.flex}>
     <InfoScreenComponent
       image={renderInfoRasterImage(image)}
       title={I18n.t(
         "bonus.sv.voucherGeneration.ko.selectBeneficiaryCategory.title"
       )}
-      body={
-        <Body style={{ textAlign: "center" }}>
-          {I18n.t(
-            "bonus.sv.voucherGeneration.ko.selectBeneficiaryCategory.body"
-          )}
-        </Body>
-      }
+      body={I18n.t(
+        "bonus.sv.voucherGeneration.ko.selectBeneficiaryCategory.body"
+      )}
     />
-  </>
+    <FooterWithButtons
+      type="SingleButton"
+      leftButton={cancelButtonProps(
+        props.onExit,
+        I18n.t("global.buttons.exit")
+      )}
+    />
+  </SafeAreaView>
 );
 
-const mapDispatchToProps = (_: Dispatch) => ({});
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  onExit: () => dispatch(svGenerateVoucherCancel())
+});
 const mapStateToProps = (_: GlobalState) => ({});
 
 export default connect(

--- a/ts/features/bonus/siciliaVola/screens/voucherGeneration/ko/SvSelectBeneficiaryCategoryKoScreen.tsx
+++ b/ts/features/bonus/siciliaVola/screens/voucherGeneration/ko/SvSelectBeneficiaryCategoryKoScreen.tsx
@@ -15,7 +15,7 @@ import { svGenerateVoucherCancel } from "../../../store/actions/voucherGeneratio
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
 
-const SvCheckIncomeKoScreen: React.FC<Props> = (props: Props) => (
+const SvSelectBeneficiaryCategoryKoScreen: React.FC<Props> = (props: Props) => (
   <SafeAreaView style={IOStyles.flex}>
     <InfoScreenComponent
       image={renderInfoRasterImage(image)}
@@ -44,4 +44,4 @@ const mapStateToProps = (_: GlobalState) => ({});
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(SvCheckIncomeKoScreen);
+)(SvSelectBeneficiaryCategoryKoScreen);


### PR DESCRIPTION
## Short description
This PR add the screen that allow the users to choose the category to which they belong.

## List of changes proposed in this pull request
- Add UI elements to the `SelectBeneficiaryCategoryScreen`
- Complete the `SvSelectBeneficiaryCategoryKoScreen`
- Modify the management of the workunit adding a navigation back if the workunit starts from 

https://user-images.githubusercontent.com/11773070/127887354-cb2f4da7-d5f8-43ca-8ddc-4d204e0556d9.mp4


## How to test
Starts the flow from the SiciliaVola service detail. Make sure you have the updated version of the master branch on dev-server .
