### PR TITLE
chore: [IA-249] Add an alert explaining why a permission is required on Android

### DIFF
--- a/ios/ItaliaApp/Info.plist
+++ b/ios/ItaliaApp/Info.plist
@@ -59,7 +59,7 @@
     <key>NSCalendarsUsageDescription</key>
     <string>IO needs access to the calendar to add event reminders</string>
     <key>NSCameraUsageDescription</key>
-    <string>IO needs access to the camera to scan QR codes</string>
+    <string>You’ll be able to read QR codes and pay pagoPA notices.</string>
     <key>NSContactsUsageDescription</key>
     <string>IO needs access to your contacts to let you add them in calendar events</string>
     <key>NSFaceIDUsageDescription</key>
@@ -77,7 +77,7 @@
     <key>NSPhotoLibraryAddUsageDescription</key>
     <string>The app needs NSPhotoLibraryAddUsageDescription permission</string>
     <key>NSPhotoLibraryUsageDescription</key>
-    <string>With IO you can save your bonuses and certificates, in addition to uploading screenshots or payment notices</string>
+    <string>You’ll be able to save bonuses, certificates and upload screenshots or payment notices.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>The app needs NSSpeechRecognitionUsageDescription permission</string>
     <key>UIAppFonts</key>

--- a/ios/ItaliaApp/it.lproj/InfoPlist.strings
+++ b/ios/ItaliaApp/it.lproj/InfoPlist.strings
@@ -1,6 +1,6 @@
-"NSCameraUsageDescription" = "IO ha necessità di accedere alla fotocamera per la scansione dei codici di pagamento";
+"NSCameraUsageDescription" = "Potrai leggere codici QR e pagare gli avvisi pagoPA.";
 "NSCalendarsUsageDescription" = "IO ha necessità di accedere ai tuoi calendari per permetterti di ricordare le scadenze";
 "NSContactsUsageDescription" = "IO ha necessità di accedere ai tuoi contatti per permetterti di aggiungerli come partecipanti alle scadenze";
 "NSFaceIDUsageDescription" = "IO ha necessità di accedere a Face ID per permetterti di effettuare un'autenticazione più veloce";
-"NSPhotoLibraryUsageDescription" = "Con IO puoi salvare bonus e certificati, o caricare screenshot e avvisi di pagamento";
+"NSPhotoLibraryUsageDescription" = "Potrai salvare bonus e certificati, caricare screenshot e avvisi di pagamento.";
 "NSMicrophoneUsageDescription" = "IO ha necessità di accedere al microfono nel caso in cui desideri mandare una nota vocale";

--- a/locales/de/index.yml
+++ b/locales/de/index.yml
@@ -798,9 +798,6 @@ wallet:
     wrongQrCode: QR-Code nicht gültig. Geben Sie die Daten manuell ein.
     byCameraTitle: Hinweis QR-Code
     setManually: Manuell eingeben
-    cameraUsagePermissionInfobox:
-      title: "IO-App Kamera-Nutzungserlaubnis"
-      message: "Die IO-App muss auf die Kamera zugreifen, um den QR-Code zu fotografieren"
     settingsAlert:
       title: Es scheint, dass der Zugriff auf die Fotogalerie verweigert wurde
       buttonText:

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -220,6 +220,15 @@ exit:
 errors:
   loginError: There was an error in the login, repeat the procedure.
   profileUpdateError: An error occurred while updating your profile.
+permissionRationale:
+  storage:
+    title: "TMP title storage"
+    message: "TMP message storage"
+    buttonPositive: "TMP buttonPositive storage"
+  camera:
+    title: "TMP title camera"
+    message: "TMP message camera"
+    buttonPositive: "TMP buttonPositive camera"
 startup:
   title: Initialization
   authentication: User authenticated

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -225,8 +225,8 @@ permissionRationale:
     title: "TMP title storage"
     message: "TMP message storage"
   camera:
-    title: "TMP title camera"
-    message: "TMP message camera"
+    title: "IO Camera usage permission"
+    message: "IO app needs Camera usage permission to shoot at the QR code"
 startup:
   title: Initialization
   authentication: User authenticated

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -160,6 +160,7 @@ global:
     update: "Update"
     findOutMore: "Find out more"
     details: "Details"
+    choose: "Scegli"
   navigator:
     messages: messages
     wallet: wallet
@@ -222,11 +223,11 @@ errors:
   profileUpdateError: An error occurred while updating your profile.
 permissionRationale:
   storage:
-    title: "TMP title storage"
-    message: "TMP message storage"
+    title: "Allow gallery access"
+    message: "You’ll be able to save bonuses, certificates and upload screenshots or payment notices."
   camera:
-    title: "IO Camera usage permission"
-    message: "IO app needs Camera usage permission to shoot at the QR code"
+    title: "Allow camera access"
+    message: "You’ll be able to read QR codes and pay pagoPA notices."
 startup:
   title: Initialization
   authentication: User authenticated

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -224,11 +224,9 @@ permissionRationale:
   storage:
     title: "TMP title storage"
     message: "TMP message storage"
-    buttonPositive: "TMP buttonPositive storage"
   camera:
     title: "TMP title camera"
     message: "TMP message camera"
-    buttonPositive: "TMP buttonPositive camera"
 startup:
   title: Initialization
   authentication: User authenticated
@@ -1362,9 +1360,6 @@ wallet:
       manually enter the data (Notice Code and Payee Fiscal Code).
     setManually: Enter manually
     enroll_cta: To scan the QR code, IO needs your permission to use your phone camera. This can be done from the 'Settings' menu of your device.
-    cameraUsagePermissionInfobox:
-      title: "IO Camera usage permission"
-      message: "IO app needs Camera usage permission to shoot at the QR code"
     settingsAlert:
       title: It seems access to Photos has been denied
       message: IO needs access to your gallery to save bonuses and certificates, in addition to uploading screenshots or payment notices

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -160,6 +160,7 @@ global:
     update: "Aggiorna"
     findOutMore: "Scopri di più"
     details: "Dettagli"
+    choose: "Scegli"
   navigator:
     messages: messaggi
     wallet: portafoglio
@@ -222,11 +223,11 @@ errors:
   profileUpdateError: Si è verificato un errore durante l'aggiornamento del tuo profilo.
 permissionRationale:
   storage:
-    title: "TMP title storage"
-    message: "TMP message storage"
+    title: "Consenti l’accesso alla galleria"
+    message: "Potrai salvare bonus e certificati, caricare screenshot e avvisi di pagamento."
   camera:
-    title: "Permesso per utilizzare la fotocamera da parte di IO"
-    message: "IO richiede di poter utilizzare la fotocamera ed inquadrare il QR code"
+    title: "Consenti l’accesso alla fotocamera"
+    message: "Potrai leggere codici QR e pagare gli avvisi pagoPA."
 startup:
   title: Inizializzazione
   authentication: Utente autenticato

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -224,11 +224,9 @@ permissionRationale:
   storage:
     title: "TMP title storage"
     message: "TMP message storage"
-    buttonPositive: "TMP buttonPositive storage"
   camera:
-    title: "TMP title camera"
-    message: "TMP message camera"
-    buttonPositive: "TMP buttonPositive camera"
+    title: "Permesso per utilizzare la fotocamera da parte di IO"
+    message: "IO richiede di poter utilizzare la fotocamera ed inquadrare il QR code"
 startup:
   title: Inizializzazione
   authentication: Utente autenticato
@@ -1385,9 +1383,6 @@ wallet:
       inserisci manualmente i dati (Codice Avviso e Codice Fiscale Ente Creditore).
     setManually: Inserisci manualmente
     enroll_cta: Per inquadrare il codice QR presente sull'avviso, devi prima consentire ad IO l'uso della fotocamera. Puoi farlo dal menu 'Impostazioni' del tuo dispositivo.
-    cameraUsagePermissionInfobox:
-      title: "Permesso per utilizzare la fotocamera da parte di IO"
-      message: "IO richiede di poter utilizzare la fotocamera ed inquadrare il QR code"
     settingsAlert:
       title: Sembra che l'accesso alle foto sia stato negato
       message: IO ha bisogno di accedere alla tua galleria per salvare bonus e certificati, o caricare screenshot e avvisi di pagamento

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -220,6 +220,15 @@ exit:
 errors:
   loginError: C'è stato un errore in fase di login, ripetere la procedura.
   profileUpdateError: Si è verificato un errore durante l'aggiornamento del tuo profilo.
+permissionRationale:
+  storage:
+    title: "TMP title storage"
+    message: "TMP message storage"
+    buttonPositive: "TMP buttonPositive storage"
+  camera:
+    title: "TMP title camera"
+    message: "TMP message camera"
+    buttonPositive: "TMP buttonPositive camera"
 startup:
   title: Inizializzazione
   authentication: Utente autenticato

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2708,7 +2708,7 @@ features:
     revoked:
       title: "Questo certificato \nnon è più valido"
     expired:
-      title: "Questo certifcato è scaduto"
+      title: "Questo certificato è scaduto"
     ko:
       genericError:
         title: "Non è stato possibile recuperare i dati del tuo certificato: riprova"

--- a/patches/patches.md
+++ b/patches/patches.md
@@ -61,3 +61,13 @@ Created on **20/08/2021**
 - As for known issue anytime a developer launch a pod install on his own machine the podfile would be updated with 
   different hashes: [here the issue](https://github.com/facebook/react-native/issues/31193)
   To be removed when updating to `react-native` *0.65*
+
+### react-native-qrcode-scanner+1.5.3
+Created on **16/09/2021**
+
+#### Reason:
+- The package use the prop `checkAndroid6Permissions` for both display the `notAuthorizedView` and display the rationale.
+  We need always to display the rationale alert and not only when requested by the Android OS. Without this patch is impossible
+  to use the `notAuthorizedView` without displaying again the alert.
+  ⚠️ The `QRCodeScanner` component, with this patch, doesn't use anymore the props permissionDialogTitle, permissionDialogMessage and
+  buttonPositive.

--- a/patches/react-native-qrcode-scanner+1.5.3.patch
+++ b/patches/react-native-qrcode-scanner+1.5.3.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/react-native-qrcode-scanner/index.js b/node_modules/react-native-qrcode-scanner/index.js
+index c65dd76..b3b8a49 100644
+--- a/node_modules/react-native-qrcode-scanner/index.js
++++ b/node_modules/react-native-qrcode-scanner/index.js
+@@ -149,11 +149,7 @@ export default class QRCodeScanner extends Component {
+       Platform.OS === 'android' &&
+       this.props.checkAndroid6Permissions
+     ) {
+-      PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.CAMERA, {
+-        title: this.props.permissionDialogTitle,
+-        message: this.props.permissionDialogMessage,
+-        buttonPositive: this.props.buttonPositive,
+-      }).then(granted => {
++      PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.CAMERA).then(granted => {
+         const isAuthorized = granted === PermissionsAndroid.RESULTS.GRANTED;
+ 
+         this.setState({ isAuthorized, isAuthorizationChecked: true });

--- a/ts/screens/wallet/payment/ScanQrCodeScreen.tsx
+++ b/ts/screens/wallet/payment/ScanQrCodeScreen.tsx
@@ -245,7 +245,7 @@ class ScanQrCodeScreen extends React.Component<Props, State> {
         I18n.t("permissionRationale.camera.message"),
         [
           {
-            text: I18n.t("global.buttons.ok"),
+            text: I18n.t("global.buttons.choose"),
             style: "default"
           }
         ]

--- a/ts/screens/wallet/payment/ScanQrCodeScreen.tsx
+++ b/ts/screens/wallet/payment/ScanQrCodeScreen.tsx
@@ -7,7 +7,14 @@ import { AmountInEuroCents, RptId } from "italia-pagopa-commons/lib/pagopa";
 import { ITuple2 } from "italia-ts-commons/lib/tuples";
 import { Container, Text, View } from "native-base";
 import * as React from "react";
-import { Alert, Dimensions, ScrollView, StyleSheet } from "react-native";
+import {
+  Alert,
+  Dimensions,
+  PermissionsAndroid,
+  Platform,
+  ScrollView,
+  StyleSheet
+} from "react-native";
 
 import * as ImagePicker from "react-native-image-picker";
 import { ImageLibraryOptions } from "react-native-image-picker/src/types";
@@ -34,6 +41,7 @@ import variables from "../../../theme/variables";
 import customVariables from "../../../theme/variables";
 import { ComponentProps } from "../../../types/react";
 import { openAppSettings } from "../../../utils/appSettings";
+import { AsyncAlert } from "../../../utils/asyncAlert";
 import { decodePagoPaQrCode } from "../../../utils/payment";
 import { showToast } from "../../../utils/showToast";
 
@@ -44,6 +52,9 @@ type Props = OwnProps & ReturnType<typeof mapDispatchToProps>;
 type State = {
   scanningState: ComponentProps<typeof CameraMarker>["state"];
   isFocused: boolean;
+  // The package react-native-qrcode-scanner automatically asks for android permission, but we have to display before an alert with
+  // the rationale
+  permissionRationaleDisplayed: boolean;
 };
 
 const screenWidth = Dimensions.get("screen").width;
@@ -209,7 +220,8 @@ class ScanQrCodeScreen extends React.Component<Props, State> {
     super(props);
     this.state = {
       scanningState: "SCANNING",
-      isFocused: false
+      isFocused: false,
+      permissionRationaleDisplayed: Platform.OS !== "android"
     };
   }
 
@@ -218,6 +230,28 @@ class ScanQrCodeScreen extends React.Component<Props, State> {
       // cancel the QR scanner reactivation before unmounting the component
       clearTimeout(this.scannerReactivateTimeoutHandler);
     }
+  }
+
+  public async componentDidMount() {
+    if (Platform.OS !== "android") {
+      return;
+    }
+    const hasPermission = await PermissionsAndroid.check(
+      PermissionsAndroid.PERMISSIONS.CAMERA
+    );
+    if (!hasPermission) {
+      await AsyncAlert(
+        I18n.t("permissionRationale.camera.title"),
+        I18n.t("permissionRationale.camera.message"),
+        [
+          {
+            text: I18n.t("global.buttons.ok"),
+            style: "default"
+          }
+        ]
+      );
+    }
+    this.setState({ permissionRationaleDisplayed: true });
   }
 
   private handleWillFocus = () => this.setState({ isFocused: true });
@@ -254,7 +288,7 @@ class ScanQrCodeScreen extends React.Component<Props, State> {
           faqCategories={["wallet"]}
         >
           <ScrollView bounces={false}>
-            {this.state.isFocused && (
+            {this.state.isFocused && this.state.permissionRationaleDisplayed && (
               <QRCodeScanner
                 onRead={(reading: { data: string }) =>
                   this.onQrCodeData(reading.data)
@@ -292,12 +326,6 @@ class ScanQrCodeScreen extends React.Component<Props, State> {
                 // "checkAndroid6Permissions" property enables permission checking for
                 // Android versions greater than 6.0 (23+).
                 checkAndroid6Permissions={true}
-                permissionDialogTitle={I18n.t(
-                  "wallet.QRtoPay.cameraUsagePermissionInfobox.title"
-                )}
-                permissionDialogMessage={I18n.t(
-                  "wallet.QRtoPay.cameraUsagePermissionInfobox.message"
-                )}
                 // "notAuthorizedView" is by default available on iOS systems ONLY.
                 // In order to make Android systems act the same as iOSs you MUST
                 // enable "checkAndroid6Permissions" property as well.

--- a/ts/utils/asyncAlert.ts
+++ b/ts/utils/asyncAlert.ts
@@ -1,0 +1,51 @@
+import { Alert, AlertButton, AlertOptions } from "react-native";
+
+/**
+ * The result of the Alert.
+ * - onPress: one button was pressed
+ * - onDismiss: The user tapped on empty space, dismissing the alert
+ */
+type AlertResult =
+  | { kind: "onPress"; text: AlertButton["text"]; style: AlertButton["style"] }
+  | { kind: "onDismiss" };
+
+/**
+ * Wraps the {@link Alert.alert} using promises instead of callback.
+ * If there are no buttons, the default button "OK" will be used, like the default implementation.
+ * @param title
+ * @param message
+ * @param buttons
+ * @param options
+ * @constructor
+ */
+export const AsyncAlert = (
+  title: string,
+  message?: string,
+  buttons?: Array<AlertButton>,
+  options?: AlertOptions
+): Promise<AlertResult> => {
+  const newButtons: Array<AlertButton> = buttons ?? [
+    { text: "OK", style: "default" }
+  ];
+
+  return new Promise(resolve => {
+    Alert.alert(
+      title,
+      message,
+      newButtons?.map(x => ({
+        ...x,
+        onPress: () => {
+          x.onPress?.();
+          resolve({ kind: "onPress", text: x.text, style: x.style });
+        }
+      })),
+      {
+        ...options,
+        onDismiss: () => {
+          options?.onDismiss?.();
+          resolve({ kind: "onDismiss" });
+        }
+      }
+    );
+  });
+};

--- a/ts/utils/asyncAlert.ts
+++ b/ts/utils/asyncAlert.ts
@@ -1,4 +1,5 @@
 import { Alert, AlertButton, AlertOptions } from "react-native";
+import I18n from "../i18n";
 
 /**
  * The result of the Alert.
@@ -25,7 +26,7 @@ export const AsyncAlert = (
   options?: AlertOptions
 ): Promise<AlertResult> => {
   const newButtons: Array<AlertButton> = buttons ?? [
-    { text: "OK", style: "default" }
+    { text: I18n.t("global.buttons.ok"), style: "default" }
   ];
 
   return new Promise(resolve => {

--- a/ts/utils/permission.ts
+++ b/ts/utils/permission.ts
@@ -27,11 +27,9 @@ export const requestIOAndroidPermission = async (
     return true;
   }
 
-  if (rationale !== undefined) {
-    await AsyncAlert(rationale.title, rationale.message, [
-      { text: rationale.buttonPositive, style: "default" }
-    ]);
-  }
+  await AsyncAlert(rationale.title, rationale.message, [
+    { text: rationale.buttonPositive, style: "default" }
+  ]);
 
   const status = await PermissionsAndroid.request(permission);
   return status === "granted";

--- a/ts/utils/permission.ts
+++ b/ts/utils/permission.ts
@@ -1,12 +1,36 @@
-import { Permission, PermissionsAndroid, Platform } from "react-native";
-// check if the given permission is granted. If not, a prompt is shown to request permission
-export const hasAndroidPermission = async (permission: Permission) => {
+import {
+  Permission,
+  PermissionsAndroid,
+  Platform,
+  Rationale
+} from "react-native";
+import { AsyncAlert } from "./asyncAlert";
+
+/**
+ * This function enhance and wraps the react-native function {@link PermissionsAndroid.request}, in order to give to the user
+ * a prominent disclosure why that permission must be requested.
+ * The default behaviour of {@link PermissionsAndroid.request} displays the alert only in for
+ * https://developer.android.com/training/permissions/requesting.html#explain (the user refused to give permissions )
+ * but we should always explain the reason, also the first time (the user did not make any choices)
+ * @param permission
+ * @param rationale
+ */
+export const requestIOAndroidPermission = async (
+  permission: Permission,
+  rationale: Rationale
+): Promise<boolean> => {
   if (Platform.OS !== "android") {
     return true;
   }
   const hasPermission = await PermissionsAndroid.check(permission);
   if (hasPermission) {
     return true;
+  }
+
+  if (rationale !== undefined) {
+    await AsyncAlert(rationale.title, rationale.message, [
+      { text: rationale.buttonPositive, style: "default" }
+    ]);
   }
 
   const status = await PermissionsAndroid.request(permission);

--- a/ts/utils/share.ts
+++ b/ts/utils/share.ts
@@ -2,7 +2,8 @@ import CameraRoll from "@react-native-community/cameraroll";
 import { fromLeft, TaskEither, tryCatch } from "fp-ts/lib/TaskEither";
 import { PermissionsAndroid, Platform } from "react-native";
 import Share from "react-native-share";
-import { hasAndroidPermission } from "./permission";
+import I18n from "../i18n";
+import { requestIOAndroidPermission } from "./permission";
 
 /**
  * share an url see https://react-native-share.github.io/react-native-share/docs/share-open#supported-options
@@ -42,8 +43,13 @@ export const isShareEnabled = () =>
 export const saveImageToGallery = (uri: string): TaskEither<Error, string> => {
   const hasPermission = tryCatch(
     () =>
-      hasAndroidPermission(
-        PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE
+      requestIOAndroidPermission(
+        PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE,
+        {
+          title: I18n.t("permissionRationale.storage.title"),
+          message: I18n.t("permissionRationale.storage.message"),
+          buttonPositive: I18n.t("permissionRationale.storage.buttonPositive")
+        }
       ),
     errorMsg => new Error(String(errorMsg))
   );

--- a/ts/utils/share.ts
+++ b/ts/utils/share.ts
@@ -48,7 +48,7 @@ export const saveImageToGallery = (uri: string): TaskEither<Error, string> => {
         {
           title: I18n.t("permissionRationale.storage.title"),
           message: I18n.t("permissionRationale.storage.message"),
-          buttonPositive: I18n.t("permissionRationale.storage.buttonPositive")
+          buttonPositive: I18n.t("global.buttons.ok")
         }
       ),
     errorMsg => new Error(String(errorMsg))

--- a/ts/utils/share.ts
+++ b/ts/utils/share.ts
@@ -48,7 +48,7 @@ export const saveImageToGallery = (uri: string): TaskEither<Error, string> => {
         {
           title: I18n.t("permissionRationale.storage.title"),
           message: I18n.t("permissionRationale.storage.message"),
-          buttonPositive: I18n.t("global.buttons.ok")
+          buttonPositive: I18n.t("global.buttons.choose")
         }
       ),
     errorMsg => new Error(String(errorMsg))


### PR DESCRIPTION
## Short description
This pr adds an alert explaining why a permission is required, before asking for that permission.


https://user-images.githubusercontent.com/26501317/133644033-fdf1fe50-0c1d-4275-b96c-fff8d8471875.mov

Gallery:

Rationale            |  Permission
:-------------------------:|:-------------------------:
<img src=https://user-images.githubusercontent.com/26501317/133650132-4fdd769b-ae70-445c-8cb5-27584689eefe.png width=300 /> |  <img src=https://user-images.githubusercontent.com/26501317/133650246-bae685c8-9652-484e-9f50-bc140c7c61b0.png width=300 />

Camera:

Rationale            |  Permission
:-------------------------:|:-------------------------:
<img src=https://user-images.githubusercontent.com/26501317/133650356-98ecf494-35be-437e-b9c8-c7b91ed45465.png width=300 /> |  <img src=https://user-images.githubusercontent.com/26501317/133650401-fcee582f-f7ee-4f25-8414-5d568f6729b9.png width=300 />


## List of changes proposed in this pull request
- Added `AsyncAlert` that allows to work with `Alert.alert` without callbacks.
- Changed `hasAndroidPermission` in `requestIOAndroidPermission`; now before asking for permission display an alert with the rationale
- Changed `ts/screens/wallet/payment/ScanQrCodeScreen.tsx` in order to display an alert with the rationale before the package `react-native-qrcode-scanner` asks for permission.

## How to test
- Revoke all the permission from the app / re-install
- Messages > EU Covid cert > Save the pass > the rationale alert should be displayed
- Wallet > Pay notice > the rationale alert should be displayed
