### PR TITLE
[IA-397] Implemented accessibility unread badge in the bottom nav

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -504,6 +504,7 @@ navigation:
   messages: Messages
   profile: Profile
   accessibility: "Section {{section}}, panel, {{order}} of 4"
+  accessibilityWithBadge: "Section {{section}}, panel, {{order}} of 4, {{unread}} new"
   selected: Is selected
 cie:
   title: Touch the card

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -504,6 +504,7 @@ navigation:
   messages: Messaggi
   profile: Profilo
   accessibility: "Sezione {{section}}, pannello, {{order}} di 4"
+  accessibilityWithBadge: "Sezione {{section}}, pannello, {{order}} di 4, {{unread}} nuovi"
   selected: È selezionato
 cie:
   title: Appoggia la carta

--- a/ts/components/NavBarLabel.tsx
+++ b/ts/components/NavBarLabel.tsx
@@ -5,6 +5,7 @@ import { connect } from "react-redux";
 import { Locales, TranslationKeys } from "../../locales/locales";
 import I18n from "../i18n";
 import ROUTES from "../navigation/routes";
+import { messagesUnreadAndUnarchivedSelector } from "../store/reducers/entities/messages/messagesStatus";
 import { preferredLanguageSelector } from "../store/reducers/persistedPreferences";
 import { GlobalState } from "../store/reducers/types";
 import { makeFontStyleObject } from "../theme/fonts";
@@ -50,19 +51,44 @@ const styles = StyleSheet.create({
   }
 });
 
+const computeAccessibilityLabel = (
+  section: string,
+  order: number,
+  unread?: number
+) =>
+  typeof unread === "undefined"
+    ? I18n.t("navigation.accessibility", {
+        section,
+        order
+      })
+    : I18n.t("navigation.accessibilityWithBadge", {
+        section,
+        order,
+        unread
+      });
+
 /**
  * This Component is used to Render the Labels of the bottom navbar of the app
  * translated in the preferred locale if it was selected
  * @param props
  */
 const NavBarLabel: React.FunctionComponent<Props> = (props: Props) => {
-  const { options, routeName, preferredLanguage } = props;
+  const { options, routeName, preferredLanguage, messagesUnread } = props;
   const locale: Locales = preferredLanguage.fold(I18n.locale, l => l);
   const label = getLabel(routeName, locale);
   const maybeOrder = fromNullable(routeOrder.get(routeName as Routes));
   const isSelected = options.focused
     ? `${I18n.t("navigation.selected")}, `
     : "";
+
+  const computeUnreadMessages =
+    routeName === ROUTES.MESSAGES_NAVIGATOR ? messagesUnread.length : undefined;
+
+  const panelAccessibilityLabel = computeAccessibilityLabel(
+    label,
+    maybeOrder.getOrElse(0),
+    computeUnreadMessages
+  );
 
   return (
     <Text
@@ -72,10 +98,7 @@ const NavBarLabel: React.FunctionComponent<Props> = (props: Props) => {
           color: options.tintColor === null ? undefined : options.tintColor
         }
       ]}
-      accessibilityLabel={`${isSelected} ${I18n.t("navigation.accessibility", {
-        section: label,
-        order: maybeOrder.getOrElse(0)
-      })}`}
+      accessibilityLabel={`${isSelected} ${panelAccessibilityLabel}`}
     >
       {label}
     </Text>
@@ -83,7 +106,8 @@ const NavBarLabel: React.FunctionComponent<Props> = (props: Props) => {
 };
 
 const mapStateToProps = (state: GlobalState) => ({
-  preferredLanguage: preferredLanguageSelector(state)
+  preferredLanguage: preferredLanguageSelector(state),
+  messagesUnread: messagesUnreadAndUnarchivedSelector(state)
 });
 
 export default connect(mapStateToProps)(NavBarLabel);

--- a/ts/components/WalletTabIcon.tsx
+++ b/ts/components/WalletTabIcon.tsx
@@ -1,9 +1,6 @@
-import * as pot from "italia-ts-commons/lib/pot";
 import React from "react";
 import { connect } from "react-redux";
-
-import { getUnreadTransactionsSelector } from "../store/reducers/entities/readTransactions";
-import { isProfileEmailValidatedSelector } from "../store/reducers/profile";
+import { getSafeUnreadTransactionsNumSelector } from "../store/reducers/entities/readTransactions";
 import { GlobalState } from "../store/reducers/types";
 import TabIconComponent from "./ui/TabIconComponent";
 
@@ -29,17 +26,8 @@ class WalletTabIcon extends React.PureComponent<Props> {
   }
 }
 
-function mapStateToProps(state: GlobalState) {
-  const transactions = getUnreadTransactionsSelector(state);
-  const isEmailValidated = isProfileEmailValidatedSelector(state);
-  const unreadTransactions =
-    pot.isSome(transactions) && isEmailValidated
-      ? Object.keys(transactions.value).length
-      : 0;
-
-  return {
-    unreadTransactions
-  };
-}
+const mapStateToProps = (state: GlobalState) => ({
+  unreadTransactions: getSafeUnreadTransactionsNumSelector(state)
+});
 
 export default connect(mapStateToProps)(WalletTabIcon);

--- a/ts/store/reducers/entities/readTransactions.ts
+++ b/ts/store/reducers/entities/readTransactions.ts
@@ -6,6 +6,7 @@ import {
   deleteReadTransaction,
   readTransaction
 } from "../../actions/wallet/transactions";
+import { isProfileEmailValidatedSelector } from "../profile";
 import { GlobalState } from "../types";
 import { getTransactions } from "../wallet/transactions";
 
@@ -54,3 +55,16 @@ export const getUnreadTransactionsSelector = createSelector(
       txs.filter(_ => _ !== undefined && transactionsRead[_.id] === undefined)
     )
 );
+
+/**
+ * This selector returns the number of unread transaction
+ * only if the current user has the email validated.
+ */
+export const getSafeUnreadTransactionsNumSelector = (state: GlobalState) => {
+  const transactions = getUnreadTransactionsSelector(state);
+  const isEmailValidated = isProfileEmailValidatedSelector(state);
+
+  return pot.isSome(transactions) && isEmailValidated
+    ? Object.keys(transactions.value).length
+    : 0;
+};


### PR DESCRIPTION
## Short description
This PR is going to add the number of unread messages / transactions as an accessibility text in the bottom nav. At the moment the number of unread items is not specified by the Voice Over.

<img width="1166" alt="Screenshot 2022-02-15 at 14 00 40" src="https://user-images.githubusercontent.com/5963683/154067202-0205422e-5043-423f-a078-2752a6be2cf3.png">

<img width="1163" alt="Screenshot 2022-02-15 at 14 00 57" src="https://user-images.githubusercontent.com/5963683/154067209-5e71deb7-28c2-4032-9889-6ad224464127.png">

## List of changes proposed in this pull request
- Implemented the number of unread item as an `accessibilityLabel` piece of information inside the `NavBarLabel` component.
- Created a `getSafeUnreadTransactionsNumSelector` to retrieve the number of unread transactions only when the current user's email has been confirmed. This is used to avoid logic replication between components.

## How to test
Using the accessibility inspector, the number of unread messages / transactions should be inside the accessibility label of each icon in the bottom navigator.
