### PR TITLE
chore: [IA-724] Add unit tests for the payment checkout WebView data

### DIFF
--- a/ts/screens/wallet/payment/__tests__/ConfirmPaymentMethodScreen.test.tsx
+++ b/ts/screens/wallet/payment/__tests__/ConfirmPaymentMethodScreen.test.tsx
@@ -10,6 +10,7 @@ import {
   myPsp,
   AuthSeq
 } from "../../../../utils/testFaker";
+import { getLookUpIdPO, newLookUpId } from "../../../../utils/pmLookUpId";
 import { renderScreenFakeNavRedux } from "../../../../utils/testWrapper";
 import { appReducer } from "../../../../store/reducers/";
 import ROUTES from "../../../../navigation/routes";
@@ -351,6 +352,8 @@ describe("Integration Tests With Actual Store and Simplified Navigation", () => 
   it("should send all the correct informations to the `PayWebViewModal` component", () => {
     const PayWebViewModalMock = PayWebViewModal as unknown as jest.Mock;
 
+    newLookUpId();
+
     const idPayment = "id";
     const language = "it";
     const idWallet = 123;
@@ -392,7 +395,8 @@ describe("Integration Tests With Actual Store and Simplified Navigation", () => 
       idPayment,
       idWallet,
       language,
-      sessionToken
+      sessionToken,
+      ...getLookUpIdPO()
     };
 
     expect(PayWebViewModalMock).toBeCalled();


### PR DESCRIPTION
## Short description
This PR is going to strengthen the unit tests in the payment checkout section. Now the data sent to the relative WebView are tested in order to prevent issues like: https://github.com/pagopa/io-app/pull/3828.

## List of changes proposed in this pull request
- Added unit tests to check for the data sent to the WebView during the checkout

## How to test
Setting the `formData` variable to `{}` (or removing values from it) inside `ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx` should not allow the tests to pass correctly.
