### PR TITLE
chore: [IA-251] Reset notification token state when the authentication is not longer valid

### DIFF
--- a/ts/store/reducers/notifications/installation.ts
+++ b/ts/store/reducers/notifications/installation.ts
@@ -11,6 +11,12 @@ import {
 } from "../../actions/notifications";
 import { Action } from "../../actions/types";
 import { GlobalState } from "../types";
+import {
+  logoutRequest,
+  sessionExpired,
+  sessionInvalid
+} from "../../actions/authentication";
+import { clearCache } from "../../actions/profile";
 
 export type InstallationState = Readonly<{
   id: string;
@@ -37,6 +43,12 @@ const reducer = (
       return { ...state, token: action.payload };
     case getType(notificationsInstallationTokenRegistered):
       return { ...state, registeredToken: action.payload };
+    // clear the state when the authentication is not longer valid
+    case getType(sessionExpired):
+    case getType(sessionInvalid):
+    case getType(logoutRequest): // even if the logout fails
+    case getType(clearCache):
+      return state;
     default:
       return state;
   }

--- a/ts/store/reducers/notifications/installation.ts
+++ b/ts/store/reducers/notifications/installation.ts
@@ -48,7 +48,7 @@ const reducer = (
     case getType(sessionInvalid):
     case getType(logoutRequest): // even if the logout fails
     case getType(clearCache):
-      return state;
+      return getInitialState();
     default:
       return state;
   }


### PR DESCRIPTION
## Short description
This PR resets the notification token store section when the authentication is not longer valid:

- logout
- session expired
- login from a different device


### how to test
- successfully tested using the APK that includes these changes https://drive.google.com/file/d/1wOq4fAvsLLwaKjXA2IGUzZRDdYulzwyj/view?usp=sharing