### PR TITLE
fix: [IA-423] Linking.openURL doesn't open urls on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,17 @@
           xmlns:tools="http://schemas.android.com/tools"
           android:installLocation="auto">
 
+  <queries>
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <data android:scheme="http"/>
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW" />
+      <data android:scheme="https"/>
+    </intent>
+  </queries>
+
   <supports-screens android:smallScreens="true"
                     android:normalScreens="true"
                     android:largeScreens="true"


### PR DESCRIPTION
## Short description
This pr fixes a bug that doesn't allow to open urls on Android, due to some changes in the new package visibility. 

https://developer.android.com/training/package-visibility/declaring


## How to test
- Services > Service details > tap "visita il sito"
- Messages > Message details > tap "DESCRIZIONE_LINK"