### PR TITLE
chore(Messaggi a valore legale): [IAMVL-26] Persist attachments preferences for MVL

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -302,6 +302,8 @@ profile:
     title: Profile
     logout: Logout/Exit
     forgetCurrentSession: Forget current session
+    clearAsyncStorage: Clear AsyncStorage
+    dumpAsyncStorage: Dump AsyncStorage content to console
     contextualHelpTitle: What you can do in your Profile
     contextualHelpContent: !include profile/profile_account_main.md
     developerModeOn: Developer mode enabled

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -302,6 +302,8 @@ profile:
     title: Profilo
     logout: Logout/Esci
     forgetCurrentSession: Dimentica sessione corrente
+    clearAsyncStorage: Cancella contenuto di AsyncStorage
+    dumpAsyncStorage: Scarica contenuto di AsyncStorage
     contextualHelpTitle: Cosa puoi fare nel tuo Profilo
     contextualHelpContent: !include profile/profile_account_main.md
     developerModeOn: Modalità sviluppatore attivata

--- a/ts/boot/__tests__/__snapshots__/persistedStore.test.ts.snap
+++ b/ts/boot/__tests__/__snapshots__/persistedStore.test.ts.snap
@@ -83,6 +83,15 @@ Object {
 }
 `;
 
+exports[`Check the addition for new fields to the persisted store. If one of this test fails, check that exists the migration before updating the snapshot! Freeze 'features.mvl' state 1`] = `
+Object {
+  "byId": Object {},
+  "preferences": Object {
+    "showAlertForAttachments": true,
+  },
+}
+`;
+
 exports[`Check the addition for new fields to the persisted store. If one of this test fails, check that exists the migration before updating the snapshot! Freeze 'identification' state 1`] = `
 Object {
   "fail": undefined,

--- a/ts/boot/__tests__/persistedStore.test.ts
+++ b/ts/boot/__tests__/persistedStore.test.ts
@@ -54,4 +54,7 @@ describe("Check the addition for new fields to the persisted store. If one of th
   it("Freeze 'wallet.wallets.walletById' state", () => {
     expect(globalState.wallet.wallets.walletById).toMatchSnapshot();
   });
+  it("Freeze 'features.mvl' state", () => {
+    expect(globalState.features.mvl).toMatchSnapshot();
+  });
 });

--- a/ts/boot/configureStoreAndPersistor.ts
+++ b/ts/boot/configureStoreAndPersistor.ts
@@ -309,8 +309,7 @@ const rootPersistConfig: PersistConfig = {
   ],
   // Transform functions used to manipulate state on store/rehydrate
   // TODO: add optionTransform https://www.pivotaltracker.com/story/show/170998374
-  transforms: [DateISO8601Transform, PotTransform],
-  debug: true
+  transforms: [DateISO8601Transform, PotTransform]
 };
 
 const persistedReducer: Reducer<PersistedGlobalState, Action> = persistReducer<
@@ -376,10 +375,10 @@ function configureStoreAndPersistor(): { store: Store; persistor: Persistor } {
   >(persistedReducer, enhancer);
   const persistor = persistStore(store);
 
-  // if (isDebuggingInChrome) {
-  // eslint-disable-next-line
-  (window as any).store = store;
-  // }
+  if (isDebuggingInChrome) {
+    // eslint-disable-next-line
+    (window as any).store = store;
+  }
 
   // Run the main saga
   sagaMiddleware.run(rootSaga);

--- a/ts/boot/configureStoreAndPersistor.ts
+++ b/ts/boot/configureStoreAndPersistor.ts
@@ -43,7 +43,7 @@ import { configureReactotron } from "./configureRectotron";
 /**
  * Redux persist will migrate the store to the current version
  */
-const CURRENT_REDUX_STORE_VERSION = 18;
+const CURRENT_REDUX_STORE_VERSION = 19;
 
 // see redux-persist documentation:
 // https://github.com/rt2zz/redux-persist/blob/master/docs/migrations.md
@@ -271,7 +271,17 @@ const migrations: MigrationManifest = {
         ..._.omit(content, "servicesMetadata")
       }
     };
-  }
+  },
+  // Version 19
+  // add features.MVL section with default preferences
+  "19": (state: PersistedState) => ({
+    ...state,
+    features: {
+      mvl: {
+        preferences: { showAlertForAttachments: true }
+      }
+    }
+  })
 };
 
 const isDebuggingInChrome = isDevEnv && !!window.navigator.userAgent;
@@ -281,8 +291,9 @@ const rootPersistConfig: PersistConfig = {
   storage: AsyncStorage,
   version: CURRENT_REDUX_STORE_VERSION,
   migrate: createMigrate(migrations, { debug: isDevEnv }),
-  // entities implement a persist reduce that avoids to persist messages. Other entities section will be persisted
-  blacklist: ["entities"],
+  // Entities and features implement a persisted reduce that avoids persisting messages.
+  // Other entities section will be persisted
+  blacklist: ["entities", "features"],
   // Sections of the store that must be persisted and rehydrated with this storage.
   whitelist: [
     "onboarding",
@@ -298,7 +309,8 @@ const rootPersistConfig: PersistConfig = {
   ],
   // Transform functions used to manipulate state on store/rehydrate
   // TODO: add optionTransform https://www.pivotaltracker.com/story/show/170998374
-  transforms: [DateISO8601Transform, PotTransform]
+  transforms: [DateISO8601Transform, PotTransform],
+  debug: true
 };
 
 const persistedReducer: Reducer<PersistedGlobalState, Action> = persistReducer<
@@ -364,10 +376,10 @@ function configureStoreAndPersistor(): { store: Store; persistor: Persistor } {
   >(persistedReducer, enhancer);
   const persistor = persistStore(store);
 
-  if (isDebuggingInChrome) {
-    // eslint-disable-next-line
-    (window as any).store = store;
-  }
+  // if (isDebuggingInChrome) {
+  // eslint-disable-next-line
+  (window as any).store = store;
+  // }
 
   // Run the main saga
   sagaMiddleware.run(rootSaga);

--- a/ts/features/common/store/reducers/index.ts
+++ b/ts/features/common/store/reducers/index.ts
@@ -1,17 +1,37 @@
 import { combineReducers } from "redux";
+import { PersistConfig, PersistPartial, persistReducer } from "redux-persist";
+import AsyncStorage from "@react-native-community/async-storage";
+
 import { Action } from "../../../../store/actions/types";
 import {
   euCovidCertReducer,
   EuCovidCertState
 } from "../../../euCovidCert/store/reducers";
-import { mvlReducer, MvlState } from "../../../mvl/store/reducers";
+import { mvlPersistor, PersistedMvlState } from "../../../mvl";
 
 export type FeaturesState = {
   euCovidCert: EuCovidCertState;
-  mvl: MvlState;
+  mvl: PersistedMvlState;
 };
 
-export const featuresReducer = combineReducers<FeaturesState, Action>({
+export type PersistedFeaturesState = FeaturesState & PersistPartial;
+
+const rootReducer = combineReducers<FeaturesState, Action>({
   euCovidCert: euCovidCertReducer,
-  mvl: mvlReducer
+  mvl: mvlPersistor
 });
+
+const CURRENT_REDUX_FEATURES_STORE_VERSION = 1;
+
+const persistConfig: PersistConfig = {
+  key: "features",
+  storage: AsyncStorage,
+  version: CURRENT_REDUX_FEATURES_STORE_VERSION,
+  // we let each vertical manage its own lists by banning everything else
+  whitelist: []
+};
+
+export const featuresPersistor = persistReducer<FeaturesState, Action>(
+  persistConfig,
+  rootReducer
+);

--- a/ts/features/mvl/index.ts
+++ b/ts/features/mvl/index.ts
@@ -1,0 +1,20 @@
+import AsyncStorage from "@react-native-community/async-storage";
+import { PersistConfig, PersistPartial, persistReducer } from "redux-persist";
+import { Action } from "../../store/actions/types";
+import { MvlState, mvlReducer as rootReducer } from "./store/reducers";
+
+const CURRENT_REDUX_MVL_STORE_VERSION = 1;
+
+export type PersistedMvlState = MvlState & PersistPartial;
+
+const persistConfig: PersistConfig = {
+  key: "mvl",
+  storage: AsyncStorage,
+  version: CURRENT_REDUX_MVL_STORE_VERSION,
+  whitelist: ["preferences"]
+};
+
+export const mvlPersistor = persistReducer<MvlState, Action>(
+  persistConfig,
+  rootReducer
+);

--- a/ts/features/mvl/screens/details/components/attachment/DownloadAttachmentConfirmationBottomSheet.tsx
+++ b/ts/features/mvl/screens/details/components/attachment/DownloadAttachmentConfirmationBottomSheet.tsx
@@ -1,14 +1,12 @@
 import { View } from "native-base";
-import * as React from "react";
-import { useState } from "react";
+import React, { useState } from "react";
 import { BottomSheetContent } from "../../../../../../components/bottomSheet/BottomSheetContent";
 import { RawCheckBox } from "../../../../../../components/core/selection/checkbox/RawCheckBox";
 import { Body } from "../../../../../../components/core/typography/Body";
 import { IOStyles } from "../../../../../../components/core/variables/IOStyles";
 import FooterWithButtons from "../../../../../../components/ui/FooterWithButtons";
 import i18n from "../../../../../../i18n";
-import { useIOSelector } from "../../../../../../store/hooks";
-import { ioBackendAuthenticationHeaderSelector } from "../../../../../../store/reducers/authentication";
+import { useIODispatch } from "../../../../../../store/hooks";
 import { useIOBottomSheetRaw } from "../../../../../../utils/bottomSheet";
 import {
   cancelButtonProps,
@@ -16,18 +14,30 @@ import {
 } from "../../../../../bonus/bonusVacanze/components/buttons/ButtonConfigurations";
 import { MvlAttachment } from "../../../../types/mvlData";
 import { handleDownloadResult } from "../../../../utils";
+import { mvlPreferencesSetWarningForAttachments } from "../../../../store/actions";
 
 type Props = {
   attachment: MvlAttachment;
-  onConfirm: () => void;
+
+  /**
+   * Initial configuration for user preferences
+   */
+  initialPreferences: { dontAskAgain: boolean };
+
+  /**
+   *  Called on right-button press with the user's selected preferences (see also {@link initialPreferences})
+   */
+  onConfirm: (preferences: { dontAskAgain: boolean }) => void;
+
   onCancel: () => void;
 };
 
 const DownloadAttachmentConfirmationBottomSheet = (
   props: Props
 ): React.ReactElement => {
-  // TODO: the preference should be serialized in the store if true when the user tap on the confirm button https://pagopa.atlassian.net/browse/IAMVL-26
-  const [dontAskAgain, setDontAskAgain] = useState<boolean>(false);
+  const [dontAskAgain, setDontAskAgain] = useState<boolean>(
+    props.initialPreferences.dontAskAgain
+  );
 
   return (
     <BottomSheetContent
@@ -41,7 +51,7 @@ const DownloadAttachmentConfirmationBottomSheet = (
           // TODO: start the download & save on device https://pagopa.atlassian.net/browse/IAMVL-27
           rightButton={{
             ...confirmButtonProps(
-              props.onConfirm,
+              () => props.onConfirm({ dontAskAgain }),
               i18n.t("global.buttons.continue")
             ),
             onPressWithGestureHandler: true
@@ -73,21 +83,24 @@ const DownloadAttachmentConfirmationBottomSheet = (
 };
 
 export const useDownloadAttachmentConfirmationBottomSheet = (
-  attachment: MvlAttachment
+  attachment: MvlAttachment,
+  authHeader: { [key: string]: string },
+  initialPreferences: { dontAskAgain: boolean }
 ) => {
   const { present, dismiss } = useIOBottomSheetRaw(375);
-
-  const authHeader = useIOSelector(ioBackendAuthenticationHeaderSelector);
+  const dispatch = useIODispatch();
 
   const openModalBox = () =>
     present(
       <DownloadAttachmentConfirmationBottomSheet
         attachment={attachment}
         onCancel={dismiss}
-        onConfirm={() => {
+        onConfirm={({ dontAskAgain }) => {
+          dispatch(mvlPreferencesSetWarningForAttachments(!dontAskAgain));
           void handleDownloadResult(attachment, authHeader);
           dismiss();
         }}
+        initialPreferences={initialPreferences}
       />,
       i18n.t("features.mvl.details.attachments.bottomSheet.title")
     );

--- a/ts/features/mvl/screens/details/components/attachment/__test__/MvlAttachments.test.tsx
+++ b/ts/features/mvl/screens/details/components/attachment/__test__/MvlAttachments.test.tsx
@@ -24,12 +24,6 @@ jest.mock("@gorhom/bottom-sheet", () => ({
   })
 }));
 
-// jeslint-disable-next-line functional/no-let
-// let mockHandleDownloadResult = jest.fn();
-// jest.mock("../../../../../utils", () => ({
-//   handleDownloadResult: (...args) =>
-// }));
-
 const spy_handleDownloadResult = jest.spyOn(
   utilsModule,
   "handleDownloadResult"
@@ -37,10 +31,6 @@ const spy_handleDownloadResult = jest.spyOn(
 
 describe("MvlAttachments", () => {
   jest.useFakeTimers();
-
-  // beforeEach(() => {
-  //   spy_handleDownloadResult.mockReset()
-  // })
 
   describe("When there are no attachments", () => {
     it("Shouldn't be rendered", () => {

--- a/ts/features/mvl/screens/details/components/attachment/__test__/MvlAttachments.test.tsx
+++ b/ts/features/mvl/screens/details/components/attachment/__test__/MvlAttachments.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { NavigationParams } from "react-navigation";
 import { createStore } from "redux";
+import { fireEvent } from "@testing-library/react-native";
 import I18n from "../../../../../../../i18n";
 import { applicationChangeState } from "../../../../../../../store/actions/application";
 import { appReducer } from "../../../../../../../store/reducers";
@@ -12,16 +13,34 @@ import {
   mvlMockOtherAttachment,
   mvlMockPdfAttachment
 } from "../../../../../types/__mock__/mvlMock";
+import { MvlPreferences } from "../../../../../store/reducers/preferences";
+import * as utilsModule from "../../../../../utils";
 import { MvlAttachments } from "../MvlAttachments";
 
+const mockBottomSheetPresent = jest.fn();
 jest.mock("@gorhom/bottom-sheet", () => ({
   useBottomSheetModal: () => ({
-    present: jest.fn()
+    present: () => mockBottomSheetPresent
   })
 }));
 
+// jeslint-disable-next-line functional/no-let
+// let mockHandleDownloadResult = jest.fn();
+// jest.mock("../../../../../utils", () => ({
+//   handleDownloadResult: (...args) =>
+// }));
+
+const spy_handleDownloadResult = jest.spyOn(
+  utilsModule,
+  "handleDownloadResult"
+);
+
 describe("MvlAttachments", () => {
   jest.useFakeTimers();
+
+  // beforeEach(() => {
+  //   spy_handleDownloadResult.mockReset()
+  // })
 
   describe("When there are no attachments", () => {
     it("Shouldn't be rendered", () => {
@@ -33,7 +52,7 @@ describe("MvlAttachments", () => {
     });
   });
 
-  describe("When there are at least one attachment", () => {
+  describe("When there is at least one attachment", () => {
     describe("And there are a pdf and another file as attachments", () => {
       it("Should render the title", () => {
         const res = renderComponent({
@@ -67,14 +86,66 @@ describe("MvlAttachments", () => {
         }
       });
     });
+
+    describe("Given the preference `showAlertForAttachments: true`", () => {
+      const preferences: MvlPreferences = { showAlertForAttachments: true };
+      describe("And the user taps on the attachment", () => {
+        const props = { attachments: [mvlMockPdfAttachment] };
+        it("Should open the bottom sheet", async () => {
+          const { getByText } = renderComponent(props, preferences);
+          const item = getByText(mvlMockPdfAttachment.displayName);
+          await fireEvent(item, "onPress");
+          expect(mockBottomSheetPresent).not.toHaveBeenCalled();
+        });
+
+        it("Should not call `handleDownloadResult`", async () => {
+          // mockHandleDownloadResult = jest.fn();
+          const { getByText } = renderComponent(props, preferences);
+          const item = getByText(mvlMockPdfAttachment.displayName);
+          await fireEvent(item, "onPress");
+          expect(spy_handleDownloadResult).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe("Given the preference `showAlertForAttachments: false`", () => {
+      const preferences: MvlPreferences = { showAlertForAttachments: false };
+      describe("And the user taps on the attachment", () => {
+        const props = { attachments: [mvlMockPdfAttachment] };
+        it("Should not open the bottom sheet", async () => {
+          const { getByText } = renderComponent(props, preferences);
+          const item = getByText(mvlMockPdfAttachment.displayName);
+          await fireEvent(item, "onPress");
+          expect(mockBottomSheetPresent).not.toHaveBeenCalled();
+        });
+        it("Should call `handleDownloadResult`", async () => {
+          // mockHandleDownloadResult = jest.fn();
+          const { getByText } = renderComponent(props, preferences);
+          const item = getByText(mvlMockPdfAttachment.displayName);
+          await fireEvent(item, "onPress");
+          expect(spy_handleDownloadResult).toHaveBeenNthCalledWith(
+            1,
+            mvlMockPdfAttachment,
+            { Authorization: "Bearer undefined" }
+          );
+        });
+      });
+    });
   });
 });
 
 const renderComponent = (
-  props: React.ComponentProps<typeof MvlAttachments>
+  props: React.ComponentProps<typeof MvlAttachments>,
+  mvlPreferences: MvlPreferences = { showAlertForAttachments: true }
 ) => {
   const globalState = appReducer(undefined, applicationChangeState("active"));
-  const store = createStore(appReducer, globalState as any);
+  const store = createStore(appReducer, {
+    ...globalState,
+    features: {
+      ...globalState.features,
+      mvl: { ...globalState.features.mvl, preferences: mvlPreferences }
+    }
+  } as any);
   return renderScreenFakeNavRedux<GlobalState, NavigationParams>(
     () => <MvlAttachments {...props} />,
     MVL_ROUTES.DETAILS,

--- a/ts/features/mvl/screens/details/components/attachment/__test__/MvlAttachments.test.tsx
+++ b/ts/features/mvl/screens/details/components/attachment/__test__/MvlAttachments.test.tsx
@@ -20,7 +20,7 @@ import { MvlAttachments } from "../MvlAttachments";
 const mockBottomSheetPresent = jest.fn();
 jest.mock("@gorhom/bottom-sheet", () => ({
   useBottomSheetModal: () => ({
-    present: () => mockBottomSheetPresent
+    present: () => mockBottomSheetPresent()
   })
 }));
 
@@ -31,6 +31,10 @@ const spy_handleDownloadResult = jest.spyOn(
 
 describe("MvlAttachments", () => {
   jest.useFakeTimers();
+
+  beforeEach(() => {
+    mockBottomSheetPresent.mockReset();
+  });
 
   describe("When there are no attachments", () => {
     it("Shouldn't be rendered", () => {
@@ -85,11 +89,10 @@ describe("MvlAttachments", () => {
           const { getByText } = renderComponent(props, preferences);
           const item = getByText(mvlMockPdfAttachment.displayName);
           await fireEvent(item, "onPress");
-          expect(mockBottomSheetPresent).not.toHaveBeenCalled();
+          expect(mockBottomSheetPresent).toHaveBeenCalled();
         });
 
         it("Should not call `handleDownloadResult`", async () => {
-          // mockHandleDownloadResult = jest.fn();
           const { getByText } = renderComponent(props, preferences);
           const item = getByText(mvlMockPdfAttachment.displayName);
           await fireEvent(item, "onPress");
@@ -109,7 +112,6 @@ describe("MvlAttachments", () => {
           expect(mockBottomSheetPresent).not.toHaveBeenCalled();
         });
         it("Should call `handleDownloadResult`", async () => {
-          // mockHandleDownloadResult = jest.fn();
           const { getByText } = renderComponent(props, preferences);
           const item = getByText(mvlMockPdfAttachment.displayName);
           await fireEvent(item, "onPress");

--- a/ts/features/mvl/store/actions/index.ts
+++ b/ts/features/mvl/store/actions/index.ts
@@ -1,4 +1,8 @@
-import { ActionType, createAsyncAction } from "typesafe-actions";
+import {
+  ActionType,
+  createAsyncAction,
+  createStandardAction
+} from "typesafe-actions";
 import {
   UIMessageId,
   WithUIMessageId
@@ -15,4 +19,10 @@ export const mvlDetailsLoad = createAsyncAction(
   "MVL_DETAILS_FAILURE"
 )<UIMessageId, Mvl, WithUIMessageId<NetworkError>>();
 
-export type MvlActions = ActionType<typeof mvlDetailsLoad>;
+export const mvlPreferencesDontAskForAttachments = createStandardAction(
+  "MVL_PREFERENCES_DONT_ASK_FOR_ATTACHMENTS"
+)();
+
+export type MvlActions = ActionType<
+  typeof mvlDetailsLoad | typeof mvlPreferencesDontAskForAttachments
+>;

--- a/ts/features/mvl/store/actions/index.ts
+++ b/ts/features/mvl/store/actions/index.ts
@@ -19,10 +19,10 @@ export const mvlDetailsLoad = createAsyncAction(
   "MVL_DETAILS_FAILURE"
 )<UIMessageId, Mvl, WithUIMessageId<NetworkError>>();
 
-export const mvlPreferencesDontAskForAttachments = createStandardAction(
-  "MVL_PREFERENCES_DONT_ASK_FOR_ATTACHMENTS"
-)();
+export const mvlPreferencesSetWarningForAttachments = createStandardAction(
+  "MVL_PREFERENCES_SET_WARNING_FOR_ATTACHMENTS"
+)<boolean>();
 
 export type MvlActions = ActionType<
-  typeof mvlDetailsLoad | typeof mvlPreferencesDontAskForAttachments
+  typeof mvlDetailsLoad | typeof mvlPreferencesSetWarningForAttachments
 >;

--- a/ts/features/mvl/store/actions/index.ts
+++ b/ts/features/mvl/store/actions/index.ts
@@ -19,6 +19,10 @@ export const mvlDetailsLoad = createAsyncAction(
   "MVL_DETAILS_FAILURE"
 )<UIMessageId, Mvl, WithUIMessageId<NetworkError>>();
 
+/**
+ * Set whether to show a warning message about security when opening attachments.
+ * The preference will be persisted.
+ */
 export const mvlPreferencesSetWarningForAttachments = createStandardAction(
   "MVL_PREFERENCES_SET_WARNING_FOR_ATTACHMENTS"
 )<boolean>();

--- a/ts/features/mvl/store/reducers/__test__/preferences.test.ts
+++ b/ts/features/mvl/store/reducers/__test__/preferences.test.ts
@@ -1,18 +1,31 @@
 import { getType } from "typesafe-actions";
-import { mvlPreferencesDontAskForAttachments } from "../../actions";
+import { mvlPreferencesSetWarningForAttachments } from "../../actions";
 import { initialState, mvlPreferencesReducer } from "../preferences";
 
 describe("the `mvlPreferencesReducer`", () => {
   describe(`when ${getType(
-    mvlPreferencesDontAskForAttachments
+    mvlPreferencesSetWarningForAttachments
   )} is received`, () => {
-    it("should set `showAlertForAttachments` to false", () => {
-      expect(
-        mvlPreferencesReducer(
-          initialState,
-          mvlPreferencesDontAskForAttachments()
-        )
-      ).toEqual({ ...initialState, showAlertForAttachments: false });
+    describe("with payload `false`", () => {
+      it("should set `showAlertForAttachments` to false", () => {
+        expect(
+          mvlPreferencesReducer(
+            { ...initialState, showAlertForAttachments: true },
+            mvlPreferencesSetWarningForAttachments(false)
+          )
+        ).toEqual({ ...initialState, showAlertForAttachments: false });
+      });
+    });
+
+    describe("with payload `true`", () => {
+      it("should set `showAlertForAttachments` to true", () => {
+        expect(
+          mvlPreferencesReducer(
+            { ...initialState, showAlertForAttachments: false },
+            mvlPreferencesSetWarningForAttachments(true)
+          )
+        ).toEqual({ ...initialState, showAlertForAttachments: true });
+      });
     });
   });
 });

--- a/ts/features/mvl/store/reducers/__test__/preferences.test.ts
+++ b/ts/features/mvl/store/reducers/__test__/preferences.test.ts
@@ -1,0 +1,18 @@
+import { getType } from "typesafe-actions";
+import { mvlPreferencesDontAskForAttachments } from "../../actions";
+import { initialState, mvlPreferencesReducer } from "../preferences";
+
+describe("the `mvlPreferencesReducer`", () => {
+  describe(`when ${getType(
+    mvlPreferencesDontAskForAttachments
+  )} is received`, () => {
+    it("should set `showAlertForAttachments` to false", () => {
+      expect(
+        mvlPreferencesReducer(
+          initialState,
+          mvlPreferencesDontAskForAttachments()
+        )
+      ).toEqual({ ...initialState, showAlertForAttachments: false });
+    });
+  });
+});

--- a/ts/features/mvl/store/reducers/index.ts
+++ b/ts/features/mvl/store/reducers/index.ts
@@ -1,12 +1,16 @@
 import { combineReducers } from "redux";
 import { Action } from "../../../../store/actions/types";
 import { mvlByIdReducer, MvlByIdState } from "./byId";
+import { mvlPreferencesReducer, MvlPreferences } from "./preferences";
 
 export type MvlState = {
   byId: MvlByIdState;
+  preferences: MvlPreferences;
 };
 
 export const mvlReducer = combineReducers<MvlState, Action>({
   // save, using the MVLId as key, the pot.Pot<MVLData, Error> response
-  byId: mvlByIdReducer
+  byId: mvlByIdReducer,
+
+  preferences: mvlPreferencesReducer
 });

--- a/ts/features/mvl/store/reducers/preferences.ts
+++ b/ts/features/mvl/store/reducers/preferences.ts
@@ -1,0 +1,36 @@
+import { createSelector } from "reselect";
+import { getType } from "typesafe-actions";
+import { Action } from "../../../../store/actions/types";
+import { GlobalState } from "../../../../store/reducers/types";
+import { mvlPreferencesDontAskForAttachments } from "../actions";
+
+export type MvlPreferences = {
+  showAlertForAttachments: boolean;
+};
+
+export const initialState: MvlPreferences = { showAlertForAttachments: true };
+
+/**
+ * Store the preferences for MVL
+ * @param state
+ * @param action
+ */
+export const mvlPreferencesReducer = (
+  state: MvlPreferences = initialState,
+  action: Action
+): MvlPreferences => {
+  switch (action.type) {
+    case getType(mvlPreferencesDontAskForAttachments):
+      return { ...state, showAlertForAttachments: false };
+  }
+
+  return state;
+};
+
+/**
+ * From MVLId to Mvl
+ */
+export const mvlPreferencesSelector = createSelector(
+  [(state: GlobalState) => state.features.mvl.preferences],
+  (_): MvlPreferences => _
+);

--- a/ts/features/mvl/store/reducers/preferences.ts
+++ b/ts/features/mvl/store/reducers/preferences.ts
@@ -2,7 +2,7 @@ import { createSelector } from "reselect";
 import { getType } from "typesafe-actions";
 import { Action } from "../../../../store/actions/types";
 import { GlobalState } from "../../../../store/reducers/types";
-import { mvlPreferencesDontAskForAttachments } from "../actions";
+import { mvlPreferencesSetWarningForAttachments } from "../actions";
 
 export type MvlPreferences = {
   showAlertForAttachments: boolean;
@@ -20,8 +20,8 @@ export const mvlPreferencesReducer = (
   action: Action
 ): MvlPreferences => {
   switch (action.type) {
-    case getType(mvlPreferencesDontAskForAttachments):
-      return { ...state, showAlertForAttachments: false };
+    case getType(mvlPreferencesSetWarningForAttachments):
+      return { ...state, showAlertForAttachments: action.payload };
   }
 
   return state;

--- a/ts/screens/profile/ProfileMainScreen.tsx
+++ b/ts/screens/profile/ProfileMainScreen.tsx
@@ -9,6 +9,7 @@ import {
   NavigationState
 } from "react-navigation";
 import { connect } from "react-redux";
+import AsyncStorage from "@react-native-community/async-storage";
 import { TranslationKeys } from "../../../locales/locales";
 import ButtonDefaultOpacity from "../../components/ButtonDefaultOpacity";
 import ContextualInfo from "../../components/ContextualInfo";
@@ -408,6 +409,41 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
                 I18n.t("profile.main.forgetCurrentSession"),
                 dispatchSessionExpired,
                 true
+              )}
+            {isDevEnv &&
+              this.debugListItem(
+                I18n.t("profile.main.clearAsyncStorage"),
+                () => {
+                  AsyncStorage.clear()
+                    .then(() => console.log("Cleared"))
+                    .catch(e => console.error(e));
+                },
+                true
+              )}
+            {isDevEnv &&
+              this.debugListItem(
+                I18n.t("profile.main.dumpAsyncStorage"),
+                () => {
+                  // eslint-disable no-console
+                  console.log("[DUMP START]");
+                  AsyncStorage.getAllKeys()
+                    .then(keys => {
+                      console.log(`\tAvailable keys: ${keys.join(", ")}`);
+                      return Promise.all(
+                        keys.map(key =>
+                          AsyncStorage.getItem(key).then(value => {
+                            // if (/(features)|(euCovidCert)|(mvl)/.test(key)) {
+                            console.log(`\tValue for ${key}\n\t\t`, value);
+                            // }
+                          })
+                        )
+                      );
+                    })
+                    .then(() => console.log("[DUMP END]"))
+                    .catch(e => console.error(e));
+                  // eslint-enable no-console
+                },
+                false
               )}
           </React.Fragment>
         )}

--- a/ts/screens/profile/ProfileMainScreen.tsx
+++ b/ts/screens/profile/ProfileMainScreen.tsx
@@ -414,9 +414,7 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
               this.debugListItem(
                 I18n.t("profile.main.clearAsyncStorage"),
                 () => {
-                  AsyncStorage.clear()
-                    .then(() => console.log("Cleared"))
-                    .catch(e => console.error(e));
+                  void AsyncStorage.clear();
                 },
                 true
               )}
@@ -424,7 +422,7 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
               this.debugListItem(
                 I18n.t("profile.main.dumpAsyncStorage"),
                 () => {
-                  // eslint-disable no-console
+                  /* eslint-disable no-console */
                   console.log("[DUMP START]");
                   AsyncStorage.getAllKeys()
                     .then(keys => {
@@ -441,7 +439,7 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
                     })
                     .then(() => console.log("[DUMP END]"))
                     .catch(e => console.error(e));
-                  // eslint-enable no-console
+                  /* eslint-enable no-console */
                 },
                 false
               )}

--- a/ts/screens/profile/ProfileMainScreen.tsx
+++ b/ts/screens/profile/ProfileMainScreen.tsx
@@ -430,9 +430,7 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
                       return Promise.all(
                         keys.map(key =>
                           AsyncStorage.getItem(key).then(value => {
-                            // if (/(features)|(euCovidCert)|(mvl)/.test(key)) {
                             console.log(`\tValue for ${key}\n\t\t`, value);
-                            // }
                           })
                         )
                       );

--- a/ts/store/reducers/entities/index.ts
+++ b/ts/store/reducers/entities/index.ts
@@ -61,7 +61,7 @@ const migrations: MigrationManifest = {
     } as PersistedEntitiesState)
 };
 
-// A custom configuration to avoid to persist messages section
+// A custom configuration to avoid persisting messages section
 export const entitiesPersistConfig: PersistConfig = {
   key: "entities",
   storage: AsyncStorage,

--- a/ts/store/reducers/index.ts
+++ b/ts/store/reducers/index.ts
@@ -6,7 +6,7 @@ import { combineReducers, Reducer } from "redux";
 import { PersistConfig, persistReducer, purgeStoredState } from "redux-persist";
 import { isActionOf } from "typesafe-actions";
 import bonusReducer from "../../features/bonus/bonusVacanze/store/reducers";
-import { featuresReducer } from "../../features/common/store/reducers";
+import { featuresPersistor } from "../../features/common/store/reducers";
 import {
   logoutFailure,
   logoutSuccess,
@@ -99,7 +99,6 @@ export const appReducer: Reducer<GlobalState, Action> = combineReducers<
   search: searchReducer,
   cie: cieReducer,
   bonus: bonusReducer,
-  features: featuresReducer,
   internalRouteNavigation: internalRouteNavigationReducer,
   assistanceTools: assistanceToolsReducer,
   //
@@ -118,6 +117,7 @@ export const appReducer: Reducer<GlobalState, Action> = combineReducers<
     identificationPersistConfig,
     identificationReducer
   ),
+  features: featuresPersistor,
   onboarding: onboardingReducer,
   notifications: notificationsReducer,
   profile: profileReducer,

--- a/ts/store/reducers/types.ts
+++ b/ts/store/reducers/types.ts
@@ -1,7 +1,7 @@
 import { PersistPartial } from "redux-persist";
 
 import { BonusState } from "../../features/bonus/bonusVacanze/store/reducers";
-import { FeaturesState } from "../../features/common/store/reducers";
+import { PersistedFeaturesState } from "../../features/common/store/reducers";
 import { AppState } from "./appState";
 import { PersistedAuthenticationState } from "./authentication";
 import { BackendInfoState } from "./backendInfo";
@@ -58,7 +58,7 @@ export type GlobalState = Readonly<{
   emailValidation: EmailValidationState;
   cie: CieState;
   bonus: BonusState;
-  features: FeaturesState;
+  features: PersistedFeaturesState;
   internalRouteNavigation: InternalRouteNavigationState;
   crossSessions: CrossSessionsState;
   assistanceTools: AssistanceToolsState;


### PR DESCRIPTION
## Short description
Persist on the device the user's preferences for MVL. The only preference available to date is whether to show a warning for attachments or not.

## List of changes proposed in this pull request
- Update [DownloadAttachmentConfirmationBottomSheet](https://github.com/pagopa/io-app/pull/3681/files#diff-04d9d7c779eec6038ab9af0b57e77a474cfeda11a4052b29b668461fcecb04f3R35) to save the preference **once the user is done** and initialize them
- Update [MvlAttachments](https://github.com/pagopa/io-app/pull/3681/files#diff-2de5ec1ba6bf2598f6aa698a983c5aff6bc00042d3fba19c30ca411622beaffeR93) to sidestep the alert based on the preference
- Add tests for [MvlAttachments](https://github.com/pagopa/io-app/pull/3681/files#diff-4c3f5a56c849be98fa85cd976e88f1c5f275d8fe83d71bada54f4fd635abedc5R80) to ensure it honours the preferences
- Add [new reducer](ts/features/mvl/store/reducers/preferences.ts) for preferences and [tests](https://github.com/pagopa/io-app/pull/3681/files#diff-b496fc9a5a634def78118b0015b1388204dcefcf3b32a55c5e5bff49a3f098f5R5) 

### Dev-only updates
Added [two buttons](https://github.com/pagopa/io-app/pull/3681/files#diff-de3c1a64bcc8fdca4c8dbc5d62dba36c8c5ded27255052ecc6526e614b1e8f5bR413) under [ProfileMainScreen](ts/screens/profile/ProfileMainScreen.tsx) to **wipe the AsyncStorage** and **dump its content to console**.
The buttons are used in the video attached to test the new feature.

## How to test

The video (on Youtube due to its size) showcases the entire path:
1. fresh installation
2. open MVL
3. tap attachment
4. flag "don't ask again"
5. download attachment
6. close the app
7. open the app
8. open MVL
3. tap attachment
5. download attachment without warning

![demo](https://www.youtube.com/embed/H7fma4Y775c)
