### PR TITLE
feat: [IA-366] Link recognition by the screen reader on Android

### DIFF
--- a/ts/components/SectionStatus/StatusContent.tsx
+++ b/ts/components/SectionStatus/StatusContent.tsx
@@ -23,6 +23,7 @@ const styles = StyleSheet.create({
 });
 
 type Props = WithTestID<{
+  accessible?: boolean;
   accessibilityHint?: string;
   accessibilityLabel?: string;
   accessibilityRole?: AccessibilityRole;
@@ -34,6 +35,7 @@ type Props = WithTestID<{
 }>;
 
 const StatusContent: React.FC<Props> = ({
+  accessible,
   accessibilityHint,
   accessibilityLabel,
   accessibilityRole,
@@ -48,7 +50,7 @@ const StatusContent: React.FC<Props> = ({
     accessibilityHint={accessibilityHint}
     accessibilityLabel={accessibilityLabel}
     accessibilityRole={accessibilityRole}
-    accessible={true}
+    accessible={accessible ?? true}
     ref={viewRef}
     style={[styles.container, { backgroundColor: IOColors[backgroundColor] }]}
     testID={"SectionStatusContent"}

--- a/ts/components/SectionStatus/index.tsx
+++ b/ts/components/SectionStatus/index.tsx
@@ -100,6 +100,7 @@ const InnerSectionStatus = (
         testID={"SectionStatusComponentPressable"}
       >
         <StatusContent
+          // disable accessibility to prevent the override of the container
           accessible={false}
           backgroundColor={backgroundColor}
           iconColor={IOColors[color]}

--- a/ts/components/SectionStatus/index.tsx
+++ b/ts/components/SectionStatus/index.tsx
@@ -100,6 +100,7 @@ const InnerSectionStatus = (
         testID={"SectionStatusComponentPressable"}
       >
         <StatusContent
+          accessible={false}
           backgroundColor={backgroundColor}
           iconColor={IOColors[color]}
           iconName={iconName}


### PR DESCRIPTION
## Short description
The screen reader on Android doesn't recognize the accessibility role in status banners that contain a link. This is caused by a child component that overrides accessibility settings where the link is declared. This PR disables accessibility on the child component.

## List of changes proposed in this pull request
- Add an (optional) `accessible` prop to the `StatusContent` component
- Disable accessibility for the `StatusComponent` in `SectionStatus` when it's wrapped in a `Tappable` that already has accessibility properties

## How to test

https://user-images.githubusercontent.com/467098/156402800-ac772391-dbb4-4d4f-b9f9-dc4f1c1f4a5c.mp4
