### PR TITLE
chore: [IA-578] Update Zendesk SDK configuration value

### DIFF
--- a/ts/utils/supportAssistance.ts
+++ b/ts/utils/supportAssistance.ts
@@ -17,15 +17,15 @@ export type AnonymousIdentity = ZendDesk.AnonymousIdentity;
 
 export const zendeskDefaultJwtConfig: ZendeskAppConfig = {
   key: "mp9agCp6LWusBxvHIGbeBmfI0wMeLIJM",
-  appId: "7f23d5b0eadc5b4f2cc83df3898c6f607bad769fe053a186",
-  clientId: "mobile_sdk_client_4bf774ed28b085195cc5",
-  url: "https://appiotest.zendesk.com"
+  appId: "4ed72c757f79ed15dfa46546dcb672fc86a0af949a119156",
+  clientId: "mobile_sdk_client_28679ae6f72da9ab5ef0",
+  url: "https://pagopa.zendesk.com"
 };
 export const zendeskDefaultAnonymousConfig: ZendeskAppConfig = {
   key: "mp9agCp6LWusBxvHIGbeBmfI0wMeLIJM",
-  appId: "8547479b47fdacd0e8f74a4fb076a41014dee620d1d890b3",
-  clientId: "mobile_sdk_client_518ee6a8160220698f97",
-  url: "https://appiotest.zendesk.com"
+  appId: "a6f500a77dc0bd00f25a5306e4217ea37c11d0e7fed1e768",
+  clientId: "mobile_sdk_client_aa8f9ebd96018279049b",
+  url: "https://pagopa.zendesk.com"
 };
 
 // If is not possible to get the assistance tool remotely assume it is none.


### PR DESCRIPTION
## Short description
This PR update the Zendesk SDK configuration value to those used in production.

## List of changes proposed in this pull request
- Modify both the anonymous and the authenticated configuration

## How to test
You can try to open a ticket anonymously both in dev and prod mode.
When you try to open a ticket as authenticated you must be in prode mode and modify this switch https://github.com/pagopa/io-app/blob/d0b98940f74e42591c5fe171de91c6e02451ba5e/ts/components/screens/BaseScreenComponent/index.tsx#L205
in order to execute Zendesk also if the remote FF is setted to instabug.
