### PR TITLE
[IA-928] Fix tab bar safe area handling in iPhone 14 Pro

### DIFF
--- a/ts/navigation/TabNavigator.tsx
+++ b/ts/navigation/TabNavigator.tsx
@@ -1,7 +1,7 @@
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import * as React from "react";
 import { StyleSheet } from "react-native";
-import deviceInfoModule from "react-native-device-info";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { makeFontStyleObject } from "../components/core/fonts";
 import { IOColors } from "../components/core/variables/IOColors";
 import MessagesTabIcon from "../components/MessagesTabIcon";
@@ -16,13 +16,11 @@ import ProfileMainScreen from "../screens/profile/ProfileMainScreen";
 import ServicesHomeScreen from "../screens/services/ServicesHomeScreen";
 import WalletHomeScreen from "../screens/wallet/WalletHomeScreen";
 import variables from "../theme/variables";
-import { isIos } from "../utils/platform";
 import { MainTabParamsList } from "./params/MainTabParamsList";
 import ROUTES from "./routes";
 
 const Tab = createBottomTabNavigator<MainTabParamsList>();
 
-const hasiOSNotch = deviceInfoModule.hasNotch() && isIos;
 const styles = StyleSheet.create({
   tabBarStyle: {
     backgroundColor: IOColors.white,
@@ -30,7 +28,6 @@ const styles = StyleSheet.create({
     paddingRight: 3,
     borderTopWidth: 0,
     paddingTop: 8,
-    height: 64 + (hasiOSNotch ? 24 : 0),
     // iOS shadow
     shadowColor: variables.footerShadowColor,
     shadowOffset: {
@@ -42,57 +39,69 @@ const styles = StyleSheet.create({
     shadowRadius: variables.footerShadowRadius,
     // Android shadow
     elevation: variables.footerElevation
-  },
-  notchPadding: hasiOSNotch ? {} : { paddingBottom: 10 }
+  }
 });
 
-export const MainTabNavigator = () => (
-  <Tab.Navigator
-    tabBarOptions={{
-      labelStyle: {
-        fontSize: 14,
-        ...makeFontStyleObject("Regular")
-      },
-      keyboardHidesTabBar: true,
-      allowFontScaling: false,
-      activeTintColor: IOColors.blue,
-      inactiveTintColor: IOColors.bluegrey,
-      style: [styles.tabBarStyle, styles.notchPadding]
-    }}
-  >
-    <Tab.Screen
-      name={ROUTES.MESSAGES_HOME}
-      component={
-        usePaginatedMessages ? PaginatedMessagesHomeScreen : MessagesHomeScreen
-      }
-      options={{
-        title: I18n.t("global.navigator.messages"),
-        tabBarIcon: ({ color }) => <MessagesTabIcon color={color} />
+export const MainTabNavigator = () => {
+  const insets = useSafeAreaInsets();
+  const tabBarHeight = 54;
+  const additionalPadding = 10;
+  const bottomInset = insets.bottom === 0 ? additionalPadding : insets.bottom;
+
+  return (
+    <Tab.Navigator
+      tabBarOptions={{
+        labelStyle: {
+          fontSize: 14,
+          ...makeFontStyleObject("Regular")
+        },
+        keyboardHidesTabBar: true,
+        allowFontScaling: false,
+        activeTintColor: IOColors.blue,
+        inactiveTintColor: IOColors.bluegrey,
+        style: [
+          styles.tabBarStyle,
+          { height: tabBarHeight + bottomInset },
+          insets.bottom === 0 ? { paddingBottom: additionalPadding } : {}
+        ]
       }}
-    />
-    <Tab.Screen
-      name={ROUTES.WALLET_HOME}
-      component={WalletHomeScreen}
-      options={{
-        title: I18n.t("global.navigator.wallet"),
-        tabBarIcon: ({ color }) => <WalletTabIcon color={color} />
-      }}
-    />
-    <Tab.Screen
-      name={ROUTES.SERVICES_HOME}
-      component={ServicesHomeScreen}
-      options={{
-        title: I18n.t("global.navigator.services"),
-        tabBarIcon: ({ color }) => <ServiceTabIcon color={color} />
-      }}
-    />
-    <Tab.Screen
-      name={ROUTES.PROFILE_MAIN}
-      component={ProfileMainScreen}
-      options={{
-        title: I18n.t("global.navigator.profile"),
-        tabBarIcon: ({ color }) => <ProfileTabIcon color={color} />
-      }}
-    />
-  </Tab.Navigator>
-);
+    >
+      <Tab.Screen
+        name={ROUTES.MESSAGES_HOME}
+        component={
+          usePaginatedMessages
+            ? PaginatedMessagesHomeScreen
+            : MessagesHomeScreen
+        }
+        options={{
+          title: I18n.t("global.navigator.messages"),
+          tabBarIcon: ({ color }) => <MessagesTabIcon color={color} />
+        }}
+      />
+      <Tab.Screen
+        name={ROUTES.WALLET_HOME}
+        component={WalletHomeScreen}
+        options={{
+          title: I18n.t("global.navigator.wallet"),
+          tabBarIcon: ({ color }) => <WalletTabIcon color={color} />
+        }}
+      />
+      <Tab.Screen
+        name={ROUTES.SERVICES_HOME}
+        component={ServicesHomeScreen}
+        options={{
+          title: I18n.t("global.navigator.services"),
+          tabBarIcon: ({ color }) => <ServiceTabIcon color={color} />
+        }}
+      />
+      <Tab.Screen
+        name={ROUTES.PROFILE_MAIN}
+        component={ProfileMainScreen}
+        options={{
+          title: I18n.t("global.navigator.profile"),
+          tabBarIcon: ({ color }) => <ProfileTabIcon color={color} />
+        }}
+      />
+    </Tab.Navigator>
+  );
+};


### PR DESCRIPTION
## Short description
In the app we use a custom tab bar height. In order to handle different phones (i.e. home button vs. indicator) we used an utility function to know whether or not the phone has a "notch". This function is broken with the new "dynamic island" of iPhone 14 Pros. As we shouldn't make assumptions about physical properties of the device, I propose this fix in order to calculate height based on metrics (bottom inset) rather than assumptions (has notch).

This PR has been tested also with iPhone 8, iPhone 13 and Android (with both navigation buttons and home indicator) to verify that there are no regressions.

## List of changes proposed in this pull request
| Bug | Fix |
| - | - |
| ![image](https://user-images.githubusercontent.com/467098/189322839-d836409c-c6cd-44c9-8ee1-a2ac6f733c89.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-09-09 at 11 49 38](https://user-images.githubusercontent.com/467098/189322972-1f73100c-e51b-4a0e-8a99-1c047fe5f398.png) |