### PR TITLE
chore(Carta della cultura): [AP-26] Update cdc service CTA action

### DIFF
--- a/ts/features/bonus/cdc/components/CdcServiceCTA.tsx
+++ b/ts/features/bonus/cdc/components/CdcServiceCTA.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { useEffect } from "react";
 import { View as RNView } from "react-native";
 import { View } from "native-base";
+import { useNavigation } from "@react-navigation/native";
 import { Label } from "../../../../components/core/typography/Label";
 import ButtonDefaultOpacity from "../../../../components/ButtonDefaultOpacity";
 import I18n from "../../../../i18n";
@@ -14,11 +15,14 @@ import { CdcBonusRequestList } from "../types/CdcBonusRequest";
 import { IOColors } from "../../../../components/core/variables/IOColors";
 import StatusContent from "../../../../components/SectionStatus/StatusContent";
 import { StatoBeneficiarioEnum } from "../../../../../definitions/cdc/StatoBeneficiario";
+import { CDC_ROUTES } from "../navigation/routes";
 
 type ReadyButtonProp = {
   bonusRequestList: CdcBonusRequestList;
 };
 const ReadyButton = (props: ReadyButtonProp) => {
+  const navigation = useNavigation();
+
   // Check if at least one year can be activable
   const activableBonuses = props.bonusRequestList.filter(
     b => b.status === StatoBeneficiarioEnum.ATTVABILE
@@ -29,8 +33,11 @@ const ReadyButton = (props: ReadyButtonProp) => {
       <ButtonDefaultOpacity
         block
         primary
-        // TODO: dispatch the navigation to the first screen of the workunit
-        onPress={() => true}
+        onPress={() => {
+          navigation.navigate(CDC_ROUTES.BONUS_REQUEST_MAIN, {
+            screen: CDC_ROUTES.INFORMATION_TOS
+          });
+        }}
         testID={"activateCardButton"}
       >
         <Label color={"white"}>


### PR DESCRIPTION
## Short description
This PR adds the navigation to the first screen of the bonus request flow when the CTA button is pressed.

## List of changes proposed in this pull request
- Added the navigation action when the activate bonus button is pressed


https://user-images.githubusercontent.com/11773070/168294599-4ac932da-46a3-4e91-ab9c-cb9b16ee9838.mp4



## How to test
After enabling the local and the remote feature flag, enter the `Carta della Cultura` service details and press the `Activate card` button.
