### PR TITLE
chore: [IA-450] Message list should remember its scroll offset

### DIFF
--- a/ts/components/messages/MessageList.tsx
+++ b/ts/components/messages/MessageList.tsx
@@ -184,7 +184,7 @@ class MessageList extends React.Component<Props, State> {
 
   private scrollTo = (index: number, animated: boolean = false) => {
     if (this.flatListRef.current && this.props.messageStates.length > 0) {
-      // this.flatListRef.current.scrollToIndex({ animated, index });
+      this.flatListRef.current.scrollToIndex({ animated, index });
     }
   };
 

--- a/ts/components/messages/MessageList.tsx
+++ b/ts/components/messages/MessageList.tsx
@@ -185,7 +185,7 @@ class MessageList extends React.Component<Props, State> {
 
   private scrollTo = (index: number, animated: boolean = false) => {
     if (this.flatListRef.current && this.props.messageStates.length > 0) {
-      this.flatListRef.current.scrollToIndex({ animated, index });
+      // this.flatListRef.current.scrollToIndex({ animated, index });
     }
   };
 
@@ -322,7 +322,6 @@ class MessageList extends React.Component<Props, State> {
     );
     return (
       <React.Fragment>
-        <NavigationEvents onWillFocus={() => this.scrollTo(0)} />
         {/* in iOS refresh indicator is shown only when user does pull to refresh on list
           so only for iOS devices the ActivityIndicator is shown in place of RefreshControl
           see https://stackoverflow.com/questions/50307314/react-native-flatlist-refreshing-not-showing-when-its-true-during-first-load

--- a/ts/components/messages/MessageList.tsx
+++ b/ts/components/messages/MessageList.tsx
@@ -14,7 +14,6 @@ import {
   StyleSheet,
   Vibration
 } from "react-native";
-import { NavigationEvents } from "react-navigation";
 import Placeholder from "rn-placeholder";
 import { CreatedMessageWithContentAndAttachments } from "../../../definitions/backend/CreatedMessageWithContentAndAttachments";
 import { ServicePublic } from "../../../definitions/backend/ServicePublic";

--- a/ts/components/messages/paginated/MessageList/index.tsx
+++ b/ts/components/messages/paginated/MessageList/index.tsx
@@ -10,7 +10,6 @@ import {
   StyleSheet,
   Vibration
 } from "react-native";
-import { NavigationEvents } from "react-navigation";
 import { connect } from "react-redux";
 import { pageSize } from "../../../../config";
 import { loadNextPageMessages } from "../../../../store/actions/messages";

--- a/ts/components/messages/paginated/MessageList/index.tsx
+++ b/ts/components/messages/paginated/MessageList/index.tsx
@@ -194,7 +194,6 @@ const MessageList = ({
 
   return (
     <>
-      <NavigationEvents onWillFocus={() => scrollTo(0)} />
       {/* in iOS refresh indicator is shown only when user does pull to refresh on list
           so only for iOS devices the ActivityIndicator is shown in place of RefreshControl
           see https://stackoverflow.com/questions/50307314/react-native-flatlist-refreshing-not-showing-when-its-true-during-first-load


### PR DESCRIPTION
## Short description
This PR removes the autoscroll on top in the messages list, since [this issue](https://www.pivotaltracker.com/n/projects/2048617/stories/167507729) is no longer present

### before
https://user-images.githubusercontent.com/822471/141496014-2f134f82-2d66-4b27-8012-688791a6abcf.mov

### now
https://user-images.githubusercontent.com/822471/141495838-be6c153b-cb9c-43f9-ba84-f7665d7a0dc1.mov


