### PR TITLE
chore: [IA-806] Show BPay in checkout payment screen

### DIFF
--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -40,7 +40,10 @@ import {
   PaymentWebViewEndReason
 } from "../../../store/actions/wallet/payment";
 import { fetchTransactionsRequestWithExpBackoff } from "../../../store/actions/wallet/transactions";
-import { isPaypalEnabledSelector } from "../../../store/reducers/backendStatus";
+import {
+  bancomatPayConfigSelector,
+  isPaypalEnabledSelector
+} from "../../../store/reducers/backendStatus";
 import { isPagoPATestEnabledSelector } from "../../../store/reducers/persistedPreferences";
 import { GlobalState } from "../../../store/reducers/types";
 import { outcomeCodesSelector } from "../../../store/reducers/wallet/outcomeCode";
@@ -86,6 +89,7 @@ import CardIcon from "../../../../img/wallet/card.svg";
 import { SelectionBox } from "../../../components/wallet/SelectionBox";
 import { getTranslatedShortNumericMonthYear } from "../../../utils/dates";
 import { getPaypalAccountEmail } from "../../../utils/paypal";
+import bancomatPayLogo from "../../../../img/wallet/payment-methods/bancomatpay-logo.png";
 
 // temporary feature flag since this feature is still WIP
 // (missing task to complete https://pagopa.atlassian.net/browse/IA-684?filter=10121)
@@ -145,7 +149,7 @@ type ComputedPaymentMethodInfo = {
 
 const getPaymentMethodInfo = (
   paymentMethod: PaymentMethod | undefined,
-  isPaypalEnabled: boolean
+  options: { isPaypalEnabled: boolean; isBPayPaymentEnabled: boolean }
 ): Option<ComputedPaymentMethodInfo> => {
   switch (paymentMethod?.kind) {
     case "CreditCard":
@@ -170,21 +174,24 @@ const getPaymentMethodInfo = (
       });
 
     case "PayPal":
-      if (isPaypalEnabled) {
-        const paypalEmail = getPaypalAccountEmail(paymentMethod.info);
-
-        return some({
-          logo: <PaypalLogo width={24} height={24} />,
-          subject: paypalEmail,
-          expiration: "",
-          caption: I18n.t("wallet.onboarding.paypal.name"),
-          accessibilityLabel: `${I18n.t(
-            "wallet.onboarding.paypal.name"
-          )}, ${paypalEmail}`
-        });
-      } else {
-        return none;
-      }
+      const paypalEmail = getPaypalAccountEmail(paymentMethod.info);
+      return some({
+        logo: <PaypalLogo width={24} height={24} />,
+        subject: paypalEmail,
+        expiration: "",
+        caption: I18n.t("wallet.onboarding.paypal.name"),
+        accessibilityLabel: `${I18n.t(
+          "wallet.onboarding.paypal.name"
+        )}, ${paypalEmail}`
+      }).filter(() => options.isPaypalEnabled);
+    case "BPay":
+      return some({
+        logo: <BrandImage image={bancomatPayLogo} scale={0.7} />,
+        subject: paymentMethod?.caption,
+        expiration: "",
+        caption: paymentMethod.info.numberObfuscated ?? "",
+        accessibilityLabel: `${I18n.t("wallet.onboarding.paypal.name")}`
+      }).filter(() => options.isBPayPaymentEnabled);
 
     default:
       return none;
@@ -303,10 +310,10 @@ const ConfirmPaymentMethodScreen: React.FC<Props> = (props: Props) => {
   // Retrieve all the informations needed by the
   // user interface based on the payment method
   // selected by the user.
-  const paymentMethodInfo = getPaymentMethodInfo(
-    paymentMethod,
-    props.isPaypalEnabled
-  ).getOrElse({
+  const paymentMethodInfo = getPaymentMethodInfo(paymentMethod, {
+    isPaypalEnabled: props.isPaypalEnabled,
+    isBPayPaymentEnabled: props.isBPayPaymentEnabled
+  }).getOrElse({
     subject: "",
     expiration: "",
     caption: "",
@@ -535,6 +542,7 @@ const mapStateToProps = (state: GlobalState) => {
     isPagoPATestEnabled: isPagoPATestEnabledSelector(state),
     outcomeCodes: outcomeCodesSelector(state),
     isPaypalEnabled: isPaypalEnabledSelector(state),
+    isBPayPaymentEnabled: bancomatPayConfigSelector(state).payment,
     payStartWebviewPayload,
     isLoading: isLoading(pmSessionToken),
     retrievingSessionTokenError: isError(pmSessionToken)

--- a/ts/screens/wallet/payment/__tests__/ConfirmPaymentMethodScreen.test.tsx
+++ b/ts/screens/wallet/payment/__tests__/ConfirmPaymentMethodScreen.test.tsx
@@ -134,6 +134,12 @@ describe("Integration Tests With Actual Store and Simplified Navigation", () => 
       creditCardPaymentMethod
     );
 
+    (bancomatPayConfigSelector as unknown as jest.Mock).mockReturnValue({
+      display: false,
+      onboarding: false,
+      payment: true
+    });
+
     const rendered = renderScreenFakeNavRedux<
       GlobalState,
       ConfirmPaymentMethodScreenNavigationParams
@@ -191,6 +197,12 @@ describe("Integration Tests With Actual Store and Simplified Navigation", () => 
     (paymentMethodByIdSelector as unknown as jest.Mock).mockReturnValue(
       payPalPaymentMethod
     );
+
+    (bancomatPayConfigSelector as unknown as jest.Mock).mockReturnValue({
+      display: false,
+      onboarding: false,
+      payment: true
+    });
 
     (isPaypalEnabledSelector as unknown as jest.Mock).mockReturnValue(true);
 

--- a/ts/screens/wallet/payment/__tests__/ConfirmPaymentMethodScreen.test.tsx
+++ b/ts/screens/wallet/payment/__tests__/ConfirmPaymentMethodScreen.test.tsx
@@ -308,9 +308,9 @@ describe("Integration Tests With Actual Store and Simplified Navigation", () => 
     );
 
     // Should display the payment method
-    rendered.getByText(bpayPaymentMethod.caption ?? "");
+    rendered.getByText(bpayPaymentMethod.caption!);
 
-    rendered.getByText(bpayPaymentMethod.info?.numberObfuscated ?? "");
+    rendered.getByText(bpayPaymentMethod.info!.numberObfuscated!);
 
     // Should render the PSP with the fees
     rendered.getByText(
@@ -323,10 +323,13 @@ describe("Integration Tests With Actual Store and Simplified Navigation", () => 
       }`
     );
 
-    // It should retrieve one `Edit` text, only
-    // the one for the payment method.
+    /**
+     * It should retrieve two `Edit` CTAs
+     * one for the payment method.
+     * one for the PSP
+     */
     expect(
       rendered.getAllByText(I18n.t("wallet.ConfirmPayment.edit"))
-    ).toHaveLength(1);
+    ).toHaveLength(2);
   });
 });

--- a/ts/screens/wallet/payment/__tests__/ConfirmPaymentMethodScreen.test.tsx
+++ b/ts/screens/wallet/payment/__tests__/ConfirmPaymentMethodScreen.test.tsx
@@ -17,13 +17,17 @@ import { GlobalState } from "../../../../store/reducers/types";
 import { reproduceSequence } from "../../../../utils/tests";
 import { formatNumberCentsToAmount } from "../../../../utils/stringBuilder";
 import {
+  BPayPaymentMethod,
   CreditCardPaymentMethod,
   PayPalPaymentMethod
 } from "../../../../types/pagopa";
 import I18n from "../../../../i18n";
 import { paymentMethodByIdSelector } from "../../../../store/reducers/wallet/wallets";
 import { pspSelectedV2ListSelector } from "../../../../store/reducers/wallet/payment";
-import { isPaypalEnabledSelector } from "../../../../store/reducers/backendStatus";
+import {
+  bancomatPayConfigSelector,
+  isPaypalEnabledSelector
+} from "../../../../store/reducers/backendStatus";
 import { getTranslatedShortNumericMonthYear } from "../../../../utils/dates";
 
 // Mock react native share
@@ -67,7 +71,8 @@ jest.mock("../../../../store/reducers/backendStatus", () => {
   return {
     __esModule: true,
     ...actualModule,
-    isPaypalEnabledSelector: jest.fn()
+    isPaypalEnabledSelector: jest.fn(),
+    bancomatPayConfigSelector: jest.fn()
   };
 });
 
@@ -97,6 +102,14 @@ const payPalPaymentMethod = {
   },
   caption: "caption"
 } as DeepPartial<PayPalPaymentMethod>;
+
+const bpayPaymentMethod = {
+  kind: "BPay",
+  caption: "BPay caption",
+  info: {
+    numberObfuscated: "***123"
+  }
+} as DeepPartial<BPayPaymentMethod>;
 
 describe("Integration Tests With Actual Store and Simplified Navigation", () => {
   afterAll(() => jest.resetAllMocks());
@@ -233,6 +246,69 @@ describe("Integration Tests With Actual Store and Simplified Navigation", () => 
       `${I18n.t(
         "wallet.onboarding.paypal.paymentCheckout.privacyDisclaimer"
       )} ${I18n.t("wallet.onboarding.paypal.paymentCheckout.privacyTerms")}`
+    );
+
+    // It should retrieve one `Edit` text, only
+    // the one for the payment method.
+    expect(
+      rendered.getAllByText(I18n.t("wallet.ConfirmPayment.edit"))
+    ).toHaveLength(1);
+  });
+
+  it("should display all the information correctly for a `BPay` payment method", () => {
+    (paymentMethodByIdSelector as unknown as jest.Mock).mockReturnValue(
+      bpayPaymentMethod
+    );
+
+    (bancomatPayConfigSelector as unknown as jest.Mock).mockReturnValue({
+      display: false,
+      onboarding: false,
+      payment: true
+    });
+
+    const bpayParams = {
+      ...params,
+      wallet: {
+        ...params.wallet,
+        paymentMethod: bpayPaymentMethod as BPayPaymentMethod
+      }
+    };
+
+    const rendered = renderScreenFakeNavRedux<
+      GlobalState,
+      ConfirmPaymentMethodScreenNavigationParams
+    >(
+      ConfirmPaymentMethodScreen,
+      ROUTES.PAYMENT_CONFIRM_PAYMENT_METHOD,
+      bpayParams,
+      myStore
+    );
+
+    // Should display the payment reason
+    rendered.getByText(bpayParams.verifica.causaleVersamento);
+
+    // Should display the payment amount
+    rendered.getByText(
+      formatNumberCentsToAmount(
+        bpayParams.verifica.importoSingoloVersamento,
+        true
+      )
+    );
+
+    // Should display the payment method
+    rendered.getByText(bpayPaymentMethod.caption ?? "");
+
+    rendered.getByText(bpayPaymentMethod.info?.numberObfuscated ?? "");
+
+    // Should render the PSP with the fees
+    rendered.getByText(
+      formatNumberCentsToAmount(params.wallet.psp?.fixedCost.amount ?? -1, true)
+    );
+
+    rendered.getByText(
+      `${I18n.t("wallet.ConfirmPayment.providedBy")} ${
+        params.wallet.psp?.businessName
+      }`
     );
 
     // It should retrieve one `Edit` text, only


### PR DESCRIPTION
## Short description
This PR adds some changes in order to display BancomatPay in the payment checkout screen.

| before  | now |
| ------------- | ------------- |
![before](https://user-images.githubusercontent.com/822471/161771561-980f24a9-d02c-4988-8da0-5962f17da523.png)| ![now](https://user-images.githubusercontent.com/822471/161771557-618307f2-2c7b-4e6c-9f58-f151435907aa.png) 

## How to test
- use dev-server by pointing this branch `IA-786-bpay-can-pay`
- turn on **[this FF](https://github.com/pagopa/io-dev-api-server/blob/c6c6a71c5c893832546f2a37c228d2d39092c87a/src/payloads/backend.ts#L237)** 
- do a payment and pick BPay as payment method
