### PR TITLE
feat: [IA-211] Change cobadge payment status representation

### DIFF
--- a/ts/utils/paymentMethodCapabilities.ts
+++ b/ts/utils/paymentMethodCapabilities.ts
@@ -51,7 +51,7 @@ const paymentNotSupportedCustomRepresentation = (
 };
 
 /**
- * Check if a payment method is supported or  not
+ * Check if a payment method is supported or not
  * If the payment method have the enableable function pagoPA, can always pay ("available")
  * "available" -> can pay
  * "arriving" -> will pay

--- a/ts/utils/paymentMethodCapabilities.ts
+++ b/ts/utils/paymentMethodCapabilities.ts
@@ -1,4 +1,5 @@
 import { none, Option, some } from "fp-ts/lib/Option";
+import { EnableableFunctionsEnum } from "../../definitions/pagopa/EnableableFunctions";
 import { TypeEnum } from "../../definitions/pagopa/walletv2/CardInfo";
 import {
   CreditCardPaymentMethod,
@@ -7,7 +8,6 @@ import {
   PaymentMethod
 } from "../types/pagopa";
 import { PaymentSupportStatus } from "../types/paymentMethodCapabilities";
-import { EnableableFunctionsEnum } from "../../definitions/pagopa/EnableableFunctions";
 import { hasFunctionEnabled } from "./walletv2";
 
 export const brandsBlackList = new Set<CreditCardType>();
@@ -42,10 +42,6 @@ const paymentNotSupportedCustomRepresentation = (
   paymentMethod: PaymentMethod
 ): PaymentSupportStatus => {
   switch (paymentMethod.kind) {
-    case "CreditCard":
-      return isCobadge(paymentMethod)
-        ? "onboardableNotImplemented"
-        : "notAvailable";
     case "Satispay":
     case "BPay":
       return "arriving";

--- a/ts/utils/paymentMethodCapabilities.ts
+++ b/ts/utils/paymentMethodCapabilities.ts
@@ -51,7 +51,7 @@ const paymentNotSupportedCustomRepresentation = (
 };
 
 /**
- * Check if a payment method is supported or not
+ * Check if a payment method is supported or  not
  * If the payment method have the enableable function pagoPA, can always pay ("available")
  * "available" -> can pay
  * "arriving" -> will pay


### PR DESCRIPTION
## Short description
This pr changes the custom payment status representation for the cobadge card. Now is just displayed "Not available" instead of a disabled toggle.

<img width="300" alt="Schermata 2021-08-30 alle 10 25 27" src="https://user-images.githubusercontent.com/26501317/131309672-b4b0030f-11fa-450f-a33f-ef94970a327d.png">


## List of changes proposed in this pull request
- Changed the custom payment status representation

## How to test
Wallet > A cobadge card > In the payment section should be visible "Not available"
