### PR TITLE
fix(Bonus Pagamenti Digitali): [IAC-142] Fix wrong translation in OptInPaymentMethodsChoiceScreen

### DIFF
--- a/ts/features/bonus/bpd/screens/optInPaymentMethods/OptInPaymentMethodsChoiceScreen.tsx
+++ b/ts/features/bonus/bpd/screens/optInPaymentMethods/OptInPaymentMethodsChoiceScreen.tsx
@@ -53,9 +53,9 @@ const generateOptionBody = (
   </>
 );
 
-const radioButtonListItems: ReadonlyArray<
+const radioButtonListItems: () => ReadonlyArray<
   RadioItem<PaymentMethodsChoiceOptions>
-> = [
+> = () => [
   {
     id: "keepPaymentMethods",
     body: generateOptionBody(
@@ -142,7 +142,7 @@ const OptInPaymentMethodsChoiceScreen = () => {
           <View spacer />
 
           <RadioButtonList<PaymentMethodsChoiceOptions>
-            items={radioButtonListItems}
+            items={radioButtonListItems()}
             selectedItem={selectedMethod || undefined}
             onPress={setSelectedMethod}
             rightSideSelection


### PR DESCRIPTION
## Short description
This PR fixes the wrong translation in the `OptInPaymentMethodsChoiceScreen`

## List of changes proposed in this pull request
- Used a function instead of a const to translate labels ( `radioButtonListItems` ) 

<img src="https://user-images.githubusercontent.com/11773070/155747915-06c3494f-07a5-4cf7-bbee-398e4a6f7949.png" width=300>

## How to test
Navigate to the `OptInPaymentMethodsChoiceScreen` dispatching the `navigateToOptInPaymentMethodsChoiceScreen` setting different languages.
