### PR TITLE
fix: [IABT-1338] Fix missing separator in the `Add Payment Method` screen

### DIFF
--- a/ts/components/wallet/PaymentMethodsList.tsx
+++ b/ts/components/wallet/PaymentMethodsList.tsx
@@ -226,7 +226,7 @@ const PaymentMethodsList: React.FunctionComponent<Props> = (props: Props) => (
         renderListItem(
           i,
           props.paymentMethods.filter(pm => pm.status !== "notImplemented")
-            .length - 1,
+            .length,
           props.sectionStatus
         )
       }


### PR DESCRIPTION
## Short description
This PR fixes the missing separator between the second-last and last element in the list.

### Preview
| Before | After
| - | - |
| <img src="https://user-images.githubusercontent.com/1255491/204485319-656327da-3fa6-4e5d-804a-a2cfbdc10b8e.png" width=350 /> | <img src="https://user-images.githubusercontent.com/1255491/204485372-76806fad-38a5-44ac-9b06-c0343f0656b5.png" width=350 />


## How to test
1. Go to _Wallet_
2. Tap on _**Aggiungi**_ (or **_Add_**) in the top right area of the screen
3. Tap on **_Metodo di pagamento_** (or **_Payment method_**)

### Notes
The bug has been reported by @fabriziofff 