### PR TITLE
fix: [IOAPPPEB-12] Avoid reload loop on Optin failure

### DIFF
--- a/ts/features/bonus/bpd/components/optInPaymentMethods/BpdOptInPaymentMethodsContainer.tsx
+++ b/ts/features/bonus/bpd/components/optInPaymentMethods/BpdOptInPaymentMethodsContainer.tsx
@@ -28,10 +28,9 @@ const BpdOptInPaymentMethodsContainer = () => {
 
   useEffect(() => {
     if (
-      (isOptInPaymentMethodsEnabled &&
-        !showOptInChecked &&
-        !isReady(showOptInChoice)) ||
-      isError(showOptInChoice)
+      isOptInPaymentMethodsEnabled &&
+      !showOptInChecked &&
+      !isReady(showOptInChoice)
     ) {
       setShowOptInChecked(true);
       // Starts the optInShouldShowChoiceHandler saga


### PR DESCRIPTION
## Short description
This PR fixes the logic that caused a retry loop on loading the optin status for BPD
