### PR TITLE
chore: [IAI-206] Add missing styles to `IOBadge`

### DIFF
--- a/ts/components/core/IOBadge.tsx
+++ b/ts/components/core/IOBadge.tsx
@@ -57,25 +57,29 @@ const borderStyle = (color: NonNullable<IOBadgeCommonProps["labelColor"]>) => {
  * A badge component styled with the
  * IO primary color.
  */
-export const IOBadge = ({ text, small, labelColor }: IOBadgeCommonProps) => (
-  <Badge
-    style={[
-      commonBadgeStyles.badge,
-      {
-        backgroundColor: labelColor
-          ? mapForegroundBackgroundColor[labelColor]
-          : IOColors.blue
-      },
-      borderStyle(labelColor ?? "white"),
-      small ? commonBadgeStyles.badgeSmall : {}
-    ]}
-  >
-    <LabelSmall
-      color={labelColor ?? "white"}
-      fontSize={small ? "small" : "regular"}
-      weight={"SemiBold"}
+export const IOBadge = ({ text, small, labelColor }: IOBadgeCommonProps) => {
+  const lColor = labelColor ?? "white";
+
+  return (
+    <Badge
+      style={[
+        commonBadgeStyles.badge,
+        {
+          backgroundColor: lColor
+            ? mapForegroundBackgroundColor[lColor]
+            : IOColors.blue
+        },
+        borderStyle(lColor ?? "white"),
+        small ? commonBadgeStyles.badgeSmall : {}
+      ]}
     >
-      {text}
-    </LabelSmall>
-  </Badge>
-);
+      <LabelSmall
+        color={lColor}
+        fontSize={small ? "small" : "regular"}
+        weight={"SemiBold"}
+      >
+        {text}
+      </LabelSmall>
+    </Badge>
+  );
+};

--- a/ts/components/core/IOBadge.tsx
+++ b/ts/components/core/IOBadge.tsx
@@ -1,19 +1,19 @@
+import { Badge } from "native-base";
 import React from "react";
 import { ColorValue, StyleSheet } from "react-native";
-import { Badge } from "native-base";
-import { IOColors } from "./variables/IOColors";
 import { LabelSmall } from "./typography/LabelSmall";
+import { IOColors, IOColorType } from "./variables/IOColors";
 
 type IOBadgeCommonProps = {
   text: string;
   small?: boolean;
-  labelColor?: "white" | "blue";
+  labelColor?: Extract<IOColorType, "bluegreyDark" | "blue" | "white" | "red">;
 };
 
 const commonBadgeStyles = StyleSheet.create({
   badge: {
-    paddingLeft: 15,
-    paddingRight: 15
+    paddingLeft: 8,
+    paddingRight: 8
   },
   badgeSmall: {
     height: 18
@@ -24,7 +24,34 @@ const commonBadgeStyles = StyleSheet.create({
 const mapForegroundBackgroundColor: Record<
   NonNullable<IOBadgeCommonProps["labelColor"]>,
   ColorValue
-> = { white: IOColors.blue, blue: IOColors.white };
+> = {
+  white: IOColors.blue,
+  blue: IOColors.white,
+  bluegreyDark: IOColors.aqua,
+  red: IOColors.white
+};
+
+const mapForegroundBorderColor: Record<
+  NonNullable<IOBadgeCommonProps["labelColor"]>,
+  ColorValue | null
+> = {
+  white: null,
+  blue: IOColors.blue,
+  bluegreyDark: null,
+  red: IOColors.red
+};
+
+const borderStyle = (color: NonNullable<IOBadgeCommonProps["labelColor"]>) => {
+  const borderColor = mapForegroundBorderColor[color];
+  if (borderColor === null) {
+    return null;
+  } else {
+    return {
+      borderColor,
+      borderWidth: 1
+    };
+  }
+};
 
 /**
  * A badge component styled with the
@@ -39,12 +66,14 @@ export const IOBadge = ({ text, small, labelColor }: IOBadgeCommonProps) => (
           ? mapForegroundBackgroundColor[labelColor]
           : IOColors.blue
       },
+      borderStyle(labelColor ?? "white"),
       small ? commonBadgeStyles.badgeSmall : {}
     ]}
   >
     <LabelSmall
       color={labelColor ?? "white"}
       fontSize={small ? "small" : "regular"}
+      weight={"SemiBold"}
     >
       {text}
     </LabelSmall>

--- a/ts/components/core/typography/LabelSmall.tsx
+++ b/ts/components/core/typography/LabelSmall.tsx
@@ -6,7 +6,7 @@ import { useTypographyFactory } from "./Factory";
 
 type AllowedColors = Extract<
   IOColorType,
-  "blue" | "bluegrey" | "red" | "white"
+  "blue" | "bluegrey" | "red" | "white" | "bluegreyDark"
 >;
 type AllowedWeight = Extract<IOFontWeight, "Bold" | "Regular" | "SemiBold">;
 type FontSize = "regular" | "small";

--- a/ts/screens/showroom/core/TypographyShowRoom.tsx
+++ b/ts/screens/showroom/core/TypographyShowRoom.tsx
@@ -1,6 +1,7 @@
 import { View } from "native-base";
 import * as React from "react";
 import { Alert, StyleSheet } from "react-native";
+import { IOBadge } from "../../../components/core/IOBadge";
 import { Body } from "../../../components/core/typography/Body";
 import { H1 } from "../../../components/core/typography/H1";
 import { H2 } from "../../../components/core/typography/H2";
@@ -39,6 +40,7 @@ export const TypographyShowroom = () => (
     <View spacer={true} extralarge={true} />
     <Monospace>MonoSpace</Monospace>
     <View spacer={true} extralarge={true} />
+    <IOBadgeRow />
   </ShowroomSection>
 );
 
@@ -190,6 +192,35 @@ export const LabelRow = () => (
       <View style={{ backgroundColor: IOColors.bluegrey }}>
         <Label color={"white"}>Label</Label>
       </View>
+    </View>
+    <View spacer={true} extralarge={true} />
+  </>
+);
+
+export const IOBadgeRow = () => (
+  <>
+    <Label>{"<IOBadge />"}</Label>
+    <View spacer={true} />
+    <View style={styles.row}>
+      <IOBadge text={"Badge"} small={true} labelColor={"white"} />
+      <View hspacer={true} />
+      <IOBadge text={"Badge"} small={true} labelColor={"bluegreyDark"} />
+      <View hspacer={true} />
+      <IOBadge text={"Badge"} small={true} labelColor={"blue"} />
+      <View hspacer={true} />
+      <IOBadge text={"Badge"} small={true} labelColor={"red"} />
+      <View hspacer={true} />
+    </View>
+    <View spacer={true} />
+    <View style={styles.row}>
+      <IOBadge text={"Badge"} labelColor={"white"} />
+      <View hspacer={true} />
+      <IOBadge text={"Badge"} labelColor={"bluegreyDark"} />
+      <View hspacer={true} />
+      <IOBadge text={"Badge"} labelColor={"blue"} />
+      <View hspacer={true} />
+      <IOBadge text={"Badge"} labelColor={"red"} />
+      <View hspacer={true} />
     </View>
     <View spacer={true} extralarge={true} />
   </>


### PR DESCRIPTION
## Short description
This pr adds some missing styles to `IOBadge`, in order to facilitate its use in place of `native-base Badge`.
<img width="393" alt="Schermata 2022-06-03 alle 16 38 21" src="https://user-images.githubusercontent.com/26501317/171876212-820772ec-5db5-4473-8376-218d51077e50.png">


## List of changes proposed in this pull request
- Add missing colors to `IOBadge`
- Change left & right padding to `8`
- Add border (when required)
- Added the `IOBadge` section in the Showroom

## How to test
👀
