### PR TITLE
chore: [IA-586] Hide zendesk if email not validated

### DIFF
--- a/ts/components/screens/BaseScreenComponent/index.tsx
+++ b/ts/components/screens/BaseScreenComponent/index.tsx
@@ -13,6 +13,7 @@ import React, {
 } from "react";
 import { ColorValue, ModalBaseProps, Platform } from "react-native";
 import { useDispatch } from "react-redux";
+import * as pot from "italia-ts-commons/lib/pot";
 import { TranslationKeys } from "../../../../locales/locales";
 import {
   defaultAttachmentTypeConfiguration,
@@ -34,6 +35,10 @@ import {
   canShowHelp
 } from "../../../utils/supportAssistance";
 import { ToolEnum } from "../../../../definitions/content/AssistanceToolConfig";
+import {
+  isProfileEmailValidatedSelector,
+  profileSelector
+} from "../../../store/reducers/profile";
 import {
   getContextualHelpConfig,
   handleOnContextualHelpDismissed,
@@ -199,6 +204,10 @@ const BaseScreenComponentFC = React.forwardRef<ReactNode, Props>(
     );
     const dispatch = useDispatch();
     const assistanceToolConfig = useIOSelector(assistanceToolConfigSelector);
+    const profile = useIOSelector(profileSelector);
+    const isProfileEmailValidated = useIOSelector(
+      isProfileEmailValidatedSelector
+    );
     const choosenTool = assistanceToolRemoteConfig(assistanceToolConfig);
 
     const onShowHelp = (): (() => void) | undefined => {
@@ -230,7 +239,10 @@ const BaseScreenComponentFC = React.forwardRef<ReactNode, Props>(
 
     // help button can be shown only when remote FF is instabug or (zendesk + ff local) and the contextualHelpConfig is defined
     const canShowHelpButton: boolean =
-      canShowHelp(choosenTool) && contextualHelpConfig !== undefined;
+      canShowHelp(
+        choosenTool,
+        !pot.isSome(profile) || isProfileEmailValidated
+      ) && contextualHelpConfig !== undefined;
     return (
       <Container>
         <BaseHeader

--- a/ts/components/screens/BaseScreenComponent/index.tsx
+++ b/ts/components/screens/BaseScreenComponent/index.tsx
@@ -13,7 +13,6 @@ import React, {
 } from "react";
 import { ColorValue, ModalBaseProps, Platform } from "react-native";
 import { useDispatch } from "react-redux";
-import * as pot from "italia-ts-commons/lib/pot";
 import { TranslationKeys } from "../../../../locales/locales";
 import {
   defaultAttachmentTypeConfiguration,
@@ -30,20 +29,14 @@ import { AccessibilityEvents, BaseHeader } from "../BaseHeader";
 import { zendeskSupportStart } from "../../../features/zendesk/store/actions";
 import { useIOSelector } from "../../../store/hooks";
 import { assistanceToolConfigSelector } from "../../../store/reducers/backendStatus";
-import {
-  assistanceToolRemoteConfig,
-  canShowHelp
-} from "../../../utils/supportAssistance";
+import { assistanceToolRemoteConfig } from "../../../utils/supportAssistance";
 import { ToolEnum } from "../../../../definitions/content/AssistanceToolConfig";
-import {
-  isProfileEmailValidatedSelector,
-  profileSelector
-} from "../../../store/reducers/profile";
 import {
   getContextualHelpConfig,
   handleOnContextualHelpDismissed,
   handleOnLinkClicked
 } from "./utils";
+import { canShowHelpSelector } from "../../../store/reducers/assistanceTools";
 
 // TODO: remove disabler when instabug is removed
 /* eslint-disable sonarjs/cognitive-complexity */
@@ -204,10 +197,8 @@ const BaseScreenComponentFC = React.forwardRef<ReactNode, Props>(
     );
     const dispatch = useDispatch();
     const assistanceToolConfig = useIOSelector(assistanceToolConfigSelector);
-    const profile = useIOSelector(profileSelector);
-    const isProfileEmailValidated = useIOSelector(
-      isProfileEmailValidatedSelector
-    );
+    const canShowHelp = useIOSelector(canShowHelpSelector);
+
     const choosenTool = assistanceToolRemoteConfig(assistanceToolConfig);
 
     const onShowHelp = (): (() => void) | undefined => {
@@ -239,10 +230,7 @@ const BaseScreenComponentFC = React.forwardRef<ReactNode, Props>(
 
     // help button can be shown only when remote FF is instabug or (zendesk + ff local) and the contextualHelpConfig is defined
     const canShowHelpButton: boolean =
-      canShowHelp(
-        choosenTool,
-        !pot.isSome(profile) || isProfileEmailValidated
-      ) && contextualHelpConfig !== undefined;
+      canShowHelp && contextualHelpConfig !== undefined;
     return (
       <Container>
         <BaseHeader

--- a/ts/components/screens/BaseScreenComponent/index.tsx
+++ b/ts/components/screens/BaseScreenComponent/index.tsx
@@ -31,12 +31,12 @@ import { useIOSelector } from "../../../store/hooks";
 import { assistanceToolConfigSelector } from "../../../store/reducers/backendStatus";
 import { assistanceToolRemoteConfig } from "../../../utils/supportAssistance";
 import { ToolEnum } from "../../../../definitions/content/AssistanceToolConfig";
+import { canShowHelpSelector } from "../../../store/reducers/assistanceTools";
 import {
   getContextualHelpConfig,
   handleOnContextualHelpDismissed,
   handleOnLinkClicked
 } from "./utils";
-import { canShowHelpSelector } from "../../../store/reducers/assistanceTools";
 
 // TODO: remove disabler when instabug is removed
 /* eslint-disable sonarjs/cognitive-complexity */

--- a/ts/features/bonus/bpd/screens/details/transaction/__test__/TransactionsUnavailable.test.tsx
+++ b/ts/features/bonus/bpd/screens/details/transaction/__test__/TransactionsUnavailable.test.tsx
@@ -3,6 +3,7 @@ import { NavigationParams } from "react-navigation";
 import { Store } from "redux";
 import configureMockStore from "redux-mock-store";
 import { some } from "fp-ts/lib/Option";
+import * as pot from "italia-ts-commons/lib/pot";
 import I18n from "../../../../../../../i18n";
 import { GlobalState } from "../../../../../../../store/reducers/types";
 import { renderScreenFakeNavRedux } from "../../../../../../../utils/testWrapper";
@@ -32,7 +33,8 @@ describe("TransactionsUnavailable component", () => {
         status: some({
           config: { assistanceTool: { tool: ToolEnum.none } } as Config
         } as BackendStatus)
-      }
+      },
+      profile: pot.some({ is_email_validated: true })
     });
   });
 

--- a/ts/screens/wallet/PaymentHistoryDetailsScreen.tsx
+++ b/ts/screens/wallet/PaymentHistoryDetailsScreen.tsx
@@ -5,7 +5,6 @@ import * as React from "react";
 import { StyleSheet } from "react-native";
 import { NavigationInjectedProps } from "react-navigation";
 import { connect } from "react-redux";
-import * as pot from "italia-ts-commons/lib/pot";
 import { EnteBeneficiario } from "../../../definitions/backend/EnteBeneficiario";
 import { PaymentRequestsGetResponse } from "../../../definitions/backend/PaymentRequestsGetResponse";
 import {
@@ -50,15 +49,11 @@ import {
   addTicketCustomField,
   appendLog,
   assistanceToolRemoteConfig,
-  canShowHelp,
   zendeskCategoryId,
   zendeskPaymentCategoryValue
 } from "../../utils/supportAssistance";
 import { ToolEnum } from "../../../definitions/content/AssistanceToolConfig";
-import {
-  isProfileEmailValidatedSelector,
-  profileSelector
-} from "../../store/reducers/profile";
+import { canShowHelpSelector } from "../../store/reducers/assistanceTools";
 
 type NavigationParams = Readonly<{
   payment: PaymentHistory;
@@ -127,7 +122,6 @@ class PaymentHistoryDetailsScreen extends React.Component<Props> {
 
     this.props.zendeskSupportWorkunitStart();
   };
-
   private choosenTool = assistanceToolRemoteConfig(
     this.props.assistanceToolConfig
   );
@@ -373,11 +367,7 @@ class PaymentHistoryDetailsScreen extends React.Component<Props> {
               </React.Fragment>
             )}
           {/* This check is redundant, since if the help can't be shown the user can't get there */}
-          {canShowHelp(
-            this.choosenTool,
-            !pot.isSome(this.props.profile) ||
-              this.props.isProfileEmailValidated
-          ) && this.renderHelper()}
+          {this.props.canShowHelp && this.renderHelper()}
         </SlidedContentComponent>
       </BaseScreenComponent>
     );
@@ -387,8 +377,7 @@ class PaymentHistoryDetailsScreen extends React.Component<Props> {
 const mapStateToProps = (state: GlobalState) => ({
   outcomeCodes: outcomeCodesSelector(state),
   assistanceToolConfig: assistanceToolConfigSelector(state),
-  profile: profileSelector(state),
-  isProfileEmailValidated: isProfileEmailValidatedSelector(state)
+  canShowHelp: canShowHelpSelector(state)
 });
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   // Start the assistance without FAQ ("n/a" is a placeholder)

--- a/ts/screens/wallet/PaymentHistoryDetailsScreen.tsx
+++ b/ts/screens/wallet/PaymentHistoryDetailsScreen.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import { StyleSheet } from "react-native";
 import { NavigationInjectedProps } from "react-navigation";
 import { connect } from "react-redux";
+import * as pot from "italia-ts-commons/lib/pot";
 import { EnteBeneficiario } from "../../../definitions/backend/EnteBeneficiario";
 import { PaymentRequestsGetResponse } from "../../../definitions/backend/PaymentRequestsGetResponse";
 import {
@@ -54,6 +55,10 @@ import {
   zendeskPaymentCategoryValue
 } from "../../utils/supportAssistance";
 import { ToolEnum } from "../../../definitions/content/AssistanceToolConfig";
+import {
+  isProfileEmailValidatedSelector,
+  profileSelector
+} from "../../store/reducers/profile";
 
 type NavigationParams = Readonly<{
   payment: PaymentHistory;
@@ -368,7 +373,11 @@ class PaymentHistoryDetailsScreen extends React.Component<Props> {
               </React.Fragment>
             )}
           {/* This check is redundant, since if the help can't be shown the user can't get there */}
-          {canShowHelp(this.choosenTool) && this.renderHelper()}
+          {canShowHelp(
+            this.choosenTool,
+            !pot.isSome(this.props.profile) ||
+              this.props.isProfileEmailValidated
+          ) && this.renderHelper()}
         </SlidedContentComponent>
       </BaseScreenComponent>
     );
@@ -377,7 +386,9 @@ class PaymentHistoryDetailsScreen extends React.Component<Props> {
 
 const mapStateToProps = (state: GlobalState) => ({
   outcomeCodes: outcomeCodesSelector(state),
-  assistanceToolConfig: assistanceToolConfigSelector(state)
+  assistanceToolConfig: assistanceToolConfigSelector(state),
+  profile: profileSelector(state),
+  isProfileEmailValidated: isProfileEmailValidatedSelector(state)
 });
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   // Start the assistance without FAQ ("n/a" is a placeholder)

--- a/ts/screens/wallet/creditCardOnboardingAttempts/CreditCardOnboardingAttemptDetailScreen.tsx
+++ b/ts/screens/wallet/creditCardOnboardingAttempts/CreditCardOnboardingAttemptDetailScreen.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import { StyleSheet } from "react-native";
 import { NavigationInjectedProps } from "react-navigation";
 import { useDispatch } from "react-redux";
-import * as pot from "italia-ts-commons/lib/pot";
 import {
   instabugLog,
   openInstabugQuestionReport,
@@ -32,16 +31,12 @@ import {
   addTicketCustomField,
   appendLog,
   assistanceToolRemoteConfig,
-  canShowHelp,
   zendeskCategoryId,
   zendeskPaymentMethodCategoryValue
 } from "../../../utils/supportAssistance";
 import { zendeskSupportStart } from "../../../features/zendesk/store/actions";
 import { ToolEnum } from "../../../../definitions/content/AssistanceToolConfig";
-import {
-  isProfileEmailValidatedSelector,
-  profileSelector
-} from "../../../store/reducers/profile";
+import { canShowHelpSelector } from "../../../store/reducers/assistanceTools";
 
 type NavigationParams = Readonly<{
   attempt: CreditCardInsertion;
@@ -86,10 +81,7 @@ const CreditCardOnboardingAttemptDetailScreen = (props: Props) => {
   const assistanceToolConfig = useIOSelector(assistanceToolConfigSelector);
   const outcomeCodes = useIOSelector(outcomeCodesSelector);
   const choosenTool = assistanceToolRemoteConfig(assistanceToolConfig);
-  const profile = useIOSelector(profileSelector);
-  const isProfileEmailValidated = useIOSelector(
-    isProfileEmailValidatedSelector
-  );
+  const canShowHelp = useIOSelector(canShowHelpSelector);
 
   const instabugLogAndOpenReport = () => {
     instabugLog(JSON.stringify(attempt), TypeLogs.INFO, instabugTag);
@@ -215,10 +207,7 @@ const CreditCardOnboardingAttemptDetailScreen = (props: Props) => {
         )}
         {renderSeparator()}
         {/* This check is redundant, since if the help can't be shown the user can't get there */}
-        {canShowHelp(
-          choosenTool,
-          !pot.isSome(profile) || isProfileEmailValidated
-        ) && renderHelper()}
+        {canShowHelp && renderHelper()}
       </SlidedContentComponent>
     </BaseScreenComponent>
   );

--- a/ts/screens/wallet/creditCardOnboardingAttempts/CreditCardOnboardingAttemptDetailScreen.tsx
+++ b/ts/screens/wallet/creditCardOnboardingAttempts/CreditCardOnboardingAttemptDetailScreen.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { StyleSheet } from "react-native";
 import { NavigationInjectedProps } from "react-navigation";
 import { useDispatch } from "react-redux";
+import * as pot from "italia-ts-commons/lib/pot";
 import {
   instabugLog,
   openInstabugQuestionReport,
@@ -37,6 +38,10 @@ import {
 } from "../../../utils/supportAssistance";
 import { zendeskSupportStart } from "../../../features/zendesk/store/actions";
 import { ToolEnum } from "../../../../definitions/content/AssistanceToolConfig";
+import {
+  isProfileEmailValidatedSelector,
+  profileSelector
+} from "../../../store/reducers/profile";
 
 type NavigationParams = Readonly<{
   attempt: CreditCardInsertion;
@@ -81,6 +86,11 @@ const CreditCardOnboardingAttemptDetailScreen = (props: Props) => {
   const assistanceToolConfig = useIOSelector(assistanceToolConfigSelector);
   const outcomeCodes = useIOSelector(outcomeCodesSelector);
   const choosenTool = assistanceToolRemoteConfig(assistanceToolConfig);
+  const profile = useIOSelector(profileSelector);
+  const isProfileEmailValidated = useIOSelector(
+    isProfileEmailValidatedSelector
+  );
+
   const instabugLogAndOpenReport = () => {
     instabugLog(JSON.stringify(attempt), TypeLogs.INFO, instabugTag);
     openInstabugQuestionReport();
@@ -205,7 +215,10 @@ const CreditCardOnboardingAttemptDetailScreen = (props: Props) => {
         )}
         {renderSeparator()}
         {/* This check is redundant, since if the help can't be shown the user can't get there */}
-        {canShowHelp(choosenTool) && renderHelper()}
+        {canShowHelp(
+          choosenTool,
+          !pot.isSome(profile) || isProfileEmailValidated
+        ) && renderHelper()}
       </SlidedContentComponent>
     </BaseScreenComponent>
   );

--- a/ts/screens/wallet/payment/TransactionErrorScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionErrorScreen.tsx
@@ -164,10 +164,8 @@ const canShowHelpButton = (
   choosenTool: ToolEnum,
   profile: ProfileState,
   isProfileEmailValidated: boolean
-): boolean => canShowHelp(
-    choosenTool,
-    !pot.isSome(profile) || isProfileEmailValidated
-  );
+): boolean =>
+  canShowHelp(choosenTool, !pot.isSome(profile) || isProfileEmailValidated);
 
 /**
  * Convert the error code into a user-readable string

--- a/ts/screens/wallet/payment/TransactionErrorScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionErrorScreen.tsx
@@ -12,7 +12,6 @@ import { NavigationInjectedProps } from "react-navigation";
 import { connect } from "react-redux";
 import { View } from "native-base";
 import { RptId, RptIdFromString } from "@pagopa/io-pagopa-commons/lib/pagopa";
-import * as pot from "italia-ts-commons/lib/pot";
 import {
   instabugLog,
   openInstabugQuestionReport,
@@ -58,18 +57,13 @@ import {
   addTicketCustomField,
   appendLog,
   assistanceToolRemoteConfig,
-  canShowHelp,
   zendeskBlockedPaymentRptIdId,
   zendeskCategoryId,
   zendeskPaymentCategoryValue
 } from "../../../utils/supportAssistance";
 import { ToolEnum } from "../../../../definitions/content/AssistanceToolConfig";
 import { zendeskSupportStart } from "../../../features/zendesk/store/actions";
-import {
-  isProfileEmailValidatedSelector,
-  profileSelector,
-  ProfileState
-} from "../../../store/reducers/profile";
+import { canShowHelpSelector } from "../../../store/reducers/assistanceTools";
 
 type NavigationParams = {
   error: Option<
@@ -159,13 +153,6 @@ const ErrorCodeCopyComponent = ({
     <CopyButtonComponent textToCopy={error} />
   </View>
 );
-
-const canShowHelpButton = (
-  choosenTool: ToolEnum,
-  profile: ProfileState,
-  isProfileEmailValidated: boolean
-): boolean =>
-  canShowHelp(choosenTool, !pot.isSome(profile) || isProfileEmailValidated);
 
 /**
  * Convert the error code into a user-readable string
@@ -378,11 +365,7 @@ const TransactionErrorScreen = (props: Props) => {
     onCancel,
     choosenTool,
     props.zendeskSupportWorkunitStart,
-    canShowHelpButton(
-      choosenTool,
-      props.profile,
-      props.isProfileEmailValidated
-    ),
+    props.canShowHelp,
     paymentHistory
   );
   const handleBackPress = () => {
@@ -409,8 +392,7 @@ const TransactionErrorScreen = (props: Props) => {
 const mapStateToProps = (state: GlobalState) => ({
   paymentsHistory: paymentsHistorySelector(state),
   assistanceToolConfig: assistanceToolConfigSelector(state),
-  profile: profileSelector(state),
-  isProfileEmailValidated: isProfileEmailValidatedSelector(state)
+  canShowHelp: canShowHelpSelector(state)
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/ts/store/reducers/assistanceTools.ts
+++ b/ts/store/reducers/assistanceTools.ts
@@ -1,8 +1,16 @@
 import { combineReducers } from "redux";
+import * as pot from "italia-ts-commons/lib/pot";
 import { Action } from "../actions/types";
 import zendeskReducer, {
   ZendeskState
 } from "../../features/zendesk/store/reducers";
+import { createSelector } from "reselect";
+import { assistanceToolConfigSelector } from "./backendStatus";
+import { isProfileEmailValidatedSelector, profileSelector } from "./profile";
+import {
+  assistanceToolRemoteConfig,
+  canShowHelp
+} from "../../utils/supportAssistance";
 
 export type AssistanceToolsState = {
   zendesk: ZendeskState;
@@ -11,5 +19,20 @@ export type AssistanceToolsState = {
 const assistanceToolsReducer = combineReducers<AssistanceToolsState, Action>({
   zendesk: zendeskReducer
 });
+
+// This selector contains the logic to show or not the help button:
+// if remote FF is instabug or (zendesk + ff local + the profile is not potSome or the email is validated )
+export const canShowHelpSelector = createSelector(
+  assistanceToolConfigSelector,
+  profileSelector,
+  isProfileEmailValidatedSelector,
+  (assistanceToolConfig, profile, isProfileEmailValidated): boolean => {
+    const remoteTool = assistanceToolRemoteConfig(assistanceToolConfig);
+    return canShowHelp(
+      remoteTool,
+      !pot.isSome(profile) || isProfileEmailValidated
+    );
+  }
+);
 
 export default assistanceToolsReducer;

--- a/ts/store/reducers/assistanceTools.ts
+++ b/ts/store/reducers/assistanceTools.ts
@@ -1,16 +1,16 @@
 import { combineReducers } from "redux";
 import * as pot from "italia-ts-commons/lib/pot";
+import { createSelector } from "reselect";
 import { Action } from "../actions/types";
 import zendeskReducer, {
   ZendeskState
 } from "../../features/zendesk/store/reducers";
-import { createSelector } from "reselect";
-import { assistanceToolConfigSelector } from "./backendStatus";
-import { isProfileEmailValidatedSelector, profileSelector } from "./profile";
 import {
   assistanceToolRemoteConfig,
   canShowHelp
 } from "../../utils/supportAssistance";
+import { assistanceToolConfigSelector } from "./backendStatus";
+import { isProfileEmailValidatedSelector, profileSelector } from "./profile";
 
 export type AssistanceToolsState = {
   zendesk: ZendeskState;

--- a/ts/utils/supportAssistance.ts
+++ b/ts/utils/supportAssistance.ts
@@ -53,13 +53,16 @@ export const zendeskPaymentMethodCategoryValue = "metodo_di_pagamento";
 export const hasSubCategories = (zendeskCategory: ZendeskCategory): boolean =>
   (zendeskCategory.zendeskSubCategories?.subCategories ?? []).length > 0;
 
-// help can be shown only when remote FF is instabug or (zendesk + ff local)
-export const canShowHelp = (assistanceTool: ToolEnum): boolean => {
+// help can be shown only when remote FF is instabug or (zendesk + local FF + emailValidated)
+export const canShowHelp = (
+  assistanceTool: ToolEnum,
+  isEmailValidated: boolean
+): boolean => {
   switch (assistanceTool) {
     case ToolEnum.instabug:
       return true;
     case ToolEnum.zendesk:
-      return zendeskEnabled;
+      return zendeskEnabled && isEmailValidated;
     case ToolEnum.web:
     case ToolEnum.none:
       return false;


### PR DESCRIPTION
## Short description
This PR hide the assistance entry points if the assistance tool is Zendesk and the email is not validated.

## List of changes proposed in this pull request
- Add the `isEmailValidated` condition in `canShowHelp` util
- Modify the entry point passing the `isEmailValidated` param (`BaseScreenComponent`, `CreditCardOnboardingAttemptDetailScreen`, `PaymentHistoryDetailsScreen`, `TransactionErrorScreen`)


https://user-images.githubusercontent.com/11773070/146794373-b0f93b54-ba47-45d8-96ef-01260daa51ee.mp4



## How to test
Try to set the `is_email_validated` flag to false i[n the dev server](https://github.com/pagopa/io-dev-api-server/blob/88e6dce8a90fd9a445350a62887babfe467155a3/src/payloads/profile.ts#L16)
