### PR TITLE
fix: [IA-947] Manual configuration not selectable during first onboarding

### DIFF
--- a/ts/screens/onboarding/OnboardingServicesPreferenceScreen.tsx
+++ b/ts/screens/onboarding/OnboardingServicesPreferenceScreen.tsx
@@ -88,9 +88,10 @@ const OnboardingServicesPreferenceScreen = (
       props.onServicePreferenceSelected(modeSelected);
     }
   };
-  const { present: confirmManualConfig } = useManualConfigBottomSheet(() =>
-    props.onServicePreferenceSelected(ServicesPreferencesModeEnum.MANUAL)
-  );
+  const { present: confirmManualConfig, manualConfigBottomSheet } =
+    useManualConfigBottomSheet(() =>
+      props.onServicePreferenceSelected(ServicesPreferencesModeEnum.MANUAL)
+    );
 
   const handleOnSelectMode = (mode: ServicesPreferencesModeEnum) => {
     // if user's choice is 'manual', open bottom sheet to ask confirmation
@@ -126,6 +127,7 @@ const OnboardingServicesPreferenceScreen = (
             disabled: !isServicesPreferenceModeSet(modeSelected)
           }}
         />
+        {manualConfigBottomSheet}
       </SafeAreaView>
     </BaseScreenComponent>
   );


### PR DESCRIPTION
## Short description
#3803 introduced a regression that made the service configuration not working as expected during the first onboarding. In particular tapping on the "manual configuration" has no effect. This PR fixes this behavior.

https://user-images.githubusercontent.com/467098/193542974-1cc3c628-7ad7-4f7b-af32-b17187b8dd13.mov

https://user-images.githubusercontent.com/467098/193543035-ed9dd29f-caca-4234-b6f2-4c82dffdf3d1.mov

## List of changes proposed in this pull request
- Added missing `manualConfigBottomSheet` to the view hierarchy of the screen

## How to test
- Perform a logout
- Set `firstOnboarding` to `true` in the [dev server config](https://github.com/pagopa/io-dev-api-server/blob/02ea784cdf244759c9dd90cac42b60ad03491b58/src/config.ts#L63)
- Perform a login
- You should see the first onboarding flow
- Make sure you can select the manual service configuration
