### PR TITLE
fix: [IA-922] Prevent multiple navigations when opening a message

### DIFF
--- a/ts/screens/messages/paginated/MessageRouterScreen.tsx
+++ b/ts/screens/messages/paginated/MessageRouterScreen.tsx
@@ -1,7 +1,7 @@
 import * as pot from "@pagopa/ts-commons/lib/pot";
 import { useNavigation } from "@react-navigation/native";
 import * as O from "fp-ts/lib/Option";
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 
@@ -122,6 +122,11 @@ const MessageRouterScreen = ({
   // used to automatically dispatch loadMessages if the pot is not some at the first rendering
   // (avoid displaying error at the first frame)
   const firstRendering = useRef(true);
+
+  // used to avoid multiple navigations dispatch
+  const [didNavigateToScreenHandler, setDidNavigateToScreenHandler] =
+    useState(false);
+
   const isLoading = !pot.isError(maybeMessageDetails);
 
   const isPnEnabled = useIOSelector(isPnEnabledSelector);
@@ -140,6 +145,10 @@ const MessageRouterScreen = ({
   }, [isServiceAvailable, loadServiceDetail, maybeMessage]);
 
   useEffect(() => {
+    if (didNavigateToScreenHandler) {
+      return;
+    }
+
     // message in the list and its details loaded: green light
     if (isStrictSome(maybeMessageDetails) && maybeMessage !== undefined) {
       // TODO: this is a mitigation to prevent user from opening
@@ -161,6 +170,7 @@ const MessageRouterScreen = ({
           isPnEnabled
         )(navigation.dispatch);
       }
+      setDidNavigateToScreenHandler(true);
       return;
     }
     if (firstRendering.current) {
@@ -169,15 +179,14 @@ const MessageRouterScreen = ({
       firstRendering.current = false;
     }
   }, [
-    loadMessageDetails,
+    didNavigateToScreenHandler,
+    fromNotification,
+    isPnEnabled,
     maybeMessage,
     maybeMessageDetails,
-    messageId,
     navigation,
-    tryLoadMessageDetails,
-    isPnEnabled,
-    fromNotification,
-    setMessageReadState
+    setMessageReadState,
+    tryLoadMessageDetails
   ]);
 
   return (


### PR DESCRIPTION
## Short description
This PR fixes a glitch caused by dispatching multiple navigations from an `useEffect` hook (maybe introduced as a regression by #4080).

https://user-images.githubusercontent.com/467098/181591695-d527714a-68e3-4dc8-a168-3d6e3c0cdaf7.mp4