### PR TITLE
chore: [IAI-209] The `pagopa_specs_diff` job must not fail if the UAT and PROD specs are different

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,6 +492,7 @@ workflows:
       - run-tests
       - run-eslint
       - run-prettier
+      - pagopa_specs_diff
 
       - run-danger:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,7 +492,6 @@ workflows:
       - run-tests
       - run-eslint
       - run-prettier
-      - pagopa_specs_diff
 
       - run-danger:
           filters:

--- a/scripts/pagopa_api_check.sh
+++ b/scripts/pagopa_api_check.sh
@@ -22,7 +22,6 @@ printf "%14s $PAGOPA_API_URL_PREFIX_TEST$PAGOPA_API_URL_SUFFIX\n" "test:"
 
 
 SEND_MSG="✅ pagopa production and test specifications have no differences"
-SEND_EXIT=0
 # mention here on channel
 MENTION_SLACK="<!here>"
 
@@ -47,7 +46,6 @@ else
     KO_MSG="[PagoPa API check] ⚠️ $MENTION_SLACK It seems *PROD* and *DEV* pagoPa specifications are different"
     echo "⚠️  It seems PROD and DEV pagoPa specifications are different"
     SEND_MSG=$KO_MSG
-    SEND_EXIT=1
     #send slack notification
     channel="#io_dev_app_status"
     res=$(curl -s -X POST -H 'Content-type: application/json' -H 'Authorization: Bearer '${IO_APP_SLACK_HELPER_BOT_TOKEN:-}'' --data '{"text":"'"$SEND_MSG"'", "channel" : "'$channel'"}' https://slack.com/api/chat.postMessage)

--- a/scripts/pagopa_api_check.sh
+++ b/scripts/pagopa_api_check.sh
@@ -51,4 +51,4 @@ else
     res=$(curl -s -X POST -H 'Content-type: application/json' -H 'Authorization: Bearer '${IO_APP_SLACK_HELPER_BOT_TOKEN:-}'' --data '{"text":"'"$SEND_MSG"'", "channel" : "'$channel'"}' https://slack.com/api/chat.postMessage)
 fi
 
-exit $SEND_EXIT
+exit 0


### PR DESCRIPTION
## Short description
This pr changes the behaviour of the `pagopa_specs_diff`, in order to send only a slack message if the UAT and PROD specs are different, avoiding the failure of the job.