### PR TITLE
fix: [IA-829] Fix crash on press the support button on Android

### DIFF
--- a/ts/features/zendesk/components/__tests__/ZendeskSupportComponent.test.tsx
+++ b/ts/features/zendesk/components/__tests__/ZendeskSupportComponent.test.tsx
@@ -7,7 +7,16 @@ import { GlobalState } from "../../../../store/reducers/types";
 import { renderScreenFakeNavRedux } from "../../../../utils/testWrapper";
 import ROUTES from "../../../../navigation/routes";
 import ZendeskSupportComponent from "../ZendeskSupportComponent";
+import {
+  idpSelected,
+  loginSuccess,
+  sessionInformationLoadSuccess
+} from "../../../../store/actions/authentication";
+import { SessionToken } from "../../../../types/SessionToken";
+import { PublicSession } from "../../../../../definitions/backend/PublicSession";
+import { SpidLevelEnum } from "../../../../../definitions/backend/SpidLevel";
 import MockZendesk from "../../../../__mocks__/io-react-native-zendesk";
+import { SpidIdp } from "../../../../../definitions/content/SpidIdp";
 import {
   getZendeskConfig,
   zendeskRequestTicketNumber
@@ -16,6 +25,13 @@ import * as zendeskNavigation from "../../store/actions/navigation";
 import { Zendesk } from "../../../../../definitions/content/Zendesk";
 import { getNetworkError } from "../../../../utils/errors";
 
+const mockPublicSession: PublicSession = {
+  bpdToken: "bpdToken",
+  myPortalToken: "myPortalToken",
+  spidLevel: SpidLevelEnum["https://www.spid.gov.it/SpidL2"],
+  walletToken: "walletToken",
+  zendeskToken: "zendeskToken"
+};
 const mockZendeskConfig: Zendesk = {
   panicMode: false
 };
@@ -36,6 +52,25 @@ describe("the ZendeskSupportComponent", () => {
     const component = renderComponent(store, false);
     store.dispatch(zendeskRequestTicketNumber.success(1));
     expect(component.getByTestId("showTicketsButton")).toBeDefined();
+  });
+  describe("when the user is authenticated with session info", () => {
+    const store = createStore(appReducer, globalState as any);
+    store.dispatch(idpSelected({} as SpidIdp));
+    store.dispatch(
+      loginSuccess({
+        token: "abc1234" as SessionToken,
+        idp: "test"
+      })
+    );
+    describe("and the zendeskToken is defined", () => {
+      store.dispatch(sessionInformationLoadSuccess(mockPublicSession));
+      it("should call setUserIdentity with the zendeskToken", () => {
+        renderComponent(store, false);
+        expect(MockZendesk.setUserIdentity).toBeCalledWith({
+          token: mockPublicSession.zendeskToken
+        });
+      });
+    });
   });
 
   describe("when the user press the zendesk open ticket button", () => {

--- a/ts/features/zendesk/screens/ZendeskAskPermissions.tsx
+++ b/ts/features/zendesk/screens/ZendeskAskPermissions.tsx
@@ -4,7 +4,6 @@ import React, { ReactNode } from "react";
 import { SafeAreaView, ScrollView } from "react-native";
 import { NavigationStackScreenProps } from "react-navigation-stack";
 import { useDispatch } from "react-redux";
-import { fromNullable } from "fp-ts/lib/Option";
 import BatteryIcon from "../../../../img/assistance/battery.svg";
 import EmailIcon from "../../../../img/assistance/email.svg";
 import FiscalCodeIcon from "../../../../img/assistance/fiscalCode.svg";
@@ -28,8 +27,7 @@ import { mixpanelTrack } from "../../../mixpanel";
 import { useIOSelector } from "../../../store/hooks";
 import {
   idpSelector,
-  isLoggedIn,
-  zendeskTokenSelector
+  isLoggedIn
 } from "../../../store/reducers/authentication";
 import { appVersionHistorySelector } from "../../../store/reducers/installation";
 import {
@@ -45,10 +43,7 @@ import {
   addTicketTag,
   anonymousAssistanceAddress,
   anonymousAssistanceAddressWithSubject,
-  AnonymousIdentity,
-  JwtIdentity,
   openSupportTicket,
-  setUserIdentity,
   zendeskCurrentAppVersionId,
   zendeskDeviceAndOSId,
   zendeskidentityProviderId,
@@ -206,7 +201,6 @@ const ZendeskAskPermissions = (props: Props) => {
   const dispatch = useDispatch();
   const workUnitCompleted = () => dispatch(zendeskSupportCompleted());
   const notAvailable = I18n.t("global.remoteStates.notAvailable");
-  const zendeskToken = useIOSelector(zendeskTokenSelector);
   const isUserLoggedIn = useIOSelector(s => isLoggedIn(s.authentication));
   const identityProvider = useIOSelector(idpSelector)
     .map(idp => idp.name)
@@ -278,17 +272,6 @@ const ZendeskAskPermissions = (props: Props) => {
   };
 
   const handleOnContinuePress = () => {
-    // First of all set the user identity
-    // If the zendeskToken is available authenticate the user with a JwtIdentity
-    // otherwise authenticate the user with an AnonymousIdentity
-    const zendeskIdentity = fromNullable(zendeskToken)
-      .map((zT: string): JwtIdentity | AnonymousIdentity => ({
-        token: zT
-      }))
-      .getOrElse({});
-
-    setUserIdentity(zendeskIdentity);
-
     // Set custom fields
     items.forEach(it => {
       if (it.value !== undefined && it.zendeskId !== undefined) {

--- a/ts/features/zendesk/screens/__tests__/ZendeskAskPermissions.test.tsx
+++ b/ts/features/zendesk/screens/__tests__/ZendeskAskPermissions.test.tsx
@@ -12,8 +12,7 @@ import * as device from "../../../../utils/device";
 import * as appVersion from "../../../../utils/appVersion";
 import {
   idpSelected,
-  loginSuccess,
-  sessionInformationLoadSuccess
+  loginSuccess
 } from "../../../../store/actions/authentication";
 import { SpidIdp } from "../../../../../definitions/content/SpidIdp";
 import { SessionToken } from "../../../../types/SessionToken";
@@ -24,8 +23,6 @@ import * as zendeskAction from "../../store/actions";
 import * as url from "../../../../utils/url";
 import { zendeskSelectedCategory } from "../../store/actions";
 import MockZendesk from "../../../../__mocks__/io-react-native-zendesk";
-import { PublicSession } from "../../../../../definitions/backend/PublicSession";
-import { SpidLevelEnum } from "../../../../../definitions/backend/SpidLevel";
 
 jest.useFakeTimers();
 
@@ -42,14 +39,6 @@ const mockedZendeskCategory = {
     "it-IT": "mock_description",
     "en-EN": "mock_description"
   }
-};
-
-const mockPublicSession: PublicSession = {
-  bpdToken: "bpdToken",
-  myPortalToken: "myPortalToken",
-  spidLevel: SpidLevelEnum["https://www.spid.gov.it/SpidL2"],
-  walletToken: "walletToken",
-  zendeskToken: "zendeskToken"
 };
 
 describe("the ZendeskAskPermissions screen", () => {
@@ -226,40 +215,6 @@ describe("the ZendeskAskPermissions screen", () => {
   describe("when the continue button is pressed", () => {
     const mixpanelTrackSpy = jest.spyOn(mixpanel, "mixpanelTrack");
 
-    it("should call setUserIdentity with the zendeskToken if the user is authenticated with session info and the zendeskToken is defined", () => {
-      const store: Store<GlobalState> = createStore(
-        appReducer,
-        globalState as any
-      );
-      store.dispatch(idpSelected({} as SpidIdp));
-      store.dispatch(
-        loginSuccess({
-          token: "abc1234" as SessionToken,
-          idp: "test"
-        })
-      );
-      store.dispatch(sessionInformationLoadSuccess(mockPublicSession));
-      store.dispatch(zendeskSelectedCategory(mockedZendeskCategory));
-      const component: RenderAPI = renderComponent(store, false);
-      const continueButton: ReactTestInstance =
-        component.getByTestId("continueButtonId");
-      fireEvent(continueButton, "onPress");
-      expect(MockZendesk.setUserIdentity).toBeCalledWith({
-        token: mockPublicSession.zendeskToken
-      });
-    });
-    it("should call setUserIdentity with the void object as input if the user is not authenticated", () => {
-      const store: Store<GlobalState> = createStore(
-        appReducer,
-        globalState as any
-      );
-      store.dispatch(zendeskSelectedCategory(mockedZendeskCategory));
-      const component: RenderAPI = renderComponent(store, false);
-      const continueButton: ReactTestInstance =
-        component.getByTestId("continueButtonId");
-      fireEvent(continueButton, "onPress");
-      expect(MockZendesk.setUserIdentity).toBeCalledWith({});
-    });
     it("should call the openSupportTicket, the mixpanelTrack and the workUnitCompleted functions", () => {
       const store: Store<GlobalState> = createStore(
         appReducer,


### PR DESCRIPTION

## Short description
This PR fixes the bug that makes the app crash on press the support button on Android.
To fix the bug the commit `d9b4bed: "chore: [IA-778] Move zendesk user identify after ask permission (#3899)"` is been reverted.

## List of changes proposed in this pull request
- Reverted the commit `d9b4bed`


https://user-images.githubusercontent.com/11773070/163956882-aff14414-f5b7-4555-9b6e-fd5e754e652e.mp4



## How to test
Try to press the support button (`?`) on an Android physical device both as an anonymous user and as authenticated one.


[IA-778]: https://pagopa.atlassian.net/browse/IA-778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ