### PR TITLE
fix: [IA-420] All space characters text cause infinite loading in the MarkDown component

### DIFF
--- a/ts/components/ui/Markdown/index.tsx
+++ b/ts/components/ui/Markdown/index.tsx
@@ -302,7 +302,6 @@ class Markdown extends React.PureComponent<Props, State> {
       height: htmlBodyHeight + (extraBodyHeight || 0)
     };
 
-
     return (
       <React.Fragment>
         {this.state.isLoading && (

--- a/ts/components/ui/Markdown/index.tsx
+++ b/ts/components/ui/Markdown/index.tsx
@@ -298,9 +298,7 @@ class Markdown extends React.PureComponent<Props, State> {
     const containerStyle: ViewStyle = {
       height: htmlBodyHeight + (extraBodyHeight || 0)
     };
-
-    const isLoading =
-      html === undefined || (html !== "" && htmlBodyHeight === 0);
+    const isLoading = html === undefined;
 
     return (
       <React.Fragment>

--- a/ts/components/ui/Markdown/index.tsx
+++ b/ts/components/ui/Markdown/index.tsx
@@ -354,9 +354,6 @@ class Markdown extends React.PureComponent<Props, State> {
 
   // When the injected html is loaded inject the script to notify the height
   private handleLoadEnd = () => {
-    this.setState({
-      isLoading: false
-    });
     if (this.props.onLoadEnd) {
       this.props.onLoadEnd();
     }
@@ -374,6 +371,9 @@ class Markdown extends React.PureComponent<Props, State> {
   // A function that handles message sent by the WebView component
   private handleWebViewMessage = (event: WebViewMessageEvent) => {
     const { dispatch } = this.props;
+    this.setState({
+      isLoading: false
+    });
 
     // We validate the format of the message with io-ts
     const messageOrErrors = WebViewMessage.decode(

--- a/ts/components/ui/Markdown/index.tsx
+++ b/ts/components/ui/Markdown/index.tsx
@@ -216,6 +216,7 @@ type State = {
   htmlBodyHeight: number;
   webviewKey: number;
   appState: string;
+  isLoading: boolean;
 };
 
 /**
@@ -230,7 +231,8 @@ class Markdown extends React.PureComponent<Props, State> {
       html: undefined,
       htmlBodyHeight: 0,
       webviewKey: 0,
-      appState: AppState.currentState
+      appState: AppState.currentState,
+      isLoading: true
     };
   }
 
@@ -263,6 +265,7 @@ class Markdown extends React.PureComponent<Props, State> {
 
     // If the children changes we need to re-compile it
     if (children !== prevChildren) {
+      this.setState({ isLoading: true });
       this.compileMarkdownAsync(
         children,
         animated,
@@ -298,11 +301,11 @@ class Markdown extends React.PureComponent<Props, State> {
     const containerStyle: ViewStyle = {
       height: htmlBodyHeight + (extraBodyHeight || 0)
     };
-    const isLoading = html === undefined;
+
 
     return (
       <React.Fragment>
-        {isLoading && (
+        {this.state.isLoading && (
           <ActivityIndicator
             testID={this.props.testID}
             size={"large"}
@@ -352,10 +355,12 @@ class Markdown extends React.PureComponent<Props, State> {
 
   // When the injected html is loaded inject the script to notify the height
   private handleLoadEnd = () => {
+    this.setState({
+      isLoading: false
+    });
     if (this.props.onLoadEnd) {
       this.props.onLoadEnd();
     }
-
     setTimeout(() => {
       // to avoid yellow box warning
       // it's ugly but it works https://github.com/react-native-community/react-native-webview/issues/341#issuecomment-466639820


### PR DESCRIPTION
## Short description
This pr fixes the unwanted behaviour: All space characters cause the MarkDown component infinite loading.

**Before**

https://user-images.githubusercontent.com/26501317/142013561-19230b7b-1fae-4fef-b9c4-fe5a974d9d1f.mov



**After**

https://user-images.githubusercontent.com/26501317/142012979-aca201bc-3d50-45f6-a90b-3085931524bd.mov


## List of changes proposed in this pull request
- Changed the `isLoading` condition in `Markdown` component

## How to test
- In any `Markdown` component -> 
```typescript
<Markdown>
{" "}
</Markdown>
```
