### PR TITLE
[IA-445] Add PayPal payment method

### DIFF
--- a/assets/paymentManager/README.MD
+++ b/assets/paymentManager/README.MD
@@ -1,3 +1,6 @@
+### 2021-11-11
+- add PayPal payment method in WalletV2. `emailPp` and `psp` are update as required ([more info](https://pagopa.atlassian.net/browse/IA-445))
+
 ### 2021-11-04
 - add PayPal search psp API `/v3/paypal/searchPSP`. All fields have been defined as required even if the original spec were not ([more info](https://pagopa.atlassian.net/browse/PM-253?focusedCommentId=22100))
 

--- a/assets/paymentManager/spec.json
+++ b/assets/paymentManager/spec.json
@@ -2479,6 +2479,35 @@
       },
       "title": "PaymentResponse"
     },
+    "PayPalInfo": {
+      "type": "object",
+      "required": [
+        "emailPp",
+        "psp"
+      ],
+      "properties": {
+        "canceled": {
+          "type": "boolean"
+        },
+        "creationDate": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "default": {
+          "type": "boolean"
+        },
+        "emailPp": {
+          "type": "string"
+        },
+        "idPp": {
+          "type": "string"
+        },
+        "psp": {
+          "$ref": "#/definitions/PayPalPsp"
+        }
+      },
+      "title": "PayPal"
+    },
     "PayPalPsp": {
       "type": "object",
       "required": [
@@ -3298,7 +3327,8 @@
             "Card",
             "Bancomat",
             "Satispay",
-            "BPay"
+            "BPay",
+            "PayPal"
           ]
         }
       },

--- a/ts/api/pagopa.ts
+++ b/ts/api/pagopa.ts
@@ -25,7 +25,6 @@ import { Omit } from "italia-ts-commons/lib/types";
 import _ from "lodash";
 import { BancomatCardsRequest } from "../../definitions/pagopa/walletv2/BancomatCardsRequest";
 import {
-  AddWalletSatispayUsingPOSTT,
   addWalletsBancomatCardUsingPOSTDecoder,
   addWalletsBPayUsingPOSTDecoder,
   addWalletsCobadgePaymentInstrumentAsCreditCardUsingPOSTDecoder,
@@ -464,7 +463,18 @@ const searchSatispay: GetConsumerUsingGETT = {
   response_decoder: getConsumerUsingGETDefaultDecoder()
 };
 
-const addSatispayToWallet: AddWalletSatispayUsingPOSTT = {
+export type AddWalletSatispayUsingPOSTTExtra = r.IPostApiRequestType<
+  { readonly Bearer: string; readonly satispayRequest: SatispayRequest },
+  "Content-Type" | "Authorization",
+  never,
+  | r.IResponseType<200, PatchedWalletV2Response>
+  | r.IResponseType<201, undefined>
+  | r.IResponseType<401, undefined>
+  | r.IResponseType<403, undefined>
+  | r.IResponseType<404, undefined>
+>;
+
+const addSatispayToWallet: AddWalletSatispayUsingPOSTTExtra = {
   method: "post",
   url: () => `/v1/satispay/add-wallet`,
   query: () => ({}),

--- a/ts/components/wallet/payment/PickAvailablePaymentMethodListItem.tsx
+++ b/ts/components/wallet/payment/PickAvailablePaymentMethodListItem.tsx
@@ -56,6 +56,12 @@ const extractInfoFromPaymentMethod = (
         title: paymentMethod.kind,
         description: nameSurname
       };
+    case "PayPal":
+      return {
+        logo: paymentMethod.icon,
+        title: paymentMethod.caption,
+        description: nameSurname
+      };
     case "Privative":
       return {
         logo: paymentMethod.icon,

--- a/ts/components/wallet/payment/PickNotAvailablePaymentMethodListItem.tsx
+++ b/ts/components/wallet/payment/PickNotAvailablePaymentMethodListItem.tsx
@@ -109,6 +109,14 @@ const extractInfoFromPaymentMethod = (
         bottomSheetTitle: arrivingBottomSheetTitle(),
         bottomSheetBody: arrivingBottomSheetBody()
       };
+    case "PayPal":
+      return {
+        logo: paymentMethod.icon,
+        title: paymentMethod.kind,
+        description: nameSurname,
+        bottomSheetTitle: arrivingBottomSheetTitle(),
+        bottomSheetBody: arrivingBottomSheetBody()
+      };
     case "Privative":
       return {
         logo: paymentMethod.icon,

--- a/ts/features/bonus/bpd/store/reducers/__mock__/bancomat.ts
+++ b/ts/features/bonus/bpd/store/reducers/__mock__/bancomat.ts
@@ -1,4 +1,4 @@
-import { WalletTypeEnum } from "../../../../../../../definitions/pagopa/walletv2/WalletV2";
+import { WalletTypeEnum } from "../../../../../../../definitions/pagopa/WalletV2";
 import { PatchedWalletV2 } from "../../../../../../types/pagopa";
 import { EnableableFunctionsEnum } from "../../../../../../../definitions/pagopa/EnableableFunctions";
 

--- a/ts/features/wallet/component/card/WalletV2PreviewCards.tsx
+++ b/ts/features/wallet/component/card/WalletV2PreviewCards.tsx
@@ -12,6 +12,7 @@ import CobadgeWalletPreview from "../../cobadge/component/CobadgeWalletPreview";
 import CreditCardWalletPreview from "../../creditCard/component/CreditCardWalletPreview";
 import PrivativeWalletPreview from "../../privative/component/PrivativeWalletPreview";
 import SatispayWalletPreview from "../../satispay/SatispayWalletPreview";
+import PayPalWalletPreview from "../../paypal/PayPalWalletPreview";
 
 type Props = ReturnType<typeof mapDispatchToProps> &
   ReturnType<typeof mapStateToProps>;
@@ -20,6 +21,8 @@ const paymentMethodPreview = (pm: PaymentMethod): React.ReactElement | null => {
   switch (pm.kind) {
     case "Satispay":
       return <SatispayWalletPreview key={pm.idWallet} satispay={pm} />;
+    case "PayPal":
+      return <PayPalWalletPreview key={pm.idWallet} paypal={pm} />;
     case "Bancomat":
       return <BancomatWalletPreview key={pm.idWallet} bancomat={pm} />;
     case "CreditCard":

--- a/ts/features/wallet/creditCard/screen/__tests__/CreditCardDetailScreen.test.tsx
+++ b/ts/features/wallet/creditCard/screen/__tests__/CreditCardDetailScreen.test.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { NavigationParams } from "react-navigation";
 import { createStore, Store } from "redux";
 import { TypeEnum } from "../../../../../../definitions/pagopa/walletv2/CardInfo";
-import { WalletTypeEnum } from "../../../../../../definitions/pagopa/walletv2/WalletV2";
+import { WalletTypeEnum } from "../../../../../../definitions/pagopa/WalletV2";
 import ROUTES from "../../../../../navigation/routes";
 import { applicationChangeState } from "../../../../../store/actions/application";
 import { fetchWalletsSuccess } from "../../../../../store/actions/wallet/wallets";

--- a/ts/features/wallet/paypal/PayPalWalletPreview.tsx
+++ b/ts/features/wallet/paypal/PayPalWalletPreview.tsx
@@ -8,11 +8,7 @@ import { IOStyles } from "../../../components/core/variables/IOStyles";
 import I18n from "../../../i18n";
 import { GlobalState } from "../../../store/reducers/types";
 import { CardLogoPreview } from "../component/card/CardLogoPreview";
-
-// TODO temporary type
-type PayPalPaymentMethod = {
-  email: string;
-};
+import { PayPalPaymentMethod } from "../../../types/pagopa";
 
 type OwnProps = {
   paypal: PayPalPaymentMethod;
@@ -38,7 +34,7 @@ const PayPalWalletPreview: React.FunctionComponent<Props> = props => (
     accessibilityLabel={getAccessibilityRepresentation()}
     left={
       <Body style={[IOStyles.flex, { paddingRight: 16 }]} numberOfLines={1}>
-        {props.paypal.email}
+        {props.paypal.info.emailPp}
       </Body>
     }
     image={payPalCard}

--- a/ts/screens/wallet/payment/__tests__/PickPaymentMethodScreen.test.tsx
+++ b/ts/screens/wallet/payment/__tests__/PickPaymentMethodScreen.test.tsx
@@ -6,7 +6,7 @@ import { NavigationParams } from "react-navigation";
 import { Action, Store } from "redux";
 import configureMockStore from "redux-mock-store";
 import { PaymentRequestsGetResponse } from "../../../../../definitions/backend/PaymentRequestsGetResponse";
-import { WalletTypeEnum } from "../../../../../definitions/pagopa/walletv2/WalletV2";
+import { WalletTypeEnum } from "../../../../../definitions/pagopa/WalletV2";
 
 import WALLET_ONBOARDING_PRIVATIVE_ROUTES from "../../../../features/wallet/onboarding/privative/navigation/routes";
 import I18n from "../../../../i18n";

--- a/ts/store/reducers/wallet/wallets.ts
+++ b/ts/store/reducers/wallet/wallets.ts
@@ -6,7 +6,7 @@ import _, { values } from "lodash";
 import { PersistPartial } from "redux-persist";
 import { createSelector } from "reselect";
 import { getType, isOfType } from "typesafe-actions";
-import { WalletTypeEnum } from "../../../../definitions/pagopa/walletv2/WalletV2";
+import { WalletTypeEnum } from "../../../../definitions/pagopa/WalletV2";
 import {
   getValueOrElse,
   remoteError,

--- a/ts/types/pagopa.ts
+++ b/ts/types/pagopa.ts
@@ -28,7 +28,7 @@ import { BPayInfo as BPayInfoPagoPa } from "../../definitions/pagopa/walletv2/BP
 import { CardInfo } from "../../definitions/pagopa/walletv2/CardInfo";
 
 import { SatispayInfo as SatispayInfoPagoPa } from "../../definitions/pagopa/walletv2/SatispayInfo";
-import { WalletTypeEnum } from "../../definitions/pagopa/walletv2/WalletV2";
+import { WalletTypeEnum } from "../../definitions/pagopa/WalletV2";
 import {
   CreditCardCVC,
   CreditCardExpirationMonth,
@@ -37,6 +37,7 @@ import {
 } from "../utils/input";
 import { TypeEnum as CreditCardTypeEnum } from "../../definitions/pagopa/walletv2/CardInfo";
 import { EnableableFunctions } from "../../definitions/pagopa/EnableableFunctions";
+import { PayPalInfo } from "../../definitions/pagopa/PayPalInfo";
 
 /**
  * Union of all possible credit card types
@@ -111,7 +112,8 @@ export type Psp = t.TypeOf<typeof Psp>;
 const PatchedPaymentMethodInfo = t.union([
   CardInfo,
   SatispayInfoPagoPa,
-  BPayInfoPagoPa
+  BPayInfoPagoPa,
+  PayPalInfo
 ]);
 export type PatchedPaymentMethodInfo = t.TypeOf<
   typeof PatchedPaymentMethodInfo
@@ -154,7 +156,8 @@ export type RawPaymentMethod =
   | RawCreditCardPaymentMethod
   | RawBPayPaymentMethod
   | RawSatispayPaymentMethod
-  | RawPrivativePaymentMethod;
+  | RawPrivativePaymentMethod
+  | RawPayPalPaymentMethod;
 
 export type RawBancomatPaymentMethod = WalletV2WithoutInfo & {
   kind: "Bancomat";
@@ -181,31 +184,35 @@ export type RawSatispayPaymentMethod = WalletV2WithoutInfo & {
   info: SatispayInfoPagoPa;
 };
 
+export type RawPayPalPaymentMethod = WalletV2WithoutInfo & {
+  kind: "PayPal";
+  info: PayPalInfo;
+};
+
 // payment methods type guards
 export const isRawBancomat = (
   pm: RawPaymentMethod | undefined
-): pm is RawBancomatPaymentMethod =>
-  pm === undefined ? false : pm.kind === "Bancomat";
+): pm is RawBancomatPaymentMethod => pm?.kind === "Bancomat";
 
 export const isRawSatispay = (
   pm: RawPaymentMethod | undefined
-): pm is RawSatispayPaymentMethod =>
-  pm === undefined ? false : pm.kind === "Satispay";
+): pm is RawSatispayPaymentMethod => pm?.kind === "Satispay";
+
+export const isRawPayPal = (
+  pm: RawPaymentMethod | undefined
+): pm is RawPayPalPaymentMethod => pm?.kind === "PayPal";
 
 export const isRawCreditCard = (
   pm: RawPaymentMethod | undefined
-): pm is RawCreditCardPaymentMethod =>
-  pm === undefined ? false : pm.kind === "CreditCard";
+): pm is RawCreditCardPaymentMethod => pm?.kind === "CreditCard";
 
 export const isRawPrivative = (
   pm: RawPaymentMethod | undefined
-): pm is RawPrivativePaymentMethod =>
-  pm === undefined ? false : pm.kind === "Privative";
+): pm is RawPrivativePaymentMethod => pm?.kind === "Privative";
 
 export const isRawBPay = (
   pm: RawPaymentMethod | undefined
-): pm is RawBPayPaymentMethod =>
-  pm === undefined ? false : pm.kind === "BPay";
+): pm is RawBPayPaymentMethod => pm?.kind === "BPay";
 
 export type PaymentMethodRepresentation = {
   // A textual representation for a payment method
@@ -238,23 +245,29 @@ export type BPayPaymentMethod = RawBPayPaymentMethod &
 export type SatispayPaymentMethod = RawSatispayPaymentMethod &
   PaymentMethodRepresentation;
 
+export type PayPalPaymentMethod = RawPayPalPaymentMethod &
+  PaymentMethodRepresentation;
+
 export type PaymentMethod =
   | BancomatPaymentMethod
   | CreditCardPaymentMethod
   | BPayPaymentMethod
   | SatispayPaymentMethod
-  | PrivativePaymentMethod;
+  | PrivativePaymentMethod
+  | PayPalPaymentMethod;
 
 // payment methods type guards
 export const isBancomat = (
   pm: PaymentMethod | undefined
-): pm is BancomatPaymentMethod =>
-  pm === undefined ? false : pm.kind === "Bancomat";
+): pm is BancomatPaymentMethod => pm?.kind === "Bancomat";
 
 export const isSatispay = (
   pm: PaymentMethod | undefined
-): pm is SatispayPaymentMethod =>
-  pm === undefined ? false : pm.kind === "Satispay";
+): pm is SatispayPaymentMethod => pm?.kind === "Satispay";
+
+export const isPayPal = (
+  pm: PaymentMethod | undefined
+): pm is PayPalPaymentMethod => pm?.kind === "PayPal";
 
 export const isCreditCard = (
   pm: PaymentMethod | undefined

--- a/ts/utils/paymentMethod.ts
+++ b/ts/utils/paymentMethod.ts
@@ -13,6 +13,7 @@ import {
 import bPayImage from "../../img/wallet/cards-icons/bPay.png";
 import pagoBancomatImage from "../../img/wallet/cards-icons/pagobancomat.png";
 import satispayImage from "../../img/wallet/cards-icons/satispay.png";
+import paypalImage from "../../img/wallet/cards-icons/paypal.png";
 import {
   cardIcons,
   getCardIconFromBrandLogo
@@ -27,6 +28,7 @@ import {
   isRawBancomat,
   isRawBPay,
   isRawCreditCard,
+  isRawPayPal,
   isRawPrivative,
   isRawSatispay,
   PaymentMethod,
@@ -35,6 +37,7 @@ import {
   RawBPayPaymentMethod,
   RawCreditCardPaymentMethod,
   RawPaymentMethod,
+  RawPayPalPaymentMethod,
   RawPrivativePaymentMethod,
   RawSatispayPaymentMethod,
   SatispayPaymentMethod
@@ -49,6 +52,8 @@ export const getPaymentMethodHash = (
   switch (pm.kind) {
     case "Satispay":
       return pm.info.uuid;
+    case "PayPal":
+      return pm.info.emailPp;
     case "BPay":
       return pm.info.uidHash;
     case "Bancomat":
@@ -96,6 +101,9 @@ export const getImageFromPaymentMethod = (
   if (isRawSatispay(paymentMethod)) {
     return satispayImage;
   }
+  if (isRawPayPal(paymentMethod)) {
+    return paypalImage;
+  }
   if (isRawBPay(paymentMethod)) {
     return bPayImage;
   }
@@ -111,8 +119,9 @@ export const getTitleFromBancomat = (
     .chain(abi => fromNullable(abi.name))
     .getOrElse(I18n.t("wallet.methods.bancomat.name"));
 
-export const getTitleForSatispay = () => I18n.t("wallet.methods.satispay.name");
-
+const getTitleForSatispay = () => I18n.t("wallet.methods.satispay.name");
+const getTitleForPaypal = (paypal: RawPayPalPaymentMethod) =>
+  paypal.info.emailPp;
 /**
  * Choose a textual representation for a {@link PatchedWalletV2}
  * @param paymentMethod
@@ -140,6 +149,9 @@ export const getTitleFromPaymentMethod = (
       paymentMethod.info.bankName ??
       I18n.t("wallet.methods.bancomatPay.name")
     );
+  }
+  if (isRawPayPal(paymentMethod)) {
+    return getTitleForPaypal(paymentMethod);
   }
   return FOUR_UNICODE_CIRCLES;
 };
@@ -220,6 +232,7 @@ export const enhancePaymentMethod = (
       return enhanceCreditCard(pm, abiList);
     case "Privative":
       return enhancePrivativeCard(pm, abiList);
+    case "PayPal":
     case "Satispay":
       return {
         ...pm,
@@ -246,6 +259,7 @@ export const isPaymentMethodExpired = (
 ): Either<Error, boolean> => {
   switch (paymentMethod.kind) {
     case "BPay":
+    case "PayPal":
     case "Satispay":
       return right(false);
     case "Bancomat":

--- a/ts/utils/walletv2.ts
+++ b/ts/utils/walletv2.ts
@@ -6,7 +6,7 @@ import { fromPredicate, Option } from "fp-ts/lib/Option";
 import { TypeEnum as WalletTypeEnumV1 } from "../../definitions/pagopa/Wallet";
 import { CardInfo, TypeEnum } from "../../definitions/pagopa/walletv2/CardInfo";
 import { SatispayInfo } from "../../definitions/pagopa/walletv2/SatispayInfo";
-import { WalletTypeEnum } from "../../definitions/pagopa/walletv2/WalletV2";
+import { WalletTypeEnum } from "../../definitions/pagopa/WalletV2";
 import {
   PatchedPaymentMethodInfo,
   PatchedWalletV2,


### PR DESCRIPTION
# ⚠️ this PR depends on https://github.com/pagopa/io-app/pull/3483
## Short description
This PR adds PayPal as handle payment method

- change `spec.json` to generate the new payment method type
- remove wrong `WalletV2` imports
- sync `PayPalWalletPreview` component with the new payment method
- add some syntax sugar by using optional chaining
