### PR TITLE
fix: [IABT-1253] If the user changes psp during a payment, a wrong payment total is displayed at the end of the operation in the thank you page

### DIFF
--- a/ts/screens/wallet/payment/common.ts
+++ b/ts/screens/wallet/payment/common.ts
@@ -41,7 +41,11 @@ export const dispatchUpdatePspForWalletAndConfirm = (dispatch: Dispatch) => (
       wallet,
       onSuccess: (
         action: ActionType<typeof paymentUpdateWalletPsp["success"]>
-      ) =>
+      ) => {
+        const psp = action.payload.updatedWallet.psp;
+        if (psp !== undefined) {
+          dispatch(paymentFetchPspsForPaymentId.success([psp]));
+        }
         dispatch(
           navigateToPaymentConfirmPaymentMethodScreen({
             rptId,
@@ -51,7 +55,8 @@ export const dispatchUpdatePspForWalletAndConfirm = (dispatch: Dispatch) => (
             wallet: action.payload.updatedWallet, // the updated wallet
             psps
           })
-        ),
+        );
+      },
       onFailure
     })
   );


### PR DESCRIPTION
## Short description
This pr fixes the bug described in the pr title. If the user chooses to change the psp during the payment, at the end of the payment the value of the default psp is displayed in the thank you page, indicating an incorrect payment total.

## List of changes proposed in this pull request
- Added `dispatch(paymentFetchPspsForPaymentId.success([psp]))` in `dispatchUpdatePspForWalletAndConfirm`, in order to update also the store state instead of navigation params only (The screen `PaymentOutcomeCodeMessage` uses the store state).

## How to test
- Messages > Choose a payment message > When request, change the psp > The payment amount should be now updated in the Choose card & psp screen > Continue with the payment > The total is now right in the `PaymentOutcomeCodeMessage`.

**Before:**

https://user-images.githubusercontent.com/26501317/133087591-907dedf8-d010-48f9-bfe8-a4393ea70b80.mov

Total with default psp: 54,68 €
Total after changing psp: 52,47 €
Thank you page amount: 54.68 €


**After:**

https://user-images.githubusercontent.com/26501317/133087175-afb5d456-5759-4293-a6ad-f36a520df4d1.mov

Total with default psp: 71,97 €
Total after changing psp: 71,41 €
Thank you page amount: 71,41 €
