### PR TITLE
chore: [IAI-44] Configure actions/stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '0 2 1/7 * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity.'
+        close-issue-message: 'This issue was closed because it has been inactive for 14 days since being marked as stale.'
+        stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity.'
+        close-pr-message: 'This pull request was closed because it has been inactive for 14 days since being marked as stale.'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
+        days-before-stale: 60
+        days-before-close: 14
+        remove-stale-when-updated: true
+        exempt-all-assignees: true
+
+


### PR DESCRIPTION
## Short description
Mark stale issues and PR and close them after a grace period.

## List of changes proposed in this pull request
- Runs every 7 days at 2am UTC
- Issues and PRs without activity in the previous **60 days** are labeled as _stale_
- Issues and PRs with _stale_ label and without activity in the previous **14 days** are closed
- any activity on the issue/PR in the grace period will remove the _stale_ label
