### PR TITLE
[IAI-159] Update Zendesk navigator

### DIFF
--- a/ts/features/zendesk/navigation/navigator.tsx
+++ b/ts/features/zendesk/navigation/navigator.tsx
@@ -1,27 +1,40 @@
-import { createCompatNavigatorFactory } from "@react-navigation/compat";
 import { createStackNavigator } from "@react-navigation/stack";
-import ZendeskSupportHelpCenter from "../screens/ZendeskSupportHelpCenter";
+import * as React from "react";
 import ZendeskAskPermissions from "../screens/ZendeskAskPermissions";
 import ZendeskChooseCategory from "../screens/ZendeskChooseCategory";
 import ZendeskChooseSubCategory from "../screens/ZendeskChooseSubCategory";
 import ZendeskPanicMode from "../screens/ZendeskPanicMode";
+import ZendeskSupportHelpCenter from "../screens/ZendeskSupportHelpCenter";
+import { ZendeskParamsList } from "./params";
 import ZENDESK_ROUTES from "./routes";
 
-export const zendeskSupportNavigator = createCompatNavigatorFactory(
-  createStackNavigator
-)(
-  {
-    [ZENDESK_ROUTES.HELP_CENTER]: { screen: ZendeskSupportHelpCenter },
-    [ZENDESK_ROUTES.PANIC_MODE]: { screen: ZendeskPanicMode },
-    [ZENDESK_ROUTES.ASK_PERMISSIONS]: { screen: ZendeskAskPermissions },
-    [ZENDESK_ROUTES.CHOOSE_CATEGORY]: { screen: ZendeskChooseCategory },
-    [ZENDESK_ROUTES.CHOOSE_SUB_CATEGORY]: { screen: ZendeskChooseSubCategory }
-  },
-  {
-    // Let each screen handles the header and navigation
-    headerMode: "none",
-    defaultNavigationOptions: {
-      gestureEnabled: false
-    }
-  }
+const Stack = createStackNavigator<ZendeskParamsList>();
+
+export const ZendeskStackNavigator = () => (
+  <Stack.Navigator
+    initialRouteName={ZENDESK_ROUTES.HELP_CENTER}
+    headerMode={"none"}
+    screenOptions={{ gestureEnabled: true }}
+  >
+    <Stack.Screen
+      name={ZENDESK_ROUTES.HELP_CENTER}
+      component={ZendeskSupportHelpCenter}
+    />
+    <Stack.Screen
+      name={ZENDESK_ROUTES.PANIC_MODE}
+      component={ZendeskPanicMode}
+    />
+    <Stack.Screen
+      name={ZENDESK_ROUTES.ASK_PERMISSIONS}
+      component={ZendeskAskPermissions}
+    />
+    <Stack.Screen
+      name={ZENDESK_ROUTES.CHOOSE_CATEGORY}
+      component={ZendeskChooseCategory}
+    />
+    <Stack.Screen
+      name={ZENDESK_ROUTES.CHOOSE_SUB_CATEGORY}
+      component={ZendeskChooseSubCategory}
+    />
+  </Stack.Navigator>
 );

--- a/ts/features/zendesk/screens/ZendeskAskPermissions.tsx
+++ b/ts/features/zendesk/screens/ZendeskAskPermissions.tsx
@@ -1,4 +1,4 @@
-import { CompatNavigationProp } from "@react-navigation/compat";
+import { RouteProp, useRoute } from "@react-navigation/native";
 import { constNull } from "fp-ts/lib/function";
 import { ListItem, View } from "native-base";
 import React, { ReactNode } from "react";
@@ -24,7 +24,6 @@ import BaseScreenComponent from "../../../components/screens/BaseScreenComponent
 import FooterWithButtons from "../../../components/ui/FooterWithButtons";
 import I18n from "../../../i18n";
 import { mixpanelTrack } from "../../../mixpanel";
-import { IOStackNavigationProp } from "../../../navigation/params/AppParamsList";
 import { useIOSelector } from "../../../store/hooks";
 import {
   idpSelector,
@@ -190,19 +189,15 @@ export type ZendeskAskPermissionsNavigationParams = {
   assistanceForPayment: boolean;
 };
 
-type Props = {
-  navigation: CompatNavigationProp<
-    IOStackNavigationProp<ZendeskParamsList, "ZENDESK_ASK_PERMISSIONS">
-  >;
-};
 /**
  * this screen shows the kinds of data the app could collect when a user is asking for assistance
  * @constructor
  */
-const ZendeskAskPermissions = (props: Props) => {
-  const assistanceForPayment = props.navigation.getParam(
-    "assistanceForPayment"
-  );
+const ZendeskAskPermissions = () => {
+  const route =
+    useRoute<RouteProp<ZendeskParamsList, "ZENDESK_ASK_PERMISSIONS">>();
+
+  const assistanceForPayment = route.params.assistanceForPayment;
 
   const dispatch = useDispatch();
   const workUnitCompleted = () => dispatch(zendeskSupportCompleted());

--- a/ts/features/zendesk/screens/ZendeskChooseCategory.tsx
+++ b/ts/features/zendesk/screens/ZendeskChooseCategory.tsx
@@ -1,5 +1,3 @@
-import { CompatNavigationProp } from "@react-navigation/compat";
-import { useNavigation } from "@react-navigation/native";
 import { ListItem } from "native-base";
 import React from "react";
 import {
@@ -17,7 +15,7 @@ import BaseScreenComponent from "../../../components/screens/BaseScreenComponent
 import IconFont from "../../../components/ui/IconFont";
 import View from "../../../components/ui/TextWithIcon";
 import I18n from "../../../i18n";
-import { IOStackNavigationProp } from "../../../navigation/params/AppParamsList";
+import { IOStackNavigationRouteProps } from "../../../navigation/params/AppParamsList";
 import { toArray } from "../../../store/helpers/indexer";
 import { useIOSelector } from "../../../store/hooks";
 import customVariables from "../../../theme/variables";
@@ -39,24 +37,17 @@ export type ZendeskChooseCategoryNavigationParams = {
   assistanceForPayment: boolean;
 };
 
-type Props = {
-  navigation: CompatNavigationProp<
-    IOStackNavigationProp<ZendeskParamsList, "ZENDESK_CHOOSE_CATEGORY">
-  >;
-};
+type Props = IOStackNavigationRouteProps<
+  ZendeskParamsList,
+  "ZENDESK_CHOOSE_CATEGORY"
+>;
 
 /**
  * this screen shows the categories for which the user can ask support with the assistance
  */
 const ZendeskChooseCategory = (props: Props) => {
   const dispatch = useDispatch();
-  const navigation =
-    useNavigation<
-      IOStackNavigationProp<ZendeskParamsList, "ZENDESK_CHOOSE_CATEGORY">
-    >();
-  const assistanceForPayment = props.navigation.getParam(
-    "assistanceForPayment"
-  );
+  const assistanceForPayment = props.route.params.assistanceForPayment;
   const zendeskConfig = useIOSelector(zendeskConfigSelector);
   const selectedCategory = (category: ZendeskCategory) =>
     dispatch(zendeskSelectedCategory(category));
@@ -93,11 +84,11 @@ const ZendeskChooseCategory = (props: Props) => {
           // Set category as custom field
           addTicketCustomField(categoriesId, category.value);
           if (hasSubCategories(category)) {
-            navigation.navigate(ZENDESK_ROUTES.CHOOSE_SUB_CATEGORY, {
+            props.navigation.navigate(ZENDESK_ROUTES.CHOOSE_SUB_CATEGORY, {
               assistanceForPayment
             });
           } else {
-            navigation.navigate(ZENDESK_ROUTES.ASK_PERMISSIONS, {
+            props.navigation.navigate(ZENDESK_ROUTES.ASK_PERMISSIONS, {
               assistanceForPayment
             });
           }

--- a/ts/features/zendesk/screens/ZendeskChooseSubCategory.tsx
+++ b/ts/features/zendesk/screens/ZendeskChooseSubCategory.tsx
@@ -1,5 +1,3 @@
-import { CompatNavigationProp } from "@react-navigation/compat";
-import { useNavigation } from "@react-navigation/native";
 import { ListItem } from "native-base";
 import React from "react";
 import {
@@ -17,7 +15,7 @@ import BaseScreenComponent from "../../../components/screens/BaseScreenComponent
 import IconFont from "../../../components/ui/IconFont";
 import View from "../../../components/ui/TextWithIcon";
 import I18n from "../../../i18n";
-import { IOStackNavigationProp } from "../../../navigation/params/AppParamsList";
+import { IOStackNavigationRouteProps } from "../../../navigation/params/AppParamsList";
 import { useIOSelector } from "../../../store/hooks";
 import customVariables from "../../../theme/variables";
 import { getFullLocale } from "../../../utils/locale";
@@ -36,11 +34,10 @@ export type ZendeskChooseSubCategoryNavigationParams = {
   assistanceForPayment: boolean;
 };
 
-type Props = {
-  navigation: CompatNavigationProp<
-    IOStackNavigationProp<ZendeskParamsList, "ZENDESK_CHOOSE_SUB_CATEGORY">
-  >;
-};
+type Props = IOStackNavigationRouteProps<
+  ZendeskParamsList,
+  "ZENDESK_CHOOSE_SUB_CATEGORY"
+>;
 
 /**
  * this screen shows the sub-categories for which the user can ask support with the assistance
@@ -49,10 +46,7 @@ type Props = {
 const ZendeskChooseSubCategory = (props: Props) => {
   const selectedCategory = useIOSelector(zendeskSelectedCategorySelector);
   const dispatch = useDispatch();
-  const navigation = useNavigation<IOStackNavigationProp<ZendeskParamsList>>();
-  const assistanceForPayment = props.navigation.getParam(
-    "assistanceForPayment"
-  );
+  const assistanceForPayment = props.route.params.assistanceForPayment;
   const selectedSubcategory = (subcategory: ZendeskSubCategory) =>
     dispatch(zendeskSelectedSubcategory(subcategory));
   const zendeskWorkUnitFailure = (reason: string) =>
@@ -86,7 +80,7 @@ const ZendeskChooseSubCategory = (props: Props) => {
           selectedSubcategory(subCategory);
           // Set sub-category as custom field
           addTicketCustomField(subCategoriesId, subCategory.value);
-          navigation.navigate("ZENDESK_ASK_PERMISSIONS", {
+          props.navigation.navigate("ZENDESK_ASK_PERMISSIONS", {
             assistanceForPayment
           });
         }}

--- a/ts/features/zendesk/screens/ZendeskSupportHelpCenter.tsx
+++ b/ts/features/zendesk/screens/ZendeskSupportHelpCenter.tsx
@@ -1,4 +1,4 @@
-import { CompatNavigationProp } from "@react-navigation/compat";
+import { RouteProp, useRoute } from "@react-navigation/native";
 import { constNull } from "fp-ts/lib/function";
 import { fromNullable, none } from "fp-ts/lib/Option";
 import * as pot from "italia-ts-commons/lib/pot";
@@ -19,7 +19,6 @@ import {
 import ActivityIndicator from "../../../components/ui/ActivityIndicator";
 import View from "../../../components/ui/TextWithIcon";
 import I18n from "../../../i18n";
-import { IOStackNavigationProp } from "../../../navigation/params/AppParamsList";
 import { loadContextualHelpData } from "../../../store/actions/content";
 import { useIOSelector } from "../../../store/hooks";
 import { getContextualHelpDataFromRouteSelector } from "../../../store/reducers/content";
@@ -153,31 +152,24 @@ const FaqManager = (props: FaqManagerProps) => {
   );
 };
 
-type Props = {
-  navigation: CompatNavigationProp<
-    IOStackNavigationProp<ZendeskParamsList, "ZENDESK_HELP_CENTER">
-  >;
-};
 /**
  * Ingress screen to access the Zendesk assistance tool
  * the user can choose to open a new ticket, follow previous conversations or read the faqs
  * @constructor
  */
-const ZendeskSupportHelpCenter = (props: Props) => {
+const ZendeskSupportHelpCenter = () => {
   const dispatch = useDispatch();
   const workUnitCancel = () => dispatch(zendeskSupportCancel());
   const workUnitComplete = () => dispatch(zendeskSupportCompleted());
 
+  const route = useRoute<RouteProp<ZendeskParamsList, "ZENDESK_HELP_CENTER">>();
+
   // Navigation prop
-  const faqCategories = props.navigation.getParam("faqCategories");
-  const contextualHelp = props.navigation.getParam("contextualHelp");
-  const contextualHelpMarkdown = props.navigation.getParam(
-    "contextualHelpMarkdown"
-  );
-  const startingRoute = props.navigation.getParam("startingRoute");
-  const assistanceForPayment = props.navigation.getParam(
-    "assistanceForPayment"
-  );
+  const faqCategories = route.params.faqCategories;
+  const contextualHelp = route.params.contextualHelp;
+  const contextualHelpMarkdown = route.params.contextualHelpMarkdown;
+  const startingRoute = route.params.startingRoute;
+  const assistanceForPayment = route.params.assistanceForPayment;
 
   const [markdownContentLoaded, setMarkdownContentLoaded] = useState<boolean>(
     !contextualHelpMarkdown

--- a/ts/navigation/AppStackNavigator.tsx
+++ b/ts/navigation/AppStackNavigator.tsx
@@ -30,7 +30,7 @@ import {
 import FIMS_ROUTES from "../features/fims/navigation/routes";
 import UADONATION_ROUTES from "../features/uaDonations/navigation/routes";
 import { UAWebViewScreen } from "../features/uaDonations/screens/UAWebViewScreen";
-import { zendeskSupportNavigator } from "../features/zendesk/navigation/navigator";
+import { ZendeskStackNavigator } from "../features/zendesk/navigation/navigator";
 import ZENDESK_ROUTES from "../features/zendesk/navigation/routes";
 import IngressScreen from "../screens/ingress/IngressScreen";
 import { setDebugCurrentRouteName } from "../store/actions/debug";
@@ -120,7 +120,7 @@ export const AppStackNavigator = () => {
       />
       <Stack.Screen
         name={ZENDESK_ROUTES.MAIN}
-        component={zendeskSupportNavigator}
+        component={ZendeskStackNavigator}
       />
       <Stack.Screen
         name={UADONATION_ROUTES.WEBVIEW}

--- a/ts/navigation/AppStackNavigator.tsx
+++ b/ts/navigation/AppStackNavigator.tsx
@@ -4,7 +4,10 @@ import {
   LinkingOptions,
   NavigationContainer
 } from "@react-navigation/native";
-import { createStackNavigator } from "@react-navigation/stack";
+import {
+  createStackNavigator,
+  TransitionPresets
+} from "@react-navigation/stack";
 import { View } from "native-base";
 import * as React from "react";
 import { useRef } from "react";
@@ -121,6 +124,7 @@ export const AppStackNavigator = () => {
       <Stack.Screen
         name={ZENDESK_ROUTES.MAIN}
         component={ZendeskStackNavigator}
+        options={{ ...TransitionPresets.ModalSlideFromBottomIOS }}
       />
       <Stack.Screen
         name={UADONATION_ROUTES.WEBVIEW}


### PR DESCRIPTION
## Short description
This pr updates the Zendesk stack navigator, in order to remove the compat layer.
This pr also restore the swipe back gesture for this navigator and change the opening animation with `ModalSlideFromBottomIOS` (agreed with @thisisjp).

## List of changes proposed in this pull request
- Removed compat layer and created the new `ZendeskStackNavigator`
- Removed the old syntax `props.navigation.getParam`
- Changed the animation for the `ZendeskStackNavigator`
