### PR TITLE
feat: [IIP-103] Fix error message when attachment download fails

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2996,8 +2996,7 @@ features:
             body: "Downloading the attachment"
           failing:
             title: "Attachment"
-            body: "An error occurred while downloading the attachment"
-            details: "Check your connection please and try again"
+            details: "An error occurred while downloading the attachment. Retry or create a ticket"
           checkBox: "OK, don't show me again"
         pdfPreview:
           title: "PDF Preview"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3020,8 +3020,7 @@ features:
             body: "Sto scaricando l'allegato"
           failing:
             title: "Allegato"
-            body: "Non sono riuscito a scaricare l'allegato"
-            details: "Per favore, controlla la tua connessione e riprova"
+            details: "Non sono riuscito a scaricare l’allegato. Riprova o apri una segnalazione"
           checkBox: "OK, non mostrarmelo più"
         pdfPreview:
           title: "Anteprima PDF"


### PR DESCRIPTION
## Short description
This PR updates the error message when an attachment download fails.

| Old | New |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-09-12 at 15 03 19](https://user-images.githubusercontent.com/467098/189661175-900fadc4-0944-4aa6-9d89-2c7181699797.png) | ![Simulator Screen Shot - iPhone 13 - 2022-09-12 at 15 01 02](https://user-images.githubusercontent.com/467098/189661217-23c5daee-a9a6-453f-9cc1-760852fc29fb.png) |
