### PR TITLE
chore: [IA-576] Upgrade react-native-zendesk IOS 

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -434,7 +434,7 @@ PODS:
     - React
   - RNVectorIcons (7.0.0):
     - React
-  - RNZendeskChat (0.3.9):
+  - RNZendeskChat (0.3.11):
     - React
     - ZendeskAnswerBotSDK (~> 2.1.3)
     - ZendeskChatSDK (~> 2.11.1)
@@ -834,7 +834,7 @@ SPEC CHECKSUMS:
   RNShare: a1d5064df7a0ebe778d001869b3f0a124bf0a491
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
   RNVectorIcons: da6fe858f5a65d7bbc3379540a889b0b12aa5976
-  RNZendeskChat: 274100b17db293af5c6e6a5f45eea3802e5c1256
+  RNZendeskChat: f8ee2903ee59c8a163ae3bb4ec95e1aa9fcc2333
   Yoga: 575c581c63e0d35c9a83f4b46d01d63abc1100ac
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
   ZendeskAnswerBotProvidersSDK: 8ef75d4484f09c324cd93ce2725364d73dbabcf5


### PR DESCRIPTION
## Short description
This PR upgrade the `io-react-native-zendesk` package to the `0.3.11` version in IOS 
For further details check #3585.
