### PR TITLE
fix: [IA-830] Fix performance issue when rendering new message pages

### DIFF
--- a/ts/components/messages/paginated/MessageList/Item.tsx
+++ b/ts/components/messages/paginated/MessageList/Item.tsx
@@ -204,7 +204,7 @@ type Props = {
   isSelectionModeEnabled: boolean;
   message: UIMessage;
   onLongPress: () => void;
-  onPress: () => void;
+  onPress: (message: UIMessage) => void;
   service?: ServicePublic;
 };
 
@@ -261,7 +261,7 @@ const MessageListItem = ({
 
   return (
     <TouchableDefaultOpacity
-      onPress={onPress}
+      onPress={() => onPress(message)}
       onLongPress={onLongPress}
       style={[styles.verticalPad]}
       accessible={true}

--- a/ts/components/messages/paginated/MessageList/helpers.tsx
+++ b/ts/components/messages/paginated/MessageList/helpers.tsx
@@ -51,7 +51,7 @@ export const renderItem =
         hasPaidBadge={hasPaidBadge(message.category)}
         isRead={message.isRead}
         message={message}
-        onPress={() => onPress(message)}
+        onPress={onPress}
         onLongPress={() => onLongPress(message)}
         isSelectionModeEnabled={!!selectedMessageIds}
         isSelected={!!selectedMessageIds?.has(message.id)}

--- a/ts/components/messages/paginated/MessagesArchive.tsx
+++ b/ts/components/messages/paginated/MessagesArchive.tsx
@@ -1,5 +1,5 @@
 import { View } from "native-base";
-import React from "react";
+import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
 
 import { UIMessage } from "../../../store/reducers/entities/messages/types";
@@ -46,13 +46,16 @@ const MessagesArchive = ({
   const selectedItemsCount = selectedItems.toUndefined()?.size ?? 0;
   const allItemsCount = messages.length;
 
-  const onPressItem = (message: UIMessage) => {
-    if (selectedItems.isSome()) {
-      toggleItem(message.id);
-    } else {
-      navigateToMessageDetail(message);
-    }
-  };
+  const onPressItem = useCallback(
+    (message: UIMessage) => {
+      if (selectedItems.isSome()) {
+        toggleItem(message.id);
+      } else {
+        navigateToMessageDetail(message);
+      }
+    },
+    [selectedItems]
+  );
 
   const onLongPressItem = (id: string) => {
     toggleItem(id);

--- a/ts/components/messages/paginated/MessagesInbox.tsx
+++ b/ts/components/messages/paginated/MessagesInbox.tsx
@@ -1,5 +1,5 @@
 import { View } from "native-base";
-import React from "react";
+import React, { useCallback } from "react";
 import { StyleSheet } from "react-native";
 
 import { UIMessage } from "../../../store/reducers/entities/messages/types";
@@ -47,13 +47,16 @@ const MessagesInbox = ({
   const selectedItemsCount = selectedItems.toUndefined()?.size ?? 0;
   const allItemsCount = messages.length;
 
-  const onPressItem = (message: UIMessage) => {
-    if (selectedItems.isSome()) {
-      toggleItem(message.id);
-    } else {
-      navigateToMessageDetail(message);
-    }
-  };
+  const onPressItem = useCallback(
+    (message: UIMessage) => {
+      if (selectedItems.isSome()) {
+        toggleItem(message.id);
+      } else {
+        navigateToMessageDetail(message);
+      }
+    },
+    [selectedItems]
+  );
 
   const onLongPressItem = (id: string) => {
     toggleItem(id);


### PR DESCRIPTION
## Short description
There's an issue in the current implementation that causes a rendering of the entire message list even if not needed (caused by the callback used for selecting messages). This PR fixes it.

## List of changes proposed in this pull request
- Wrap `onPressItem` with `useCallback` in order to avoid re-rendering of message list items.