### PR TITLE
chore: [IA-576] Upgrade io-react-native-zendesk

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "hastscript": "^7.0.2",
     "hoist-non-react-statics": "^3.0.1",
     "instabug-reactnative": "^9.1.6",
-    "io-react-native-zendesk": "https://github.com/pagopa/io-react-native-zendesk.git#0.3.9",
+    "io-react-native-zendesk": "https://github.com/pagopa/io-react-native-zendesk.git#0.3.11",
     "io-ts": "1.8.5",
     "italia-ts-commons": "8.6.0",
     "jail-monkey": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8348,9 +8348,9 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
-"io-react-native-zendesk@https://github.com/pagopa/io-react-native-zendesk.git#0.3.9":
-  version "0.3.9"
-  resolved "https://github.com/pagopa/io-react-native-zendesk.git#2ec77029950534f85f9389284ba4f145c42009b7"
+"io-react-native-zendesk@https://github.com/pagopa/io-react-native-zendesk.git#0.3.11":
+  version "0.3.11"
+  resolved "https://github.com/pagopa/io-react-native-zendesk.git#ed1e9426de5cd7d97a688ddf83bb0da7eab7dd60"
 
 io-ts@1.8.5:
   version "1.8.5"


### PR DESCRIPTION
## Short description
This PR upgrade the `io-react-native-zendesk` package to the `0.3.11` version.
This version introduce the possibility to send log and custom field and remove the possibility to open a ticket from the ticket list.