### PR TITLE
fix: [IA-654] The logic to check if a data is expired is wrong

### DIFF
--- a/ts/utils/__tests__/dates.test.ts
+++ b/ts/utils/__tests__/dates.test.ts
@@ -53,6 +53,11 @@ describe("getExpireStatus", () => {
     MockDate.set(new Date(2022, 1, 1));
     // card: 2023-01
     expect(isExpired("1", "23")).toEqual(right(false));
+
+    // now: 2022-12-31
+    MockDate.set(new Date(2022, 11, 31));
+    // card: 2023-01
+    expect(isExpired("1", "23")).toEqual(right(false));
   });
 
   it("should mark the date as expired when passing as argument the previous month", () => {

--- a/ts/utils/__tests__/dates.test.ts
+++ b/ts/utils/__tests__/dates.test.ts
@@ -48,6 +48,11 @@ describe("getExpireStatus", () => {
     // 31/01/2020
     MockDate.set(new Date(2020, 0, 31));
     expect(isExpired(1, 2020)).toEqual(right(false));
+
+    // now: 2022-02-01
+    MockDate.set(new Date(2022, 1, 1));
+    // card: 2023-01
+    expect(isExpired("1", "23")).toEqual(right(false));
   });
 
   it("should mark the date as expired when passing as argument the previous month", () => {

--- a/ts/utils/dates.ts
+++ b/ts/utils/dates.ts
@@ -161,12 +161,13 @@ export const isExpired = (
 ): Either<Error, boolean> => {
   const maybeMonth = decodeCreditCardMonth(expireMonth);
   const maybeYear = decodeCreditCardYear(expireYear);
-
   return maybeYear
     .chain(year =>
       maybeMonth.map(month => {
         const now = new Date();
-        return year < now.getFullYear() || month < now.getMonth() + 1;
+        const nowYearMonth = new Date(now.getFullYear(), now.getMonth());
+        const cardExpirationDate = new Date(year, month - 1);
+        return nowYearMonth > cardExpirationDate;
       })
     )
     .mapLeft(_ => new Error("invalid input"));

--- a/ts/utils/dates.ts
+++ b/ts/utils/dates.ts
@@ -165,8 +165,8 @@ export const isExpired = (
     .chain(year =>
       maybeMonth.map(month => {
         const now = new Date();
-        const nowYearMonth = new Date(now.getFullYear(), now.getMonth());
-        const cardExpirationDate = new Date(year, month - 1);
+        const nowYearMonth = new Date(now.getFullYear(), now.getMonth()+1);
+        const cardExpirationDate = new Date(year, month);
         return nowYearMonth > cardExpirationDate;
       })
     )

--- a/ts/utils/dates.ts
+++ b/ts/utils/dates.ts
@@ -165,7 +165,7 @@ export const isExpired = (
     .chain(year =>
       maybeMonth.map(month => {
         const now = new Date();
-        const nowYearMonth = new Date(now.getFullYear(), now.getMonth()+1);
+        const nowYearMonth = new Date(now.getFullYear(), now.getMonth() + 1);
         const cardExpirationDate = new Date(year, month);
         return nowYearMonth > cardExpirationDate;
       })


### PR DESCRIPTION
## Short description
This PR fixes a wrong logic that checks if a date is expired or not
The error is about the comparison, this is how this logic actually works

- current year is less than the given one -> expired ✅ 
or
- current month is less than the given one -> expired 🐞 

So assuming you are checking `isExpired(2023,1)` today (2022-02-01) it will return true (expired 😨 )

### computed at 2022-02-01
| before  | fixed |
| ------------- | ------------- |
![Preferences](https://user-images.githubusercontent.com/822471/151977190-fc70a58b-d6d9-405f-bf5e-f247c806c2fb.png) | ![Privacy](https://user-images.githubusercontent.com/822471/151977195-69a672f5-7019-44fc-bbf2-98ef06f4c941.png)

## How to test
- try to execute `isExpired` with one of these inputs (assuming now is today -> 2022-02-01)
    - `isExpired(2023,1)`
    - `isExpired(2024,1)`
