### PR TITLE
chore: [IA-639] Test epic icon

### DIFF
--- a/scripts/ts/common/ticket/types.ts
+++ b/scripts/ts/common/ticket/types.ts
@@ -2,7 +2,7 @@ import { jiraTicketBaseUrl } from "./jira";
 import { JiraIssueType, RemoteJiraTicket } from "./jira/types";
 import { PivotalStory, PivotalStoryType } from "./pivotal/types";
 
-export type GenericTicketType = "feat" | "fix" | "chore";
+export type GenericTicketType = "feat" | "fix" | "chore" | "epic";
 
 /**
  * A generic representation of a ticket, platform independent
@@ -32,7 +32,7 @@ const convertJiraTypeToGeneric = (
     case "Bug":
       return "fix";
     case "Epic":
-      return "feat";
+      return "epic";
     case "Sub-task":
     case "Sottotask":
       return "chore";

--- a/scripts/ts/danger/commentPrWithTicketsInfo.ts
+++ b/scripts/ts/danger/commentPrWithTicketsInfo.ts
@@ -1,11 +1,8 @@
-import { DangerDSLType } from "danger/distribution/dsl/DangerDSL";
 import { isLeft, isRight } from "fp-ts/lib/Either";
 import { Errors } from "io-ts";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 import { GenericTicket, GenericTicketType } from "../common/ticket/types";
 import { GenericTicketRetrievalResults } from "./utils/titleParser";
-
-declare const danger: DangerDSLType;
 
 export declare function warn(message: string): void;
 export declare function markdown(message: string): void;
@@ -13,7 +10,8 @@ export declare function markdown(message: string): void;
 const StoryEmoji: Record<GenericTicketType, string> = {
   feat: "🌟",
   fix: "🐞",
-  chore: "⚙️"
+  chore: "⚙️",
+  epic: "⚡"
 };
 
 /**
@@ -51,7 +49,6 @@ const renderTickets = (ticketList: ReadonlyArray<GenericTicket>) => {
       return `  * ${renderTicket(s)}${subtask}`;
     })
     .join("\n");
-
   markdown(`
 ## Affected stories
 ${ticketListToString}\n`);

--- a/scripts/ts/danger/commentPrWithTicketsInfo.ts
+++ b/scripts/ts/danger/commentPrWithTicketsInfo.ts
@@ -1,8 +1,11 @@
+import { DangerDSLType } from "danger/distribution/dsl/DangerDSL";
 import { isLeft, isRight } from "fp-ts/lib/Either";
 import { Errors } from "io-ts";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 import { GenericTicket, GenericTicketType } from "../common/ticket/types";
 import { GenericTicketRetrievalResults } from "./utils/titleParser";
+
+declare const danger: DangerDSLType;
 
 export declare function warn(message: string): void;
 export declare function markdown(message: string): void;

--- a/scripts/ts/danger/utils/changelog.ts
+++ b/scripts/ts/danger/utils/changelog.ts
@@ -7,10 +7,12 @@ import { GenericTicket, GenericTicketType } from "../../common/ticket/types";
 const storyTag = new Map<GenericTicketType, string>([
   ["feat", "feat"],
   ["fix", "fix"],
-  ["chore", "chore"]
+  ["chore", "chore"],
+  ["epic", "epic"]
 ]);
 
 const storyOrder = new Map<GenericTicketType, number>([
+  ["epic", 3],
   ["feat", 2],
   ["fix", 1],
   ["chore", 0]

--- a/scripts/ts/danger/utils/changelog.ts
+++ b/scripts/ts/danger/utils/changelog.ts
@@ -8,7 +8,7 @@ const storyTag = new Map<GenericTicketType, string>([
   ["feat", "feat"],
   ["fix", "fix"],
   ["chore", "chore"],
-  ["epic", "epic"]
+  ["epic", "feat"]
 ]);
 
 const storyOrder = new Map<GenericTicketType, number>([


### PR DESCRIPTION
## Short description
This PR adds the `epic` case handling.
ATM a task of an epic is reported as follows

<img width="462" alt="Schermata 2022-01-21 alle 11 16 29" src="https://user-images.githubusercontent.com/822471/150509679-c73a46f8-4925-4b2e-bde6-9b448cf43802.png">

With these changes, this is the new report
<img width="728" alt="Schermata 2022-01-21 alle 11 16 59" src="https://user-images.githubusercontent.com/822471/150509787-bc3f1a05-733d-4876-aa06-75a0d5cba3ea.png">

Note: this task is intentionally child of an epic just for tests purposes
