### PR TITLE
chore: [IA-873] Improve the new Pin Screen's a11y

### DIFF
--- a/ts/components/PinCreationForm.tsx
+++ b/ts/components/PinCreationForm.tsx
@@ -102,7 +102,8 @@ export const PinCreationForm = ({ onSubmit }: Props) => {
               keyboardType: "number-pad",
               maxLength: pinLength,
               onEndEditing: handlePinBlur,
-              secureTextEntry: true
+              secureTextEntry: true,
+              returnKeyType: "done"
             }}
             icon={isPinValid ? undefined : "io-warning"}
             iconColor={IOColors.red}
@@ -131,7 +132,8 @@ export const PinCreationForm = ({ onSubmit }: Props) => {
               keyboardType: "number-pad",
               maxLength: pinLength,
               onEndEditing: handlePinConfirmationBlur,
-              secureTextEntry: true
+              secureTextEntry: true,
+              returnKeyType: "done"
             }}
             icon={isPinConfirmationValid ? undefined : "io-warning"}
             iconColor={IOColors.red}

--- a/ts/components/PinCreationForm.tsx
+++ b/ts/components/PinCreationForm.tsx
@@ -95,6 +95,7 @@ export const PinCreationForm = ({ onSubmit }: Props) => {
         <View style={{ position: "relative", marginTop: 30 }}>
           <LabelledItem
             label={I18n.t("onboarding.pin.pinLabel")}
+            accessibilityLabel={I18n.t("onboarding.pin.pinLabel")}
             inputProps={{
               value: pin,
               onChangeText: setPin,
@@ -123,6 +124,7 @@ export const PinCreationForm = ({ onSubmit }: Props) => {
         <View style={{ position: "relative", marginTop: 45 }}>
           <LabelledItem
             label={I18n.t("onboarding.pin.pinConfirmationLabel")}
+            accessibilityLabel={I18n.t("onboarding.pin.pinConfirmationLabel")}
             inputProps={{
               value: pinConfirmation,
               onChangeText: setPinConfirmation,

--- a/ts/components/PinCreationForm.tsx
+++ b/ts/components/PinCreationForm.tsx
@@ -121,7 +121,8 @@ export const PinCreationForm = ({ onSubmit }: Props) => {
               maxLength: pinLength,
               onEndEditing: handlePinBlur,
               secureTextEntry: true,
-              returnKeyType: "done"
+              returnKeyType: "done",
+              contextMenuHidden: true
             }}
             icon={isPinValid ? undefined : "io-warning"}
             iconColor={IOColors.red}
@@ -155,7 +156,8 @@ export const PinCreationForm = ({ onSubmit }: Props) => {
               maxLength: pinLength,
               onEndEditing: handlePinConfirmationBlur,
               secureTextEntry: true,
-              returnKeyType: "done"
+              returnKeyType: "done",
+              contextMenuHidden: true
             }}
             icon={isPinConfirmationValid ? undefined : "io-warning"}
             iconColor={IOColors.red}

--- a/ts/components/PinCreationForm.tsx
+++ b/ts/components/PinCreationForm.tsx
@@ -81,6 +81,24 @@ export const PinCreationForm = ({ onSubmit }: Props) => {
     [isFormValid, handleSubmit]
   );
 
+  const pinFieldA11yLabel = React.useMemo(
+    () =>
+      `${I18n.t("onboarding.pin.pinLabel")}${
+        !isPinValid ? ", " + I18n.t("onboarding.pin.errors.length") : ""
+      }`,
+    [isPinValid]
+  );
+
+  const pinConfirmationFieldA11yLabel = React.useMemo(
+    () =>
+      `${I18n.t("onboarding.pin.pinConfirmationLabel")}${
+        !isPinConfirmationValid
+          ? ", " + I18n.t("onboarding.pin.errors.match")
+          : ""
+      }`,
+    [isPinConfirmationValid]
+  );
+
   return (
     <View style={styles.flex}>
       <ScrollView style={[IOStyles.horizontalContentPadding, { flex: 1 }]}>
@@ -95,7 +113,7 @@ export const PinCreationForm = ({ onSubmit }: Props) => {
         <View style={{ position: "relative", marginTop: 30 }}>
           <LabelledItem
             label={I18n.t("onboarding.pin.pinLabel")}
-            accessibilityLabel={I18n.t("onboarding.pin.pinLabel")}
+            accessibilityLabel={pinFieldA11yLabel}
             inputProps={{
               value: pin,
               onChangeText: setPin,
@@ -114,7 +132,11 @@ export const PinCreationForm = ({ onSubmit }: Props) => {
           />
 
           {!isPinValid && (
-            <View style={{ position: "absolute", bottom: -25, left: 2 }}>
+            <View
+              style={{ position: "absolute", bottom: -25, left: 2 }}
+              accessibilityElementsHidden={true}
+              importantForAccessibility="no-hide-descendants"
+            >
               <LabelSmall weight="Regular" color="red">
                 {I18n.t("onboarding.pin.errors.length")}
               </LabelSmall>
@@ -125,7 +147,7 @@ export const PinCreationForm = ({ onSubmit }: Props) => {
         <View style={{ position: "relative", marginTop: 45 }}>
           <LabelledItem
             label={I18n.t("onboarding.pin.pinConfirmationLabel")}
-            accessibilityLabel={I18n.t("onboarding.pin.pinConfirmationLabel")}
+            accessibilityLabel={pinConfirmationFieldA11yLabel}
             inputProps={{
               value: pinConfirmation,
               onChangeText: setPinConfirmation,
@@ -146,7 +168,11 @@ export const PinCreationForm = ({ onSubmit }: Props) => {
           />
 
           {!isPinConfirmationValid && (
-            <View style={{ position: "absolute", bottom: -25, left: 2 }}>
+            <View
+              style={{ position: "absolute", bottom: -25, left: 2 }}
+              accessibilityElementsHidden={true}
+              importantForAccessibility="no-hide-descendants"
+            >
               <LabelSmall weight="Regular" color="red">
                 {I18n.t("onboarding.pin.errors.match")}
               </LabelSmall>


### PR DESCRIPTION
## Short description
This PR is going to improve the accessibility of the Pin Creation screen (in both the onboarding and the profile).

https://user-images.githubusercontent.com/5963683/171025501-cbe9ab4d-d2ad-4355-9790-82eb187c1f9b.mov

## List of changes proposed in this pull request
- Added accessibility label for the two fields
- Managed the errors inside the accessibility labels instead of using different text elements
- Added the `done` return key in the keyboard
- **Bonus:** Disabled the paste behaviour on the fields

## How to test
Using the Voice Over in the pin creation screen during the onboarding or in the profile it should be possible to correctly navigate the various fields.