### PR TITLE
chore(Messaggi a valore legale): [IAMVL-33] Update legal message error screen

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2845,8 +2845,8 @@ features:
       subtitle: "Please wait"
     ko:
       genericError:
-        title: "TMP Generic error title"
-        subtitle: "TMP Generic error subtitle"
+        title: "There was an error retrieving the message"
+        subtitle: "Please try again"
     details:
       hasAttachments: "contains attachments"
       attachments:

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2873,8 +2873,8 @@ features:
       subtitle: "Attendi qualche secondo"
     ko:
       genericError:
-        title: "TMP Generic error title"
-        subtitle: "TMP Generic error subtitle"
+        title: "Si è verificato un errore nel recupero del messaggio"
+        subtitle: "Riprova per favore"
     details:
       hasAttachments: "contiene allegati"
       attachments:

--- a/ts/features/mvl/screens/ko/MvlGenericErrorScreen.tsx
+++ b/ts/features/mvl/screens/ko/MvlGenericErrorScreen.tsx
@@ -32,7 +32,6 @@ export const MvlGenericErrorScreen = (props: Props): React.ReactElement => {
     <BaseScreenComponent goBack={true} contextualHelp={emptyContextualHelp}>
       <SafeAreaView style={IOStyles.flex} testID={"MvlGenericErrorScreen"}>
         <ScrollView style={[IOStyles.horizontalContentPadding]}>
-          <H1>TMP MvlGenericErrorScreen</H1>
           <View spacer={true} extralarge={true} />
           <View spacer={true} extralarge={true} />
           <InfoScreenComponent

--- a/ts/features/mvl/screens/ko/MvlGenericErrorScreen.tsx
+++ b/ts/features/mvl/screens/ko/MvlGenericErrorScreen.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import { SafeAreaView, ScrollView } from "react-native";
 import image from "../../../../../img/servicesStatus/error-detail-icon.png";
 import { Body } from "../../../../components/core/typography/Body";
-import { H1 } from "../../../../components/core/typography/H1";
 import { IOStyles } from "../../../../components/core/variables/IOStyles";
 import { renderInfoRasterImage } from "../../../../components/infoScreen/imageRendering";
 import { InfoScreenComponent } from "../../../../components/infoScreen/InfoScreenComponent";


### PR DESCRIPTION
## Short description
This pr updates the copy for the `MvlGenericErrorScreen`

<img width="300" alt="Schermata 2021-12-23 alle 15 00 15" src="https://user-images.githubusercontent.com/26501317/147250665-57a62e33-66c5-44d8-bb7e-18aed7a60430.png">

## How to test
- Dispatch `NavigationService.dispatchNavigationAction( navigateToMvlDetailsScreen({ id: "id" as UIMessageId }) )` and configure the dev server to fails when request the legal message details
- modify https://github.com/pagopa/io-app/blob/d866cee05be2016382aec4c42577e5d7d26c239a/ts/features/mvl/screens/MvlRouterScreen.tsx#L56 with: `return <MvlGenericErrorScreen id={mvlId} />`
