### PR TITLE
[IAMVL-63] Use message ID to retrieve the attachment

### DIFF
--- a/ts/features/mvl/saga/networking/handleGetMvlDetails.ts
+++ b/ts/features/mvl/saga/networking/handleGetMvlDetails.ts
@@ -27,11 +27,11 @@ const generateAttachmentUrl = (
 /**
  * convert the remote legal message attachment into the relative local domain model
  * @param attachment
- * @param id
+ * @param messageId
  */
 const convertMvlAttachment = (
   attachment: Attachment,
-  id: string
+  messageId: UIMessageId
 ): MvlAttachment =>
   // TODO some values are forced or mocked, specs should be improved https://pagopa.atlassian.net/browse/IAMVL-31
   ({
@@ -39,7 +39,7 @@ const convertMvlAttachment = (
     displayName: attachment.name,
     contentType: attachment.content_type.toLowerCase(),
     resourceUrl: {
-      href: generateAttachmentUrl(id, attachment.id as MvlAttachmentId)
+      href: generateAttachmentUrl(messageId, attachment.id as MvlAttachmentId)
     }
   });
 
@@ -67,7 +67,7 @@ const convertMvlDetail = (
         plain: eml.plain_text_content
       },
       attachments: eml.attachments.map(attachment =>
-        convertMvlAttachment(attachment, certData.data.envelope_id)
+        convertMvlAttachment(attachment, id)
       ),
       metadata: {
         id: msgId as MvlId,


### PR DESCRIPTION
## Short description
As per [the new specs](https://github.com/pagopa/io-backend/pull/864/files#diff-ac5f41902728c87f4277af9405ffbdf02ba3225a7987805c9b9603119e691e7bR323) we will use the `message.id` value to retrieve an attachment.

## How to test
Run the app against https://github.com/pagopa/io-dev-api-server/pull/126 and verify that by tapping on a legal message you can still open it.

Task https://pagopa.atlassian.net/browse/IAMVL-63
