### PR TITLE
fix: [IA-237] /payment-activations fails if it takes longer than a second

### DIFF
--- a/ts/utils/fetch.ts
+++ b/ts/utils/fetch.ts
@@ -97,7 +97,7 @@ export const constantPollingFetch = (
   shouldAbort: Promise<boolean>,
   retries: number,
   delay: number,
-  timeout: Millisecond = 1000 as Millisecond
+  timeout: Millisecond = fetchTimeout
 ) => {
   // Override default react-native fetch with whatwg's that supports aborting
   // eslint-disable-next-line


### PR DESCRIPTION
## Short description
This pr increases the timeout for `constantPollingFetch` in order to avoid the failure of `/payment-activations` if it takes more than a second.

## List of changes proposed in this pull request
- Increase `timeout` default value in `constantPollingFetch`

## How to test
1. In dev server change https://github.com/pagopa/io-dev-api-server/blob/133c4c4164ac6528aa84c3ccb916513859bdbbc6/src/global.ts#L15 to 3000 milliseconds.
1. Try a payment
1. Without this commit the payment remains blocked 
<img width="300" alt="Schermata 2021-09-13 alle 11 39 29" src="https://user-images.githubusercontent.com/26501317/133061422-78604313-9687-4946-a8c1-3a541b26f003.png">

