### PR TITLE
fix: [IABT-1371] Make the loading indicator more visible while scrolling the message list

### DIFF
--- a/ts/components/messages/paginated/MessageList/index.tsx
+++ b/ts/components/messages/paginated/MessageList/index.tsx
@@ -7,7 +7,8 @@ import {
   FlatList,
   RefreshControl,
   StyleSheet,
-  Vibration
+  Vibration,
+  View
 } from "react-native";
 import { connect } from "react-redux";
 
@@ -80,6 +81,9 @@ const styles = StyleSheet.create({
   },
   activityIndicator: {
     padding: 12
+  },
+  bottomSpacer: {
+    height: 60
   }
 });
 
@@ -257,7 +261,7 @@ const MessageList = ({
     if (messages.length > 0 && !nextCursor) {
       return <EdgeBorderComponent />;
     }
-    return null;
+    return <View style={styles.bottomSpacer} />;
   };
 
   return (
@@ -292,7 +296,7 @@ const MessageList = ({
         }}
         onLayout={handleOnLayoutChange}
         onEndReached={onEndReached}
-        onEndReachedThreshold={0.1}
+        onEndReachedThreshold={0.25}
         testID={testID}
         ListFooterComponent={renderListFooter}
       />


### PR DESCRIPTION
## Short description
On Android, when the user reaches the end of the message list, the scrolling stops like hitting a wall. Then the next page gets fetched, but the loading indicator remains hidden below the visible area. This PR aims to improve this UX.

## List of changes proposed in this pull request
- Add a space at the end of the message list so that scrolling stops a bit over the latest message (this leaves some space that will be filled by the loading indicator);
- Increase the `onEndReachedThreshold` so that page loading begins a bit earlier. 

## How to test
Configure the dev server to return several pages of messages (optionally with some delay). Then start scrolling and verify the the loading indicator is always visible at the end of the list.

https://user-images.githubusercontent.com/467098/163397428-d8d7aeb7-97b8-4b45-a7d1-e9ac7a4342f9.mp4

https://user-images.githubusercontent.com/467098/163397522-1056def3-9084-4ce8-9efb-77295195d88f.mp4

