### PR TITLE
fix: [IAI-75] The devIoApp team is not tagged in the final notification message after successfully complete a release

### DIFF
--- a/scripts/ts/notifyNewAppVersion/notifyNewAppVersion.ts
+++ b/scripts/ts/notifyNewAppVersion/notifyNewAppVersion.ts
@@ -20,7 +20,7 @@ const main = async () => {
       "<https://pagopa.atlassian.net/wiki/spaces/IOAPP/pages/345932988/Release+produzione+beta#Frequenza-rilasci|:calendar: Calendario rilasci> - " +
       "<https://pagopa.atlassian.net/wiki/spaces/IOAPP/pages/22020162/Beta+interna|:test_tube: Come partecipo alla beta interna?> - " +
       "<https://pagopa.atlassian.net/wiki/spaces/IOAPP/pages/22020162/Beta+interna#%F0%9F%90%9E-Come-segnalo-un-bug?|:ladybug: Come segnalo un bug?>\n" +
-      "cc @devioapp",
+      "cc <!subteam^S02GBHCR486>",
     destinationChannel,
     false
   );


### PR DESCRIPTION
## Short description
This pr fixes the slack tagging syntax in order to have the right behaviour and correcly notify the team after a successfully release.
