### PR TITLE
feat: [IA-633] Allow back during SPID webview loading

### DIFF
--- a/ts/screens/authentication/IdpLoginScreen.tsx
+++ b/ts/screens/authentication/IdpLoginScreen.tsx
@@ -106,7 +106,8 @@ const styles = StyleSheet.create({
   },
   flex2: {
     flex: 2
-  }
+  },
+  webViewWrapper: { flex: 1 }
 });
 
 /**
@@ -319,7 +320,7 @@ class IdpLoginScreen extends React.Component<Props, State> {
         }`}
       >
         {!hasError && (
-          <View style={{ backgroundColor: "blue", flex: 1 }}>
+          <View style={styles.webViewWrapper}>
             <WebView
               androidCameraAccessDisabled={true}
               androidMicrophoneAccessDisabled={true}

--- a/ts/screens/authentication/IdpLoginScreen.tsx
+++ b/ts/screens/authentication/IdpLoginScreen.tsx
@@ -305,7 +305,7 @@ class IdpLoginScreen extends React.Component<Props, State> {
 
     if (!loggedOutWithIdpAuth) {
       // This condition will be true only temporarily (if the navigation occurs
-      // before the redux state is updated succesfully)
+      // before the redux state is updated successfully)
       return <LoadingSpinnerOverlay isLoading={true} />;
     }
     const loginUri = getIdpLoginUri(loggedOutWithIdpAuth.idp.id);
@@ -319,19 +319,21 @@ class IdpLoginScreen extends React.Component<Props, State> {
         }`}
       >
         {!hasError && (
-          <WebView
-            androidCameraAccessDisabled={true}
-            androidMicrophoneAccessDisabled={true}
-            textZoom={100}
-            originWhitelist={originSchemasWhiteList}
-            source={{ uri: loginUri }}
-            onError={this.handleLoadingError}
-            javaScriptEnabled={true}
-            onNavigationStateChange={this.handleNavigationStateChange}
-            onShouldStartLoadWithRequest={this.handleShouldStartLoading}
-          />
+          <View style={{ backgroundColor: "blue", flex: 1 }}>
+            <WebView
+              androidCameraAccessDisabled={true}
+              androidMicrophoneAccessDisabled={true}
+              textZoom={100}
+              originWhitelist={originSchemasWhiteList}
+              source={{ uri: loginUri }}
+              onError={this.handleLoadingError}
+              javaScriptEnabled={true}
+              onNavigationStateChange={this.handleNavigationStateChange}
+              onShouldStartLoadWithRequest={this.handleShouldStartLoading}
+            />
+            {this.renderMask()}
+          </View>
         )}
-        {this.renderMask()}
       </BaseScreenComponent>
     );
   }


### PR DESCRIPTION
## Short description
This PR changes the loading layout to avoid it fills the entire screen. With these changes the header is touchable so the user can go back. In Android the back hardware works as usual.

### before
https://user-images.githubusercontent.com/822471/150543308-8bc5d5b0-87d5-4478-8a30-6f0b6fc80301.mov

### after
https://user-images.githubusercontent.com/822471/150543341-b9796a18-9b4f-42b3-9e8a-d24f58d41824.mov

## List of changes proposed in this pull request
- `IdpLoginScreen.tsx` now the loading layout is not full screen 

## How to test
- [add some delay](https://github.com/pagopa/io-dev-api-server/blob/35496a6690965872263fff8b23a61a587e7a88d2/src/config.ts#L55) to the dev server to reproduce a certain loading
