### PR TITLE
[IA-560] Use MessageCategory from definitions

### DIFF
--- a/ts/__mocks__/messages.ts
+++ b/ts/__mocks__/messages.ts
@@ -4,6 +4,7 @@ import { TimeToLiveSeconds } from "../../definitions/backend/TimeToLiveSeconds";
 import { ServiceId } from "../../definitions/backend/ServiceId";
 import { ServicePublic } from "../../definitions/backend/ServicePublic";
 import { OrganizationFiscalCode } from "../../definitions/backend/OrganizationFiscalCode";
+import { MessageCategory } from "../../definitions/backend/MessageCategory";
 import {
   NextPageMessagesSuccessPayload,
   PreviousPageMessagesSuccessPayload,
@@ -76,7 +77,7 @@ const successPayloadMessages: ReloadMessagesPayload["messages"] = [
   {
     id: messageId_1,
     fiscalCode: apiPayload.items[0].fiscal_code as FiscalCode,
-    category: { tag: "GENERIC" },
+    category: { tag: "GENERIC" } as MessageCategory,
     createdAt: new Date("2021-10-18T16:00:35.541Z"),
     serviceId: serviceId_1,
     timeToLive,
@@ -88,7 +89,7 @@ const successPayloadMessages: ReloadMessagesPayload["messages"] = [
   {
     id: messageId_2,
     fiscalCode: apiPayload.items[1].fiscal_code as FiscalCode,
-    category: { tag: "GENERIC" },
+    category: { tag: "GENERIC" } as MessageCategory,
     createdAt: new Date("2021-10-18T16:00:34.541Z"),
     serviceId: serviceId_1,
     timeToLive,
@@ -100,7 +101,7 @@ const successPayloadMessages: ReloadMessagesPayload["messages"] = [
   {
     id: messageId_3,
     fiscalCode: apiPayload.items[2].fiscal_code as FiscalCode,
-    category: { tag: "GENERIC" },
+    category: { tag: "GENERIC" } as MessageCategory,
     createdAt: new Date("2021-10-18T16:00:30.541Z"),
     serviceId: serviceId_2,
     timeToLive,

--- a/ts/components/messages/paginated/MessageList/Item.tsx
+++ b/ts/components/messages/paginated/MessageList/Item.tsx
@@ -6,15 +6,13 @@ import { StyleSheet, Text, View } from "react-native";
 import { Badge } from "native-base";
 
 import { ServicePublic } from "../../../../../definitions/backend/ServicePublic";
+import { MessageCategory } from "../../../../../definitions/backend/MessageCategory";
 import I18n from "../../../../i18n";
 import {
   convertDateToWordDistance,
   convertReceivedDateToAccessible
 } from "../../../../utils/convertDateToWordDistance";
-import {
-  MessageCategory,
-  UIMessage
-} from "../../../../store/reducers/entities/messages/types";
+import { UIMessage } from "../../../../store/reducers/entities/messages/types";
 import TouchableDefaultOpacity from "../../../TouchableDefaultOpacity";
 import { H5 } from "../../../core/typography/H5";
 import { H3 } from "../../../core/typography/H3";

--- a/ts/components/messages/paginated/MessageList/__tests__/Item.test.ts.tsx
+++ b/ts/components/messages/paginated/MessageList/__tests__/Item.test.ts.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { fireEvent, render } from "@testing-library/react-native";
 
+import { MessageCategory } from "../../../../../../definitions/backend/MessageCategory";
 import { successReloadMessagesPayload } from "../../../../../__mocks__/messages";
 import Item from "../Item";
 
@@ -9,7 +10,7 @@ jest.useFakeTimers();
 const messages = successReloadMessagesPayload.messages;
 
 const defaultProps: React.ComponentProps<typeof Item> = {
-  category: { tag: "GENERIC" },
+  category: { tag: "GENERIC" } as MessageCategory,
   hasPaidBadge: false,
   isRead: false,
   isArchived: false,
@@ -48,7 +49,10 @@ describe("MessageList Item component", () => {
     it("should match the snapshot", () => {
       expect(
         render(
-          <Item {...defaultProps} category={{ tag: "EU_COVID_CERT" }} />
+          <Item
+            {...defaultProps}
+            category={{ tag: "EU_COVID_CERT" } as MessageCategory}
+          />
         ).toJSON()
       ).toMatchSnapshot();
     });

--- a/ts/components/messages/paginated/MessageList/helpers.tsx
+++ b/ts/components/messages/paginated/MessageList/helpers.tsx
@@ -1,10 +1,8 @@
 import React from "react";
 import { Animated, FlatList, ListRenderItemInfo } from "react-native";
 
-import {
-  MessageCategory,
-  UIMessage
-} from "../../../../store/reducers/entities/messages/types";
+import { MessageCategory } from "../../../../../definitions/backend/MessageCategory";
+import { UIMessage } from "../../../../store/reducers/entities/messages/types";
 import { MessageStatus } from "../../../../store/reducers/entities/messages/messagesStatus";
 import ItemSeparatorComponent from "../../../ItemSeparatorComponent";
 import { ErrorLoadingComponent } from "../../ErrorLoadingComponent";

--- a/ts/store/reducers/entities/messages/transformers.ts
+++ b/ts/store/reducers/entities/messages/transformers.ts
@@ -1,11 +1,12 @@
 import { PublicMessage } from "../../../../../definitions/backend/PublicMessage";
 import { EnrichedMessage } from "../../../../../definitions/backend/EnrichedMessage";
 import { CreatedMessageWithContentAndAttachments } from "../../../../../definitions/backend/CreatedMessageWithContentAndAttachments";
+import { MessageCategory } from "../../../../../definitions/backend/MessageCategory";
+import { TagEnum } from "../../../../../definitions/backend/MessageCategoryBase";
 
 import {
   Attachment,
   EUCovidCertificate,
-  MessageCategory,
   PaymentData,
   PrescriptionData,
   UIMessage,
@@ -15,19 +16,19 @@ import {
 
 /**
  * Map an enriched message item from API to the app domain.
+ * Since `category` is optional, it falls back on GENERIC.
  *
  * @param messageFromApi
  */
 export const toUIMessage = (messageFromApi: PublicMessage): UIMessage => {
   const enriched = messageFromApi as EnrichedMessage;
-  // TODO: replace with actual types from API, for now use it if available
-  // see https://pagopa.atlassian.net/browse/IA-554
-  const category: MessageCategory | undefined = (messageFromApi as any)
-    .category;
+  const category: MessageCategory = enriched.category || {
+    tag: TagEnum.GENERIC
+  };
   return {
     id: messageFromApi.id as UIMessageId,
     fiscalCode: messageFromApi.fiscal_code,
-    category: category ?? { tag: "GENERIC" },
+    category,
     createdAt: new Date(messageFromApi.created_at),
     serviceId: messageFromApi.sender_service_id,
     serviceName: enriched.service_name,

--- a/ts/store/reducers/entities/messages/types.ts
+++ b/ts/store/reducers/entities/messages/types.ts
@@ -8,15 +8,10 @@ import { PaymentNoticeNumber } from "../../../../../definitions/backend/PaymentN
 import { PublicMessage } from "../../../../../definitions/backend/PublicMessage";
 import { ServiceId } from "../../../../../definitions/backend/ServiceId";
 import { TimeToLiveSeconds } from "../../../../../definitions/backend/TimeToLiveSeconds";
-
-// TODO: use type from API definitions once they are available
-export type MessageCategory =
-  | { tag: "EU_COVID_CERT" }
-  | { tag: "PAYMENT"; rptId: string }
-  | { tag: "GENERIC" };
+import { MessageCategory } from "../../../../../definitions/backend/MessageCategory";
 
 /**
- * The unique ID of a UIMessage and UIMessageDetails, used to avoid to pass wrong id as parameters
+ * The unique ID of a UIMessage and UIMessageDetails, used to avoid passing the wrong ID as parameters
  */
 export type UIMessageId = string & IUnitTag<"UIMessageId">;
 
@@ -29,11 +24,7 @@ export type WithUIMessageId<T> = T & {
  */
 export type UIMessage = WithUIMessageId<{
   fiscalCode: FiscalCode;
-
-  // TODO:  https://pagopa.atlassian.net/browse/IA-417
-  //        and https://pagopa.atlassian.net/browse/IA-418
   category: MessageCategory;
-
   createdAt: Date;
   serviceId: ServiceId;
   serviceName: string;


### PR DESCRIPTION
## Short description
Replace temporary definition of `MessageCategory` with the one generated from the API specs.

## How to test
Build, lint, run tests.
