### PR TITLE
fix: [IA-466] Cannot cancel CIE login if a wrong PIN is inserted

### DIFF
--- a/ts/screens/authentication/cie/CieWrongCiePinScreen.tsx
+++ b/ts/screens/authentication/cie/CieWrongCiePinScreen.tsx
@@ -33,7 +33,7 @@ class CieWrongCiePinScreen extends React.PureComponent<Props> {
   private renderFooterButtons = () => {
     const cancelButtonProps = {
       bordered: true,
-      onPress: this.props.abort,
+      onPress: resetToAuthenticationRoute,
       title: I18n.t("global.buttons.cancel")
     };
     const retryButtonProps = {
@@ -80,8 +80,6 @@ class CieWrongCiePinScreen extends React.PureComponent<Props> {
     );
   }
 }
-const mapDispatchToProps = (_: Dispatch) => ({
-  abort: () => resetToAuthenticationRoute()
-});
+const mapDispatchToProps = (_: Dispatch) => ({});
 
 export default connect(undefined, mapDispatchToProps)(CieWrongCiePinScreen);

--- a/ts/screens/authentication/cie/CieWrongCiePinScreen.tsx
+++ b/ts/screens/authentication/cie/CieWrongCiePinScreen.tsx
@@ -81,7 +81,7 @@ class CieWrongCiePinScreen extends React.PureComponent<Props> {
   }
 }
 const mapDispatchToProps = (_: Dispatch) => ({
-  abort: () => resetToAuthenticationRoute
+  abort: () => resetToAuthenticationRoute()
 });
 
 export default connect(undefined, mapDispatchToProps)(CieWrongCiePinScreen);


### PR DESCRIPTION
## Short description
This pr fixes the impossibility to cancel the CIE login if a wrong PIN is inserted (a regression introduced in 900d7fb52444d2424b0fbfc1637e91724b73e754)

**Before**

https://user-images.githubusercontent.com/26501317/142186986-86c70edd-7674-4f23-88d8-3a90838b47b9.mov

**After**

https://user-images.githubusercontent.com/26501317/142186916-8ce13c68-3c17-4071-893b-dc1a3cedc14d.mov


## List of changes proposed in this pull request
- Call the `resetToAuthenticationRoute` when the user tap on `Cancel`

## How to test
Login with CIE > insert a wrong pin > Press `Cancel`
