### PR TITLE
chore(Messaggi a valore legale): [IAMVL-36] Fetch service if not present

### DIFF
--- a/ts/features/mvl/screens/details/MvlDetailsScreen.tsx
+++ b/ts/features/mvl/screens/details/MvlDetailsScreen.tsx
@@ -5,7 +5,7 @@ import { SafeAreaView, ScrollView } from "react-native";
 import { IOStyles } from "../../../../components/core/variables/IOStyles";
 import CtaBar from "../../../../components/messages/paginated/MessageDetail/common/CtaBar";
 import BaseScreenComponent from "../../../../components/screens/BaseScreenComponent";
-import { useIOSelector } from "../../../../store/hooks";
+import { useIODispatch, useIOSelector } from "../../../../store/hooks";
 import {
   serviceByIdSelector,
   serviceMetadataByIdSelector
@@ -18,6 +18,8 @@ import { MvlAttachments } from "./components/attachment/MvlAttachments";
 import { MvlBody } from "./components/MvlBody";
 import { MvlDetailsHeader } from "./components/MvlDetailsHeader";
 import { MvlMetadataComponent } from "./components/MvlMetadata";
+import { useEffect } from "react";
+import { loadServiceDetail } from "../../../../store/actions/services";
 
 type Props = { mvl: Mvl };
 
@@ -37,6 +39,12 @@ export const MvlDetailsScreen = (props: Props): React.ReactElement => {
   const { service, serviceMetadata } = useIOSelector(state =>
     selectServiceState(state, props)
   );
+  const dispatch = useIODispatch();
+  useEffect(() => {
+    if (service === undefined) {
+      dispatch(loadServiceDetail.request(props.mvl.message.serviceId));
+    }
+  }, [dispatch, props.mvl.message.serviceId, service]);
 
   return (
     <BaseScreenComponent goBack={true} contextualHelp={emptyContextualHelp}>

--- a/ts/features/mvl/screens/details/MvlDetailsScreen.tsx
+++ b/ts/features/mvl/screens/details/MvlDetailsScreen.tsx
@@ -1,6 +1,6 @@
 import * as pot from "italia-ts-commons/lib/pot";
 import { View } from "native-base";
-import * as React from "react";
+import React, { useEffect } from "react";
 import { SafeAreaView, ScrollView } from "react-native";
 import { IOStyles } from "../../../../components/core/variables/IOStyles";
 import CtaBar from "../../../../components/messages/paginated/MessageDetail/common/CtaBar";
@@ -13,13 +13,12 @@ import {
 import { toUIService } from "../../../../store/reducers/entities/services/transformers";
 import { GlobalState } from "../../../../store/reducers/types";
 import { emptyContextualHelp } from "../../../../utils/emptyContextualHelp";
+import { loadServiceDetail } from "../../../../store/actions/services";
 import { Mvl } from "../../types/mvlData";
 import { MvlAttachments } from "./components/attachment/MvlAttachments";
 import { MvlBody } from "./components/MvlBody";
 import { MvlDetailsHeader } from "./components/MvlDetailsHeader";
 import { MvlMetadataComponent } from "./components/MvlMetadata";
-import { useEffect } from "react";
-import { loadServiceDetail } from "../../../../store/actions/services";
 
 type Props = { mvl: Mvl };
 


### PR DESCRIPTION
## Short description
If a service for MVL is not present, try to load it.
There is no retry strategy.

## How to test
I've assigned the first service in the list to all the messages on the dev-server, then returned the list [1 ... 10] from `/services`. Opening the legal message will trigger a `MVL_DETAILS_REQUEST` as in the picture.

<img width="1093" alt="Screenshot 2021-12-29 at 15 42 15" src="https://user-images.githubusercontent.com/2094604/147673804-103ec80b-2ce1-4ef2-86f8-dbcaae7d14ea.png">

