### PR TITLE
fix: [IA-656] Fix e2e test

### DIFF
--- a/ts/features/wallet/onboarding/__e2e__/creditCardOnboarding.e2e.ts
+++ b/ts/features/wallet/onboarding/__e2e__/creditCardOnboarding.e2e.ts
@@ -58,10 +58,10 @@ describe("Credit Card onboarding", () => {
       await element(by.label("Done")).atIndex(0).tap();
       await element(by.text(I18n.t("global.buttons.continue"))).tap();
 
-      await waitFor(element(by.text(I18n.t("global.buttons.continue"))))
+      await waitFor(element(by.id("saveOrContinueButton")))
         .toBeVisible()
         .withTimeout(e2eWaitRenderTimeout);
-      await element(by.text(I18n.t("global.buttons.continue"))).tap();
+      await element(by.id("saveOrContinueButton")).tap();
 
       // Wait for 3ds webview
       await waitFor(element(by.text(I18n.t("wallet.challenge3ds.description"))))

--- a/ts/screens/wallet/ConfirmCardDetailsScreen.tsx
+++ b/ts/screens/wallet/ConfirmCardDetailsScreen.tsx
@@ -195,7 +195,8 @@ class ConfirmCardDetailsScreen extends React.Component<Props, State> {
         ),
       title: isInPayment
         ? I18n.t("wallet.saveCardInPayment.save")
-        : I18n.t("global.buttons.continue")
+        : I18n.t("global.buttons.continue"),
+      testID: "saveOrContinueButton"
     };
 
     const secondaryButtonProps = {


### PR DESCRIPTION
## Short description
This PR fixes the bug in the e2e test introduced with https://github.com/pagopa/io-app/pull/3691 .
It use the `testId` instead of the text to identify the continue button.

## List of changes proposed in this pull request
- Added the `testId` to the continue button in the `ConfirmCardDetailsScreen`
- Use the `testId` instead of the text to identify the button

## How to test
Run the `ts/features/wallet/onboarding/__e2e__/creditCardOnboarding.e2e.ts` test 
