### PR TITLE
Update Android Manifest with a flag required to save images to Camera Roll

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -55,6 +55,7 @@
     android:usesCleartextTraffic="true"
     android:roundIcon="@mipmap/ic_launcher_round"
     android:allowBackup="false"
+    android:requestLegacyExternalStorage="true"
     android:theme="@style/AppTheme">
 
     <!-- START Required by react-native-push-notification -->


### PR DESCRIPTION
## Short description
This PR adds a missing flag to the `<application>` element in the `AndroidManifest.xml` file. such flag is required by the library [react-native-cameraroll](https://github.com/react-native-cameraroll/react-native-cameraroll) in order to save images to the camera roll, on devices running Android 10 (SDK 29).

## List of changes proposed in this pull request
- AndroidManifest has been edited, adding a single line with `android:requestLegacyExternalStorage="true"` property

## How to test
To reproduce the original bug, you have to use a device (or an Emulator) running Android 10. Your message list has to have a message containing a valid Greenpass. Select it, scroll down to the Save button and follow the procedure to save it to the Camera Roll. Give all the permissions required in this process.
Any previous application version should show an error message, after saving, requiring you to give the appropriate permission (even if you gave the permission). After this update, the error message will disappear.
This PR should also be tested on devices (or emulators) running Android 11/12/13, in order to check for regressions
