### PR TITLE
fix: [IA-112] Fixes BPD transaction detail bottom sheet hiding elements on VO enabled

### DIFF
--- a/ts/components/core/variables/IOStyles.ts
+++ b/ts/components/core/variables/IOStyles.ts
@@ -16,7 +16,6 @@ export const IOStyles = StyleSheet.create({
     paddingRight: themeVariables.contentPadding
   },
   row: {
-    flex: 1,
     flexDirection: "row"
   }
 });

--- a/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionDetailComponent.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/detail/BpdTransactionDetailComponent.tsx
@@ -168,7 +168,7 @@ export const BpdTransactionDetailComponent: React.FunctionComponent<Props> = pro
       <View spacer={true} />
       <Body>{paymentMethod}</Body>
       <View spacer={true} />
-      <View style={[IOStyles.flex, IOStyles.row]}>
+      <View style={IOStyles.row}>
         <Image
           source={props.transaction.image}
           style={styles.image}


### PR DESCRIPTION
## Short description
This PR fixes bad visualization when VO is enabled on the Transaction detail bottom sheet

| Before | After | VO Disabled |
| ------ | ------ | ------ | 
| ![image](https://user-images.githubusercontent.com/3959405/133065090-6dd176b9-e2fd-41e1-98af-b04e06e51bc0.png)| ![image](https://user-images.githubusercontent.com/3959405/133065028-8f03d36b-fce1-49f2-8aef-2ece8785cc53.png)| ![image](https://user-images.githubusercontent.com/3959405/133065239-034e9198-8115-4a8d-a176-1bfa475399e7.png)|
