### PR TITLE
chore(Carta Giovani Nazionale): [IOACGN-68] Refactors bucket code request component to avoid huge bucket consuption

### DIFF
--- a/ts/features/bonus/cgn/components/merchants/discount/CgnBucketCodeComponent.tsx
+++ b/ts/features/bonus/cgn/components/merchants/discount/CgnBucketCodeComponent.tsx
@@ -12,7 +12,10 @@ import { isError, isLoading, isReady } from "../../../../bpd/model/RemoteValue";
 import Eye from "../../../../../../../img/icons/Eye.svg";
 import ActivityIndicator from "../../../../../../components/ui/ActivityIndicator";
 import { cgnBucketSelector } from "../../../store/reducers/bucket";
-import { cgnCodeFromBucket } from "../../../store/actions/bucket";
+import {
+  cgnCodeFromBucket,
+  cgnCodeFromBucketReset
+} from "../../../store/actions/bucket";
 import IconFont from "../../../../../../components/ui/IconFont";
 import { clipboardSetStringWithFeedback } from "../../../../../../utils/clipboard";
 import { H3 } from "../../../../../../components/core/typography/H3";
@@ -39,9 +42,41 @@ const styles = StyleSheet.create({
 
 const COPY_ICON_SIZE = 24;
 const FEEDBACK_TIMEOUT = 3000 as Millisecond;
+const EMPTY_CODE_CONTENT = "••••••••••";
+type ContentProps = {
+  onRequestBucket: () => void;
+};
 
-const CgnBucketCodeContent = () => {
-  const [isCodeVisible, setIsCodeVisible] = React.useState(false);
+const BucketCodeHandler = ({
+  onPress,
+  content,
+  icon
+}: {
+  onPress: () => void;
+  content: string;
+  icon: React.ReactElement;
+}) => (
+  <TouchableWithoutFeedback
+    onPress={onPress}
+    accessible={true}
+    accessibilityRole={"button"}
+    accessibilityHint={I18n.t("bonus.cgn.accessibility.code")}
+  >
+    <View style={[styles.row, styles.codeContainer]}>
+      <BaseTypography
+        weight={"Bold"}
+        color={"bluegreyDark"}
+        font={"RobotoMono"}
+        style={styles.codeText}
+      >
+        {content}
+      </BaseTypography>
+
+      {icon}
+    </View>
+  </TouchableWithoutFeedback>
+);
+const CgnBucketCodeContent = (props: ContentProps) => {
   const [isTap, setIsTap] = React.useState(false);
   const timerRetry = useRef<number | undefined>(undefined);
 
@@ -82,36 +117,17 @@ const CgnBucketCodeContent = () => {
       ]
     );
 
+  useEffect(() => {
+    if (
+      isError(bucketResponse) ||
+      (isReady(bucketResponse) && bucketResponse.value.kind === "unhandled")
+    ) {
+      showAlertError();
+    }
+  }, [bucketResponse]);
+
   if (isLoading(bucketResponse)) {
     return <ActivityIndicator />;
-  }
-
-  if (isError(bucketResponse)) {
-    return (
-      <TouchableWithoutFeedback
-        onPress={showAlertError}
-        accessible={true}
-        accessibilityRole={"button"}
-        accessibilityHint={I18n.t("bonus.cgn.accessibility.code")}
-      >
-        <View style={[styles.row, styles.codeContainer]}>
-          <BaseTypography
-            weight={"Bold"}
-            color={"bluegreyDark"}
-            font={"RobotoMono"}
-            style={styles.codeText}
-          >
-            {"••••••••••"}
-          </BaseTypography>
-
-          <Eye
-            width={COPY_ICON_SIZE}
-            height={COPY_ICON_SIZE}
-            fill={IOColors.blue}
-          />
-        </View>
-      </TouchableWithoutFeedback>
-    );
   }
 
   // we got an error no code is available
@@ -132,53 +148,49 @@ const CgnBucketCodeContent = () => {
     );
   }
 
-  return (
-    <TouchableWithoutFeedback
-      onPress={isCodeVisible ? handleCopyPress : () => setIsCodeVisible(true)}
-      accessible={true}
-      accessibilityRole={"button"}
-      accessibilityHint={I18n.t("bonus.cgn.accessibility.code")}
-    >
-      <View style={[styles.row, styles.codeContainer]}>
-        <BaseTypography
-          weight={"Bold"}
-          color={"bluegreyDark"}
-          font={"RobotoMono"}
-          style={styles.codeText}
-        >
-          {isCodeVisible &&
-          isReady(bucketResponse) &&
-          isDiscountBucketCodeResponseSuccess(bucketResponse.value)
-            ? bucketResponse.value.value.code
-            : "••••••••••"}
-        </BaseTypography>
-
-        {isCodeVisible &&
-        isReady(bucketResponse) &&
-        isDiscountBucketCodeResponseSuccess(bucketResponse.value) ? (
+  if (isReady(bucketResponse) && bucketResponse.value.kind === "success") {
+    return (
+      <BucketCodeHandler
+        onPress={handleCopyPress}
+        content={bucketResponse.value.value.code}
+        icon={
           <IconFont
             name={isTap ? "io-complete" : "io-copy"}
             size={COPY_ICON_SIZE}
             color={IOColors.blue}
             style={styles.flexEnd}
           />
-        ) : (
-          <Eye
-            width={COPY_ICON_SIZE}
-            height={COPY_ICON_SIZE}
-            fill={IOColors.blue}
-          />
-        )}
-      </View>
-    </TouchableWithoutFeedback>
+        }
+      />
+    );
+  }
+
+  return (
+    <BucketCodeHandler
+      onPress={props.onRequestBucket}
+      content={EMPTY_CODE_CONTENT}
+      icon={
+        <Eye
+          width={COPY_ICON_SIZE}
+          height={COPY_ICON_SIZE}
+          fill={IOColors.blue}
+        />
+      }
+    />
   );
 };
 const CgnBucketCodeComponent = ({ discountId }: Props) => {
   const dispatch = useIODispatch();
 
-  useEffect(() => {
+  const requestBucketCode = () =>
     dispatch(cgnCodeFromBucket.request(discountId));
-  }, []);
+
+  useEffect(
+    () => () => {
+      dispatch(cgnCodeFromBucketReset());
+    },
+    [dispatch]
+  );
 
   return (
     <View testID={"bucket-code-component"}>
@@ -186,7 +198,7 @@ const CgnBucketCodeComponent = ({ discountId }: Props) => {
         {I18n.t("bonus.cgn.merchantDetail.title.discountCode")}
       </H3>
       <View spacer small />
-      <CgnBucketCodeContent />
+      <CgnBucketCodeContent onRequestBucket={requestBucketCode} />
     </View>
   );
 };

--- a/ts/features/bonus/cgn/store/actions/bucket.ts
+++ b/ts/features/bonus/cgn/store/actions/bucket.ts
@@ -1,4 +1,8 @@
-import { ActionType, createAsyncAction, createStandardAction } from "typesafe-actions";
+import {
+  ActionType,
+  createAsyncAction,
+  createStandardAction
+} from "typesafe-actions";
 import { NetworkError } from "../../../../../utils/errors";
 import { Discount } from "../../../../../../definitions/cgn/merchants/Discount";
 import { DiscountBucketCodeResponse } from "../../types/DiscountBucketCodeResponse";

--- a/ts/features/bonus/cgn/store/actions/bucket.ts
+++ b/ts/features/bonus/cgn/store/actions/bucket.ts
@@ -1,4 +1,4 @@
-import { ActionType, createAsyncAction } from "typesafe-actions";
+import { ActionType, createAsyncAction, createStandardAction } from "typesafe-actions";
 import { NetworkError } from "../../../../../utils/errors";
 import { Discount } from "../../../../../../definitions/cgn/merchants/Discount";
 import { DiscountBucketCodeResponse } from "../../types/DiscountBucketCodeResponse";
@@ -12,4 +12,10 @@ export const cgnCodeFromBucket = createAsyncAction(
   "CGN_BUCKET_CODE_FAILURE"
 )<Discount["id"], DiscountBucketCodeResponse, NetworkError>();
 
-export type CgnBucketActions = ActionType<typeof cgnCodeFromBucket>;
+export const cgnCodeFromBucketReset = createStandardAction(
+  "CGN_BUCKET_CODE_RESET"
+)<void>();
+
+export type CgnBucketActions =
+  | ActionType<typeof cgnCodeFromBucket>
+  | ActionType<typeof cgnCodeFromBucketReset>;

--- a/ts/features/bonus/cgn/store/reducers/bucket.ts
+++ b/ts/features/bonus/cgn/store/reducers/bucket.ts
@@ -9,7 +9,7 @@ import {
   remoteUndefined,
   RemoteValue
 } from "../../../bpd/model/RemoteValue";
-import { cgnCodeFromBucket } from "../actions/bucket";
+import { cgnCodeFromBucket, cgnCodeFromBucketReset } from "../actions/bucket";
 import { DiscountBucketCodeResponse } from "../../types/DiscountBucketCodeResponse";
 
 export type CgnBucketState = {
@@ -39,6 +39,10 @@ const reducer = (
       return {
         ...state,
         data: remoteError(action.payload)
+      };
+    case getType(cgnCodeFromBucketReset):
+      return {
+        ...INITIAL_STATE
       };
   }
   return state;


### PR DESCRIPTION
## Short description
This PR refactors CGN Bucket code component to avoid automatic bucket code request (and consuption).
Now the Code is requested only when users tap on the related Eye icon.

## How to test
Check for an available CGN merchant with bucketCode discount type, then open a discount and ask for a bucket code.


https://user-images.githubusercontent.com/3959405/159334291-313497b3-3cea-4e61-9ca0-461cf4e57b8b.mp4


