### PR TITLE
fix: [IABT-1382] Do not consider PPT_PAGAMENTO_DUPLICATO as error 

### DIFF
--- a/ts/features/pn/components/PnMessageDetails.tsx
+++ b/ts/features/pn/components/PnMessageDetails.tsx
@@ -16,7 +16,10 @@ import {
 } from "../../../screens/wallet/payment/components/TransactionSummary";
 import { useOnFirstRender } from "../../../utils/hooks/useOnFirstRender";
 import { paymentVerifica } from "../../../store/actions/wallet/payment";
-import { getRptIdFromNoticeNumber } from "../../../utils/payment";
+import {
+  getRptIdFromNoticeNumber,
+  isDuplicatedPayment
+} from "../../../utils/payment";
 import { PaymentNoticeNumber } from "../../../../definitions/backend/PaymentNoticeNumber";
 import { OrganizationFiscalCode } from "../../../../definitions/backend/OrganizationFiscalCode";
 import FooterWithButtons from "../../../components/ui/FooterWithButtons";
@@ -114,10 +117,7 @@ export const PnMessageDetails = (props: Props) => {
 
   const scrollViewRef = React.createRef<ScrollView>();
 
-  const errorOrUndefined = paymentVerificationError.toUndefined();
-  const isPaid =
-    errorOrUndefined === "PAA_PAGAMENTO_DUPLICATO" ||
-    errorOrUndefined === "PPT_PAGAMENTO_DUPLICATO";
+  const isPaid = isDuplicatedPayment(paymentVerificationError);
 
   return (
     <>

--- a/ts/features/pn/components/PnMessageDetails.tsx
+++ b/ts/features/pn/components/PnMessageDetails.tsx
@@ -114,6 +114,11 @@ export const PnMessageDetails = (props: Props) => {
 
   const scrollViewRef = React.createRef<ScrollView>();
 
+  const errorOrUndefined = paymentVerificationError.toUndefined();
+  const isPaid =
+    errorOrUndefined === "PAA_PAGAMENTO_DUPLICATO" ||
+    errorOrUndefined === "PPT_PAGAMENTO_DUPLICATO";
+
   return (
     <>
       {firstLoadingRequest && paymentVerificationError.isSome() && (
@@ -148,10 +153,7 @@ export const PnMessageDetails = (props: Props) => {
                   paymentVerification={paymentVerification}
                   paymentNoticeNumber={maybePayment.noticeCode}
                   organizationFiscalCode={maybePayment.creditorTaxId}
-                  isPaid={
-                    paymentVerificationError.toUndefined() ===
-                    "PAA_PAGAMENTO_DUPLICATO"
-                  }
+                  isPaid={isPaid}
                 />
                 {paymentVerificationError.isSome() && (
                   <TransactionSummaryErrorDetails

--- a/ts/screens/wallet/payment/NewTransactionSummaryScreen.tsx
+++ b/ts/screens/wallet/payment/NewTransactionSummaryScreen.tsx
@@ -181,12 +181,16 @@ const NewTransactionSummaryScreen = ({
   const showsInlineError = paymentStartOrigin === "message";
 
   const errorOrUndefined = error.toUndefined();
+  const isPaid =
+    errorOrUndefined === "PAA_PAGAMENTO_DUPLICATO" ||
+    errorOrUndefined === "PPT_PAGAMENTO_DUPLICATO";
+
   const isError = error.isSome();
   useEffect(() => {
     if (!isError) {
       return;
     }
-    if (errorOrUndefined === "PAA_PAGAMENTO_DUPLICATO") {
+    if (isPaid) {
       onDuplicatedPayment();
     }
     // in case of a payment verification error we should navigate
@@ -204,7 +208,8 @@ const NewTransactionSummaryScreen = ({
     onDuplicatedPayment,
     navigateToPaymentTransactionError,
     showsInlineError,
-    paymentVerification
+    paymentVerification,
+    isPaid
   ]);
 
   const goBack = () => {
@@ -268,7 +273,7 @@ const NewTransactionSummaryScreen = ({
             paymentVerification={paymentVerification}
             paymentNoticeNumber={paymentNoticeNumber}
             organizationFiscalCode={organizationFiscalCode}
-            isPaid={errorOrUndefined === "PAA_PAGAMENTO_DUPLICATO"}
+            isPaid={isPaid}
           />
           {showsInlineError && pot.isError(paymentVerification) && (
             <TransactionSummaryErrorDetails

--- a/ts/screens/wallet/payment/NewTransactionSummaryScreen.tsx
+++ b/ts/screens/wallet/payment/NewTransactionSummaryScreen.tsx
@@ -52,7 +52,11 @@ import {
 } from "../../../store/reducers/backendStatus";
 import { alertNoPayablePaymentMethods } from "../../../utils/paymentMethod";
 import { showToast } from "../../../utils/showToast";
-import { DetailV2Keys, getV2ErrorMainType } from "../../../utils/payment";
+import {
+  DetailV2Keys,
+  getV2ErrorMainType,
+  isDuplicatedPayment
+} from "../../../utils/payment";
 import {
   zendeskSelectedCategory,
   zendeskSupportStart
@@ -181,9 +185,7 @@ const NewTransactionSummaryScreen = ({
   const showsInlineError = paymentStartOrigin === "message";
 
   const errorOrUndefined = error.toUndefined();
-  const isPaid =
-    errorOrUndefined === "PAA_PAGAMENTO_DUPLICATO" ||
-    errorOrUndefined === "PPT_PAGAMENTO_DUPLICATO";
+  const isPaid = isDuplicatedPayment(error);
 
   const isError = error.isSome();
   useEffect(() => {

--- a/ts/screens/wallet/payment/components/TransactionSummaryErrorDetails.tsx
+++ b/ts/screens/wallet/payment/components/TransactionSummaryErrorDetails.tsx
@@ -8,6 +8,7 @@ import I18n from "../../../../i18n";
 import { TransactionSummaryError } from "../NewTransactionSummaryScreen";
 import { clipboardSetStringWithFeedback } from "../../../../utils/clipboard";
 import { Detail_v2Enum } from "../../../../../definitions/backend/PaymentProblemJson";
+import { isDuplicatedPayment } from "../../../../utils/payment";
 import { TransactionSummaryRow } from "./TransactionSummary";
 
 type Props = Readonly<{
@@ -35,8 +36,7 @@ export const TransactionSummaryErrorDetails = ({
   const errorOrUndefined = error.toUndefined();
   if (
     errorOrUndefined === undefined ||
-    errorOrUndefined === "PAA_PAGAMENTO_DUPLICATO" ||
-    errorOrUndefined === "PPT_PAGAMENTO_DUPLICATO" ||
+    isDuplicatedPayment(error) ||
     !Object.keys(Detail_v2Enum).includes(errorOrUndefined)
   ) {
     return null;

--- a/ts/screens/wallet/payment/components/TransactionSummaryErrorDetails.tsx
+++ b/ts/screens/wallet/payment/components/TransactionSummaryErrorDetails.tsx
@@ -36,6 +36,7 @@ export const TransactionSummaryErrorDetails = ({
   if (
     errorOrUndefined === undefined ||
     errorOrUndefined === "PAA_PAGAMENTO_DUPLICATO" ||
+    errorOrUndefined === "PPT_PAGAMENTO_DUPLICATO" ||
     !Object.keys(Detail_v2Enum).includes(errorOrUndefined)
   ) {
     return null;

--- a/ts/utils/payment.ts
+++ b/ts/utils/payment.ts
@@ -38,6 +38,12 @@ import {
   DetailEnum
 } from "../../definitions/backend/PaymentProblemJson";
 import { PspData } from "../../definitions/pagopa/PspData";
+import { PayloadForAction } from "../types/utils";
+import {
+  paymentAttiva,
+  paymentIdPolling,
+  paymentVerifica
+} from "../store/actions/wallet/payment";
 import { getTranslatedShortNumericMonthYear } from "./dates";
 import { getFullLocale, getLocalePrimaryWithFallback } from "./locale";
 import { maybeInnerProperty } from "./options";
@@ -440,3 +446,20 @@ export const getPickPaymentMethodDescription = (
       })
     : fromNullable(paymentMethod.info.holder).getOrElse(defaultHolder);
 };
+
+export const isDuplicatedPayment = (
+  error: Option<
+    PayloadForAction<
+      | typeof paymentVerifica["failure"]
+      | typeof paymentAttiva["failure"]
+      | typeof paymentIdPolling["failure"]
+    >
+  >
+) =>
+  error
+    .map(
+      detail =>
+        detail === "PAA_PAGAMENTO_DUPLICATO" ||
+        detail === "PPT_PAGAMENTO_DUPLICATO"
+    )
+    .getOrElse(false);

--- a/ts/utils/payment.ts
+++ b/ts/utils/payment.ts
@@ -456,10 +456,8 @@ export const isDuplicatedPayment = (
     >
   >
 ) =>
-  error
-    .map(
-      detail =>
-        detail === "PAA_PAGAMENTO_DUPLICATO" ||
-        detail === "PPT_PAGAMENTO_DUPLICATO"
-    )
-    .getOrElse(false);
+  error.exists(
+    detail =>
+      detail === "PAA_PAGAMENTO_DUPLICATO" ||
+      detail === "PPT_PAGAMENTO_DUPLICATO"
+  );


### PR DESCRIPTION
## Short description
This PR fixes a bug for which payments with the `PPT_PAGAMENTO_DUPLICATO` status are not correctly reported as paid.

| Bug | Fix |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-08-03 at 17 46 15](https://user-images.githubusercontent.com/467098/182652220-5583374c-6b9c-4e1e-8dfb-30e248e4457f.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-03 at 17 46 30](https://user-images.githubusercontent.com/467098/182652264-92472f05-b749-41c5-ac2d-a72334d5ac32.png) |
| ![Simulator Screen Shot - iPhone 13 - 2022-08-03 at 16 31 28](https://user-images.githubusercontent.com/467098/182652305-7ee3c63e-1c12-45be-b7a3-4b9786069e67.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-03 at 16 45 38](https://user-images.githubusercontent.com/467098/182652395-282230c3-6b45-45e8-a205-7ae45eb91ae8.png) |

