### PR TITLE
fix: [IA-705] Payment banner shows incorrect total when transaction has no fee

### DIFF
--- a/ts/components/wallet/PaymentBannerComponent.tsx
+++ b/ts/components/wallet/PaymentBannerComponent.tsx
@@ -29,8 +29,6 @@ const styles = StyleSheet.create({
   }
 });
 
-const noFee = "-";
-
 /**
  * This component displays a summary on the transaction.
  * Used for the screens from the identification of the transaction to the end of the procedure.
@@ -54,7 +52,7 @@ const PaymentBannerComponent: React.SFC<Props> = props => {
       <View style={styles.row}>
         <Text white={true}>{I18n.t("wallet.ConfirmPayment.fee")}</Text>
         <Text white={true}>
-          {props.fee ? formatNumberCentsToAmount(props.fee, true) : noFee}
+          {formatNumberCentsToAmount(props.fee ?? 0, true)}
         </Text>
       </View>
       <View style={styles.row}>
@@ -62,7 +60,7 @@ const PaymentBannerComponent: React.SFC<Props> = props => {
           {I18n.t("wallet.total")}
         </Text>
         <Text white={true} bold={true}>
-          {props.fee ? formatNumberCentsToAmount(totalAmount, true) : noFee}
+          {formatNumberCentsToAmount(totalAmount, true)}
         </Text>
       </View>
     </View>

--- a/ts/components/wallet/PaymentBannerComponent.tsx
+++ b/ts/components/wallet/PaymentBannerComponent.tsx
@@ -51,7 +51,7 @@ const PaymentBannerComponent: React.SFC<Props> = props => {
       </View>
       <View style={styles.row}>
         <Text white={true}>{I18n.t("wallet.ConfirmPayment.fee")}</Text>
-        <Text white={true}>
+        <Text white={true} testID={"PaymentBannerComponentFee"}>
           {formatNumberCentsToAmount(props.fee ?? 0, true)}
         </Text>
       </View>
@@ -59,7 +59,7 @@ const PaymentBannerComponent: React.SFC<Props> = props => {
         <Text white={true} bold={true}>
           {I18n.t("wallet.total")}
         </Text>
-        <Text white={true} bold={true}>
+        <Text white={true} bold={true} testID={"PaymentBannerComponentTotal"}>
           {formatNumberCentsToAmount(totalAmount, true)}
         </Text>
       </View>

--- a/ts/components/wallet/__test__/PaymentBannerComponent.test.tsx
+++ b/ts/components/wallet/__test__/PaymentBannerComponent.test.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+import { render } from "@testing-library/react-native";
+import PaymentBannerComponent from "../PaymentBannerComponent";
+import { ImportoEuroCents } from "../../../../definitions/backend/ImportoEuroCents";
+import { formatNumberCentsToAmount } from "../../../utils/stringBuilder";
+
+describe("PaymentBannerComponent", () => {
+  describe("given a transaction fee", () => {
+    const currentAmount = 1500;
+    const fee = 1000;
+    const transactionWithFee = {
+      paymentReason: "test",
+      currentAmount: currentAmount as ImportoEuroCents,
+      fee: fee as ImportoEuroCents
+    };
+
+    it("renders the fee localized with the currency", () => {
+      const fixture = formatNumberCentsToAmount(fee, true);
+      const component = render(
+        <PaymentBannerComponent {...transactionWithFee} />
+      );
+      expect(
+        component.queryByTestId("PaymentBannerComponentFee")
+      ).toHaveTextContent(fixture);
+    });
+
+    it("renders the sum of current amount and fee as total", () => {
+      const fixture = formatNumberCentsToAmount(currentAmount + fee, true);
+      const component = render(
+        <PaymentBannerComponent {...transactionWithFee} />
+      );
+      expect(
+        component.queryByTestId("PaymentBannerComponentTotal")
+      ).toHaveTextContent(fixture);
+    });
+  });
+
+  describe("given no transaction fee", () => {
+    const currentAmount = 1500;
+    const fee = 0;
+    const transactionWithoutFee = {
+      paymentReason: "test",
+      currentAmount: currentAmount as ImportoEuroCents,
+      fee: fee as ImportoEuroCents
+    };
+
+    it("renders 0 localized with the currency as fee", () => {
+      const fixture = formatNumberCentsToAmount(0, true);
+      const component = render(
+        <PaymentBannerComponent {...transactionWithoutFee} />
+      );
+      expect(
+        component.queryByTestId("PaymentBannerComponentFee")
+      ).toHaveTextContent(fixture);
+    });
+
+    it("renders the current amount as total", () => {
+      const fixture = formatNumberCentsToAmount(currentAmount, true);
+      const component = render(
+        <PaymentBannerComponent {...transactionWithoutFee} />
+      );
+      expect(
+        component.queryByTestId("PaymentBannerComponentTotal")
+      ).toHaveTextContent(fixture);
+    });
+  });
+});


### PR DESCRIPTION
## Short description
When a payment doesn't have a transaction fee, the confirmation screen shows `-` instead of the total amount. This PR fixes it, showing `0` (formatted) as fee, and the right amount as total.

## How to test
Setup the dev server to return a fee of `0` for the transaction, then perform a payment.
| Before | After |
| - | - |
| ![Simulator Screen Shot - iPhone 12 - 2022-03-07 at 15 30 02](https://user-images.githubusercontent.com/467098/157053590-d638c8f5-5ec8-440b-a806-e31ddf82ec27.png) | ![Simulator Screen Shot - iPhone 12 - 2022-03-07 at 15 29 49](https://user-images.githubusercontent.com/467098/157053631-f0e3bf30-4132-439d-a68a-fdae25ac0600.png) |


