### PR TITLE
fix: [IA-703] Regression in the layout of the footer with a safe area

### DIFF
--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -315,44 +315,47 @@ const ConfirmPaymentMethodScreen: React.FC<Props> = (props: Props) => {
           </View>
         </Content>
 
-        <View footer={true}>
-          <ButtonDefaultOpacity
-            block={true}
-            primary={true}
-            // a payment is running
-            disabled={props.payStartWebviewPayload.isSome()}
-            onPress={() =>
-              props.dispatchPaymentStart({
-                idWallet: wallet.idWallet,
-                idPayment,
-                language: getLocalePrimaryWithFallback()
-              })
-            }
-          >
-            <Text>{`${I18n.t(
-              "wallet.ConfirmPayment.goToPay"
-            )} ${formatNumberCentsToAmount(totalAmount, true)}`}</Text>
-          </ButtonDefaultOpacity>
-          <View spacer={true} />
-          <View style={styles.parent}>
+        <View style={styles.footerContainer}>
+          {/* the actual footer must be wrapped in this container in order to keep a white background below the safe area */}
+          <View footer={true}>
             <ButtonDefaultOpacity
-              style={styles.child}
               block={true}
-              cancel={true}
-              onPress={props.onCancel}
-              testID={"cancelPaymentButton"}
+              primary={true}
+              // a payment is running
+              disabled={props.payStartWebviewPayload.isSome()}
+              onPress={() =>
+                props.dispatchPaymentStart({
+                  idWallet: wallet.idWallet,
+                  idPayment,
+                  language: getLocalePrimaryWithFallback()
+                })
+              }
             >
-              <Text>{I18n.t("global.buttons.cancel")}</Text>
+              <Text>{`${I18n.t(
+                "wallet.ConfirmPayment.goToPay"
+              )} ${formatNumberCentsToAmount(totalAmount, true)}`}</Text>
             </ButtonDefaultOpacity>
-            <View hspacer={true} />
-            <ButtonDefaultOpacity
-              style={styles.childTwice}
-              block={true}
-              bordered={true}
-              onPress={props.pickPaymentMethod}
-            >
-              <Text>{I18n.t("wallet.ConfirmPayment.change")}</Text>
-            </ButtonDefaultOpacity>
+            <View spacer={true} />
+            <View style={styles.parent}>
+              <ButtonDefaultOpacity
+                style={styles.child}
+                block={true}
+                cancel={true}
+                onPress={props.onCancel}
+                testID={"cancelPaymentButton"}
+              >
+                <Text>{I18n.t("global.buttons.cancel")}</Text>
+              </ButtonDefaultOpacity>
+              <View hspacer={true} />
+              <ButtonDefaultOpacity
+                style={styles.childTwice}
+                block={true}
+                bordered={true}
+                onPress={props.pickPaymentMethod}
+              >
+                <Text>{I18n.t("wallet.ConfirmPayment.change")}</Text>
+              </ButtonDefaultOpacity>
+            </View>
           </View>
         </View>
         {props.payStartWebviewPayload.isSome() && (


### PR DESCRIPTION
## Short description
#3718 introduced a regression on a fix that was previously made with #3728. In particular a wrapping view for the footer has been removed. This PR re-introduces it, restoring the right behavior.

## List of changes proposed in this pull request
- Wrap the actual footer in  `<View style={styles.footerContainer}>...</View>`

| Before | After |
| - | - |
| ![Simulator Screen Shot - iPhone 12 - 2022-03-07 at 11 24 08](https://user-images.githubusercontent.com/467098/157014469-b6aad57b-1ad3-40fd-af66-4ad1f31aea8d.png) | ![Simulator Screen Shot - iPhone 12 - 2022-03-07 at 11 08 30](https://user-images.githubusercontent.com/467098/157014495-d89d5a27-2252-42fd-9fc7-da17736a6f0e.png) |

## How to test
Start a payment and navigate to `PAYMENT_CONFIRM_PAYMENT_METHOD` screen with an iPhone X-like simulator. You shouldn't see any "hole" in the bottom safe area.
