### PR TITLE
fix: [IA-921] Disable navigation gestures on Android

### DIFF
--- a/ts/features/bonus/cdc/navigation/CdcStackNavigator.tsx
+++ b/ts/features/bonus/cdc/navigation/CdcStackNavigator.tsx
@@ -4,7 +4,7 @@ import CdcBonusRequestInformationTos from "../screens/CdcBonusRequestInformation
 import CdcBonusRequestSelectYear from "../screens/CdcBonusRequestSelectYear";
 import CdcBonusRequestSelectResidence from "../screens/CdcBonusRequestSelectResidence";
 import CdcBonusRequestBonusRequested from "../screens/CdcBonusRequestBonusRequested";
-import { areGestureEnabled } from "../../../../utils/navigation";
+import { isGestureEnabled } from "../../../../utils/navigation";
 import { CdcBonusRequestParamsList } from "./params";
 import { CDC_ROUTES } from "./routes";
 
@@ -14,7 +14,7 @@ export const CdcStackNavigator = () => (
   <Stack.Navigator
     initialRouteName={CDC_ROUTES.INFORMATION_TOS}
     headerMode={"none"}
-    screenOptions={{ gestureEnabled: areGestureEnabled }}
+    screenOptions={{ gestureEnabled: isGestureEnabled }}
   >
     <Stack.Screen
       name={CDC_ROUTES.INFORMATION_TOS}

--- a/ts/features/bonus/cdc/navigation/CdcStackNavigator.tsx
+++ b/ts/features/bonus/cdc/navigation/CdcStackNavigator.tsx
@@ -4,6 +4,7 @@ import CdcBonusRequestInformationTos from "../screens/CdcBonusRequestInformation
 import CdcBonusRequestSelectYear from "../screens/CdcBonusRequestSelectYear";
 import CdcBonusRequestSelectResidence from "../screens/CdcBonusRequestSelectResidence";
 import CdcBonusRequestBonusRequested from "../screens/CdcBonusRequestBonusRequested";
+import { areGestureEnabled } from "../../../../utils/navigation";
 import { CdcBonusRequestParamsList } from "./params";
 import { CDC_ROUTES } from "./routes";
 
@@ -13,7 +14,7 @@ export const CdcStackNavigator = () => (
   <Stack.Navigator
     initialRouteName={CDC_ROUTES.INFORMATION_TOS}
     headerMode={"none"}
-    screenOptions={{ gestureEnabled: true }}
+    screenOptions={{ gestureEnabled: areGestureEnabled }}
   >
     <Stack.Screen
       name={CDC_ROUTES.INFORMATION_TOS}

--- a/ts/features/bonus/cgn/navigation/navigator.tsx
+++ b/ts/features/bonus/cgn/navigation/navigator.tsx
@@ -1,7 +1,7 @@
 import { PathConfigMap } from "@react-navigation/core";
 import { createStackNavigator } from "@react-navigation/stack";
 import * as React from "react";
-import { areGestureEnabled } from "../../../../utils/navigation";
+import { isGestureEnabled } from "../../../../utils/navigation";
 import CgnActivationCompletedScreen from "../screens/activation/CgnActivationCompletedScreen";
 import CgnActivationIneligibleScreen from "../screens/activation/CgnActivationIneligibleScreen";
 import CgnActivationLoadingScreen from "../screens/activation/CgnActivationLoadingScreen";
@@ -49,7 +49,7 @@ export const CgnActivationNavigator = () => (
   <ActivationStack.Navigator
     initialRouteName={CGN_ROUTES.ACTIVATION.INFORMATION_TOS}
     headerMode="none"
-    screenOptions={{ gestureEnabled: areGestureEnabled }}
+    screenOptions={{ gestureEnabled: isGestureEnabled }}
   >
     <ActivationStack.Screen
       name={CGN_ROUTES.ACTIVATION.INFORMATION_TOS}
@@ -92,7 +92,7 @@ export const CgnDetailsNavigator = () => (
   <DetailStack.Navigator
     initialRouteName={CGN_ROUTES.DETAILS.DETAILS}
     headerMode="none"
-    screenOptions={{ gestureEnabled: areGestureEnabled }}
+    screenOptions={{ gestureEnabled: isGestureEnabled }}
   >
     <DetailStack.Screen
       name={CGN_ROUTES.DETAILS.DETAILS}
@@ -131,7 +131,7 @@ export const CgnEYCAActivationNavigator = () => (
   <EycaActivationStack.Navigator
     initialRouteName={CGN_ROUTES.EYCA.ACTIVATION.LOADING}
     headerMode="none"
-    screenOptions={{ gestureEnabled: areGestureEnabled }}
+    screenOptions={{ gestureEnabled: isGestureEnabled }}
   >
     <EycaActivationStack.Screen
       name={CGN_ROUTES.EYCA.ACTIVATION.LOADING}

--- a/ts/features/bonus/cgn/navigation/navigator.tsx
+++ b/ts/features/bonus/cgn/navigation/navigator.tsx
@@ -1,6 +1,7 @@
 import { PathConfigMap } from "@react-navigation/core";
 import { createStackNavigator } from "@react-navigation/stack";
 import * as React from "react";
+import { areGestureEnabled } from "../../../../utils/navigation";
 import CgnActivationCompletedScreen from "../screens/activation/CgnActivationCompletedScreen";
 import CgnActivationIneligibleScreen from "../screens/activation/CgnActivationIneligibleScreen";
 import CgnActivationLoadingScreen from "../screens/activation/CgnActivationLoadingScreen";
@@ -48,7 +49,7 @@ export const CgnActivationNavigator = () => (
   <ActivationStack.Navigator
     initialRouteName={CGN_ROUTES.ACTIVATION.INFORMATION_TOS}
     headerMode="none"
-    screenOptions={{ gestureEnabled: true }}
+    screenOptions={{ gestureEnabled: areGestureEnabled }}
   >
     <ActivationStack.Screen
       name={CGN_ROUTES.ACTIVATION.INFORMATION_TOS}
@@ -91,7 +92,7 @@ export const CgnDetailsNavigator = () => (
   <DetailStack.Navigator
     initialRouteName={CGN_ROUTES.DETAILS.DETAILS}
     headerMode="none"
-    screenOptions={{ gestureEnabled: true }}
+    screenOptions={{ gestureEnabled: areGestureEnabled }}
   >
     <DetailStack.Screen
       name={CGN_ROUTES.DETAILS.DETAILS}
@@ -130,7 +131,7 @@ export const CgnEYCAActivationNavigator = () => (
   <EycaActivationStack.Navigator
     initialRouteName={CGN_ROUTES.EYCA.ACTIVATION.LOADING}
     headerMode="none"
-    screenOptions={{ gestureEnabled: true }}
+    screenOptions={{ gestureEnabled: areGestureEnabled }}
   >
     <EycaActivationStack.Screen
       name={CGN_ROUTES.EYCA.ACTIVATION.LOADING}

--- a/ts/features/bonus/siciliaVola/navigation/navigator.tsx
+++ b/ts/features/bonus/siciliaVola/navigation/navigator.tsx
@@ -1,7 +1,7 @@
 import { PathConfigMap } from "@react-navigation/core";
 import { createStackNavigator } from "@react-navigation/stack";
 import * as React from "react";
-import { areGestureEnabled } from "../../../../utils/navigation";
+import { isGestureEnabled } from "../../../../utils/navigation";
 import CheckStatusRouterScreen from "../screens/voucherGeneration/CheckStatusRouterScreen";
 import DisabledAdditionalInfoScreen from "../screens/voucherGeneration/DisabledAdditionalInfoScreen";
 import SvCheckIncomeKoScreen from "../screens/voucherGeneration/ko/SvCheckIncomeKoScreen";
@@ -42,7 +42,7 @@ export const SvVoucherListNavigator = () => (
   <ListStack.Navigator
     initialRouteName={SV_ROUTES.VOUCHER_LIST.LIST}
     headerMode="none"
-    screenOptions={{ gestureEnabled: areGestureEnabled }}
+    screenOptions={{ gestureEnabled: isGestureEnabled }}
   >
     <ListStack.Screen
       name={SV_ROUTES.VOUCHER_LIST.LIST}
@@ -61,7 +61,7 @@ export const SvVoucherGenerationNavigator = () => (
   <GenerationStack.Navigator
     initialRouteName={SV_ROUTES.VOUCHER_GENERATION.CHECK_STATUS}
     headerMode="none"
-    screenOptions={{ gestureEnabled: areGestureEnabled }}
+    screenOptions={{ gestureEnabled: isGestureEnabled }}
   >
     <GenerationStack.Screen
       name={SV_ROUTES.VOUCHER_GENERATION.CHECK_STATUS}

--- a/ts/features/bonus/siciliaVola/navigation/navigator.tsx
+++ b/ts/features/bonus/siciliaVola/navigation/navigator.tsx
@@ -1,6 +1,7 @@
 import { PathConfigMap } from "@react-navigation/core";
 import { createStackNavigator } from "@react-navigation/stack";
 import * as React from "react";
+import { areGestureEnabled } from "../../../../utils/navigation";
 import CheckStatusRouterScreen from "../screens/voucherGeneration/CheckStatusRouterScreen";
 import DisabledAdditionalInfoScreen from "../screens/voucherGeneration/DisabledAdditionalInfoScreen";
 import SvCheckIncomeKoScreen from "../screens/voucherGeneration/ko/SvCheckIncomeKoScreen";
@@ -41,7 +42,7 @@ export const SvVoucherListNavigator = () => (
   <ListStack.Navigator
     initialRouteName={SV_ROUTES.VOUCHER_LIST.LIST}
     headerMode="none"
-    screenOptions={{ gestureEnabled: true }}
+    screenOptions={{ gestureEnabled: areGestureEnabled }}
   >
     <ListStack.Screen
       name={SV_ROUTES.VOUCHER_LIST.LIST}
@@ -60,7 +61,7 @@ export const SvVoucherGenerationNavigator = () => (
   <GenerationStack.Navigator
     initialRouteName={SV_ROUTES.VOUCHER_GENERATION.CHECK_STATUS}
     headerMode="none"
-    screenOptions={{ gestureEnabled: true }}
+    screenOptions={{ gestureEnabled: areGestureEnabled }}
   >
     <GenerationStack.Screen
       name={SV_ROUTES.VOUCHER_GENERATION.CHECK_STATUS}

--- a/ts/features/euCovidCert/navigation/navigator.tsx
+++ b/ts/features/euCovidCert/navigation/navigator.tsx
@@ -1,6 +1,6 @@
 import { createStackNavigator } from "@react-navigation/stack";
 import * as React from "react";
-import { areGestureEnabled } from "../../../utils/navigation";
+import { isGestureEnabled } from "../../../utils/navigation";
 import EuCovidCertificateRouterScreen from "../screens/EuCovidCertificateRouterScreen";
 import { EuCovidCertMarkdownDetailsScreen } from "../screens/valid/EuCovidCertMarkdownDetailsScreen";
 import { EuCovidCertQrCodeFullScreen } from "../screens/valid/EuCovidCertQrCodeFullScreen";
@@ -13,7 +13,7 @@ export const EUCovidCertStackNavigator = () => (
   <Stack.Navigator
     initialRouteName={EUCOVIDCERT_ROUTES.CERTIFICATE}
     headerMode={"none"}
-    screenOptions={{ gestureEnabled: areGestureEnabled }}
+    screenOptions={{ gestureEnabled: isGestureEnabled }}
   >
     <Stack.Screen
       name={EUCOVIDCERT_ROUTES.CERTIFICATE}

--- a/ts/features/euCovidCert/navigation/navigator.tsx
+++ b/ts/features/euCovidCert/navigation/navigator.tsx
@@ -1,5 +1,6 @@
 import { createStackNavigator } from "@react-navigation/stack";
 import * as React from "react";
+import { areGestureEnabled } from "../../../utils/navigation";
 import EuCovidCertificateRouterScreen from "../screens/EuCovidCertificateRouterScreen";
 import { EuCovidCertMarkdownDetailsScreen } from "../screens/valid/EuCovidCertMarkdownDetailsScreen";
 import { EuCovidCertQrCodeFullScreen } from "../screens/valid/EuCovidCertQrCodeFullScreen";
@@ -12,7 +13,7 @@ export const EUCovidCertStackNavigator = () => (
   <Stack.Navigator
     initialRouteName={EUCOVIDCERT_ROUTES.CERTIFICATE}
     headerMode={"none"}
-    screenOptions={{ gestureEnabled: true }}
+    screenOptions={{ gestureEnabled: areGestureEnabled }}
   >
     <Stack.Screen
       name={EUCOVIDCERT_ROUTES.CERTIFICATE}

--- a/ts/features/mvl/navigation/navigator.tsx
+++ b/ts/features/mvl/navigation/navigator.tsx
@@ -1,6 +1,6 @@
 import { createStackNavigator } from "@react-navigation/stack";
 import * as React from "react";
-import { areGestureEnabled } from "../../../utils/navigation";
+import { isGestureEnabled } from "../../../utils/navigation";
 import { MvlAttachmentPreview } from "../screens/details/components/attachment/MvlAttachmentPreview";
 import { MvlCertificatesScreen } from "../screens/metadata/MvlCertificatesScreen";
 import { MvlRecipientsScreen } from "../screens/metadata/MvlRecipientsScreen";
@@ -15,7 +15,7 @@ export const MvlStackNavigator = () => (
   <Stack.Navigator
     initialRouteName={MVL_ROUTES.DETAILS}
     headerMode={"none"}
-    screenOptions={{ gestureEnabled: areGestureEnabled }}
+    screenOptions={{ gestureEnabled: isGestureEnabled }}
   >
     <Stack.Screen name={MVL_ROUTES.DETAILS} component={MvlRouterScreen} />
     <Stack.Screen

--- a/ts/features/mvl/navigation/navigator.tsx
+++ b/ts/features/mvl/navigation/navigator.tsx
@@ -1,5 +1,6 @@
 import { createStackNavigator } from "@react-navigation/stack";
 import * as React from "react";
+import { areGestureEnabled } from "../../../utils/navigation";
 import { MvlAttachmentPreview } from "../screens/details/components/attachment/MvlAttachmentPreview";
 import { MvlCertificatesScreen } from "../screens/metadata/MvlCertificatesScreen";
 import { MvlRecipientsScreen } from "../screens/metadata/MvlRecipientsScreen";
@@ -14,7 +15,7 @@ export const MvlStackNavigator = () => (
   <Stack.Navigator
     initialRouteName={MVL_ROUTES.DETAILS}
     headerMode={"none"}
-    screenOptions={{ gestureEnabled: true }}
+    screenOptions={{ gestureEnabled: areGestureEnabled }}
   >
     <Stack.Screen name={MVL_ROUTES.DETAILS} component={MvlRouterScreen} />
     <Stack.Screen

--- a/ts/features/pn/navigation/navigator.tsx
+++ b/ts/features/pn/navigation/navigator.tsx
@@ -1,6 +1,6 @@
 import { createStackNavigator } from "@react-navigation/stack";
 import * as React from "react";
-import { areGestureEnabled } from "../../../utils/navigation";
+import { isGestureEnabled } from "../../../utils/navigation";
 import { PnAttachmentPreview } from "../screens/PnAttachmentPreview";
 import { PnMessageDetailsScreen } from "../screens/PnMessageDetailsScreen";
 import { PnParamsList } from "./params";
@@ -12,7 +12,7 @@ export const PnStackNavigator = () => (
   <Stack.Navigator
     initialRouteName={PN_ROUTES.MESSAGE_DETAILS}
     headerMode={"none"}
-    screenOptions={{ gestureEnabled: areGestureEnabled }}
+    screenOptions={{ gestureEnabled: isGestureEnabled }}
   >
     <Stack.Screen
       name={PN_ROUTES.MESSAGE_DETAILS}

--- a/ts/features/pn/navigation/navigator.tsx
+++ b/ts/features/pn/navigation/navigator.tsx
@@ -1,5 +1,6 @@
 import { createStackNavigator } from "@react-navigation/stack";
 import * as React from "react";
+import { areGestureEnabled } from "../../../utils/navigation";
 import { PnAttachmentPreview } from "../screens/PnAttachmentPreview";
 import { PnMessageDetailsScreen } from "../screens/PnMessageDetailsScreen";
 import { PnParamsList } from "./params";
@@ -11,7 +12,7 @@ export const PnStackNavigator = () => (
   <Stack.Navigator
     initialRouteName={PN_ROUTES.MESSAGE_DETAILS}
     headerMode={"none"}
-    screenOptions={{ gestureEnabled: true }}
+    screenOptions={{ gestureEnabled: areGestureEnabled }}
   >
     <Stack.Screen
       name={PN_ROUTES.MESSAGE_DETAILS}

--- a/ts/features/zendesk/navigation/navigator.tsx
+++ b/ts/features/zendesk/navigation/navigator.tsx
@@ -1,6 +1,6 @@
 import { createStackNavigator } from "@react-navigation/stack";
 import * as React from "react";
-import { areGestureEnabled } from "../../../utils/navigation";
+import { isGestureEnabled } from "../../../utils/navigation";
 import ZendeskAskPermissions from "../screens/ZendeskAskPermissions";
 import ZendeskChooseCategory from "../screens/ZendeskChooseCategory";
 import ZendeskChooseSubCategory from "../screens/ZendeskChooseSubCategory";
@@ -15,7 +15,7 @@ export const ZendeskStackNavigator = () => (
   <Stack.Navigator
     initialRouteName={ZENDESK_ROUTES.HELP_CENTER}
     headerMode={"none"}
-    screenOptions={{ gestureEnabled: areGestureEnabled }}
+    screenOptions={{ gestureEnabled: isGestureEnabled }}
   >
     <Stack.Screen
       name={ZENDESK_ROUTES.HELP_CENTER}

--- a/ts/features/zendesk/navigation/navigator.tsx
+++ b/ts/features/zendesk/navigation/navigator.tsx
@@ -1,5 +1,6 @@
 import { createStackNavigator } from "@react-navigation/stack";
 import * as React from "react";
+import { areGestureEnabled } from "../../../utils/navigation";
 import ZendeskAskPermissions from "../screens/ZendeskAskPermissions";
 import ZendeskChooseCategory from "../screens/ZendeskChooseCategory";
 import ZendeskChooseSubCategory from "../screens/ZendeskChooseSubCategory";
@@ -14,7 +15,7 @@ export const ZendeskStackNavigator = () => (
   <Stack.Navigator
     initialRouteName={ZENDESK_ROUTES.HELP_CENTER}
     headerMode={"none"}
-    screenOptions={{ gestureEnabled: true }}
+    screenOptions={{ gestureEnabled: areGestureEnabled }}
   >
     <Stack.Screen
       name={ZENDESK_ROUTES.HELP_CENTER}

--- a/ts/navigation/MessagesNavigator.tsx
+++ b/ts/navigation/MessagesNavigator.tsx
@@ -12,6 +12,7 @@ import PaginatedMessageRouterScreen from "../screens/messages/paginated/MessageR
 import { PnStackNavigator } from "../features/pn/navigation/navigator";
 import PN_ROUTES from "../features/pn/navigation/routes";
 import { useIOSelector } from "../store/hooks";
+import { areGestureEnabled } from "../utils/navigation";
 import { isPnEnabledSelector } from "../store/reducers/backendStatus";
 import { MessagesParamsList } from "./params/MessagesParamsList";
 import ROUTES from "./routes";
@@ -25,7 +26,7 @@ export const MessagesStackNavigator = () => {
     <Stack.Navigator
       initialRouteName={ROUTES.MESSAGE_ROUTER}
       headerMode={"none"}
-      screenOptions={{ gestureEnabled: true }}
+      screenOptions={{ gestureEnabled: areGestureEnabled }}
     >
       <Stack.Screen
         name={ROUTES.MESSAGE_ROUTER}

--- a/ts/navigation/MessagesNavigator.tsx
+++ b/ts/navigation/MessagesNavigator.tsx
@@ -12,7 +12,7 @@ import PaginatedMessageRouterScreen from "../screens/messages/paginated/MessageR
 import { PnStackNavigator } from "../features/pn/navigation/navigator";
 import PN_ROUTES from "../features/pn/navigation/routes";
 import { useIOSelector } from "../store/hooks";
-import { areGestureEnabled } from "../utils/navigation";
+import { isGestureEnabled } from "../utils/navigation";
 import { isPnEnabledSelector } from "../store/reducers/backendStatus";
 import { MessagesParamsList } from "./params/MessagesParamsList";
 import ROUTES from "./routes";
@@ -26,7 +26,7 @@ export const MessagesStackNavigator = () => {
     <Stack.Navigator
       initialRouteName={ROUTES.MESSAGE_ROUTER}
       headerMode={"none"}
-      screenOptions={{ gestureEnabled: areGestureEnabled }}
+      screenOptions={{ gestureEnabled: isGestureEnabled }}
     >
       <Stack.Screen
         name={ROUTES.MESSAGE_ROUTER}

--- a/ts/navigation/ProfileNavigator.tsx
+++ b/ts/navigation/ProfileNavigator.tsx
@@ -22,6 +22,7 @@ import ServicesPreferenceScreen from "../screens/profile/ServicesPreferenceScree
 import ShareDataScreen from "../screens/profile/ShareDataScreen";
 import WebPlayground from "../screens/profile/WebPlayground";
 import { Showroom } from "../screens/showroom/Showroom";
+import { areGestureEnabled } from "../utils/navigation";
 import { ProfileParamsList } from "./params/ProfileParamsList";
 import ROUTES from "./routes";
 
@@ -34,7 +35,7 @@ const ProfileStackNavigator = () => (
   <Stack.Navigator
     initialRouteName={ROUTES.PROFILE_DATA}
     headerMode={"none"}
-    screenOptions={{ gestureEnabled: true }}
+    screenOptions={{ gestureEnabled: areGestureEnabled }}
   >
     <Stack.Screen name={ROUTES.PROFILE_DATA} component={ProfileDataScreen} />
     <Stack.Screen

--- a/ts/navigation/ProfileNavigator.tsx
+++ b/ts/navigation/ProfileNavigator.tsx
@@ -22,7 +22,7 @@ import ServicesPreferenceScreen from "../screens/profile/ServicesPreferenceScree
 import ShareDataScreen from "../screens/profile/ShareDataScreen";
 import WebPlayground from "../screens/profile/WebPlayground";
 import { Showroom } from "../screens/showroom/Showroom";
-import { areGestureEnabled } from "../utils/navigation";
+import { isGestureEnabled } from "../utils/navigation";
 import { ProfileParamsList } from "./params/ProfileParamsList";
 import ROUTES from "./routes";
 
@@ -35,7 +35,7 @@ const ProfileStackNavigator = () => (
   <Stack.Navigator
     initialRouteName={ROUTES.PROFILE_DATA}
     headerMode={"none"}
-    screenOptions={{ gestureEnabled: areGestureEnabled }}
+    screenOptions={{ gestureEnabled: isGestureEnabled }}
   >
     <Stack.Screen name={ROUTES.PROFILE_DATA} component={ProfileDataScreen} />
     <Stack.Screen

--- a/ts/navigation/ServicesNavigator.tsx
+++ b/ts/navigation/ServicesNavigator.tsx
@@ -8,7 +8,7 @@ import {
 import SV_ROUTES from "../features/bonus/siciliaVola/navigation/routes";
 import ServiceDetailsScreen from "../screens/services/ServiceDetailsScreen";
 import ServicesWebviewScreen from "../screens/services/ServicesWebviewScreen";
-import { areGestureEnabled } from "../utils/navigation";
+import { isGestureEnabled } from "../utils/navigation";
 import ROUTES from "./routes";
 
 const Stack = createStackNavigator();
@@ -17,7 +17,7 @@ const ServicesNavigator = () => (
   <Stack.Navigator
     initialRouteName={ROUTES.SERVICE_DETAIL}
     headerMode={"none"}
-    screenOptions={{ gestureEnabled: areGestureEnabled }}
+    screenOptions={{ gestureEnabled: isGestureEnabled }}
   >
     <Stack.Screen
       name={ROUTES.SERVICE_DETAIL}

--- a/ts/navigation/ServicesNavigator.tsx
+++ b/ts/navigation/ServicesNavigator.tsx
@@ -8,6 +8,7 @@ import {
 import SV_ROUTES from "../features/bonus/siciliaVola/navigation/routes";
 import ServiceDetailsScreen from "../screens/services/ServiceDetailsScreen";
 import ServicesWebviewScreen from "../screens/services/ServicesWebviewScreen";
+import { areGestureEnabled } from "../utils/navigation";
 import ROUTES from "./routes";
 
 const Stack = createStackNavigator();
@@ -16,7 +17,7 @@ const ServicesNavigator = () => (
   <Stack.Navigator
     initialRouteName={ROUTES.SERVICE_DETAIL}
     headerMode={"none"}
-    screenOptions={{ gestureEnabled: true }}
+    screenOptions={{ gestureEnabled: areGestureEnabled }}
   >
     <Stack.Screen
       name={ROUTES.SERVICE_DETAIL}

--- a/ts/utils/navigation.ts
+++ b/ts/utils/navigation.ts
@@ -22,8 +22,8 @@ export const convertUrlToNavigationLink = (path: string) =>
   path.replace(IO_INTERNAL_LINK_PREFIX, "/");
 
 /**
- * This variable should be used on every `gestureEnabled` settings
+ * This variable should be used on every `gestureEnabled` setting
  * in the navigator. This prevents the gestures to be enabled on Android
- * creating glitches with the scroll on old Android versions.
+ * creating glitches with the scroll on old Android versions (version 9 and below).
  */
 export const areGestureEnabled = Platform.OS !== "android";

--- a/ts/utils/navigation.ts
+++ b/ts/utils/navigation.ts
@@ -26,4 +26,4 @@ export const convertUrlToNavigationLink = (path: string) =>
  * in the navigator. This prevents the gestures to be enabled on Android
  * creating glitches with the scroll on old Android versions (version 9 and below).
  */
-export const areGestureEnabled = Platform.OS !== "android";
+export const isGestureEnabled = Platform.OS !== "android";

--- a/ts/utils/navigation.ts
+++ b/ts/utils/navigation.ts
@@ -1,4 +1,5 @@
 // gets the current screen from navigation state
+import { Platform } from "react-native";
 import { navigationRef } from "../navigation/NavigationService";
 import ROUTES from "../navigation/routes";
 
@@ -19,3 +20,10 @@ export const IO_INTERNAL_LINK_PREFIX = IO_INTERNAL_LINK_PROTOCOL + "//";
 
 export const convertUrlToNavigationLink = (path: string) =>
   path.replace(IO_INTERNAL_LINK_PREFIX, "/");
+
+/**
+ * This variable should be used on every `gestureEnabled` settings
+ * in the navigator. This prevents the gestures to be enabled on Android
+ * creating glitches with the scroll on old Android versions.
+ */
+export const areGestureEnabled = Platform.OS !== "android";


### PR DESCRIPTION
## Short description
This PR is going to disable the navigation gestures on Android due to a bug present on Android 9 and below causing various `ScrollView` around the app to not work properly.

<details>
<summary>Before</summary>

https://user-images.githubusercontent.com/5963683/182397049-572c0001-31a1-402a-8607-c3a8a01b95c5.mov 

</details>

<details>
<summary>After</summary>

https://user-images.githubusercontent.com/5963683/182397347-7863c685-0d1e-471b-8698-b004e7d5ff0c.mov 

</details>

## List of changes proposed in this pull request
- Created an `isGestureEnabled` flag
- Replaced all the `gestureEnabled: true` with the new `isGestureEnabled` flag

## How to test
Using an emulator with Android 9 and below all the `ScrollView` should work properly (for example the Green Pass details or the CGN category list).
