### PR TITLE
[IA-911] Fix a race condition in the last app version upsert during the startup

### DIFF
--- a/ts/sagas/profile.ts
+++ b/ts/sagas/profile.ts
@@ -434,6 +434,11 @@ function* checkStoreHashedFiscalCode(
 function* checkLoadedProfile(
   profileLoadSuccessAction: ActionType<typeof profileLoadSuccess>
 ) {
+  // This saga will upsert the `last_app_version` value in the
+  // profile only if it actually changed from the one stored in
+  // the backend.
+  yield* call(upsertAppVersionSaga);
+
   yield* all([
     call(checkPreferredLanguage, profileLoadSuccessAction),
     call(checkStoreHashedFiscalCode, profileLoadSuccessAction)
@@ -467,15 +472,22 @@ export function* watchProfile(
 /**
  * Upsert the user's latest app version, only if it's different
  * from the one stored in the backend.
+ *
+ * ⚠️ This saga will _block_ if the upsert request will be triggered
+ * because of possible race conditions with the profile version.
  */
-export function* upsertAppVersionSaga(
-  userProfile: InitializedProfile,
-  createOrUpdateProfile: ReturnType<
-    typeof BackendClient
-  >["createOrUpdateProfile"]
-) {
-  const maybeStoredVersion = fromNullable(userProfile.last_app_version);
+export function* upsertAppVersionSaga() {
+  const profileState: ReturnType<typeof profileSelector> = yield* select(
+    profileSelector
+  );
 
+  // If we don't have the profile inside the state there is
+  // something wrong.
+  if (pot.isNone(profileState)) {
+    return;
+  }
+
+  const maybeStoredVersion = fromNullable(profileState.value.last_app_version);
   const rawAppVersion = yield* call(getAppVersion);
   const maybeAppVersion = fromEither(AppVersion.decode(rawAppVersion));
 
@@ -496,7 +508,12 @@ export function* upsertAppVersionSaga(
     last_app_version: maybeAppVersion.value
   });
 
-  yield* call(createOrUpdateProfileSaga, createOrUpdateProfile, requestAction);
+  yield* put(requestAction);
+
+  // Here we are waiting for the response in order to block
+  // other possible upsert requests that would cause a race
+  // condition with the profile version number.
+  yield* take([profileUpsert.success, profileUpsert.failure]);
 }
 
 // to ensure right code encapsulation we export functions/variables just for tests purposes

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -95,7 +95,6 @@ import {
 import { updateInstallationSaga } from "./notifications";
 import {
   loadProfile,
-  upsertAppVersionSaga,
   watchProfile,
   watchProfileRefreshRequestsSaga,
   watchProfileUpsertRequestsSaga
@@ -278,15 +277,6 @@ export function* initializeApplicationSaga(): Generator<
   }
 
   const userProfile = maybeUserProfile.value;
-
-  // This saga will upsert the `last_app_version` value in the
-  // profile only if it actually changed from the one stored in
-  // the backend.
-  yield* call(
-    upsertAppVersionSaga,
-    userProfile,
-    backendClient.createOrUpdateProfile
-  );
 
   // If user logged in with different credentials, but this device still has
   // user data loaded, then delete data keeping current session (user already


### PR DESCRIPTION
## Short description
This PR is going to fix a race condition happening during the startup while upserting the latest app version used by the user into the profile. This race condition would trigger two upsert actions that would create two `POST` HTTP request with the same profile version of `0`. **The bug is present only during the first onboarding of an user.**

https://user-images.githubusercontent.com/5963683/178703308-8e79c9ae-220b-4224-89c3-6feb501caed3.mov

## List of changes proposed in this pull request
- Moved the `upsertAppVersionSaga` inside `checkLoadedProfile`
- Made `upsertAppVersionSaga` blocking while updating the profile

## How to test
During the first onboarding of a user (`profile.firstOnboarding = true` in the dev server) two `POST` HTTP requests to the profile should be triggered but with different `version` in the request body (watch the video for more informations).
