### PR TITLE
chore(Carta Giovani Nazionale): [IOACGN-78] Fixes landing page to open automatically media playback

### DIFF
--- a/ts/components/WebviewComponent.tsx
+++ b/ts/components/WebviewComponent.tsx
@@ -47,6 +47,7 @@ const WebviewComponent = (props: Props) => {
             androidCameraAccessDisabled={true}
             androidMicrophoneAccessDisabled={true}
             allowsInlineMediaPlayback={true}
+            mediaPlaybackRequiresUserAction={true}
             style={IOStyles.flex}
             ref={ref}
             onLoadEnd={() => setLoading(false)}

--- a/ts/components/__tests__/__snapshots__/WebviewComponent.test.tsx.snap
+++ b/ts/components/__tests__/__snapshots__/WebviewComponent.test.tsx.snap
@@ -97,6 +97,7 @@ exports[`WebviewComponent tests snapshot for component 1`] = `
         injectedJavaScriptBeforeContentLoadedForMainFrameOnly={true}
         injectedJavaScriptForMainFrameOnly={true}
         javaScriptEnabled={true}
+        mediaPlaybackRequiresUserAction={true}
         messagingEnabled={false}
         onContentProcessDidTerminate={[Function]}
         onError={[Function]}


### PR DESCRIPTION
## Short description
This PR aims to fix the issue for CGN landing page webview that automatically opens the full-screen media player on iOS devices.

## How to test
Go to CGN Landing Page Playground under profile/debug section and open https://www.sportesalute.eu/ as a test
