### PR TITLE
fix: [IA-224] Upgrade react-native-webview and fix cie login

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -332,8 +332,8 @@ PODS:
     - React
   - react-native-view-shot (3.1.2):
     - React
-  - react-native-webview (10.4.0):
-    - React
+  - react-native-webview (11.13.0):
+    - React-Core
   - React-perflogger (0.64.2)
   - React-RCTActionSheet (0.64.2):
     - React-Core/RCTActionSheetHeaders (= 0.64.2)
@@ -766,7 +766,7 @@ SPEC CHECKSUMS:
   react-native-slider: e99fc201cefe81270fc9d81714a7a0f5e566b168
   react-native-splash-screen: 200d11d188e2e78cea3ad319964f6142b6384865
   react-native-view-shot: 4475fde003fe8a210053d1f98fb9e06c1d834e1c
-  react-native-webview: 1ad70b21fb9e44811e33a99e43a4b68b94806a6d
+  react-native-webview: 133a6a5149f963259646e710b4545c67ef35d7c9
   React-perflogger: 25373e382fed75ce768a443822f07098a15ab737
   React-RCTActionSheet: af7796ba49ffe4ca92e7277a5d992d37203f7da5
   React-RCTAnimation: 6a2e76ab50c6f25b428d81b76a5a45351c4d77aa

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "react-native-svg": "^12.1.1",
     "react-native-vector-icons": "^7.0.0",
     "react-native-view-shot": "3.1.2",
-    "react-native-webview": "10.4.0",
+    "react-native-webview": "^11.13.0",
     "react-navigation": "^4.4.4",
     "react-navigation-drawer": "^1.4.0",
     "react-navigation-redux-helpers": "^3.0.0",
@@ -250,7 +250,8 @@
     "@types/react": "16.7.18",
     "@types/prop-types": "15.5.5",
     "fp-ts": "1.12.0",
-    "io-ts": "1.8.5"
+    "io-ts": "1.8.5",
+    "react-devtools-core": "4.13.0"
   },
   "detox": {
     "test-runner": "./node_modules/.bin/jest",

--- a/ts/components/cie/CieRequestAuthenticationOverlay.tsx
+++ b/ts/components/cie/CieRequestAuthenticationOverlay.tsx
@@ -1,37 +1,26 @@
-/**
- * A screen to manage the request of authentication once the pin of the user's CIE has been inserted+
- */
 import { View } from "native-base";
 import * as React from "react";
-import { BackHandler, StyleSheet, Platform } from "react-native";
+import { createRef, useEffect, useReducer } from "react";
+import { Platform } from "react-native";
 import WebView from "react-native-webview";
 import {
   WebViewErrorEvent,
+  WebViewNavigation,
   WebViewNavigationEvent
 } from "react-native-webview/lib/WebViewTypes";
+import { useHardwareBackButton } from "../../features/bonus/bonusVacanze/components/hooks/useHardwareBackButton";
 import I18n from "../../i18n";
 import { getIdpLoginUri } from "../../utils/login";
+import { closeInjectedScript } from "../../utils/webview";
+import { IOStyles } from "../core/variables/IOStyles";
 import { withLoadingSpinner } from "../helpers/withLoadingSpinner";
 import GenericErrorComponent from "../screens/GenericErrorComponent";
-import { closeInjectedScript } from "../../utils/webview";
 
-type Props = {
-  onClose: () => void;
-  onSuccess: (authorizationUri: string) => void;
-};
-
-type State = {
-  hasError: boolean;
-  findOpenApp: boolean;
-  webViewKey: number;
-  injectJavascript?: string;
-};
-
-const styles = StyleSheet.create({
-  flex: {
-    flex: 1
-  }
-});
+// to make sure the server recognizes the client as valid iPhone device (iOS only) we use a custom header
+// on Android it is not required
+const iOSUserAgent =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1";
+const userAgent = Platform.select({ ios: iOSUserAgent, default: undefined });
 
 // INFA PROD -> xx_servizicie
 // INFRA DEV -> xx_servizicie_test
@@ -50,47 +39,53 @@ const injectJs = `
   }
 `;
 
-// to make sure the server recognizes the client as valid iPhone device (iOS only) we use a custom header
-// on Android it is not required
-const iOSUserAgent =
-  "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1";
-const userAgent = Platform.select({ ios: iOSUserAgent, default: undefined });
+type Props = {
+  onClose: () => void;
+  onSuccess: (authorizationUri: string) => void;
+};
 
-export default class CieRequestAuthenticationOverlay extends React.PureComponent<
-  Props,
-  State
-> {
-  private webView = React.createRef<WebView>();
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      hasError: false,
-      findOpenApp: false,
-      webViewKey: 1
-    };
+type InnerAction =
+  | { kind: "foundAuthUrl"; authUrl: string }
+  | { kind: "setError" }
+  | { kind: "retry" };
+
+type State = {
+  authUrl: string | undefined;
+  error: boolean;
+  key: number;
+};
+
+const initState: State = {
+  authUrl: undefined,
+  error: false,
+  key: 1
+};
+
+const reducer = (state: State, action: InnerAction): State => {
+  switch (action.kind) {
+    case "foundAuthUrl":
+      return { ...state, authUrl: action.authUrl };
+    case "setError":
+      return { ...state, error: true };
+    case "retry":
+      return { ...state, error: false, key: state.key + 1 };
   }
+};
 
-  private handleBackEvent = () => {
-    this.props.onClose();
-    return true;
-  };
+const CieWebView = (props: Props) => {
+  const [{ authUrl, key, error }, dispatch] = useReducer(reducer, initState);
+  const webView = createRef<WebView>();
 
-  public componentDidMount() {
-    BackHandler.addEventListener("hardwareBackPress", this.handleBackEvent);
-  }
+  useEffect(() => {
+    if (authUrl !== undefined) {
+      props.onSuccess(authUrl);
+    }
+  }, [authUrl]);
 
-  public componentWillUnmount() {
-    BackHandler.removeEventListener("hardwareBackPress", this.handleBackEvent);
-  }
-
-  private handleOnError = () => {
-    this.setState({
-      hasError: true
-    });
-  };
-
-  private handleOnShouldStartLoadWithRequest = (event: any): boolean => {
-    if (this.state.findOpenApp) {
+  const handleOnShouldStartLoadWithRequest = (
+    event: WebViewNavigation
+  ): boolean => {
+    if (authUrl !== undefined) {
       return false;
     }
     // on iOS when authnRequestString is present in the url, it means we have all stuffs to go on.
@@ -100,12 +95,10 @@ export default class CieRequestAuthenticationOverlay extends React.PureComponent
       event.url.indexOf("authnRequestString") !== -1
     ) {
       // avoid redirect and follow the 'happy path'
-      if (this.webView.current !== null) {
-        this.setState({ findOpenApp: true }, () => {
-          this.props.onSuccess(
-            // cie-ios sdk asks for "OpenApp?nextUrl=" as prefix
-            event.url.replace("nextUrl=", "OpenApp?nextUrl=")
-          );
+      if (webView.current !== null) {
+        dispatch({
+          kind: "foundAuthUrl",
+          authUrl: event.url.replace("nextUrl=", "OpenApp?nextUrl=")
         });
       }
       return false;
@@ -113,81 +106,94 @@ export default class CieRequestAuthenticationOverlay extends React.PureComponent
 
     // Once the returned url contains the "OpenApp" string, then the authorization has been given
     if (event.url && event.url.indexOf("OpenApp") !== -1) {
-      this.setState({ findOpenApp: true }, () => {
-        this.props.onSuccess(event.url);
-      });
+      dispatch({ kind: "foundAuthUrl", authUrl: event.url });
+      console.log("return false");
       return false;
     }
     return true;
   };
 
-  private renderError = () => (
-    <GenericErrorComponent
-      avoidNavigationEvents={true}
-      onRetry={this.handleOnRetry}
-      onCancel={this.props.onClose}
-      image={require("../../../img/broken-link.png")} // TODO: use custom or generic image?
-      text={I18n.t("authentication.errors.network.title")} // TODO: use custom or generic text?
-    />
-  );
-
-  // Updating the webView key its content is refreshed
-  private handleOnRetry = () => {
-    const webViewKey = this.state.webViewKey + 1;
-    this.setState({
-      webViewKey,
-      hasError: false
-    });
+  const handleOnError = () => {
+    dispatch({ kind: "setError" });
   };
 
-  private handleOnLoadEnd = (e: WebViewNavigationEvent | WebViewErrorEvent) => {
+  const handleOnLoadEnd = (e: WebViewNavigationEvent | WebViewErrorEvent) => {
     if (e.nativeEvent.title === "Pagina web non disponibile") {
-      this.handleOnError();
+      handleOnError();
     }
     // inject JS on every page load end
-    if (this.webView.current) {
-      this.webView.current.injectJavaScript(closeInjectedScript(injectJs));
+    if (webView.current) {
+      webView.current.injectJavaScript(closeInjectedScript(injectJs));
     }
   };
 
-  private renderWebView() {
+  if (error) {
     return (
-      <View style={styles.flex}>
-        {!this.state.findOpenApp && (
-          <WebView
-            ref={this.webView}
-            userAgent={userAgent}
-            javaScriptEnabled={true}
-            injectedJavaScript={injectJs}
-            onLoadEnd={this.handleOnLoadEnd}
-            onError={this.handleOnError}
-            onShouldStartLoadWithRequest={
-              this.handleOnShouldStartLoadWithRequest
-            }
-            source={{
-              uri: getIdpLoginUri(CIE_IDP_ID)
-            }}
-            key={this.state.webViewKey}
-          />
-        )}
-      </View>
-    );
-  }
-
-  public render(): React.ReactNode {
-    if (this.state.hasError) {
-      return this.renderError();
-    }
-    const ContainerComponent = withLoadingSpinner(() => (
-      <View>{this.renderWebView()}</View>
-    ));
-    return (
-      <ContainerComponent
-        isLoading={true}
-        loadingOpacity={1.0}
-        loadingCaption={I18n.t("global.genericWaiting")}
-        onCancel={this.props.onClose}
+      <ErrorComponent
+        onRetry={() => dispatch({ kind: "retry" })}
+        onClose={props.onClose}
       />
     );
   }
-}
+
+  const WithLoading = withLoadingSpinner(() => (
+    <View style={IOStyles.flex}>
+      {authUrl === undefined && (
+        <WebView
+          ref={webView}
+          userAgent={userAgent}
+          javaScriptEnabled={true}
+          injectedJavaScript={injectJs}
+          onLoadEnd={handleOnLoadEnd}
+          onError={handleOnError}
+          onShouldStartLoadWithRequest={handleOnShouldStartLoadWithRequest}
+          source={{
+            uri: getIdpLoginUri(CIE_IDP_ID)
+          }}
+          key={key}
+        />
+      )}
+    </View>
+  ));
+
+  return (
+    <WithLoading
+      isLoading={true}
+      loadingOpacity={1.0}
+      loadingCaption={I18n.t("global.genericWaiting")}
+      onCancel={props.onClose}
+    />
+  );
+};
+
+const ErrorComponent = (
+  props: { onRetry: () => void } & Pick<Props, "onClose">
+) => (
+  <GenericErrorComponent
+    avoidNavigationEvents={true}
+    onRetry={props.onRetry}
+    onCancel={props.onClose}
+    image={require("../../../img/broken-link.png")} // TODO: use custom or generic image?
+    text={I18n.t("authentication.errors.network.title")} // TODO: use custom or generic text?
+  />
+);
+
+/**
+ * A screen to manage the request of authentication once the pin of the user's CIE has been inserted
+ * 1) Start the first request with the getIdpLoginUri(CIE_IDP_ID) uri
+ * 2) Accepts all the redirects until the uri with the right path is found and stop the loading
+ * 3) Dispatch the found uri using the `onSuccess` callback
+ * @param props
+ * @constructor
+ */
+export const CieRequestAuthenticationOverlay = (
+  props: Props
+): React.ReactElement => {
+  // Disable android back button
+  useHardwareBackButton(() => {
+    props.onClose();
+    return true;
+  });
+
+  return <CieWebView {...props} />;
+};

--- a/ts/components/cie/CieRequestAuthenticationOverlay.tsx
+++ b/ts/components/cie/CieRequestAuthenticationOverlay.tsx
@@ -107,7 +107,6 @@ const CieWebView = (props: Props) => {
     // Once the returned url contains the "OpenApp" string, then the authorization has been given
     if (event.url && event.url.indexOf("OpenApp") !== -1) {
       dispatch({ kind: "foundAuthUrl", authUrl: event.url });
-      console.log("return false");
       return false;
     }
     return true;

--- a/ts/screens/authentication/cie/CieCardReaderScreen.tsx
+++ b/ts/screens/authentication/cie/CieCardReaderScreen.tsx
@@ -317,8 +317,6 @@ class CieCardReaderScreen extends React.PureComponent<Props, State> {
   };
 
   private handleCieSuccess = (cieConsentUri: string) => {
-    console.log("cieConsentUri" + cieConsentUri);
-    // return;
     if (this.state.readingState === ReadingState.completed) {
       return;
     }

--- a/ts/screens/authentication/cie/CieCardReaderScreen.tsx
+++ b/ts/screens/authentication/cie/CieCardReaderScreen.tsx
@@ -317,6 +317,8 @@ class CieCardReaderScreen extends React.PureComponent<Props, State> {
   };
 
   private handleCieSuccess = (cieConsentUri: string) => {
+    console.log("cieConsentUri" + cieConsentUri);
+    // return;
     if (this.state.readingState === ReadingState.completed) {
       return;
     }

--- a/ts/screens/authentication/cie/CieConsentDataUsageScreen.tsx
+++ b/ts/screens/authentication/cie/CieConsentDataUsageScreen.tsx
@@ -2,14 +2,17 @@
  * A screen to display, by a webview, the consent to send user sensitive data
  * to backend and proceed with the onbording process
  */
+import { View } from "native-base";
 import * as React from "react";
 import { Alert, BackHandler } from "react-native";
 import WebView from "react-native-webview";
-import { WebViewNavigation } from "react-native-webview/lib/WebViewTypes";
+import {
+  WebViewHttpErrorEvent,
+  WebViewNavigation
+} from "react-native-webview/lib/WebViewTypes";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { NavigationStackScreenProps } from "react-navigation-stack";
 import { connect } from "react-redux";
-import { View } from "native-base";
 import LoadingSpinnerOverlay from "../../../components/LoadingSpinnerOverlay";
 import GenericErrorComponent from "../../../components/screens/GenericErrorComponent";
 import TopScreenComponent from "../../../components/screens/TopScreenComponent";
@@ -92,6 +95,14 @@ class CieConsentDataUsageScreen extends React.Component<Props, State> {
     this.setState({ hasError: true });
   };
 
+  private handleHttpError = (event: WebViewHttpErrorEvent) => {
+    this.props.loginFailure(
+      new Error(
+        `HTTP error ${event.nativeEvent.description} with Authorization uri`
+      )
+    );
+  };
+
   private handleLoginSuccess = (token: SessionToken) => {
     this.setState({ isLoginSuccess: true }, () => {
       this.props.loginSuccess(token);
@@ -153,6 +164,7 @@ class CieConsentDataUsageScreen extends React.Component<Props, State> {
           onShouldStartLoadWithRequest={this.handleShouldStartLoading}
           renderLoading={() => loaderComponent}
           onError={this.handleWebViewError}
+          onHttpError={this.handleHttpError}
         />
       );
     }

--- a/ts/screens/authentication/cie/CieConsentDataUsageScreen.tsx
+++ b/ts/screens/authentication/cie/CieConsentDataUsageScreen.tsx
@@ -99,7 +99,6 @@ class CieConsentDataUsageScreen extends React.Component<Props, State> {
   };
 
   private handleShouldStartLoading = (event: WebViewNavigation): boolean => {
-    console.log("handleShouldStartLoading" + event.url);
     const isLoginUrlWithToken = onLoginUriChanged(
       this.handleLoginFailure,
       this.handleLoginSuccess

--- a/ts/screens/authentication/cie/CieConsentDataUsageScreen.tsx
+++ b/ts/screens/authentication/cie/CieConsentDataUsageScreen.tsx
@@ -99,6 +99,7 @@ class CieConsentDataUsageScreen extends React.Component<Props, State> {
   };
 
   private handleShouldStartLoading = (event: WebViewNavigation): boolean => {
+    console.log("handleShouldStartLoading" + event.url);
     const isLoginUrlWithToken = onLoginUriChanged(
       this.handleLoginFailure,
       this.handleLoginSuccess

--- a/ts/screens/authentication/cie/CiePinScreen.tsx
+++ b/ts/screens/authentication/cie/CiePinScreen.tsx
@@ -135,7 +135,7 @@ const CiePinScreen: React.FC<Props> = props => {
     showAnimatedModal(
       <CieRequestAuthenticationOverlay
         onClose={handleAuthenticationOverlayOnClose}
-        onSuccess={url => setAuthUrlGenerated(url)}
+        onSuccess={setAuthUrlGenerated}
       />,
       BottomTopAnimation
     );

--- a/ts/screens/authentication/cie/CiePinScreen.tsx
+++ b/ts/screens/authentication/cie/CiePinScreen.tsx
@@ -1,11 +1,11 @@
 import { Millisecond } from "italia-ts-commons/lib/units";
 import { View } from "native-base";
 import React, {
-  useState,
+  useCallback,
+  useContext,
   useEffect,
   useRef,
-  useContext,
-  useCallback
+  useState
 } from "react";
 import {
   Keyboard,
@@ -17,8 +17,11 @@ import {
 import { NavigationContext, NavigationInjectedProps } from "react-navigation";
 import { connect } from "react-redux";
 import AdviceComponent from "../../../components/AdviceComponent";
-import CieRequestAuthenticationOverlay from "../../../components/cie/CieRequestAuthenticationOverlay";
+import ButtonDefaultOpacity from "../../../components/ButtonDefaultOpacity";
+import { CieRequestAuthenticationOverlay } from "../../../components/cie/CieRequestAuthenticationOverlay";
 import CiePinpad from "../../../components/CiePinpad";
+import { Link } from "../../../components/core/typography/Link";
+import { IOColors } from "../../../components/core/variables/IOColors";
 import { ScreenContentHeader } from "../../../components/screens/ScreenContentHeader";
 import TopScreenComponent from "../../../components/screens/TopScreenComponent";
 import FooterWithButtons from "../../../components/ui/FooterWithButtons";
@@ -26,20 +29,17 @@ import {
   BottomTopAnimation,
   LightModalContext
 } from "../../../components/ui/LightModal";
+import Markdown from "../../../components/ui/Markdown";
 import I18n from "../../../i18n";
 import ROUTES from "../../../navigation/routes";
 import { nfcIsEnabled } from "../../../store/actions/cie";
 import { Dispatch, ReduxProps } from "../../../store/actions/types";
 import variables from "../../../theme/variables";
 import { setAccessibilityFocus } from "../../../utils/accessibility";
+import { useIOBottomSheet } from "../../../utils/bottomSheet";
 
 import { isIos } from "../../../utils/platform";
-import { useIOBottomSheet } from "../../../utils/bottomSheet";
 import { openWebUrl } from "../../../utils/url";
-import { Link } from "../../../components/core/typography/Link";
-import Markdown from "../../../components/ui/Markdown";
-import ButtonDefaultOpacity from "../../../components/ButtonDefaultOpacity";
-import { IOColors } from "../../../components/core/variables/IOColors";
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   requestNfcEnabledCheck: () => dispatch(nfcIsEnabled.request())
@@ -79,6 +79,9 @@ const CiePinScreen: React.FC<Props> = props => {
   const [pin, setPin] = useState("");
   const continueButtonRef = useRef<FooterWithButtons>(null);
   const pinPadViewRef = useRef<View>(null);
+  const [authUrlGenerated, setAuthUrlGenerated] = useState<string | undefined>(
+    undefined
+  );
 
   useEffect(() => {
     if (pin.length === CIE_PIN_LENGTH) {
@@ -103,7 +106,7 @@ const CiePinScreen: React.FC<Props> = props => {
     320
   );
 
-  const onProceedToCardReaderScreen = async (url: string) => {
+  const onProceedToCardReaderScreen = (url: string) => {
     setPin("");
     navigate({
       routeName: ROUTES.CIE_CARD_READER_SCREEN,
@@ -114,6 +117,12 @@ const CiePinScreen: React.FC<Props> = props => {
     });
     hideModal();
   };
+
+  useEffect(() => {
+    if (authUrlGenerated !== undefined) {
+      onProceedToCardReaderScreen(authUrlGenerated);
+    }
+  }, [authUrlGenerated]);
 
   const handleAuthenticationOverlayOnClose = () => {
     setPin("");
@@ -126,7 +135,7 @@ const CiePinScreen: React.FC<Props> = props => {
     showAnimatedModal(
       <CieRequestAuthenticationOverlay
         onClose={handleAuthenticationOverlayOnClose}
-        onSuccess={onProceedToCardReaderScreen}
+        onSuccess={url => setAuthUrlGenerated(url)}
       />,
       BottomTopAnimation
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -11524,10 +11524,10 @@ react-deep-force-update@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.1.2.tgz#3d2ae45c2c9040cbb1772be52f8ea1ade6ca2ee1"
   integrity sha512-WUSQJ4P/wWcusaH+zZmbECOk7H5N2pOIl0vzheeornkIMhu+qrNdGFm0bDZLCb0hSF0jf/kH1SgkNGfBdTc4wA==
 
-react-devtools-core@^4.6.0:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.8.2.tgz#4465f2e8de7795564aa20f28b2f3a9737586db23"
-  integrity sha512-3Lv3nI8FPAwKqUco35oOlgf+4j8mgYNnIcDv2QTfxEqg2G69q17ZJ8ScU9aBnymS28YC1OW+kTxLmdIQeTN8yg==
+react-devtools-core@4.13.0, react-devtools-core@^4.6.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.13.0.tgz#fa80ee03b1a975c1d9898e24de841e45a4b22d30"
+  integrity sha512-KR+0pLw8wTjOVr+9AECe5ctmycaAjbmxN3bbdB0vmlwm0JkxNnKMxDzanf+4V8IuPBQWgm8qdWpbSOqhu1l14g==
   dependencies:
     shell-quote "^1.6.1"
     ws "^7"
@@ -11886,10 +11886,10 @@ react-native-view-shot@3.1.2:
   resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-3.1.2.tgz#8c8e84c67a4bc8b603e697dbbd59dbc9b4f84825"
   integrity sha512-9u9fPtp6a52UMoZ/UCPrCjKZk8tnkI9To0Eh6yYnLKFEGkRZ7Chm6DqwDJbYJHeZrheCCopaD5oEOnRqhF4L2Q==
 
-react-native-webview@10.4.0:
-  version "10.4.0"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-10.4.0.tgz#81602b42618eb1b085074e5b16755610ca4bdadf"
-  integrity sha512-S+325GL+JgdoVuAxuYgtxJka8noBSKgy3RmxHAfjI0wM+bQrV4xK/lBSbVvB+zmILZqXdbuDCfjpuvKrx++xdQ==
+react-native-webview@^11.13.0:
+  version "11.13.0"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-11.13.0.tgz#a2eca0f87b2ae9bba0dd8144594aeff9947cc5d6"
+  integrity sha512-jjQAKWv8JzRmcn76fMe4lXD84AAeR7kn43kAmUe1GX312BMLaP+RbKlgpYAlNuOBXL0YirItGKDrpaD0bNROOA==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
## Short description
This pr updates `react-native-webview` and fixes a regression due to a library upgrade. 
The pr https://github.com/react-native-webview/react-native-webview/pull/1590 changed the logic with which the method `shouldOverrideUrlLoading` wait the results from the JavaScript callback `onShouldStartLoadWithRequest`, in order to choose if the loading of the page should be overwritten, waiting for the result with a timeout lock.

In our previous implementation, in `CieRequestAuthenticationOverlay.handleOnShouldStartLoadWithRequest` was called the callback `this.props.onSuccess(event.url)` when the authentication url was found, and the component `CiePinScreen` used this callback to call direcly `onProceedToCardReaderScreen`, triggering a navigation.
Doing all these sequences of operation inside the callback of `handleOnShouldStartLoadWithRequest` blocks the JavaScript thread for `493 ms` and the native code generate a:

`W/unknown:RNCWebViewManager: Did not receive response to shouldOverrideUrlLoading in time, defaulting to allow loading.`

causing the link to load and making it no longer valid for authentication.
To solve this, the component `CieRequestAuthenticationOverlay` has been chaanged to functional component (`43,3 ms` vs `65,2 ms` after change the state when the authUrl was found) and the component `CiePinScreen` doesn't do a direct navigation when receive `onSuccess`, but instead update the state in order to trigger the navigation at the next rendering using the `hook`.

## List of changes proposed in this pull request
- Updated `react-native-webview` to `11.13.0`
- Set `"react-devtools-core": "4.13.0"` as resolution dependency in order to be compatible with flipper.
- Changed `CieRequestAuthenticationOverlay.tsx` to a functional component in order to avoid some re-rendering.
- Changed `CiePinScreen.tsx` in order to avoid to dispatch directly a navigation action inside the `onSuccess` callback.
