### PR TITLE
chore: [IA-627] Integrate Zendesk analytics

### DIFF
--- a/ts/features/zendesk/components/ZendeskSupportComponent.tsx
+++ b/ts/features/zendesk/components/ZendeskSupportComponent.tsx
@@ -39,6 +39,7 @@ import {
 } from "../store/reducers";
 import { getValueOrElse } from "../../bonus/bpd/model/RemoteValue";
 import { H3 } from "../../../components/core/typography/H3";
+import { mixpanelTrack } from "../../../mixpanel";
 
 type Props = {
   assistanceForPayment: boolean;
@@ -149,6 +150,7 @@ const ZendeskSupportComponent = (props: Props) => {
         <>
           <ButtonDefaultOpacity
             onPress={() => {
+              void mixpanelTrack("ZENDESK_SHOW_TICKETS");
               showSupportTickets();
               workUnitCompleted();
             }}

--- a/ts/features/zendesk/screens/ZendeskAskPermissions.tsx
+++ b/ts/features/zendesk/screens/ZendeskAskPermissions.tsx
@@ -50,6 +50,7 @@ import {
   zendeskDeviceAndOSId,
   zendeskidentityProviderId
 } from "../../../utils/supportAssistance";
+import { mixpanelTrack } from "../../../mixpanel";
 
 /**
  * id is optional since some items should recognized since they can be removed from the whole list
@@ -213,6 +214,7 @@ const ZendeskAskPermissions = (props: Props) => {
 
   const handleOnCancel = () => {
     openWebUrl(assistanceWebFormLink);
+    void mixpanelTrack("ZENDESK_DENY_PERMISSIONS");
     workUnitCompleted();
   };
 
@@ -236,6 +238,7 @@ const ZendeskAskPermissions = (props: Props) => {
     // if is not possible to get the config, if the config has any category or if is an assistanceForPayment request open directly a ticket.
     if (canSkipCategoryChoice()) {
       openSupportTicket();
+      void mixpanelTrack("ZENDESK_OPEN_TICKET");
       workUnitCompleted();
     } else {
       navigation.navigate(navigateToZendeskChooseCategory());

--- a/ts/features/zendesk/screens/ZendeskChooseCategory.tsx
+++ b/ts/features/zendesk/screens/ZendeskChooseCategory.tsx
@@ -33,6 +33,7 @@ import {
   openSupportTicket
 } from "../../../utils/supportAssistance";
 import { getFullLocale } from "../../../utils/locale";
+import { mixpanelTrack } from "../../../mixpanel";
 
 /**
  * this screen shows the categories for which the user can ask support with the assistance
@@ -80,6 +81,7 @@ const ZendeskChooseCategory = () => {
             navigation.navigate(navigateToZendeskChooseSubCategory());
           } else {
             openSupportTicket();
+            void mixpanelTrack("ZENDESK_OPEN_TICKET");
             zendeskWorkunitComplete();
           }
         }}

--- a/ts/features/zendesk/screens/ZendeskChooseSubCategory.tsx
+++ b/ts/features/zendesk/screens/ZendeskChooseSubCategory.tsx
@@ -28,6 +28,7 @@ import {
 } from "../store/actions";
 import { getFullLocale } from "../../../utils/locale";
 import { ZendeskSubCategory } from "../../../../definitions/content/ZendeskSubCategory";
+import { mixpanelTrack } from "../../../mixpanel";
 
 /**
  * this screen shows the sub-categories for which the user can ask support with the assistance
@@ -68,6 +69,7 @@ const ZendeskChooseSubCategory = () => {
           // Set sub-category as custom field
           addTicketCustomField(subCategoriesId, subCategory.value);
           openSupportTicket();
+          void mixpanelTrack("ZENDESK_OPEN_TICKET");
           zendeskWorkunitComplete();
         }}
         first={listItem.index === 0}


### PR DESCRIPTION
## Short description
This PR integrates the Zendesk workflow tracked events with the new ones below.

## List of changes proposed in this pull request
| Event name | Attributes | Description |
| ------------- | ------------- | ------------- |
| ZENDESK_SHOW_TICKETS  |  | the user chooses to see the already opened tickets |
| ZENDESK_DENY_PERMISSIONS  |   | the user denies the permission to send data to the assistance in the `ZendeskAskPermissions` screen |
| ZENDESK_OPEN_TICKET  |  | the user open a ticket from the `ZendeskAskPermissions`, the `ZendeskChooseCategory` or the `ZendeskChooseSubCategory` screen |
