### PR TITLE
fix: [IA-263] Wrong spacing in navigation bar for iPhone 13

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -412,7 +412,7 @@ PODS:
     - React-Core
   - RNDateTimePicker (3.5.2):
     - React-Core
-  - RNDeviceInfo (8.1.3):
+  - RNDeviceInfo (8.3.3):
     - React-Core
   - RNFS (2.16.6):
     - React
@@ -786,7 +786,7 @@ SPEC CHECKSUMS:
   RNCClipboard: ddd4d291537f1667209c9c405aaa4307297e252e
   RNCPushNotificationIOS: 61a7c72bd1ebad3568025957d001e0f0e7b32191
   RNDateTimePicker: 7658208086d86d09e1627b5c34ba0cf237c60140
-  RNDeviceInfo: 8d3a29207835f972bce883723882980143270d55
+  RNDeviceInfo: cc7de0772378f85d8f36ae439df20f05c590a651
   RNFS: 2bd9eb49dc82fa9676382f0585b992c424cd59df
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNI18n: e2f7e76389fcc6e84f2c8733ea89b92502351fd8

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "react-native-calendar-events": "2.2.0",
     "react-native-camera": "^3.44.3",
     "react-native-config": "1.4.3",
-    "react-native-device-info": "^8.1.3",
+    "react-native-device-info": "^8.3.3",
     "react-native-exception-handler": "^2.10.8",
     "react-native-fingerprint-scanner": "^6.0.0",
     "react-native-flag-secure-android": "git://github.com/pagopa/react-native-flag-secure-android.git#7afcf2a418b945f976a4f0e7a72e89301253c795",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11613,10 +11613,10 @@ react-native-config@1.4.3:
   resolved "https://registry.yarnpkg.com/react-native-config/-/react-native-config-1.4.3.tgz#22de798ffea621c2683abfa3fc054e17dd2cf1cc"
   integrity sha512-KcrlImtkrANeYMT5VM3NaXO5+nyxZkY42CVW8FCHThVqLa5xkNwQJSn8RXu+pNn5WpUatxYgUTP5ZqUpA4/ZKQ==
 
-react-native-device-info@^8.1.3:
-  version "8.1.3"
-  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-8.1.3.tgz#022fc01372632bf80c0a6d201aab53344efc715f"
-  integrity sha512-73e3wiGFL8DvIXEd8x4Aq+mO8mZvHARwfYorIEu+X0trLHY92bP5Ict8DJHDjCQ0+HtAvpA4Wda2VoUVN1zh6Q==
+react-native-device-info@^8.3.3:
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-8.3.3.tgz#05c1900602d174b58c6ac927d748a785d76d0898"
+  integrity sha512-l8/3MHq6O9PRWSrKwy63WvDCnt8IXOce86AEkJFVVtKR9cAGLLaFyXUGyqIc5T/kpCyOqofOattVDjZGUn/zAQ==
 
 react-native-drawer@2.5.1:
   version "2.5.1"


### PR DESCRIPTION
## Short description
This pr upgrades `react-native-device-info` in order to support the latest iPhone 13 and correcly calculate the required spacing in the navigation bar.

Before            |  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/26501317/135085132-064b0429-b7e3-452d-9ba0-0fb61da22ab3.png" width="300">|  <img src="https://user-images.githubusercontent.com/26501317/135085208-fb657825-e251-4777-952e-a7b50305e65d.png" width="300">

## List of changes proposed in this pull request
- Upgrade `react-native-device-info` to the latest version

## How to test
- Run on iPhone 13
