### PR TITLE
chore: [IA-886] Change UADonations on iOS

### DIFF
--- a/ts/features/uaDonations/screens/UAWebViewScreen.tsx
+++ b/ts/features/uaDonations/screens/UAWebViewScreen.tsx
@@ -8,7 +8,7 @@ import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import { Route, useNavigation, useRoute } from "@react-navigation/native";
 import { View } from "native-base";
 import React, { useEffect, useState } from "react";
-import { SafeAreaView, StyleSheet } from "react-native";
+import { Linking, Platform, SafeAreaView, StyleSheet } from "react-native";
 import WebView from "react-native-webview";
 import { WebViewMessageEvent } from "react-native-webview/lib/WebViewTypes";
 import URLParse from "url-parse";
@@ -30,6 +30,7 @@ import {
 import { navigateToPaymentTransactionSummaryScreen } from "../../../store/actions/navigation";
 import { paymentInitializeState } from "../../../store/actions/wallet/payment";
 import { useIODispatch } from "../../../store/hooks";
+import { checkoutUADonationsUrl } from "../../../urls";
 import { emptyContextualHelp } from "../../../utils/emptyContextualHelp";
 import { showToast } from "../../../utils/showToast";
 import { isStringNullyOrEmpty } from "../../../utils/strings";
@@ -191,6 +192,13 @@ export const UAWebViewScreen = () => {
   const [errorType, setErrorType] = useState<"webview" | "data" | undefined>();
 
   useEffect(() => {
+    if (Platform.OS === "ios") {
+      Linking.openURL(checkoutUADonationsUrl).catch(_ =>
+        showToast(I18n.t("genericError"))
+      );
+      navigation.goBack();
+    }
+
     if (uri === undefined) {
       setErrorType("data");
     } else {
@@ -200,7 +208,7 @@ export const UAWebViewScreen = () => {
         setErrorType("data");
       }
     }
-  }, [uri]);
+  }, [uri, navigation]);
 
   // trigger the payment flow within the given data
   const startDonationPayment = (

--- a/ts/urls.ts
+++ b/ts/urls.ts
@@ -3,3 +3,5 @@ export const euCovidCertificateUrl = "https://www.dgc.gov.it/";
 
 // IO urls
 export const ioSuppliersUrl = "https://io.italia.it/app-content/fornitori";
+
+export const checkoutUADonationsUrl = "https://checkout.pagopa.it/dona";


### PR DESCRIPTION
## Short description
This pr changes the way to donate on iOS. Now, when tapping on the UABanner or a message CTA a new Safari browser pointing to `https://checkout.pagopa.it/dona` will be opened.


Tap on banner:

https://user-images.githubusercontent.com/26501317/173864481-72229674-ce30-4ff1-8b60-4eff850e2f51.mov

Tap on CTA:

https://user-images.githubusercontent.com/26501317/173864561-ee1ece47-413f-42ed-8a16-0921f87af436.mov


## List of changes proposed in this pull request
- Added `checkoutUADonationsUrl`
- Changed the mount logic for `iOS`

## How to test
- On iOS: Tap on the Donation banner or add a CTA with `ioit://UADONATION_ROUTES_WEBVIEW?urlToLoad=https://assets.cdn.io.italia.it/html/donate.html`. Tapping on these two items should open Safari.
- On Android should works as always
