### PR TITLE
[IABT-1370] Match against message detail route

### DIFF
--- a/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionSummaryScreen.tsx
@@ -171,7 +171,10 @@ class TransactionSummaryScreen extends React.Component<Props> {
       const startRoute = this.props.navigation.getParam("startRoute");
       if (startRoute !== undefined) {
         // The payment flow is inside the wallet stack, if we start outside this stack we need to reset the stack
-        if (startRoute.routeName === ROUTES.MESSAGE_DETAIL) {
+        if (
+          startRoute.routeName === ROUTES.MESSAGE_DETAIL ||
+          startRoute.routeName === ROUTES.MESSAGE_DETAIL_PAGINATED
+        ) {
           this.props.navigation.dispatch(StackActions.popToTop());
         }
         this.props.navigation.navigate(startRoute);


### PR DESCRIPTION
## Short description
Fix the navigation error by matching against the MESSAGE_DETAIL_PAGINATED route. 
Crash scenario is now not reproducible as well.


https://user-images.githubusercontent.com/2094604/162914313-47690618-e2dd-4e2f-9658-04f0b542e02e.mov

