### PR TITLE
chore: [IA-595] Hide show tickets button

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -434,7 +434,7 @@ PODS:
     - React
   - RNVectorIcons (7.0.0):
     - React
-  - RNZendeskChat (0.3.12):
+  - RNZendeskChat (0.3.13):
     - React
     - ZendeskAnswerBotSDK (~> 2.1.3)
     - ZendeskChatSDK (~> 2.11.1)
@@ -834,7 +834,7 @@ SPEC CHECKSUMS:
   RNShare: a1d5064df7a0ebe778d001869b3f0a124bf0a491
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
   RNVectorIcons: da6fe858f5a65d7bbc3379540a889b0b12aa5976
-  RNZendeskChat: 2607a1ef5d0ff8b8f0e5efa16022c6c3e62c2504
+  RNZendeskChat: f6a9cb5a28ebf798639985151952375b8faef84d
   Yoga: 575c581c63e0d35c9a83f4b46d01d63abc1100ac
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
   ZendeskAnswerBotProvidersSDK: 8ef75d4484f09c324cd93ce2725364d73dbabcf5

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "hastscript": "^7.0.2",
     "hoist-non-react-statics": "^3.0.1",
     "instabug-reactnative": "^9.1.6",
-    "io-react-native-zendesk": "https://github.com/pagopa/io-react-native-zendesk.git#0.3.12",
+    "io-react-native-zendesk": "https://github.com/pagopa/io-react-native-zendesk.git#0.3.13",
     "io-ts": "1.8.5",
     "italia-ts-commons": "8.6.0",
     "jail-monkey": "^2.3.2",

--- a/ts/features/zendesk/components/ZendeskSupportComponent.tsx
+++ b/ts/features/zendesk/components/ZendeskSupportComponent.tsx
@@ -104,7 +104,7 @@ const ZendeskSupportComponent = (props: Props) => {
 
     setUserIdentity(zendeskIdentity);
     requestTicketNumber();
-  }, [zendeskConfig, zendeskToken, profile]);
+  }, [requestTicketNumber, zendeskConfig, zendeskToken, profile]);
 
   const handleContactSupportPress = () => {
     if (isPanicModeActive(zendeskRemoteConfig)) {

--- a/ts/features/zendesk/components/ZendeskSupportComponent.tsx
+++ b/ts/features/zendesk/components/ZendeskSupportComponent.tsx
@@ -93,7 +93,9 @@ const ZendeskSupportComponent = (props: Props) => {
       .getOrElse({});
 
     setUserIdentity(zendeskIdentity);
-    hasOpenedTickets().then(setShowAlreadyOpenedTicketButton);
+    hasOpenedTickets().then((n: number) =>
+      setShowAlreadyOpenedTicketButton(n > 0)
+    );
   }, [zendeskToken, profile]);
 
   const handleContactSupportPress = () => {

--- a/ts/features/zendesk/components/ZendeskSupportComponent.tsx
+++ b/ts/features/zendesk/components/ZendeskSupportComponent.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 import * as pot from "italia-ts-commons/lib/pot";
 import { fromNullable, Option } from "fp-ts/lib/Option";
 import { useDispatch } from "react-redux";
-import { H3, View } from "native-base";
+import { View } from "native-base";
 import { zendeskTokenSelector } from "../../../store/reducers/authentication";
 import {
   AnonymousIdentity,
@@ -38,6 +38,7 @@ import {
   zendeskTicketNumberSelector
 } from "../store/reducers";
 import { getValueOrElse } from "../../bonus/bpd/model/RemoteValue";
+import { H3 } from "../../../components/core/typography/H3";
 
 type Props = {
   assistanceForPayment: boolean;

--- a/ts/features/zendesk/components/ZendeskSupportComponent.tsx
+++ b/ts/features/zendesk/components/ZendeskSupportComponent.tsx
@@ -7,6 +7,7 @@ import { H3, View } from "native-base";
 import { zendeskTokenSelector } from "../../../store/reducers/authentication";
 import {
   AnonymousIdentity,
+  hasOpenedTickets,
   initSupportAssistance,
   isPanicModeActive,
   JwtIdentity,
@@ -51,7 +52,8 @@ const ZendeskSupportComponent = (props: Props) => {
   const navigation = useNavigationContext();
   const dispatch = useDispatch();
   const workUnitCompleted = () => dispatch(zendeskSupportCompleted());
-
+  const [showAlreadyOpenedTicketButton, setShowAlreadyOpenedTicketButton] =
+    React.useState<boolean>(false);
   const [zendeskConfig, setZendeskConfig] = React.useState<ZendeskAppConfig>(
     zendeskToken
       ? { ...zendeskDefaultJwtConfig, token: zendeskToken }
@@ -91,6 +93,7 @@ const ZendeskSupportComponent = (props: Props) => {
       .getOrElse({});
 
     setUserIdentity(zendeskIdentity);
+    hasOpenedTickets().then(setShowAlreadyOpenedTicketButton);
   }, [zendeskToken, profile]);
 
   const handleContactSupportPress = () => {
@@ -128,21 +131,25 @@ const ZendeskSupportComponent = (props: Props) => {
           {I18n.t("support.helpCenter.cta.contactSupport")}
         </Label>
       </ButtonDefaultOpacity>
-      <View spacer={true} />
-      <ButtonDefaultOpacity
-        onPress={() => {
-          showSupportTickets();
-          workUnitCompleted();
-        }}
-        style={{
-          alignSelf: "stretch"
-        }}
-        disabled={false}
-        bordered={true}
-        testID={"showTicketsButton"}
-      >
-        <Label>{I18n.t("support.helpCenter.cta.seeReports")}</Label>
-      </ButtonDefaultOpacity>
+      {showAlreadyOpenedTicketButton && (
+        <>
+          <View spacer={true} />
+          <ButtonDefaultOpacity
+            onPress={() => {
+              showSupportTickets();
+              workUnitCompleted();
+            }}
+            style={{
+              alignSelf: "stretch"
+            }}
+            disabled={false}
+            bordered={true}
+            testID={"showTicketsButton"}
+          >
+            <Label>{I18n.t("support.helpCenter.cta.seeReports")}</Label>
+          </ButtonDefaultOpacity>
+        </>
+      )}
     </>
   );
 };

--- a/ts/features/zendesk/components/ZendeskSupportComponent.tsx
+++ b/ts/features/zendesk/components/ZendeskSupportComponent.tsx
@@ -96,9 +96,9 @@ const ZendeskSupportComponent = (props: Props) => {
       .getOrElse({});
 
     setUserIdentity(zendeskIdentity);
-    hasOpenedTickets().then((n: number) =>
-      setShowAlreadyOpenedTicketButton(n > 0)
-    );
+    hasOpenedTickets()
+      .then((n: number) => setShowAlreadyOpenedTicketButton(n > 0))
+      .catch(_ => setShowAlreadyOpenedTicketButton(false));
   }, [zendeskConfig, zendeskToken, profile]);
 
   const handleContactSupportPress = () => {

--- a/ts/features/zendesk/components/ZendeskSupportComponent.tsx
+++ b/ts/features/zendesk/components/ZendeskSupportComponent.tsx
@@ -61,13 +61,16 @@ const ZendeskSupportComponent = (props: Props) => {
   );
 
   useEffect(() => {
-    const maybeProfile: Option<InitializedProfile> = pot.toOption(profile);
-
     setZendeskConfig(
       zendeskToken
         ? { ...zendeskDefaultJwtConfig, token: zendeskToken }
         : zendeskDefaultAnonymousConfig
     );
+  }, [zendeskToken]);
+
+  useEffect(() => {
+    const maybeProfile: Option<InitializedProfile> = pot.toOption(profile);
+
     initSupportAssistance(zendeskConfig);
 
     // In Zendesk we have two configuration: JwtConfig and AnonymousConfig.
@@ -96,7 +99,7 @@ const ZendeskSupportComponent = (props: Props) => {
     hasOpenedTickets().then((n: number) =>
       setShowAlreadyOpenedTicketButton(n > 0)
     );
-  }, [zendeskToken, profile]);
+  }, [zendeskConfig, zendeskToken, profile]);
 
   const handleContactSupportPress = () => {
     if (isPanicModeActive(zendeskRemoteConfig)) {

--- a/ts/features/zendesk/components/ZendeskSupportComponent.tsx
+++ b/ts/features/zendesk/components/ZendeskSupportComponent.tsx
@@ -58,8 +58,6 @@ const ZendeskSupportComponent = (props: Props) => {
   const zendeskRemoteConfig = useIOSelector(zendeskConfigSelector);
   const navigation = useNavigationContext();
   const dispatch = useDispatch();
-  const requestTicketNumber = () =>
-    dispatch(zendeskRequestTicketNumber.request());
   const ticketsNumber = useIOSelector(zendeskTicketNumberSelector);
   const workUnitCompleted = () => dispatch(zendeskSupportCompleted());
   const [zendeskConfig, setZendeskConfig] = React.useState<ZendeskAppConfig>(
@@ -104,8 +102,8 @@ const ZendeskSupportComponent = (props: Props) => {
       .getOrElse({});
 
     setUserIdentity(zendeskIdentity);
-    requestTicketNumber();
-  }, [requestTicketNumber, zendeskConfig, zendeskToken, profile]);
+    dispatch(zendeskRequestTicketNumber.request());
+  }, [dispatch, zendeskConfig, zendeskToken, profile]);
 
   const handleContactSupportPress = () => {
     if (isPanicModeActive(zendeskRemoteConfig)) {

--- a/ts/features/zendesk/components/ZendeskSupportComponent.tsx
+++ b/ts/features/zendesk/components/ZendeskSupportComponent.tsx
@@ -136,9 +136,9 @@ const ZendeskSupportComponent = (props: Props) => {
           {I18n.t("support.helpCenter.cta.contactSupport")}
         </Label>
       </ButtonDefaultOpacity>
+      <View spacer={true} />
       {showAlreadyOpenedTicketButton && (
         <>
-          <View spacer={true} />
           <ButtonDefaultOpacity
             onPress={() => {
               showSupportTickets();
@@ -153,6 +153,7 @@ const ZendeskSupportComponent = (props: Props) => {
           >
             <Label>{I18n.t("support.helpCenter.cta.seeReports")}</Label>
           </ButtonDefaultOpacity>
+          <View spacer={true} />
         </>
       )}
     </>

--- a/ts/features/zendesk/components/__tests__/ZendeskSupportComponent.test.tsx
+++ b/ts/features/zendesk/components/__tests__/ZendeskSupportComponent.test.tsx
@@ -66,11 +66,10 @@ describe("the ZendeskSupportComponent", () => {
   });
   describe("when the user press the zendesk show tickets button", () => {
     describe("if the user already open a ticket", () => {
-      const store = createStore(appReducer, globalState as any);
-      const component = renderComponent(store);
-      store.dispatch(zendeskRequestTicketNumber.success(1));
-
       it("should call showTickets", () => {
+        const store = createStore(appReducer, globalState as any);
+        const component = renderComponent(store);
+        store.dispatch(zendeskRequestTicketNumber.success(1));
         const zendeskButton = component.getByTestId("showTicketsButton");
         fireEvent(zendeskButton, "onPress");
         expect(MockZendesk.showTickets).toBeCalledWith();

--- a/ts/features/zendesk/components/__tests__/ZendeskSupportComponent.test.tsx
+++ b/ts/features/zendesk/components/__tests__/ZendeskSupportComponent.test.tsx
@@ -17,6 +17,7 @@ import { PublicSession } from "../../../../../definitions/backend/PublicSession"
 import { SpidLevelEnum } from "../../../../../definitions/backend/SpidLevel";
 import MockZendesk from "../../../../__mocks__/io-react-native-zendesk";
 import { SpidIdp } from "../../../../../definitions/content/SpidIdp";
+import { zendeskRequestTicketNumber } from "../../store/actions";
 
 const mockPublicSession: PublicSession = {
   bpdToken: "bpdToken",
@@ -34,9 +35,10 @@ describe("the ZendeskSupportComponent", () => {
     const component = renderComponent(store);
     expect(component.getByTestId("contactSupportButton")).toBeDefined();
   });
-  it("should render the zendesk show tickets button", () => {
+  it("should render the zendesk show tickets button, if the user already open a ticket", () => {
     const store = createStore(appReducer, globalState as any);
     const component = renderComponent(store);
+    store.dispatch(zendeskRequestTicketNumber.success(1));
     expect(component.getByTestId("showTicketsButton")).toBeDefined();
   });
   describe("when the user is authenticated with session info", () => {
@@ -63,13 +65,16 @@ describe("the ZendeskSupportComponent", () => {
     it.todo("should call openTicket");
   });
   describe("when the user press the zendesk show tickets button", () => {
-    it("should call showTickets", () => {
+    describe("if the user already open a ticket", () => {
       const store = createStore(appReducer, globalState as any);
-
       const component = renderComponent(store);
-      const zendeskButton = component.getByTestId("showTicketsButton");
-      fireEvent(zendeskButton, "onPress");
-      expect(MockZendesk.showTickets).toBeCalledWith();
+      store.dispatch(zendeskRequestTicketNumber.success(1));
+
+      it("should call showTickets", () => {
+        const zendeskButton = component.getByTestId("showTicketsButton");
+        fireEvent(zendeskButton, "onPress");
+        expect(MockZendesk.showTickets).toBeCalledWith();
+      });
     });
   });
 });

--- a/ts/features/zendesk/saga/index.ts
+++ b/ts/features/zendesk/saga/index.ts
@@ -1,9 +1,14 @@
 // watch for all actions regarding Zendesk
 import { takeLatest } from "redux-saga/effects";
-import { getZendeskConfig, zendeskSupportStart } from "../store/actions";
+import {
+  getZendeskConfig,
+  zendeskRequestTicketNumber,
+  zendeskSupportStart
+} from "../store/actions";
 import { ContentClient } from "../../../api/content";
 import { zendeskSupport } from "./orchestration";
 import { handleGetZendeskConfig } from "./networking/handleGetZendeskConfig";
+import { handleHasOpenedTickets } from "./networking/handleHasOpenedTickets";
 
 export function* watchZendeskSupportSaga() {
   const contentClient = ContentClient();
@@ -15,4 +20,6 @@ export function* watchZendeskSupportSaga() {
     handleGetZendeskConfig,
     contentClient.getZendeskConfig
   );
+
+  yield takeLatest(zendeskRequestTicketNumber.request, handleHasOpenedTickets);
 }

--- a/ts/features/zendesk/saga/networking/handleHasOpenedTickets.ts
+++ b/ts/features/zendesk/saga/networking/handleHasOpenedTickets.ts
@@ -1,0 +1,17 @@
+import { call, put } from "redux-saga/effects";
+import { SagaReturnType } from "@redux-saga/core/effects";
+import { zendeskRequestTicketNumber } from "../../store/actions";
+import { getError } from "../../../../utils/errors";
+import { hasOpenedTickets } from "../../../../utils/supportAssistance";
+
+// retrieve the number of ticket opened by the user from the Zendesk SDK
+export function* handleHasOpenedTickets() {
+  try {
+    const response: SagaReturnType<typeof hasOpenedTickets> = yield call(
+      hasOpenedTickets
+    );
+    yield put(zendeskRequestTicketNumber.success(response));
+  } catch (e) {
+    yield put(zendeskRequestTicketNumber.failure(getError(e)));
+  }
+}

--- a/ts/features/zendesk/store/actions/index.ts
+++ b/ts/features/zendesk/store/actions/index.ts
@@ -67,6 +67,15 @@ export const zendeskSelectedCategory = createStandardAction(
   "ZENDESK_SELECTED_CATEGORY"
 )<ZendeskCategory>();
 
+/**
+ * Request the ticket the user opened in Zendesk
+ */
+export const zendeskRequestTicketNumber = createAsyncAction(
+  "ZENDESK_TICKET_NUMBER_REQUEST",
+  "ZENDESK_TICKET_NUMBER_SUCCESS",
+  "ZENDESK_TICKET_NUMBER_FAILURE"
+)<void, number, Error>();
+
 export type ZendeskSupportActions =
   | ActionType<typeof zendeskSupportStart>
   | ActionType<typeof zendeskSupportCompleted>
@@ -74,4 +83,5 @@ export type ZendeskSupportActions =
   | ActionType<typeof zendeskSupportBack>
   | ActionType<typeof zendeskSupportFailure>
   | ActionType<typeof getZendeskConfig>
-  | ActionType<typeof zendeskSelectedCategory>;
+  | ActionType<typeof zendeskSelectedCategory>
+  | ActionType<typeof zendeskRequestTicketNumber>;

--- a/ts/features/zendesk/store/reducers/index.ts
+++ b/ts/features/zendesk/store/reducers/index.ts
@@ -11,7 +11,11 @@ import {
 } from "../../../bonus/bpd/model/RemoteValue";
 import { NetworkError } from "../../../../utils/errors";
 import { Action } from "../../../../store/actions/types";
-import { getZendeskConfig, zendeskSelectedCategory } from "../actions";
+import {
+  getZendeskConfig,
+  zendeskRequestTicketNumber,
+  zendeskSelectedCategory
+} from "../actions";
 import { GlobalState } from "../../../../store/reducers/types";
 
 type ZendeskValue = {
@@ -26,10 +30,12 @@ export type ZendeskConfig = RemoteValue<ZendeskValue, NetworkError>;
 export type ZendeskState = {
   zendeskConfig: ZendeskConfig;
   selectedCategory?: ZendeskCategory;
+  ticketNumber: RemoteValue<number, Error>;
 };
 
 const INITIAL_STATE: ZendeskState = {
-  zendeskConfig: remoteUndefined
+  zendeskConfig: remoteUndefined,
+  ticketNumber: remoteUndefined
 };
 
 const reducer = (
@@ -38,9 +44,14 @@ const reducer = (
 ): ZendeskState => {
   switch (action.type) {
     case getType(getZendeskConfig.request):
-      return { zendeskConfig: remoteLoading };
+      return {
+        ...state,
+        zendeskConfig: remoteLoading,
+        selectedCategory: undefined
+      };
     case getType(getZendeskConfig.success):
       return {
+        ...state,
         zendeskConfig: remoteReady({
           panicMode: action.payload.panicMode,
           zendeskCategories: action.payload.zendeskCategories
@@ -56,10 +67,17 @@ const reducer = (
       };
     case getType(getZendeskConfig.failure):
       return {
+        ...state,
         zendeskConfig: remoteError(action.payload)
       };
     case getType(zendeskSelectedCategory):
       return { ...state, selectedCategory: action.payload };
+    case getType(zendeskRequestTicketNumber.request):
+      return { ...state, ticketNumber: remoteLoading };
+    case getType(zendeskRequestTicketNumber.success):
+      return { ...state, ticketNumber: remoteReady(action.payload) };
+    case getType(zendeskRequestTicketNumber.failure):
+      return { ...state, ticketNumber: remoteError(action.payload) };
   }
   return state;
 };
@@ -73,6 +91,12 @@ export const zendeskSelectedCategorySelector = createSelector(
   [(state: GlobalState) => state.assistanceTools.zendesk.selectedCategory],
   (zendeskConfig: ZendeskCategory | undefined): ZendeskCategory | undefined =>
     zendeskConfig
+);
+
+export const zendeskTicketNumberSelector = createSelector(
+  [(state: GlobalState) => state.assistanceTools.zendesk.ticketNumber],
+  (ticketNumber: RemoteValue<number, Error>): RemoteValue<number, Error> =>
+    ticketNumber
 );
 
 export default reducer;

--- a/ts/utils/supportAssistance.ts
+++ b/ts/utils/supportAssistance.ts
@@ -45,6 +45,7 @@ export const showSupportTickets = ZendDesk.showTickets;
 export const resetAssistanceData = ZendDesk.reset;
 export const addTicketCustomField = ZendDesk.addTicketCustomField;
 export const appendLog = ZendDesk.appendLog;
+export const hasOpenedTickets = ZendDesk.hasOpenedTickets;
 export const zendeskCategoryId = "1900004702053";
 export const zendeskBlockedPaymentRptIdId = "4414297346833";
 export const zendeskDeviceAndOSId = "4414316795921";

--- a/yarn.lock
+++ b/yarn.lock
@@ -8348,9 +8348,9 @@ invert-kv@^2.0.0:
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-2.0.0.tgz#7393f5afa59ec9ff5f67a27620d11c226e3eec02"
   integrity sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==
 
-"io-react-native-zendesk@https://github.com/pagopa/io-react-native-zendesk.git#0.3.12":
-  version "0.3.12"
-  resolved "https://github.com/pagopa/io-react-native-zendesk.git#1210e3e9f7e21ce259e10dc877ef5048dbfcb21e"
+"io-react-native-zendesk@https://github.com/pagopa/io-react-native-zendesk.git#0.3.13":
+  version "0.3.13"
+  resolved "https://github.com/pagopa/io-react-native-zendesk.git#946e86f7c713c1a8a6dec44e5abdc1cf7b8628b3"
 
 io-ts@1.8.5:
   version "1.8.5"


### PR DESCRIPTION
## THIS PR DEPENDS ON https://github.com/pagopa/io-react-native-zendesk/pull/12
## Short description
This PR hide the show tickets button if the user has never created a ticket.

## List of changes proposed in this pull request
- Upgrade io-react-native-zendesk to the version 0.3.13
- Show the show tickets button only if the user has created at least one ticket

https://user-images.githubusercontent.com/11773070/146978297-5eb6bdb5-19ac-4a05-b5ac-bf16f51b40c5.mp4


https://user-images.githubusercontent.com/11773070/146979011-00a4c42d-d7e7-4d02-9eb9-116a45ad4ee9.mov




## How to test
Try to remove the app, press the assistance button.
Then try to open a ticket.
Finally try to press again the assistance button.
