### PR TITLE
fix: [IABT-1300] Centered label text in `TransactionErrorScreen`

### DIFF
--- a/ts/screens/wallet/payment/TransactionErrorScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionErrorScreen.tsx
@@ -146,7 +146,9 @@ const ErrorCodeCopyComponent = ({
   error: keyof typeof Detail_v2Enum;
 }): React.ReactElement => (
   <View testID={"error-code-copy-component"}>
-    <H4 weight={"Regular"}>{I18n.t("wallet.errors.assistanceLabel")}</H4>
+    <H4 weight={"Regular"} style={{ textAlign: "center" }}>
+      {I18n.t("wallet.errors.assistanceLabel")}
+    </H4>
     <H4 weight={"Bold"} testID={"error-code"} style={{ textAlign: "center" }}>
       {error}
     </H4>


### PR DESCRIPTION
## Short description
This PR is going to fix an alignment error in `TransactionErrorScreen`, centering the label text.

| Before | After |
| ------ | ------|
|  <img width="410" alt="Screenshot 2022-02-22 at 12 19 57" src="https://user-images.githubusercontent.com/5963683/155122315-8063046c-ee42-4030-965e-33ea6920c35c.png"> |  <img width="410" alt="Screenshot 2022-02-22 at 12 19 17" src="https://user-images.githubusercontent.com/5963683/155122339-717a8864-da01-4389-a8d9-d07f25a4a469.png"> |

## List of changes proposed in this pull request
- Centered the text in `TransactionErrorScreen`

## How to test
Setting `wallet.verificaError` as `Detail_v2Enum.PPT_STAZIONE_INT_PA_SCONOSCIUTA` in the dev server configuration, and executing a payment, the resulting error screen should be centered correctly.
