### PR TITLE
chore: [IA-593] Disable Instabug attachments & screen recording

### DIFF
--- a/ts/boot/configureInstabug.ts
+++ b/ts/boot/configureInstabug.ts
@@ -103,6 +103,7 @@ export const openInstabugQuestionReport = (
     attachmentTypeConfiguration.extraScreenshot,
     // the gallery attachment & screen recording are disabled because it is impossible to display
     // a prominent disclosure before this request and Instabug will be removed
+    // https://pagopa.atlassian.net/wiki/spaces/IOAPP/pages/444727486/2021-11-18+Android#2021-12-21
     false,
     false
   );

--- a/ts/boot/configureInstabug.ts
+++ b/ts/boot/configureInstabug.ts
@@ -101,6 +101,8 @@ export const openInstabugQuestionReport = (
   Instabug.setEnabledAttachmentTypes(
     attachmentTypeConfiguration.screenshot,
     attachmentTypeConfiguration.extraScreenshot,
+    // the gallery attachment & screen recording are disabled because it is impossible to display
+    // a prominent disclosure before this request and Instabug will be removed
     false,
     false
   );

--- a/ts/boot/configureInstabug.ts
+++ b/ts/boot/configureInstabug.ts
@@ -102,7 +102,7 @@ export const openInstabugQuestionReport = (
     attachmentTypeConfiguration.screenshot,
     attachmentTypeConfiguration.extraScreenshot,
     false,
-    attachmentTypeConfiguration.screenRecording
+    false
   );
   BugReporting.showWithOptions(BugReporting.reportType.question, [
     BugReporting.option.commentFieldRequired,

--- a/ts/boot/configureInstabug.ts
+++ b/ts/boot/configureInstabug.ts
@@ -101,7 +101,7 @@ export const openInstabugQuestionReport = (
   Instabug.setEnabledAttachmentTypes(
     attachmentTypeConfiguration.screenshot,
     attachmentTypeConfiguration.extraScreenshot,
-    attachmentTypeConfiguration.galleryImage,
+    false,
     attachmentTypeConfiguration.screenRecording
   );
   BugReporting.showWithOptions(BugReporting.reportType.question, [


### PR DESCRIPTION
## Short description
This pr disables the Instabug attachments & screen recording.

<img width="300" alt="Schermata 2021-12-21 alle 17 27 43" src="https://user-images.githubusercontent.com/26501317/146964603-0d099bcf-6db5-4e94-8bdb-cdd1a413cc53.png">
