### PR TITLE
chore(Zendesk): [ASZ-124] Update io-react-native-zendesk

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -221,7 +221,7 @@ dependencies {
         force = true
     }
     implementation 'com.squareup.okhttp3:logging-interceptor:3.12.12'
-    
+
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";
         debugImplementation files(hermesPath + "hermes-debug.aar")
@@ -233,6 +233,7 @@ dependencies {
     implementation project(':@react-native-clipboard_clipboard')
     implementation project(':react-native-fingerprint-scanner')
     implementation project(':react-native-art')
+    implementation "org.jetbrains.kotlin:kotlin-reflect:1.3.41"
 }
 
 // Run this once to be able to run the application with BUCK

--- a/ios/ItaliaApp.xcodeproj/project.pbxproj
+++ b/ios/ItaliaApp.xcodeproj/project.pbxproj
@@ -442,23 +442,26 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ItaliaApp/Pods-ItaliaApp-frameworks.sh",
-				"${PODS_ROOT}/ZendeskAnswerBotProvidersSDK/AnswerBotProvidersSDK.framework",
-				"${PODS_ROOT}/ZendeskAnswerBotSDK/AnswerBotSDK.framework",
-				"${PODS_ROOT}/ZendeskChatProvidersSDK/ChatProvidersSDK.framework",
-				"${PODS_ROOT}/ZendeskChatSDK/ChatSDK.framework",
-				"${PODS_ROOT}/ZendeskCommonUISDK/CommonUISDK.framework",
-				"${PODS_ROOT}/ZendeskCoreSDK/ZendeskCoreSDK.framework",
-				"${PODS_ROOT}/ZendeskMessagingAPISDK/MessagingAPI.framework",
-				"${PODS_ROOT}/ZendeskMessagingSDK/MessagingSDK.framework",
-				"${PODS_ROOT}/ZendeskSupportProvidersSDK/SupportProvidersSDK.framework",
-				"${PODS_ROOT}/ZendeskSupportSDK/SupportSDK.framework",
 				"${PODS_ROOT}/hermes-engine/destroot/Library/Frameworks/iphoneos/hermes.framework",
 				"${PODS_ROOT}/../../node_modules/instabug-reactnative/ios/Instabug.framework",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL/OpenSSL.framework/OpenSSL",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/AnswerBotProvidersSDK/AnswerBotProvidersSDK.framework/AnswerBotProvidersSDK",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/AnswerBotSDK/AnswerBotSDK.framework/AnswerBotSDK",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ChatProvidersSDK/ChatProvidersSDK.framework/ChatProvidersSDK",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ChatSDK/ChatSDK.framework/ChatSDK",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/CommonUISDK/CommonUISDK.framework/CommonUISDK",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ZendeskCoreSDK/ZendeskCoreSDK.framework/ZendeskCoreSDK",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/MessagingAPI/MessagingAPI.framework/MessagingAPI",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/MessagingSDK/MessagingSDK.framework/MessagingSDK",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/SDKConfigurations/SDKConfigurations.framework/SDKConfigurations",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/SupportProvidersSDK/SupportProvidersSDK.framework/SupportProvidersSDK",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/SupportSDK/SupportSDK.framework/SupportSDK",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Instabug.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AnswerBotProvidersSDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AnswerBotSDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ChatProvidersSDK.framework",
@@ -467,12 +470,9 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZendeskCoreSDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MessagingAPI.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MessagingSDK.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDKConfigurations.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SupportProvidersSDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SupportSDK.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Instabug.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDKConfigurations.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -576,23 +576,26 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ItaliaApp-ItaliaAppTests/Pods-ItaliaApp-ItaliaAppTests-frameworks.sh",
-				"${PODS_ROOT}/ZendeskAnswerBotProvidersSDK/AnswerBotProvidersSDK.framework",
-				"${PODS_ROOT}/ZendeskAnswerBotSDK/AnswerBotSDK.framework",
-				"${PODS_ROOT}/ZendeskChatProvidersSDK/ChatProvidersSDK.framework",
-				"${PODS_ROOT}/ZendeskChatSDK/ChatSDK.framework",
-				"${PODS_ROOT}/ZendeskCommonUISDK/CommonUISDK.framework",
-				"${PODS_ROOT}/ZendeskCoreSDK/ZendeskCoreSDK.framework",
-				"${PODS_ROOT}/ZendeskMessagingAPISDK/MessagingAPI.framework",
-				"${PODS_ROOT}/ZendeskMessagingSDK/MessagingSDK.framework",
-				"${PODS_ROOT}/ZendeskSupportProvidersSDK/SupportProvidersSDK.framework",
-				"${PODS_ROOT}/ZendeskSupportSDK/SupportSDK.framework",
 				"${PODS_ROOT}/hermes-engine/destroot/Library/Frameworks/iphoneos/hermes.framework",
 				"${PODS_ROOT}/../../node_modules/instabug-reactnative/ios/Instabug.framework",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL/OpenSSL.framework/OpenSSL",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/AnswerBotProvidersSDK/AnswerBotProvidersSDK.framework/AnswerBotProvidersSDK",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/AnswerBotSDK/AnswerBotSDK.framework/AnswerBotSDK",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ChatProvidersSDK/ChatProvidersSDK.framework/ChatProvidersSDK",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ChatSDK/ChatSDK.framework/ChatSDK",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/CommonUISDK/CommonUISDK.framework/CommonUISDK",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ZendeskCoreSDK/ZendeskCoreSDK.framework/ZendeskCoreSDK",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/MessagingAPI/MessagingAPI.framework/MessagingAPI",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/MessagingSDK/MessagingSDK.framework/MessagingSDK",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/SDKConfigurations/SDKConfigurations.framework/SDKConfigurations",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/SupportProvidersSDK/SupportProvidersSDK.framework/SupportProvidersSDK",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/SupportSDK/SupportSDK.framework/SupportSDK",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Instabug.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AnswerBotProvidersSDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AnswerBotSDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ChatProvidersSDK.framework",
@@ -601,12 +604,9 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZendeskCoreSDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MessagingAPI.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MessagingSDK.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDKConfigurations.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SupportProvidersSDK.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SupportSDK.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Instabug.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDKConfigurations.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -65,7 +65,7 @@ PODS:
   - jail-monkey (2.3.2):
     - React
   - libevent (2.1.12)
-  - Mixpanel (3.6.1)
+  - Mixpanel (3.6.5)
   - OpenSSL-Universal (1.1.180)
   - Permission-Calendars (2.2.2):
     - RNPermissions
@@ -436,37 +436,37 @@ PODS:
     - React
   - RNVectorIcons (7.0.0):
     - React
-  - RNZendeskChat (0.3.4):
+  - RNZendeskChat (0.3.9):
     - React
-    - ZendeskAnswerBotSDK
-    - ZendeskChatSDK
-    - ZendeskSupportSDK (~> 5.0.5)
+    - ZendeskAnswerBotSDK (~> 2.1.3)
+    - ZendeskChatSDK (~> 2.11.1)
+    - ZendeskMessagingAPISDK (~> 3.8.2)
+    - ZendeskSupportSDK (~> 5.3.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
-  - ZendeskAnswerBotProvidersSDK (2.0.5):
-    - ZendeskSupportProvidersSDK (~> 5.0.5)
-  - ZendeskAnswerBotSDK (2.0.5):
-    - ZendeskAnswerBotProvidersSDK (~> 2.0.5)
-    - ZendeskMessagingSDK (~> 3.6.0)
-  - ZendeskChatProvidersSDK (2.7.0)
-  - ZendeskChatSDK (2.7.0):
-    - ZendeskChatProvidersSDK (~> 2.7.0)
-    - ZendeskMessagingSDK (~> 3.6.0)
-  - ZendeskCommonUISDK (5.0.0):
-    - ZendeskSDKConfigurationsSDK (~> 1.1.5)
-  - ZendeskCoreSDK (2.4.1)
-  - ZendeskMessagingAPISDK (3.6.0):
-    - ZendeskSDKConfigurationsSDK (~> 1.1.5)
-  - ZendeskMessagingSDK (3.6.0):
-    - ZendeskCommonUISDK (~> 5.0.0)
-    - ZendeskMessagingAPISDK (~> 3.6.0)
+  - ZendeskAnswerBotProvidersSDK (2.1.3):
+    - ZendeskSupportProvidersSDK (~> 5.3.0)
+  - ZendeskAnswerBotSDK (2.1.3):
+    - ZendeskAnswerBotProvidersSDK (~> 2.1.3)
+    - ZendeskMessagingSDK (~> 3.8.2)
+  - ZendeskChatProvidersSDK (2.11.1)
+  - ZendeskChatSDK (2.11.1):
+    - ZendeskChatProvidersSDK (~> 2.11.1)
+    - ZendeskMessagingSDK (~> 3.8.2)
+  - ZendeskCommonUISDK (6.1.1)
+  - ZendeskCoreSDK (2.5.1)
+  - ZendeskMessagingAPISDK (3.8.2):
+    - ZendeskSDKConfigurationsSDK (~> 1.1.8)
+  - ZendeskMessagingSDK (3.8.2):
+    - ZendeskCommonUISDK (~> 6.1.1)
+    - ZendeskMessagingAPISDK (~> 3.8.2)
   - ZendeskSDKConfigurationsSDK (1.1.8)
-  - ZendeskSupportProvidersSDK (5.0.5):
-    - ZendeskCoreSDK (~> 2.4.0)
-  - ZendeskSupportSDK (5.0.5):
-    - ZendeskMessagingSDK (~> 3.6.0)
-    - ZendeskSupportProvidersSDK (~> 5.0.5)
+  - ZendeskSupportProvidersSDK (5.3.0):
+    - ZendeskCoreSDK (~> 2.5.1)
+  - ZendeskSupportSDK (5.3.0):
+    - ZendeskMessagingSDK (~> 3.8.2)
+    - ZendeskSupportProvidersSDK (~> 5.3.0)
 
 DEPENDENCIES:
   - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
@@ -771,7 +771,7 @@ SPEC CHECKSUMS:
   instabug-reactnative: aae9da235f22a48455fd837f5983c144d169330c
   jail-monkey: d7c5048b2336f22ee9c9e0efa145f1f917338ea9
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  Mixpanel: 61e6d8c0717c8e94ccc6d3a1ae8677b9a78f64c5
+  Mixpanel: de8296d8568806ab17bfced0f823c908b808e1e0
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   Permission-Calendars: 17bb6a871acc7580754be7b56cfb25537e1b57de
   Permission-Camera: 5d2aaf95592660b6dcb5e8d1d90ed5d0156cad02
@@ -840,20 +840,20 @@ SPEC CHECKSUMS:
   RNShare: a1d5064df7a0ebe778d001869b3f0a124bf0a491
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
   RNVectorIcons: da6fe858f5a65d7bbc3379540a889b0b12aa5976
-  RNZendeskChat: cfd82228c7601d9c100d0a4ed6266944d81e7600
+  RNZendeskChat: 274100b17db293af5c6e6a5f45eea3802e5c1256
   Yoga: 575c581c63e0d35c9a83f4b46d01d63abc1100ac
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
-  ZendeskAnswerBotProvidersSDK: 294a835f26545e5da4e0e9b168cceab8aca930c6
-  ZendeskAnswerBotSDK: 58889818d89e041478e2fa8266f159f4851b6ec3
-  ZendeskChatProvidersSDK: 478e7eb4c725c7b4c1c64fa1206ec369346267e4
-  ZendeskChatSDK: b972e1ef63d84fb5b908f2d9a682e98b48eafc86
-  ZendeskCommonUISDK: 0b5ae632c28545c6f7e0791902f5672494d5ccd0
-  ZendeskCoreSDK: 2dc9457ae01d024ca02f60f6134ad1ad90136c29
-  ZendeskMessagingAPISDK: 29ce93e76b4833a2257d837de17a0efaeef867e5
-  ZendeskMessagingSDK: bdb534cc75853fab1bc201ce97faadf9accdd1ab
+  ZendeskAnswerBotProvidersSDK: 8ef75d4484f09c324cd93ce2725364d73dbabcf5
+  ZendeskAnswerBotSDK: 5427374afc76811d17ef47db8c20967cee84ee2b
+  ZendeskChatProvidersSDK: 37901c1c7529722d71ffade971bb984edd74a5e1
+  ZendeskChatSDK: e312c1899c52eff0ef2b7219385c5aaac3d9e76e
+  ZendeskCommonUISDK: 5808802951ad2bb424f0bed4259dc3c0ce9b52ec
+  ZendeskCoreSDK: 19a18e5ef2edcb18f4dbc0ea0d12bd31f515712a
+  ZendeskMessagingAPISDK: 144e0fb0e633a3c4e73149b781ab65338938d5a8
+  ZendeskMessagingSDK: 500e83d9413481e95180c37ddca0d4ef9d515600
   ZendeskSDKConfigurationsSDK: 8371b468db0d09e9198f6c5a97818826943ee1ee
-  ZendeskSupportProvidersSDK: d21ce8eb3df1066338c7d3875bb818b32c3f124e
-  ZendeskSupportSDK: 7e29a825e862aba217b7b89f7d3397f7deef586a
+  ZendeskSupportProvidersSDK: 2bdf8544f7cd0fd4c002546f5704b813845beb2a
+  ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
 
 PODFILE CHECKSUM: eb8085af15261f979e57ec1a58985cd1ed011308
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -65,7 +65,7 @@ PODS:
   - jail-monkey (2.3.2):
     - React
   - libevent (2.1.12)
-  - Mixpanel (3.6.5)
+  - Mixpanel (3.6.1)
   - OpenSSL-Universal (1.1.180)
   - Permission-Calendars (2.2.2):
     - RNPermissions
@@ -771,7 +771,7 @@ SPEC CHECKSUMS:
   instabug-reactnative: aae9da235f22a48455fd837f5983c144d169330c
   jail-monkey: d7c5048b2336f22ee9c9e0efa145f1f917338ea9
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  Mixpanel: de8296d8568806ab17bfced0f823c908b808e1e0
+  Mixpanel: 61e6d8c0717c8e94ccc6d3a1ae8677b9a78f64c5
   OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   Permission-Calendars: 17bb6a871acc7580754be7b56cfb25537e1b57de
   Permission-Camera: 5d2aaf95592660b6dcb5e8d1d90ed5d0156cad02

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "hoist-non-react-statics": "^3.0.1",
     "instabug-reactnative": "^9.1.6",
     "io-ts": "1.8.5",
-    "io-react-native-zendesk": "https://github.com/pagopa/io-react-native-zendesk.git#0.3.8",
+    "io-react-native-zendesk": "https://github.com/pagopa/io-react-native-zendesk.git#0.3.9",
     "italia-ts-commons": "8.6.0",
     "jail-monkey": "^2.3.2",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "hoist-non-react-statics": "^3.0.1",
     "instabug-reactnative": "^9.1.6",
     "io-ts": "1.8.5",
-    "io-react-native-zendesk": "https://github.com/pagopa/io-react-native-zendesk.git#0.3.4",
+    "io-react-native-zendesk": "https://github.com/pagopa/io-react-native-zendesk.git#0.3.8",
     "italia-ts-commons": "8.6.0",
     "jail-monkey": "^2.3.2",
     "lodash": "^4.17.21",

--- a/ts/components/messages/paginated/MessageList/index.tsx
+++ b/ts/components/messages/paginated/MessageList/index.tsx
@@ -223,6 +223,16 @@ const MessageList = ({
     />
   );
 
+  const renderListFooter = () => {
+    if (isLoadingMore || isReloadingAll) {
+      return <Loader />;
+    }
+    if (messages.length > 0 && !nextCursor) {
+      return <EdgeBorderComponent />;
+    }
+    return null;
+  };
+
   return (
     <>
       {/* in iOS refresh indicator is shown only when user does pull to refresh on list
@@ -263,15 +273,7 @@ const MessageList = ({
         onLayout={handleOnLayoutChange}
         onEndReached={onEndReached}
         onEndReachedThreshold={0.1}
-        ListFooterComponent={() => {
-          if (isLoadingMore || isReloadingAll) {
-            return <Loader />;
-          }
-          if (messages.length > 0 && !nextCursor) {
-            <EdgeBorderComponent />;
-          }
-          return null;
-        }}
+        ListFooterComponent={renderListFooter}
       />
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -8230,9 +8230,9 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
-"io-react-native-zendesk@https://github.com/pagopa/io-react-native-zendesk.git#0.3.8":
-  version "0.3.8"
-  resolved "https://github.com/pagopa/io-react-native-zendesk.git#05b4ce9c951599e21ea7d4926f327296ce973a49"
+"io-react-native-zendesk@https://github.com/pagopa/io-react-native-zendesk.git#0.3.9":
+  version "0.3.9"
+  resolved "https://github.com/pagopa/io-react-native-zendesk.git#2ec77029950534f85f9389284ba4f145c42009b7"
 
 io-ts@1.8.5:
   version "1.8.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8230,9 +8230,9 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
-"io-react-native-zendesk@https://github.com/pagopa/io-react-native-zendesk.git#0.3.4":
-  version "0.3.4"
-  resolved "https://github.com/pagopa/io-react-native-zendesk.git#e2ba121ba5fb6c07c4bfe9748d9685301dd6ca31"
+"io-react-native-zendesk@https://github.com/pagopa/io-react-native-zendesk.git#0.3.8":
+  version "0.3.8"
+  resolved "https://github.com/pagopa/io-react-native-zendesk.git#05b4ce9c951599e21ea7d4926f327296ce973a49"
 
 io-ts@1.8.5:
   version "1.8.5"


### PR DESCRIPTION
## Short description
This PR update the `io-react-native-zendesk` to the **0.3.9**.
[This version](https://github.com/pagopa/io-react-native-zendesk/pull/6) expose 2 new methods: 
- `openTicket`
- `showTickets`

## List of changes proposed in this pull request
- Updated io-react-native-zendesk to 0.3.9
- Fixed kotlin-reflect version at 1.3.41 as we have 2 package using 2 different version of this package and this leads to compilation error

## How to test
Try to run both on Android and IOS.
I suggest to remove the `Podfile.lock` before start.
