### PR TITLE
fix: [IA-544] Align mocks to io-services-metadata update

### DIFF
--- a/ts/store/reducers/__mock__/backendStatus.ts
+++ b/ts/store/reducers/__mock__/backendStatus.ts
@@ -188,7 +188,10 @@ export const baseRawBackendStatus: BackendStatus = {
     },
     bpd_ranking: true,
     bpd_ranking_v2: true,
-    cgn_merchants_v2: false
+    cgn_merchants_v2: false,
+    zendesk: {
+      active: false
+    }
   }
 };
 
@@ -205,7 +208,10 @@ export const baseBackendConfig: Config = {
   },
   bpd_ranking: true,
   bpd_ranking_v2: true,
-  cgn_merchants_v2: true
+  cgn_merchants_v2: true,
+  zendesk: {
+    active: false
+  }
 };
 
 export const withBpdRankingConfig = (


### PR DESCRIPTION
## Short description
This PR fix a bug introduced with https://github.com/pagopa/io-services-metadata/pull/522 which caused CI tests to fail.

## List of changes proposed in this pull request 
- Update test mocks adding the `zendesk` value in the `backendStatus.ts` file

## How to test
Run `yarn tsc --noemit`
