### PR TITLE
feat: [IA-640] The `VersionInfoOverlay` component is now enabled in the debug mode

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -10,8 +10,6 @@ PAGOPA_API_URL_PREFIX_TEST='https://acardste.vaservices.eu:443/pp-restapi-CD'
 DEBUG_REMOTE_PUSH_NOTIFICATION=NO
 # If set to "YES" an Alert is rendered when an error was received from the biometric identification
 DEBUG_BIOMETRIC_IDENTIFICATION=NO
-# display app version, backend version and screen name on top of each screen
-DISPLAY_VERSION_INFO_OVERLAY=NO
 # Seconds of background activity before asking the unlock code login
 BACKGROUND_ACTIVITY_TIMEOUT_S=30
 # timeout of fetch for calling the pagoPA SOAP APIs

--- a/.env.production
+++ b/.env.production
@@ -10,8 +10,6 @@ PAGOPA_API_URL_PREFIX_TEST='https://acardste.vaservices.eu:443/pp-restapi-CD'
 DEBUG_REMOTE_PUSH_NOTIFICATION=NO
 # If set to "YES" an Alert is rendered when an error was received from the biometric identification
 DEBUG_BIOMETRIC_IDENTIFICATION=NO
-# display app version, backend version and screen name on top of each screen
-DISPLAY_VERSION_INFO_OVERLAY=NO
 # Seconds of background activity before asking the unlock code login
 BACKGROUND_ACTIVITY_TIMEOUT_S=30
 # timeout of fetch for calling the pagoPA SOAP APIs

--- a/README.md
+++ b/README.md
@@ -281,7 +281,6 @@ You need to edit it to match your environment. Here is a still NOT complete tabl
 
 | NAME                           | DEFAULT |                                                                                                 |
 |--------------------------------|---------|-------------------------------------------------------------------------------------------------|
-| `DISPLAY_VERSION_INFO_OVERLAY` | NO | If set to "YES" the app version, backend version and current screen name are rendered in an overlay view. |
 | `DEBUG_BIOMETRIC_IDENTIFICATION` | NO      | If set to "YES" an Alert is rendered with the exact result code of the biometric identification. |
 | `TOT_MESSAGE_FETCH_WORKERS` | 5 | Number of workers to create for message detail fetching. This means that we will have at most a number of concurrent fetches (of the message detail) equal to the number of the workers.
 

--- a/ts/RootContainer.tsx
+++ b/ts/RootContainer.tsx
@@ -24,6 +24,7 @@ import { setDebugCurrentRouteName } from "./store/actions/debug";
 import { navigateToDeepLink, setDeepLink } from "./store/actions/deepLink";
 import { navigateBack } from "./store/actions/navigation";
 import { trackScreen } from "./store/middlewares/navigation";
+import { isDebugModeEnabledSelector } from "./store/reducers/debug";
 import { preferredLanguageSelector } from "./store/reducers/persistedPreferences";
 import { GlobalState } from "./store/reducers/types";
 import { getNavigateActionFromDeepLink } from "./utils/deepLink";
@@ -144,7 +145,7 @@ class RootContainer extends React.PureComponent<Props> {
             trackScreen(prevState, currentState);
           }}
         />
-        {shouldDisplayVersionInfoOverlay && <VersionInfoOverlay />}
+        {this.props.isDebugModeEnabled && <VersionInfoOverlay />}
         {!isStringNullyOrEmpty(testOverlayCaption) && (
           <BetaTestingOverlay
             title={`🛠️ TEST VERSION 🛠️`}
@@ -160,7 +161,8 @@ class RootContainer extends React.PureComponent<Props> {
 
 const mapStateToProps = (state: GlobalState) => ({
   preferredLanguage: preferredLanguageSelector(state),
-  deepLinkState: state.deepLink
+  deepLinkState: state.deepLink,
+  isDebugModeEnabled: isDebugModeEnabledSelector(state)
 });
 
 const mapDispatchToProps = {

--- a/ts/RootContainer.tsx
+++ b/ts/RootContainer.tsx
@@ -10,7 +10,7 @@ import { BetaTestingOverlay } from "./components/BetaTestingOverlay";
 import FlagSecureComponent from "./components/FlagSecure";
 import { LightModalRoot } from "./components/ui/LightModal";
 import VersionInfoOverlay from "./components/VersionInfoOverlay";
-import { shouldDisplayVersionInfoOverlay, testOverlayCaption } from "./config";
+import { testOverlayCaption } from "./config";
 
 import { setLocale } from "./i18n";
 import AppNavigator from "./navigation/AppNavigator";

--- a/ts/config.ts
+++ b/ts/config.ts
@@ -125,9 +125,6 @@ export const totServiceFetchWorkers = t.Integer.decode(
   parseInt(Config.TOT_SERVICE_FETCH_WORKERS, 10)
 ).getOrElse(DEFAULT_TOT_SERVICE_FETCH_WORKERS);
 
-export const shouldDisplayVersionInfoOverlay =
-  Config.DISPLAY_VERSION_INFO_OVERLAY === "YES";
-
 export const shufflePinPadOnPayment =
   Config.SHUFFLE_PINPAD_ON_PAYMENT === "YES";
 


### PR DESCRIPTION
## Short description
This PR will enable the `VersionInfoOverlay` directly in the debug mode, without using a specific feature flag.

## List of changes proposed in this pull request
- The `VersionInfoOverlay` is now automatically turned on in the debug mode.
- Removed the `shouldDisplayVersionInfoOverlay` flag.

https://user-images.githubusercontent.com/5963683/152001113-f02836b4-a342-437d-a817-ee504180e3f5.mov

## How to test
Entering debug mode (from the preferences, pressing 5 times on the app version) should activate an overlay on top with the route name
