### PR TITLE
fix: [IA-235] Crash when inserting email during CIE onboarding

### DIFF
--- a/ts/components/helpers/withValidatedEmail.tsx
+++ b/ts/components/helpers/withValidatedEmail.tsx
@@ -46,12 +46,10 @@ class ModalRemindEmailValidationOverlay extends React.Component<ModalProps> {
   };
 
   private handleForcedClose = () => {
-    console.log("handleForcedClose");
     // due a known bug (see https://github.com/react-navigation/react-navigation/issues/4867)
     // when the user is in onboarding phase and he asks to go to insert email screen
     // the navigation is forced reset
-    const resetAction = StackActions.popToTop();
-    this.props.navigation.dispatch(resetAction);
+    this.props.navigation.dispatch(StackActions.popToTop());
     this.props.navigation.dispatch(navigateToEmailInsertScreen());
   };
 

--- a/ts/components/helpers/withValidatedEmail.tsx
+++ b/ts/components/helpers/withValidatedEmail.tsx
@@ -46,14 +46,13 @@ class ModalRemindEmailValidationOverlay extends React.Component<ModalProps> {
   };
 
   private handleForcedClose = () => {
+    console.log("handleForcedClose");
     // due a known bug (see https://github.com/react-navigation/react-navigation/issues/4867)
     // when the user is in onboarding phase and he asks to go to insert email screen
     // the navigation is forced reset
-    const resetAction = StackActions.reset({
-      index: 0,
-      actions: [navigateToEmailInsertScreen()]
-    });
+    const resetAction = StackActions.popToTop();
     this.props.navigation.dispatch(resetAction);
+    this.props.navigation.dispatch(navigateToEmailInsertScreen());
   };
 
   public render() {

--- a/ts/screens/onboarding/EmailInsertScreen.tsx
+++ b/ts/screens/onboarding/EmailInsertScreen.tsx
@@ -163,8 +163,7 @@ class EmailInsertScreen extends React.PureComponent<Props, State> {
   };
 
   private navigateToEmailReadScreen = () => {
-    const resetAction = StackActions.popToTop();
-    this.props.navigation.dispatch(resetAction);
+    this.props.navigation.dispatch(StackActions.popToTop());
     this.props.navigation.dispatch(navigateToEmailReadScreen());
   };
 

--- a/ts/screens/onboarding/EmailInsertScreen.tsx
+++ b/ts/screens/onboarding/EmailInsertScreen.tsx
@@ -163,11 +163,9 @@ class EmailInsertScreen extends React.PureComponent<Props, State> {
   };
 
   private navigateToEmailReadScreen = () => {
-    const resetAction = StackActions.reset({
-      index: 0,
-      actions: [navigateToEmailReadScreen()]
-    });
+    const resetAction = StackActions.popToTop();
     this.props.navigation.dispatch(resetAction);
+    this.props.navigation.dispatch(navigateToEmailReadScreen());
   };
 
   public componentDidMount() {

--- a/ts/screens/onboarding/EmailReadScreen.tsx
+++ b/ts/screens/onboarding/EmailReadScreen.tsx
@@ -128,12 +128,8 @@ export class EmailReadScreen extends React.PureComponent<Props> {
         title: I18n.t("email.edit.cta"),
         onPress: () => {
           if (!isOnboardingCompleted) {
-            const resetAction = StackActions.reset({
-              index: 0,
-              actions: [navigateToEmailInsertScreen()]
-            });
+            const resetAction = StackActions.popToTop();
             this.props.navigation.dispatch(resetAction);
-            return;
           }
           this.props.navigateToEmailInsertScreen();
         }

--- a/ts/screens/onboarding/EmailReadScreen.tsx
+++ b/ts/screens/onboarding/EmailReadScreen.tsx
@@ -128,8 +128,7 @@ export class EmailReadScreen extends React.PureComponent<Props> {
         title: I18n.t("email.edit.cta"),
         onPress: () => {
           if (!isOnboardingCompleted) {
-            const resetAction = StackActions.popToTop();
-            this.props.navigation.dispatch(resetAction);
+            this.props.navigation.dispatch(StackActions.popToTop());
           }
           this.props.navigateToEmailInsertScreen();
         }


### PR DESCRIPTION
## Short description
This pr fixes the crash that occurs when an user insert the email during the first CIE onboarding and others rare edge cases.

https://user-images.githubusercontent.com/26501317/133102372-403fbbcd-f8ed-4c7d-96a5-3c5b56c048cd.mov

## List of changes proposed in this pull request
- Replace `StackActions.reset` with `StackActions.popToTop`

## How to test
- On dev server replace https://github.com/pagopa/io-dev-api-server/blob/fe91bdfe8d90f3044f636f0f9610cfda49e5ff61/src/payloads/profile.ts#L84 with `cieProfileFirstOnboarding`
- Logout
- Login
- Insert email
- Now onboarding continues without crashing 