### PR TITLE
fix: [IA-305] The content of error component has bad valign

### DIFF
--- a/ts/components/screens/GenericErrorComponent.tsx
+++ b/ts/components/screens/GenericErrorComponent.tsx
@@ -25,6 +25,7 @@ const styles = StyleSheet.create({
   center: {
     alignItems: "center"
   },
+  contentContainerStyle: { flexGrow: 1, justifyContent: "center" },
   errorText: {
     fontSize: customVariables.fontSize2,
     paddingTop: customVariables.contentPadding
@@ -79,7 +80,11 @@ export default class GenericErrorComponent extends React.PureComponent<Props> {
             onDidFocus={() => setAccessibilityFocus(this.elementRef)}
           />
         )}
-        <Content bounces={false} testID={this.props.testID}>
+        <Content
+          bounces={false}
+          testID={this.props.testID}
+          contentContainerStyle={styles.contentContainerStyle}
+        >
           <View style={styles.center}>
             <View spacer={true} extralarge={true} />
             <Image


### PR DESCRIPTION
## Short description
The error component should align the content vertically in the middle.

| before  | now |
| ------------- | ------------- |
![pre](https://user-images.githubusercontent.com/822471/138312932-88810330-533b-4202-9d5b-263a1fa90944.png) | ![post](https://user-images.githubusercontent.com/822471/138312940-642754a9-3335-4251-a405-fbf20da6b955.png)




