### PR TITLE
chore: [IAI-83] Store test results on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
           command: |
               TEST=$(circleci tests glob **/__test*__/*.ts* | circleci tests split)
               mkdir -p ./reports/junit/
-              yarn test $TEST
+              yarn test $TEST --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: ./reports/junit
       - run: ./scripts/codecov.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,9 +127,6 @@ jobs:
       - store_test_results:
           path: ./reports/junit/
 
-      - store_artifacts:
-          path: ./reports/junit
-
     parallelism: 8
 
   # Runs ESlint checks on PR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,10 @@ jobs:
               TEST=$(circleci tests glob **/__test*__/*.ts* | circleci tests split)
               yarn test $TEST
       - run: ./scripts/codecov.sh
+
+      - store_test_results:
+          path: test-results
+
     parallelism: 8
 
   # Runs ESlint checks on PR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,7 @@ jobs:
       - run:
           command: |
               TEST=$(circleci tests glob **/__test*__/*.ts* | circleci tests split)
+              mkdir -p test-results
               yarn test $TEST
       - run: ./scripts/codecov.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
           command: |
               TEST=$(circleci tests glob **/__test*__/*.ts* | circleci tests split)
               mkdir -p ./reports/junit/
-              yarn test $TEST --reporters=default --reporters=jest-junit
+              yarn test:ci $TEST --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: ./reports/junit
       - run: ./scripts/codecov.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,9 @@ jobs:
           command: |
               TEST=$(circleci tests glob **/__test*__/*.ts* | circleci tests split)
               mkdir -p test-results
-              yarn test $TEST
+              yarn test $TEST --testResultsProcessor="jest-junit"
+          environment:
+            JEST_JUNIT_OUTPUT: "test-results/test-results.xml"
       - run: ./scripts/codecov.sh
 
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,14 +118,13 @@ jobs:
       - run:
           command: |
               TEST=$(circleci tests glob **/__test*__/*.ts* | circleci tests split)
-              mkdir -p ./reports/junit/
               yarn test:ci $TEST --reporters=default --reporters=jest-junit
           environment:
-            JEST_JUNIT_OUTPUT_DIR: ./reports/junit
+            JEST_JUNIT_OUTPUT_DIR: ./tmp/reports/junit
       - run: ./scripts/codecov.sh
 
       - store_test_results:
-          path: ./reports/junit/
+          path: ./tmp/reports/junit/
 
     parallelism: 8
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,9 @@ jobs:
       - store_test_results:
           path: ./reports/junit/
 
+      - store_artifacts:
+          path: ./reports/junit
+
     parallelism: 8
 
   # Runs ESlint checks on PR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,14 +118,14 @@ jobs:
       - run:
           command: |
               TEST=$(circleci tests glob **/__test*__/*.ts* | circleci tests split)
-              mkdir -p test-results
-              yarn test $TEST --testResultsProcessor="jest-junit"
+              mkdir -p ./reports/junit/
+              yarn test $TEST
           environment:
-            JEST_JUNIT_OUTPUT: "test-results/test-results.xml"
+            JEST_JUNIT_OUTPUT_DIR: ./reports/junit
       - run: ./scripts/codecov.sh
 
       - store_test_results:
-          path: test-results
+          path: ./reports/junit/
 
     parallelism: 8
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "start-breaking-cycle": "yarn pre-cycle && standard-version -t \"\" --prerelease rc --release-as major",
     "attach": "react-native attach",
     "postinstall": "patch-package && rn-nodeify --install path,buffer && chmod +x ./bin/add-ios-source-maps.sh && ./bin/add-ios-source-maps.sh && chmod +x ./bin/add-ios-env-config.sh && ./bin/add-ios-env-config.sh",
-    "test": "jest -w 1",
+    "test": "jest --ci --runInBand --reporters=default --reporters=jest-junit",
     "test:dev": "jest --detectOpenHandles --coverage=false",
     "prettify": "prettier --write \"ts/**/*.(ts|tsx)\"",
     "prettier:check": "prettier --check \"ts/**/*.(ts|tsx)\"",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "start-breaking-cycle": "yarn pre-cycle && standard-version -t \"\" --prerelease rc --release-as major",
     "attach": "react-native attach",
     "postinstall": "patch-package && rn-nodeify --install path,buffer && chmod +x ./bin/add-ios-source-maps.sh && ./bin/add-ios-source-maps.sh && chmod +x ./bin/add-ios-env-config.sh && ./bin/add-ios-env-config.sh",
-    "test": "jest --ci --runInBand",
+    "test:ci": "jest --ci --runInBand",
     "test:dev": "jest --detectOpenHandles --coverage=false",
     "prettify": "prettier --write \"ts/**/*.(ts|tsx)\"",
     "prettier:check": "prettier --check \"ts/**/*.(ts|tsx)\"",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "start-breaking-cycle": "yarn pre-cycle && standard-version -t \"\" --prerelease rc --release-as major",
     "attach": "react-native attach",
     "postinstall": "patch-package && rn-nodeify --install path,buffer && chmod +x ./bin/add-ios-source-maps.sh && ./bin/add-ios-source-maps.sh && chmod +x ./bin/add-ios-env-config.sh && ./bin/add-ios-env-config.sh",
-    "test": "jest --ci --runInBand --reporters=default --reporters=jest-junit",
+    "test": "jest -w 1 --reporters=default --reporters=jest-junit",
     "test:dev": "jest --detectOpenHandles --coverage=false",
     "prettify": "prettier --write \"ts/**/*.(ts|tsx)\"",
     "prettier:check": "prettier --check \"ts/**/*.(ts|tsx)\"",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "start-breaking-cycle": "yarn pre-cycle && standard-version -t \"\" --prerelease rc --release-as major",
     "attach": "react-native attach",
     "postinstall": "patch-package && rn-nodeify --install path,buffer && chmod +x ./bin/add-ios-source-maps.sh && ./bin/add-ios-source-maps.sh && chmod +x ./bin/add-ios-env-config.sh && ./bin/add-ios-env-config.sh",
-    "test": "jest -w 1",
+    "test": "jest --ci --runInBand",
     "test:dev": "jest --detectOpenHandles --coverage=false",
     "prettify": "prettier --write \"ts/**/*.(ts|tsx)\"",
     "prettier:check": "prettier --check \"ts/**/*.(ts|tsx)\"",

--- a/package.json
+++ b/package.json
@@ -227,6 +227,7 @@
     "fs-extra": "^7.0.0",
     "italia-utils": "^4.1.1",
     "jest": "^26.6.3",
+    "jest-junit": "^13.0.0",
     "js-yaml": "^3.13.1",
     "jsdoc-to-markdown": "^6.0.1",
     "metro-react-native-babel-preset": "^0.64.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "start-breaking-cycle": "yarn pre-cycle && standard-version -t \"\" --prerelease rc --release-as major",
     "attach": "react-native attach",
     "postinstall": "patch-package && rn-nodeify --install path,buffer && chmod +x ./bin/add-ios-source-maps.sh && ./bin/add-ios-source-maps.sh && chmod +x ./bin/add-ios-env-config.sh && ./bin/add-ios-env-config.sh",
-    "test": "jest -w 1 --reporters=default --reporters=jest-junit",
+    "test": "jest -w 1",
     "test:dev": "jest --detectOpenHandles --coverage=false",
     "prettify": "prettier --write \"ts/**/*.(ts|tsx)\"",
     "prettier:check": "prettier --check \"ts/**/*.(ts|tsx)\"",

--- a/ts/components/core/__test__/fontsAndroid.test.ts
+++ b/ts/components/core/__test__/fontsAndroid.test.ts
@@ -14,7 +14,8 @@ describe("makeFontStyleObject behaviour on Android", () => {
   });
   it("fontWeight and fontStyle should be undefined", () => {
     const font = makeFontStyleObject();
-    expect(font.fontStyle).toBeUndefined();
+    // expect(font.fontStyle).toBeUndefined();
+    expect(font.fontStyle).toBeDefined();
     expect(font.fontWeight).toBeUndefined();
   });
   it("default font family should be Titillium if specify the weight", () => {

--- a/ts/components/core/__test__/fontsAndroid.test.ts
+++ b/ts/components/core/__test__/fontsAndroid.test.ts
@@ -14,8 +14,7 @@ describe("makeFontStyleObject behaviour on Android", () => {
   });
   it("fontWeight and fontStyle should be undefined", () => {
     const font = makeFontStyleObject();
-    // expect(font.fontStyle).toBeUndefined();
-    expect(font.fontStyle).toBeDefined();
+    expect(font.fontStyle).toBeUndefined();
     expect(font.fontWeight).toBeUndefined();
   });
   it("default font family should be Titillium if specify the weight", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3533,6 +3533,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^2.1.0, ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -8960,6 +8965,16 @@ jest-jasmine2@^26.6.3:
     pretty-format "^26.6.2"
     throat "^5.0.0"
 
+jest-junit@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-13.0.0.tgz#479be347457aad98ae8a5983a23d7c3ec526c9a3"
+  integrity sha512-JSHR+Dhb32FGJaiKkqsB7AR3OqWKtldLd6ZH2+FJ8D4tsweb8Id8zEVReU4+OlrRO1ZluqJLQEETm+Q6/KilBg==
+  dependencies:
+    mkdirp "^1.0.4"
+    strip-ansi "^6.0.1"
+    uuid "^8.3.2"
+    xml "^1.0.1"
+
 jest-leak-detector@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-26.6.2.tgz#7717cf118b92238f2eba65054c8a0c9c653a91af"
@@ -14374,6 +14389,13 @@ strip-ansi@^6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
@@ -15726,6 +15748,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmlbuilder@^9.0.7:
   version "9.0.7"


### PR DESCRIPTION
## Short description
This pr adds the `store_test_results` step in order to have a quick overview when a test fails:

 
![Schermata 2021-11-03 alle 18 30 47](https://user-images.githubusercontent.com/26501317/140159733-dd2c01a2-4a2e-46dd-92ad-fca8c42d15a4.png)

![Schermata 2021-11-03 alle 18 13 11](https://user-images.githubusercontent.com/26501317/140136759-73e96dcc-afbf-4b12-bac1-5a8a5c62ded3.png)

In addition to this, will enable the use of test insights https://circleci.com/docs/2.0/insights-tests/, visible from https://app.circleci.com/insights/github/pagopa/io-app/workflows/build/tests?branch=master

## List of changes proposed in this pull request
- Changed  test workflow in `.circleci/config.yml`, in order to store the test results.
- Added `jest-junit` to transform the output in the CircleCI required format
- Changed the `test` command in `test:ci` and modified the parameters in order to better support the run on CI.