### PR TITLE
feat: [IIP-63] Change PDF preview error copy

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3007,7 +3007,9 @@ features:
           save: "Save"
           savedAtLocation: "Document {{name}} was successfully saved in your Download folder."
           errors:
-            previewing: "Non è possibile mostrare l'anteprima del documento. E' comunque possibile salvarlo e aprirlo con un'applicazione per i PDF"
+            previewing:
+              title: "Preview is not available"
+              body: "To view the document, download and open it with a PDF reader app."
             sharing: "An error occurred while sharing the document"
             opening: "An error occurred while opening the document. You may not have a PDF reader installed."
             saving: "An error occurred while saving the document"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3032,7 +3032,9 @@ features:
           save: "Salva"
           savedAtLocation: "Il documento {{name}} è stato salvato nella cartella Download."
           errors:
-            previewing: "Non è possibile mostrare l'anteprima del documento. E' comunque possibile salvarlo e aprirlo con un'applicazione per i PDF"
+            previewing:
+              title: "L’anteprima non è disponibile"
+              body: "Per visualizzare il documento, scaricalo e aprilo con un’app di lettura PDF."
             sharing: "Si è verificato un errore condividendo il documento."
             opening: "Si è verificato un errore aprendo il documento. Potresti non avere installata l'applicazione per i PDF."
             saving: "Si è verificato un errore salvando il documento."

--- a/ts/features/messages/components/MessageAttachmentPreview.tsx
+++ b/ts/features/messages/components/MessageAttachmentPreview.tsx
@@ -140,7 +140,10 @@ export const MessageAttachmentPreview = (props: Props): React.ReactElement => {
           <InfoScreenComponent
             image={renderInfoRasterImage(image)}
             title={I18n.t(
-              "features.mvl.details.attachments.pdfPreview.errors.previewing"
+              "features.mvl.details.attachments.pdfPreview.errors.previewing.title"
+            )}
+            body={I18n.t(
+              "features.mvl.details.attachments.pdfPreview.errors.previewing.body"
             )}
           />
         )}


### PR DESCRIPTION
## Short description
This PR updates the copy of the error message when attachment preview fails.

## List of changes proposed in this pull request
| Old | New |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-08-22 at 17 08 23](https://user-images.githubusercontent.com/467098/185955439-a235dd73-f7c5-4683-a2ca-9bc00295f442.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-22 at 17 07 10](https://user-images.githubusercontent.com/467098/185955477-8a69af78-efab-4845-bf43-9eb443cf33c4.png) |
 