### PR TITLE
chore: [IAI-182] Enable iOS push notification in dev mode

### DIFF
--- a/ts/boot/configurePushNotification.ts
+++ b/ts/boot/configurePushNotification.ts
@@ -68,7 +68,7 @@ function handleMessageReload() {
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
 function configurePushNotifications() {
-  // if isDevEnv is enabled and we are on Android, we need to disable the push notification to avoid crash for missing firebase settings
+  // if isDevEnv is enabled and we are on Android, we need to disable the push notifications to avoid crash for missing firebase settings
   if (isDevEnv && Platform.OS === "android") {
     return;
   }

--- a/ts/boot/configurePushNotification.ts
+++ b/ts/boot/configurePushNotification.ts
@@ -6,7 +6,7 @@ import { constNull } from "fp-ts/lib/function";
 import { fromEither, fromNullable } from "fp-ts/lib/Option";
 import * as t from "io-ts";
 import { NonEmptyString } from "italia-ts-commons/lib/strings";
-import { Alert } from "react-native";
+import { Alert, Platform } from "react-native";
 import PushNotification from "react-native-push-notification";
 import * as pot from "@pagopa/ts-commons/lib/pot";
 
@@ -68,8 +68,8 @@ function handleMessageReload() {
 
 // eslint-disable-next-line sonarjs/cognitive-complexity
 function configurePushNotifications() {
-  // if isDevEnv, disable push notification to avoid crash for missing firebase settings
-  if (isDevEnv) {
+  // if isDevEnv is enabled and we are on Android, we need to disable the push notification to avoid crash for missing firebase settings
+  if (isDevEnv && Platform.OS === "android") {
     return;
   }
 


### PR DESCRIPTION
## Short description
This pr enables the push notifications on iOS when we are in dev mode.
Now is possible to simulate a push notification without commenting any part of the code, just using the command `xcrun simctl push B72B45FE-6DFF-4945-A53B-74918ED7A07A it.pagopa.app.io test.apns` or drag and drop the `apns` file to the emulator.
