### PR TITLE
[AP-39] Fix wrong order of the bonus in the select residence screen

### DIFF
--- a/ts/features/bonus/cdc/screens/CdcBonusRequestSelectResidence.tsx
+++ b/ts/features/bonus/cdc/screens/CdcBonusRequestSelectResidence.tsx
@@ -27,6 +27,7 @@ import { H3 } from "../../../../components/core/typography/H3";
 import BonusIcon from "../../../../../img/features/cdc/bonus.svg";
 import { ResidentChoice } from "../types/CdcBonusRequest";
 import { cdcSelectedBonus as cdcSelectedBonusAction } from "../store/actions/cdcBonusRequest";
+import { compareSelectedBonusByYear } from "../utils/bonusRequest";
 
 const getCheckResidencyItems = (): ReadonlyArray<RadioItem<ResidentChoice>> => [
   {
@@ -69,11 +70,15 @@ const CdcBonusRequestSelectResidence = () => {
             {I18n.t("bonus.cdc.bonusRequest.selectResidence.info")}
           </H4>
 
-          {cdcSelectedBonus.map(b => (
+          {[...cdcSelectedBonus].sort(compareSelectedBonusByYear).map(b => (
             <>
               <View spacer large />
               <View
-                style={{ flex: 1, flexDirection: "row", alignItems: "center" }}
+                style={{
+                  flex: 1,
+                  flexDirection: "row",
+                  alignItems: "center"
+                }}
               >
                 <BonusIcon width={20} height={20} />
                 <View hspacer />

--- a/ts/features/bonus/cdc/screens/CdcBonusRequestSelectYear.tsx
+++ b/ts/features/bonus/cdc/screens/CdcBonusRequestSelectYear.tsx
@@ -26,6 +26,7 @@ import {
   cancelButtonProps,
   confirmButtonProps
 } from "../../bonusVacanze/components/buttons/ButtonConfigurations";
+import { compareSelectedBonusByYear } from "../utils/bonusRequest";
 
 const CdcBonusRequestSelectYear = () => {
   const navigation =
@@ -77,7 +78,7 @@ const CdcBonusRequestSelectYear = () => {
             {I18n.t("bonus.cdc.bonusRequest.selectYear.body")}
           </H4>
           <View spacer large />
-          {activableBonus.map(b => (
+          {[...activableBonus].sort(compareSelectedBonusByYear).map(b => (
             <View key={b.year}>
               <View style={{ flexDirection: "row" }}>
                 <CheckBox

--- a/ts/features/bonus/cdc/utils/__tests__/bonusRequest.test.ts
+++ b/ts/features/bonus/cdc/utils/__tests__/bonusRequest.test.ts
@@ -1,0 +1,21 @@
+import { compareSelectedBonusByYear } from "../bonusRequest";
+import { Anno } from "../../../../../../definitions/cdc/Anno";
+
+describe("compareSelectedBonusByYear", () => {
+  it("Should return 1 if the year of the first bonus is greater than the second one", () => {
+    expect(
+      compareSelectedBonusByYear(
+        { year: "2019" as Anno },
+        { year: "2018" as Anno }
+      )
+    ).toEqual(1);
+  });
+  it("Should return -1 if the year of the first bonus is smaller than the second one", () => {
+    expect(
+      compareSelectedBonusByYear(
+        { year: "2018" as Anno },
+        { year: "2019" as Anno }
+      )
+    ).toEqual(-1);
+  });
+});

--- a/ts/features/bonus/cdc/utils/bonusRequest.ts
+++ b/ts/features/bonus/cdc/utils/bonusRequest.ts
@@ -1,0 +1,7 @@
+import { CdcSelectedBonus } from "../types/CdcBonusRequest";
+
+// Utility function used to sort the array of selectedBonus by year
+export const compareSelectedBonusByYear = (
+  firstBonus: CdcSelectedBonus,
+  secondBonus: CdcSelectedBonus
+) => (firstBonus.year > secondBonus.year ? 1 : -1);


### PR DESCRIPTION
## Short description
This PR fixes the bug that let the `CdcBonusRequestSelectResidence` screen shows the selection of residence items not sorted by year.

## List of changes proposed in this pull request
- Added the `compareSelectedBonusByYear` function.
- Sorted the elements shown both in `CdcBonusRequestSelectResidence` and in `CdcBonusRequestSelectYear` screens.

**Before**

https://user-images.githubusercontent.com/11773070/174306399-e3c0b946-4d68-4f5d-8c65-d776b87c31b3.mp4


**After**

https://user-images.githubusercontent.com/11773070/174306252-def09b57-83d5-46bc-8643-76de772196b8.mp4


## How to test
The test suite is provided.
Request the Carta della cultura and try to select in the `CdcBonusRequestSelectYear` screens the years in a random order. Checks in the `CdcBonusRequestSelectResidence` that the items are sorted ascending by year