### PR TITLE
fix: [IABT-1366,IABT-1367] Requests might be silently cancelled when archiving multiple messages at once

### DIFF
--- a/ts/sagas/messages/watchUpsertMessageStatusAttribues.ts
+++ b/ts/sagas/messages/watchUpsertMessageStatusAttribues.ts
@@ -1,4 +1,4 @@
-import { call, put, takeLatest } from "typed-redux-saga/macro";
+import { call, put, takeEvery } from "typed-redux-saga/macro";
 import { ActionType, getType } from "typesafe-actions";
 
 import { BackendClient } from "../../api/backend";
@@ -25,7 +25,7 @@ type LocalBeClient = ReturnType<
 export default function* watcher(
   putMessage: LocalBeClient
 ): Generator<ReduxSagaEffect, void, SagaCallReturnType<typeof putMessage>> {
-  yield* takeLatest(
+  yield* takeEvery(
     getType(upsertMessageStatusAttributes.request),
     tryUpsertMessageStatusAttributes(putMessage)
   );


### PR DESCRIPTION
## Short description
Although you can select multiple messages to archive/unarchive, each of them sends a single request to the backend. In some conditions it might happen that some requests get cancelled without neither succeeding nor failing.

This PR addresses the issue.

## List of changes proposed in this pull request
- Replace `takeLatest` with `takeEvery` in the saga watcher

## How to test
Select all the messages in the Inbox, put the device in Flight Mode (or shutdown the dev server) and tap on Archive. Messages should be moved to the Archive at first, but when the requests fail they should all be moved back to the Inbox.
