### PR TITLE
fix: [IA-733] The email client is not open when the user denies consent to share information

### DIFF
--- a/ts/features/zendesk/screens/ZendeskAskPermissions.tsx
+++ b/ts/features/zendesk/screens/ZendeskAskPermissions.tsx
@@ -266,7 +266,7 @@ const ZendeskAskPermissions = (props: Props) => {
           "warning"
         );
       }
-    );
+    )();
     void mixpanelTrack("ZENDESK_DENY_PERMISSIONS");
     workUnitCompleted();
   };


### PR DESCRIPTION
## Short description
This PR fixes the bug that didn't allow to open the email client when the user denied consent to share information during the Zendesk ticket opening.


https://user-images.githubusercontent.com/11773070/158214885-f988f27b-0bea-46c6-9412-0d7c3c618a91.mp4



## How to test
Try to open a ticket and deny the consent to share information.
If you are running the app in the simulator, or if you don't have the email client installed on your phone, you should see the information toast.
