### PR TITLE
fix: [IAI-212] Outdated libraries script doesn't run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,6 +492,7 @@ workflows:
       - run-tests
       - run-eslint
       - run-prettier
+      - check-outdated-dependencies
 
       - run-danger:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,7 +492,6 @@ workflows:
       - run-tests
       - run-eslint
       - run-prettier
-      - check-outdated-dependencies
 
       - run-danger:
           filters:

--- a/scripts/ts/checkOutdatedDependencies/checkOutdatedDependencies.ts
+++ b/scripts/ts/checkOutdatedDependencies/checkOutdatedDependencies.ts
@@ -6,7 +6,6 @@ import { Errors } from "io-ts";
 import { readableReport } from "italia-ts-commons/lib/reporters";
 import * as semver from "semver";
 import { slackPostMessage } from "../common/slack/postMessage";
-import { convertUnknownToError } from "../../../ts/utils/errors";
 import { generateSlackMessage } from "./generateSlackMessage";
 import { initOutdatedStats } from "./types/defaultValues";
 import { DependenciesTable } from "./types/DependeciesTable";

--- a/scripts/ts/checkOutdatedDependencies/checkOutdatedDependencies.ts
+++ b/scripts/ts/checkOutdatedDependencies/checkOutdatedDependencies.ts
@@ -130,7 +130,9 @@ const main = async () => {
     }
   } catch (e) {
     console.log("Generic error while executing the script:");
-    console.log(convertUnknownToError(e).message);
+    // We don't use convertUnknownToError because this script is executed in isolated mode and doesn't have access to the app codebase
+    const error = e as Error;
+    console.log(error.message);
   }
 };
 


### PR DESCRIPTION
## Short description
This pr fixes the execution of the `checkOutdatedDependencies` script, removing the `convertUnknownToError` import. Since the script is executed with `ts-node` in isolation mode, we don't have access to the app code. 
