### PR TITLE
fix(Bonus Pagamenti Digitali): optInStatus should be optional

### DIFF
--- a/ts/features/bonus/bpd/api/patchedTypes.ts
+++ b/ts/features/bonus/bpd/api/patchedTypes.ts
@@ -10,17 +10,17 @@ import { CitizenOptInStatusEnum } from "../../../../../definitions/bpd/citizen_v
 const PatchedCitizenResourceR = t.interface({
   enabled: t.boolean,
 
-  fiscalCode: t.string,
-  optInStatus: enumType<CitizenOptInStatusEnum>(
-    CitizenOptInStatusEnum,
-    "optInStatus"
-  )
+  fiscalCode: t.string
 });
 
 // optional attributes
 const PatchedCitizenResourceO = t.partial({
   payoffInstr: t.string,
-  payoffInstrType: t.string
+  payoffInstrType: t.string,
+  optInStatus: enumType<CitizenOptInStatusEnum>(
+    CitizenOptInStatusEnum,
+    "optInStatus"
+  )
 });
 
 export const PatchedCitizenResource = t.intersection(

--- a/ts/features/bonus/bpd/saga/networking/index.ts
+++ b/ts/features/bonus/bpd/saga/networking/index.ts
@@ -26,6 +26,7 @@ export function* executeAndDispatchV2(
         // (note the required header will be injected automatically)
         {} as any
       );
+    console.log(enrollCitizenIOResult);
     if (enrollCitizenIOResult.isRight()) {
       if (enrollCitizenIOResult.value.status === 200) {
         const { enabled, payoffInstr, technicalAccount, optInStatus } =
@@ -89,9 +90,16 @@ export function* putOptInStatusCitizenV2(
       );
     if (updateCitizenIOResult.isRight()) {
       if (updateCitizenIOResult.value.status === 200) {
-        const { optInStatus } = updateCitizenIOResult.value.value;
-        yield put(bpdUpdateOptInStatusMethod.success(optInStatus));
-        return;
+        if (updateCitizenIOResult.value.value.optInStatus) {
+          const { optInStatus } = updateCitizenIOResult.value.value;
+          yield put(bpdUpdateOptInStatusMethod.success(optInStatus));
+          return;
+        } else {
+          // it should not never happen
+          bpdUpdateOptInStatusMethod.failure(
+            new Error(`optInStatus is undefined`)
+          );
+        }
       } else {
         bpdUpdateOptInStatusMethod.failure(
           new Error(`response status ${updateCitizenIOResult.value.status}`)

--- a/ts/features/bonus/bpd/saga/networking/index.ts
+++ b/ts/features/bonus/bpd/saga/networking/index.ts
@@ -94,7 +94,7 @@ export function* putOptInStatusCitizenV2(
           yield put(bpdUpdateOptInStatusMethod.success(optInStatus));
           return;
         } else {
-          // it should not never happen
+          // it should never happen
           bpdUpdateOptInStatusMethod.failure(
             new Error(`optInStatus is undefined`)
           );

--- a/ts/features/bonus/bpd/saga/networking/index.ts
+++ b/ts/features/bonus/bpd/saga/networking/index.ts
@@ -26,7 +26,6 @@ export function* executeAndDispatchV2(
         // (note the required header will be injected automatically)
         {} as any
       );
-    console.log(enrollCitizenIOResult);
     if (enrollCitizenIOResult.isRight()) {
       if (enrollCitizenIOResult.value.status === 200) {
         const { enabled, payoffInstr, technicalAccount, optInStatus } =

--- a/ts/sagas/wallet/pagopaApis.ts
+++ b/ts/sagas/wallet/pagopaApis.ts
@@ -392,18 +392,6 @@ export function* deleteAllPaymentMethodsByFunctionRequestHandler(
       typeof deleteAllByFunctionApiWithRefresh
     > = yield call(deleteAllByFunctionApiWithRefresh);
     if (deleteResponse.isRight() && deleteResponse.value.status === 200) {
-      const notDeletedMethodsCount =
-        deleteResponse.value.value.data?.notDeletedWallets ?? -1;
-      // some error occurred while deletion
-      if (notDeletedMethodsCount !== 0) {
-        yield put(
-          deleteAllPaymentMethodsByFunction.failure({
-            error: Error("can't delete some methods"),
-            notDeletedMethodsCount
-          })
-        );
-        return;
-      }
       const deletedMethodsCount =
         deleteResponse.value.value.data?.deletedWallets ?? -1;
 


### PR DESCRIPTION
## Short description
This PR sync the spec with production where `optInStatus` is not returned yet within the citizen payload
It also fixes a logic where the network saga dispatches a failure when `notDeletedMethod` are `!== 0`