### PR TITLE
[IAMVL-94] Do not open PN messages automatically from push notifications

### DIFF
--- a/ts/components/messages/paginated/hooks/useMessageOpening.tsx
+++ b/ts/components/messages/paginated/hooks/useMessageOpening.tsx
@@ -18,7 +18,8 @@ export const useMessageOpening = () => {
       navigation.navigate(ROUTES.MESSAGES_NAVIGATOR, {
         screen: ROUTES.MESSAGE_ROUTER_PAGINATED,
         params: {
-          messageId: message.id
+          messageId: message.id,
+          fromNotification: false
         }
       });
     },

--- a/ts/sagas/identification.ts
+++ b/ts/sagas/identification.ts
@@ -180,7 +180,8 @@ function* startAndHandleIdentificationResult(
       if (usePaginatedMessages) {
         NavigationService.dispatchNavigationAction(
           navigateToPaginatedMessageRouterAction({
-            messageId: messageId as UIMessageId
+            messageId: messageId as UIMessageId,
+            fromNotification: true
           })
         );
       } else {

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -573,7 +573,8 @@ export function* initializeApplicationSaga(): Generator<
     if (usePaginatedMessages) {
       NavigationService.dispatchNavigationAction(
         navigateToPaginatedMessageRouterAction({
-          messageId: messageId as UIMessageId
+          messageId: messageId as UIMessageId,
+          fromNotification: true
         })
       );
     } else {

--- a/ts/sagas/startup/watchNotificationSaga.ts
+++ b/ts/sagas/startup/watchNotificationSaga.ts
@@ -44,7 +44,8 @@ export function* watchNotificationSaga(
       if (usePaginatedMessages) {
         NavigationService.dispatchNavigationAction(
           navigateToPaginatedMessageRouterAction({
-            messageId: messageId as UIMessageId
+            messageId: messageId as UIMessageId,
+            fromNotification: true
           })
         );
       } else {

--- a/ts/screens/messages/paginated/MessageRouterScreen.tsx
+++ b/ts/screens/messages/paginated/MessageRouterScreen.tsx
@@ -40,13 +40,14 @@ import {
 import { serviceByIdSelector } from "../../../store/reducers/entities/services/servicesById";
 import { GlobalState } from "../../../store/reducers/types";
 import { emptyContextualHelp } from "../../../utils/emptyContextualHelp";
-import { useOnFirstRender } from "../../../utils/hooks/useOnFirstRender";
 import { isStrictSome } from "../../../utils/pot";
 import { getMessageById } from "../../../store/reducers/entities/messages/paginatedById";
 import { navigateToPnMessageDetailsScreen } from "../../../features/pn/navigation/actions";
+import ROUTES from "../../../navigation/routes";
 
 export type MessageRouterScreenPaginatedNavigationParams = {
   messageId: UIMessageId;
+  fromNotification: boolean;
 };
 
 type NavigationProps = IOStackNavigationRouteProps<
@@ -112,7 +113,8 @@ const MessageRouterScreen = ({
   maybeMessage,
   maybeMessageDetails,
   messageId,
-  setMessageReadState
+  setMessageReadState,
+  fromNotification
 }: Props): React.ReactElement => {
   const navigation = useNavigation();
   // used to automatically dispatch loadMessages if the pot is not some at the first rendering
@@ -127,12 +129,6 @@ const MessageRouterScreen = ({
     loadMessageDetails(messageId);
   }, [maybeMessage, messageId, loadMessageById, loadMessageDetails]);
 
-  useOnFirstRender(() => {
-    if (maybeMessage !== undefined && !maybeMessage.isRead) {
-      setMessageReadState(maybeMessage);
-    }
-  });
-
   useEffect(() => {
     if (!isServiceAvailable && maybeMessage) {
       loadServiceDetail(maybeMessage.serviceId);
@@ -142,10 +138,24 @@ const MessageRouterScreen = ({
   useEffect(() => {
     // message in the list and its details loaded: green light
     if (isStrictSome(maybeMessageDetails) && maybeMessage !== undefined) {
-      navigateToScreenHandler(
-        maybeMessage,
-        maybeMessageDetails.value
-      )(navigation.dispatch);
+      // TODO: this is a mitigation to prevent user from opening
+      // a PN message without a confirmation. If the user taps on
+      // a push notification from PN, she will navigate to the inbox
+      // instead of the message details. A better solution with a good
+      // UX will come later.
+      //
+      // https://pagopa.atlassian.net/browse/IA-917
+      if (fromNotification && maybeMessage.category.tag === "PN") {
+        navigation.navigate(ROUTES.MAIN, {
+          screen: ROUTES.MESSAGES_HOME
+        });
+      } else {
+        setMessageReadState(maybeMessage);
+        navigateToScreenHandler(
+          maybeMessage,
+          maybeMessageDetails.value
+        )(navigation.dispatch);
+      }
       return;
     }
     if (firstRendering.current) {
@@ -159,7 +169,9 @@ const MessageRouterScreen = ({
     maybeMessageDetails,
     messageId,
     navigation,
-    tryLoadMessageDetails
+    tryLoadMessageDetails,
+    fromNotification,
+    setMessageReadState
   ]);
 
   return (
@@ -196,6 +208,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
 
 const mapStateToProps = (state: GlobalState, ownProps: NavigationProps) => {
   const messageId = ownProps.route.params.messageId;
+  const fromNotification = ownProps.route.params.fromNotification;
   const maybeMessage = pot.toUndefined(getMessageById(state, messageId));
   const isServiceAvailable = O.fromNullable(maybeMessage?.serviceId)
     .map(serviceId => serviceByIdSelector(serviceId)(state) || pot.none)
@@ -206,7 +219,8 @@ const mapStateToProps = (state: GlobalState, ownProps: NavigationProps) => {
     isServiceAvailable,
     maybeMessage,
     maybeMessageDetails,
-    messageId
+    messageId,
+    fromNotification
   };
 };
 


### PR DESCRIPTION
## Short description
This PR introduces a mitigation in order to prevent the user from opening a PN message without confirmation when tapping on a push notification.

The proposed solution is suboptimal at the moment, but it's needed to respect a legal requirement. A more pleasant UX will come later with a refactoring of the push notifications handling.

Beware that this PR only affects PN messages, other kind of messages are handled as usual.

## List of changes proposed in this pull request
- Added the `fromNotification` prop to the `MessageRouterScreen`
- Added a check before navigating to the message details
- `setMessageReadState` has been moved to prevent upserting it too early

## How to test
Use the [IIP-18-add-pn-endpoints](https://github.com/pagopa/io-dev-api-server/tree/IIP-18-add-pn-endpoints) branch of the dev server and add this to your `config.json`:
```
{
  "messages": {
    "pnCount": 1
  },
  "services": {
    "includePn": true
  }
}
```
Make sure you set `PN_ENABLED=YES` to `.env` and run the app, than take note of the PN message ID (using Flipper or Reactotron) in your inbox. Create a `.apns` file with this content (replace `message_id` accordingly):
```
{
    "aps": {
        "alert": "Hai ricevuto un nuovo messaggio da IO",
        "badge" : 0
    },
    "message_id": "00000000000000000000000010",
    "Simulator Target Bundle": "it.pagopa.app.io"
}
```
Drag and drop this file to the iOS simulatore with the app in background. Tap on the notification.