### PR TITLE
chore: [IA-801] Remove donation banner from archive and search

### DIFF
--- a/ts/components/messages/paginated/MessageList/index.tsx
+++ b/ts/components/messages/paginated/MessageList/index.tsx
@@ -12,7 +12,6 @@ import {
 import { connect } from "react-redux";
 
 import { maximumItemsFromAPI, pageSize } from "../../../../config";
-import { UaDonationsBanner } from "../../../../features/uaDonations/components/UaDonationsBanner";
 import I18n from "../../../../i18n";
 import {
   Filter,
@@ -87,6 +86,7 @@ const styles = StyleSheet.create({
 
 type OwnProps = {
   ListEmptyComponent?: EmptyComponent;
+  ListHeaderComponent?: React.ReactElement;
 
   /** @deprecated This list is used instead of the messages from the store */
   filteredMessages?: ReadonlyArray<UIMessage>;
@@ -147,6 +147,7 @@ type Props = OwnProps &
  */
 const MessageList = ({
   ListEmptyComponent,
+  ListHeaderComponent,
   filteredMessages,
   onLongPressItem,
   hasPaidBadge,
@@ -263,7 +264,7 @@ const MessageList = ({
       {isRefreshing && isFirstLoad && <Loader />}
 
       <AnimatedFlatList
-        ListHeaderComponent={<UaDonationsBanner />}
+        ListHeaderComponent={ListHeaderComponent}
         ItemSeparatorComponent={ItemSeparator}
         ListEmptyComponent={renderEmptyList({
           error,

--- a/ts/components/messages/paginated/MessagesInbox.tsx
+++ b/ts/components/messages/paginated/MessagesInbox.tsx
@@ -8,6 +8,7 @@ import { EmptyListComponent } from "../EmptyListComponent";
 
 import { useItemsSelection } from "../../../utils/hooks/useItemsSelection";
 import ListSelectionBar from "../../ListSelectionBar";
+import { UaDonationsBanner } from "../../../features/uaDonations/components/UaDonationsBanner";
 import MessageList from "./MessageList";
 
 const styles = StyleSheet.create({
@@ -84,6 +85,7 @@ const MessagesInbox = ({
           onLongPressItem={onLongPressItem}
           selectedMessageIds={selectedItems.toUndefined()}
           ListEmptyComponent={ListEmptyComponent}
+          ListHeaderComponent={<UaDonationsBanner />}
         />
       </View>
       {isSelecting && (


### PR DESCRIPTION
## Short description
Donation banner should only be presented in messages inbox.

## List of changes proposed in this pull request
- Remove `UaDonationsBanner` from `MessageList` and add a `ListHeaderComponent` prop
- Inject `UaDonationsBanner` as `ListHeaderComponent` from `MessagesInbox`

## How to test
Make sure you have `uaDonationsEnabled` config set to true and navigate Inbox, Archive and Search.

| Before | After |
| - | - |
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-04-01 at 16 00 09](https://user-images.githubusercontent.com/467098/161279353-6f937856-0db6-49d2-ba29-8f704fbff7f9.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-04-01 at 15 59 43](https://user-images.githubusercontent.com/467098/161279337-7c182bd0-a9cb-40e7-a5ce-22511e2f0c7e.png) |
|  ![Simulator Screen Shot - iPhone 13 Pro - 2022-04-01 at 16 00 11](https://user-images.githubusercontent.com/467098/161279398-5725bd3f-23d4-4139-a387-0087eb38f730.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-04-01 at 15 59 45](https://user-images.githubusercontent.com/467098/161279472-da26c7f2-9993-4125-8f3a-e9e345f125e9.png) |
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-04-01 at 16 00 15](https://user-images.githubusercontent.com/467098/161279512-8a755938-e817-4cec-8186-c7c9fe65b27f.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-04-01 at 15 59 51](https://user-images.githubusercontent.com/467098/161279547-4cd303f3-b534-4387-bb1a-f76aed2afc9b.png) |



