### PR TITLE
chore: [IAI-53] Restore autolink & Flipper on Android

### DIFF
--- a/android/app/src/debug/java/it/pagopa/io/app/ReactNativeFlipper.java
+++ b/android/app/src/debug/java/it/pagopa/io/app/ReactNativeFlipper.java
@@ -4,7 +4,7 @@
  * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
  * directory of this source tree.
  */
-package com.rndiffapp;
+package it.pagopa.io.app;
 import android.content.Context;
 import com.facebook.flipper.android.AndroidFlipperClient;
 import com.facebook.flipper.android.utils.FlipperUtils;

--- a/android/app/src/main/java/it/pagopa/io/app/MainApplication.java
+++ b/android/app/src/main/java/it/pagopa/io/app/MainApplication.java
@@ -1,46 +1,13 @@
 package it.pagopa.io.app;
 
-import com.robinpowered.react.ScreenBrightness.ScreenBrightnessPackage;
-import com.AlexanderZaytsev.RNI18n.RNI18nPackage;
-import com.sha256lib.Sha256Package;
-import com.kevinejohn.RNMixpanel.RNMixpanel;
-import com.learnium.RNDeviceInfo.RNDeviceInfo;
-import com.lugg.ReactNativeConfig.ReactNativeConfigPackage;
 import com.facebook.react.ReactApplication;
-import com.swmansion.reanimated.ReanimatedPackage;
-import com.reactnativecommunity.clipboard.ClipboardPackage;
-import com.reactnativecommunity.cookies.CookieManagerPackage;
-import com.reactnativecommunity.cameraroll.CameraRollPackage;
-import fr.greweb.reactnativeviewshot.RNViewShotPackage;
-import com.gantix.JailMonkey.JailMonkeyPackage;
-import com.BV.LinearGradient.LinearGradientPackage;
-import cl.json.RNSharePackage;
-import com.reactnativecommunity.asyncstorage.AsyncStoragePackage;
-import com.lewin.qrcode.QRScanReaderPackage;
-import com.imagepicker.ImagePickerPackage;
-import com.kristiansorens.flagsecure.FlagSecurePackage;
-import com.rnfs.RNFSPackage;
-import com.levelasquez.androidopensettings.AndroidOpenSettingsPackage;
-import com.swmansion.gesturehandler.react.RNGestureHandlerPackage;
-import com.calendarevents.RNCalendarEventsPackage;
-import com.ocetnik.timer.BackgroundTimerPackage;
-import com.horcrux.svg.SvgPackage;
-import org.devio.rn.splashscreen.SplashScreenReactPackage;
-import com.masteratul.exceptionhandler.ReactNativeExceptionHandlerPackage;
-import org.reactnative.camera.RNCameraPackage;
-import com.dieam.reactnativepushnotification.ReactNativePushNotificationPackage;
-import com.oblador.keychain.KeychainPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
-import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
 import com.instabug.reactlibrary.RNInstabugReactnativePackage;
-import com.reactnativecommunity.webview.RNCWebViewPackage;
 import it.ipzs.cieidsdk.native_bridge.CiePackage;
 import com.reactnativecommunity.rnpermissions.RNPermissionsPackage;
-import com.reactcommunity.rndatetimepicker.RNDateTimePickerPackage;
 import com.reactnativecommunity.art.ARTPackage;
-import com.hieuvp.fingerprint.ReactNativeFingerprintScannerPackage;
 
 import com.facebook.react.PackageList;
 
@@ -49,8 +16,6 @@ import android.content.Context;
 import com.facebook.react.ReactInstanceManager;
 import java.lang.reflect.InvocationTargetException;
 
-
-import java.util.Arrays;
 import java.util.List;
 
 public class MainApplication extends Application implements ReactApplication {

--- a/android/app/src/main/java/it/pagopa/io/app/MainApplication.java
+++ b/android/app/src/main/java/it/pagopa/io/app/MainApplication.java
@@ -70,26 +70,12 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(new MainReactPackage(),
-            new ReanimatedPackage(),
-            new ARTPackage(),
-            new CookieManagerPackage(),
-            new ClipboardPackage(),
-            new CameraRollPackage(),
-            new RNViewShotPackage(),
-            new JailMonkeyPackage(),
-            new LinearGradientPackage(),
-            new RNSharePackage(), new ScreenBrightnessPackage(), new AsyncStoragePackage(), new QRScanReaderPackage(),
-          new ImagePickerPackage(), new FlagSecurePackage(), new RNFSPackage(), new AndroidOpenSettingsPackage(),
-          new RNGestureHandlerPackage(), new RNCalendarEventsPackage(), new RNCWebViewPackage(),
-          new ReactNativeFingerprintScannerPackage(), new BackgroundTimerPackage(), new SvgPackage(),
-          new SplashScreenReactPackage(), new ReactNativeExceptionHandlerPackage(), new RNCameraPackage(),
-          new ReactNativePushNotificationPackage(), new KeychainPackage(), new RNI18nPackage(), new Sha256Package(),
-          new RNMixpanel(), new RNDeviceInfo(), new ReactNativeConfigPackage(),new CiePackage(),new RNPermissionsPackage(),new RNDateTimePickerPackage(),
-          new RNInstabugReactnativePackage.Builder(BuildConfig.INSTABUG_TOKEN, MainApplication.this)
-              .setInvocationEvent("none").setPrimaryColor("#0073E6").build());
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      packages.add(new RNPermissionsPackage());
+      packages.add(new CiePackage());
+      packages.add(new ARTPackage());
+      return packages;
     }
-
   };
 
   @Override
@@ -101,6 +87,10 @@ public class MainApplication extends Application implements ReactApplication {
   public void onCreate() {
 
     super.onCreate();
+    new RNInstabugReactnativePackage
+      .Builder(BuildConfig.INSTABUG_TOKEN, MainApplication.this)
+      .setInvocationEvent("none")
+      .setPrimaryColor("#0073E6").build();
     SoLoader.init(this, /* native exopackage */ false);
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
   }

--- a/android/app/src/main/java/it/pagopa/io/app/MainApplication.java
+++ b/android/app/src/main/java/it/pagopa/io/app/MainApplication.java
@@ -76,7 +76,7 @@ public class MainApplication extends Application implements ReactApplication {
           We use reflection here to pick up the class that initializes Flipper,
          since Flipper library is not available in release mode
          */
-         Class<?> aClass = Class.forName("it.pagopa.io.app");
+         Class<?> aClass = Class.forName("it.pagopa.io.app.ReactNativeFlipper");
          aClass
            .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
            .invoke(null, context, reactInstanceManager);


### PR DESCRIPTION
## Short description

At the moment, every time we add a new native library, we should also manually register the package in `MainApplication.getPackages`, even if the library supports autolink.

This pr restores the autolink on Android for the supported library, from now on it is no longer necessary to add a library manually if it have the support.

This pr also allows to use Flipper again with Android.

## List of changes proposed in this pull request
- Changed `getPackages()` in order to use the autogenerated list `new PackageList(this).getPackages()`
- Added the missing library that doesn't support the autolinking yet.

## How to test
- `yarn run-android`
