### PR TITLE
fix: [IABT-1369] Check against service when entering the message detail view

### DIFF
--- a/ts/screens/messages/paginated/MessageRouterScreen.tsx
+++ b/ts/screens/messages/paginated/MessageRouterScreen.tsx
@@ -3,6 +3,8 @@ import React, { useCallback, useEffect, useRef } from "react";
 import { NavigationStackScreenProps } from "react-navigation-stack";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
+import * as O from "fp-ts/lib/Option";
+
 import { TagEnum } from "../../../../definitions/backend/MessageCategoryBase";
 import BaseScreenComponent from "../../../components/screens/BaseScreenComponent";
 
@@ -24,6 +26,7 @@ import {
   reloadAllMessages,
   upsertMessageStatusAttributes
 } from "../../../store/actions/messages";
+import { loadServiceDetail } from "../../../store/actions/services";
 import {
   navigateBack,
   navigateToPaginatedMessageDetailScreenAction
@@ -39,6 +42,7 @@ import {
   UIMessageDetails,
   UIMessageId
 } from "../../../store/reducers/entities/messages/types";
+import { serviceByIdSelector } from "../../../store/reducers/entities/services/servicesById";
 import { GlobalState } from "../../../store/reducers/types";
 import { emptyContextualHelp } from "../../../utils/emptyContextualHelp";
 import { useNavigationContext } from "../../../utils/hooks/useOnFocus";
@@ -94,8 +98,10 @@ const navigateToScreenHandler =
 const MessageRouterScreen = ({
   cancel,
   cursors,
+  isServiceAvailable,
   loadMessageDetails,
   loadPreviousPage,
+  loadServiceDetail,
   reloadPage,
   maybeMessage,
   maybeMessageDetails,
@@ -133,6 +139,12 @@ const MessageRouterScreen = ({
       setMessageReadState(maybeMessage);
     }
   });
+
+  useEffect(() => {
+    if (!isServiceAvailable && maybeMessage) {
+      loadServiceDetail(maybeMessage.serviceId);
+    }
+  }, [isServiceAvailable, loadServiceDetail]);
 
   useEffect(() => {
     // message in the list and its details loaded: green light
@@ -188,6 +200,8 @@ const mapDispatchToProps = (dispatch: Dispatch, ownProps: OwnProps) => {
         })
       ),
     reloadPage: () => dispatch(reloadAllMessages.request({ pageSize, filter })),
+    loadServiceDetail: (serviceId: string) =>
+      dispatch(loadServiceDetail.request(serviceId)),
     setMessageReadState: (message: UIMessage) =>
       dispatch(
         upsertMessageStatusAttributes.request({
@@ -202,10 +216,15 @@ const mapStateToProps = (state: GlobalState, ownProps: OwnProps) => {
   const messageId = ownProps.navigation.getParam("messageId");
   const isArchived = Boolean(ownProps.navigation.getParam("isArchived"));
   const maybeMessage = allPaginated.getById(state, messageId);
+  const isServiceAvailable = O.fromNullable(maybeMessage?.serviceId)
+    .map(serviceId => serviceByIdSelector(serviceId)(state) || pot.none)
+    .map(_ => Boolean(pot.toUndefined(_)))
+    .getOrElse(false);
   const maybeMessageDetails = getDetailsByMessageId(state, messageId);
   const { archive, inbox } = getCursors(state);
   return {
     cursors: isArchived ? archive : inbox,
+    isServiceAvailable,
     maybeMessage,
     maybeMessageDetails,
     messageId

--- a/ts/screens/messages/paginated/__tests__/MessageRouterScreen.test.tsx
+++ b/ts/screens/messages/paginated/__tests__/MessageRouterScreen.test.tsx
@@ -17,6 +17,7 @@ import {
   loadPreviousPageMessages,
   reloadAllMessages
 } from "../../../../store/actions/messages";
+import { loadServiceDetail } from "../../../../store/actions/services";
 import { navigateToPaginatedMessageDetailScreenAction } from "../../../../store/actions/navigation";
 import { appReducer } from "../../../../store/reducers";
 import { AllPaginated } from "../../../../store/reducers/entities/messages/allPaginated";
@@ -74,6 +75,7 @@ describe("MessageRouterScreen", () => {
 
   describe("when is already running, with a populated messages state", () => {
     const previousCursor = successLoadNextPageMessagesPayload.messages[0].id;
+    const serviceId = successLoadNextPageMessagesPayload.messages[0].serviceId;
     const allPaginated = {
       inbox: {
         data: pot.some({
@@ -133,9 +135,15 @@ describe("MessageRouterScreen", () => {
             loadMessageDetails.request({ id })
           );
         });
+        it("should dispatch `loadServiceDetail`", () => {
+          const { spyStoreDispatch } = renderComponent(id, { allPaginated });
+          expect(spyStoreDispatch).toHaveBeenCalledWith(
+            loadServiceDetail.request(serviceId)
+          );
+        });
         it("should not dispatch any other action", () => {
           const { spyStoreDispatch } = renderComponent(id, { allPaginated });
-          expect(spyStoreDispatch).toHaveBeenCalledTimes(1);
+          expect(spyStoreDispatch).toHaveBeenCalledTimes(2);
         });
       });
 
@@ -159,13 +167,18 @@ describe("MessageRouterScreen", () => {
             })
           );
         });
-
+        it("should dispatch `loadServiceDetail`", () => {
+          const { spyStoreDispatch } = renderComponent(id, { allPaginated });
+          expect(spyStoreDispatch).toHaveBeenCalledWith(
+            loadServiceDetail.request(serviceId)
+          );
+        });
         it("should not dispatch any other action", () => {
           const { spyStoreDispatch } = renderComponent(id, {
             allPaginated,
             detailsById
           });
-          expect(spyStoreDispatch).toHaveBeenCalledTimes(0);
+          expect(spyStoreDispatch).toHaveBeenCalledTimes(1);
         });
       });
     });

--- a/ts/screens/messages/paginated/__tests__/MessageRouterScreen.test.tsx
+++ b/ts/screens/messages/paginated/__tests__/MessageRouterScreen.test.tsx
@@ -168,6 +168,7 @@ describe("MessageRouterScreen", () => {
           );
         });
         it("should dispatch `loadServiceDetail`", () => {
+          // eslint-disable-next-line sonarjs/no-identical-functions
           const { spyStoreDispatch } = renderComponent(id, { allPaginated });
           expect(spyStoreDispatch).toHaveBeenCalledWith(
             loadServiceDetail.request(serviceId)

--- a/ts/screens/messages/paginated/__tests__/MessageRouterScreen.test.tsx
+++ b/ts/screens/messages/paginated/__tests__/MessageRouterScreen.test.tsx
@@ -167,8 +167,8 @@ describe("MessageRouterScreen", () => {
             })
           );
         });
+        // eslint-disable-next-line sonarjs/no-identical-functions
         it("should dispatch `loadServiceDetail`", () => {
-          // eslint-disable-next-line sonarjs/no-identical-functions
           const { spyStoreDispatch } = renderComponent(id, { allPaginated });
           expect(spyStoreDispatch).toHaveBeenCalledWith(
             loadServiceDetail.request(serviceId)


### PR DESCRIPTION
## Short description
Is a service is not available in the message details view, fetch it.

## List of changes proposed in this pull request
- check against the service in the Router screen
- fetch the service if needed

## How to test
Cannot share a screencast because I've tested it against my personal account in production.

Instructions:
1. open a message from a local service (in my case: _Anagrafe_)
2. tap on the service's link in the bottom of the message
3. services' card will open (_this_ is the fix)
