### PR TITLE
fix: [IA-616] The initializeApplicationSaga could be executed before the NavigationService initialization

### DIFF
--- a/ts/RootContainer.tsx
+++ b/ts/RootContainer.tsx
@@ -15,6 +15,7 @@ import { shouldDisplayVersionInfoOverlay, testOverlayCaption } from "./config";
 import { setLocale } from "./i18n";
 import AppNavigator from "./navigation/AppNavigator";
 import NavigationService from "./navigation/NavigationService";
+import { OPERISSUES_10_track } from "./sagas/startup";
 import RootModal from "./screens/modal/RootModal";
 import {
   applicationChangeState,
@@ -29,7 +30,6 @@ import { GlobalState } from "./store/reducers/types";
 import { getNavigateActionFromDeepLink } from "./utils/deepLink";
 import { getCurrentRouteName } from "./utils/navigation";
 import { isStringNullyOrEmpty } from "./utils/strings";
-import { OPERISSUES_10_track } from "./sagas/startup";
 
 type Props = ReturnType<typeof mapStateToProps> & typeof mapDispatchToProps;
 
@@ -68,7 +68,6 @@ class RootContainer extends React.PureComponent<Props> {
 
   public componentDidMount() {
     initialiseInstabug();
-    console.log("RootContainer [componentDidMount]");
 
     if (Platform.OS === "android") {
       Linking.getInitialURL()
@@ -84,7 +83,7 @@ class RootContainer extends React.PureComponent<Props> {
     this.updateLocale();
     // Hide splash screen
     SplashScreen.hide();
-    OPERISSUES_10_track("New App Session");
+    OPERISSUES_10_track("RootContainer.componentDidMount");
   }
 
   /**

--- a/ts/RootContainer.tsx
+++ b/ts/RootContainer.tsx
@@ -68,6 +68,7 @@ class RootContainer extends React.PureComponent<Props> {
 
   public componentDidMount() {
     initialiseInstabug();
+    console.log("RootContainer [componentDidMount]");
 
     if (Platform.OS === "android") {
       Linking.getInitialURL()

--- a/ts/navigation/NavigationService.ts
+++ b/ts/navigation/NavigationService.ts
@@ -13,15 +13,18 @@ import {
 } from "../utils/navigation";
 
 // eslint-disable-next-line functional/no-let
-let navigator: NavigationContainerComponent | null;
+let navigator: NavigationContainerComponent | null | undefined;
 // eslint-disable-next-line functional/no-let
 let currentRouteState: NavigationState | null = null;
 
 const setTopLevelNavigator = (
-  navigatorRef: NavigationContainerComponent | null
+  navigatorRef: NavigationContainerComponent | null | undefined
 ) => {
   navigator = navigatorRef;
 };
+
+const getNavigator = (): NavigationContainerComponent | null | undefined =>
+  navigator;
 
 const setCurrentState = (state: NavigationState) => {
   // This is a security check since sometime the onNavigationStateChange could return an undefined state ignoring the type
@@ -50,6 +53,7 @@ const getCurrentState = (): NavigationState | null => currentRouteState;
 // add other navigation functions that you need and export them
 export default {
   navigate,
+  getNavigator,
   setTopLevelNavigator,
   dispatchNavigationAction,
   setCurrentState,

--- a/ts/navigation/NavigationService.ts
+++ b/ts/navigation/NavigationService.ts
@@ -38,6 +38,14 @@ const withLogging =
 const setTopLevelNavigator = (
   navigatorRef: NavigationContainerComponent | null | undefined
 ) => {
+  // TODO: remove when the bug is confirmed as solved
+  instabugLog(
+    `Initialize setTopLevelNavigator with argument ${
+      navigator !== null && navigator !== undefined
+    }`,
+    TypeLogs.DEBUG,
+    "NavigationService"
+  );
   navigator = navigatorRef;
 };
 

--- a/ts/sagas/mixpanel.ts
+++ b/ts/sagas/mixpanel.ts
@@ -12,6 +12,12 @@ export function* initMixpanel(): Generator<Effect, void, boolean> {
   const isMixpanelEnabledResult: ReturnType<typeof isMixpanelEnabled> =
     yield select(isMixpanelEnabled);
 
+  instabugLog(
+    `isMixpanelEnabledResult: ${isMixpanelEnabledResult}`,
+    TypeLogs.DEBUG,
+    "initMixpanel"
+  );
+
   if (isMixpanelEnabledResult ?? true) {
     // initialize mixpanel
     yield call(initializeMixPanel);

--- a/ts/sagas/mixpanel.ts
+++ b/ts/sagas/mixpanel.ts
@@ -12,12 +12,6 @@ export function* initMixpanel(): Generator<Effect, void, boolean> {
   const isMixpanelEnabledResult: ReturnType<typeof isMixpanelEnabled> =
     yield select(isMixpanelEnabled);
 
-  instabugLog(
-    `isMixpanelEnabledResult: ${isMixpanelEnabledResult}`,
-    TypeLogs.DEBUG,
-    "initMixpanel"
-  );
-
   if (isMixpanelEnabledResult ?? true) {
     // initialize mixpanel
     yield call(initializeMixPanel);

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -46,7 +46,10 @@ import { watchBonusCgnSaga } from "../features/bonus/cgn/saga";
 import { watchBonusSvSaga } from "../features/bonus/siciliaVola/saga";
 import { watchEUCovidCertificateSaga } from "../features/euCovidCert/saga";
 import { watchMvlSaga } from "../features/mvl/saga";
+import { watchZendeskSupportSaga } from "../features/zendesk/saga";
 import I18n from "../i18n";
+import { mixpanelTrack } from "../mixpanel";
+import NavigationService from "../navigation/NavigationService";
 import { startApplicationInitialization } from "../store/actions/application";
 import { sessionExpired } from "../store/actions/authentication";
 import { previousInstallationDataDeleteSuccess } from "../store/actions/installation";
@@ -76,16 +79,17 @@ import {
 import { PinString } from "../types/PinString";
 import { SagaCallReturnType } from "../types/utils";
 import { deletePin, getPin } from "../utils/keychain";
-import { watchZendeskSupportSaga } from "../features/zendesk/saga";
-import { mixpanelFlush, mixpanelTrack } from "../mixpanel";
-import { isStringNullyOrEmpty } from "../utils/strings";
 import { localeDateFormat } from "../utils/locale";
-import NavigationService from "../navigation/NavigationService";
+import { isStringNullyOrEmpty } from "../utils/strings";
 import {
   startAndReturnIdentificationResult,
   watchIdentification
 } from "./identification";
 import { previousInstallationDataDeleteSaga } from "./installation";
+import watchLoadMessageDetails from "./messages/watchLoadMessageDetails";
+import watchLoadNextPageMessages from "./messages/watchLoadNextPageMessages";
+import watchLoadPreviousPageMessages from "./messages/watchLoadPreviousPageMessages";
+import watchReloadAllMessages from "./messages/watchReloadAllMessages";
 import {
   askMixpanelOptIn,
   handleSetMixpanelEnabled,
@@ -116,10 +120,6 @@ import {
 } from "./startup/watchCheckSessionSaga";
 import { watchLoadMessages } from "./startup/watchLoadMessagesSaga";
 import { watchLoadMessageWithRelationsSaga } from "./startup/watchLoadMessageWithRelationsSaga";
-import watchLoadNextPageMessages from "./messages/watchLoadNextPageMessages";
-import watchLoadPreviousPageMessages from "./messages/watchLoadPreviousPageMessages";
-import watchReloadAllMessages from "./messages/watchReloadAllMessages";
-import watchLoadMessageDetails from "./messages/watchLoadMessageDetails";
 import { watchLogoutSaga } from "./startup/watchLogoutSaga";
 import { watchMessageLoadSaga } from "./startup/watchMessageLoadSaga";
 import { watchSessionExpiredSaga } from "./startup/watchSessionExpiredSaga";
@@ -152,12 +152,11 @@ export const OPERISSUES_10_track = (
     TypeLogs.DEBUG,
     `${localeDateFormat(new Date(), "%d/%m/%Y-%H:%M:%S")}-${tag}`
   );
-  void mixpanelTrack(`${tag}${event}`, properties);
-  void mixpanelFlush();
 };
 
 const WAIT_INITIALIZE_SAGA = 5000 as Millisecond;
 const navigatorPollingTime = 125 as Millisecond;
+const warningWaitNavigatorTime = 10000 as Millisecond;
 
 /**
  * Handles the application startup and the main application logic loop
@@ -174,22 +173,14 @@ export function* initializeApplicationSaga(): Generator<Effect, void, any> {
   //           order to force the user to choose unlock code and run through onboarding
   //           every new installation.
 
-  // eslint-disable-next-line functional/no-let
-  let navigator: ReturnType<typeof NavigationService.getNavigator> = yield call(
-    NavigationService.getNavigator
-  );
-
-  // before continuing we must wait for the navigatorService to be ready
-  while (navigator === null || navigator === undefined) {
-    yield delay(navigatorPollingTime);
-    navigator = yield call(NavigationService.getNavigator);
-  }
+  // check if mixpanel could be initialized
+  yield call(initMixpanel);
+  yield call(waitForNavigatorServiceInitialization);
 
   yield call(previousInstallationDataDeleteSaga);
   yield put(previousInstallationDataDeleteSuccess());
   yield call(OPERISSUES_10_track, "initializeApplicationSaga_1");
-  // check if mixpanel could be initialized
-  yield call(initMixpanel);
+
   yield call(OPERISSUES_10_track, "initializeApplicationSaga_2");
   // listen for mixpanel enabling events
   yield takeLatest(setMixpanelEnabled, handleSetMixpanelEnabled);
@@ -594,6 +585,45 @@ export function* initializeApplicationSaga(): Generator<Effect, void, any> {
     yield call(navigateToMainNavigatorAction);
     yield call(OPERISSUES_10_track, "initializeApplicationSaga_80");
   }
+}
+
+function* waitForNavigatorServiceInitialization() {
+  // eslint-disable-next-line functional/no-let
+  let navigator: ReturnType<typeof NavigationService.getNavigator> = yield call(
+    NavigationService.getNavigator
+  );
+
+  // eslint-disable-next-line functional/no-let
+  let timeoutLogged = false;
+
+  const startTime = performance.now();
+
+  // before continuing we must wait for the navigatorService to be ready
+  while (navigator === null || navigator === undefined) {
+    const elapsedTime = performance.now() - startTime;
+    if (!timeoutLogged && elapsedTime >= warningWaitNavigatorTime) {
+      timeoutLogged = true;
+      instabugLog(
+        `NavigationService is not initialized after ${elapsedTime} ms`,
+        TypeLogs.ERROR,
+        "initializeApplicationSaga"
+      );
+      yield call(mixpanelTrack, "NAVIGATION_SERVICE_INITIALIZATION_TIMEOUT");
+    }
+    yield delay(navigatorPollingTime);
+    navigator = yield call(NavigationService.getNavigator);
+  }
+
+  const initTime = performance.now() - startTime;
+
+  instabugLog(
+    `NavigationService initialized after ${initTime} ms`,
+    TypeLogs.DEBUG,
+    "initializeApplicationSaga"
+  );
+  yield call(mixpanelTrack, "NAVIGATION_SERVICE_INITIALIZATION_COMPLETED", {
+    elapsedTime: initTime
+  });
 }
 
 export function* startupSaga(): IterableIterator<Effect> {

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -156,6 +156,8 @@ export const OPERISSUES_10_track = (
 };
 
 const WAIT_INITIALIZE_SAGA = 5000 as Millisecond;
+const navigatorPollingTime = 125 as Millisecond;
+
 /**
  * Handles the application startup and the main application logic loop
  */
@@ -178,7 +180,7 @@ export function* initializeApplicationSaga(): Generator<Effect, void, any> {
 
   // before continuing we must wait for the navigatorService to be ready
   while (navigator === null || navigator === undefined) {
-    yield delay(125);
+    yield delay(navigatorPollingTime);
     navigator = yield call(NavigationService.getNavigator);
   }
 

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -156,7 +156,7 @@ export const OPERISSUES_10_track = (
 
 const WAIT_INITIALIZE_SAGA = 5000 as Millisecond;
 const navigatorPollingTime = 125 as Millisecond;
-const warningWaitNavigatorTime = 10000 as Millisecond;
+const warningWaitNavigatorTime = 2000 as Millisecond;
 
 /**
  * Handles the application startup and the main application logic loop

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -171,6 +171,17 @@ export function* initializeApplicationSaga(): Generator<Effect, void, any> {
   //           order to force the user to choose unlock code and run through onboarding
   //           every new installation.
 
+  // eslint-disable-next-line functional/no-let
+  let navigator: ReturnType<typeof NavigationService.getNavigator> = yield call(
+    NavigationService.getNavigator
+  );
+
+  // before continuing we must wait for the navigatorService to be ready
+  while (navigator === null || navigator === undefined) {
+    yield delay(125);
+    navigator = yield call(NavigationService.getNavigator);
+  }
+
   yield call(previousInstallationDataDeleteSaga);
   yield put(previousInstallationDataDeleteSuccess());
   yield call(OPERISSUES_10_track, "initializeApplicationSaga_1");

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -587,6 +587,10 @@ export function* initializeApplicationSaga(): Generator<Effect, void, any> {
   }
 }
 
+/**
+ * Wait until the {@link NavigationService} is initialized.
+ * The NavigationService is initialized when is called {@link RootContainer} componentDidMount and the ref is set with setTopLevelNavigator
+ */
 function* waitForNavigatorServiceInitialization() {
   // eslint-disable-next-line functional/no-let
   let navigator: ReturnType<typeof NavigationService.getNavigator> = yield call(

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -80,6 +80,7 @@ import { watchZendeskSupportSaga } from "../features/zendesk/saga";
 import { mixpanelFlush, mixpanelTrack } from "../mixpanel";
 import { isStringNullyOrEmpty } from "../utils/strings";
 import { localeDateFormat } from "../utils/locale";
+import NavigationService from "../navigation/NavigationService";
 import {
   startAndReturnIdentificationResult,
   watchIdentification


### PR DESCRIPTION
## Short description
This pr fixes a bug that could cause the execution of the `initializeApplicationSaga` before the `NavigationService` initialization.

## List of changes proposed in this pull request
- Added logging in `NavigationService` in order to understand if there are call to `NavigationService` before the initialization.
- Changed `initializeApplicationSaga` in order to wait for the `NavigationService` initialization.
