### PR TITLE
chore: [IA-909] Copy changes to the card holder base + error

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1403,8 +1403,8 @@ wallet:
       holder:
         label: Card holder
         description:
-          base: "Enter as shown on the card"
-          error: "Enter exactly as shown on the card"
+          base: "Follow the order on your card"
+          error: "Do not use accented characters or symbols"
       pan: Card number
       expirationDate: Expiration date
       securityCode: Card security code
@@ -1417,8 +1417,8 @@ wallet:
       securityCode4D: "••••"
     accessibility:
       holder:
-        base: "Card holder, enter as shown on the card"
-        error: "Card holder. Please, do not use accented letters"
+        base: "Card holder, follow the order on your card"
+        error: "Card holder, do not use accented characters or symbols"
       pan:
         base: "Card number"
         error: "Card number. Please, enter at least {{minLength}} digits"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1421,8 +1421,8 @@ wallet:
       holder:
         label: Intestatario carta
         description:
-          base: "Inserisci come riportato sulla carta"
-          error: "Inserisci esattamente come riportato sulla carta"
+          base: "Segui l’ordine riportato sulla carta"
+          error: "Non usare lettere accentate o simboli"
       pan: Numero carta
       expirationDate: Data di scadenza
       securityCode: Codice di sicurezza
@@ -1435,8 +1435,8 @@ wallet:
       securityCode4D: "••••"
     accessibility:
       holder:
-        base: "Intestatario carta, inserisci come riportato sulla carta"
-        error: "Intestatario carta. Per favore, non utilizzare lettere accentate"
+        base: "Intestatario carta, segui l’ordine riportato sulla carta"
+        error: "Intestatario carta, non usare lettere accentate o simboli"
       pan:
         base: "Numero carta"
         error: "Numero carta. Per favore, inserisci almeno {{minLength}} cifre"


### PR DESCRIPTION
A couple of strings were made clearer for users to understand better requirements and errors while inserting the card holder name of a card they're onboarding in their IO wallet.
