### PR TITLE
chore(IDPay): [IODPAY-51] Avoid XState machine recreation on provider rerendering

### DIFF
--- a/ts/features/idpay/onboarding/xstate/provider.tsx
+++ b/ts/features/idpay/onboarding/xstate/provider.tsx
@@ -7,6 +7,7 @@ import {
   IDPAY_API_TEST_TOKEN,
   IDPAY_API_UAT_BASEURL
 } from "../../../../config";
+import { useXStateMachine } from "../../../../hooks/useXStateMachine";
 import {
   AppParamsList,
   IOStackNavigationProp
@@ -32,7 +33,7 @@ type Props = {
 };
 
 const IDPayOnboardingMachineProvider = (props: Props) => {
-  const { children } = props;
+  const [machine] = useXStateMachine(createIDPayOnboardingMachine);
 
   const sessionInfo = useIOSelector(sessionInfoSelector);
 
@@ -49,8 +50,6 @@ const IDPayOnboardingMachineProvider = (props: Props) => {
 
   const onboardingClient = createOnboardingClient(IDPAY_API_UAT_BASEURL, token);
 
-  const machine = createIDPayOnboardingMachine();
-
   const services = createServicesImplementation(onboardingClient);
 
   const actions = createActionsImplementation(navigation);
@@ -62,7 +61,7 @@ const IDPayOnboardingMachineProvider = (props: Props) => {
 
   return (
     <OnboardingMachineContext.Provider value={machineService}>
-      {children}
+      {props.children}
     </OnboardingMachineContext.Provider>
   );
 };

--- a/ts/hooks/useXStateMachine.tsx
+++ b/ts/hooks/useXStateMachine.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+type MachineCreatorFn<T> = () => T;
+
+const useXStateMachine = <T,>(fn: MachineCreatorFn<T>): [T] => {
+  const machine = React.useRef<T | undefined>(undefined);
+
+  if (machine.current === undefined) {
+    // eslint-disable-next-line functional/immutable-data
+    machine.current = fn();
+    // eslint-disable-next-line no-console
+    console.log("Created new xstate machine");
+  }
+
+  return [machine.current];
+};
+
+export { useXStateMachine };

--- a/ts/hooks/useXStateMachine.tsx
+++ b/ts/hooks/useXStateMachine.tsx
@@ -8,8 +8,6 @@ const useXStateMachine = <T,>(fn: MachineCreatorFn<T>): [T] => {
   if (machine.current === undefined) {
     // eslint-disable-next-line functional/immutable-data
     machine.current = fn();
-    // eslint-disable-next-line no-console
-    console.log("Created new xstate machine");
   }
 
   return [machine.current];


### PR DESCRIPTION
## Short description
To avoid the recreation os the xstate machine we use a custom hook that maintains the machine as Ref

## List of changes proposed in this pull request
- A generic useXStateMachine hook
- Change the provider to use the new hook

## How to test
The warning message stating that the machine has been changed do not occurs anymore