### PR TITLE
feat: [IA-467] Add an alert explaining why the calendar permissions are required on Android

### DIFF
--- a/ios/ItaliaApp/Info.plist
+++ b/ios/ItaliaApp/Info.plist
@@ -66,7 +66,7 @@
     <key>NSBluetoothPeripheralUsageDescription</key>
     <string>The app needs NSBluetoothPeripheralUsageDescription permission</string>
     <key>NSCalendarsUsageDescription</key>
-    <string>IO needs access to the calendar to add event reminders</string>
+    <string>TMP IOS CALENDAR</string>
     <key>NSCameraUsageDescription</key>
     <string>You’ll be able to read QR codes and pay pagoPA notices.</string>
     <key>NSContactsUsageDescription</key>

--- a/ios/ItaliaApp/Info.plist
+++ b/ios/ItaliaApp/Info.plist
@@ -66,7 +66,7 @@
     <key>NSBluetoothPeripheralUsageDescription</key>
     <string>The app needs NSBluetoothPeripheralUsageDescription permission</string>
     <key>NSCalendarsUsageDescription</key>
-    <string>TMP IOS CALENDAR</string>
+    <string>So that you’ll be able to add deadlines to your calendar and set a reminder.</string>
     <key>NSCameraUsageDescription</key>
     <string>You’ll be able to read QR codes and pay pagoPA notices.</string>
     <key>NSContactsUsageDescription</key>

--- a/ios/ItaliaApp/it.lproj/InfoPlist.strings
+++ b/ios/ItaliaApp/it.lproj/InfoPlist.strings
@@ -1,5 +1,5 @@
 "NSCameraUsageDescription" = "Potrai leggere codici QR e pagare gli avvisi pagoPA.";
-"NSCalendarsUsageDescription" = "TMP IOS CALENDAR";
+"NSCalendarsUsageDescription" = "Se acconsenti, potrai aggiungere le scadenze al tuo calendario e impostare un promemoria.";
 "NSContactsUsageDescription" = "IO ha necessità di accedere ai tuoi contatti per permetterti di aggiungerli come partecipanti alle scadenze";
 "NSFaceIDUsageDescription" = "IO ha necessità di accedere a Face ID per permetterti di effettuare un'autenticazione più veloce";
 "NSPhotoLibraryUsageDescription" = "Potrai salvare bonus e certificati, caricare screenshot e avvisi di pagamento.";

--- a/ios/ItaliaApp/it.lproj/InfoPlist.strings
+++ b/ios/ItaliaApp/it.lproj/InfoPlist.strings
@@ -1,5 +1,5 @@
 "NSCameraUsageDescription" = "Potrai leggere codici QR e pagare gli avvisi pagoPA.";
-"NSCalendarsUsageDescription" = "IO ha necessità di accedere ai tuoi calendari per permetterti di ricordare le scadenze";
+"NSCalendarsUsageDescription" = "TMP IOS CALENDAR";
 "NSContactsUsageDescription" = "IO ha necessità di accedere ai tuoi contatti per permetterti di aggiungerli come partecipanti alle scadenze";
 "NSFaceIDUsageDescription" = "IO ha necessità di accedere a Face ID per permetterti di effettuare un'autenticazione più veloce";
 "NSPhotoLibraryUsageDescription" = "Potrai salvare bonus e certificati, caricare screenshot e avvisi di pagamento.";

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -227,6 +227,9 @@ permissionRationale:
   camera:
     title: "Allow camera access"
     message: "You’ll be able to read QR codes and pay pagoPA notices."
+  calendar:
+    title: "TMP CALENDAR TITLE"
+    message: "TMP CALENDAR BODY"
 startup:
   title: Initialization
   authentication: User authenticated

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -228,8 +228,8 @@ permissionRationale:
     title: "Allow camera access"
     message: "You’ll be able to read QR codes and pay pagoPA notices."
   calendar:
-    title: "TMP CALENDAR TITLE"
-    message: "TMP CALENDAR BODY"
+    title: "Allow calendar access"
+    message: "You’ll be able to add deadlines to your calendar and set a reminder."
 startup:
   title: Initialization
   authentication: User authenticated

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -227,6 +227,9 @@ permissionRationale:
   camera:
     title: "Consenti l’accesso alla fotocamera"
     message: "Potrai leggere codici QR e pagare gli avvisi pagoPA."
+  calendar:
+    title: "TMP CALENDAR TITLE"
+    message: "TMP CALENDAR BODY"
 startup:
   title: Inizializzazione
   authentication: Utente autenticato

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -228,8 +228,8 @@ permissionRationale:
     title: "Consenti l’accesso alla fotocamera"
     message: "Potrai leggere codici QR e pagare gli avvisi pagoPA."
   calendar:
-    title: "TMP CALENDAR TITLE"
-    message: "TMP CALENDAR BODY"
+    title: "Consenti l’accesso al calendario"
+    message: "Potrai aggiungere le scadenze al tuo calendario e impostare un promemoria."
 startup:
   title: Inizializzazione
   authentication: Utente autenticato

--- a/ts/components/messages/CalendarEventButton.tsx
+++ b/ts/components/messages/CalendarEventButton.tsx
@@ -1,6 +1,11 @@
 import { Text } from "native-base";
 import React from "react";
-import { Alert, Dimensions, StyleSheet } from "react-native";
+import {
+  Alert,
+  Dimensions,
+  PermissionsAndroid,
+  StyleSheet
+} from "react-native";
 import { Calendar } from "react-native-calendar-events";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
@@ -26,6 +31,7 @@ import {
   saveCalendarEvent,
   searchEventInCalendar
 } from "../../utils/calendar";
+import { requestIOAndroidPermission } from "../../utils/permission";
 import ButtonDefaultOpacity from "../ButtonDefaultOpacity";
 import { withLightModalContext } from "../helpers/withLightModalContext";
 import SelectCalendarModal from "../SelectCalendarModal";
@@ -227,13 +233,22 @@ class CalendarEventButton extends React.PureComponent<Props, State> {
   };
 
   // Create an action to add or remove the event
-  private onPressHandler = () => {
+  private onPressHandler = async () => {
     const { calendarEvent, message, preferredCalendar } = this.props;
     const { due_date } = message.content;
 
     if (due_date === undefined) {
       return;
     }
+
+    await requestIOAndroidPermission(
+      PermissionsAndroid.PERMISSIONS.WRITE_CALENDAR,
+      {
+        title: I18n.t("permissionRationale.calendar.title"),
+        message: I18n.t("permissionRationale.calendar.message"),
+        buttonPositive: I18n.t("global.buttons.choose")
+      }
+    );
 
     // Check the authorization status
     void checkAndRequestPermission()

--- a/ts/screens/profile/PreferencesScreen.tsx
+++ b/ts/screens/profile/PreferencesScreen.tsx
@@ -5,7 +5,7 @@
 import * as pot from "italia-ts-commons/lib/pot";
 import { List } from "native-base";
 import * as React from "react";
-import { Alert } from "react-native";
+import { Alert, PermissionsAndroid } from "react-native";
 import { NavigationScreenProp, NavigationState } from "react-navigation";
 import { connect } from "react-redux";
 import { withLightModalContext } from "../../components/helpers/withLightModalContext";
@@ -42,6 +42,7 @@ import {
 } from "../../utils/locale";
 import { ServicesPreferencesModeEnum } from "../../../definitions/backend/ServicesPreferencesMode";
 import ScreenContent from "../../components/screens/ScreenContent";
+import { requestIOAndroidPermission } from "../../utils/permission";
 
 type OwnProps = Readonly<{
   navigation: NavigationScreenProp<NavigationState>;
@@ -91,7 +92,16 @@ class PreferencesScreen extends React.Component<Props> {
     super(props);
   }
 
-  private checkPermissionThenGoCalendar = () => {
+  private checkPermissionThenGoCalendar = async () => {
+    await requestIOAndroidPermission(
+      PermissionsAndroid.PERMISSIONS.WRITE_CALENDAR,
+      {
+        title: I18n.t("permissionRationale.storage.title"),
+        message: I18n.t("permissionRationale.storage.message"),
+        buttonPositive: I18n.t("global.buttons.choose")
+      }
+    );
+
     void checkAndRequestPermission()
       .then(calendarPermission => {
         if (calendarPermission.authorized) {

--- a/ts/screens/profile/PreferencesScreen.tsx
+++ b/ts/screens/profile/PreferencesScreen.tsx
@@ -96,8 +96,8 @@ class PreferencesScreen extends React.Component<Props> {
     await requestIOAndroidPermission(
       PermissionsAndroid.PERMISSIONS.WRITE_CALENDAR,
       {
-        title: I18n.t("permissionRationale.storage.title"),
-        message: I18n.t("permissionRationale.storage.message"),
+        title: I18n.t("permissionRationale.calendar.title"),
+        message: I18n.t("permissionRationale.calendar.message"),
         buttonPositive: I18n.t("global.buttons.choose")
       }
     );


### PR DESCRIPTION
## Short description
This pr adds an alert explaining why the calendar permissions are required on Android, when the app requires the calendar access.

https://user-images.githubusercontent.com/26501317/142449067-0552e8a5-6453-48e8-93c6-e01b9c38235d.mov


## List of changes proposed in this pull request
- Added `requestIOAndroidPermission` in `CalendarEventButton.tsx` and `PreferencesScreen.tsx`
- Updated 

## How to test
With the app without any permission:
Messages > A message with a "reminder" > tap on the reminder
Profile > Preferences > Favourite calendar 
