### PR TITLE
fix: [IA-440] Wrong color assignment in SectionStatus

### DIFF
--- a/ts/components/SectionStatus/index.tsx
+++ b/ts/components/SectionStatus/index.tsx
@@ -13,7 +13,7 @@ import { openWebUrl } from "../../utils/url";
 import { getFullLocale } from "../../utils/locale";
 import { LevelEnum } from "../../../definitions/content/SectionStatus";
 import { useNavigationContext } from "../../utils/hooks/useOnFocus";
-import { IOColorType } from "../core/variables/IOColors";
+import { IOColors, IOColorType } from "../core/variables/IOColors";
 import { Link } from "../core/typography/Link";
 import StatusContent from "./StatusContent";
 
@@ -79,7 +79,7 @@ const InnerSectionStatus = (
         "global.accessibility.alert"
       )}`}
       backgroundColor={backgroundColor}
-      iconColor={color}
+      iconColor={IOColors[color]}
       iconName={iconName}
       testID={"SectionStatusComponentContent"}
       viewRef={viewRef}

--- a/ts/components/SectionStatus/index.tsx
+++ b/ts/components/SectionStatus/index.tsx
@@ -101,7 +101,7 @@ const InnerSectionStatus = (
       >
         <StatusContent
           backgroundColor={backgroundColor}
-          iconColor={color}
+          iconColor={IOColors[color]}
           iconName={iconName}
           viewRef={viewRef}
           labelColor={color}


### PR DESCRIPTION
## Short description
This pr fixes an error that occurs because a wrong color is assigned to the `StatusContent` component

```
 ERROR  Warning: Failed prop type: Invalid prop `color` supplied to `Text`: bluegreyDark
Valid color formats are
  - '#f0f' (#rgb)
  - '#f0fc' (#rgba)
  - '#ff00ff' (#rrggbb)
  - '#ff00ff00' (#rrggbbaa)
  - 'rgb(255, 255, 255)'
  - 'rgba(255, 255, 255, 1.0)'
  - 'hsl(360, 100%, 100%)'
  - 'hsla(360, 100%, 100%, 1.0)'
  - 'transparent'
  - 'red'
  - 0xff00ff00 (0xrrggbbaa)

Bad object: {
  "fontSize": 24,
  "color": "bluegreyDark",
  "alignSelf": "center",
  "fontFamily": "io-icon-font",
  "fontWeight": "normal",
  "fontStyle": "normal"
}
    at Text
    in Icon (at IconFont.tsx:20)
    in IconFont (at connectStyle.js:392)
    in Styled(IconFont) (at StatusContent.tsx:56)
    in RCTView (at View.js:34)
    in View (at StatusContent.tsx:47)
    in StatusContent (at SectionStatus/index.tsx:102)
```

## List of changes proposed in this pull request
- Change with the right color type
