### PR TITLE
[IA-265,IA-264,IA-260] Improve and update UI/Copy CIE

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -611,6 +611,16 @@ authentication:
       readerCardTitle: Hold the card for a few seconds
       readerCardHeader: We are reading the data of your CIE and verifying its validity.
       readerCardFooter: Hold the card in this position for a few more seconds
+      iosAlert:
+        readingInstructions: Keep your electronic ID card on the back of the iPhone, at the top.
+        moreTags: More NFC cards have been identified. Please bring one card at a time.
+        readingInProgress: Reading in progress, hold the card still for a few seconds...
+        readingSuccess: Successful reading.\nYou can remove the card while we complete the data verification.
+        invalidCard: The card used does not appear to be an Electronic Identity Card (CIE).
+        tagLost: You removed the card too soon.
+        cardLocked: CIE card locked
+        wrongPin1AttemptLeft: Wrong PIN, you still have 1 try
+        wrongPin2AttemptLeft: Wrong PIN, you still have 2 attempts
       error:
         readerCardLostTitle: Hold the card again for a few seconds
         readerCardLostTitleiOS: You removed the card too soon.

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -619,6 +619,16 @@ authentication:
       readerCardTitle: Tieni ferma la carta per qualche secondo
       readerCardHeader: Stiamo leggendo i dati della tua carta d'identità e verificandone la sua validità.
       readerCardFooter: Tieni ferma la carta in questa posizione ancora per qualche secondo
+      iosAlert:
+        readingInstructions: Tieni la tua carta d'identità elettronica sul retro dell'iPhone, nella parte in alto.
+        moreTags: Sono stati individuate più carte NFC. Per favore avvicina una carta alla volta.
+        readingInProgress: Lettura in corso, tieni ferma la carta ancora per qualche secondo...
+        readingSuccess: Lettura avvenuta con successo.\nPuoi rimuovere la carta mentre completiamo la verifica dei dati.
+        invalidCard: La carta utilizzata non sembra essere una Carta di Identità Elettronica (CIE).
+        tagLost: Hai rimosso la carta troppo presto.
+        cardLocked: Carta CIE bloccata
+        wrongPin1AttemptLeft: PIN errato, hai ancora 1 tentativo
+        wrongPin2AttemptLeft: PIN errato, hai ancora 2 tentativi
       error:
         readerCardLostTitle: Avvicina nuovamente la carta
         readerCardLostTitleiOS: Hai rimosso la carta troppo presto

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@gorhom/bottom-sheet": "^1.4.1",
-    "@pagopa/react-native-cie": "^1.1.2",
+    "@pagopa/react-native-cie": "^1.1.3",
     "@pagopa/ts-commons": "^9.4.0",
     "@react-native-clipboard/clipboard": "^1.8.4",
     "@react-native-community/async-storage": "^1.6.1",

--- a/ts/screens/authentication/cie/CieCardReaderScreen.tsx
+++ b/ts/screens/authentication/cie/CieCardReaderScreen.tsx
@@ -115,6 +115,41 @@ const WAIT_TIMEOUT_NAVIGATION_ACCESSIBILITY = 5000 as Millisecond;
 const VIBRATION = 100 as Millisecond;
 const accessibityTimeout = 100 as Millisecond;
 
+// some texts changes depending on current running Platform
+/* waiting card */
+const getWaitingCardTextiOS = () => ({
+  title: I18n.t("authentication.cie.card.titleiOS"),
+  subtitle: I18n.t("authentication.cie.card.layCardMessageHeaderiOS"),
+  content: ""
+});
+const getWaitingCardTextDefault = () => ({
+  title: I18n.t("authentication.cie.card.title"),
+  subtitle: I18n.t("authentication.cie.card.layCardMessageHeader"),
+  content: I18n.t("authentication.cie.card.layCardMessageFooter")
+});
+const getWaitingCardText = Platform.select({
+  ios: getWaitingCardTextiOS,
+  default: getWaitingCardTextDefault
+});
+
+/* error */
+const getErrorTextiOS = (errorMessage: string) => ({
+  title: I18n.t("authentication.cie.card.error.readerCardLostTitleiOS"),
+  subtitle: I18n.t("authentication.cie.card.error.readerCardLostHeaderiOS"),
+  content: errorMessage
+});
+
+const getErrorTextDefault = (errorMessage: string) => ({
+  title: I18n.t("authentication.cie.card.error.readerCardLostTitle"),
+  subtitle: I18n.t("authentication.cie.card.error.readerCardLostHeader"),
+  content: errorMessage
+});
+const getErrorText = (errorMessage: string = "") =>
+  Platform.select({
+    ios: getErrorTextiOS(""),
+    default: getErrorTextDefault(errorMessage)
+  });
+
 /**
  *  This screen shown while reading the card
  */
@@ -132,9 +167,7 @@ class CieCardReaderScreen extends React.PureComponent<Props, State> {
       - completed (the reading has been completed)
       */
       readingState: ReadingState.waiting_card,
-      title: I18n.t("authentication.cie.card.title"),
-      subtitle: I18n.t("authentication.cie.card.layCardMessageHeader"),
-      content: I18n.t("authentication.cie.card.layCardMessageFooter"),
+      ...getWaitingCardText(),
       isScreenReaderEnabled: false
     };
     this.startCieiOS = this.startCieiOS.bind(this);
@@ -258,19 +291,7 @@ class CieCardReaderScreen extends React.PureComponent<Props, State> {
         break;
       case ReadingState.error:
         this.setState(
-          {
-            title: I18n.t(
-              isIos
-                ? "authentication.cie.card.error.readerCardLostTitleiOS"
-                : "authentication.cie.card.error.readerCardLostTitle"
-            ),
-            subtitle: I18n.t(
-              isIos
-                ? "authentication.cie.card.error.readerCardLostHeaderiOS"
-                : "authentication.cie.card.error.readerCardLostHeader"
-            ),
-            content: isIos ? "" : this.state.errorMessage
-          },
+          getErrorText(this.state.errorMessage),
           this.announceUpdate
         );
         break;
@@ -289,24 +310,7 @@ class CieCardReaderScreen extends React.PureComponent<Props, State> {
         break;
       // waiting_card state
       default:
-        this.setState(
-          {
-            title: I18n.t(
-              isIos
-                ? "authentication.cie.card.titleiOS"
-                : "authentication.cie.card.title"
-            ),
-            subtitle: I18n.t(
-              isIos
-                ? "authentication.cie.card.layCardMessageHeaderiOS"
-                : "authentication.cie.card.layCardMessageHeader"
-            ),
-            content: isIos
-              ? ""
-              : I18n.t("authentication.cie.card.layCardMessageFooter")
-          },
-          this.announceUpdate
-        );
+        this.setState(getWaitingCardText(), this.announceUpdate);
     }
   };
 
@@ -333,9 +337,7 @@ class CieCardReaderScreen extends React.PureComponent<Props, State> {
         this.state.isScreenReaderEnabled
           ? WAIT_TIMEOUT_NAVIGATION_ACCESSIBILITY
           : // if is iOS don't wait. The thank you page is shown natively
-          Platform.OS === "ios"
-          ? 0
-          : WAIT_TIMEOUT_NAVIGATION
+            Platform.select({ ios: 0, default: WAIT_TIMEOUT_NAVIGATION })
       );
     });
   };

--- a/ts/screens/authentication/cie/CieCardReaderScreen.tsx
+++ b/ts/screens/authentication/cie/CieCardReaderScreen.tsx
@@ -415,7 +415,7 @@ class CieCardReaderScreen extends React.PureComponent<Props, State> {
             title: I18n.t("global.buttons.cancel")
           }}
           rightButton={{
-            onPress: async () => await this.startCieiOS(),
+            onPress: this.startCieiOS,
             title: I18n.t("authentication.cie.nfc.retry")
           }}
         />

--- a/ts/screens/authentication/cie/CiePinScreen.tsx
+++ b/ts/screens/authentication/cie/CiePinScreen.tsx
@@ -37,8 +37,6 @@ import { Dispatch, ReduxProps } from "../../../store/actions/types";
 import variables from "../../../theme/variables";
 import { setAccessibilityFocus } from "../../../utils/accessibility";
 import { useIOBottomSheet } from "../../../utils/bottomSheet";
-
-import { isIos } from "../../../utils/platform";
 import { openWebUrl } from "../../../utils/url";
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -168,14 +166,6 @@ const CiePinScreen: React.FC<Props> = props => {
             onPinChanged={setPin}
             onSubmit={showModal}
           />
-          <View spacer={true} />
-          {isIos && (
-            <AdviceComponent
-              iconName={"io-bug"}
-              text={I18n.t("global.disclaimer_beta")}
-              iconColor={"black"}
-            />
-          )}
           <View spacer={true} />
           <AdviceComponent
             text={I18n.t("login.expiration_info")}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2318,10 +2318,10 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@pagopa/react-native-cie@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@pagopa/react-native-cie/-/react-native-cie-1.1.2.tgz#a261393c81c760db22fd214362376d9ab6939986"
-  integrity sha512-p27Rz21GlFP++vsD7rME6ouHbRjVsLqE6ouFFNIIVLt6x0bm+mWtL5Cr+mOubOU/5EDs3kbWJl7J9hSNuJXWbw==
+"@pagopa/react-native-cie@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@pagopa/react-native-cie/-/react-native-cie-1.1.3.tgz#ae00d997825c4e79152bf3986ab4e705b4465956"
+  integrity sha512-fAPL7xjr0IHWVWPhDsUJYtXFAwo2zM2TfNAi7mkLDoktBIsbTavfvXnx/jTxNgGvhqGWXIOVvZLGIgIhAsXpaw==
 
 "@pagopa/ts-commons@^9.4.0":
   version "9.4.0"


### PR DESCRIPTION
## Short description
This PR enhances some UI and text about the CIE authentication flow.
It changes few things:

- update react-native-cie to support [iOS string customization ](https://github.com/pagopa/io-cie-ios-sdk/pull/8)
- remove an hint when CIE PIN insertion is prompted
- init the CIE SDK (iOS) to customize (and localize) some displayed texts
- do some refactoring to improve code readability 

### hint removed
| before  | after |
| ------------- | ------------- |
![before](https://user-images.githubusercontent.com/822471/135659084-ffabd095-c2ab-4ffb-b72e-bffafb1d87d9.png) | ![after](https://user-images.githubusercontent.com/822471/135659089-f2725c92-7839-46c1-884b-881ca7a0c2ab.png)

### CIE iOS authentication (with customized strings)
https://user-images.githubusercontent.com/822471/135659155-f9a23454-ec78-4d8b-9cfc-4b25bfe1931b.MP4



