### PR TITLE
chore: [IAI-202] Save the dev-server output stream in the CI logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,6 +503,9 @@ workflows:
       - run-e2e-test-IOS:
           requires:
             - compile-typescript
+          filters:
+            branches:
+              only: master
 
   # Release workflow triggered only when a new release tag is pushed
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,9 +503,6 @@ workflows:
       - run-e2e-test-IOS:
           requires:
             - compile-typescript
-          filters:
-            branches:
-              only: master
 
   # Release workflow triggered only when a new release tag is pushed
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,7 +459,7 @@ jobs:
             cp ../scripts/api-config.json config/config.json
             yarn
             yarn generate:all
-            yarn start > /tmp/io-dev-api-server.log &
+            yarn start &> /tmp/io-dev-api-server.log &
             # wait for the server to be up and running
             sleep 10
             cd ..


### PR DESCRIPTION
## Short description
This PR is going to enable the dev-server output stream in the CI logs during the end-to-end tests.

## List of changes proposed in this pull request
- Used `&>` instead of `>`

## How to test
🦄