### PR TITLE
fix: [IA-134] Use Infobox for Cashback transactions' info

### DIFF
--- a/ts/features/bonus/bpd/components/BpdTransactionSummaryComponent.tsx
+++ b/ts/features/bonus/bpd/components/BpdTransactionSummaryComponent.tsx
@@ -4,14 +4,12 @@ import { StyleSheet } from "react-native";
 import { TouchableWithoutFeedback } from "@gorhom/bottom-sheet";
 import { Body } from "../../../../components/core/typography/Body";
 import { H4 } from "../../../../components/core/typography/H4";
-import { H5 } from "../../../../components/core/typography/H5";
 import { InfoBox } from "../../../../components/box/InfoBox";
 import { useIOBottomSheet } from "../../../../utils/bottomSheet";
 import { Link } from "../../../../components/core/typography/Link";
 import { openWebUrl } from "../../../../utils/url";
 import Markdown from "../../../../components/ui/Markdown";
 import { IOColors } from "../../../../components/core/variables/IOColors";
-import IconFont from "../../../../components/ui/IconFont";
 import I18n from "../../../../i18n";
 import { localeDateFormat } from "../../../../utils/locale";
 import {
@@ -106,19 +104,15 @@ const BpdTransactionSummaryComponent: React.FunctionComponent<Props> = (
   return (
     <>
       <View style={styles.row}>
-        <IconFont name={"io-notice"} size={24} color={IOColors.blue} />
-        <View hspacer={true} small={true} />
-        <View>
-          <H5 color={"bluegrey"} weight={"Regular"}>
+        <InfoBox iconName={"io-notice"} iconSize={32}>
+          <H4 weight={"Regular"}>
             {I18n.t("bonus.bpd.details.transaction.detail.summary.lastUpdated")}
-            <H5 color={"bluegrey"} weight={"SemiBold"}>
-              {props.lastUpdateDate}
-            </H5>
-          </H5>
+            <H4>{props.lastUpdateDate}</H4>
+          </H4>
           <Link onPress={present} weight={"SemiBold"}>
             {I18n.t("bonus.bpd.details.transaction.detail.summary.link")}
           </Link>
-        </View>
+        </InfoBox>
       </View>
 
       <View spacer={true} />


### PR DESCRIPTION
## Short description
Following up from https://github.com/pagopa/io-app/pull/3338 @fabriziofff 

## List of changes proposed in this pull request
- Use InfoBox component
- Note that we the color changes slightly (from `blueGreyDark` to `blueGrey`) due to the constraints of our typography @thisisjp 

## How to test
Navigate to Wallet -> Cashback -> Your Transactions

| Before | After |
| :----------: | :----------: |
| ![Screenshot 2021-09-01 at 16 50 11](https://user-images.githubusercontent.com/2094604/131693626-2eb2223c-a3a5-4d84-afbe-f5cfd393e71f.png) |  ![Screenshot 2021-09-01 at 16 47 47](https://user-images.githubusercontent.com/2094604/131693648-22d38860-1020-4410-9eab-a5348ec7b7af.png) |

