### PR TITLE
fix: [IAI-59] Wrong time for workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -540,7 +540,7 @@ workflows:
   weekly-report:
     triggers:
       - schedule:
-          cron: "0 16 * * 5"
+          cron: "0 14 * * 5"
           filters:
             branches:
               only:


### PR DESCRIPTION
## Short description
This pr changes the time for the `weekly-report` workflow execution.
