### PR TITLE
feat: [IA-400] The `C.F.` text will be read as `Codice fiscale` by the Voice Over

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1799,6 +1799,7 @@ services:
   emptyListMessage: There are no services available at this time, pull down to refresh
 serviceDetail:
   fiscalCode: "Organization's fiscal code"
+  fiscalCodeAccessibility: "Organization's fiscal code"
   contacts:
     title: "This service can:"
   headerTitle: "Service details"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1825,6 +1825,7 @@ services:
   emptyListMessage: Non ci sono servizi disponibili al momento, trascina in basso per aggiornare
 serviceDetail:
   fiscalCode: "C.F. Ente"
+  fiscalCodeAccessibility: "Codice fiscale Ente" 
   contacts:
     title: "Questo servizio può:"
   headerTitle: "Dettagli del Servizio"

--- a/ts/components/services/ServiceMetadata/index.tsx
+++ b/ts/components/services/ServiceMetadata/index.tsx
@@ -77,7 +77,7 @@ const ServiceMetadataComponent: React.FC<Props> = ({
           label={"serviceDetail.fiscalCode"}
           onPress={getItemOnPress(organizationFiscalCode, "COPY")}
           accessibilityLabel={genServiceMetadataAccessibilityLabel(
-            I18n.t("serviceDetail.fiscalCode"),
+            I18n.t("serviceDetail.fiscalCodeAccessibility"),
             organizationFiscalCode,
             I18n.t("clipboard.copyText")
           )}


### PR DESCRIPTION
## Short description
This PR will make the VO read the `C.F.` text as `Codice fiscale`.

<img width="1192" alt="image" src="https://user-images.githubusercontent.com/5963683/154457523-46824660-a0c4-4f5f-af2b-ab5cd13ec76b.png">

## List of changes proposed in this pull request
- Created an accessibility i18n to describe how `C.F.` will be read by the VO

## How to test
In the service details screen, the description `C.F. Ente` should be read as `Codice fiscale Ente`. The accessibility label should match in the Accessibility Inspector.
