### PR TITLE
chore: Sync Podfile.lock for RNSVG

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -434,8 +434,8 @@ PODS:
     - React
   - RNShare (7.3.5):
     - React-Core
-  - RNSVG (12.1.1):
-    - React
+  - RNSVG (12.3.0):
+    - React-Core
   - RNVectorIcons (7.0.0):
     - React
   - RNZendeskChat (0.3.20):
@@ -844,7 +844,7 @@ SPEC CHECKSUMS:
   RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
   RNSha256: ab608b2185fb806185a2cc112e0474065842e085
   RNShare: 730a2773b1e0007425f2f111dcf75208a919c902
-  RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
+  RNSVG: 302bfc9905bd8122f08966dc2ce2d07b7b52b9f8
   RNVectorIcons: da6fe858f5a65d7bbc3379540a889b0b12aa5976
   RNZendeskChat: 2edfe52bac3a2487b6f6c435aadfe919f75bd6a1
   Yoga: 575c581c63e0d35c9a83f4b46d01d63abc1100ac


### PR DESCRIPTION
## Short description
This pr sync the `RNSVG`version in `Podfile.lock` following https://github.com/pagopa/io-app/pull/3800