### PR TITLE
fix: [IA-827] Message is still shown as unread after opening it

### DIFF
--- a/ts/store/reducers/entities/messages/allPaginated.ts
+++ b/ts/store/reducers/entities/messages/allPaginated.ts
@@ -399,6 +399,17 @@ const reduceUpsertMessageStatusAttributes = (
       }))
     });
 
+  // Replaces a message with the same ID in the collection (if found)
+  const replace = (message: UIMessage, collection: Collection): Collection => ({
+    ...collection,
+    data: pot.map(collection.data, old => ({
+      ...old,
+      page: old.page.map(oldMessage =>
+        oldMessage.id === message.id ? message : oldMessage
+      )
+    }))
+  });
+
   const refreshCursors = (of: Collection): Collection => ({
     ...of,
     data: pot.map(of.data, old => ({
@@ -418,18 +429,25 @@ const reduceUpsertMessageStatusAttributes = (
       const message = action.payload.message;
       if (message) {
         const { update } = action.payload;
-        if (update.tag === "bulk" || update.tag === "reading") {
-          // We only update TRUE for is_read state
-          // eslint-disable-next-line functional/immutable-data
-          message.isRead = true;
+        const isRead =
+          update.tag === "reading" || update.tag === "bulk" || message.isRead;
+
+        if (update.tag === "reading") {
+          return {
+            ...state,
+            archive: replace({ ...message, isRead }, state.archive),
+            inbox: replace({ ...message, isRead }, state.inbox)
+          };
         }
+
         if (update.tag === "bulk" || update.tag === "archiving") {
-          // eslint-disable-next-line functional/immutable-data
-          message.isArchived = update.isArchived;
           if (update.isArchived) {
             return {
               ...state,
-              archive: insert(message, state.archive),
+              archive: insert(
+                { ...message, isRead, isArchived: true },
+                state.archive
+              ),
               inbox: remove(message, state.inbox),
               latestMessageOperation: undefined
             };
@@ -437,7 +455,10 @@ const reduceUpsertMessageStatusAttributes = (
             return {
               ...state,
               archive: remove(message, state.archive),
-              inbox: insert(message, state.inbox),
+              inbox: insert(
+                { ...message, isRead, isArchived: false },
+                state.inbox
+              ),
               latestMessageOperation: undefined
             };
           }
@@ -450,14 +471,16 @@ const reduceUpsertMessageStatusAttributes = (
       const message = action.payload.payload.message;
       if (message) {
         const { update } = action.payload.payload;
-        if (update.tag === "bulk" || update.tag === "reading") {
-          // We only update TRUE for is_read state
-          // eslint-disable-next-line functional/immutable-data
-          message.isRead = false;
+
+        if (update.tag === "reading") {
+          return {
+            ...state,
+            archive: replace(message, state.archive),
+            inbox: replace(message, state.inbox)
+          };
         }
+
         if (update.tag === "bulk" || update.tag === "archiving") {
-          // eslint-disable-next-line functional/immutable-data
-          message.isArchived = !update.isArchived;
           if (update.isArchived) {
             return {
               ...state,


### PR DESCRIPTION
## Short description
There's a buggy implementation when upserting the message read state after opening it. One failing scenario is opening a message from a push notification that leaves the message in an unread state. This PR aims to fix it.

https://user-images.githubusercontent.com/467098/182607569-f41c5325-58e7-4b8a-b902-96a7a5335ff5.mp4

https://user-images.githubusercontent.com/467098/182608293-c6c8bd1e-1c9d-43a4-8f54-814d80ff5db9.mp4

## List of changes proposed in this pull request
- Added a failing test to reproduce the bug
- Fixed the bug 😊

## How to test
Simulate a push notification with an unread message ID and tap on it. Go back to the inbox. The message should be marked as read.