### PR TITLE
fix: [IA-233] React.forwardRef is missing a param

### DIFF
--- a/ts/components/screens/BaseScreenComponent/index.tsx
+++ b/ts/components/screens/BaseScreenComponent/index.tsx
@@ -80,7 +80,7 @@ const contextualHelpModalAnimation = Platform.select<
 });
 
 const BaseScreenComponentFC = React.forwardRef<ReactNode, Props>(
-  (props: Props) => {
+  (props: Props, _) => {
     const {
       accessibilityEvents,
       accessibilityLabel,


### PR DESCRIPTION
## Short description
This pr fixes an error generated by `React.forwardRef` missing a parameter.

```
ERROR  Warning: forwardRef render functions accept exactly two parameters: props and ref. %s Did you forget to use the ref parameter?
```