### PR TITLE
fix: [IA-735] Fix payment method switch loader alignment on Android

### DIFF
--- a/ts/components/wallet/FavoriteMethodSwitch.tsx
+++ b/ts/components/wallet/FavoriteMethodSwitch.tsx
@@ -13,6 +13,7 @@ import {
   getFavoriteWalletId
 } from "../../store/reducers/wallet/wallets";
 import { PaymentMethod } from "../../types/pagopa";
+import { isAndroid } from "../../utils/platform";
 import { handleSetFavourite } from "../../utils/wallet";
 import { IOStyleVariables } from "../core/variables/IOStyleVariables";
 import Switch from "../ui/Switch";
@@ -50,7 +51,12 @@ const FavoritePaymentMethodSwitch = (props: Props) => {
   );
 
   const rightElement = isLoading ? (
-    <View style={{ width: IOStyleVariables.switchWidth }}>
+    <View
+      style={{
+        width: IOStyleVariables.switchWidth,
+        alignSelf: isAndroid ? "center" : undefined
+      }}
+    >
       <ActivityIndicator
         color={"black"}
         accessible={false}


### PR DESCRIPTION
## Short description
This PR is going to fix the switch loader alignment showed while setting a favourite payment method on Android.

❓ This fix takes for granted that on iOS the switch must be aligned to the top while on Android it's centered.

### Android preview
https://user-images.githubusercontent.com/5963683/159962249-40cddb58-5236-418c-a6d1-5e9249e3f2a2.mov

### iOS preview
https://user-images.githubusercontent.com/5963683/159962265-082d98da-67e2-4de0-8532-78fb558c6ef8.mov

## List of changes proposed in this pull request
- Fixed the loader alignment on Android

## How to test
Go into the wallet and set a payment method as favourite, the loader should be aligned correctly both on iOS and Android.
