### PR TITLE
feat: [IA-663] Show PAA_SYSTEM_ERROR payment code error

### DIFF
--- a/ts/utils/payment.ts
+++ b/ts/utils/payment.ts
@@ -223,7 +223,8 @@ const ecSet = new Set<DetailV2Keys>([
   "PAA_ID_DOMINIO_ERRATO",
   "PAA_ID_INTERMEDIARIO_ERRATO",
   "PAA_STAZIONE_INT_ERRATA",
-  "PAA_ATTIVA_RPT_IMPORTO_NON_VALIDO"
+  "PAA_ATTIVA_RPT_IMPORTO_NON_VALIDO",
+  "PAA_SYSTEM_ERROR"
 ]);
 
 const v2ErrorMacrosMap = new Map<MainErrorType, Set<DetailV2Keys>>([


### PR DESCRIPTION
## Short description
This PR adds the `PAA_SYSTEM_ERROR` error code to the "ente" cases.
In this way when the error occurs the relative code will be shown


| before  | after |
| ------------- | ------------- |
![before](https://user-images.githubusercontent.com/822471/153633464-536e392e-643f-43f9-9f4b-a1a25698d442.png) | ![after](https://user-images.githubusercontent.com/822471/153632959-52e60d2b-5d53-421d-aa66-42a6b01d2b04.png)

## How to test
- use the dev-server and set [here](https://github.com/pagopa/io-dev-api-server/blob/7e2e597c210f0f5cb40a50b8046c7ebb46ee94c2/src/config.ts#L90) this
    -  ![Schermata 2022-02-11 alle 17 48 09](https://user-images.githubusercontent.com/822471/153633276-003e1bf6-674e-4f13-817d-9bba50db0ccc.png)

