### PR TITLE
chore: [IA-480] Handle back on Paypal onboarding

### DIFF
--- a/ts/components/screens/BaseHeader.tsx
+++ b/ts/components/screens/BaseHeader.tsx
@@ -88,6 +88,7 @@ interface OwnProps {
   };
   customGoBack?: React.ReactNode;
   titleColor?: IOColorType;
+  backButtonTestID?: string;
 }
 
 type Props = OwnProps &
@@ -274,13 +275,17 @@ class BaseHeaderComponent extends React.PureComponent<Props, State> {
   };
 
   private renderGoBack = () => {
-    const { goBack, dark, customGoBack } = this.props;
+    const { goBack, dark, customGoBack, backButtonTestID } = this.props;
     return customGoBack ? (
       <Left>{customGoBack}</Left>
     ) : (
       goBack && (
         <Left>
-          <GoBackButton testID={"back-button"} onPress={goBack} white={dark} />
+          <GoBackButton
+            testID={backButtonTestID ?? "back-button"}
+            onPress={goBack}
+            white={dark}
+          />
         </Left>
       )
     );

--- a/ts/components/screens/BaseScreenComponent/index.tsx
+++ b/ts/components/screens/BaseScreenComponent/index.tsx
@@ -61,7 +61,7 @@ interface OwnProps {
   appLogo?: boolean;
   searchType?: SearchType;
   reportAttachmentTypes?: DefaultReportAttachmentTypeConfiguration;
-
+  backButtonTestID?: string;
   // As of now, the following prop is propagated through 4 levels
   // to finally display a checkbox in SendSupportRequestOptions
   shouldAskForScreenshotWithInitialValue?: boolean;
@@ -92,6 +92,7 @@ const BaseScreenComponentFC = React.forwardRef<ReactNode, Props>(
       accessibilityEvents,
       accessibilityLabel,
       appLogo,
+      backButtonTestID,
       children,
       contextualHelp,
       contextualHelpMarkdown,
@@ -237,6 +238,7 @@ const BaseScreenComponentFC = React.forwardRef<ReactNode, Props>(
           onAccessibilityNavigationHeaderFocus={
             onAccessibilityNavigationHeaderFocus
           }
+          backButtonTestID={backButtonTestID}
           accessibilityEvents={accessibilityEvents}
           accessibilityLabel={accessibilityLabel}
           showInstabugChat={showInstabugChat}

--- a/ts/features/bonus/cgn/screens/merchants/CgnMerchantsListScreen.tsx
+++ b/ts/features/bonus/cgn/screens/merchants/CgnMerchantsListScreen.tsx
@@ -128,42 +128,47 @@ const CgnMerchantsListScreen: React.FunctionComponent<Props> = (
     Keyboard.dismiss();
   };
 
-  return isReady(props.onlineMerchants) && isReady(props.offlineMerchants) ? (
+  return (
     <BaseScreenComponent
       goBack
       headerTitle={I18n.t("bonus.cgn.merchantsList.navigationTitle")}
       contextualHelp={emptyContextualHelp}
     >
       <SafeAreaView style={IOStyles.flex}>
-        <View style={[IOStyles.horizontalContentPadding]}>
-          <H1>{I18n.t("bonus.cgn.merchantsList.screenTitle")}</H1>
-          <Item>
-            <LabelledItem
-              icon={"io-search"}
-              iconPosition={"right"}
-              inputProps={{
-                value: searchValue,
-                autoFocus: true,
-                onChangeText: setSearchValue,
-                placeholder: I18n.t("global.buttons.search")
-              }}
+        {isReady(props.onlineMerchants) && isReady(props.offlineMerchants) ? (
+          <>
+            <View style={[IOStyles.horizontalContentPadding]}>
+              <H1>{I18n.t("bonus.cgn.merchantsList.screenTitle")}</H1>
+              <Item>
+                <LabelledItem
+                  icon={"io-search"}
+                  iconPosition={"right"}
+                  inputProps={{
+                    value: searchValue,
+                    autoFocus: true,
+                    onChangeText: setSearchValue,
+                    placeholder: I18n.t("global.buttons.search")
+                  }}
+                />
+              </Item>
+            </View>
+            <CgnMerchantsListView
+              merchantList={merchantList}
+              onItemPress={onItemPress}
             />
-          </Item>
-        </View>
-        <CgnMerchantsListView
-          merchantList={merchantList}
-          onItemPress={onItemPress}
-        />
+          </>
+        ) : (
+          <LoadingErrorComponent
+            isLoading={
+              isLoading(props.offlineMerchants) ||
+              isLoading(props.onlineMerchants)
+            }
+            loadingCaption={I18n.t("global.remoteStates.loading")}
+            onRetry={initLoadingLists}
+          />
+        )}
       </SafeAreaView>
     </BaseScreenComponent>
-  ) : (
-    <LoadingErrorComponent
-      isLoading={
-        isLoading(props.offlineMerchants) || isLoading(props.onlineMerchants)
-      }
-      loadingCaption={I18n.t("global.remoteStates.loading")}
-      onRetry={initLoadingLists}
-    />
   );
 };
 

--- a/ts/features/wallet/onboarding/paypal/screen/PayPalOnboardingCheckoutScreen.tsx
+++ b/ts/features/wallet/onboarding/paypal/screen/PayPalOnboardingCheckoutScreen.tsx
@@ -3,6 +3,7 @@ import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { Option } from "fp-ts/lib/Option";
 import { NavigationContext } from "react-navigation";
+import { Alert } from "react-native";
 import BaseScreenComponent from "../../../../../components/screens/BaseScreenComponent";
 import I18n from "../../../../../i18n";
 import { emptyContextualHelp } from "../../../../../utils/emptyContextualHelp";
@@ -49,6 +50,7 @@ const LoadingOrError = (loadingProps: {
 const CheckoutContent = (
   props: Props & {
     onCheckoutCompleted: (outcode: Option<string>) => void;
+    onGoBack: () => void;
   }
 ) => {
   const [isOnboardingCompleted, setIsOnboardingComplete] = useState(false);
@@ -84,7 +86,7 @@ const CheckoutContent = (
             props.onCheckoutCompleted(outcomeCode);
           }}
           outcomeQueryparamName={webViewOutcomeParamName}
-          onGoBack={props.goBack}
+          onGoBack={props.onGoBack}
           modalHeaderTitle={I18n.t("wallet.onboarding.paypal.headerTitle")}
         />
       );
@@ -114,14 +116,28 @@ const PayPalOnboardingCheckoutScreen = (props: Props) => {
     navigation.dispatch(navigateToPayPalCheckoutCompleted());
   };
 
+  const handleBack = () => {
+    Alert.alert(I18n.t("wallet.abortWebView.title"), "", [
+      {
+        text: I18n.t("wallet.abortWebView.confirm"),
+        onPress: props.goBack,
+        style: "cancel"
+      },
+      {
+        text: I18n.t("wallet.abortWebView.cancel")
+      }
+    ]);
+  };
+
   return (
     <BaseScreenComponent
-      goBack={props.goBack}
+      goBack={handleBack}
       headerTitle={I18n.t("wallet.onboarding.paypal.headerTitle")}
       contextualHelp={emptyContextualHelp}
     >
       <CheckoutContent
         {...props}
+        onGoBack={handleBack}
         onCheckoutCompleted={handleCheckoutCompleted}
       />
     </BaseScreenComponent>

--- a/ts/features/wallet/onboarding/paypal/screen/PayPalOnboardingCheckoutScreen.tsx
+++ b/ts/features/wallet/onboarding/paypal/screen/PayPalOnboardingCheckoutScreen.tsx
@@ -132,6 +132,7 @@ const PayPalOnboardingCheckoutScreen = (props: Props) => {
 
   return (
     <BaseScreenComponent
+      backButtonTestID={"host-back-button"}
       goBack={handleBack}
       headerTitle={I18n.t("wallet.onboarding.paypal.headerTitle")}
       contextualHelp={emptyContextualHelp}

--- a/ts/features/wallet/onboarding/paypal/screen/PayPalOnboardingCheckoutScreen.tsx
+++ b/ts/features/wallet/onboarding/paypal/screen/PayPalOnboardingCheckoutScreen.tsx
@@ -116,6 +116,7 @@ const PayPalOnboardingCheckoutScreen = (props: Props) => {
     navigation.dispatch(navigateToPayPalCheckoutCompleted());
   };
 
+  // notify the user that the current onboarding operation could be interrupted
   const handleBack = () => {
     Alert.alert(I18n.t("wallet.abortWebView.title"), "", [
       {

--- a/ts/features/wallet/onboarding/paypal/screen/PayPalOnboardingCheckoutScreen.tsx
+++ b/ts/features/wallet/onboarding/paypal/screen/PayPalOnboardingCheckoutScreen.tsx
@@ -116,7 +116,7 @@ const PayPalOnboardingCheckoutScreen = (props: Props) => {
     navigation.dispatch(navigateToPayPalCheckoutCompleted());
   };
 
-  // notify the user that the current onboarding operation could be interrupted
+  // notify the user that the current onboarding operation will be interrupted
   const handleBack = () => {
     Alert.alert(I18n.t("wallet.abortWebView.title"), "", [
       {

--- a/ts/features/wallet/onboarding/paypal/screen/__tests__/PayPalOnboardingCheckoutScreen.test.tsx
+++ b/ts/features/wallet/onboarding/paypal/screen/__tests__/PayPalOnboardingCheckoutScreen.test.tsx
@@ -1,5 +1,7 @@
 import { createStore, Store } from "redux";
 import { NavigationParams } from "react-navigation";
+import { Alert } from "react-native";
+import { fireEvent } from "@testing-library/react-native";
 import { appReducer } from "../../../../../../store/reducers";
 import { setLocale } from "../../../../../../i18n";
 import { renderScreenFakeNavRedux } from "../../../../../../utils/testWrapper";
@@ -13,6 +15,8 @@ import {
 import PAYPAL_ROUTES from "../../navigation/routes";
 import { PaymentManagerToken } from "../../../../../../types/pagopa";
 import { pspList } from "../__mocks__/psp";
+
+jest.spyOn(Alert, "alert");
 
 describe("PayPalOnboardingCheckoutScreen", () => {
   beforeAll(() => {
@@ -105,6 +109,42 @@ describe("PayPalOnboardingCheckoutScreen", () => {
       expect(
         render.component.queryByTestId("PayWebViewModalTestID")
       ).not.toBeNull();
+    });
+
+    it(`the back button (soft&hard) should show an alert`, () => {
+      const globalState = appReducer(
+        undefined,
+        walletAddPaypalRefreshPMToken.request()
+      );
+      const store = createStore(appReducer, globalState as any);
+      const render = renderComponent(store);
+      expect(
+        render.component.queryByTestId(
+          "PayPalOnboardingCheckoutScreenLoadingError"
+        )
+      ).not.toBeNull();
+      store.dispatch(
+        walletAddPaypalRefreshPMToken.success("a token" as PaymentManagerToken)
+      );
+      store.dispatch(walletAddPaypalPspSelected(pspList[0]));
+      /**
+       * this component has 2 back buttons:
+       * 1- in the screen that includes the modal
+       * 2- in the modal
+       */
+      const screenBackButton =
+        render.component.queryByTestId("host-back-button");
+      expect(screenBackButton).not.toBeNull();
+      const modalBackButton = render.component.queryByTestId("back-button");
+      expect(modalBackButton).not.toBeNull();
+      if (screenBackButton != null) {
+        fireEvent.press(screenBackButton);
+        expect(Alert.alert).toHaveBeenCalledTimes(1);
+      }
+      if (modalBackButton != null) {
+        fireEvent.press(modalBackButton);
+        expect(Alert.alert).toHaveBeenCalledTimes(2);
+      }
     });
   });
 });


### PR DESCRIPTION
## Short description
This PR adds the handling of back (hard&soft) while the user is onboarding his/her Paypal account, in the checkout phase

https://user-images.githubusercontent.com/822471/147812941-64c9e463-f30e-4a42-a1ae-4dd2413e8d56.mp4

## How to test
- add a Paypal account and in the checkout screen press `back`
