### PR TITLE
fix: [IA-838] Automatically check for new messages on focus

### DIFF
--- a/ts/components/messages/paginated/MessageList/index.tsx
+++ b/ts/components/messages/paginated/MessageList/index.tsx
@@ -1,6 +1,6 @@
 import { none, Option, some } from "fp-ts/lib/Option";
 import * as pot from "italia-ts-commons/lib/pot";
-import { Millisecond } from "italia-ts-commons/lib/units";
+import { Millisecond } from "@pagopa/ts-commons/lib/units";
 import React, { useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,

--- a/ts/components/messages/paginated/MessageList/index.tsx
+++ b/ts/components/messages/paginated/MessageList/index.tsx
@@ -254,12 +254,7 @@ const MessageList = ({
         }
 
         setIsRefreshing(true);
-
-        if (messages.length === 0) {
-          reloadAll();
-        } else if (previousCursor !== undefined) {
-          loadPreviousPage(previousCursor);
-        }
+        reloadAll();
       }}
     />
   ) : undefined;

--- a/ts/components/messages/paginated/MessageList/index.tsx
+++ b/ts/components/messages/paginated/MessageList/index.tsx
@@ -1,5 +1,6 @@
 import { none, Option, some } from "fp-ts/lib/Option";
 import * as pot from "italia-ts-commons/lib/pot";
+import { Millisecond } from "italia-ts-commons/lib/units";
 import React, { useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
@@ -39,6 +40,7 @@ import customVariables, {
   VIBRATION_LONG_PRESS_DURATION
 } from "../../../../theme/variables";
 import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
+import { useActionOnFocus } from "../../../../utils/hooks/useOnFocus";
 import { showToast } from "../../../../utils/showToast";
 import { EdgeBorderComponent } from "../../../screens/EdgeBorderComponent";
 import {
@@ -126,6 +128,9 @@ const animated = {
   scrollEventThrottle: 8
 };
 
+// Do not refresh again automatically before minimumRefreshInterval has passed
+const minimumRefreshInterval = 60000 as Millisecond; // 1 minute
+
 type Props = OwnProps &
   ReturnType<typeof mapStateToProps> &
   ReturnType<typeof mapDispatchToProps>;
@@ -194,6 +199,13 @@ const MessageList = ({
     },
     () => shouldUseLoad && !didLoad
   );
+
+  useActionOnFocus(() => {
+    // check if there are new messages when the component becomes focused
+    if (previousCursor) {
+      loadPreviousPage(previousCursor);
+    }
+  }, minimumRefreshInterval);
 
   useEffect(() => {
     if (error) {

--- a/ts/screens/messages/paginated/__tests__/MessagesHomeScreen.test.tsx
+++ b/ts/screens/messages/paginated/__tests__/MessagesHomeScreen.test.tsx
@@ -35,6 +35,7 @@ jest.mock("@react-navigation/native", () => {
     useNavigation: () => ({
       navigate: mockNavigate,
       dispatch: jest.fn(),
+      isFocused: jest.fn(),
       addListener: () => jest.fn()
     })
   };


### PR DESCRIPTION
## Short description
Right now the message list is fetched automatically with an app cold start. Then messages are only fetched manually by the user with the pull-to-refresh gesture. With this PR I want to add an automatic check for new messages when the list becomes focused (with a minimum interval of 1 minute to prevent pressure to the backend).

As a bonus, now the refresh gesture always causes a reload of the message list (either Inbox or Archive). Before, if there were messages, it asked just for new ones. In this way the manual refresh can be used to recover messages state in case the client goes out of sync with the backend. 

## List of changes proposed in this pull request
- Use `useActionOnFocus` to load new messages automatically (no more than once per minute)
- Always reload the messages list when manually refreshing

## How to test
Run the app with a tool that logs network requests (Flipper/Reactotron), switch tabs back and forth and look how calls to `/v1/messages` are dispatched.
