### PR TITLE
fix(Piattaforma Notifiche): [IAMVL-92] PN message details is blank if abstract is empty

### DIFF
--- a/ts/features/pn/components/PnMessageDetailsContent.tsx
+++ b/ts/features/pn/components/PnMessageDetailsContent.tsx
@@ -5,6 +5,7 @@ import { H1 } from "../../../components/core/typography/H1";
 import { H2 } from "../../../components/core/typography/H2";
 import { PNMessage } from "../store/types/types";
 import customVariables from "../../../theme/variables";
+import { isStringNullyOrEmpty } from "../../../utils/strings";
 
 const styles = StyleSheet.create({
   subject: {
@@ -19,11 +20,11 @@ type Props = Readonly<{ message: PNMessage }>;
 
 export const PnMessageDetailsContent = (props: Props & ViewProps) => (
   <View style={props.style}>
-    {props.message.senderDenomination && (
+    {!isStringNullyOrEmpty(props.message.senderDenomination) && (
       <H2>{props.message.senderDenomination}</H2>
     )}
     <H1 style={styles.subject}>{props.message.subject}</H1>
-    {props.message.abstract && (
+    {!isStringNullyOrEmpty(props.message.abstract) && (
       <Body style={styles.abstract}>{props.message.abstract}</Body>
     )}
   </View>


### PR DESCRIPTION
## Short description
This PR fixes a bug in the PN message details screen. When some strings are empty, the rendering fails with this error:

<img src="https://user-images.githubusercontent.com/467098/180787022-948ad592-4160-46b0-ae45-9efa0b682f19.png" width="360" />

## List of changes proposed in this pull request
- Use `isStringNullyOrEmpty` for checking string value
