### PR TITLE
feat: [IA-304] Add "what is a psp" bottom sheet info

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1009,6 +1009,9 @@ wallet:
           row2Description2: ". You'll see the right amount before confirming the payment."
           row3Description1: "Privacy Policy"
           row3Description2: "Terms and Conditions"
+        whatIsPspBottomSheet:
+          title: "Cos’è il gestore della transazione?"
+          body: "È il soggetto, conosciuto anche come PSP (Prestatore di Servizi di Pagamento), che incassa l’importo per conto dell’Ente Creditore e può applicare un costo per il servizio offerto.\nAd ogni pagamento, potrai scegliere il gestore che ti conviene di più, che tu sia cliente o no."
       onBoardingCompleted:
         title: "That's it!"
         body: "Now have a look at the current settings of your new method."

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1010,8 +1010,8 @@ wallet:
           row3Description1: "Privacy Policy"
           row3Description2: "Terms and Conditions"
         whatIsPspBottomSheet:
-          title: "Cos’è il gestore della transazione?"
-          body: "È il soggetto, conosciuto anche come PSP (Prestatore di Servizi di Pagamento), che incassa l’importo per conto dell’Ente Creditore e può applicare un costo per il servizio offerto.\nAd ogni pagamento, potrai scegliere il gestore che ti conviene di più, che tu sia cliente o no."
+          title: "What is a payment provider?"
+          body: "The Payment Service Provider (PSP) collects the amount on behalf of the Payee, and it may charge a fee for its service.\nWhenever you'll pay, you can to choose the provider that suits you best, whether you're a customer or not."
       onBoardingCompleted:
         title: "That's it!"
         body: "Now have a look at the current settings of your new method."

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1027,6 +1027,9 @@ wallet:
           row2Description2: ". Vedrai l'importo esatto prima della conferma."
           row3Description1: "Informativa Privacy"
           row3Description2: "Termini e condizioni d’uso"
+        whatIsPspBottomSheet:
+          title: "Cos’è il gestore della transazione?"
+          body: "È il soggetto, conosciuto anche come PSP (Prestatore di Servizi di Pagamento), che incassa l’importo per conto dell’Ente Creditore e può applicare un costo per il servizio offerto.\nAd ogni pagamento, potrai scegliere il gestore che ti conviene di più, che tu sia cliente o no."
       onBoardingCompleted:
         title: "Fatto!"
         body: "Ora puoi dare uno sguardo alle impostazioni del tuo nuovo metodo."

--- a/ts/features/wallet/onboarding/paypal/screen/PayPalPspSelectionScreen.tsx
+++ b/ts/features/wallet/onboarding/paypal/screen/PayPalPspSelectionScreen.tsx
@@ -167,7 +167,12 @@ const PayPalPpsSelectionScreen = (props: Props): React.ReactElement | null => {
             <View spacer={true} small={true} />
             <ScrollView>
               <Body>{locales.body}</Body>
-              <Link onPress={presentWhatIsPspBottomSheet}>{locales.link}</Link>
+              <Link
+                onPress={presentWhatIsPspBottomSheet}
+                testID={"whatIsPSPTestID"}
+              >
+                {locales.link}
+              </Link>
               <View spacer={true} large={true} />
               <RadioListHeader
                 leftColumnTitle={locales.leftColumnTitle}

--- a/ts/features/wallet/onboarding/paypal/screen/PayPalPspSelectionScreen.tsx
+++ b/ts/features/wallet/onboarding/paypal/screen/PayPalPspSelectionScreen.tsx
@@ -28,6 +28,7 @@ import { H4 } from "../../../../../components/core/typography/H4";
 import { GlobalState } from "../../../../../store/reducers/types";
 import { LoadingErrorComponent } from "../../../../bonus/bonusVacanze/components/loadingErrorScreen/LoadingErrorComponent";
 import { PspRadioItem } from "../components/PspRadioItem";
+import { useIOBottomSheet } from "../../../../../utils/bottomSheet";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
@@ -107,6 +108,12 @@ const getLocales = () => ({
   leftColumnTitle: I18n.t("wallet.onboarding.paypal.selectPsp.leftColumnTitle"),
   rightColumnTitle: I18n.t(
     "wallet.onboarding.paypal.selectPsp.rightColumnTitle"
+  ),
+  whatIsPspBody: I18n.t(
+    "wallet.onboarding.paypal.selectPsp.whatIsPspBottomSheet.body"
+  ),
+  whatIsPspTitle: I18n.t(
+    "wallet.onboarding.paypal.selectPsp.whatIsPspBottomSheet.title"
   )
 });
 
@@ -135,6 +142,11 @@ const buttonsProps = () => {
  */
 const PayPalPpsSelectionScreen = (props: Props): React.ReactElement | null => {
   const locales = getLocales();
+  const { present: presentWhatIsPspBottomSheet } = useIOBottomSheet(
+    <Body>{locales.whatIsPspBody}</Body>,
+    locales.whatIsPspTitle,
+    280
+  );
   const pspList = getValueOrElse(props.pspList, []);
   // auto select if the psp list has 1 element
   const [selectedPsp, setSelectedPsp] = useState<PayPalPsp["id"] | undefined>(
@@ -155,8 +167,7 @@ const PayPalPpsSelectionScreen = (props: Props): React.ReactElement | null => {
             <View spacer={true} small={true} />
             <ScrollView>
               <Body>{locales.body}</Body>
-              {/* TODO see https://pagopa.atlassian.net/browse/IA-304 */}
-              <Link onPress={constNull}>{locales.link}</Link>
+              <Link onPress={presentWhatIsPspBottomSheet}>{locales.link}</Link>
               <View spacer={true} large={true} />
               <RadioListHeader
                 leftColumnTitle={locales.leftColumnTitle}

--- a/ts/features/wallet/onboarding/paypal/screen/__tests__/PayPalPpsSelectionScreen.test.tsx
+++ b/ts/features/wallet/onboarding/paypal/screen/__tests__/PayPalPpsSelectionScreen.test.tsx
@@ -1,16 +1,24 @@
 import { NavigationParams } from "react-navigation";
 import { createStore, Store } from "redux";
+import { fireEvent } from "@testing-library/react-native";
 import { appReducer } from "../../../../../../store/reducers";
 import { applicationChangeState } from "../../../../../../store/actions/application";
 import { renderScreenFakeNavRedux } from "../../../../../../utils/testWrapper";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import PayPalPpsSelectionScreen from "../PayPalPspSelectionScreen";
 
-jest.mock("@gorhom/bottom-sheet", () => ({
-  useBottomSheetModal: () => ({
-    present: jest.fn()
-  })
-}));
+const mockPresentBottomSheet = jest.fn();
+jest.mock("../../../../../../utils/bottomSheet", () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const react = require("react-native");
+  return {
+    __esModule: true,
+    BottomSheetScrollView: react.ScrollView,
+    TouchableWithoutFeedback: react.TouchableWithoutFeedback,
+    useIOBottomSheetRaw: () => ({ present: mockPresentBottomSheet }),
+    useIOBottomSheet: () => ({ present: mockPresentBottomSheet })
+  };
+});
 
 describe("PayPalPpsSelectionScreen", () => {
   jest.useFakeTimers();
@@ -33,6 +41,16 @@ describe("PayPalPpsSelectionScreen", () => {
   it.todo(
     "error and retry button should be shown when some error occurred while retrieving data"
   );
+
+  it(`"what is a psp" link should be defined and open a bottom sheet on onPress`, () => {
+    const render = renderComponent(store);
+    const link = render.component.queryByTestId("whatIsPSPTestID");
+    expect(link).not.toBeNull();
+    if (link) {
+      fireEvent.press(link);
+      expect(mockPresentBottomSheet).toBeCalledTimes(1);
+    }
+  });
 });
 
 const renderComponent = (store: Store) => ({

--- a/ts/features/wallet/onboarding/paypal/screen/__tests__/PayPalPpsSelectionScreen.test.tsx
+++ b/ts/features/wallet/onboarding/paypal/screen/__tests__/PayPalPpsSelectionScreen.test.tsx
@@ -44,7 +44,11 @@ describe("PayPalPpsSelectionScreen", () => {
 
   it(`"what is a psp" link should be defined and open a bottom sheet on onPress`, () => {
     const render = renderComponent(store);
-    const link = render.component.queryByTestId("whatIsPSPTestID");
+    const link = render.component.getByText(
+      I18n.t("wallet.onboarding.paypal.selectPsp.link")
+    );
+    fireEvent.press(link);
+    expect(mockPresentBottomSheet).toBeCalledTimes(1);
     expect(link).not.toBeNull();
     if (link) {
       fireEvent.press(link);

--- a/ts/features/wallet/onboarding/paypal/screen/__tests__/PayPalPpsSelectionScreen.test.tsx
+++ b/ts/features/wallet/onboarding/paypal/screen/__tests__/PayPalPpsSelectionScreen.test.tsx
@@ -6,6 +6,7 @@ import { applicationChangeState } from "../../../../../../store/actions/applicat
 import { renderScreenFakeNavRedux } from "../../../../../../utils/testWrapper";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import PayPalPpsSelectionScreen from "../PayPalPspSelectionScreen";
+import I18n from "../../../../../../i18n";
 
 const mockPresentBottomSheet = jest.fn();
 jest.mock("../../../../../../utils/bottomSheet", () => {
@@ -47,8 +48,6 @@ describe("PayPalPpsSelectionScreen", () => {
     const link = render.component.getByText(
       I18n.t("wallet.onboarding.paypal.selectPsp.link")
     );
-    fireEvent.press(link);
-    expect(mockPresentBottomSheet).toBeCalledTimes(1);
     expect(link).not.toBeNull();
     if (link) {
       fireEvent.press(link);


### PR DESCRIPTION
## Short description
This PR adds the bottom sheet to know more about what a psp is.

### iOS
https://user-images.githubusercontent.com/822471/140279919-ac37d164-132a-4740-b250-69028a777b51.mov

### Android
https://user-images.githubusercontent.com/822471/140279948-9bca18da-91b1-4506-bf09-e9d40ab6b1e4.mov

## How to test
- Replace the navigation screen in some route
for example in `MessageNavigator` _ts/navigation/MessagesNavigator.ts_
```typescript
[ROUTES.MESSAGE_DETAIL]: {
    screen: PayPalPpsSelectionScreen
  }
```
