### PR TITLE
chore: [IA-217] Track biometric capabilities

### DIFF
--- a/ts/__mocks__/react-native-fingerprint-scanner.ts
+++ b/ts/__mocks__/react-native-fingerprint-scanner.ts
@@ -1,0 +1,5 @@
+export default {
+  isSensorAvailable: () => Promise.resolve("Touch ID"),
+  authenticate: () => Promise.resolve(),
+  release: () => Promise.resolve()
+};

--- a/ts/components/Pinpad/index.tsx
+++ b/ts/components/Pinpad/index.tsx
@@ -7,13 +7,13 @@ import { Text, View } from "native-base";
 import * as React from "react";
 import { Alert, Dimensions, StyleSheet, ViewStyle } from "react-native";
 import I18n from "../../i18n";
-import { BiometryPrintableSimpleType } from "../../screens/onboarding/FingerprintScreen";
 import customVariables from "../../theme/variables";
 import { PinString } from "../../types/PinString";
 import { ComponentProps } from "../../types/react";
 import { PIN_LENGTH, PIN_LENGTH_SIX } from "../../utils/constants";
 import { ShakeAnimation } from "../animations/ShakeAnimation";
 import { Link } from "../core/typography/Link";
+import { BiometricsValidType } from "../../utils/biometrics";
 import InputPlaceHolder from "./InputPlaceholder";
 import { DigitRpr, KeyPad } from "./KeyPad";
 
@@ -77,7 +77,7 @@ class Pinpad extends React.PureComponent<Props, State> {
    * the available biometry functionality available on the device
    */
   private getBiometryIconName(
-    biometryPrintableSimpleType: BiometryPrintableSimpleType
+    biometryPrintableSimpleType: BiometricsValidType
   ): DigitRpr {
     switch (biometryPrintableSimpleType) {
       case "BIOMETRICS":
@@ -113,10 +113,10 @@ class Pinpad extends React.PureComponent<Props, State> {
   };
 
   /**
-   * the pad can be componed by
+   * The pad can be composed by
    * - strings
    * - chars
-   * - icons (from icon font): they has to be declared as 'icon:<ICONAME>' (width 48) or 'sicon:<ICONAME>' (width 17)
+   * - icons (from icon font): they has to be declared as 'icon:<ICON_NAME>' (width 48) or 'sicon:<ICON_NAME>' (width 17)
    */
   private pinPadDigits = (): ComponentProps<typeof KeyPad>["digits"] => {
     const { pinPadValues } = this.state;

--- a/ts/mixpanel.ts
+++ b/ts/mixpanel.ts
@@ -5,6 +5,7 @@ import { isScreenReaderEnabled } from "./utils/accessibility";
 import { getAppVersion } from "./utils/appVersion";
 import { isAndroid, isIos } from "./utils/platform";
 import { getDeviceId, getFontScale } from "./utils/device";
+import { getBiometricsType } from "./utils/biometrics";
 
 // eslint-disable-next-line
 export let mixpanel: MixpanelInstance | undefined;
@@ -22,22 +23,6 @@ export const initializeMixPanel = async () => {
   await setupMixpanel(mixpanel);
 };
 
-type IOBiometricTechnology =
-  | "FINGERPRINT"
-  | "FACEID"
-  | "IRIS"
-  | "PALMPRINT"
-  | "RETINA"
-  | "HANDGEOMETRY"
-  | "VOICE";
-
-type IOBiometricStatus = "UNAVAILABLE" | "DISABLED";
-type IOBiometric = IOBiometricTechnology | IOBiometricStatus;
-
-function getBiometricTechnology(): IOBiometric {
-  return "UNAVAILABLE";
-}
-
 const setupMixpanel = async (mp: MixpanelInstance) => {
   const screenReaderEnabled: boolean = await isScreenReaderEnabled();
   await mp.optInTracking();
@@ -48,12 +33,13 @@ const setupMixpanel = async (mp: MixpanelInstance) => {
     await mp.disableIpAddressGeolocalization();
   }
   const fontScale = await getFontScale();
+  const biometricTechnology = await getBiometricsType();
   await mp.registerSuperProperties({
     isScreenReaderEnabled: screenReaderEnabled,
     fontScale,
     appReadableVersion: getAppVersion(),
     colorScheme: Appearance.getColorScheme(),
-    biometricTechnology: getBiometricTechnology()
+    biometricTechnology
   });
   // Identify the user using the device uniqueId
   await mp.identify(getDeviceId());

--- a/ts/mixpanel.ts
+++ b/ts/mixpanel.ts
@@ -22,6 +22,22 @@ export const initializeMixPanel = async () => {
   await setupMixpanel(mixpanel);
 };
 
+type IOBiometricTechnology =
+  | "FINGERPRINT"
+  | "FACEID"
+  | "IRIS"
+  | "PALMPRINT"
+  | "RETINA"
+  | "HANDGEOMETRY"
+  | "VOICE";
+
+type IOBiometricStatus = "UNAVAILABLE" | "DISABLED";
+type IOBiometric = IOBiometricTechnology | IOBiometricStatus;
+
+function getBiometricTechnology(): IOBiometric {
+  return "UNAVAILABLE";
+}
+
 const setupMixpanel = async (mp: MixpanelInstance) => {
   const screenReaderEnabled: boolean = await isScreenReaderEnabled();
   await mp.optInTracking();
@@ -36,7 +52,8 @@ const setupMixpanel = async (mp: MixpanelInstance) => {
     isScreenReaderEnabled: screenReaderEnabled,
     fontScale,
     appReadableVersion: getAppVersion(),
-    colorScheme: Appearance.getColorScheme()
+    colorScheme: Appearance.getColorScheme(),
+    biometricTechnology: getBiometricTechnology()
   });
   // Identify the user using the device uniqueId
   await mp.identify(getDeviceId());

--- a/ts/sagas/startup/checkAcknowledgedFingerprintSaga.ts
+++ b/ts/sagas/startup/checkAcknowledgedFingerprintSaga.ts
@@ -3,13 +3,11 @@ import { navigateToOnboardingFingerprintScreenAction } from "../../store/actions
 import { fingerprintAcknowledge } from "../../store/actions/onboarding";
 import { preferenceFingerprintIsEnabledSaveSuccess } from "../../store/actions/persistedPreferences";
 import { isFingerprintAcknowledgedSelector } from "../../store/reducers/onboarding";
-import { getFingerprintSettings } from "../../utils/biometric";
-
-export type BiometrySimpleType =
-  | "BIOMETRICS"
-  | "FACE_ID"
-  | "TOUCH_ID"
-  | "UNAVAILABLE";
+import {
+  BiometricsType,
+  getBiometricsType,
+  isBiometricsValidType
+} from "../../utils/biometrics";
 
 /**
  * Query TouchID library to retrieve availability information. The ONLY cases
@@ -23,19 +21,19 @@ export type BiometrySimpleType =
 function* onboardFingerprintIfAvailableSaga(): Generator<
   Effect,
   void,
-  BiometrySimpleType
+  BiometricsType
 > {
   // Check if user device has biometric recognition feature by trying to
   // query data from TouchID library
-  const biometryTypeOrUnsupportedReason = yield call(getFingerprintSettings);
+  const biometricsType = yield call(getBiometricsType);
 
-  if (biometryTypeOrUnsupportedReason !== "UNAVAILABLE") {
+  if (isBiometricsValidType(biometricsType)) {
     // If biometric recognition is available, navigate to the Fingerprint
     // Screen and wait for the user to press "Continue". Otherwise the whole
     // step is bypassed
     yield put(
       navigateToOnboardingFingerprintScreenAction({
-        biometryType: biometryTypeOrUnsupportedReason
+        biometryType: biometricsType
       })
     );
 

--- a/ts/screens/modal/IdentificationModal.tsx
+++ b/ts/screens/modal/IdentificationModal.tsx
@@ -221,7 +221,9 @@ class IdentificationModal extends React.PureComponent<Props, State> {
         .then(
           () => {
             if (this.state.biometryType) {
-              this.onFingerprintRequest(this.onIdentificationSuccessHandler);
+              void this.onFingerprintRequest(
+                this.onIdentificationSuccessHandler
+              );
             }
           },
           _ => undefined

--- a/ts/screens/onboarding/FingerprintScreen.tsx
+++ b/ts/screens/onboarding/FingerprintScreen.tsx
@@ -8,18 +8,45 @@ import { ScreenContentHeader } from "../../components/screens/ScreenContentHeade
 import TopScreenComponent from "../../components/screens/TopScreenComponent";
 import FooterWithButtons from "../../components/ui/FooterWithButtons";
 import I18n from "../../i18n";
-import { BiometrySimpleType } from "../../sagas/startup/checkAcknowledgedFingerprintSaga";
 import {
   abortOnboarding,
   fingerprintAcknowledge
 } from "../../store/actions/onboarding";
 import { Dispatch } from "../../store/actions/types";
+import { BiometricsValidType } from "../../utils/biometrics";
 
 type NavigationParams = Readonly<{
-  biometryType: BiometrySimpleType;
+  biometryType: BiometricsValidType;
 }>;
 
-export type BiometryPrintableSimpleType = "BIOMETRICS" | "TOUCH_ID" | "FACE_ID";
+/**
+ * Print the only BiometrySimplePrintableType values that are passed to the UI
+ */
+function localizeBiometricsType(
+  biometryPrintableSimpleType: BiometricsValidType
+): string {
+  switch (biometryPrintableSimpleType) {
+    case "BIOMETRICS":
+      return I18n.t("onboarding.fingerprint.body.enrolledType.fingerprint");
+    case "FACE_ID":
+      return I18n.t("onboarding.fingerprint.body.enrolledType.faceId");
+    case "TOUCH_ID":
+      return I18n.t("onboarding.fingerprint.body.enrolledType.touchId");
+  }
+}
+
+/**
+ * Print the icon according to current biometry status
+ */
+function getBiometryIconName(biometryType: BiometricsValidType): string {
+  switch (biometryType) {
+    case "FACE_ID":
+      return "io-face-id";
+    case "BIOMETRICS":
+    case "TOUCH_ID":
+      return "io-fingerprint";
+  }
+}
 
 type Props = NavigationInjectedProps<NavigationParams> &
   ReturnType<typeof mapDispatchToProps>;
@@ -34,38 +61,6 @@ const contextualHelpMarkdown: ContextualHelpPropsMarkdown = {
  * the instruction to enable the fingerprint/faceID usage
  */
 class FingerprintScreen extends React.PureComponent<Props> {
-  /**
-   * Print the only BiometrySimplePrintableType values that are passed to the UI
-   * @param biometrySimplePrintableType
-   */
-  private renderBiometryType(
-    biometryPrintableSimpleType: BiometryPrintableSimpleType
-  ): string {
-    switch (biometryPrintableSimpleType) {
-      case "BIOMETRICS":
-        return I18n.t("onboarding.fingerprint.body.enrolledType.fingerprint");
-      case "FACE_ID":
-        return I18n.t("onboarding.fingerprint.body.enrolledType.faceId");
-      case "TOUCH_ID":
-        return I18n.t("onboarding.fingerprint.body.enrolledType.touchId");
-    }
-  }
-
-  /**
-   * Print the icon according to current biometry status
-   * @param biometrySimplePrintableType
-   */
-  private getBiometryIconName(biometryType: BiometrySimpleType) {
-    switch (biometryType) {
-      case "FACE_ID":
-        return "io-face-id";
-      case "BIOMETRICS":
-      case "TOUCH_ID":
-      case "UNAVAILABLE":
-        return "io-fingerprint";
-    }
-  }
-
   private handleGoBack = () =>
     Alert.alert(
       I18n.t("onboarding.alert.title"),
@@ -95,14 +90,12 @@ class FingerprintScreen extends React.PureComponent<Props> {
       >
         <ScreenContentHeader
           title={I18n.t("onboarding.fingerprint.title")}
-          iconFont={{ name: this.getBiometryIconName(biometryType) }}
+          iconFont={{ name: getBiometryIconName(biometryType) }}
         />
         <Content>
           <Text>
             {I18n.t("onboarding.fingerprint.body.enrolledText", {
-              biometryType: this.renderBiometryType(
-                biometryType as BiometryPrintableSimpleType
-              )
+              biometryType: localizeBiometricsType(biometryType)
             })}
           </Text>
         </Content>

--- a/ts/screens/profile/SecurityScreen.tsx
+++ b/ts/screens/profile/SecurityScreen.tsx
@@ -12,8 +12,9 @@ import { identificationRequest } from "../../store/actions/identification";
 import { shufflePinPadOnPayment } from "../../config";
 import {
   biometricAuthenticationRequest,
-  getFingerprintSettings
-} from "../../utils/biometric";
+  getBiometricsType,
+  isBiometricsValidType
+} from "../../utils/biometrics";
 import { showToast } from "../../utils/showToast";
 import { preferenceFingerprintIsEnabledSaveSuccess } from "../../store/actions/persistedPreferences";
 import { useScreenReaderEnabled } from "../../utils/accessibility";
@@ -36,11 +37,9 @@ const SecurityScreen: FC<Props> = ({
   const [isFingerprintAvailable, setIsFingerprintAvailable] = useState(false);
 
   useEffect(() => {
-    getFingerprintSettings().then(
-      biometryTypeOrUnsupportedReason => {
-        setIsFingerprintAvailable(
-          biometryTypeOrUnsupportedReason !== "UNAVAILABLE"
-        );
+    getBiometricsType().then(
+      biometricsType => {
+        setIsFingerprintAvailable(isBiometricsValidType(biometricsType));
       },
       _ => undefined
     );

--- a/ts/screens/profile/SecurityScreen.tsx
+++ b/ts/screens/profile/SecurityScreen.tsx
@@ -55,7 +55,7 @@ const SecurityScreen: FC<Props> = ({
       return;
     }
     // if user asks to disable biometric recnognition is required to proceed
-    biometricAuthenticationRequest(
+    void biometricAuthenticationRequest(
       () => setFingerprintPreference(biometricPreference),
       _ =>
         showToast(

--- a/ts/utils/__tests__/biometrics.test.ts
+++ b/ts/utils/__tests__/biometrics.test.ts
@@ -1,0 +1,88 @@
+import FingerprintScanner from "react-native-fingerprint-scanner";
+
+import * as mixpanel from "../../mixpanel";
+import {
+  biometricAuthenticationRequest,
+  getBiometricsType,
+  isBiometricsValidType
+} from "../biometrics";
+
+describe("getBiometricsType function", () => {
+  it.each`
+    input           | expected
+    ${"Touch ID"}   | ${"TOUCH_ID"}
+    ${"Face ID"}    | ${"FACE_ID"}
+    ${"Biometrics"} | ${"BIOMETRICS"}
+  `("returns $expected when $input is given", async ({ input, expected }) => {
+    const spy = jest.spyOn(FingerprintScanner, "isSensorAvailable");
+    spy.mockResolvedValue(input);
+    const result = await getBiometricsType();
+    expect(result).toMatch(expected);
+  });
+
+  it("returns UNKNOWN for any undocumented resolved value", async () => {
+    const spy = jest.spyOn(FingerprintScanner, "isSensorAvailable");
+    spy.mockResolvedValue("literally anything, even 🤡" as any);
+    const result = await getBiometricsType();
+    expect(result).toMatch("UNKNOWN");
+  });
+
+  describe("when an error occurs", () => {
+    it("returns UNAVAILABLE", async () => {
+      const spy = jest.spyOn(FingerprintScanner, "isSensorAvailable");
+      spy.mockRejectedValue("it exploded");
+      const result = await getBiometricsType();
+      expect(result).toMatch("UNAVAILABLE");
+    });
+
+    it("reports BIOMETRIC_ERROR to mixpanel", async () => {
+      const sensorSpy = jest.spyOn(FingerprintScanner, "isSensorAvailable");
+      sensorSpy.mockRejectedValue("it exploded");
+      const mixpanelSpy = jest.spyOn(mixpanel, "mixpanelTrack");
+      await getBiometricsType();
+      expect(mixpanelSpy).toHaveBeenCalledWith("BIOMETRIC_ERROR", {
+        error: "it exploded"
+      });
+    });
+  });
+});
+
+describe("isBiometricsValidType function", () => {
+  it.each`
+    input            | expected
+    ${"UNAVAILABLE"} | ${false}
+    ${"UNKNOWN"}     | ${false}
+    ${"BIOMETRICS"}  | ${true}
+    ${"FACE_ID"}     | ${true}
+    ${"TOUCH_ID"}    | ${true}
+  `("returns $expected when $input is given", ({ input, expected }) => {
+    expect(isBiometricsValidType(input)).toBe(expected);
+  });
+});
+
+describe("biometricAuthenticationRequest function", () => {
+  describe("when authentication succeeds", () => {
+    it("should call the success callback", async () => {
+      const spyAuthenticate = jest.spyOn(FingerprintScanner, "authenticate");
+      const spyRelease = jest.spyOn(FingerprintScanner, "release");
+      const spyOnSuccess = jest.fn();
+      await biometricAuthenticationRequest(spyOnSuccess, jest.fn());
+      expect(spyAuthenticate).toHaveBeenCalled();
+      expect(spyOnSuccess).toHaveBeenCalledWith();
+      expect(spyRelease).toHaveBeenCalled();
+    });
+  });
+
+  describe("when authentication fails", () => {
+    it("should call the error callback with the error message", async () => {
+      const spyAuthenticate = jest.spyOn(FingerprintScanner, "authenticate");
+      spyAuthenticate.mockRejectedValue("error");
+      const spyRelease = jest.spyOn(FingerprintScanner, "release");
+      const spyOnError = jest.fn();
+      await biometricAuthenticationRequest(jest.fn(), spyOnError);
+      expect(spyAuthenticate).toHaveBeenCalled();
+      expect(spyOnError).toHaveBeenCalledWith("error");
+      expect(spyRelease).toHaveBeenCalled();
+    });
+  });
+});

--- a/ts/utils/__tests__/biometrics.test.ts
+++ b/ts/utils/__tests__/biometrics.test.ts
@@ -35,9 +35,9 @@ describe("getBiometricsType function", () => {
       expect(result).toMatch("UNAVAILABLE");
     });
 
-    it("reports BIOMETRIC_ERROR to mixpanel", async () => {
+    it("reports BIOMETRIC_ERROR to mixpanel with the relevant message", async () => {
       const sensorSpy = jest.spyOn(FingerprintScanner, "isSensorAvailable");
-      sensorSpy.mockRejectedValue("it exploded");
+      sensorSpy.mockRejectedValue(new Error("it exploded"));
       const mixpanelSpy = jest.spyOn(mixpanel, "mixpanelTrack");
       await getBiometricsType();
       expect(mixpanelSpy).toHaveBeenCalledWith("BIOMETRIC_ERROR", {

--- a/ts/utils/biometrics.ts
+++ b/ts/utils/biometrics.ts
@@ -2,52 +2,60 @@ import { Alert, Platform } from "react-native";
 import FingerprintScanner, {
   AuthenticateAndroid,
   AuthenticateIOS,
+  Biometrics,
   FingerprintScannerError
 } from "react-native-fingerprint-scanner";
 import { isDebugBiometricIdentificationEnabled } from "../config";
 import I18n from "../i18n";
 import { mixpanelTrack } from "../mixpanel";
-import { BiometrySimpleType } from "../sagas/startup/checkAcknowledgedFingerprintSaga";
+
+export type BiometricsErrorType =
+  // possibly working, but the string returned is undocumented
+  | "UNKNOWN"
+
+  // unspeakable horrors happened somewhere under the hood
+  | "UNAVAILABLE";
+
+export type BiometricsValidType =
+  // happy path
+  "BIOMETRICS" | "FACE_ID" | "TOUCH_ID";
+
+export type BiometricsType = BiometricsErrorType | BiometricsValidType;
 
 /**
  * Retrieve biometric settings from the base system. This function wraps the basic
  * method "isSensorAvailable" of react-native-fingerprint-scanner library and simplifies the possible returned values in
- * function of its usage:
- * * FaceID/TouchID/Biometrics: in case of biometric recognition supported.
- * * Throws an error in case the Biometric option is not enrolled or not available on the device
+ * function of its usage.
  *
  * More info about library can be found here: https://github.com/hieuvp/react-native-fingerprint-scanner
  */
-export function getFingerprintSettings(): Promise<BiometrySimpleType> {
-  return new Promise((resolve, _) => {
-    FingerprintScanner.isSensorAvailable()
-      .then(biometryType => {
-        switch (biometryType) {
-          case "Touch ID":
-            resolve("TOUCH_ID");
-            break;
-          case "Face ID":
-            resolve("FACE_ID");
-            break;
-          case "Biometrics":
-            resolve("BIOMETRICS");
-            break;
-          default:
-            resolve("UNAVAILABLE");
-            break;
-        }
-      })
-      .catch(e => {
-        void mixpanelTrack("BIOMETRIC_ERROR", { error: e });
-        resolve("UNAVAILABLE");
-      });
-  });
-}
+export const getBiometricsType = (): Promise<BiometricsType> =>
+  FingerprintScanner.isSensorAvailable()
+    .then((biometryType: Biometrics) => {
+      switch (biometryType) {
+        case "Touch ID":
+          return "TOUCH_ID";
+        case "Face ID":
+          return "FACE_ID";
+        case "Biometrics":
+          return "BIOMETRICS";
+        default:
+          return "UNKNOWN";
+      }
+    })
+    .catch(e => {
+      void mixpanelTrack("BIOMETRIC_ERROR", { error: e });
+      return "UNAVAILABLE";
+    });
+
+export const isBiometricsValidType = (
+  biometrics: BiometricsType
+): biometrics is BiometricsValidType => !biometrics.startsWith("UN");
 
 export const biometricAuthenticationRequest = (
   onSuccess: () => void,
   onError: (e: FingerprintScannerError) => void
-) => {
+): Promise<void> =>
   FingerprintScanner.authenticate(
     Platform.select({
       ios: {
@@ -75,4 +83,3 @@ export const biometricAuthenticationRequest = (
       // We need to explicitly release the listener to avoid bugs on android platform
       void FingerprintScanner.release();
     });
-};

--- a/ts/utils/biometrics.ts
+++ b/ts/utils/biometrics.ts
@@ -9,12 +9,15 @@ import { isDebugBiometricIdentificationEnabled } from "../config";
 import I18n from "../i18n";
 import { mixpanelTrack } from "../mixpanel";
 
-export type BiometricsErrorType =
+const biometricErrors = [
   // possibly working, but the string returned is undocumented
-  | "UNKNOWN"
+  "UNKNOWN",
 
   // unspeakable horrors happened somewhere under the hood
-  | "UNAVAILABLE";
+  "UNAVAILABLE"
+] as const;
+
+export type BiometricsErrorType = typeof biometricErrors[number];
 
 export type BiometricsValidType =
   // happy path
@@ -44,13 +47,14 @@ export const getBiometricsType = (): Promise<BiometricsType> =>
       }
     })
     .catch(e => {
-      void mixpanelTrack("BIOMETRIC_ERROR", { error: e });
+      void mixpanelTrack("BIOMETRIC_ERROR", { error: e.message ?? "unknown" });
       return "UNAVAILABLE";
     });
 
 export const isBiometricsValidType = (
   biometrics: BiometricsType
-): biometrics is BiometricsValidType => !biometrics.startsWith("UN");
+): biometrics is BiometricsValidType =>
+  !biometricErrors.some(err => biometrics === err);
 
 export const biometricAuthenticationRequest = (
   onSuccess: () => void,


### PR DESCRIPTION
## Short description
Please check [this comment](https://pagopa.atlassian.net/browse/IA-217?focusedCommentId=16078) for a summary and access to the dashboard.

## List of changes proposed in this pull request
- Add property to recognize biometrics type
- Move responsibilites to `utils/biometrics` module, together with the [type definitions](https://github.com/pagopa/io-app/compare/master...IA-217-track-biometric#diff-f1b567fd9a43d3ac2b5ea0042e3fd85db7cf41c709d5c68c26a96f7845973098R12)
- Refactor the usage of `utils/biometrics` and its naming (moving from _*finger*_ to _*biometrics*_)
- Improve significantly the test coverage in `ts/utils/__tests__/biometrics.test.ts`

## How to test

1. Install the app
2. Log in for the first time
3. Enable biometrics
5. Check the dashboard for the relevant events

Tested on:
* Redmi Note 8 (11)
* iPhone 11 (14.4) 
* iPhone 12 (14.5) _emulator_
* Samsung Tab A7 (10)
