### PR TITLE
[IA-431] Fixed multiple logout request issue

### DIFF
--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -503,6 +503,8 @@ export function* initializeApplicationSaga(): Generator<Effect, void, any> {
   yield fork(watchApplicationActivitySaga);
 
   // Watch for requests to logout
+  // Since this saga is spawned and not forked
+  // it will handle its own cancelation logic.
   yield spawn(watchLogoutSaga, backendClient.logout);
 
   yield fork(watchIdentification, storedPin);

--- a/ts/sagas/startup/__tests__/watchLogoutSaga.test.ts
+++ b/ts/sagas/startup/__tests__/watchLogoutSaga.test.ts
@@ -1,0 +1,49 @@
+import { testSaga } from "redux-saga-test-plan";
+import { getType } from "typesafe-actions";
+import {
+  logoutFailure,
+  logoutRequest,
+  logoutSuccess
+} from "../../../store/actions/authentication";
+import { watchLogoutSaga, logoutSaga } from "../watchLogoutSaga";
+
+const logout = jest.fn();
+
+const takeCancellableAction = [
+  getType(logoutRequest),
+  getType(logoutSuccess),
+  getType(logoutFailure)
+];
+
+const logoutRequestAct = logoutRequest({ keepUserData: true });
+const logoutSuccessAct = logoutSuccess({ keepUserData: true });
+const logoutFailureAct = logoutFailure({
+  error: new Error(),
+  options: { keepUserData: true }
+});
+
+describe("watchLogoutSaga", () => {
+  it("should execute the normal logout flow cancelling the saga", () => {
+    testSaga(watchLogoutSaga, logout)
+      .next()
+      .take(takeCancellableAction)
+      .next(logoutRequestAct)
+      .fork(logoutSaga, logout, logoutRequestAct)
+      .next()
+      .take(takeCancellableAction)
+      .next(logoutSuccessAct)
+      .isDone();
+  });
+
+  it("should execute a failed logout flow cancelling the saga", () => {
+    testSaga(watchLogoutSaga, logout)
+      .next()
+      .take(takeCancellableAction)
+      .next(logoutRequestAct)
+      .fork(logoutSaga, logout, logoutRequestAct)
+      .next()
+      .take(takeCancellableAction)
+      .next(logoutFailureAct)
+      .isDone();
+  });
+});

--- a/ts/sagas/startup/watchLogoutSaga.ts
+++ b/ts/sagas/startup/watchLogoutSaga.ts
@@ -1,5 +1,5 @@
 import { readableReport } from "italia-ts-commons/lib/reporters";
-import { call, Effect, put, take, fork } from "redux-saga/effects";
+import { call, put, take, fork } from "redux-saga/effects";
 import { ActionType, getType } from "typesafe-actions";
 import { BackendClient } from "../../api/backend";
 import { startApplicationInitialization } from "../../store/actions/application";

--- a/ts/sagas/startup/watchLogoutSaga.ts
+++ b/ts/sagas/startup/watchLogoutSaga.ts
@@ -68,13 +68,22 @@ export function* watchLogoutSaga(
   // in duplicated processes.
   while (true) {
     const cancellableAction: ActionType<
-      typeof logoutRequest | typeof logoutSuccess
-    > = yield take([getType(logoutRequest), getType(logoutSuccess)]);
+      typeof logoutRequest | typeof logoutSuccess | typeof logoutFailure
+    > = yield take([
+      getType(logoutRequest),
 
-    if (cancellableAction.type === "LOGOUT_REQUEST") {
+      // Since the logout in the user interface
+      // happens with both a success and a failure action
+      // this saga will be cancelled in both the cases.
+      getType(logoutSuccess),
+      getType(logoutFailure)
+    ]);
+
+    if (cancellableAction.type === getType(logoutRequest)) {
       yield fork(logoutSaga, logout, cancellableAction);
-    } else {
-      break;
+      continue;
     }
+
+    break;
   }
 }

--- a/ts/sagas/startup/watchLogoutSaga.ts
+++ b/ts/sagas/startup/watchLogoutSaga.ts
@@ -12,7 +12,7 @@ import { resetToAuthenticationRoute } from "../../store/actions/navigation";
 import { SagaCallReturnType } from "../../types/utils";
 import { resetAssistanceData } from "../../utils/supportAssistance";
 
-function* logoutSaga(
+export function* logoutSaga(
   logout: ReturnType<typeof BackendClient>["logout"],
   action: ActionType<typeof logoutRequest>
 ) {

--- a/ts/sagas/startup/watchLogoutSaga.ts
+++ b/ts/sagas/startup/watchLogoutSaga.ts
@@ -1,5 +1,5 @@
 import { readableReport } from "italia-ts-commons/lib/reporters";
-import { call, Effect, put, takeEvery } from "redux-saga/effects";
+import { call, Effect, put, take, fork } from "redux-saga/effects";
 import { ActionType, getType } from "typesafe-actions";
 import { BackendClient } from "../../api/backend";
 import { startApplicationInitialization } from "../../store/actions/application";
@@ -12,57 +12,69 @@ import { resetToAuthenticationRoute } from "../../store/actions/navigation";
 import { SagaCallReturnType } from "../../types/utils";
 import { resetAssistanceData } from "../../utils/supportAssistance";
 
+function* logoutSaga(
+  logout: ReturnType<typeof BackendClient>["logout"],
+  action: ActionType<typeof logoutRequest>
+) {
+  // Issue a logout request to the backend, asking to delete the session
+  // FIXME: if there's no connectivity to the backend, this request will
+  //        block for a while.
+  try {
+    const response: SagaCallReturnType<typeof logout> = yield call(logout, {});
+    if (response.isRight()) {
+      if (response.value.status === 200) {
+        yield put(logoutSuccess(action.payload));
+      } else {
+        // We got a error, send a LOGOUT_FAILURE action so we can log it using Mixpanel
+        const error = Error(
+          response.value.status === 500 && response.value.value.title
+            ? response.value.value.title
+            : "Unknown error"
+        );
+        yield put(logoutFailure({ error, options: action.payload }));
+      }
+    } else {
+      const logoutError = {
+        error: Error(readableReport(response.value)),
+        options: action.payload
+      };
+      yield put(logoutFailure(logoutError));
+    }
+  } catch (error) {
+    const logoutError = {
+      error,
+      options: action.payload
+    };
+    yield put(logoutFailure(logoutError));
+  } finally {
+    // clean up any assistance data
+    resetAssistanceData();
+    // If keepUserData is false, startApplicationInitialization is
+    // dispatched within the componentDidMount of IngressScreen
+    resetToAuthenticationRoute();
+    yield put(startApplicationInitialization());
+  }
+}
+
 /**
  * Handles the logout flow
  */
-// eslint-disable-next-line
 export function* watchLogoutSaga(
   logout: ReturnType<typeof BackendClient>["logout"]
-): Iterator<Effect> {
-  yield takeEvery(
-    getType(logoutRequest),
-    function* (action: ActionType<typeof logoutRequest>) {
-      // Issue a logout request to the backend, asking to delete the session
-      // FIXME: if there's no connectivity to the backend, this request will
-      //        block for a while.
-      try {
-        const response: SagaCallReturnType<typeof logout> = yield call(
-          logout,
-          {}
-        );
-        if (response.isRight()) {
-          if (response.value.status === 200) {
-            yield put(logoutSuccess(action.payload));
-          } else {
-            // We got a error, send a LOGOUT_FAILURE action so we can log it using Mixpanel
-            const error = Error(
-              response.value.status === 500 && response.value.value.title
-                ? response.value.value.title
-                : "Unknown error"
-            );
-            yield put(logoutFailure({ error, options: action.payload }));
-          }
-        } else {
-          const logoutError = {
-            error: Error(readableReport(response.value)),
-            options: action.payload
-          };
-          yield put(logoutFailure(logoutError));
-        }
-      } catch (error) {
-        const logoutError = {
-          error,
-          options: action.payload
-        };
-        yield put(logoutFailure(logoutError));
-      } finally {
-        // clean up any assistance data
-        resetAssistanceData();
-        // If keepUserData is false, startApplicationInitialization is
-        // dispatched within the componentDidMount of IngressScreen
-        resetToAuthenticationRoute();
-        yield put(startApplicationInitialization());
-      }
+) {
+  // This saga will handle its own cancelation because
+  // it will be spawned using `spawn` instead of `fork`,
+  // thus being detached from the main saga, and resulting
+  // in duplicated processes.
+  while (true) {
+    const cancellableAction: ActionType<
+      typeof logoutRequest | typeof logoutSuccess
+    > = yield take([getType(logoutRequest), getType(logoutSuccess)]);
+
+    if (cancellableAction.type === "LOGOUT_REQUEST") {
+      yield fork(logoutSaga, logout, cancellableAction);
+    } else {
+      break;
     }
-  );
+  }
 }


### PR DESCRIPTION
## Short description
This PR is going to fix a logic bug in the logout section. Executing multiple login in a single app instance (login -> logout -> login -> logout) would result in multiple logout sagas being dispatched thus increasing the number of logout requests to the backend at each login.

The cause of this issue is related to the `watchLogoutSaga` being called using `spawn`. This change happened in the following PR: https://github.com/pagopa/io-app/pull/1417. The current fix will maintain the `spawn` behaviour untouched.

## List of changes proposed in this pull request
- Implemented a cancellation logic in `watchLogoutSaga`.

## How to test
Executing multiple login in a single instance won't change the number of logout requests to the backend.
