### PR TITLE
feat: [IA-211] Remove cobadge payment status disabled toggle

### DIFF
--- a/ts/features/wallet/component/__test__/PagoPaPaymentCapability.test.tsx
+++ b/ts/features/wallet/component/__test__/PagoPaPaymentCapability.test.tsx
@@ -114,7 +114,7 @@ describe("PagoPaPaymentCapability", () => {
     expect(component.getByText("Incompatible")).toBeTruthy();
   });
 
-  it("should render a disabled switch if passed a co-badge, payment method of kind CreditCard with issuerAbiCode and doesn't have enableableFunction pagoPA", () => {
+  it("should render a badge with the text Incompatible if passed a co-badge, payment method of kind CreditCard with issuerAbiCode and doesn't have enableableFunction pagoPA", () => {
     const aNonMaestroCreditCard = {
       info: {
         brand: CreditCardType.decode("VISA").value,
@@ -129,8 +129,7 @@ describe("PagoPaPaymentCapability", () => {
     } as PaymentMethod;
 
     const component = renderTestTarget(aPaymentMethod);
-    const disabledSwitch = component.queryByTestId("switchOnboardCard");
-    expect(disabledSwitch).not.toBeNull();
+    expect(component.getByText("Incompatible")).not.toBeNull();
   });
   it('should render a badge with test "Incompatible" if passed a privative card, payment method of kind CreditCard with issuerAbiCode and type = PRV', () => {
     const aNonMaestroCreditCard = {

--- a/ts/utils/__tests__/paymentMethodCapabilities.test.ts
+++ b/ts/utils/__tests__/paymentMethodCapabilities.test.ts
@@ -85,7 +85,7 @@ describe("isPaymentMethodSupported", () => {
 
     expect(isPaymentSupported(aPaymentMethod)).toEqual("notAvailable");
   });
-  it("should return onboardableNotImplemented if is a cobadge card", () => {
+  it("should return notAvailable if is a cobadge card", () => {
     const aCreditCard = {
       kind: "CreditCard",
       info: {
@@ -100,9 +100,7 @@ describe("isPaymentMethodSupported", () => {
       enableableFunctions: [EnableableFunctionsEnum.BPD]
     } as PaymentMethod;
 
-    expect(isPaymentSupported(aPaymentMethod)).toEqual(
-      "onboardableNotImplemented"
-    );
+    expect(isPaymentSupported(aPaymentMethod)).toEqual("notAvailable");
   });
 
   it("should return arriving if the payment method is of kind Satispay", () => {

--- a/ts/utils/paymentMethodCapabilities.ts
+++ b/ts/utils/paymentMethodCapabilities.ts
@@ -51,7 +51,7 @@ const paymentNotSupportedCustomRepresentation = (
 };
 
 /**
- * Check if a payment method is supported or  not
+ * Check if a payment method is supported or not
  * If the payment method have the enableable function pagoPA, can always pay ("available")
  * "available" -> can pay
  * "arriving" -> will pay

--- a/ts/utils/paymentMethodCapabilities.ts
+++ b/ts/utils/paymentMethodCapabilities.ts
@@ -1,4 +1,5 @@
 import { none, Option, some } from "fp-ts/lib/Option";
+import { EnableableFunctionsEnum } from "../../definitions/pagopa/EnableableFunctions";
 import { TypeEnum } from "../../definitions/pagopa/walletv2/CardInfo";
 import {
   CreditCardPaymentMethod,
@@ -7,7 +8,6 @@ import {
   PaymentMethod
 } from "../types/pagopa";
 import { PaymentSupportStatus } from "../types/paymentMethodCapabilities";
-import { EnableableFunctionsEnum } from "../../definitions/pagopa/EnableableFunctions";
 import { hasFunctionEnabled } from "./walletv2";
 
 export const brandsBlackList = new Set<CreditCardType>();
@@ -42,10 +42,6 @@ const paymentNotSupportedCustomRepresentation = (
   paymentMethod: PaymentMethod
 ): PaymentSupportStatus => {
   switch (paymentMethod.kind) {
-    case "CreditCard":
-      return isCobadge(paymentMethod)
-        ? "onboardableNotImplemented"
-        : "notAvailable";
     case "Satispay":
     case "BPay":
       return "arriving";

--- a/ts/utils/paymentMethodCapabilities.ts
+++ b/ts/utils/paymentMethodCapabilities.ts
@@ -51,7 +51,7 @@ const paymentNotSupportedCustomRepresentation = (
 };
 
 /**
- * Check if a payment method is supported or not
+ * Check if a payment method is supported or  not
  * If the payment method have the enableable function pagoPA, can always pay ("available")
  * "available" -> can pay
  * "arriving" -> will pay


### PR DESCRIPTION
## Short description
This pr changes the custom payment status representation for the cobadge card. Now is just displayed "Not available" instead of a disabled toggle.

<img width="300" alt="Schermata 2021-08-30 alle 10 25 27" src="https://user-images.githubusercontent.com/26501317/131309672-b4b0030f-11fa-450f-a33f-ef94970a327d.png">


## List of changes proposed in this pull request
- Changed the custom payment status representation

## How to test
Wallet > A cobadge card > In the payment section should be visible "Not available"
