### PR TITLE
chore(Carta della cultura): [AP-33] Update cdc swagger

### DIFF
--- a/assets/CdcSwagger.yml
+++ b/assets/CdcSwagger.yml
@@ -66,7 +66,7 @@ definitions:
   StatoBeneficiario:
     type: string
     enum:
-      - ATTVABILE
+      - ATTIVABILE
       - INATTIVABILE
       - ATTIVO
       - VALUTAZIONE
@@ -102,13 +102,10 @@ definitions:
   RichiestaCartaErrata:
     type: object
     required:
-      - annoRiferimento
       - status
     properties:
       type:
         type: string
-      annoRiferimento:
-        $ref: '#/definitions/Anno'
       title:
         type: string
       status:

--- a/ts/features/bonus/cdc/components/CdcServiceCTA.tsx
+++ b/ts/features/bonus/cdc/components/CdcServiceCTA.tsx
@@ -26,7 +26,7 @@ const ReadyButton = (props: ReadyButtonProp) => {
 
   // Check if at least one year can be activable
   const activableBonuses = props.bonusRequestList.filter(
-    b => b.status === StatoBeneficiarioEnum.ATTVABILE
+    b => b.status === StatoBeneficiarioEnum.ATTIVABILE
   );
 
   if (activableBonuses.length > 0) {

--- a/ts/features/bonus/cdc/components/__test__/CdcServiceCTA.test.ts
+++ b/ts/features/bonus/cdc/components/__test__/CdcServiceCTA.test.ts
@@ -15,7 +15,7 @@ jest.useFakeTimers();
 
 const mockActivableBonus: CdcBonusRequest = {
   year: "2018" as Anno,
-  status: StatoBeneficiarioEnum.ATTVABILE
+  status: StatoBeneficiarioEnum.ATTIVABILE
 };
 const mockPendingBonus: CdcBonusRequest = {
   year: "2018" as Anno,

--- a/ts/features/bonus/cdc/screens/CdcBonusRequestSelectYear.tsx
+++ b/ts/features/bonus/cdc/screens/CdcBonusRequestSelectYear.tsx
@@ -40,7 +40,7 @@ const CdcBonusRequestSelectYear = () => {
     () =>
       isReady(cdcBonusList)
         ? cdcBonusList.value.filter(
-            b => b.status === StatoBeneficiarioEnum.ATTVABILE
+            b => b.status === StatoBeneficiarioEnum.ATTIVABILE
           )
         : [],
     [cdcBonusList]

--- a/ts/features/bonus/cdc/screens/__test__/CdcBonusRequestSelectYear.test.ts
+++ b/ts/features/bonus/cdc/screens/__test__/CdcBonusRequestSelectYear.test.ts
@@ -20,8 +20,8 @@ const notActivableBonuses = [
 ];
 
 const activableBonuses = [
-  { year: "2021" as Anno, status: StatoBeneficiarioEnum.ATTVABILE },
-  { year: "2022" as Anno, status: StatoBeneficiarioEnum.ATTVABILE },
+  { year: "2021" as Anno, status: StatoBeneficiarioEnum.ATTIVABILE },
+  { year: "2022" as Anno, status: StatoBeneficiarioEnum.ATTIVABILE },
   { year: "2023" as Anno, status: StatoBeneficiarioEnum.VALUTAZIONE }
 ];
 

--- a/ts/features/bonus/cdc/store/reducers/__test__/cdcBonusRequest.test.ts
+++ b/ts/features/bonus/cdc/store/reducers/__test__/cdcBonusRequest.test.ts
@@ -24,7 +24,7 @@ import { Anno } from "../../../../../../../definitions/cdc/Anno";
 import { EsitoRichiestaEnum } from "../../../../../../../definitions/cdc/EsitoRichiesta";
 
 const mockBonusRequest: CdcBonusRequest = {
-  status: StatoBeneficiarioEnum.ATTVABILE,
+  status: StatoBeneficiarioEnum.ATTIVABILE,
   year: "2022" as Anno
 };
 

--- a/ts/features/bonus/cdc/store/reducers/cdcBonusRequest.ts
+++ b/ts/features/bonus/cdc/store/reducers/cdcBonusRequest.ts
@@ -85,7 +85,7 @@ export const isCdcEnrolledSelector = createSelector(
       bonusList,
       constUndefined,
       constUndefined,
-      bl => bl.every(b => b.status !== StatoBeneficiarioEnum.ATTVABILE),
+      bl => bl.every(b => b.status !== StatoBeneficiarioEnum.ATTIVABILE),
       constUndefined
     )
 );


### PR DESCRIPTION
## Short description
This PR updates the swagger of the `Carta della cultura`

## List of changes proposed in this pull request
- Fix typo in `StatoBeneficiario` -> `ATTIVABILE`
- Remove `annoRiferimento` from `RichiestaCartaErrata`

## How to test
Generate the type and check that all works fine
