### PR TITLE
feat: [IA-728] Saga and networking for upserting message attributes

### DIFF
--- a/ts/api/backend.ts
+++ b/ts/api/backend.ts
@@ -55,7 +55,9 @@ import {
   upsertUserDataProcessingDefaultDecoder,
   UpsertUserDataProcessingT,
   upsertUserMetadataDefaultDecoder,
-  UpsertUserMetadataT
+  UpsertUserMetadataT,
+  upsertMessageStatusAttributesDefaultDecoder,
+  UpsertMessageStatusAttributesT
 } from "../../definitions/backend/requestTypes";
 import { SessionToken } from "../types/SessionToken";
 import { constantPollingFetch, defaultRetryingFetch } from "../utils/fetch";
@@ -233,6 +235,15 @@ export function BackendClient(
     query: _ => ({}),
     headers: tokenHeaderProducer,
     response_decoder: getUserMessageDefaultDecoder()
+  };
+
+  const upsertMessageStatusAttributesT: UpsertMessageStatusAttributesT = {
+    method: "put",
+    url: params => `/api/v1/messages/${params.id}/message-status`,
+    query: _ => ({}),
+    body: params => JSON.stringify(params.messageStatusChange),
+    headers: composeHeaderProducers(tokenHeaderProducer, ApiHeaderJson),
+    response_decoder: upsertMessageStatusAttributesDefaultDecoder()
   };
 
   const getProfileT: GetUserProfileT = {
@@ -446,6 +457,9 @@ export function BackendClient(
       createFetchRequestForApi(getMessagesT, options)
     ),
     getMessage: withBearerToken(createFetchRequestForApi(getMessageT, options)),
+    upsertMessageStatusAttributes: withBearerToken(
+      createFetchRequestForApi(upsertMessageStatusAttributesT, options)
+    ),
     getProfile: withBearerToken(createFetchRequestForApi(getProfileT, options)),
     createOrUpdateProfile: withBearerToken(
       createFetchRequestForApi(createOrUpdateProfileT, options)

--- a/ts/boot/__tests__/migrateToPagination.test.ts
+++ b/ts/boot/__tests__/migrateToPagination.test.ts
@@ -47,7 +47,7 @@ describe("migrateToPagination module", function () {
         A: { isRead: true, isArchived: true },
         B: { isRead: true, isArchived: false },
         C: { isRead: false, isArchived: true },
-        D: { isRead: false, isArchived: false }
+        D: { isRead: false, isArchived: false } // doesn't require migration
       };
       const store = makeStore(statuses);
       const result = await migrateToPagination(store, mockUpsert);
@@ -55,7 +55,7 @@ describe("migrateToPagination module", function () {
       expect(mockUpsert).toHaveBeenCalledWith("A", statuses.A);
       expect(mockUpsert).toHaveBeenCalledWith("B", statuses.B);
       expect(mockUpsert).toHaveBeenCalledWith("C", statuses.C);
-      expect(mockUpsert).toHaveBeenCalledWith("D", statuses.D);
+      expect(mockUpsert).toHaveBeenCalledTimes(3);
       expect(store.dispatch).toHaveBeenCalledWith(
         removeMessages(Object.keys(statuses))
       );
@@ -67,7 +67,7 @@ describe("migrateToPagination module", function () {
           A: { isRead: true, isArchived: true },
           B: { isRead: true, isArchived: false },
           C: { isRead: false, isArchived: true },
-          D: { isRead: false, isArchived: false }
+          D: { isRead: false, isArchived: false } // doesn't require migration
         };
         const store = makeStore(statuses);
         const result = await migrateToPagination(
@@ -85,7 +85,7 @@ describe("migrateToPagination module", function () {
         expect(mockUpsert).toHaveBeenCalledWith("A", statuses.A);
         expect(mockUpsert).toHaveBeenCalledWith("B", statuses.B);
         expect(mockUpsert).toHaveBeenCalledWith("C", statuses.C);
-        expect(mockUpsert).toHaveBeenCalledWith("D", statuses.D);
+        expect(mockUpsert).toHaveBeenCalledTimes(3);
         expect(store.dispatch).toHaveBeenCalledWith(
           removeMessages(["A", "C", "D"])
         );

--- a/ts/boot/migrateToPagination.ts
+++ b/ts/boot/migrateToPagination.ts
@@ -31,7 +31,9 @@ export default async function init(
   const requests: Array<Promise<Either.Either<Failure, string>>> = allIds.map(
     async id => {
       const messageStatus = data[id];
-      if (messageStatus) {
+      // we only migrate non-default updates
+      const needsMigration = messageStatus?.isRead || messageStatus?.isArchived;
+      if (messageStatus && needsMigration) {
         try {
           await upsert(id, messageStatus);
           return Either.right<Failure, string>(id);

--- a/ts/components/messages/paginated/MessageList/helpers.tsx
+++ b/ts/components/messages/paginated/MessageList/helpers.tsx
@@ -3,7 +3,6 @@ import { Animated, FlatList, ListRenderItemInfo } from "react-native";
 
 import { MessageCategory } from "../../../../../definitions/backend/MessageCategory";
 import { UIMessage } from "../../../../store/reducers/entities/messages/types";
-import { MessageStatus } from "../../../../store/reducers/entities/messages/messagesStatus";
 import ItemSeparatorComponent from "../../../ItemSeparatorComponent";
 import { ErrorLoadingComponent } from "../../ErrorLoadingComponent";
 import MessageListItem from "./Item";
@@ -33,7 +32,6 @@ export const ItemSeparator = () => <ItemSeparatorComponent noPadded={true} />;
 export const AnimatedFlatList = Animated.createAnimatedComponent(FlatList);
 
 type RenderItemProps = {
-  getMessageStatus: (id: string) => MessageStatus;
   hasPaidBadge: (id: MessageCategory) => boolean;
   onLongPress: (message: UIMessage) => void;
   onPress: (message: UIMessage) => void;
@@ -41,20 +39,18 @@ type RenderItemProps = {
 };
 export const renderItem =
   ({
-    getMessageStatus,
     hasPaidBadge,
     onLongPress,
     onPress,
     selectedMessageIds
   }: RenderItemProps) =>
-  ({ item: message }: ListRenderItemInfo<UIMessage>) => {
-    const { isRead, isArchived } = getMessageStatus(message.id);
-    return (
+  ({ item: message }: ListRenderItemInfo<UIMessage>) =>
+    (
       <MessageListItem
         category={message.category}
         hasPaidBadge={hasPaidBadge(message.category)}
-        isRead={isRead}
-        isArchived={isArchived}
+        isRead={message.isRead}
+        isArchived={message.isArchived}
         message={message}
         onPress={() => onPress(message)}
         onLongPress={() => onLongPress(message)}
@@ -62,7 +58,6 @@ export const renderItem =
         isSelected={!!selectedMessageIds?.has(message.id)}
       />
     );
-  };
 
 export type EmptyComponent = React.ComponentProps<
   typeof FlatList

--- a/ts/components/messages/paginated/MessageList/index.tsx
+++ b/ts/components/messages/paginated/MessageList/index.tsx
@@ -42,7 +42,6 @@ import { showToast } from "../../../../utils/showToast";
 import { isIos } from "../../../../utils/platform";
 import { EdgeBorderComponent } from "../../../screens/EdgeBorderComponent";
 import { isNoticePaid } from "../../../../store/reducers/entities/payments";
-import { getMessageStatus } from "../../../../store/reducers/entities/messages/messagesStatus";
 import {
   AnimatedFlatList,
   EmptyComponent,
@@ -157,7 +156,6 @@ const MessageList = ({
   // extracted from the store
   allMessages,
   error,
-  getMessageStatus,
   isLoadingMore,
   isRefreshing,
   isReloadingAll,
@@ -272,7 +270,6 @@ const MessageList = ({
         refreshing={isRefreshing}
         renderItem={renderItem({
           hasPaidBadge,
-          getMessageStatus,
           onLongPress,
           onPress: onPressItem,
           selectedMessageIds
@@ -316,7 +313,6 @@ const mapStateToProps = (state: GlobalState, { filter }: OwnProps) => {
 
   return {
     allMessages,
-    getMessageStatus: (id: string) => getMessageStatus(state, id),
     error,
     hasPaidBadge: (category: UIMessage["category"]) =>
       isNoticePaid(state, category),

--- a/ts/features/euCovidCert/screens/EuCovidCertificateRouterScreen.tsx
+++ b/ts/features/euCovidCert/screens/EuCovidCertificateRouterScreen.tsx
@@ -5,6 +5,7 @@ import { NavigationStackScreenProps } from "react-navigation-stack";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { DEPRECATED_setMessageReadState } from "../../../store/actions/messages";
+import { usePaginatedMessages } from "../../../config";
 import { GlobalState } from "../../../store/reducers/types";
 import { euCovidCertificateGet } from "../store/actions";
 import {
@@ -105,8 +106,10 @@ const EuCovidCertificateRouterScreen = (
 
   useEffect(() => {
     if (firstLoading.current) {
-      // At the first rendering, set the message to read
-      setMessageRead(messageId);
+      if (!usePaginatedMessages) {
+        // TODO: remove once we publish pagination
+        setMessageRead(messageId);
+      }
       // check if a load is required
       if (shouldBeLoaded(authCode)) {
         loadCertificate(authCode);

--- a/ts/features/euCovidCert/screens/EuCovidCertificateRouterScreen.tsx
+++ b/ts/features/euCovidCert/screens/EuCovidCertificateRouterScreen.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 import { NavigationStackScreenProps } from "react-navigation-stack";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
-import { setMessageReadState } from "../../../store/actions/messages";
+import { DEPRECATED_setMessageReadState } from "../../../store/actions/messages";
 import { GlobalState } from "../../../store/reducers/types";
 import { euCovidCertificateGet } from "../store/actions";
 import {
@@ -152,7 +152,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   loadCertificate: (authCode: EUCovidCertificateAuthCode) =>
     dispatch(euCovidCertificateGet.request(authCode)),
   setMessageRead: (messageId: string) =>
-    dispatch(setMessageReadState(messageId, true, "unknown"))
+    dispatch(DEPRECATED_setMessageReadState(messageId, true, "unknown"))
 });
 
 const mapStateToProps = (state: GlobalState) => ({

--- a/ts/features/mvl/screens/MvlRouterScreen.tsx
+++ b/ts/features/mvl/screens/MvlRouterScreen.tsx
@@ -1,7 +1,7 @@
 import * as pot from "italia-ts-commons/lib/pot";
 import * as React from "react";
 import { NavigationStackScreenProps } from "react-navigation-stack";
-import { setMessageReadState } from "../../../store/actions/messages";
+import { DEPRECATED_setMessageReadState } from "../../../store/actions/messages";
 import { useIODispatch, useIOSelector } from "../../../store/hooks";
 import { isMessageRead } from "../../../store/reducers/entities/messages/messagesStatus";
 import { UIMessageId } from "../../../store/reducers/entities/messages/types";
@@ -52,7 +52,7 @@ export const MvlRouterScreen = (
   const isRead = useIOSelector(state => isMessageRead(state, mvlId));
   useOnFirstRender(() => {
     if (!isRead) {
-      dispatch(setMessageReadState(mvlId, true, "unknown"));
+      dispatch(DEPRECATED_setMessageReadState(mvlId, true, "unknown"));
     }
     if (!pot.isSome(mvlPot)) {
       dispatch(mvlDetailsLoad.request(mvlId));

--- a/ts/features/mvl/screens/MvlRouterScreen.tsx
+++ b/ts/features/mvl/screens/MvlRouterScreen.tsx
@@ -6,6 +6,7 @@ import { useIODispatch, useIOSelector } from "../../../store/hooks";
 import { isMessageRead } from "../../../store/reducers/entities/messages/messagesStatus";
 import { UIMessageId } from "../../../store/reducers/entities/messages/types";
 import { useOnFirstRender } from "../../../utils/hooks/useOnFirstRender";
+import { usePaginatedMessages } from "../../../config";
 import { mvlDetailsLoad } from "../store/actions";
 import { mvlFromIdSelector } from "../store/reducers/byId";
 import { Mvl } from "../types/mvlData";
@@ -51,7 +52,8 @@ export const MvlRouterScreen = (
   const dispatch = useIODispatch();
   const isRead = useIOSelector(state => isMessageRead(state, mvlId));
   useOnFirstRender(() => {
-    if (!isRead) {
+    if (!isRead && !usePaginatedMessages) {
+      // TODO: remove once we publish pagination
       dispatch(DEPRECATED_setMessageReadState(mvlId, true, "unknown"));
     }
     if (!pot.isSome(mvlPot)) {

--- a/ts/features/mvl/screens/__test__/MvlRouterScreen.test.tsx
+++ b/ts/features/mvl/screens/__test__/MvlRouterScreen.test.tsx
@@ -6,7 +6,7 @@ import { Action } from "../../../../store/actions/types";
 import { appReducer } from "../../../../store/reducers";
 import { GlobalState } from "../../../../store/reducers/types";
 import { renderScreenFakeNavRedux } from "../../../../utils/testWrapper";
-import { setMessageReadState } from "../../../../store/actions/messages";
+import { DEPRECATED_setMessageReadState } from "../../../../store/actions/messages";
 import MVL_ROUTES from "../../navigation/routes";
 import { mvlDetailsLoad } from "../../store/actions";
 import { mvlMock, mvlMockId } from "../../types/__mock__/mvlMock";
@@ -48,7 +48,7 @@ describe("MvlRouterScreen behaviour", () => {
     it("Should set the message ID as read", () => {
       const { store } = renderWithDefaultStore();
       expect(store.getActions()).toContainEqual(
-        setMessageReadState(mvlMockId, true, "unknown")
+        DEPRECATED_setMessageReadState(mvlMockId, true, "unknown")
       );
     });
 
@@ -147,7 +147,7 @@ describe("MvlRouterScreen behaviour", () => {
       const { store } = renderWithDefaultStore();
       store.dispatch(success);
       expect(store.getActions()).toContainEqual(
-        setMessageReadState(mvlMockId, true, "unknown")
+        DEPRECATED_setMessageReadState(mvlMockId, true, "unknown")
       );
     });
   });

--- a/ts/sagas/messages/__tests__/watchUpsertMessageStatusAttributes.test.ts
+++ b/ts/sagas/messages/__tests__/watchUpsertMessageStatusAttributes.test.ts
@@ -1,0 +1,97 @@
+import { right } from "fp-ts/lib/Either";
+import { getType } from "typesafe-actions";
+import { testSaga } from "redux-saga-test-plan";
+import util from "util";
+
+import {
+  upsertMessageStatusAttributes as action,
+  UpsertMessageStatusAttributesPayload
+} from "../../../store/actions/messages";
+import { testTryUpsertMessageStatusAttributes } from "../watchUpsertMessageStatusAttribues";
+
+const tryUpsertMessageStatusAttributes = testTryUpsertMessageStatusAttributes!;
+
+describe("tryUpsertMessageStatusAttributes", () => {
+  util.inspect.defaultOptions.depth = null;
+
+  const actionPayload: UpsertMessageStatusAttributesPayload = {
+    id: "A",
+    update: { tag: "bulk", isArchiving: true }
+  };
+
+  const callPayload = {
+    id: "A",
+    messageStatusChange: {
+      change_type: "bulk",
+      is_archived: true,
+      is_read: true
+    }
+  };
+
+  describe("when the response is successful", () => {
+    it(`should put ${getType(
+      action.success
+    )} with the original payload`, () => {
+      const putMessage = jest.fn();
+      testSaga(
+        tryUpsertMessageStatusAttributes(putMessage),
+        action.request(actionPayload)
+      )
+        .next()
+        .call(putMessage, callPayload)
+        .next(right({ status: 200, value: {} }))
+        .put(action.success(actionPayload))
+        .next()
+        .isDone();
+    });
+  });
+
+  describe("when the response is an Error", () => {
+    it(`should put ${getType(action.failure)} with the error message`, () => {
+      const putMessage = jest.fn();
+      testSaga(
+        tryUpsertMessageStatusAttributes(putMessage),
+        action.request(actionPayload)
+      )
+        .next()
+        .call(putMessage, callPayload)
+        .next(
+          right({
+            status: 500,
+            value: { title: "462e5dffdb46435995d545999bed6b11" }
+          })
+        )
+        .put(
+          action.failure({
+            error: new Error("462e5dffdb46435995d545999bed6b11"),
+            payload: actionPayload
+          })
+        )
+        .next()
+        .isDone();
+    });
+  });
+
+  describe("when the handler throws", () => {
+    it(`should catch it and put ${getType(action.failure)}`, () => {
+      const putMessage = () => {
+        throw new Error("462e5dffdb46435995d545999bed6b11");
+      };
+      testSaga(
+        tryUpsertMessageStatusAttributes(putMessage),
+        action.request(actionPayload)
+      )
+        .next()
+        .call(putMessage, callPayload)
+        .next()
+        .put(
+          action.failure({
+            error: new TypeError("Cannot read property 'fold' of undefined"),
+            payload: actionPayload
+          })
+        )
+        .next()
+        .isDone();
+    });
+  });
+});

--- a/ts/sagas/messages/__tests__/watchUpsertMessageStatusAttributes.test.ts
+++ b/ts/sagas/messages/__tests__/watchUpsertMessageStatusAttributes.test.ts
@@ -1,7 +1,6 @@
 import { right } from "fp-ts/lib/Either";
 import { getType } from "typesafe-actions";
 import { testSaga } from "redux-saga-test-plan";
-import util from "util";
 
 import {
   upsertMessageStatusAttributes as action,
@@ -12,8 +11,6 @@ import { testTryUpsertMessageStatusAttributes } from "../watchUpsertMessageStatu
 const tryUpsertMessageStatusAttributes = testTryUpsertMessageStatusAttributes!;
 
 describe("tryUpsertMessageStatusAttributes", () => {
-  util.inspect.defaultOptions.depth = null;
-
   const actionPayload: UpsertMessageStatusAttributesPayload = {
     id: "A",
     update: { tag: "bulk", isArchived: true },

--- a/ts/sagas/messages/__tests__/watchUpsertMessageStatusAttributes.test.ts
+++ b/ts/sagas/messages/__tests__/watchUpsertMessageStatusAttributes.test.ts
@@ -13,8 +13,7 @@ const tryUpsertMessageStatusAttributes = testTryUpsertMessageStatusAttributes!;
 describe("tryUpsertMessageStatusAttributes", () => {
   const actionPayload: UpsertMessageStatusAttributesPayload = {
     id: "A",
-    update: { tag: "bulk", isArchived: true },
-    messageType: "unknown"
+    update: { tag: "bulk", isArchived: true }
   };
 
   const callPayload = {

--- a/ts/sagas/messages/__tests__/watchUpsertMessageStatusAttributes.test.ts
+++ b/ts/sagas/messages/__tests__/watchUpsertMessageStatusAttributes.test.ts
@@ -16,7 +16,8 @@ describe("tryUpsertMessageStatusAttributes", () => {
 
   const actionPayload: UpsertMessageStatusAttributesPayload = {
     id: "A",
-    update: { tag: "bulk", isArchiving: true }
+    update: { tag: "bulk", isArchived: true },
+    messageType: "unknown"
   };
 
   const callPayload = {

--- a/ts/sagas/messages/watchUpsertMessageStatusAttribues.ts
+++ b/ts/sagas/messages/watchUpsertMessageStatusAttribues.ts
@@ -42,7 +42,7 @@ function validatePayload(
     case "archiving":
       return {
         change_type: "archiving",
-        is_archived: payload.update.isArchiving
+        is_archived: payload.update.isArchived
       } as MessageStatusArchivingChange;
     case "reading":
       return {
@@ -53,7 +53,7 @@ function validatePayload(
       return {
         change_type: "bulk",
         is_read: true,
-        is_archived: payload.update.isArchiving
+        is_archived: payload.update.isArchived
       } as MessageStatusBulkChange;
     default:
       throw new TypeError("invalid payload");

--- a/ts/sagas/messages/watchUpsertMessageStatusAttribues.ts
+++ b/ts/sagas/messages/watchUpsertMessageStatusAttribues.ts
@@ -12,8 +12,8 @@ import { MessageStatusChange } from "../../../definitions/backend/MessageStatusC
 import { MessageStatusBulkChange } from "../../../definitions/backend/MessageStatusBulkChange";
 import { MessageStatusReadingChange } from "../../../definitions/backend/MessageStatusReadingChange";
 import { MessageStatusArchivingChange } from "../../../definitions/backend/MessageStatusArchivingChange";
-import { handleResponse } from "./utils";
 import { isTestEnv } from "../../utils/environment";
+import { handleResponse } from "./utils";
 
 type LocalActionType = ActionType<
   typeof upsertMessageStatusAttributes["request"]

--- a/ts/sagas/messages/watchUpsertMessageStatusAttribues.ts
+++ b/ts/sagas/messages/watchUpsertMessageStatusAttribues.ts
@@ -1,0 +1,98 @@
+import { call, put, takeLatest } from "typed-redux-saga/macro";
+import { ActionType, getType } from "typesafe-actions";
+
+import { BackendClient } from "../../api/backend";
+import {
+  upsertMessageStatusAttributes,
+  UpsertMessageStatusAttributesPayload
+} from "../../store/actions/messages";
+import { ReduxSagaEffect, SagaCallReturnType } from "../../types/utils";
+import { getError } from "../../utils/errors";
+import { MessageStatusChange } from "../../../definitions/backend/MessageStatusChange";
+import { MessageStatusBulkChange } from "../../../definitions/backend/MessageStatusBulkChange";
+import { MessageStatusReadingChange } from "../../../definitions/backend/MessageStatusReadingChange";
+import { MessageStatusArchivingChange } from "../../../definitions/backend/MessageStatusArchivingChange";
+import { handleResponse } from "./utils";
+import { isTestEnv } from "../../utils/environment";
+
+type LocalActionType = ActionType<
+  typeof upsertMessageStatusAttributes["request"]
+>;
+type LocalBeClient = ReturnType<
+  typeof BackendClient
+>["upsertMessageStatusAttributes"];
+
+export default function* watcher(
+  putMessage: LocalBeClient
+): Generator<ReduxSagaEffect, void, SagaCallReturnType<typeof putMessage>> {
+  yield* takeLatest(
+    getType(upsertMessageStatusAttributes.request),
+    tryUpsertMessageStatusAttributes(putMessage)
+  );
+}
+
+/**
+ * @throws invalid payload
+ * @param payload
+ */
+function validatePayload(
+  payload: UpsertMessageStatusAttributesPayload
+): MessageStatusChange {
+  switch (payload.update.tag) {
+    case "archiving":
+      return {
+        change_type: "archiving",
+        is_archived: payload.update.isArchiving
+      } as MessageStatusArchivingChange;
+    case "reading":
+      return {
+        change_type: "reading",
+        is_read: true
+      } as MessageStatusReadingChange;
+    case "bulk":
+      return {
+        change_type: "bulk",
+        is_read: true,
+        is_archived: payload.update.isArchiving
+      } as MessageStatusBulkChange;
+    default:
+      throw new TypeError("invalid payload");
+  }
+}
+
+function tryUpsertMessageStatusAttributes(putMessage: LocalBeClient) {
+  return function* gen(
+    action: LocalActionType
+  ): Generator<ReduxSagaEffect, void, SagaCallReturnType<typeof putMessage>> {
+    try {
+      const messageStatusChange = validatePayload(action.payload);
+      const response: SagaCallReturnType<typeof putMessage> = yield* call(
+        putMessage,
+        { id: action.payload.id, messageStatusChange }
+      );
+
+      const nextAction = handleResponse<unknown>(
+        response,
+        _ => upsertMessageStatusAttributes.success(action.payload),
+        error =>
+          upsertMessageStatusAttributes.failure({
+            error: getError(error),
+            payload: action.payload
+          })
+      );
+
+      yield* put(nextAction);
+    } catch (error) {
+      yield* put(
+        upsertMessageStatusAttributes.failure({
+          error: getError(error),
+          payload: action.payload
+        })
+      );
+    }
+  };
+}
+
+export const testTryUpsertMessageStatusAttributes = isTestEnv
+  ? tryUpsertMessageStatusAttributes
+  : undefined;

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -86,6 +86,7 @@ import watchLoadMessageDetails from "./messages/watchLoadMessageDetails";
 import watchLoadNextPageMessages from "./messages/watchLoadNextPageMessages";
 import watchLoadPreviousPageMessages from "./messages/watchLoadPreviousPageMessages";
 import watchReloadAllMessages from "./messages/watchReloadAllMessages";
+import watchUpsertMessageStatusAttribues from "./messages/watchUpsertMessageStatusAttribues";
 import {
   askMixpanelOptIn,
   handleSetMixpanelEnabled,
@@ -491,6 +492,10 @@ export function* initializeApplicationSaga(): Generator<
     yield* fork(watchLoadPreviousPageMessages, backendClient.getMessages);
     yield* fork(watchReloadAllMessages, backendClient.getMessages);
     yield* fork(watchLoadMessageDetails, backendClient.getMessage);
+    yield* fork(
+      watchUpsertMessageStatusAttribues,
+      backendClient.upsertMessageStatusAttributes
+    );
   }
 
   // Load a message when requested

--- a/ts/screens/messages/MessageDetailScreen/index.tsx
+++ b/ts/screens/messages/MessageDetailScreen/index.tsx
@@ -13,7 +13,7 @@ import I18n from "../../../i18n";
 import {
   loadMessageWithRelations,
   MessageReadType,
-  setMessageReadState
+  DEPRECATED_setMessageReadState
 } from "../../../store/actions/messages";
 import { navigateToServiceDetailsScreen } from "../../../store/actions/navigation";
 import { loadServiceDetail } from "../../../store/actions/services";
@@ -172,7 +172,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     messageId: string,
     isRead: boolean,
     messageType: MessageReadType
-  ) => dispatch(setMessageReadState(messageId, isRead, messageType)),
+  ) => dispatch(DEPRECATED_setMessageReadState(messageId, isRead, messageType)),
   navigateToServiceDetailsScreen: (
     params: ServiceDetailsScreenNavigationParams
   ) => navigateToServiceDetailsScreen(params)

--- a/ts/screens/messages/MessagesHomeScreen.tsx
+++ b/ts/screens/messages/MessagesHomeScreen.tsx
@@ -22,7 +22,7 @@ import SectionStatusComponent from "../../components/SectionStatus";
 import I18n from "../../i18n";
 import {
   DEPRECATED_loadMessages as loadMessages,
-  setMessagesArchivedState
+  DEPRECATED_setMessagesArchivedState
 } from "../../store/actions/messages";
 import { navigateToMessageRouterScreen } from "../../store/actions/navigation";
 import { loadServiceDetail } from "../../store/actions/services";
@@ -355,7 +355,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   updateMessagesArchivedState: (
     ids: ReadonlyArray<string>,
     archived: boolean
-  ) => dispatch(setMessagesArchivedState(ids, archived))
+  ) => dispatch(DEPRECATED_setMessagesArchivedState(ids, archived))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(MessagesHomeScreen);

--- a/ts/screens/messages/paginated/MessageDetailScreen.tsx
+++ b/ts/screens/messages/paginated/MessageDetailScreen.tsx
@@ -4,23 +4,17 @@ import React from "react";
 import { ActivityIndicator, StyleSheet } from "react-native";
 import { NavigationStackScreenProps } from "react-navigation-stack";
 import { connect } from "react-redux";
-import { TagEnum } from "../../../../definitions/backend/MessageCategoryPayment";
 import MessageDetailComponent from "../../../components/messages/paginated/MessageDetail";
 
 import BaseScreenComponent, {
   ContextualHelpPropsMarkdown
 } from "../../../components/screens/BaseScreenComponent";
 import I18n from "../../../i18n";
-import {
-  loadMessageDetails,
-  MessageReadType,
-  upsertMessageStatusAttributes
-} from "../../../store/actions/messages";
+import { loadMessageDetails } from "../../../store/actions/messages";
 import { navigateToServiceDetailsScreen } from "../../../store/actions/navigation";
 import { loadServiceDetail } from "../../../store/actions/services";
 import { Dispatch, ReduxProps } from "../../../store/actions/types";
 import { getDetailsByMessageId } from "../../../store/reducers/entities/messages/detailsById";
-import { isMessageRead } from "../../../store/reducers/entities/messages/messagesStatus";
 import {
   UIMessage,
   UIMessageId
@@ -76,22 +70,14 @@ const renderLoadingState = () => (
 const MessageDetailScreen = ({
   goBack,
   hasPaidBadge,
-  isRead,
   loadMessageDetails,
   maybeServiceMetadata,
   message,
   messageDetails,
   refreshService,
-  service,
-  setMessageReadState
+  service
 }: Props) => {
   useOnFirstRender(() => {
-    if (!isRead) {
-      setMessageReadState(
-        message.id,
-        message.category.tag === TagEnum.PAYMENT ? TagEnum.PAYMENT : "unknown"
-      );
-    }
     if (
       pot.isError(messageDetails) ||
       (pot.isNone(messageDetails) && !pot.isLoading(messageDetails))
@@ -157,7 +143,6 @@ const MessageDetailScreen = ({
 const mapStateToProps = (state: GlobalState, ownProps: OwnProps) => {
   const message: UIMessage = ownProps.navigation.getParam("message");
   const messageDetails = getDetailsByMessageId(state, message.id);
-  const isRead = isMessageRead(state, message.id);
   const goBack = () => ownProps.navigation.goBack();
   const service = pot
     .toOption(serviceByIdSelector(message.serviceId)(state) || pot.none)
@@ -171,7 +156,6 @@ const mapStateToProps = (state: GlobalState, ownProps: OwnProps) => {
 
   return {
     goBack,
-    isRead,
     hasPaidBadge,
     message,
     messageDetails,
@@ -184,15 +168,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   refreshService: (serviceId: string) =>
     dispatch(loadServiceDetail.request(serviceId)),
   loadMessageDetails: (id: UIMessageId) =>
-    dispatch(loadMessageDetails.request({ id })),
-  setMessageReadState: (messageId: string, messageType: MessageReadType) =>
-    dispatch(
-      upsertMessageStatusAttributes.request({
-        id: messageId,
-        update: { tag: "reading" },
-        messageType
-      })
-    )
+    dispatch(loadMessageDetails.request({ id }))
 });
 
 export default connect(

--- a/ts/screens/messages/paginated/MessageDetailScreen.tsx
+++ b/ts/screens/messages/paginated/MessageDetailScreen.tsx
@@ -14,7 +14,7 @@ import I18n from "../../../i18n";
 import {
   loadMessageDetails,
   MessageReadType,
-  setMessageReadState
+  upsertMessageStatusAttributes
 } from "../../../store/actions/messages";
 import { navigateToServiceDetailsScreen } from "../../../store/actions/navigation";
 import { loadServiceDetail } from "../../../store/actions/services";
@@ -89,7 +89,6 @@ const MessageDetailScreen = ({
     if (!isRead) {
       setMessageReadState(
         message.id,
-        true,
         message.category.tag === TagEnum.PAYMENT ? TagEnum.PAYMENT : "unknown"
       );
     }
@@ -186,11 +185,14 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
     dispatch(loadServiceDetail.request(serviceId)),
   loadMessageDetails: (id: UIMessageId) =>
     dispatch(loadMessageDetails.request({ id })),
-  setMessageReadState: (
-    messageId: string,
-    isRead: boolean,
-    messageType: MessageReadType
-  ) => dispatch(setMessageReadState(messageId, isRead, messageType))
+  setMessageReadState: (messageId: string, messageType: MessageReadType) =>
+    dispatch(
+      upsertMessageStatusAttributes.request({
+        id: messageId,
+        update: { tag: "reading" },
+        messageType
+      })
+    )
 });
 
 export default connect(

--- a/ts/screens/messages/paginated/MessageRouterScreen.tsx
+++ b/ts/screens/messages/paginated/MessageRouterScreen.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useEffect, useRef } from "react";
 import { NavigationStackScreenProps } from "react-navigation-stack";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
-import { TagEnum as TagEnumPayment } from "../../../../definitions/backend/MessageCategoryPayment";
 import { TagEnum } from "../../../../definitions/backend/MessageCategoryBase";
 import BaseScreenComponent from "../../../components/screens/BaseScreenComponent";
 
@@ -22,7 +21,6 @@ import NavigationService from "../../../navigation/NavigationService";
 import {
   loadMessageDetails,
   loadPreviousPageMessages,
-  MessageReadType,
   reloadAllMessages,
   upsertMessageStatusAttributes
 } from "../../../store/actions/messages";
@@ -132,12 +130,7 @@ const MessageRouterScreen = ({
 
   useOnFirstRender(() => {
     if (maybeMessage !== undefined && !maybeMessage.isRead) {
-      setMessageReadState(
-        maybeMessage.id,
-        maybeMessage.category.tag === TagEnumPayment.PAYMENT
-          ? TagEnumPayment.PAYMENT
-          : "unknown"
-      );
+      setMessageReadState(maybeMessage.id);
     }
   });
 
@@ -195,12 +188,11 @@ const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => {
         })
       ),
     reloadPage: () => dispatch(reloadAllMessages.request({ pageSize, filter })),
-    setMessageReadState: (messageId: string, messageType: MessageReadType) =>
+    setMessageReadState: (messageId: string) =>
       dispatch(
         upsertMessageStatusAttributes.request({
           id: messageId,
-          update: { tag: "reading" },
-          messageType
+          update: { tag: "reading" }
         })
       )
   };

--- a/ts/store/actions/messages.ts
+++ b/ts/store/actions/messages.ts
@@ -118,12 +118,16 @@ export const reloadAllMessages = createAsyncAction(
   MessagesFailurePayload
 >();
 
+export type MessageReadType =
+  | Extract<MessageCategory["tag"], TagEnum.PAYMENT>
+  | "unknown";
 export type UpsertMessageStatusAttributesPayload = {
   id: string;
   update:
-    | { tag: "archiving"; isArchiving: boolean }
+    | { tag: "archiving"; isArchived: boolean }
     | { tag: "reading" }
-    | { tag: "bulk"; isArchiving: boolean };
+    | { tag: "bulk"; isArchived: boolean };
+  messageType: MessageReadType;
 };
 export const upsertMessageStatusAttributes = createAsyncAction(
   "UPSERT_MESSAGE_STATUS_ATTRIBUTES_REQUEST",
@@ -147,16 +151,19 @@ export const DEPRECATED_loadMessages = createAsyncAction(
 export const removeMessages =
   createStandardAction("MESSAGES_REMOVE")<ReadonlyArray<string>>();
 
-export type MessageReadType =
-  | Extract<MessageCategory["tag"], TagEnum.PAYMENT>
-  | "unknown";
-export const setMessageReadState = createAction(
+/**
+ *  @deprecated Please use actions with pagination instead
+ */
+export const DEPRECATED_setMessageReadState = createAction(
   "MESSAGES_SET_READ",
   resolve => (id: string, read: boolean, messageType: MessageReadType) =>
     resolve({ id, read, messageType }, { id, read })
 );
 
-export const setMessagesArchivedState = createAction(
+/**
+ *  @deprecated Please use actions with pagination instead
+ */
+export const DEPRECATED_setMessagesArchivedState = createAction(
   "MESSAGES_SET_ARCHIVED",
   resolve => (ids: ReadonlyArray<string>, archived: boolean) =>
     resolve({ ids, archived })
@@ -171,6 +178,6 @@ export type MessagesActions =
   | ActionType<typeof loadMessageDetails>
   | ActionType<typeof DEPRECATED_loadMessages>
   | ActionType<typeof removeMessages>
-  | ActionType<typeof setMessageReadState>
+  | ActionType<typeof DEPRECATED_setMessageReadState>
   | ActionType<typeof upsertMessageStatusAttributes>
-  | ActionType<typeof setMessagesArchivedState>;
+  | ActionType<typeof DEPRECATED_setMessagesArchivedState>;

--- a/ts/store/actions/messages.ts
+++ b/ts/store/actions/messages.ts
@@ -118,6 +118,23 @@ export const reloadAllMessages = createAsyncAction(
   MessagesFailurePayload
 >();
 
+export type UpsertMessageStatusAttributesPayload = {
+  id: string;
+  update:
+    | { tag: "archiving"; isArchiving: boolean }
+    | { tag: "reading" }
+    | { tag: "bulk"; isArchiving: boolean };
+};
+export const upsertMessageStatusAttributes = createAsyncAction(
+  "UPSERT_MESSAGE_STATUS_ATTRIBUTES_REQUEST",
+  "UPSERT_MESSAGE_STATUS_ATTRIBUTES_SUCCESS",
+  "UPSERT_MESSAGE_STATUS_ATTRIBUTES_FAILURE"
+)<
+  UpsertMessageStatusAttributesPayload,
+  UpsertMessageStatusAttributesPayload,
+  { error: Error; payload: UpsertMessageStatusAttributesPayload }
+>();
+
 /**
  *  @deprecated Please use actions with pagination instead
  */
@@ -155,4 +172,5 @@ export type MessagesActions =
   | ActionType<typeof DEPRECATED_loadMessages>
   | ActionType<typeof removeMessages>
   | ActionType<typeof setMessageReadState>
+  | ActionType<typeof upsertMessageStatusAttributes>
   | ActionType<typeof setMessagesArchivedState>;

--- a/ts/store/actions/messages.ts
+++ b/ts/store/actions/messages.ts
@@ -118,16 +118,12 @@ export const reloadAllMessages = createAsyncAction(
   MessagesFailurePayload
 >();
 
-export type MessageReadType =
-  | Extract<MessageCategory["tag"], TagEnum.PAYMENT>
-  | "unknown";
 export type UpsertMessageStatusAttributesPayload = {
   id: string;
   update:
     | { tag: "archiving"; isArchived: boolean }
     | { tag: "reading" }
     | { tag: "bulk"; isArchived: boolean };
-  messageType: MessageReadType;
 };
 export const upsertMessageStatusAttributes = createAsyncAction(
   "UPSERT_MESSAGE_STATUS_ATTRIBUTES_REQUEST",
@@ -151,6 +147,9 @@ export const DEPRECATED_loadMessages = createAsyncAction(
 export const removeMessages =
   createStandardAction("MESSAGES_REMOVE")<ReadonlyArray<string>>();
 
+export type MessageReadType =
+  | Extract<MessageCategory["tag"], TagEnum.PAYMENT>
+  | "unknown";
 /**
  *  @deprecated Please use actions with pagination instead
  */

--- a/ts/store/middlewares/analytics.ts
+++ b/ts/store/middlewares/analytics.ts
@@ -51,7 +51,8 @@ import {
   DEPRECATED_loadMessage,
   DEPRECATED_loadMessages as loadMessages,
   removeMessages,
-  setMessageReadState
+  DEPRECATED_setMessageReadState,
+  upsertMessageStatusAttributes
 } from "../actions/messages";
 import { setMixpanelEnabled } from "../actions/mixpanel";
 import {
@@ -247,13 +248,16 @@ const trackAction =
           messagesIdsToRemoveFromCache: action.payload
         });
       }
-      case getType(setMessageReadState): {
+      case getType(DEPRECATED_setMessageReadState): {
         if (action.payload.read === true) {
           setInstabugUserAttribute("lastSeenMessageID", action.payload.id);
         }
         return mp.track(action.type, action.payload);
       }
-
+      case getType(upsertMessageStatusAttributes.success): {
+        // TODO: update to keep the current metrics
+        break;
+      }
       // instabug
       case getType(instabugReportClosed):
       case getType(instabugReportOpened):

--- a/ts/store/middlewares/analytics.ts
+++ b/ts/store/middlewares/analytics.ts
@@ -255,7 +255,7 @@ const trackAction =
         return mp.track(action.type, action.payload);
       }
       case getType(upsertMessageStatusAttributes.success): {
-        // TODO: update to keep the current metrics
+        // TODO: update to keep metrics consistent
         break;
       }
       // instabug

--- a/ts/store/middlewares/analytics.ts
+++ b/ts/store/middlewares/analytics.ts
@@ -255,7 +255,12 @@ const trackAction =
         return mp.track(action.type, action.payload);
       }
       case getType(upsertMessageStatusAttributes.success): {
-        // TODO: update to keep metrics consistent
+        if (
+          action.payload.update.tag === "bulk" ||
+          action.payload.update.tag === "reading"
+        ) {
+          setInstabugUserAttribute("lastSeenMessageID", action.payload.id);
+        }
         break;
       }
       // instabug

--- a/ts/store/reducers/entities/__tests__/messagesStatus.test.ts
+++ b/ts/store/reducers/entities/__tests__/messagesStatus.test.ts
@@ -5,8 +5,8 @@ import { MessageContent } from "../../../../../definitions/backend/MessageConten
 import {
   DEPRECATED_loadMessage,
   removeMessages,
-  setMessageReadState,
-  setMessagesArchivedState
+  DEPRECATED_setMessageReadState,
+  DEPRECATED_setMessagesArchivedState
 } from "../../../actions/messages";
 import { Action } from "../../../actions/types";
 import reducer, {
@@ -65,7 +65,7 @@ describe("messagesStatus reducer", () => {
     expect(
       reducer(
         undefined,
-        setMessageReadState(messageWithContent.id, true, "unknown")
+        DEPRECATED_setMessageReadState(messageWithContent.id, true, "unknown")
       )
     ).toEqual({
       [messageWithContent.id]: { ...EMPTY_MESSAGE_STATUS, isRead: true }
@@ -76,7 +76,7 @@ describe("messagesStatus reducer", () => {
     expect(
       reducer(
         undefined,
-        setMessageReadState(messageWithContent.id, false, "unknown")
+        DEPRECATED_setMessageReadState(messageWithContent.id, false, "unknown")
       )
     ).toEqual({
       [messageWithContent.id]: { ...EMPTY_MESSAGE_STATUS, isRead: false }
@@ -87,7 +87,7 @@ describe("messagesStatus reducer", () => {
     expect(
       reducer(
         undefined,
-        setMessagesArchivedState([messageWithContent.id], true)
+        DEPRECATED_setMessagesArchivedState([messageWithContent.id], true)
       )
     ).toEqual({
       [messageWithContent.id]: { ...EMPTY_MESSAGE_STATUS, isArchived: true }
@@ -108,7 +108,7 @@ describe("messagesStatus reducer", () => {
     expect(
       reducer(
         undefined,
-        setMessagesArchivedState([messageWithContent.id], false)
+        DEPRECATED_setMessagesArchivedState([messageWithContent.id], false)
       )
     ).toEqual({
       [messageWithContent.id]: { ...EMPTY_MESSAGE_STATUS, isArchived: false }
@@ -123,7 +123,7 @@ describe("messagesStatus reducer", () => {
         "3": EMPTY_MESSAGE_STATUS,
         "4": EMPTY_MESSAGE_STATUS
       },
-      setMessageReadState("4", true, "unknown")
+      DEPRECATED_setMessageReadState("4", true, "unknown")
     );
     testLength(state, 4);
     const stateAfterRemove = reducer(state, removeMessages(["1", "2", "3"]));

--- a/ts/store/reducers/entities/messages/messagesStatus.ts
+++ b/ts/store/reducers/entities/messages/messagesStatus.ts
@@ -4,8 +4,8 @@ import { getType } from "typesafe-actions";
 import {
   DEPRECATED_loadMessage,
   removeMessages,
-  setMessageReadState,
-  setMessagesArchivedState
+  DEPRECATED_setMessageReadState,
+  DEPRECATED_setMessagesArchivedState
 } from "../../../actions/messages";
 import { Action } from "../../../actions/types";
 import { GlobalState } from "../../types";
@@ -43,7 +43,7 @@ const reducer = (
       };
     }
 
-    case getType(setMessageReadState): {
+    case getType(DEPRECATED_setMessageReadState): {
       const { id, read } = action.payload;
       // if misses, set the default values for given message
       const prevState = state[id] || EMPTY_MESSAGE_STATUS;
@@ -55,7 +55,7 @@ const reducer = (
         }
       };
     }
-    case getType(setMessagesArchivedState): {
+    case getType(DEPRECATED_setMessagesArchivedState): {
       const { ids, archived } = action.payload;
       const updatedMessageStates = ids.reduce<{
         [key: string]: MessageStatus;


### PR DESCRIPTION
## Short description
We implement the networking and logic for upserting message attributes _read_ and _archived_. I've connected the _read_ status to test it, while the _archived_ action is more complex due to sorting edge cases and will be handled in a separate task.

## List of changes proposed in this pull request
- new backend [endpoint](https://github.com/pagopa/io-app/pull/3848/files#diff-ac04d289df4b924fd0e2cee9ddaa414ad33332daf86424260ab533c21a284193R460)
- new [saga](ts/sagas/messages/watchUpsertMessageStatusAttribues.ts), [action](https://github.com/pagopa/io-app/pull/3848/files#diff-5b727d84caebb631cf6843fbd8f3595a97801341cee749b8d9535aabdbc12460R128), and [tests](ts/sagas/messages/__tests__/watchUpsertMessageStatusAttributes.test.ts)
- former [read](https://github.com/pagopa/io-app/pull/3848/files#diff-5b727d84caebb631cf6843fbd8f3595a97801341cee749b8d9535aabdbc12460R156) and [archived](https://github.com/pagopa/io-app/pull/3848/files#diff-5b727d84caebb631cf6843fbd8f3595a97801341cee749b8d9535aabdbc12460R165) actions are now deprecated
- _read_ and _archived_ are now [coming from backend](https://github.com/pagopa/io-app/pull/3848/files#diff-5d2069c099684d6a56a86df750b25c4cbf098b242c751215afab02b8f5a592a6R53) 🎉 
- had to fix [a small bug](https://github.com/pagopa/io-app/pull/3848/files#diff-bcbf6afc3d95f5b125321b43a35962fc8b5fa5186b29df65796d739bd9113817R35) to avoid migration of non-necessary messages, and [its test](https://github.com/pagopa/io-app/pull/3848/files#diff-67144522210873f6e25ec306e8dc26f17aa2b6626dd44f2c5a5b931db6ea53faR58) 
- the _read_ status is now handled at [MessageRouterScreen level](https://github.com/pagopa/io-app/pull/3848/files#diff-d26076117cc01e414c1a19c57e64ffbded662df3c965361935d414d9bb7fa01dR191) 
- the optimistic UI for _read_ status [is implemented](https://github.com/pagopa/io-app/pull/3848/files#diff-482523dcf54c84f4e40e09c47ee2eeca62c92423ef82ff98aae91839199d8c16R323)

## How to test

1. spin up the server and the app with pagination enabled, using [this branch](https://github.com/pagopa/io-dev-api-server/pull/143)
2. open an unread message
3. close it
4. if you uninstall the app and install again (keeping the server running!) you'll notice that the read status is persisted

https://user-images.githubusercontent.com/2094604/159440177-fcc50f5c-08ea-4945-a6f7-962fd261ad2b.mov


