### PR TITLE
chore(Carta Giovani Nazionale): [IOACGN-30] Handles the case of CGN in a different state from active for conflicting activation

### DIFF
--- a/ts/features/bonus/cgn/screens/activation/CgnActivationIneligibleScreen.tsx
+++ b/ts/features/bonus/cgn/screens/activation/CgnActivationIneligibleScreen.tsx
@@ -30,7 +30,7 @@ const CgnActivationIneligibleScreen = (props: Props): React.ReactElement => (
       type="SingleButton"
       leftButton={cancelButtonProps(
         props.onCancel,
-        I18n.t("global.buttons.exit")
+        I18n.t("global.buttons.close")
       )}
     />
   </SafeAreaView>

--- a/ts/features/bonus/cgn/screens/activation/CgnActivationPendingScreen.tsx
+++ b/ts/features/bonus/cgn/screens/activation/CgnActivationPendingScreen.tsx
@@ -30,7 +30,7 @@ const CgnActivationPendingScreen = (props: Props): React.ReactElement => (
       type="SingleButton"
       leftButton={cancelButtonProps(
         props.onExit,
-        I18n.t("global.buttons.exit")
+        I18n.t("global.buttons.close")
       )}
     />
   </SafeAreaView>

--- a/ts/features/bonus/cgn/screens/activation/CgnAlreadyActiveScreen.tsx
+++ b/ts/features/bonus/cgn/screens/activation/CgnAlreadyActiveScreen.tsx
@@ -4,14 +4,20 @@ import { SafeAreaView } from "react-native";
 import { InfoScreenComponent } from "../../../../../components/infoScreen/InfoScreenComponent";
 import { renderInfoRasterImage } from "../../../../../components/infoScreen/imageRendering";
 import FooterWithButtons from "../../../../../components/ui/FooterWithButtons";
-import { cancelButtonProps, confirmButtonProps } from "../../../bonusVacanze/components/buttons/ButtonConfigurations";
+import {
+  cancelButtonProps,
+  confirmButtonProps
+} from "../../../bonusVacanze/components/buttons/ButtonConfigurations";
 import { IOStyles } from "../../../../../components/core/variables/IOStyles";
 import { cgnActivationCancel } from "../../store/actions/activation";
 import image from "../../../../../../img/messages/empty-due-date-list-icon.png";
 import I18n from "../../../../../i18n";
 import { navigateToCgnDetails } from "../../navigation/actions";
 import { useIODispatch, useIOSelector } from "../../../../../store/hooks";
-import { isCgnDetailsLoading, isCgnEnrolledSelector } from "../../store/reducers/details";
+import {
+  isCgnDetailsLoading,
+  isCgnEnrolledSelector
+} from "../../store/reducers/details";
 import { cgnDetails } from "../../store/actions/details";
 import ActivityIndicator from "../../../../../components/ui/ActivityIndicator";
 

--- a/ts/features/bonus/cgn/screens/activation/CgnAlreadyActiveScreen.tsx
+++ b/ts/features/bonus/cgn/screens/activation/CgnAlreadyActiveScreen.tsx
@@ -4,17 +4,14 @@ import { SafeAreaView } from "react-native";
 import { InfoScreenComponent } from "../../../../../components/infoScreen/InfoScreenComponent";
 import { renderInfoRasterImage } from "../../../../../components/infoScreen/imageRendering";
 import FooterWithButtons from "../../../../../components/ui/FooterWithButtons";
-import { confirmButtonProps } from "../../../bonusVacanze/components/buttons/ButtonConfigurations";
+import { cancelButtonProps, confirmButtonProps } from "../../../bonusVacanze/components/buttons/ButtonConfigurations";
 import { IOStyles } from "../../../../../components/core/variables/IOStyles";
 import { cgnActivationCancel } from "../../store/actions/activation";
 import image from "../../../../../../img/messages/empty-due-date-list-icon.png";
 import I18n from "../../../../../i18n";
 import { navigateToCgnDetails } from "../../navigation/actions";
 import { useIODispatch, useIOSelector } from "../../../../../store/hooks";
-import {
-  isCgnDetailsLoading,
-  isCgnEnrolledSelector
-} from "../../store/reducers/details";
+import { isCgnDetailsLoading, isCgnEnrolledSelector } from "../../store/reducers/details";
 import { cgnDetails } from "../../store/actions/details";
 import ActivityIndicator from "../../../../../components/ui/ActivityIndicator";
 
@@ -67,9 +64,9 @@ const CgnAlreadyActiveScreen = (): React.ReactElement => {
       />
       <FooterWithButtons
         type="SingleButton"
-        leftButton={confirmButtonProps(
+        leftButton={cancelButtonProps(
           () => dispatch(cgnActivationCancel()),
-          I18n.t("global.buttons.exit")
+          I18n.t("global.buttons.close")
         )}
       />
     </SafeAreaView>

--- a/ts/features/bonus/cgn/screens/activation/CgnAlreadyActiveScreen.tsx
+++ b/ts/features/bonus/cgn/screens/activation/CgnAlreadyActiveScreen.tsx
@@ -1,9 +1,6 @@
 import * as React from "react";
 import { useEffect } from "react";
-import { connect } from "react-redux";
 import { SafeAreaView } from "react-native";
-import { GlobalState } from "../../../../../store/reducers/types";
-import { Dispatch } from "../../../../../store/actions/types";
 import { InfoScreenComponent } from "../../../../../components/infoScreen/InfoScreenComponent";
 import { renderInfoRasterImage } from "../../../../../components/infoScreen/imageRendering";
 import FooterWithButtons from "../../../../../components/ui/FooterWithButtons";
@@ -14,7 +11,10 @@ import image from "../../../../../../img/messages/empty-due-date-list-icon.png";
 import I18n from "../../../../../i18n";
 import { navigateToCgnDetails } from "../../navigation/actions";
 import { useIODispatch, useIOSelector } from "../../../../../store/hooks";
-import { isCgnDetailsLoading, isCgnEnrolledSelector } from "../../store/reducers/details";
+import {
+  isCgnDetailsLoading,
+  isCgnEnrolledSelector
+} from "../../store/reducers/details";
 import { cgnDetails } from "../../store/actions/details";
 import ActivityIndicator from "../../../../../components/ui/ActivityIndicator";
 
@@ -76,16 +76,4 @@ const CgnAlreadyActiveScreen = (): React.ReactElement => {
   );
 };
 
-const mapStateToProps = (_: GlobalState) => ({});
-
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  navigateToDetail: () => {
-    dispatch(cgnActivationCancel());
-    navigateToCgnDetails();
-  }
-});
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(CgnAlreadyActiveScreen);
+export default CgnAlreadyActiveScreen;

--- a/ts/features/bonus/cgn/screens/activation/CgnAlreadyActiveScreen.tsx
+++ b/ts/features/bonus/cgn/screens/activation/CgnAlreadyActiveScreen.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useEffect } from "react";
 import { connect } from "react-redux";
 import { SafeAreaView } from "react-native";
 import { GlobalState } from "../../../../../store/reducers/types";
@@ -12,30 +13,68 @@ import { cgnActivationCancel } from "../../store/actions/activation";
 import image from "../../../../../../img/messages/empty-due-date-list-icon.png";
 import I18n from "../../../../../i18n";
 import { navigateToCgnDetails } from "../../navigation/actions";
-
-type Props = ReturnType<typeof mapStateToProps> &
-  ReturnType<typeof mapDispatchToProps>;
+import { useIODispatch, useIOSelector } from "../../../../../store/hooks";
+import { isCgnDetailsLoading, isCgnEnrolledSelector } from "../../store/reducers/details";
+import { cgnDetails } from "../../store/actions/details";
+import ActivityIndicator from "../../../../../components/ui/ActivityIndicator";
 
 /**
  * Screen which is displayed when a user requested a CGN activation
  * but it is yet active
  */
-const CgnAlreadyActiveScreen = (props: Props): React.ReactElement => (
-  <SafeAreaView style={IOStyles.flex}>
-    <InfoScreenComponent
-      image={renderInfoRasterImage(image)}
-      title={I18n.t("bonus.cgn.activation.alreadyActive.title")}
-      body={I18n.t("bonus.cgn.activation.alreadyActive.body")}
-    />
-    <FooterWithButtons
-      type="SingleButton"
-      leftButton={confirmButtonProps(
-        props.navigateToDetail,
-        I18n.t("bonus.cgn.cta.goToDetail")
-      )}
-    />
-  </SafeAreaView>
-);
+const CgnAlreadyActiveScreen = (): React.ReactElement => {
+  const dispatch = useIODispatch();
+  const navigateToDetail = () => {
+    dispatch(cgnActivationCancel());
+    navigateToCgnDetails();
+  };
+  useEffect(() => {
+    dispatch(cgnDetails.request());
+  }, []);
+
+  const isCgnEnrolled = useIOSelector(isCgnEnrolledSelector);
+  const isCGNloading = useIOSelector(isCgnDetailsLoading);
+
+  if (isCGNloading) {
+    return <ActivityIndicator />;
+  }
+  if (isCgnEnrolled) {
+    return (
+      <SafeAreaView style={IOStyles.flex}>
+        <InfoScreenComponent
+          image={renderInfoRasterImage(image)}
+          title={I18n.t("bonus.cgn.activation.alreadyActive.title")}
+          body={I18n.t("bonus.cgn.activation.alreadyActive.body")}
+        />
+        <FooterWithButtons
+          type="SingleButton"
+          leftButton={confirmButtonProps(
+            navigateToDetail,
+            I18n.t("bonus.cgn.cta.goToDetail")
+          )}
+        />
+      </SafeAreaView>
+    );
+  }
+  return (
+    <SafeAreaView style={IOStyles.flex}>
+      <InfoScreenComponent
+        image={renderInfoRasterImage(image)}
+        title={
+          "Non è possibile attivare la CGN perché in uno stato inconsistente"
+        }
+        body={I18n.t("bonus.cgn.activation.error.body")}
+      />
+      <FooterWithButtons
+        type="SingleButton"
+        leftButton={confirmButtonProps(
+          () => dispatch(cgnActivationCancel()),
+          I18n.t("global.buttons.exit")
+        )}
+      />
+    </SafeAreaView>
+  );
+};
 
 const mapStateToProps = (_: GlobalState) => ({});
 


### PR DESCRIPTION
## Short description
This PR handles a special case that would cause ambiguity through activation of a new CGN card.

This may happen mainly if a user asks to unsubscribe from CGN and then request for a new card. If the card is still in a **PENDING_DELETE** state the activation would respond with a status **409** (Cannot activate the user's cgn because another updateCgn request was found for this user or it is already active.)

In this case we need to check for the real CGN status in order to display the correct information: 
- Already active -> go to detail
- Inconsistent status -> please try again later

## How to test
Change io-dev-api-server CGN apis as listed:
- `POST /activation` -> `res.sendStatus(409)`
- `GET /status` -> ` res.status(200).json({
    status: "PENDING_DELETE",
    activation_date: new Date(firstCgnActivationRequestTime),
    expiration_date: faker.date.future()
  });`

Than start the CGN activation flow.