### PR TITLE
fix: [IAI-199] Crash `Java.lang.NoSuchMethodError` for `okhttp3`

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -238,7 +238,7 @@ dependencies {
 
     implementation project(':react-native-cie')
 
-    implementation ("com.squareup.okhttp3:okhttp:3.12.12"){
+    implementation ("com.squareup.okhttp3:okhttp:4.9.2"){
         force = true
     }
     implementation 'com.squareup.okhttp3:logging-interceptor:3.12.12'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -241,7 +241,7 @@ dependencies {
     implementation ("com.squareup.okhttp3:okhttp:4.9.2"){
         force = true
     }
-    implementation 'com.squareup.okhttp3:logging-interceptor:3.12.12'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.9.2'
 
     if (enableHermes) {
         def hermesPath = "../../node_modules/hermes-engine/android/";


### PR DESCRIPTION
## Short description
This pr fixes the crash on Android due to different `okhttp3` versions, triggered by the update of `react-native`. This is just a temporary fix, the final solution should be implemented in https://pagopa.atlassian.net/browse/IAI-200 or the next time that we are going to upgrade react-native we will have the same problem.

## List of changes proposed in this pull request
- Updated `android/app/build.gradle`, forcing the same `okhttp3` version required by `react-native`.

## How to test
- Build the app on Android in production mode -> access & run
