### PR TITLE
fix: [IA-223] Revert react-native-webview

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -328,8 +328,8 @@ PODS:
     - React
   - react-native-view-shot (3.1.2):
     - React
-  - react-native-webview (11.13.0):
-    - React-Core
+  - react-native-webview (10.4.0):
+    - React
   - React-perflogger (0.64.2)
   - React-RCTActionSheet (0.64.2):
     - React-Core/RCTActionSheetHeaders (= 0.64.2)
@@ -759,7 +759,7 @@ SPEC CHECKSUMS:
   react-native-slider: e99fc201cefe81270fc9d81714a7a0f5e566b168
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
   react-native-view-shot: 4475fde003fe8a210053d1f98fb9e06c1d834e1c
-  react-native-webview: 133a6a5149f963259646e710b4545c67ef35d7c9
+  react-native-webview: 1ad70b21fb9e44811e33a99e43a4b68b94806a6d
   React-perflogger: 25373e382fed75ce768a443822f07098a15ab737
   React-RCTActionSheet: af7796ba49ffe4ca92e7277a5d992d37203f7da5
   React-RCTAnimation: 6a2e76ab50c6f25b428d81b76a5a45351c4d77aa

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "react-native-touch-id": "^4.4.1",
     "react-native-vector-icons": "^7.0.0",
     "react-native-view-shot": "3.1.2",
-    "react-native-webview": "11.13.0",
+    "react-native-webview": "10.4.0",
     "react-navigation": "^4.4.4",
     "react-navigation-drawer": "^1.4.0",
     "react-navigation-redux-helpers": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11713,10 +11713,10 @@ react-native-view-shot@3.1.2:
   resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-3.1.2.tgz#8c8e84c67a4bc8b603e697dbbd59dbc9b4f84825"
   integrity sha512-9u9fPtp6a52UMoZ/UCPrCjKZk8tnkI9To0Eh6yYnLKFEGkRZ7Chm6DqwDJbYJHeZrheCCopaD5oEOnRqhF4L2Q==
 
-react-native-webview@11.13.0:
-  version "11.13.0"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.13.0.tgz#a2eca0f87b2ae9bba0dd8144594aeff9947cc5d6"
-  integrity sha512-jjQAKWv8JzRmcn76fMe4lXD84AAeR7kn43kAmUe1GX312BMLaP+RbKlgpYAlNuOBXL0YirItGKDrpaD0bNROOA==
+react-native-webview@10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-10.4.0.tgz#81602b42618eb1b085074e5b16755610ca4bdadf"
+  integrity sha512-S+325GL+JgdoVuAxuYgtxJka8noBSKgy3RmxHAfjI0wM+bQrV4xK/lBSbVvB+zmILZqXdbuDCfjpuvKrx++xdQ==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
## Short description
This pr reverts the `react-native-webview` because the upgrade of the library it does not allow you to complete the login via CIE. In the next iteration the library will be upgraded and fixed the wrong CIE behaviour.

## List of changes proposed in this pull request
- Downgrade `react-native-webview`

