### PR TITLE
fix: [IA-502] Return EdgeBorderComponent in list footer

### DIFF
--- a/ts/components/messages/paginated/MessageList/index.tsx
+++ b/ts/components/messages/paginated/MessageList/index.tsx
@@ -223,6 +223,16 @@ const MessageList = ({
     />
   );
 
+  const renderListFooter = () => {
+    if (isLoadingMore || isReloadingAll) {
+      return <Loader />;
+    }
+    if (messages.length > 0 && !nextCursor) {
+      return <EdgeBorderComponent />;
+    }
+    return null;
+  };
+
   return (
     <>
       {/* in iOS refresh indicator is shown only when user does pull to refresh on list
@@ -263,15 +273,7 @@ const MessageList = ({
         onLayout={handleOnLayoutChange}
         onEndReached={onEndReached}
         onEndReachedThreshold={0.1}
-        ListFooterComponent={() => {
-          if (isLoadingMore || isReloadingAll) {
-            return <Loader />;
-          }
-          if (messages.length > 0 && !nextCursor) {
-            <EdgeBorderComponent />;
-          }
-          return null;
-        }}
+        ListFooterComponent={renderListFooter}
       />
     </>
   );


### PR DESCRIPTION
## Short description
Add [a return statement](https://github.com/pagopa/io-app/compare/IA-502-edgebordercomponent-not-rendered?expand=1#diff-a0ab177007bd8f5d749d9e7494df01aaddde642f3d379c200e99e9c6048b9b17R231) to the `ListFooterComponent` and extract it to its own function to improve readability.
There was actually a warning in the IDE but I missed it 🤷 

## How to test

Turn on the pagination flag and access the Messages.

| Before        | After           |
| ------------- |-------------|
| ![Screenshot 2021-11-26 at 10 36 49](https://user-images.githubusercontent.com/2094604/143559856-30ac59e2-15fd-49f9-b566-c8246bac6e31.png) | ![Screenshot 2021-11-26 at 10 37 07](https://user-images.githubusercontent.com/2094604/143559843-0672debc-bbd5-45bc-8e19-39b5f9c959a8.png)





