### PR TITLE
chore: [IAI-110] Upgrade macOS resources on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ defaults_macos: &defaults_macos
   <<: *defaults
   macos:
     xcode: "12.5.1"
+  resource_class: macos.x86.medium.gen2
   working_directory: /Users/distiller/italia-app
   environment:
     # Fastlane requires locale set to UTF-8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,9 +493,9 @@ workflows:
       - run-e2e-test-IOS:
           requires:
             - compile-typescript
-#          filters:
-#            branches:
-#              only: master
+          filters:
+            branches:
+              only: master
 
   # Release workflow triggered only when a new release tag is pushed
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,9 +493,9 @@ workflows:
       - run-e2e-test-IOS:
           requires:
             - compile-typescript
-          filters:
-            branches:
-              only: master
+#          filters:
+#            branches:
+#              only: master
 
   # Release workflow triggered only when a new release tag is pushed
   release:


### PR DESCRIPTION
## Short description
This pr changes the resource class for macOS to `macos.x86.medium.gen2` in order to reduce the build time. For more information see https://discuss.circleci.com/t/coming-soon-gen2-macos-resources/41886 

`run-e2e-test-IOS`:

Before            |  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/26501317/150375941-7a0ef582-f3de-41b4-a8d7-9eb563f70430.png" width="400">|  <img src="https://user-images.githubusercontent.com/26501317/150375986-75714aa8-f435-4888-8df1-1562f4437ef2.png" width="400">

## List of changes proposed in this pull request
- Changed resource class for macos to `macos.x86.medium.gen2`
