### PR TITLE
fix: [IA-611] When the MessageDetail can't get the relative sender services, app crashes

### DIFF
--- a/ts/components/messages/MessageDetailComponent.tsx
+++ b/ts/components/messages/MessageDetailComponent.tsx
@@ -1,4 +1,4 @@
-import { fromNullable } from "fp-ts/lib/Option";
+import { fromNullable, Option } from "fp-ts/lib/Option";
 import { Content, H3, Text, View } from "native-base";
 import DeviceInfo from "react-native-device-info";
 import * as React from "react";
@@ -101,16 +101,9 @@ export default class MessageDetailComponent extends React.PureComponent<
     return paymentExpirationInfo(this.props.message);
   }
 
-  get service() {
+  get service(): Option<ServicePublic> {
     const { serviceDetail } = this.props;
-    return fromNullable(
-      serviceDetail ??
-        ({
-          organization_name: I18n.t("messages.errorLoading.senderInfo"),
-          department_name: I18n.t("messages.errorLoading.departmentInfo"),
-          service_name: I18n.t("messages.errorLoading.serviceInfo")
-        } as ServicePublic)
-    );
+    return fromNullable(serviceDetail);
   }
 
   get payment() {


### PR DESCRIPTION
## Short description
This PR fixes a bug that causes a crash
The previous logic expected a service even when it is not available (it uses an `Option` but it can't never be `none`)
Since the service shape could change is very dangerous to have a dummy/default service and **force a cast** on it
So the fix consists in deal with the service as it can come: `some` or `none`

### the bug
https://user-images.githubusercontent.com/822471/147917218-940cdf70-3fc2-47de-bf65-1ac961066c7b.mov


### the fix
https://user-images.githubusercontent.com/822471/147917199-4d9c92c8-b64a-4ee6-af72-4bbd7eabc6c5.mov

### note
the fix should work with `legacy` and `pagination` mode

## How to test
- use the dev-server [to deny the app gets services details](https://github.com/pagopa/io-dev-api-server/blob/69371e5b4449225b0891b69f33553ac7e6065bb4/src/routers/service.ts#L38) (i.e return 404/500)
