### PR TITLE
chore: [IA-408] Remove close button in PayPal onboarding success screen

### DIFF
--- a/ts/features/wallet/onboarding/paypal/__tests__/PayPalOnboardingCompletedSuccessScreen.test.tsx
+++ b/ts/features/wallet/onboarding/paypal/__tests__/PayPalOnboardingCompletedSuccessScreen.test.tsx
@@ -29,7 +29,6 @@ describe("PayPalOnboardingCompletedSuccessScreen", () => {
   it(`buttons should be defined`, () => {
     const render = renderComponent(store);
     expect(render.component.queryByTestId("primaryButtonId")).not.toBeNull();
-    expect(render.component.queryByTestId("secondaryButtonId")).not.toBeNull();
   });
 });
 

--- a/ts/features/wallet/onboarding/paypal/screen/PayPalOnboardingCompletedSuccessScreen.tsx
+++ b/ts/features/wallet/onboarding/paypal/screen/PayPalOnboardingCompletedSuccessScreen.tsx
@@ -9,19 +9,16 @@ import BaseScreenComponent from "../../../../../components/screens/BaseScreenCom
 import { InfoScreenComponent } from "../../../../../components/infoScreen/InfoScreenComponent";
 import { renderInfoRasterImage } from "../../../../../components/infoScreen/imageRendering";
 import successImage from "../../../../../../img/pictograms/payment-completed.png";
-import {
-  cancelButtonProps,
-  confirmButtonProps
-} from "../../../../bonus/bonusVacanze/components/buttons/ButtonConfigurations";
+import { confirmButtonProps } from "../../../../bonus/bonusVacanze/components/buttons/ButtonConfigurations";
 import { GlobalState } from "../../../../../store/reducers/types";
 import I18n from "../../../../../i18n";
-import { FooterStackButton } from "../../../../bonus/bonusVacanze/components/buttons/FooterStackButtons";
+import FooterWithButtons from "../../../../../components/ui/FooterWithButtons";
 type Props = ReturnType<typeof mapStateToProps> &
   ReturnType<typeof mapDispatchToProps>;
 
 /**
  * this screen shows that the onboarding is completed successfully
- * footer button can dismiss the screen or navigate to the PayPal method details
+ * footer button navigates to the PayPal method details
  * @param props
  * @constructor
  */
@@ -40,25 +37,14 @@ const PayPalOnboardingCompletedSuccessScreen = (props: Props) => (
         title={I18n.t("wallet.onboarding.paypal.onBoardingCompleted.title")}
         body={I18n.t("wallet.onboarding.paypal.onBoardingCompleted.body")}
       />
-      <FooterStackButton
-        buttons={[
-          confirmButtonProps(
-            props.methodDetails,
-            I18n.t(
-              "wallet.onboarding.paypal.onBoardingCompleted.primaryButton"
-            ),
-            undefined,
-            "primaryButtonId"
-          ),
-          cancelButtonProps(
-            props.onClose,
-            I18n.t(
-              "wallet.onboarding.paypal.onBoardingCompleted.secondaryButton"
-            ),
-            undefined,
-            "secondaryButtonId"
-          )
-        ]}
+      <FooterWithButtons
+        type={"SingleButton"}
+        leftButton={confirmButtonProps(
+          props.methodDetails,
+          I18n.t("wallet.onboarding.paypal.onBoardingCompleted.primaryButton"),
+          undefined,
+          "primaryButtonId"
+        )}
       />
     </SafeAreaView>
   </BaseScreenComponent>

--- a/ts/features/wallet/onboarding/paypal/screen/PayPalOnboardingCompletedSuccessScreen.tsx
+++ b/ts/features/wallet/onboarding/paypal/screen/PayPalOnboardingCompletedSuccessScreen.tsx
@@ -52,7 +52,6 @@ const PayPalOnboardingCompletedSuccessScreen = (props: Props) => (
 
 const mapDispatchToProps = (_: Dispatch) => ({
   // TODO replace with the effective handler
-  onClose: constNull,
   methodDetails: constNull
 });
 

--- a/ts/features/wallet/onboarding/paypal/screen/__tests__/PayPalOnboardingCompletedSuccessScreen.test.tsx
+++ b/ts/features/wallet/onboarding/paypal/screen/__tests__/PayPalOnboardingCompletedSuccessScreen.test.tsx
@@ -1,11 +1,11 @@
 import { createStore, Store } from "redux";
 import { NavigationParams } from "react-navigation";
-import { appReducer } from "../../../../../store/reducers";
-import { applicationChangeState } from "../../../../../store/actions/application";
-import { renderScreenFakeNavRedux } from "../../../../../utils/testWrapper";
-import { GlobalState } from "../../../../../store/reducers/types";
-import PayPalOnboardingCompletedSuccessScreen from "../screen/PayPalOnboardingCompletedSuccessScreen";
-import { setLocale } from "../../../../../i18n";
+import { appReducer } from "../../../../../../store/reducers";
+import { applicationChangeState } from "../../../../../../store/actions/application";
+import { renderScreenFakeNavRedux } from "../../../../../../utils/testWrapper";
+import { GlobalState } from "../../../../../../store/reducers/types";
+import PayPalOnboardingCompletedSuccessScreen from "../PayPalOnboardingCompletedSuccessScreen";
+import { setLocale } from "../../../../../../i18n";
 
 describe("PayPalOnboardingCompletedSuccessScreen", () => {
   beforeAll(() => {

--- a/ts/features/wallet/onboarding/paypal/screen/__tests__/__snapshots__/PayPalOnboardingCompletedSuccessScreen.test.tsx.snap
+++ b/ts/features/wallet/onboarding/paypal/screen/__tests__/__snapshots__/PayPalOnboardingCompletedSuccessScreen.test.tsx.snap
@@ -298,6 +298,7 @@ exports[`PayPalOnboardingCompletedSuccessScreen should match the snapshot 1`] = 
                 </Text>
               </View>
               <View
+                pointerEvents="box-none"
                 style={
                   Array [
                     Object {},
@@ -308,6 +309,7 @@ exports[`PayPalOnboardingCompletedSuccessScreen should match the snapshot 1`] = 
                     },
                   ]
                 }
+                testID="FooterWithButtons"
               >
                 <View
                   style={
@@ -336,7 +338,7 @@ exports[`PayPalOnboardingCompletedSuccessScreen should match the snapshot 1`] = 
                       Array [
                         Object {},
                         Object {
-                          "justifyContent": "flex-end",
+                          "flexDirection": "row",
                         },
                       ]
                     }
@@ -366,8 +368,9 @@ exports[`PayPalOnboardingCompletedSuccessScreen should match the snapshot 1`] = 
                       onStartShouldSetResponder={[Function]}
                       style={
                         Object {
+                          "alignContent": "center",
                           "alignItems": "center",
-                          "alignSelf": "stretch",
+                          "alignSelf": "flex-start",
                           "backgroundColor": "#007aff",
                           "borderBottomWidth": null,
                           "borderColor": "#007aff",
@@ -377,9 +380,10 @@ exports[`PayPalOnboardingCompletedSuccessScreen should match the snapshot 1`] = 
                           "borderTopWidth": null,
                           "borderWidth": undefined,
                           "elevation": 2,
+                          "flex": 1,
                           "flexDirection": "row",
                           "height": 45,
-                          "justifyContent": "space-between",
+                          "justifyContent": "center",
                           "opacity": 1,
                           "paddingBottom": 6,
                           "paddingTop": 6,
@@ -393,90 +397,23 @@ exports[`PayPalOnboardingCompletedSuccessScreen should match the snapshot 1`] = 
                     >
                       <Text
                         style={
-                          Object {
-                            "backgroundColor": "transparent",
-                            "color": "#fff",
-                            "fontFamily": "System",
-                            "fontSize": 16.5,
-                            "marginLeft": 0,
-                            "marginRight": 0,
-                            "paddingLeft": 16,
-                            "paddingRight": 16,
-                          }
+                          Array [
+                            Object {
+                              "backgroundColor": "transparent",
+                              "color": "#fff",
+                              "fontFamily": "System",
+                              "fontSize": 16.5,
+                              "marginLeft": 0,
+                              "marginRight": 0,
+                              "paddingLeft": 16,
+                              "paddingRight": 16,
+                            },
+                            undefined,
+                            undefined,
+                          ]
                         }
                       >
                         Vedi metodo
-                      </Text>
-                    </View>
-                    <View
-                      spacer={true}
-                      style={Object {}}
-                    />
-                    <View
-                      accessibilityRole="button"
-                      accessibilityState={
-                        Object {
-                          "disabled": undefined,
-                        }
-                      }
-                      accessible={true}
-                      focusable={true}
-                      forwardedRef={[Function]}
-                      hitSlop={
-                        Object {
-                          "bottom": 4,
-                          "top": 4,
-                        }
-                      }
-                      onClick={[Function]}
-                      onResponderGrant={[Function]}
-                      onResponderMove={[Function]}
-                      onResponderRelease={[Function]}
-                      onResponderTerminate={[Function]}
-                      onResponderTerminationRequest={[Function]}
-                      onStartShouldSetResponder={[Function]}
-                      style={
-                        Object {
-                          "alignItems": "center",
-                          "alignSelf": "stretch",
-                          "backgroundColor": "transparent",
-                          "borderBottomWidth": 1,
-                          "borderColor": "#007aff",
-                          "borderLeftWidth": 1,
-                          "borderRadius": 5,
-                          "borderRightWidth": 1,
-                          "borderTopWidth": 1,
-                          "borderWidth": 1,
-                          "elevation": null,
-                          "flexDirection": "row",
-                          "height": 45,
-                          "justifyContent": "space-between",
-                          "opacity": 1,
-                          "paddingBottom": 6,
-                          "paddingTop": 6,
-                          "shadowColor": null,
-                          "shadowOffset": null,
-                          "shadowOpacity": null,
-                          "shadowRadius": null,
-                        }
-                      }
-                      testID="secondaryButtonId"
-                    >
-                      <Text
-                        style={
-                          Object {
-                            "backgroundColor": "transparent",
-                            "color": "#007aff",
-                            "fontFamily": "System",
-                            "fontSize": 16.5,
-                            "marginLeft": 0,
-                            "marginRight": 0,
-                            "paddingLeft": 16,
-                            "paddingRight": 16,
-                          }
-                        }
-                      >
-                        Chiudi
                       </Text>
                     </View>
                   </View>


### PR DESCRIPTION
## Short description
Since the PayPal onboarding workflow has been change on few details, `close` button is not longer needed

### minor changes
- moved `PayPalOnboardingCompletedSuccessScreen` tests from `paypal/__tests__` to `paypal/screen/__tests__`

| before  | after |
| ------------- | ------------- |
![before](https://user-images.githubusercontent.com/822471/139868006-be896209-2aca-41e5-8172-ec2c4625e622.png) | ![after](https://user-images.githubusercontent.com/822471/139868018-6aeb862b-e7a2-4354-aeff-c6d5133eeafc.png)
