### PR TITLE
fix: [IABT-1381] Copy payment notice number to the clipboard without spaces

### DIFF
--- a/ts/screens/wallet/payment/components/TransactionSummary.tsx
+++ b/ts/screens/wallet/payment/components/TransactionSummary.tsx
@@ -269,7 +269,7 @@ export const TransactionSummary = (props: Props): React.ReactElement => {
         title={I18n.t("payment.noticeCode")}
         subtitle={formattedPaymentNoticeNumber}
         onPress={() =>
-          clipboardSetStringWithFeedback(formattedPaymentNoticeNumber)
+          clipboardSetStringWithFeedback(props.paymentNoticeNumber)
         }
       />
       <TransactionSummaryRow


### PR DESCRIPTION
## Short description

This small PR modifies the payment notice number clipboard copy to prevent spaces.