### PR TITLE
chore: [IA-587] Add Zendesk analytics

### DIFF
--- a/ts/features/zendesk/analytics/index.ts
+++ b/ts/features/zendesk/analytics/index.ts
@@ -20,7 +20,6 @@ const trackZendesk =
     switch (action.type) {
       case getType(zendeskSupportCompleted):
       case getType(zendeskSupportCancel):
-      case getType(zendeskSupportBack):
       case getType(getZendeskConfig.request):
       case getType(getZendeskConfig.success):
         return mp.track(action.type);

--- a/ts/features/zendesk/analytics/index.ts
+++ b/ts/features/zendesk/analytics/index.ts
@@ -1,0 +1,46 @@
+import { getType } from "typesafe-actions";
+import { mixpanel } from "../../../mixpanel";
+import { Action } from "../../../store/actions/types";
+
+import {
+  getZendeskConfig,
+  zendeskSelectedCategory,
+  zendeskSupportBack,
+  zendeskSupportCancel,
+  zendeskSupportCompleted,
+  zendeskSupportFailure,
+  zendeskSupportStart
+} from "../store/actions";
+import { getNetworkErrorMessage } from "../../../utils/errors";
+
+const trackZendesk =
+  (mp: NonNullable<typeof mixpanel>) =>
+  (action: Action): Promise<void> => {
+    switch (action.type) {
+      case getType(zendeskSupportCompleted):
+      case getType(zendeskSupportCancel):
+      case getType(zendeskSupportBack):
+      case getType(zendeskSupportFailure):
+      case getType(getZendeskConfig.request):
+      case getType(getZendeskConfig.success):
+        return mp.track(action.type);
+      case getType(zendeskSupportStart):
+        return mp.track(action.type, {
+          isAssistanceForPayment: action.payload.assistanceForPayment
+        });
+      case getType(zendeskSelectedCategory):
+        return mp.track(action.type, {
+          category: action.payload.value
+        });
+      case getType(getZendeskConfig.failure):
+        return mp.track(action.type, {
+          reason: getNetworkErrorMessage(action.payload)
+        });
+    }
+    return Promise.resolve();
+  };
+
+const emptyTracking = (_: NonNullable<typeof mixpanel>) => (__: Action) =>
+  Promise.resolve();
+
+export default false ? trackZendesk : emptyTracking;

--- a/ts/features/zendesk/analytics/index.ts
+++ b/ts/features/zendesk/analytics/index.ts
@@ -12,6 +12,7 @@ import {
   zendeskSupportStart
 } from "../store/actions";
 import { getNetworkErrorMessage } from "../../../utils/errors";
+import { zendeskEnabled } from "../../../config";
 
 const trackZendesk =
   (mp: NonNullable<typeof mixpanel>) =>
@@ -20,13 +21,16 @@ const trackZendesk =
       case getType(zendeskSupportCompleted):
       case getType(zendeskSupportCancel):
       case getType(zendeskSupportBack):
-      case getType(zendeskSupportFailure):
       case getType(getZendeskConfig.request):
       case getType(getZendeskConfig.success):
         return mp.track(action.type);
       case getType(zendeskSupportStart):
         return mp.track(action.type, {
           isAssistanceForPayment: action.payload.assistanceForPayment
+        });
+      case getType(zendeskSupportFailure):
+        return mp.track(action.type, {
+          reason: action.payload
         });
       case getType(zendeskSelectedCategory):
         return mp.track(action.type, {
@@ -43,4 +47,4 @@ const trackZendesk =
 const emptyTracking = (_: NonNullable<typeof mixpanel>) => (__: Action) =>
   Promise.resolve();
 
-export default false ? trackZendesk : emptyTracking;
+export default zendeskEnabled ? trackZendesk : emptyTracking;

--- a/ts/features/zendesk/analytics/index.ts
+++ b/ts/features/zendesk/analytics/index.ts
@@ -5,7 +5,6 @@ import { Action } from "../../../store/actions/types";
 import {
   getZendeskConfig,
   zendeskSelectedCategory,
-  zendeskSupportBack,
   zendeskSupportCancel,
   zendeskSupportCompleted,
   zendeskSupportFailure,

--- a/ts/features/zendesk/saga/orchestration/index.ts
+++ b/ts/features/zendesk/saga/orchestration/index.ts
@@ -3,6 +3,7 @@ import { NavigationActions } from "react-navigation";
 import { ActionType } from "typesafe-actions";
 import {
   executeWorkUnit,
+  withFailureHandling,
   withResetNavigationStack
 } from "../../../../sagas/workUnit";
 import {
@@ -38,7 +39,7 @@ function* zendeskSupportWorkUnit(
 export function* zendeskSupport(
   zendeskStart: ActionType<typeof zendeskSupportStart>
 ) {
-  yield call(withResetNavigationStack, () =>
-    zendeskSupportWorkUnit(zendeskStart)
+  yield call(withFailureHandling, () =>
+    withResetNavigationStack(() => zendeskSupportWorkUnit(zendeskStart))
   );
 }

--- a/ts/features/zendesk/screens/ZendeskChooseCategory.tsx
+++ b/ts/features/zendesk/screens/ZendeskChooseCategory.tsx
@@ -47,12 +47,11 @@ const ZendeskChooseCategory = () => {
   const zendeskWorkUnitFailure = (reason: string) =>
     dispatch(zendeskSupportFailure(reason));
 
-  zendeskWorkUnitFailure("Config undefined");
   // It should never happens since if config is undefined or in error the user can open directly a ticket and if it is in loading the user
   // should wait in the ZendeskSupportHelpCenter screen
   if (!isReady(zendeskConfig)) {
     zendeskWorkUnitFailure("Config undefined");
-    return;
+    return null;
   }
 
   const categories: ReadonlyArray<ZendeskCategory> = toArray(
@@ -63,7 +62,8 @@ const ZendeskChooseCategory = () => {
 
   // It should never happens since if the zendeskCategories are not in the config or if the array is void the user can open directly a ticket
   if (categories.length === 0 || categoriesId === undefined) {
-    return <WorkunitGenericFailure />;
+    zendeskWorkUnitFailure("The config has no categories");
+    return null;
   }
 
   const locale = getFullLocale();

--- a/ts/features/zendesk/screens/ZendeskChooseCategory.tsx
+++ b/ts/features/zendesk/screens/ZendeskChooseCategory.tsx
@@ -19,12 +19,12 @@ import { toArray } from "../../../store/helpers/indexer";
 import { H4 } from "../../../components/core/typography/H4";
 import customVariables from "../../../theme/variables";
 import IconFont from "../../../components/ui/IconFont";
-import WorkunitGenericFailure from "../../../components/error/WorkunitGenericFailure";
 import { useNavigationContext } from "../../../utils/hooks/useOnFocus";
 import { navigateToZendeskChooseSubCategory } from "../store/actions/navigation";
 import {
   zendeskSelectedCategory,
-  zendeskSupportCompleted
+  zendeskSupportCompleted,
+  zendeskSupportFailure
 } from "../store/actions";
 import { ZendeskCategory } from "../../../../definitions/content/ZendeskCategory";
 import {
@@ -43,11 +43,15 @@ const ZendeskChooseCategory = () => {
   const selectedCategory = (category: ZendeskCategory) =>
     dispatch(zendeskSelectedCategory(category));
   const zendeskWorkunitComplete = () => dispatch(zendeskSupportCompleted());
+  const zendeskWorkUnitFailure = (reason: string) =>
+    dispatch(zendeskSupportFailure(reason));
 
+  zendeskWorkUnitFailure("Config undefined");
   // It should never happens since if config is undefined or in error the user can open directly a ticket and if it is in loading the user
   // should wait in the ZendeskSupportHelpCenter screen
   if (!isReady(zendeskConfig)) {
-    return <WorkunitGenericFailure />;
+    zendeskWorkUnitFailure("Config undefined");
+    return;
   }
 
   const categories: ReadonlyArray<ZendeskCategory> = toArray(
@@ -56,7 +60,8 @@ const ZendeskChooseCategory = () => {
 
   // It should never happens since if the zendeskCategories are not in the config or if the array is void the user can open directly a ticket
   if (categories.length === 0) {
-    return <WorkunitGenericFailure />;
+    zendeskWorkUnitFailure("No category retrieved");
+    return;
   }
 
   const locale = getFullLocale();

--- a/ts/features/zendesk/screens/ZendeskChooseCategory.tsx
+++ b/ts/features/zendesk/screens/ZendeskChooseCategory.tsx
@@ -50,7 +50,7 @@ const ZendeskChooseCategory = () => {
   // It should never happens since if config is undefined or in error the user can open directly a ticket and if it is in loading the user
   // should wait in the ZendeskSupportHelpCenter screen
   if (!isReady(zendeskConfig)) {
-    zendeskWorkUnitFailure("Config undefined");
+    zendeskWorkUnitFailure("Config is not ready");
     return null;
   }
 

--- a/ts/features/zendesk/screens/ZendeskChooseSubCategory.tsx
+++ b/ts/features/zendesk/screens/ZendeskChooseSubCategory.tsx
@@ -17,12 +17,14 @@ import { zendeskSelectedCategorySelector } from "../store/reducers";
 import { H4 } from "../../../components/core/typography/H4";
 import customVariables from "../../../theme/variables";
 import IconFont from "../../../components/ui/IconFont";
-import WorkunitGenericFailure from "../../../components/error/WorkunitGenericFailure";
 import {
   hasSubCategories,
   openSupportTicket
 } from "../../../utils/supportAssistance";
-import { zendeskSupportCompleted } from "../store/actions";
+import {
+  zendeskSupportCompleted,
+  zendeskSupportFailure
+} from "../store/actions";
 import { getFullLocale } from "../../../utils/locale";
 import { ZendeskSubCategory } from "../../../../definitions/content/ZendeskSubCategory";
 
@@ -34,15 +36,19 @@ const ZendeskChooseSubCategory = () => {
   const selectedCategory = useIOSelector(zendeskSelectedCategorySelector);
   const dispatch = useDispatch();
   const zendeskWorkunitComplete = () => dispatch(zendeskSupportCompleted());
+  const zendeskWorkUnitFailure = (reason: string) =>
+    dispatch(zendeskSupportFailure(reason));
 
   // It should never happens since it is selected in the previous screen
   if (selectedCategory === undefined) {
-    return <WorkunitGenericFailure />;
+    zendeskWorkUnitFailure("The category has not been selected");
+    return;
   }
 
   // It should never happens since it is checked in the previous screen
   if (!hasSubCategories(selectedCategory)) {
-    return <WorkunitGenericFailure />;
+    zendeskWorkUnitFailure("The selected category has no sub-categories");
+    return;
   }
 
   const subCategories =

--- a/ts/features/zendesk/screens/ZendeskChooseSubCategory.tsx
+++ b/ts/features/zendesk/screens/ZendeskChooseSubCategory.tsx
@@ -43,13 +43,13 @@ const ZendeskChooseSubCategory = () => {
   // It should never happens since it is selected in the previous screen
   if (selectedCategory === undefined) {
     zendeskWorkUnitFailure("The category has not been selected");
-    return;
+    return null;
   }
 
   // It should never happens since it is checked in the previous screen
   if (!hasSubCategories(selectedCategory)) {
     zendeskWorkUnitFailure("The selected category has no sub-categories");
-    return;
+    return null;
   }
 
   // The check for subCategories and subCategoriesId is already done just above

--- a/ts/features/zendesk/screens/ZendeskSupportHelpCenter.tsx
+++ b/ts/features/zendesk/screens/ZendeskSupportHelpCenter.tsx
@@ -14,7 +14,7 @@ import View from "../../../components/ui/TextWithIcon";
 import {
   getZendeskConfig,
   ZendeskStartPayload,
-  zendeskSupportBack,
+  zendeskSupportCancel,
   zendeskSupportCompleted
 } from "../store/actions";
 import ZendeskSupportComponent from "../components/ZendeskSupportComponent";
@@ -152,7 +152,7 @@ type Props = NavigationInjectedProps<ZendeskStartPayload>;
  */
 const ZendeskSupportHelpCenter = (props: Props) => {
   const dispatch = useDispatch();
-  const workUnitBack = () => dispatch(zendeskSupportBack());
+  const workUnitCancel = () => dispatch(zendeskSupportCancel());
   const workUnitComplete = () => dispatch(zendeskSupportCompleted());
 
   // Navigation prop
@@ -196,7 +196,7 @@ const ZendeskSupportHelpCenter = (props: Props) => {
       customGoBack={<View />}
       customRightIcon={{
         iconName: "io-close",
-        onPress: workUnitBack,
+        onPress: workUnitCancel,
         accessibilityLabel: I18n.t("global.accessibility.contextualHelp.close")
       }}
       headerTitle={I18n.t("support.helpCenter.header")}

--- a/ts/features/zendesk/store/actions/index.ts
+++ b/ts/features/zendesk/store/actions/index.ts
@@ -40,13 +40,6 @@ export const zendeskSupportCancel = createStandardAction(
 )<void>();
 
 /**
- * The user chooses `back` from the first screen
- */
-export const zendeskSupportBack = createStandardAction(
-  "ZENDESK_SUPPORT_BACK"
-)<void>();
-
-/**
  * The workflow fails
  */
 export const zendeskSupportFailure = createStandardAction(
@@ -71,7 +64,6 @@ export type ZendeskSupportActions =
   | ActionType<typeof zendeskSupportStart>
   | ActionType<typeof zendeskSupportCompleted>
   | ActionType<typeof zendeskSupportCancel>
-  | ActionType<typeof zendeskSupportBack>
   | ActionType<typeof zendeskSupportFailure>
   | ActionType<typeof getZendeskConfig>
   | ActionType<typeof zendeskSelectedCategory>;

--- a/ts/features/zendesk/store/actions/index.ts
+++ b/ts/features/zendesk/store/actions/index.ts
@@ -40,6 +40,13 @@ export const zendeskSupportCancel = createStandardAction(
 )<void>();
 
 /**
+ * The user chooses `back` from the first screen
+ */
+export const zendeskSupportBack = createStandardAction(
+  "ZENDESK_SUPPORT_BACK"
+)<void>();
+
+/**
  * The workflow fails
  */
 export const zendeskSupportFailure = createStandardAction(
@@ -64,6 +71,7 @@ export type ZendeskSupportActions =
   | ActionType<typeof zendeskSupportStart>
   | ActionType<typeof zendeskSupportCompleted>
   | ActionType<typeof zendeskSupportCancel>
+  | ActionType<typeof zendeskSupportBack>
   | ActionType<typeof zendeskSupportFailure>
   | ActionType<typeof getZendeskConfig>
   | ActionType<typeof zendeskSelectedCategory>;

--- a/ts/features/zendesk/store/actions/index.ts
+++ b/ts/features/zendesk/store/actions/index.ts
@@ -57,9 +57,9 @@ export const zendeskSupportFailure = createStandardAction(
  * Request the zendesk config
  */
 export const getZendeskConfig = createAsyncAction(
-  "GET_ZENDESK_CONFIG_REQUEST",
-  "GET_ZENDESK_CONFIG_SUCCESS",
-  "GET_ZENDESK_CONFIG_FAILURE"
+  "ZENDESK_CONFIG_REQUEST",
+  "ZENDESK_CONFIG_SUCCESS",
+  "ZENDESK_CONFIG_FAILURE"
 )<void, Zendesk, NetworkError>();
 
 // user selected a category

--- a/ts/store/middlewares/analytics.ts
+++ b/ts/store/middlewares/analytics.ts
@@ -15,6 +15,7 @@ import trackPaypalOnboarding from "../../features/wallet/onboarding/paypal/analy
 import { trackBPayAction } from "../../features/wallet/onboarding/bancomatPay/analytics";
 import { trackCoBadgeAction } from "../../features/wallet/onboarding/cobadge/analytics";
 import { trackPrivativeAction } from "../../features/wallet/onboarding/privative/analytics";
+import trackZendesk from "../../features/zendesk/analytics/index";
 import { mixpanel } from "../../mixpanel";
 import { getNetworkErrorMessage } from "../../utils/errors";
 import {
@@ -434,6 +435,7 @@ export const actionTracking =
       void trackServiceAction(mixpanel)(action);
       void trackEuCovidCertificateActions(mixpanel)(action);
       void trackPaypalOnboarding(mixpanel)(action);
+      void trackZendesk(mixpanel)(action);
     }
     return next(action);
   };


### PR DESCRIPTION
## Short description
This PR adds the track the events that happens in the Zendesk request workflow.

## List of changes proposed in this pull request
The following events has been tracked:

| Eventi name | Attributes | Description |
| ------------- | ------------- | ------------- |
| ZENDESK_SUPPORT_COMPLETED  |  | the service request workflow has been completed. Either a new ticket has been opened, or the user has entered the list of open tickets, or the user has gone to an internal redirect link, or the user has exited screen panic mode  |
| ZENDESK_SUPPORT_CANCEL  |   | the X button was pressed in the help center screen |
| GET_ZENDESK_CONFIG_REQUEST  |  | remote configuration of Zendesk was required  |
| GET_ZENDESK_CONFIG_SUCCESS  |  | the remote configuration of Zendesk was successfully recovered  |
| ZENDESK_SUPPORT_START  | **isAssistanceForPayment**: true if it starts from a failed payment, a failed payment detail or a failed credit card entry attempt detail  | assistance was requested starting from a failed payment, a failed payment detail or a failed credit card entry attempt detail |
| ZENDESK_SUPPORT_FAILURE  | **reason**: the failure reason. Can be one of these values: `Config undefined`, `The config has no categories`, `The category has not been selected`, `The selected category has no sub-categories` | An unexpected error has occurred |
| ZENDESK_SELECTED_CATEGORY  | **category**: one of the possible category values.  | the user has chosen the category for which he wants assistance |
| GET_ZENDESK_CONFIG_FAILURE  | **reason**: the reason for the failure | An attempt to retrieve the zendesk remote configuration failed  |