### PR TITLE
fix: [IA-856] Onboarding cannot be completed after a logout

### DIFF
--- a/ts/sagas/startup/completeOnboardingSaga.ts
+++ b/ts/sagas/startup/completeOnboardingSaga.ts
@@ -1,5 +1,5 @@
 import { call, take } from "typed-redux-saga/macro";
-import { NavigationActions } from "@react-navigation/compat";
+import { CommonActions } from "@react-navigation/native";
 import NavigationService from "../../navigation/NavigationService";
 import ROUTES from "../../navigation/routes";
 import { completeOnboarding } from "../../store/actions/onboarding";
@@ -7,8 +7,8 @@ import { completeOnboarding } from "../../store/actions/onboarding";
 export function* completeOnboardingSaga() {
   yield* call(
     NavigationService.dispatchNavigationAction,
-    NavigationActions.navigate({
-      routeName: ROUTES.ONBOARDING_COMPLETED
+    CommonActions.navigate(ROUTES.ONBOARDING, {
+      screen: ROUTES.ONBOARDING_COMPLETED
     })
   );
 

--- a/ts/screens/onboarding/__tests__/OnboardingCompletedScreen.test.tsx
+++ b/ts/screens/onboarding/__tests__/OnboardingCompletedScreen.test.tsx
@@ -1,7 +1,7 @@
 import { testSaga } from "redux-saga-test-plan";
 import { fireEvent } from "@testing-library/react-native";
 import configureMockStore from "redux-mock-store";
-import { NavigationActions } from "@react-navigation/compat";
+import { CommonActions } from "@react-navigation/native";
 import { completeOnboardingSaga } from "../../../sagas/startup/completeOnboardingSaga";
 import OnboardingCompletedScreen from "../OnboardingCompletedScreen";
 import I18n from "../../../i18n";
@@ -36,8 +36,8 @@ describe("Given the completeOnboardingSaga", () => {
         .next()
         .call(
           NavigationService.dispatchNavigationAction,
-          NavigationActions.navigate({
-            routeName: ROUTES.ONBOARDING_COMPLETED
+          CommonActions.navigate(ROUTES.ONBOARDING, {
+            screen: ROUTES.ONBOARDING_COMPLETED
           })
         )
         .next()


### PR DESCRIPTION
## Short description
The new navigation library needs the full navigation path for a given screen, unless you're in the same navigator of the destination. This branch fixes this for the "thank you" screen at the end of the onboarding.

![Simulator Screen Shot - iPhone 13 Pro - 2022-05-05 at 15 28 30](https://user-images.githubusercontent.com/467098/166938857-4402c342-bf93-41e3-ae02-d17e7fdf199f.png)

## List of changes proposed in this pull request
- Use `CommonActions.navigate` instead of `NavigationActions.navigate`;

## How to test
Logout, then login again and verify that the "thank you" screen is shown and dismissed when tapping on the CTA.
