### PR TITLE
fix: [IABT-1291] Wrong payment history selection

### DIFF
--- a/ts/screens/wallet/payment/TransactionErrorScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionErrorScreen.tsx
@@ -132,13 +132,13 @@ const ErrorCodeCopyComponent = ({
  * @param maybeError
  * @param rptId
  * @param onCancel
- * @param payment
+ * @param paymentHistory
  */
 export const errorTransactionUIElements = (
   maybeError: NavigationParams["error"],
   rptId: RptId,
   onCancel: () => void,
-  payment?: PaymentHistory
+  paymentHistory?: PaymentHistory
 ): ScreenUIContents => {
   const errorORUndefined = maybeError.toUndefined();
 
@@ -150,7 +150,7 @@ export const errorTransactionUIElements = (
     };
   }
   const requestAssistance = () =>
-    requestAssistanceForPaymentFailure(rptId, payment);
+    requestAssistanceForPaymentFailure(rptId, paymentHistory);
 
   const errorMacro = getV2ErrorMainType(errorORUndefined);
   const validError = t.keyof(Detail_v2Enum).decode(errorORUndefined);
@@ -296,16 +296,19 @@ const TransactionErrorScreen = (props: Props) => {
   const { paymentsHistory } = props;
 
   const codiceAvviso = getCodiceAvviso(rptId);
+  const organizationFiscalCode = rptId.organizationFiscalCode;
 
-  const payment = paymentsHistory.find(
-    p => codiceAvviso === getCodiceAvviso(p.data)
+  const paymentHistory = paymentsHistory.find(
+    p =>
+      codiceAvviso === getCodiceAvviso(p.data) &&
+      organizationFiscalCode === p.data.organizationFiscalCode
   );
 
   const { title, subtitle, footerButtons, image } = errorTransactionUIElements(
     error,
     rptId,
     onCancel,
-    payment
+    paymentHistory
   );
   const handleBackPress = () => {
     props.backToEntrypointPayment();

--- a/ts/store/reducers/__tests__/paymentsHistory.test.ts
+++ b/ts/store/reducers/__tests__/paymentsHistory.test.ts
@@ -170,7 +170,7 @@ describe("payments history", () => {
     expect(state[0].transaction).toEqual(validTransaction);
   });
 
-  it("should recognize a sucessfully payment", () => {
+  it("should recognize a successfully payment", () => {
     expect(isPaymentDoneSuccessfully(state[0])).toEqual(some(true));
   });
 
@@ -182,6 +182,20 @@ describe("payments history", () => {
 
   it("should recognize a failed payment", () => {
     expect(isPaymentDoneSuccessfully(state[0])).toEqual(some(false));
+  });
+
+  it("should add a payment in the history because it has the same notice number but a different organization fiscal code", () => {
+    state = reducer(
+      state,
+      paymentVerifica.request({
+        rptId: {
+          ...anRptId,
+          organizationFiscalCode: "00000000001" as OrganizationFiscalCode
+        },
+        startOrigin: "message"
+      })
+    );
+    expect(state.length).toEqual(2);
   });
 
   it("should add a payment in the history", () => {
@@ -196,7 +210,7 @@ describe("payments history", () => {
         startOrigin: "message"
       })
     );
-    expect(state.length).toEqual(2);
+    expect(state.length).toEqual(3);
     expect(state[1].verified_data).toEqual(undefined);
   });
 


### PR DESCRIPTION
## Short description
When an error occurred during a payment user can ask for assistance. In that moment some payment data are sent attached to the ticket.
This PR fixes a bug that picks wrongly a payment from history considering only the notice number and not also the organization fiscal code. The ID of a payment is the couple `noticeNumber` + `organizationFiscalCode`

### how to test
- setup the dev-server to [return an error on verifica](https://github.com/pagopa/io-dev-api-server/blob/56c3a36711b93233598ddd602e0ba7b5e0183a9c/src/config.ts#L85)
- make a payment from manual insertion by inserting `000000000000000000` as notice number and `00000000000` as organization fiscal code
- change the error type on dev-server, whatever you want but different from the previous one
- make a payment from manual insertion by inserting `000000000000000000` as notice number and `00000000001` as organization fiscal code
- ask for assistance. The attached data should contain the info of the last payment (with the bug it sent the data of the first payment)