### PR TITLE
fix: [IA-308] Status banner position in messages when the screen reader is OFF

### DIFF
--- a/ts/screens/messages/MessagesHomeScreen.tsx
+++ b/ts/screens/messages/MessagesHomeScreen.tsx
@@ -42,8 +42,10 @@ import { makeFontStyleObject } from "../../theme/fonts";
 import customVariables from "../../theme/variables";
 import { HEADER_HEIGHT, MESSAGE_ICON_HEIGHT } from "../../utils/constants";
 import { sectionStatusSelector } from "../../store/reducers/backendStatus";
-import { setAccessibilityFocus } from "../../utils/accessibility";
-import { isScreenReaderEnabled } from "../../utils/accessibility";
+import {
+  isScreenReaderEnabled,
+  setAccessibilityFocus
+} from "../../utils/accessibility";
 import FocusAwareStatusBar from "../../components/ui/FocusAwareStatusBar";
 
 type Props = NavigationStackScreenProps &

--- a/ts/screens/messages/MessagesHomeScreen.tsx
+++ b/ts/screens/messages/MessagesHomeScreen.tsx
@@ -43,6 +43,7 @@ import customVariables from "../../theme/variables";
 import { HEADER_HEIGHT, MESSAGE_ICON_HEIGHT } from "../../utils/constants";
 import { sectionStatusSelector } from "../../store/reducers/backendStatus";
 import { setAccessibilityFocus } from "../../utils/accessibility";
+import { isScreenReaderEnabled } from "../../utils/accessibility";
 import FocusAwareStatusBar from "../../components/ui/FocusAwareStatusBar";
 
 type Props = NavigationStackScreenProps &
@@ -51,6 +52,7 @@ type Props = NavigationStackScreenProps &
 
 type State = {
   currentTab: number;
+  isScreenReaderEnabled: boolean;
 };
 
 const styles = StyleSheet.create({
@@ -99,7 +101,8 @@ class MessagesHomeScreen extends React.PureComponent<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      currentTab: 0
+      currentTab: 0,
+      isScreenReaderEnabled: false
     };
   }
 
@@ -124,12 +127,23 @@ class MessagesHomeScreen extends React.PureComponent<Props, State> {
     );
   };
 
-  public componentDidMount() {
+  public async componentDidMount() {
     this.onRefreshMessages();
+    const srEnabled = await isScreenReaderEnabled();
+    this.setState({ isScreenReaderEnabled: srEnabled });
   }
 
   public render() {
     const { isSearchEnabled } = this.props;
+
+    const statusComponent = (
+      <SectionStatusComponent
+        sectionKey={"messages"}
+        onSectionRef={v => {
+          setAccessibilityFocus(v, 100 as Millisecond);
+        }}
+      />
+    );
 
     return (
       <TopScreenComponent
@@ -148,12 +162,7 @@ class MessagesHomeScreen extends React.PureComponent<Props, State> {
           barStyle={"dark-content"}
           backgroundColor={customVariables.colorWhite}
         />
-        <SectionStatusComponent
-          sectionKey={"messages"}
-          onSectionRef={v => {
-            setAccessibilityFocus(v, 100 as Millisecond);
-          }}
-        />
+        {this.state.isScreenReaderEnabled && statusComponent}
         {!isSearchEnabled && (
           <React.Fragment>
             <AnimatedScreenContentHeader
@@ -165,6 +174,7 @@ class MessagesHomeScreen extends React.PureComponent<Props, State> {
           </React.Fragment>
         )}
         {isSearchEnabled && this.renderSearch()}
+        {!this.state.isScreenReaderEnabled && statusComponent}
       </TopScreenComponent>
     );
   }

--- a/ts/screens/messages/paginated/MessagesHomeScreen.tsx
+++ b/ts/screens/messages/paginated/MessagesHomeScreen.tsx
@@ -21,7 +21,10 @@ import {
 import { GlobalState } from "../../../store/reducers/types";
 import { MESSAGE_ICON_HEIGHT } from "../../../utils/constants";
 import { sectionStatusSelector } from "../../../store/reducers/backendStatus";
-import { setAccessibilityFocus } from "../../../utils/accessibility";
+import {
+  setAccessibilityFocus,
+  useScreenReaderEnabled
+} from "../../../utils/accessibility";
 import { allMessagesSelector } from "../../../store/reducers/entities/messages/allPaginated";
 import { pageSize } from "../../../config";
 import MessageList from "../../../components/messages/paginated/MessageList";
@@ -62,6 +65,17 @@ const MessagesHomeScreen = ({
     reloadFirstPage();
   }, []);
 
+  const isScreenReaderEnabled = useScreenReaderEnabled();
+
+  const statusComponent = (
+    <SectionStatusComponent
+      sectionKey={"messages"}
+      onSectionRef={v => {
+        setAccessibilityFocus(v, 100 as Millisecond);
+      }}
+    />
+  );
+
   return (
     <TopScreenComponent
       accessibilityEvents={{
@@ -78,12 +92,7 @@ const MessagesHomeScreen = ({
         barStyle={"dark-content"}
         backgroundColor={customVariables.colorWhite}
       />
-      <SectionStatusComponent
-        sectionKey={"messages"}
-        onSectionRef={v => {
-          setAccessibilityFocus(v, 100 as Millisecond);
-        }}
-      />
+      {isScreenReaderEnabled && statusComponent}
       {!isSearchEnabled && (
         <React.Fragment>
           <ScreenContentHeader
@@ -115,6 +124,7 @@ const MessagesHomeScreen = ({
           .getOrElse(
             <SearchNoResultMessage errorType="InvalidSearchBarText" />
           )}
+      {!isScreenReaderEnabled && statusComponent}
     </TopScreenComponent>
   );
 };


### PR DESCRIPTION
## Short description
The status banner in messages home screen should be shown on top when the screen reader is ON, but on bottom when the SR is OFF. At the moment it is always shown on top. This PR fixes it (both paginated messages and not).

## List of changes proposed in this pull request
- Add `isScreenReaderEnabled` state (`false` by default) in `MessagesHomeScreen` (updated in `componentDidMount` with `isScreenReaderEnabled()`)
- In `paginated/MessagesHomeScreen` the `useScreenReaderEnabled()` function is used instead

## How to test
Enable a status message in the dev server and run the app both with the screen reader enabled and disabled. Beware that the status is just read once when the component is mounted, so when you switch the settings, please re-launch the app from scratch.
| SR disabled | SR enabled |
| - | - |
| ![IMG_0103](https://user-images.githubusercontent.com/467098/156335264-f81c0023-ce03-4181-ae79-46ed85093d66.PNG) | ![IMG_0102](https://user-images.githubusercontent.com/467098/156335310-9995e6c1-6f88-4ae8-adac-7d5f6f1a512e.PNG) |