### PR TITLE
[IA-199] Update PM payment-status API

### DIFF
--- a/ts/api/pagopa.ts
+++ b/ts/api/pagopa.ts
@@ -47,6 +47,7 @@ import {
   AddWalletCreditCardUsingPOSTT,
   addWalletSatispayUsingPOSTDecoder,
   changePayOptionDecoder,
+  ChangePayOptionT,
   checkPaymentUsingGETDefaultDecoder,
   CheckPaymentUsingGETT,
   DeleteBySessionCookieExpiredUsingDELETET,
@@ -90,7 +91,6 @@ import { BPayRequest } from "../../definitions/pagopa/walletv2/BPayRequest";
 import { CobadegPaymentInstrumentsRequest } from "../../definitions/pagopa/walletv2/CobadegPaymentInstrumentsRequest";
 import { format } from "../utils/dates";
 import { getLookUpId, pmLookupHeaderKey } from "../utils/pmLookUpId";
-import { WalletPaymentstatus } from "../../definitions/pagopa/WalletPaymentstatus";
 
 /**
  * A decoder that ignores the content of the payload and only decodes the status
@@ -566,26 +566,12 @@ const addBPayToWallet: AddWalletsBPayUsingPOSTTExtra = {
   response_decoder: addWalletsBPayUsingPOSTDecoder(PatchedWalletV2ListResponse)
 };
 
-// Request type definition
-export type ChangePayOptionT = r.IPutApiRequestType<
-  {
-    readonly Bearer: string;
-    readonly idWallet: number;
-    readonly walletPaymentstatus: WalletPaymentstatus;
-  },
-  "Content-Type" | "Authorization",
-  never,
-  | r.IResponseType<200, PatchedWalletV2Response>
-  | r.IResponseType<400, undefined>
-  | r.IResponseType<404, undefined>
-  | r.IResponseType<500, undefined>
->;
-
 const updatePaymentStatus: ChangePayOptionT = {
   method: "put",
   url: ({ idWallet }) => `/v2/wallet/${idWallet}/payment-status`,
   query: () => ({}),
-  body: ({ walletPaymentstatus }) => JSON.stringify(walletPaymentstatus),
+  body: ({ walletPaymentStatusRequest }) =>
+    JSON.stringify(walletPaymentStatusRequest),
   headers: composeHeaderProducers(tokenHeaderProducer, ApiHeaderJson),
   response_decoder: changePayOptionDecoder(PatchedWalletV2Response)
 };
@@ -802,7 +788,7 @@ export function PaymentManagerClient(
         )
       )({
         idWallet: payload.idWallet,
-        walletPaymentstatus: { pagoPA: payload.paymentEnabled }
+        walletPaymentStatusRequest: { data: { pagoPA: payload.paymentEnabled } }
       })
   };
 }


### PR DESCRIPTION
## ⚠️ this PR depends ON
- https://github.com/pagopa/io-services-metadata/pull/460 (required)
- https://github.com/pagopa/io-dev-api-server/pull/73 (optional, to test with _dev-server_)

## Short description
This PR updates the handling of PaymentManager API `/v2/wallet/{idWallet}/payment-status` since it requires a request payload with the new value nested inside the `data` field

## how to test
- https://github.com/pagopa/io-services-metadata/pull/460 must be merged
- `yarn generate:all`
- you can test in two environments:
    - by [activating the PM UAT ](https://pagopa.atlassian.net/wiki/spaces/IOAPP/pages/286654841/Attivare+pagoPA+UAT)
    - using the dev-server (https://github.com/pagopa/io-dev-api-server/pull/73 must be merged)

