### PR TITLE
[IAGP-74] Do not specify album for saving EU Covid certificate on Android

### DIFF
--- a/ts/features/euCovidCert/utils/__test__/screenshot.test.ts
+++ b/ts/features/euCovidCert/utils/__test__/screenshot.test.ts
@@ -57,12 +57,9 @@ describe("EuCovidCertificate screenshot", () => {
 
   describe("given default screenshotOptions", () => {
     const options = screenshotOptions;
-    it("filename and album are returned from locales", () => {
+    it("filename is returned from locales", () => {
       expect(options.filename).toEqual(
         I18n.t("features.euCovidCertificate.common.title")
-      );
-      expect(options.album).toEqual(
-        I18n.t("features.euCovidCertificate.save.album")
       );
     });
   });

--- a/ts/features/euCovidCert/utils/screenshot.ts
+++ b/ts/features/euCovidCert/utils/screenshot.ts
@@ -5,6 +5,7 @@ import { Dimensions } from "react-native";
 import RNFS from "react-native-fs";
 import { saveImageToGallery } from "../../../utils/share";
 import I18n from "../../../i18n";
+import { isIos } from "../../../utils/platform";
 
 type CaptureScreenshotEvents = {
   onSuccess?: () => void; // invoked on success
@@ -22,7 +23,7 @@ export const screenshotOptions: ScreenshotOptions = {
   width: Dimensions.get("window").width,
   format: "png",
   filename: I18n.t("features.euCovidCertificate.common.title"),
-  album: I18n.t("features.euCovidCertificate.save.album")
+  album: isIos ? I18n.t("features.euCovidCertificate.save.album") : undefined
 };
 
 /**


### PR DESCRIPTION
## Short description
This PR partially revert #3753. We don't want to save EU Covid certificate in a custom album on Android.

## List of changes proposed in this pull request
- `screenshotOptions` returns `undefined` as `album` when running on Android.

## How to test
Save a Covid certificate on Android and verify that it is saved in the default DCIM folder. In iOS this shouldn't have any impact.
