### PR TITLE
chore: [IAI-179] Remove "upload sourcemap to Instabug" build phase on iOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -498,13 +498,6 @@ workflows:
             branches:
               ignore: master
 
-      - ios-beta-release:
-          requires:
-            - compile-typescript
-            - run-tests
-            - run-eslint
-            - run-prettier
-
       # TODO: Native Android e2e tests
       # TODO: Slack integration
       - run-e2e-test-IOS:


### PR DESCRIPTION
## Short description
This pr removes the "upload sourcemap to Instabug" build phase on iOS.

