### PR TITLE
fix(Piattaforma Notifiche): [IAMVL-99] Attachment ID might not be unique per user

### DIFF
--- a/ts/features/messages/components/MessageAttachmentPreview.tsx
+++ b/ts/features/messages/components/MessageAttachmentPreview.tsx
@@ -132,9 +132,9 @@ export const MessageAttachmentPreview = (props: Props): React.ReactElement => {
   const [isError, setIsError] = useState(false);
 
   const messageId = props.messageId;
-  const id = props.attachmentId;
+  const attachmentId = props.attachmentId;
   const downloadPot = useIOSelector(state =>
-    mvlDownloadFromAttachmentSelector(state, { messageId, id })
+    mvlDownloadFromAttachmentSelector(state, { messageId, id: attachmentId })
   );
   const download = pot.toUndefined(downloadPot);
   return download ? (

--- a/ts/features/messages/components/MessageAttachmentPreview.tsx
+++ b/ts/features/messages/components/MessageAttachmentPreview.tsx
@@ -4,8 +4,8 @@ import Pdf from "react-native-pdf";
 import ReactNativeBlobUtil from "react-native-blob-util";
 import * as pot from "italia-ts-commons/lib/pot";
 import {
-  mvlAttachmentDownloadFromIdSelector,
-  MvlDownload
+  MvlDownload,
+  mvlDownloadFromAttachmentSelector
 } from "../../mvl/store/reducers/downloads";
 import { isIos } from "../../../utils/platform";
 import FooterWithButtons from "../../../components/ui/FooterWithButtons";
@@ -22,6 +22,7 @@ import image from "../../../../img/servicesStatus/error-detail-icon.png";
 import { InfoScreenComponent } from "../../../components/infoScreen/InfoScreenComponent";
 import { renderInfoRasterImage } from "../../../components/infoScreen/imageRendering";
 import { IOColors } from "../../../components/core/variables/IOColors";
+import { UIMessageId } from "../../../store/reducers/entities/messages/types";
 
 const styles = StyleSheet.create({
   container: {
@@ -118,6 +119,7 @@ const renderFooter = (
   );
 
 type Props = {
+  messageId: UIMessageId;
   attachmentId: MvlAttachmentId;
   onLoadComplete?: () => void;
   onError?: () => void;
@@ -129,9 +131,10 @@ type Props = {
 export const MessageAttachmentPreview = (props: Props): React.ReactElement => {
   const [isError, setIsError] = useState(false);
 
-  const attachmentId = props.attachmentId;
+  const messageId = props.messageId;
+  const id = props.attachmentId;
   const downloadPot = useIOSelector(state =>
-    mvlAttachmentDownloadFromIdSelector(state, attachmentId)
+    mvlDownloadFromAttachmentSelector(state, { messageId, id })
   );
   const download = pot.toUndefined(downloadPot);
   return download ? (

--- a/ts/features/mvl/index.ts
+++ b/ts/features/mvl/index.ts
@@ -1,5 +1,4 @@
 import AsyncStorage from "@react-native-community/async-storage";
-import _ from "lodash";
 import {
   createMigrate,
   MigrationManifest,

--- a/ts/features/mvl/index.ts
+++ b/ts/features/mvl/index.ts
@@ -1,11 +1,30 @@
 import AsyncStorage from "@react-native-community/async-storage";
-import { PersistConfig, PersistPartial, persistReducer } from "redux-persist";
+import _ from "lodash";
+import {
+  createMigrate,
+  MigrationManifest,
+  PersistConfig,
+  PersistedState,
+  PersistPartial,
+  persistReducer
+} from "redux-persist";
 import { Action } from "../../store/actions/types";
 import { PotTransform } from "../../store/transforms/potTransform";
+import { isDevEnv } from "../../utils/environment";
 import { MvlState, mvlReducer as rootReducer } from "./store/reducers";
 
-const CURRENT_REDUX_MVL_STORE_VERSION = 1;
-
+const CURRENT_REDUX_MVL_STORE_VERSION = 2;
+const migrations: MigrationManifest = {
+  // version 2
+  // reset "downloads" section because of changing how they are stored
+  "2": (state: PersistedState): PersistedMvlState => {
+    const entities = state as PersistedMvlState;
+    return {
+      ...entities,
+      downloads: {}
+    };
+  }
+};
 export type PersistedMvlState = MvlState & PersistPartial;
 
 export const mvlPersistConfig: PersistConfig = {
@@ -13,6 +32,7 @@ export const mvlPersistConfig: PersistConfig = {
   storage: AsyncStorage,
   version: CURRENT_REDUX_MVL_STORE_VERSION,
   whitelist: ["preferences", "downloads"],
+  migrate: createMigrate(migrations, { debug: isDevEnv }),
   transforms: [PotTransform]
 };
 

--- a/ts/features/mvl/index.ts
+++ b/ts/features/mvl/index.ts
@@ -18,9 +18,9 @@ const migrations: MigrationManifest = {
   // version 2
   // reset "downloads" section because of changing how they are stored
   "2": (state: PersistedState): PersistedMvlState => {
-    const entities = state as PersistedMvlState;
+    const mvl = state as PersistedMvlState;
     return {
-      ...entities,
+      ...mvl,
       downloads: {}
     };
   }

--- a/ts/features/mvl/saga/networking/downloadMvlAttachment.ts
+++ b/ts/features/mvl/saga/networking/downloadMvlAttachment.ts
@@ -9,7 +9,7 @@ import { MvlAttachment } from "../../types/mvlData";
 import { getError } from "../../../../utils/errors";
 
 export const MvlAttachmentsDirectoryPath =
-  RNFS.CachesDirectoryPath + "/mvl/attachments";
+  RNFS.CachesDirectoryPath + "/attachments";
 
 /**
  * Builds the save path for the given attachment
@@ -17,6 +17,8 @@ export const MvlAttachmentsDirectoryPath =
  */
 const savePath = (attachment: MvlAttachment) =>
   MvlAttachmentsDirectoryPath +
+  "/" +
+  attachment.messageId +
   "/" +
   attachment.id +
   "/" +

--- a/ts/features/mvl/saga/networking/handleGetMvlDetails.ts
+++ b/ts/features/mvl/saga/networking/handleGetMvlDetails.ts
@@ -36,6 +36,7 @@ const convertMvlAttachment = (
 ): MvlAttachment =>
   // TODO some values are forced or mocked, specs should be improved https://pagopa.atlassian.net/browse/IAMVL-31
   ({
+    messageId,
     id: attachment.id as MvlAttachmentId,
     displayName: attachment.name,
     contentType: attachment.content_type.toLowerCase(),

--- a/ts/features/mvl/screens/details/MvlDetailsScreen.tsx
+++ b/ts/features/mvl/screens/details/MvlDetailsScreen.tsx
@@ -52,11 +52,12 @@ export const MvlDetailsScreen = (props: Props): React.ReactElement => {
     }
   }, [dispatch, props.mvl.message.serviceId, service]);
 
+  const messageId = props.mvl.message.id;
   const openAttachment = useCallback(
     (attachmentId: MvlAttachmentId) => {
-      navigation.navigate(MVL_ROUTES.ATTACHMENT, { attachmentId });
+      navigation.navigate(MVL_ROUTES.ATTACHMENT, { messageId, attachmentId });
     },
-    [navigation]
+    [messageId, navigation]
   );
 
   return (

--- a/ts/features/mvl/screens/details/components/attachment/MvlAttachmentDownload.tsx
+++ b/ts/features/mvl/screens/details/components/attachment/MvlAttachmentDownload.tsx
@@ -18,12 +18,12 @@ import { MvlAttachment, MvlAttachmentId } from "../../../../types/mvlData";
 import { mvlPreferencesSetWarningForAttachments } from "../../../../store/actions";
 import { showToast } from "../../../../../../utils/showToast";
 import { mvlAttachmentDownload } from "../../../../store/actions/downloads";
-import { mvlAttachmentDownloadFromIdSelector } from "../../../../store/reducers/downloads";
 import { isIos } from "../../../../../../utils/platform";
 import { ContentTypeValues } from "../../../../../../types/contentType";
 import { useIOBottomSheetModal } from "../../../../../../utils/hooks/bottomSheet";
 import { mvlPreferencesSelector } from "../../../../store/reducers/preferences";
 import { mixpanelTrack } from "../../../../../../mixpanel";
+import { mvlDownloadFromAttachmentSelector } from "../../../../store/reducers/downloads";
 
 const BOTTOM_SHEET_HEIGHT = 375;
 
@@ -94,7 +94,7 @@ export const useMvlAttachmentDownload = (
   const { showAlertForAttachments } = useIOSelector(mvlPreferencesSelector);
 
   const downloadPot = useIOSelector(state =>
-    mvlAttachmentDownloadFromIdSelector(state, attachment.id)
+    mvlDownloadFromAttachmentSelector(state, attachment)
   );
 
   const openAttachment = useCallback(async () => {

--- a/ts/features/mvl/screens/details/components/attachment/MvlAttachmentPreview.tsx
+++ b/ts/features/mvl/screens/details/components/attachment/MvlAttachmentPreview.tsx
@@ -3,14 +3,22 @@ import { MvlAttachmentId } from "../../../../types/mvlData";
 import { IOStackNavigationRouteProps } from "../../../../../../navigation/params/AppParamsList";
 import { MvlParamsList } from "../../../../navigation/params";
 import { MessageAttachmentPreview } from "../../../../../messages/components/MessageAttachmentPreview";
+import { UIMessageId } from "../../../../../../store/reducers/entities/messages/types";
 
 export type MvlAttachmentPreviewNavigationParams = Readonly<{
+  messageId: UIMessageId;
   attachmentId: MvlAttachmentId;
 }>;
 
 export const MvlAttachmentPreview = (
   props: IOStackNavigationRouteProps<MvlParamsList, "MVL_ATTACHMENT">
 ): React.ReactElement => {
+  const messageId = props.route.params.messageId;
   const attachmentId = props.route.params.attachmentId;
-  return <MessageAttachmentPreview attachmentId={attachmentId} />;
+  return (
+    <MessageAttachmentPreview
+      messageId={messageId}
+      attachmentId={attachmentId}
+    />
+  );
 };

--- a/ts/features/mvl/screens/details/components/attachment/__test__/MvlAttachments.test.tsx
+++ b/ts/features/mvl/screens/details/components/attachment/__test__/MvlAttachments.test.tsx
@@ -71,7 +71,11 @@ describe("MvlAttachments", () => {
               openPreview: jest.fn()
             },
             { showAlertForAttachments: false },
-            { [mvlMockPdfAttachment.id]: loadingPot }
+            {
+              [mvlMockPdfAttachment.messageId]: {
+                [mvlMockPdfAttachment.id]: loadingPot
+              }
+            }
           );
           expect(
             res.queryByTestId("attachmentActivityIndicator")
@@ -97,7 +101,11 @@ describe("MvlAttachments", () => {
               openPreview: jest.fn()
             },
             { showAlertForAttachments: false },
-            { [mvlMockPdfAttachment.id]: notLoadingPot }
+            {
+              [mvlMockPdfAttachment.messageId]: {
+                [mvlMockPdfAttachment.id]: notLoadingPot
+              }
+            }
           );
           expect(res.queryByTestId("attachmentActivityIndicator")).toBeNull();
         });

--- a/ts/features/mvl/store/actions/downloads.ts
+++ b/ts/features/mvl/store/actions/downloads.ts
@@ -21,4 +21,4 @@ export const mvlAttachmentDownload = createAsyncAction(
  */
 export const mvlRemoveCachedAttachment = createStandardAction(
   "MVL_ATTACHMENT_REMOVE_CACHED"
-)<{ id: string; path: string | undefined }>();
+)<{ attachment: MvlAttachment; path: string | undefined }>();

--- a/ts/features/mvl/store/reducers/__test__/downloads.test.ts
+++ b/ts/features/mvl/store/reducers/__test__/downloads.test.ts
@@ -22,7 +22,9 @@ describe("mvlDownloadsReducer", () => {
 
       it("then it returns pot.loading", () => {
         expect(
-          pot.isLoading(afterRequestState[attachment.id] ?? pot.none)
+          pot.isLoading(
+            afterRequestState[attachment.messageId][attachment.id] ?? pot.none
+          )
         ).toBeTruthy();
       });
 
@@ -36,7 +38,7 @@ describe("mvlDownloadsReducer", () => {
                   attachment,
                   path
                 })
-              )[attachment.id] ?? pot.none
+              )[attachment.messageId][attachment.id] ?? pot.none
             )
           ).toBeTruthy();
         });
@@ -52,7 +54,7 @@ describe("mvlDownloadsReducer", () => {
                   attachment,
                   error: new Error()
                 })
-              )[attachment.id] ?? pot.none
+              )[attachment.messageId][attachment.id] ?? pot.none
             )
           ).toBeTruthy();
         });
@@ -65,7 +67,7 @@ describe("mvlDownloadsReducer", () => {
               mvlDownloadsReducer(
                 afterRequestState,
                 mvlAttachmentDownload.cancel(attachment)
-              )[attachment.id] ?? pot.none
+              )[attachment.messageId][attachment.id] ?? pot.none
             )
           ).toBeTruthy();
         });
@@ -76,7 +78,9 @@ describe("mvlDownloadsReducer", () => {
   describe("given a downloaded attachment", () => {
     const attachment = mvlMockPdfAttachment;
     const initialState: MvlDownloads = {
-      [attachment.id]: pot.some({ attachment, path })
+      [attachment.messageId]: {
+        [attachment.id]: pot.some({ attachment, path })
+      }
     };
 
     describe("when clearing the attachment", () => {
@@ -85,8 +89,8 @@ describe("mvlDownloadsReducer", () => {
           pot.isNone(
             mvlDownloadsReducer(
               initialState,
-              mvlRemoveCachedAttachment({ id: attachment.id, path })
-            )[attachment.id] ?? pot.none
+              mvlRemoveCachedAttachment({ attachment, path })
+            )[attachment.messageId][attachment.id] ?? pot.none
           )
         ).toBeTruthy();
       });

--- a/ts/features/mvl/types/__mock__/mvlMock.ts
+++ b/ts/features/mvl/types/__mock__/mvlMock.ts
@@ -35,6 +35,7 @@ export const mvlMockBody: MvlBody = {
 };
 
 export const mvlMockPdfAttachment: MvlAttachment = {
+  messageId: message_1.id as UIMessageId,
   id: "1" as MvlAttachmentId,
   displayName: "invoice.pdf",
   contentType: "application/pdf",
@@ -43,6 +44,7 @@ export const mvlMockPdfAttachment: MvlAttachment = {
 };
 
 export const mvlMockOtherAttachment: MvlAttachment = {
+  messageId: message_1.id as UIMessageId,
   id: "2" as MvlAttachmentId,
   displayName: "image.png",
   contentType: "other",

--- a/ts/features/mvl/types/mvlData.ts
+++ b/ts/features/mvl/types/mvlData.ts
@@ -3,6 +3,7 @@ import { ValidUrl } from "@pagopa/ts-commons/lib/url";
 import { EmailAddress } from "../../../../definitions/backend/EmailAddress";
 import {
   UIMessageDetails,
+  UIMessageId,
   WithUIMessageId
 } from "../../../store/reducers/entities/messages/types";
 import { Byte } from "../../../types/digitalInformationUnit";
@@ -23,6 +24,9 @@ export type MvlId = string & IUnitTag<"MvlId">;
  * Represent an attachment with the metadata and resourceUrl to retrieve the attachment
  */
 export type MvlAttachment = {
+  // the message ID that contains the attachment
+  messageId: UIMessageId;
+  // the ID of the attachment (only guaranteed to be unique per message)
   id: MvlAttachmentId;
   // a display name for the file
   displayName: string;

--- a/ts/features/pn/components/PnMessageDetails.tsx
+++ b/ts/features/pn/components/PnMessageDetails.tsx
@@ -111,11 +111,15 @@ export const PnMessageDetails = (props: Props) => {
     }
   }, [rptId, navigation]);
 
+  const messageId = props.messageId;
   const openAttachment = useCallback(
     (attachmentId: MvlAttachmentId) => {
-      navigation.navigate(PN_ROUTES.MESSAGE_ATTACHMENT, { attachmentId });
+      navigation.navigate(PN_ROUTES.MESSAGE_ATTACHMENT, {
+        messageId,
+        attachmentId
+      });
     },
-    [navigation]
+    [messageId, navigation]
   );
 
   useOnFirstRender(verifyPaymentIfNeeded);

--- a/ts/features/pn/screens/PnAttachmentPreview.tsx
+++ b/ts/features/pn/screens/PnAttachmentPreview.tsx
@@ -4,8 +4,10 @@ import { MvlAttachmentId } from "../../mvl/types/mvlData";
 import { IOStackNavigationRouteProps } from "../../../navigation/params/AppParamsList";
 import { MessageAttachmentPreview } from "../../messages/components/MessageAttachmentPreview";
 import { mixpanelTrack } from "../../../mixpanel";
+import { UIMessageId } from "../../../store/reducers/entities/messages/types";
 
 export type PnAttachmentPreviewNavigationParams = Readonly<{
+  messageId: UIMessageId;
   attachmentId: MvlAttachmentId;
 }>;
 
@@ -15,9 +17,12 @@ export const PnAttachmentPreview = (
     "PN_ROUTES_MESSAGE_ATTACHMENT"
   >
 ): React.ReactElement => {
+  const messageId = props.route.params.messageId;
   const attachmentId = props.route.params.attachmentId;
+
   return (
     <MessageAttachmentPreview
+      messageId={messageId}
       attachmentId={attachmentId}
       onError={() => {
         void mixpanelTrack("PN_ATTACHMENT_PREVIEW_STATUS", {

--- a/ts/features/pn/store/types/transformers.ts
+++ b/ts/features/pn/store/types/transformers.ts
@@ -22,7 +22,7 @@ export const toPNMessage = (
       ...maybeNotification.value,
       serviceId: messageFromApi.sender_service_id,
       attachments: messageFromApi.third_party_message.attachments?.map(_ => ({
-        id: _.id as string as MvlAttachmentId,
+        id: (messageFromApi.id + "/" + _.id) as MvlAttachmentId,
         displayName: _.name ?? _.id,
         contentType: _.content_type ?? ContentTypeValues.applicationOctetStream,
         resourceUrl: { href: generateAttachmentUrl(messageFromApi.id, _.url) }

--- a/ts/features/pn/store/types/transformers.ts
+++ b/ts/features/pn/store/types/transformers.ts
@@ -1,5 +1,6 @@
 import { ThirdPartyMessageWithContent } from "../../../../../definitions/backend/ThirdPartyMessageWithContent";
 import { apiUrlPrefix } from "../../../../config";
+import { UIMessageId } from "../../../../store/reducers/entities/messages/types";
 import { ContentTypeValues } from "../../../../types/contentType";
 import { MvlAttachmentId } from "../../../mvl/types/mvlData";
 import { PNMessage, FullReceivedNotification } from "./types";
@@ -22,7 +23,8 @@ export const toPNMessage = (
       ...maybeNotification.value,
       serviceId: messageFromApi.sender_service_id,
       attachments: messageFromApi.third_party_message.attachments?.map(_ => ({
-        id: (messageFromApi.id + "/" + _.id) as MvlAttachmentId,
+        messageId: messageFromApi.id as UIMessageId,
+        id: _.id as string as MvlAttachmentId,
         displayName: _.name ?? _.id,
         contentType: _.content_type ?? ContentTypeValues.applicationOctetStream,
         resourceUrl: { href: generateAttachmentUrl(messageFromApi.id, _.url) }


### PR DESCRIPTION
## Short description
Attachment IDs are not guaranteed to be unique per user. Instead they are unique per message. Until now attachments were cached in the app using their ID. This could cause a collision if two attachments use the same ID, even if they are contained in different messages.

With this PR we're changing how an attachment is indexed in app (using the both the message and the attachment ID).

## List of changes proposed in this pull request
- Added `messageId` property to the `MvlAttachment` type
- Changed the `MvlDownloads` type in order to use `messageId` as a key to group attachments
- Updated the `mvlDownloadsReducer` and the selector
- Added a migration to clear old stored downloads (if any)
- Updated screens in order to use the new selector
- Updated tests

## How to test
Use the [IIP-18-add-pn-endpoints](https://github.com/pagopa/io-dev-api-server/tree/IIP-18-add-pn-endpoints) branch of the dev server and add this to your `config.json`:
```
{
  "messages": {
    "pnCount": 2
  },
  "services": {
    "includePn": true
  }
}
```
Then open both the PN messages and download all the attachments. Verify with Flipper how the store behaves.
| Old | New |
| - | - |
| <img width="350" alt="Schermata 2022-09-22 alle 17 16 38" src="https://user-images.githubusercontent.com/467098/191794972-765f2819-b0c0-4f71-9f23-8cd882af2f43.png"> | <img width="350" alt="Schermata 2022-09-22 alle 17 14 25" src="https://user-images.githubusercontent.com/467098/191795031-a5bab9cd-1d7c-4a8b-8530-fdcc48c069b3.png"> |
