### PR TITLE
fix: [IA-814] An empty screen is shown when an error occurred in SPID login 

### DIFF
--- a/ts/screens/authentication/IdpLoginScreen.tsx
+++ b/ts/screens/authentication/IdpLoginScreen.tsx
@@ -303,32 +303,34 @@ class IdpLoginScreen extends React.Component<Props, State> {
           loggedOutWithIdpAuth.idp.name
         }`}
       >
-        {!hasError && (
+        {
           <View style={styles.webViewWrapper}>
-            <WebView
-              cacheEnabled={false}
-              androidCameraAccessDisabled={true}
-              androidMicrophoneAccessDisabled={true}
-              textZoom={100}
-              originWhitelist={originSchemasWhiteList}
-              source={{ uri: loginUri }}
-              onError={this.handleLoadingError}
-              javaScriptEnabled={true}
-              onNavigationStateChange={this.handleNavigationStateChange}
-              onShouldStartLoadWithRequest={this.handleShouldStartLoading}
-            />
+            {!hasError && (
+              <WebView
+                cacheEnabled={false}
+                androidCameraAccessDisabled={true}
+                androidMicrophoneAccessDisabled={true}
+                textZoom={100}
+                originWhitelist={originSchemasWhiteList}
+                source={{ uri: loginUri }}
+                onError={this.handleLoadingError}
+                javaScriptEnabled={true}
+                onNavigationStateChange={this.handleNavigationStateChange}
+                onShouldStartLoadWithRequest={this.handleShouldStartLoading}
+              />
+            )}
             {this.renderMask()}
           </View>
-        )}
+        }
       </BaseScreenComponent>
     );
   }
 }
 
 const mapStateToProps = (state: GlobalState) => {
-  const selectedtIdp = selectedIdentityProviderSelector(state);
+  const selectedIdp = selectedIdentityProviderSelector(state);
 
-  const selectedIdpTextData = fromNullable(selectedtIdp).fold(none, idp =>
+  const selectedIdpTextData = fromNullable(selectedIdp).fold(none, idp =>
     idpContextualHelpDataFromIdSelector(idp.id)(state)
   );
 

--- a/ts/screens/authentication/IdpLoginScreen.tsx
+++ b/ts/screens/authentication/IdpLoginScreen.tsx
@@ -303,25 +303,23 @@ class IdpLoginScreen extends React.Component<Props, State> {
           loggedOutWithIdpAuth.idp.name
         }`}
       >
-        {
-          <View style={styles.webViewWrapper}>
-            {!hasError && (
-              <WebView
-                cacheEnabled={false}
-                androidCameraAccessDisabled={true}
-                androidMicrophoneAccessDisabled={true}
-                textZoom={100}
-                originWhitelist={originSchemasWhiteList}
-                source={{ uri: loginUri }}
-                onError={this.handleLoadingError}
-                javaScriptEnabled={true}
-                onNavigationStateChange={this.handleNavigationStateChange}
-                onShouldStartLoadWithRequest={this.handleShouldStartLoading}
-              />
-            )}
-            {this.renderMask()}
-          </View>
-        }
+        <View style={styles.webViewWrapper}>
+          {!hasError && (
+            <WebView
+              cacheEnabled={false}
+              androidCameraAccessDisabled={true}
+              androidMicrophoneAccessDisabled={true}
+              textZoom={100}
+              originWhitelist={originSchemasWhiteList}
+              source={{ uri: loginUri }}
+              onError={this.handleLoadingError}
+              javaScriptEnabled={true}
+              onNavigationStateChange={this.handleNavigationStateChange}
+              onShouldStartLoadWithRequest={this.handleShouldStartLoading}
+            />
+          )}
+          {this.renderMask()}
+        </View>
       </BaseScreenComponent>
     );
   }


### PR DESCRIPTION
## Short description
This PR fixes a bug that causes to display a void content when an error with SPID login is detected

| before  | after |
| ------------- | ------------- |
![before](https://user-images.githubusercontent.com/822471/162238128-300fe214-aaf2-448f-bd8d-31eed125c640.png) | ![after](https://user-images.githubusercontent.com/822471/162239759-35b43215-8df3-4ca6-9052-886479ebcd48.png)

## How to test
- simulate an error in the SPID login webview
