### PR TITLE
chore: [IA-906] Update `tosVersion` to `4.0`

### DIFF
--- a/ts/config.ts
+++ b/ts/config.ts
@@ -113,7 +113,7 @@ export const newTransactionSummaryEnabled =
 export const pnEnabled = Config.PN_ENABLED === "YES";
 
 // version of ToS
-export const tosVersion: NonNegativeNumber = 2.4 as NonNegativeNumber;
+export const tosVersion: NonNegativeNumber = 4.0 as NonNegativeNumber;
 
 export const fetchTimeout = t.Integer.decode(
   parseInt(Config.FETCH_TIMEOUT_MS, 10)


### PR DESCRIPTION
## Short description
This PR is going to update the `tosVersion` config to `4.0` in order to forcefully show the ToS screen to the user.

## List of changes proposed in this pull request
- Bumped `tosVersion` to `4.0`

## How to test
The ToS screen should be visible after opening the app.
