### PR TITLE
feat: [IAI-5] Automatically notify when a new app version is available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,17 @@ jobs:
       - run: '[ -z "IO_APP_SLACK_HELPER_BOT_TOKEN" ] || yarn ts-node --skip-project -O
        ''{"lib":["es2015"]}'' scripts/ts/checkOutdatedDependencies/checkOutdatedDependencies.ts'
 
+  # Send a Slack message to notify the release of a new app version in beta
+  notify-new-app-version:
+    <<: *defaults_js
+
+    steps:
+      - checkout
+      - *restore_node_cache
+      - *install_node_modules
+      - run: '[ -z "IO_APP_SLACK_HELPER_BOT_TOKEN" ] || yarn ts-node --skip-project -O
+       ''{"lib":["es2015"]}'' scripts/ts/notifyNewAppVersion/notifyNewAppVersion.ts'
+
   # Create signed Android release
   android-release:
     <<: *defaults_android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,7 +459,6 @@ workflows:
       - compile-typescript
       - run-tests
       - run-eslint
-      - notify-new-app-version
 
       - run-danger:
           filters:
@@ -508,6 +507,17 @@ workflows:
             - compile-typescript
             - run-tests
             - run-eslint
+          filters:
+            tags:
+              only: *release_tag
+            branches:
+              ignore: /.*/
+
+      # Send a Slack message to notify the release of a new app version in beta
+      - notify-new-app-version:
+          requires:
+            - ios-beta-release
+            - alpha-release-android
           filters:
             tags:
               only: *release_tag

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,6 +459,7 @@ workflows:
       - compile-typescript
       - run-tests
       - run-eslint
+      - notify-new-app-version
 
       - run-danger:
           filters:

--- a/scripts/ts/common/slack/postMessage.ts
+++ b/scripts/ts/common/slack/postMessage.ts
@@ -35,7 +35,7 @@ export const slackPostMessage = async (
   const jsonResponse = await res.json();
   if (jsonResponse.ok === false) {
     throw new Error(
-      `An error occured with the Slack API: ${jsonResponse.error}`
+      `An error occurred with the Slack API: ${jsonResponse.error}`
     );
   }
 

--- a/scripts/ts/notifyNewAppVersion/notifyNewAppVersion.ts
+++ b/scripts/ts/notifyNewAppVersion/notifyNewAppVersion.ts
@@ -5,6 +5,9 @@ import { slackPostMessage } from "../common/slack/postMessage";
 const destinationChannel = "#prod_io";
 const packagePath = "package.json";
 
+/**
+ * Send a Slack message to notify the release of a new app version in beta
+ */
 const main = async () => {
   const packageJson = JSON.parse(fs.readFileSync(packagePath).toString("utf8"));
   const appVersion = packageJson.version as string;

--- a/scripts/ts/notifyNewAppVersion/notifyNewAppVersion.ts
+++ b/scripts/ts/notifyNewAppVersion/notifyNewAppVersion.ts
@@ -1,0 +1,27 @@
+/* eslint-disable no-console */
+import * as fs from "fs-extra";
+import { slackPostMessage } from "../common/slack/postMessage";
+
+const destinationChannel = "#test";
+const packagePath = "package.json";
+
+const main = async () => {
+  const packageJson = JSON.parse(fs.readFileSync(packagePath).toString("utf8"));
+  const appVersion = packageJson.version as string;
+
+  await slackPostMessage(
+    "È disponibile la nuova versione `" +
+      appVersion +
+      "` dell’app :io-app: in test interno.\n" +
+      "<https://github.com/pagopa/io-app/blob/master/CHANGELOG.md|:memo: Changelog> - " +
+      "<https://pagopa.atlassian.net/wiki/spaces/IOAPP/pages/345932988/Release+produzione+beta#Frequenza-rilasci|:calendar: Calendario rilasci> - " +
+      "<https://pagopa.atlassian.net/wiki/spaces/IOAPP/pages/22020162/Beta+interna|:test_tube: Come partecipo alla beta interna?> - " +
+      "<https://pagopa.atlassian.net/wiki/spaces/IOAPP/pages/22020162/Beta+interna#%F0%9F%90%9E-Come-segnalo-un-bug?|:ladybug: Come segnalo un bug?>",
+    destinationChannel,
+    false
+  );
+};
+
+void main()
+  .then()
+  .catch(ex => console.log(`Fail to execute 'notifyNewAppVersion':\n ${ex}`));

--- a/scripts/ts/notifyNewAppVersion/notifyNewAppVersion.ts
+++ b/scripts/ts/notifyNewAppVersion/notifyNewAppVersion.ts
@@ -2,7 +2,7 @@
 import * as fs from "fs-extra";
 import { slackPostMessage } from "../common/slack/postMessage";
 
-const destinationChannel = "#test";
+const destinationChannel = "#prod_io";
 const packagePath = "package.json";
 
 const main = async () => {


### PR DESCRIPTION
## Short description
This pr adds a new step to the `release` workflow, in order to send a slack message after the iOS and Android builds.

## List of changes proposed in this pull request
- Added new job `notify-new-app-version` executed after `ios-beta-release` and `alpha-release-android`.
- Added a new ts script `scripts/ts/notifyNewAppVersion/notifyNewAppVersion.ts` in order to send the required message.
