### PR TITLE
fix: [IA-447] In MessageDetailsScreen the link to related services doesn't work

### DIFF
--- a/ts/screens/messages/MessageDetailScreen/index.tsx
+++ b/ts/screens/messages/MessageDetailScreen/index.tsx
@@ -49,7 +49,7 @@ const contextualHelpMarkdown: ContextualHelpPropsMarkdown = {
 };
 
 export class MessageDetailScreen extends React.PureComponent<Props, never> {
-  onServiceLinkPressHandler = (service: ServicePublic) => {
+  private onServiceLinkPressHandler = (service: ServicePublic) => {
     // When a service gets selected, before navigating to the service detail
     // screen, we issue a loadServiceMetadata request to refresh the service metadata
     this.props.navigateToServiceDetailsScreen({
@@ -110,7 +110,9 @@ export class MessageDetailScreen extends React.PureComponent<Props, never> {
           potMessage={potMessage}
           messageId={messageId}
           onRetry={() => maybeMeta.map(meta => loadMessageWithRelations(meta))}
-          onServiceLinkPressHandler={(id: string) => refreshService(id)}
+          onServiceLinkPressHandler={_ =>
+            this.props.maybeService.map(this.onServiceLinkPressHandler)
+          }
           paymentsByRptId={paymentsByRptId}
           service={maybeService.toUndefined()}
           maybeServiceMetadata={maybeServiceMetadata}

--- a/ts/screens/messages/MessageDetailScreen/index.tsx
+++ b/ts/screens/messages/MessageDetailScreen/index.tsx
@@ -94,8 +94,7 @@ export class MessageDetailScreen extends React.PureComponent<Props, never> {
       paymentsByRptId,
       potMessage,
       maybeMeta,
-      maybeServiceMetadata,
-      refreshService
+      maybeServiceMetadata
     } = this.props;
 
     return (


### PR DESCRIPTION
## Short description
This pr fixes a bug that doesn't allow to interact with the service link in the MessageDetailsScreen.

**Before**

https://user-images.githubusercontent.com/26501317/141475530-12d534be-dbd2-4c58-8a5b-38619c4e0c86.mov

**After**

https://user-images.githubusercontent.com/26501317/141475690-c2c70fba-4429-404b-848e-e3592a339129.mov

## List of changes proposed in this pull request
- Restore the navigation to the service detail.

## How to test
- Messages > Message details > scroll to the end > tap on the message service