### PR TITLE
chore(Messaggi a valore legale): [IAMVL-8] Add types, actions, store, reducers & saga entrypoint

### DIFF
--- a/scripts/check_urls/check_urls.py
+++ b/scripts/check_urls/check_urls.py
@@ -222,7 +222,7 @@ if not run_test and __name__ == '__main__':
 		"https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf",
 		"https://www.trusttechnologies.it/contatti/#form"}
 	locales = (abspath(join(dirname(__file__), "../..", "locales")), {})
-	ts_dir = (abspath(join(dirname(__file__), "../..", "ts")), {"testFaker.ts", "PayWebViewModal.tsx", "paymentPayloads.ts"})
+	ts_dir = (abspath(join(dirname(__file__), "../..", "ts")), {"testFaker.ts", "PayWebViewModal.tsx", "paymentPayloads.ts", "mvlMock.ts"})
 	for directory, black_list in [locales, ts_dir]:
 		files_found = scan_directory(directory, black_list, urls_black_list)
 		print("found %d files in %s" % (len(files_found.keys()), directory))

--- a/ts/features/common/store/reducers/index.ts
+++ b/ts/features/common/store/reducers/index.ts
@@ -4,11 +4,14 @@ import {
   euCovidCertReducer,
   EuCovidCertState
 } from "../../../euCovidCert/store/reducers";
+import { mvlReducer, MVLState } from "../../../mvl/store/reducers";
 
 export type FeaturesState = {
   euCovidCert: EuCovidCertState;
+  mvl: MVLState;
 };
 
 export const featuresReducer = combineReducers<FeaturesState, Action>({
-  euCovidCert: euCovidCertReducer
+  euCovidCert: euCovidCertReducer,
+  mvl: mvlReducer
 });

--- a/ts/features/common/store/reducers/index.ts
+++ b/ts/features/common/store/reducers/index.ts
@@ -4,11 +4,11 @@ import {
   euCovidCertReducer,
   EuCovidCertState
 } from "../../../euCovidCert/store/reducers";
-import { mvlReducer, MVLState } from "../../../mvl/store/reducers";
+import { mvlReducer, MvlState } from "../../../mvl/store/reducers";
 
 export type FeaturesState = {
   euCovidCert: EuCovidCertState;
-  mvl: MVLState;
+  mvl: MvlState;
 };
 
 export const featuresReducer = combineReducers<FeaturesState, Action>({

--- a/ts/features/euCovidCert/saga/index.ts
+++ b/ts/features/euCovidCert/saga/index.ts
@@ -21,7 +21,7 @@ export function* watchEUCovidCertificateSaga(
   yield takeLatest(
     euCovidCertificateGet.request,
     function* (action: ActionType<typeof euCovidCertificateGet.request>) {
-      // wait backoff time it there were previous errors
+      // wait backoff time if there were previous errors
       yield call(waitBackoffError, euCovidCertificateGet.failure);
       yield call(
         handleGetEuCovidCertificate,

--- a/ts/features/mvl/saga/index.ts
+++ b/ts/features/mvl/saga/index.ts
@@ -1,5 +1,5 @@
 import { SagaIterator } from "redux-saga";
-import { call, delay, takeLatest } from "redux-saga/effects";
+import { call, takeLatest } from "redux-saga/effects";
 import { ActionType } from "typesafe-actions";
 import { SessionToken } from "../../../types/SessionToken";
 import { waitBackoffError } from "../../../utils/backoffError";

--- a/ts/features/mvl/saga/index.ts
+++ b/ts/features/mvl/saga/index.ts
@@ -19,7 +19,7 @@ export function* watchMvlSaga(_: SessionToken): SagaIterator {
   yield takeLatest(
     mvlDetailsLoad.request,
     function* (action: ActionType<typeof mvlDetailsLoad.request>) {
-      // wait backoff time it there were previous errors
+      // wait backoff time if there were previous errors
       yield call(waitBackoffError, mvlDetailsLoad.failure);
       yield call(handleGetMvl, null, action);
     }

--- a/ts/features/mvl/saga/index.ts
+++ b/ts/features/mvl/saga/index.ts
@@ -1,0 +1,27 @@
+import { SagaIterator } from "redux-saga";
+import { call, delay, takeLatest } from "redux-saga/effects";
+import { ActionType } from "typesafe-actions";
+import { SessionToken } from "../../../types/SessionToken";
+import { waitBackoffError } from "../../../utils/backoffError";
+import { mvlDetailsLoad } from "../store/actions";
+import { handleGetMvl } from "./networking/handleGetMvlDetails";
+
+/**
+ * Handle the MVL Requests
+ * TODO: stub entrypoint
+ * @param _
+ */
+export function* watchMvlSaga(_: SessionToken): SagaIterator {
+  // TODO: backendClient
+  // const mvlClient = MvlClient(apiUrlPrefix, bearerToken);
+
+  // handle the request for a new mvlDetailsLoad
+  yield takeLatest(
+    mvlDetailsLoad.request,
+    function* (action: ActionType<typeof mvlDetailsLoad.request>) {
+      // wait backoff time it there were previous errors
+      yield call(waitBackoffError, mvlDetailsLoad.failure);
+      yield call(handleGetMvl, null, action);
+    }
+  );
+}

--- a/ts/features/mvl/saga/networking/handleGetMvlDetails.ts
+++ b/ts/features/mvl/saga/networking/handleGetMvlDetails.ts
@@ -1,0 +1,20 @@
+import { delay, put } from "redux-saga/effects";
+import { ActionType } from "typesafe-actions";
+import { mvlDetailsLoad } from "../../store/actions";
+import { mvlMockData } from "../../types/__mock__/mvlMock";
+
+/**
+ * Handle the remote call to retrieve the MVL details
+ * TODO: Placeholder stub, implement me!
+ * @param _
+ * @param __
+ */
+export function* handleGetMvl(
+  // TODO: this will be the backend remote call
+  _: unknown,
+  __: ActionType<typeof mvlDetailsLoad.request>
+) {
+  // TODO: remote call -> convert from remote data format to MvlData -> dispatch
+  yield delay(125);
+  yield put(mvlDetailsLoad.success(mvlMockData));
+}

--- a/ts/features/mvl/saga/networking/handleGetMvlDetails.ts
+++ b/ts/features/mvl/saga/networking/handleGetMvlDetails.ts
@@ -7,14 +7,14 @@ import { mvlMockData } from "../../types/__mock__/mvlMock";
  * Handle the remote call to retrieve the MVL details
  * TODO: Placeholder stub, implement me!
  * @param _
- * @param __
+ * @param action
  */
 export function* handleGetMvl(
   // TODO: this will be the backend remote call
   _: unknown,
-  __: ActionType<typeof mvlDetailsLoad.request>
+  action: ActionType<typeof mvlDetailsLoad.request>
 ) {
   // TODO: remote call -> convert from remote data format to MvlData -> dispatch
   yield delay(125);
-  yield put(mvlDetailsLoad.success(mvlMockData));
+  yield put(mvlDetailsLoad.success({ ...mvlMockData, id: action.payload }));
 }

--- a/ts/features/mvl/store/actions/index.ts
+++ b/ts/features/mvl/store/actions/index.ts
@@ -1,0 +1,14 @@
+import { ActionType, createAsyncAction } from "typesafe-actions";
+import { NetworkError } from "../../../../utils/errors";
+import { MVLData, MVLId, WithMVLId } from "../../types/MVLData";
+
+/**
+ * The user requests the MVL details, starting from the MVLId
+ */
+export const mvlLoadDetails = createAsyncAction(
+  "MVL_DETAILS_REQUEST",
+  "MVL_DETAILS_SUCCESS",
+  "MVL_DETAILS_FAILURE"
+)<MVLId, MVLData, WithMVLId<NetworkError>>();
+
+export type MVLActions = ActionType<typeof mvlLoadDetails>;

--- a/ts/features/mvl/store/actions/index.ts
+++ b/ts/features/mvl/store/actions/index.ts
@@ -1,6 +1,6 @@
 import { ActionType, createAsyncAction } from "typesafe-actions";
 import { NetworkError } from "../../../../utils/errors";
-import { MvlData, MvlId, WithMVLId } from "../../types/MvlData";
+import { MvlData, MvlId, WithMVLId } from "../../types/mvlData";
 
 /**
  * The user requests the MVL details, starting from the MVLId

--- a/ts/features/mvl/store/actions/index.ts
+++ b/ts/features/mvl/store/actions/index.ts
@@ -1,6 +1,6 @@
 import { ActionType, createAsyncAction } from "typesafe-actions";
 import { NetworkError } from "../../../../utils/errors";
-import { MVLData, MVLId, WithMVLId } from "../../types/MVLData";
+import { MvlData, MvlId, WithMVLId } from "../../types/MvlData";
 
 /**
  * The user requests the MVL details, starting from the MVLId
@@ -9,6 +9,6 @@ export const mvlLoadDetails = createAsyncAction(
   "MVL_DETAILS_REQUEST",
   "MVL_DETAILS_SUCCESS",
   "MVL_DETAILS_FAILURE"
-)<MVLId, MVLData, WithMVLId<NetworkError>>();
+)<MvlId, MvlData, WithMVLId<NetworkError>>();
 
-export type MVLActions = ActionType<typeof mvlLoadDetails>;
+export type MvlActions = ActionType<typeof mvlLoadDetails>;

--- a/ts/features/mvl/store/actions/index.ts
+++ b/ts/features/mvl/store/actions/index.ts
@@ -5,10 +5,10 @@ import { MvlData, MvlId, WithMVLId } from "../../types/MvlData";
 /**
  * The user requests the MVL details, starting from the MVLId
  */
-export const mvlLoadDetails = createAsyncAction(
+export const mvlDetailsLoad = createAsyncAction(
   "MVL_DETAILS_REQUEST",
   "MVL_DETAILS_SUCCESS",
   "MVL_DETAILS_FAILURE"
 )<MvlId, MvlData, WithMVLId<NetworkError>>();
 
-export type MvlActions = ActionType<typeof mvlLoadDetails>;
+export type MvlActions = ActionType<typeof mvlDetailsLoad>;

--- a/ts/features/mvl/store/reducers/__test__/byId.test.ts
+++ b/ts/features/mvl/store/reducers/__test__/byId.test.ts
@@ -19,7 +19,7 @@ const mockFailure: WithMVLId<NetworkError> = {
 
 const errorFromFailure = new Error(getNetworkErrorMessage(mockFailure));
 
-describe("byAuthCode reducer & selector behaviour", () => {
+describe("mvl.byId reducer & selector behaviour", () => {
   jest.useFakeTimers();
 
   describe("When no mvlDetailsLoad have not been dispatch", () => {

--- a/ts/features/mvl/store/reducers/__test__/byId.test.ts
+++ b/ts/features/mvl/store/reducers/__test__/byId.test.ts
@@ -1,0 +1,109 @@
+import * as pot from "italia-ts-commons/lib/pot";
+import { createStore } from "redux";
+import { applicationChangeState } from "../../../../../store/actions/application";
+import { appReducer } from "../../../../../store/reducers";
+import {
+  getGenericError,
+  getNetworkErrorMessage,
+  NetworkError
+} from "../../../../../utils/errors";
+import { mvlMockData, mvlMockId } from "../../../types/__mock__/mvlMock";
+import { WithMVLId } from "../../../types/mvlData";
+import { mvlDetailsLoad } from "../../actions";
+import { mvlFromIdSelector } from "../byId";
+
+const mockFailure: WithMVLId<NetworkError> = {
+  id: mvlMockId,
+  ...getGenericError(new Error("A generic error"))
+};
+
+const errorFromFailure = new Error(getNetworkErrorMessage(mockFailure));
+
+describe("byAuthCode reducer & selector behaviour", () => {
+  jest.useFakeTimers();
+
+  describe("When no mvlDetailsLoad have not been dispatch", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    it("should have mvl initial state equals to {}", () => {
+      expect(globalState.features.mvl.byId).toStrictEqual({});
+    });
+    it("should return pot.none for any call to mvlFromIdSelector", () => {
+      expect(mvlFromIdSelector(globalState, mvlMockId)).toStrictEqual(pot.none);
+    });
+  });
+
+  describe("When mvlDetailsLoad.request has been dispatch", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+    store.dispatch(mvlDetailsLoad.request(mvlMockId));
+    it("should return pot.noneLoading when call mvlFromIdSelector with the same id", () => {
+      const byId = store.getState().features.mvl.byId;
+
+      expect(byId[mvlMockId]).toStrictEqual(pot.noneLoading);
+      expect(mvlFromIdSelector(store.getState(), mvlMockId)).toStrictEqual(
+        pot.noneLoading
+      );
+    });
+  });
+
+  describe("When mvlDetailsLoad.success has been dispatched after a mvlDetailsLoad.request", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+    store.dispatch(mvlDetailsLoad.request(mvlMockId));
+    store.dispatch(mvlDetailsLoad.success(mvlMockData));
+    it("should return pot.some when call mvlFromIdSelector with the same id", () => {
+      const byId = store.getState().features.mvl.byId;
+
+      expect(byId[mvlMockId]).toStrictEqual(pot.some(mvlMockData));
+      expect(mvlFromIdSelector(store.getState(), mvlMockId)).toStrictEqual(
+        pot.some(mvlMockData)
+      );
+    });
+  });
+
+  describe("When mvlDetailsLoad.failure has been dispatched after a mvlDetailsLoad.request", () => {
+    it("should return pot.some when call mvlFromIdSelector with the same id", () => {
+      const globalState = appReducer(
+        undefined,
+        applicationChangeState("active")
+      );
+      const store = createStore(appReducer, globalState as any);
+      store.dispatch(mvlDetailsLoad.request(mvlMockId));
+      store.dispatch(mvlDetailsLoad.failure(mockFailure));
+      const byId = store.getState().features.mvl.byId;
+
+      expect(byId[mvlMockId]).toStrictEqual(pot.noneError(errorFromFailure));
+      expect(mvlFromIdSelector(store.getState(), mvlMockId)).toStrictEqual(
+        pot.noneError(errorFromFailure)
+      );
+    });
+
+    describe("And follows a mvlDetailsLoad.request and mvlDetailsLoad.success", () => {
+      const globalState = appReducer(
+        undefined,
+        applicationChangeState("active")
+      );
+      const store = createStore(appReducer, globalState as any);
+      store.dispatch(mvlDetailsLoad.request(mvlMockId));
+      store.dispatch(mvlDetailsLoad.failure(mockFailure));
+      it("should return pot.noneLoading first and pot.some", () => {
+        store.dispatch(mvlDetailsLoad.request(mvlMockId));
+        expect(store.getState().features.mvl.byId[mvlMockId]).toStrictEqual(
+          pot.noneLoading
+        );
+        expect(mvlFromIdSelector(store.getState(), mvlMockId)).toStrictEqual(
+          pot.noneLoading
+        );
+
+        store.dispatch(mvlDetailsLoad.success(mvlMockData));
+
+        expect(store.getState().features.mvl.byId[mvlMockId]).toStrictEqual(
+          pot.some(mvlMockData)
+        );
+        expect(mvlFromIdSelector(store.getState(), mvlMockId)).toStrictEqual(
+          pot.some(mvlMockData)
+        );
+      });
+    });
+  });
+});

--- a/ts/features/mvl/store/reducers/byId.ts
+++ b/ts/features/mvl/store/reducers/byId.ts
@@ -10,7 +10,7 @@ import {
 } from "../../../../store/reducers/IndexedByIdPot";
 import { GlobalState } from "../../../../store/reducers/types";
 import { getNetworkErrorMessage } from "../../../../utils/errors";
-import { MvlData, MvlId } from "../../types/MvlData";
+import { MvlData, MvlId } from "../../types/mvlData";
 import { mvlDetailsLoad } from "../actions";
 
 export type MvlByIdState = IndexedById<pot.Pot<MvlData, Error>>;

--- a/ts/features/mvl/store/reducers/byId.ts
+++ b/ts/features/mvl/store/reducers/byId.ts
@@ -11,7 +11,7 @@ import {
 import { GlobalState } from "../../../../store/reducers/types";
 import { getNetworkErrorMessage } from "../../../../utils/errors";
 import { MvlData, MvlId } from "../../types/MvlData";
-import { mvlLoadDetails } from "../actions";
+import { mvlDetailsLoad } from "../actions";
 
 export type MvlByIdState = IndexedById<pot.Pot<MvlData, Error>>;
 
@@ -25,11 +25,11 @@ export const mvlByIdReducer = (
   action: Action
 ): MvlByIdState => {
   switch (action.type) {
-    case getType(mvlLoadDetails.request):
+    case getType(mvlDetailsLoad.request):
       return toLoading(action.payload, state);
-    case getType(mvlLoadDetails.success):
+    case getType(mvlDetailsLoad.success):
       return toSome(action.payload.id, state, action.payload);
-    case getType(mvlLoadDetails.failure):
+    case getType(mvlDetailsLoad.failure):
       return toError(
         action.payload.id,
         state,

--- a/ts/features/mvl/store/reducers/byId.ts
+++ b/ts/features/mvl/store/reducers/byId.ts
@@ -10,10 +10,10 @@ import {
 } from "../../../../store/reducers/IndexedByIdPot";
 import { GlobalState } from "../../../../store/reducers/types";
 import { getNetworkErrorMessage } from "../../../../utils/errors";
-import { MVLData, MVLId } from "../../types/MVLData";
+import { MvlData, MvlId } from "../../types/MvlData";
 import { mvlLoadDetails } from "../actions";
 
-export type MVLByIdState = IndexedById<pot.Pot<MVLData, Error>>;
+export type MvlByIdState = IndexedById<pot.Pot<MvlData, Error>>;
 
 /**
  * Store the MVL data based on the MVLId used to issue the request
@@ -21,9 +21,9 @@ export type MVLByIdState = IndexedById<pot.Pot<MVLData, Error>>;
  * @param action
  */
 export const mvlByIdReducer = (
-  state: MVLByIdState = {},
+  state: MvlByIdState = {},
   action: Action
-): MVLByIdState => {
+): MvlByIdState => {
   switch (action.type) {
     case getType(mvlLoadDetails.request):
       return toLoading(action.payload, state);
@@ -46,7 +46,7 @@ export const mvlByIdReducer = (
 export const mvlFromIdSelector = createSelector(
   [
     (state: GlobalState) => state.features.mvl.byId,
-    (_: GlobalState, id: MVLId) => id
+    (_: GlobalState, id: MvlId) => id
   ],
-  (byId, id): pot.Pot<MVLData, Error> => byId[id] ?? pot.none
+  (byId, id): pot.Pot<MvlData, Error> => byId[id] ?? pot.none
 );

--- a/ts/features/mvl/store/reducers/byId.ts
+++ b/ts/features/mvl/store/reducers/byId.ts
@@ -1,0 +1,52 @@
+import * as pot from "italia-ts-commons/lib/pot";
+import { createSelector } from "reselect";
+import { getType } from "typesafe-actions";
+import { Action } from "../../../../store/actions/types";
+import { IndexedById } from "../../../../store/helpers/indexer";
+import {
+  toError,
+  toLoading,
+  toSome
+} from "../../../../store/reducers/IndexedByIdPot";
+import { GlobalState } from "../../../../store/reducers/types";
+import { getNetworkErrorMessage } from "../../../../utils/errors";
+import { MVLData, MVLId } from "../../types/MVLData";
+import { mvlLoadDetails } from "../actions";
+
+export type MVLByIdState = IndexedById<pot.Pot<MVLData, Error>>;
+
+/**
+ * Store the MVL data based on the MVLId used to issue the request
+ * @param state
+ * @param action
+ */
+export const mvlByIdReducer = (
+  state: MVLByIdState = {},
+  action: Action
+): MVLByIdState => {
+  switch (action.type) {
+    case getType(mvlLoadDetails.request):
+      return toLoading(action.payload, state);
+    case getType(mvlLoadDetails.success):
+      return toSome(action.payload.id, state, action.payload);
+    case getType(mvlLoadDetails.failure):
+      return toError(
+        action.payload.id,
+        state,
+        new Error(getNetworkErrorMessage(action.payload))
+      );
+  }
+
+  return state;
+};
+
+/**
+ * From MVLId to MvlData
+ */
+export const mvlFromIdSelector = createSelector(
+  [
+    (state: GlobalState) => state.features.mvl.byId,
+    (_: GlobalState, id: MVLId) => id
+  ],
+  (byId, id): pot.Pot<MVLData, Error> => byId[id] ?? pot.none
+);

--- a/ts/features/mvl/store/reducers/index.ts
+++ b/ts/features/mvl/store/reducers/index.ts
@@ -1,12 +1,12 @@
 import { combineReducers } from "redux";
 import { Action } from "../../../../store/actions/types";
-import { mvlByIdReducer, MVLByIdState } from "./byId";
+import { mvlByIdReducer, MvlByIdState } from "./byId";
 
-export type MVLState = {
-  byId: MVLByIdState;
+export type MvlState = {
+  byId: MvlByIdState;
 };
 
-export const mvlReducer = combineReducers<MVLState, Action>({
+export const mvlReducer = combineReducers<MvlState, Action>({
   // save, using the MVLId as key, the pot.Pot<MVLData, Error> response
   byId: mvlByIdReducer
 });

--- a/ts/features/mvl/store/reducers/index.ts
+++ b/ts/features/mvl/store/reducers/index.ts
@@ -1,0 +1,12 @@
+import { combineReducers } from "redux";
+import { Action } from "../../../../store/actions/types";
+import { mvlByIdReducer, MVLByIdState } from "./byId";
+
+export type MVLState = {
+  byId: MVLByIdState;
+};
+
+export const mvlReducer = combineReducers<MVLState, Action>({
+  // save, using the MVLId as key, the pot.Pot<MVLData, Error> response
+  byId: mvlByIdReducer
+});

--- a/ts/features/mvl/types/MVLData.ts
+++ b/ts/features/mvl/types/MVLData.ts
@@ -1,0 +1,59 @@
+import { IUnitTag } from "@pagopa/ts-commons/lib/units";
+import { ValidUrl } from "@pagopa/ts-commons/lib/url";
+import { ContentType } from "../../../types/contentType";
+import { Byte } from "../../../types/digitalInformationUnit";
+
+/**
+ * The unique ID of a MVLId, used to avoid to pass wrong id as parameters
+ */
+export type MVLId = string & IUnitTag<"MVLId">;
+
+/**
+ * The content of the MVL with two possible representation
+ */
+type MVLBody = {
+  html: string;
+  plain?: string;
+};
+
+/**
+ * Represent an attachment with the metadata and resourceUrl to retrieve the attachment
+ */
+type MVLAttachment = {
+  // a display name for the file
+  name: string;
+  // atm we have to distinguish only the pdf files from the others for a custom (future) view
+  contentType: Extract<ContentType, "application/pdf"> | "undefined";
+  // size (in Byte) of the attachment, for display purpose
+  size: Byte;
+  // The url that can be used to retrieve the resource
+  resourceUrl: ValidUrl;
+};
+
+/**
+ * Additional metadata
+ * TODO: Just an initial stub, should be completed and refined
+ */
+type MVLMetadata = {
+  sender: string;
+  receiver: string;
+  cc: ReadonlyArray<string>;
+  // a placeholder for certificates data
+  certificates: ReadonlyArray<unknown>;
+  // a placeholder for signature details
+  signature: unknown;
+};
+
+/**
+ * Represent a MVL (Messaggio a valore legale - Legal message)
+ */
+export type MVLData = {
+  // The unique Id of the message
+  id: MVLId;
+  // The body (content) that could be html (mandatory) or plain (optional)
+  body: MVLBody;
+  // The MVL could have some attachments with metadata and the url to download the resource
+  attachments: ReadonlyArray<MVLAttachment>;
+  // Some additional metadata that should be represented
+  metadata: MVLMetadata;
+};

--- a/ts/features/mvl/types/MVLData.ts
+++ b/ts/features/mvl/types/MVLData.ts
@@ -8,6 +8,10 @@ import { Byte } from "../../../types/digitalInformationUnit";
  */
 export type MVLId = string & IUnitTag<"MVLId">;
 
+export type WithMVLId<T> = T & {
+  id: MVLId;
+};
+
 /**
  * The content of the MVL with two possible representation
  */
@@ -47,13 +51,11 @@ type MVLMetadata = {
 /**
  * Represent a MVL (Messaggio a valore legale - Legal message)
  */
-export type MVLData = {
-  // The unique Id of the message
-  id: MVLId;
+export type MVLData = WithMVLId<{
   // The body (content) that could be html (mandatory) or plain (optional)
   body: MVLBody;
   // The MVL could have some attachments with metadata and the url to download the resource
   attachments: ReadonlyArray<MVLAttachment>;
   // Some additional metadata that should be represented
   metadata: MVLMetadata;
-};
+}>;

--- a/ts/features/mvl/types/MvlData.ts
+++ b/ts/features/mvl/types/MvlData.ts
@@ -6,16 +6,16 @@ import { Byte } from "../../../types/digitalInformationUnit";
 /**
  * The unique ID of a MVLId, used to avoid to pass wrong id as parameters
  */
-export type MVLId = string & IUnitTag<"MVLId">;
+export type MvlId = string & IUnitTag<"MvlId">;
 
 export type WithMVLId<T> = T & {
-  id: MVLId;
+  id: MvlId;
 };
 
 /**
  * The content of the MVL with two possible representation
  */
-type MVLBody = {
+type MvlBody = {
   html: string;
   plain?: string;
 };
@@ -23,7 +23,7 @@ type MVLBody = {
 /**
  * Represent an attachment with the metadata and resourceUrl to retrieve the attachment
  */
-type MVLAttachment = {
+type MvlAttachment = {
   // a display name for the file
   name: string;
   // atm we have to distinguish only the pdf files from the others for a custom (future) view
@@ -38,7 +38,7 @@ type MVLAttachment = {
  * Additional metadata
  * TODO: Just an initial stub, should be completed and refined
  */
-type MVLMetadata = {
+type MvlMetadata = {
   sender: string;
   receiver: string;
   cc: ReadonlyArray<string>;
@@ -51,11 +51,11 @@ type MVLMetadata = {
 /**
  * Represent a MVL (Messaggio a valore legale - Legal message)
  */
-export type MVLData = WithMVLId<{
+export type MvlData = WithMVLId<{
   // The body (content) that could be html (mandatory) or plain (optional)
-  body: MVLBody;
+  body: MvlBody;
   // The MVL could have some attachments with metadata and the url to download the resource
-  attachments: ReadonlyArray<MVLAttachment>;
+  attachments: ReadonlyArray<MvlAttachment>;
   // Some additional metadata that should be represented
-  metadata: MVLMetadata;
+  metadata: MvlMetadata;
 }>;

--- a/ts/features/mvl/types/__mock__/mvlMock.ts
+++ b/ts/features/mvl/types/__mock__/mvlMock.ts
@@ -1,3 +1,4 @@
+import { EmailAddress } from "../../../../../definitions/backend/EmailAddress";
 import { Byte } from "../../../../types/digitalInformationUnit";
 import {
   MvlAttachment,
@@ -29,9 +30,9 @@ export const mvlMockOtherAttachment: MvlAttachment = {
 };
 
 export const mvlMockMetadata: MvlMetadata = {
-  sender: "sender@mailpec.com",
-  receiver: "receiver@emailpec.com",
-  cc: ["cc1@emailpec.com", "cc2@emailpec.com"],
+  sender: "sender@mailpec.com" as EmailAddress,
+  receiver: "receiver@emailpec.com" as EmailAddress,
+  cc: ["cc1@emailpec.com" as EmailAddress, "cc2@emailpec.com" as EmailAddress],
   certificates: [],
   signature: null
 };

--- a/ts/features/mvl/types/__mock__/mvlMock.ts
+++ b/ts/features/mvl/types/__mock__/mvlMock.ts
@@ -23,7 +23,7 @@ export const mvlMockPdfAttachment: MvlAttachment = {
 
 export const mvlMockOtherAttachment: MvlAttachment = {
   name: "image.png",
-  contentType: "undefined",
+  contentType: "other",
   size: 125952 as Byte,
   resourceUrl: { href: "htts://www.randomImage.com/image.png" }
 };

--- a/ts/features/mvl/types/__mock__/mvlMock.ts
+++ b/ts/features/mvl/types/__mock__/mvlMock.ts
@@ -5,7 +5,7 @@ import {
   MvlData,
   MvlId,
   MvlMetadata
-} from "../MvlData";
+} from "../mvlData";
 
 export const mvlMockId = "mockId" as MvlId;
 

--- a/ts/features/mvl/types/__mock__/mvlMock.ts
+++ b/ts/features/mvl/types/__mock__/mvlMock.ts
@@ -1,0 +1,44 @@
+import { Byte } from "../../../../types/digitalInformationUnit";
+import {
+  MvlAttachment,
+  MvlBody,
+  MvlData,
+  MvlId,
+  MvlMetadata
+} from "../MvlData";
+
+export const mvlMockId = "mockId" as MvlId;
+
+export const mvlMockBody: MvlBody = {
+  html: "This is an html <b>text</b>",
+  plain: "This is a plain text"
+};
+
+export const mvlMockPdfAttachment: MvlAttachment = {
+  name: "invoice.pdf",
+  contentType: "application/pdf",
+  size: 125952 as Byte,
+  resourceUrl: { href: "htts://www.invoicepdf.com/invoce.pdf" }
+};
+
+export const mvlMockOtherAttachment: MvlAttachment = {
+  name: "image.png",
+  contentType: "undefined",
+  size: 125952 as Byte,
+  resourceUrl: { href: "htts://www.randomImage.com/image.png" }
+};
+
+export const mvlMockMetadata: MvlMetadata = {
+  sender: "sender@mailpec.com",
+  receiver: "receiver@emailpec.com",
+  cc: ["cc1@emailpec.com", "cc2@emailpec.com"],
+  certificates: [],
+  signature: null
+};
+
+export const mvlMockData: MvlData = {
+  id: mvlMockId,
+  body: mvlMockBody,
+  attachments: [mvlMockPdfAttachment, mvlMockPdfAttachment],
+  metadata: mvlMockMetadata
+};

--- a/ts/features/mvl/types/mvlData.ts
+++ b/ts/features/mvl/types/mvlData.ts
@@ -1,5 +1,6 @@
 import { IUnitTag } from "@pagopa/ts-commons/lib/units";
 import { ValidUrl } from "@pagopa/ts-commons/lib/url";
+import { EmailAddress } from "../../../../definitions/backend/EmailAddress";
 import { ContentType } from "../../../types/contentType";
 import { Byte } from "../../../types/digitalInformationUnit";
 
@@ -39,9 +40,9 @@ export type MvlAttachment = {
  * TODO: Just an initial stub, should be completed and refined
  */
 export type MvlMetadata = {
-  sender: string;
-  receiver: string;
-  cc: ReadonlyArray<string>;
+  sender: EmailAddress;
+  receiver: EmailAddress;
+  cc: ReadonlyArray<EmailAddress>;
   // a placeholder for certificates data
   certificates: ReadonlyArray<unknown>;
   // a placeholder for signature details

--- a/ts/features/mvl/types/mvlData.ts
+++ b/ts/features/mvl/types/mvlData.ts
@@ -27,7 +27,7 @@ export type MvlAttachment = {
   // a display name for the file
   name: string;
   // atm we have to distinguish only the pdf files from the others for a custom (future) view
-  contentType: Extract<ContentType, "application/pdf"> | "undefined";
+  contentType: Extract<ContentType, "application/pdf"> | "other";
   // size (in Byte) of the attachment, for display purpose
   size: Byte;
   // The url that can be used to retrieve the resource

--- a/ts/features/mvl/types/mvlData.ts
+++ b/ts/features/mvl/types/mvlData.ts
@@ -15,7 +15,7 @@ export type WithMVLId<T> = T & {
 /**
  * The content of the MVL with two possible representation
  */
-type MvlBody = {
+export type MvlBody = {
   html: string;
   plain?: string;
 };
@@ -23,7 +23,7 @@ type MvlBody = {
 /**
  * Represent an attachment with the metadata and resourceUrl to retrieve the attachment
  */
-type MvlAttachment = {
+export type MvlAttachment = {
   // a display name for the file
   name: string;
   // atm we have to distinguish only the pdf files from the others for a custom (future) view
@@ -38,7 +38,7 @@ type MvlAttachment = {
  * Additional metadata
  * TODO: Just an initial stub, should be completed and refined
  */
-type MvlMetadata = {
+export type MvlMetadata = {
   sender: string;
   receiver: string;
   cc: ReadonlyArray<string>;

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -29,6 +29,7 @@ import {
   bpdEnabled,
   cgnEnabled,
   euCovidCertificateEnabled,
+  mvlEnabled,
   pagoPaApiUrlPrefix,
   pagoPaApiUrlPrefixTest,
   svEnabled,
@@ -39,6 +40,7 @@ import { watchBonusBpdSaga } from "../features/bonus/bpd/saga";
 import { watchBonusCgnSaga } from "../features/bonus/cgn/saga";
 import { watchBonusSvSaga } from "../features/bonus/siciliaVola/saga";
 import { watchEUCovidCertificateSaga } from "../features/euCovidCert/saga";
+import { watchMvlSaga } from "../features/mvl/saga";
 import I18n from "../i18n";
 import { startApplicationInitialization } from "../store/actions/application";
 import { sessionExpired } from "../store/actions/authentication";
@@ -361,6 +363,11 @@ export function* initializeApplicationSaga(): Generator<Effect, void, any> {
   if (euCovidCertificateEnabled) {
     // Start watching for EU Covid Certificate actions
     yield fork(watchEUCovidCertificateSaga, sessionToken);
+  }
+
+  if (mvlEnabled) {
+    // Start watching for EU Covid Certificate actions
+    yield fork(watchMvlSaga, sessionToken);
   }
 
   // Load the user metadata

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -366,7 +366,7 @@ export function* initializeApplicationSaga(): Generator<Effect, void, any> {
   }
 
   if (mvlEnabled) {
-    // Start watching for EU Covid Certificate actions
+    // Start watching for MVL actions
     yield fork(watchMvlSaga, sessionToken);
   }
 

--- a/ts/store/actions/types.ts
+++ b/ts/store/actions/types.ts
@@ -13,7 +13,7 @@ import { BpdActions } from "../../features/bonus/bpd/store/actions";
 import { CgnActions } from "../../features/bonus/cgn/store/actions";
 import { SvActions } from "../../features/bonus/siciliaVola/store/actions";
 import { EuCovidCertActions } from "../../features/euCovidCert/store/actions";
-import { MVLActions } from "../../features/mvl/store/actions";
+import { MvlActions } from "../../features/mvl/store/actions";
 import { AbiActions } from "../../features/wallet/onboarding/bancomat/store/actions";
 import { BPayActions } from "../../features/wallet/onboarding/bancomatPay/store/actions";
 import { CoBadgeActions } from "../../features/wallet/onboarding/cobadge/store/actions";
@@ -98,7 +98,7 @@ export type Action =
   | EuCovidCertActions
   | OutcomeCodeActions
   | SvActions
-  | MVLActions;
+  | MvlActions;
 
 export type Dispatch = DispatchAPI<Action>;
 

--- a/ts/store/actions/types.ts
+++ b/ts/store/actions/types.ts
@@ -13,13 +13,14 @@ import { BpdActions } from "../../features/bonus/bpd/store/actions";
 import { CgnActions } from "../../features/bonus/cgn/store/actions";
 import { SvActions } from "../../features/bonus/siciliaVola/store/actions";
 import { EuCovidCertActions } from "../../features/euCovidCert/store/actions";
+import { MVLActions } from "../../features/mvl/store/actions";
 import { AbiActions } from "../../features/wallet/onboarding/bancomat/store/actions";
 import { BPayActions } from "../../features/wallet/onboarding/bancomatPay/store/actions";
 import { CoBadgeActions } from "../../features/wallet/onboarding/cobadge/store/actions";
+import { PayPalOnboardingActions } from "../../features/wallet/onboarding/paypal/store/actions";
 import { PrivativeActions } from "../../features/wallet/onboarding/privative/store/actions";
 import { SatispayActions } from "../../features/wallet/onboarding/satispay/store/actions";
 import { GlobalState } from "../reducers/types";
-import { PayPalOnboardingActions } from "../../features/wallet/onboarding/paypal/store/actions";
 import { AnalyticsActions } from "./analytics";
 import { ApplicationActions } from "./application";
 import { AuthenticationActions } from "./authentication";
@@ -96,7 +97,8 @@ export type Action =
   | CgnActions
   | EuCovidCertActions
   | OutcomeCodeActions
-  | SvActions;
+  | SvActions
+  | MVLActions;
 
 export type Dispatch = DispatchAPI<Action>;
 

--- a/ts/store/reducers/backoffError.ts
+++ b/ts/store/reducers/backoffError.ts
@@ -8,6 +8,7 @@ import {
   bpdTransactionsLoadPage,
   bpdTransactionsLoadRequiredData
 } from "../../features/bonus/bpd/store/actions/transactions";
+import { mvlDetailsLoad } from "../../features/mvl/store/actions";
 import { Action } from "../actions/types";
 import {
   fetchTransactionsFailure,
@@ -49,6 +50,7 @@ const monitoredActions: ReadonlyArray<
     bpdTransactionsLoadRequiredData.success
   ],
   [euCovidCertificateGet.failure, euCovidCertificateGet.success],
+  [mvlDetailsLoad.failure, mvlDetailsLoad.success],
   [svPossibleVoucherStateGet.failure, svPossibleVoucherStateGet.success],
   [svVoucherListGet.failure, svVoucherListGet.success],
   [svGetPdfVoucher.failure, svGetPdfVoucher.success]

--- a/ts/types/contentType.ts
+++ b/ts/types/contentType.ts
@@ -1,0 +1,6 @@
+// TODO: add additional content-type
+export type ContentType =
+  | "image/png"
+  | "image/svg"
+  | "application/pdf"
+  | "application/octet-stream";

--- a/ts/types/digitalInformationUnit.ts
+++ b/ts/types/digitalInformationUnit.ts
@@ -1,0 +1,7 @@
+import { IUnitTag } from "@pagopa/ts-commons/lib/units";
+
+export type Byte = number & IUnitTag<"Byte">;
+export type KiloByte = number & IUnitTag<"KiloByte">;
+export type MegaByte = number & IUnitTag<"MegaByte">;
+export type GigaByte = number & IUnitTag<"GigaByte">;
+export type TeraByte = number & IUnitTag<"TeraByte">;


### PR DESCRIPTION
## Short description
This pr adds the types, actions, store, reducers and saga entrypoint required for the legal messages.

## List of changes proposed in this pull request
- Added `ts/types/digitalInformationUnit.ts` in order to have unambiguous types to measure the digital information
- Added `ts/types/contentType.ts` in order to have a unique enumeration in the app for content-types 
- Defined the datamodel, based on the required data. This could be change in future based also on the API specification. 
`MvlData` represents the MVL with all the information required to render it. It is composed by a body (`MvlBody`), a list of possible attachments (`ReadonlyArray<MvlAttachment>`) and some metadata (`MvlMetadata`). All the `MvlData` have an unique `MvlId`, defined as unique tagged, in order to avoid to mix generic `string` with MVL ids.
- Created a new async action `mvlDetailsLoad`, in order to represent the request and the outcome of the remote loading.
- Create a new store section `byId` under `features/mvl`, defined as `IndexedById<pot.Pot<MvlData, Error>>` and used to index all the requests and results of the MVL loading.
<img width="290" alt="Schermata 2021-12-02 alle 12 45 35" src="https://user-images.githubusercontent.com/26501317/144416056-b1f82288-32a7-477e-8ce6-63ffa226398f.png">

- Added the related reducer & selector
- Added `watchMvlSaga` as entrypoint for all the (maybe future) saga watchers related to MVL
- Added `handleGetMvl` saga stub, that will handle the `mvlDetailsLoad.request`, will generate a remote request and will transform the remote data in `MvlData`
- Added the configuration to `ts/store/reducers/backoffError.ts` in order to support the back-off.
- Added a new exception to `scripts/check_urls/check_urls.py` in order to have false positive with the mock file `ts/features/mvl/types/__mock__/mvlMock.ts`

## How to test
**Jest**
- run `ts/features/mvl/store/reducers/__test__/byId.test.ts`

**Manual**
- Enable `MVL_ENABLED`
- Dispatch a `mvlDetailsLoad.request`
- Observe the store changes

https://user-images.githubusercontent.com/26501317/144417697-a790ac24-c45c-49c0-8170-9135214b3b68.mov
