### PR TITLE
chore: Revert "Upgrade CircleCI Android image"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ defaults_js: &defaults_js
 defaults_android: &defaults_android
   <<: *defaults
   docker:
-    - image: cimg/android:2021.10.2-node
+    - image: circleci/android:api-23-node
   environment:
     TERM: "dumb"
     ANDROID_SDK_BUILD_TOOLS_REVISION: "28.0.3"


### PR DESCRIPTION
## Short description
This pr reverts https://github.com/pagopa/io-app/pull/3466 since the new image need some additional tweaking in order to be used correcly.
