### PR TITLE
chore: [IA-821] Add an E2E test to the payment flow that starts from a message

### DIFF
--- a/ts/__e2e__/payment.e2e.ts
+++ b/ts/__e2e__/payment.e2e.ts
@@ -22,7 +22,40 @@ describe("Payment", () => {
           .toBeVisible()
           .withTimeout(e2eWaitRenderTimeout);
       });
+
+      describe("when navigating to the wallet", () => {
+        it("then the wallet root screen should be visible", async () => {
+          await openPaymentFromMessage();
+
+          const cancelButton = element(
+            by.text(I18n.t("global.buttons.cancel"))
+          );
+          await waitFor(cancelButton)
+            .toBeVisible()
+            .withTimeout(e2eWaitRenderTimeout);
+          await cancelButton.tap();
+
+          const backButton = element(by.id("back-button"));
+          await waitFor(backButton)
+            .toBeVisible()
+            .withTimeout(e2eWaitRenderTimeout);
+          await backButton.tap();
+
+          const walletButton = element(
+            by.text(I18n.t("global.navigator.wallet"))
+          );
+          await waitFor(walletButton)
+            .toBeVisible()
+            .withTimeout(e2eWaitRenderTimeout);
+          await walletButton.tap();
+
+          await waitFor(element(by.text(I18n.t("wallet.payNotice"))))
+            .toBeVisible()
+            .withTimeout(e2eWaitRenderTimeout);
+        });
+      });
     });
+
     describe("And press cancel in the payment confirm screen", () => {
       it("Should return to the message details screen", async () => {
         await openPaymentFromMessage();

--- a/ts/screens/messages/paginated/MessageDetailScreen.tsx
+++ b/ts/screens/messages/paginated/MessageDetailScreen.tsx
@@ -121,6 +121,7 @@ const MessageDetailScreen = ({
       <BaseScreenComponent
         headerTitle={I18n.t("messageDetails.headerTitle")}
         goBack={goBack}
+        backButtonTestID={"back-button"}
         contextualHelpMarkdown={contextualHelpMarkdown}
         faqCategories={["messages_detail"]}
       >


### PR DESCRIPTION
## Short description
This PR introduces an E2E test as a guard for preventing future regressions on #3904.

https://user-images.githubusercontent.com/467098/162976186-d8545842-4887-4ae3-be13-b9acbb10c78d.mov


