### PR TITLE
[IOAPPCOM-13] On iPhone 14 the CTA inside the message detail screen does not respect the Safe Area

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -484,7 +484,7 @@ PODS:
     - React-Core
   - RNDateTimePicker (3.5.2):
     - React-Core
-  - RNDeviceInfo (8.3.3):
+  - RNDeviceInfo (10.3.0):
     - React-Core
   - RNFS (2.18.0):
     - React
@@ -884,7 +884,7 @@ SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
+  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 0045cf98ca4a48af3bf7108d85b1c243740fa289
   FBReactNativeSpec: 82e74141263f8c962e288f5cd6b5d149cdc8afe1
   Flipper: 53851f5b89559bb6e251572589dc166d1f8d6e2e
@@ -897,7 +897,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: 51cf8b6f5b0931e251c57d4d60a15a1c2ba546aa
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
+  glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleMLKit: 0d7f5aa2f8a2f2ea9d849a05abdbe80974b0ec83
   GoogleToolboxForMac: 8bef7c7c5cf7291c687cf5354f39f9db6399ad34
@@ -916,7 +916,7 @@ SPEC CHECKSUMS:
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   Protobuf: 3724efa50cb2846d7ccebc8691c574e85fd74471
-  RCT-Folly: 803a9cfd78114b2ec0f140cfa6fa2a6bafb2d685
+  RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a
   RCTRequired: 85c60c4bde8241278be2c93420de4c65475a2151
   RCTTypeSafety: 15990f289215eb0fc65c5eb6e2610faeeda8d5e1
   React: 6cfa9367042a85f6235740420df017d51efc6494
@@ -969,7 +969,7 @@ SPEC CHECKSUMS:
   RNCPicker: abc646b53a3d28ccfa3232c927a0ca52e0cf024d
   RNCPushNotificationIOS: 61a7c72bd1ebad3568025957d001e0f0e7b32191
   RNDateTimePicker: 7658208086d86d09e1627b5c34ba0cf237c60140
-  RNDeviceInfo: cc7de0772378f85d8f36ae439df20f05c590a651
+  RNDeviceInfo: 4701f0bf2a06b34654745053db0ce4cb0c53ada7
   RNFS: 3ab21fa6c56d65566d1fb26c2228e2b6132e5e32
   RNGestureHandler: e1ad51d31a580755079d5124d3ab66f0fcaa8311
   RNI18n: e2f7e76389fcc6e84f2c8733ea89b92502351fd8

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "react-native-blob-util": "0.15.0",
     "react-native-calendar-events": "2.2.0",
     "react-native-config": "^1.4.5",
-    "react-native-device-info": "^8.3.3",
+    "react-native-device-info": "^10.3.0",
     "react-native-exception-handler": "^2.10.8",
     "react-native-fingerprint-scanner": "^6.0.0",
     "react-native-flag-secure-android": "^1.0.3",

--- a/patches/react-native-device-info+10.3.0.patch
+++ b/patches/react-native-device-info+10.3.0.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/react-native-device-info/lib/typescript/internal/privateTypes.d.ts b/node_modules/react-native-device-info/lib/typescript/internal/privateTypes.d.ts
-index 7ca9a81..9c274ab 100644
+index f137e75..0f06706 100644
 --- a/node_modules/react-native-device-info/lib/typescript/internal/privateTypes.d.ts
 +++ b/node_modules/react-native-device-info/lib/typescript/internal/privateTypes.d.ts
-@@ -79,12 +79,8 @@ interface ExposedNativeMethods {
+@@ -78,12 +78,8 @@ interface ExposedNativeMethods {
      getInstallReferrerSync: () => string;
      getInstanceId: () => Promise<string>;
      getInstanceIdSync: () => string;
@@ -16,10 +16,10 @@ index 7ca9a81..9c274ab 100644
      getMaxMemorySync: () => number;
      getPhoneNumber: () => Promise<string>;
 diff --git a/node_modules/react-native-device-info/src/index.ts b/node_modules/react-native-device-info/src/index.ts
-index b298fd9..c611f04 100644
+index 4ec2138..2731038 100644
 --- a/node_modules/react-native-device-info/src/index.ts
 +++ b/node_modules/react-native-device-info/src/index.ts
-@@ -58,13 +58,6 @@ export const [getAndroidId, getAndroidIdSync] = getSupportedPlatformInfoFunction
+@@ -59,13 +59,6 @@ export const [getAndroidId, getAndroidIdSync] = getSupportedPlatformInfoFunction
    defaultValue: 'unknown',
  });
  
@@ -33,7 +33,7 @@ index b298fd9..c611f04 100644
  export const [isCameraPresent, isCameraPresentSync] = getSupportedPlatformInfoFunctions({
    supportedPlatforms: ['android', 'windows', 'web'],
    getter: () => RNDeviceInfo.isCameraPresent(),
-@@ -72,23 +65,6 @@ export const [isCameraPresent, isCameraPresentSync] = getSupportedPlatformInfoFu
+@@ -73,24 +66,6 @@ export const [isCameraPresent, isCameraPresentSync] = getSupportedPlatformInfoFu
    defaultValue: false,
  });
  
@@ -54,10 +54,11 @@ index b298fd9..c611f04 100644
 -  }
 -  return 'unknown';
 -}
- 
+-
  export const getDeviceId = () =>
    getSupportedPlatformInfoSync({
-@@ -823,12 +799,8 @@ const deviceInfoModule: DeviceInfoModule = {
+     defaultValue: 'unknown',
+@@ -895,12 +870,8 @@ const deviceInfoModule: DeviceInfoModule = {
    getInstallReferrerSync,
    getInstanceId,
    getInstanceIdSync,
@@ -71,10 +72,10 @@ index b298fd9..c611f04 100644
    getManufacturerSync,
    getMaxMemory,
 diff --git a/node_modules/react-native-device-info/src/internal/privateTypes.ts b/node_modules/react-native-device-info/src/internal/privateTypes.ts
-index c345201..3032eb8 100644
+index fb71735..0a9bb10 100644
 --- a/node_modules/react-native-device-info/src/internal/privateTypes.ts
 +++ b/node_modules/react-native-device-info/src/internal/privateTypes.ts
-@@ -84,12 +84,8 @@ interface ExposedNativeMethods {
+@@ -83,12 +83,8 @@ interface ExposedNativeMethods {
    getInstallReferrerSync: () => string;
    getInstanceId: () => Promise<string>;
    getInstanceIdSync: () => string;

--- a/ts/components/messages/paginated/MessageDetail/index.tsx
+++ b/ts/components/messages/paginated/MessageDetail/index.tsx
@@ -131,7 +131,6 @@ const MessageDetailsComponent = ({
           messageDetails={messageDetails}
           service={service}
           serviceMetadata={serviceMetadata}
-          legacySafeArea={true}
         />
       </>
     </>

--- a/ts/screens/messages/paginated/MessageDetailScreen.tsx
+++ b/ts/screens/messages/paginated/MessageDetailScreen.tsx
@@ -3,9 +3,10 @@ import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
 import { Text as NBText, View } from "native-base";
 import React from "react";
-import { ActivityIndicator, StyleSheet } from "react-native";
+import { ActivityIndicator, SafeAreaView, StyleSheet } from "react-native";
 import { connect } from "react-redux";
 import { ServiceId } from "../../../../definitions/backend/ServiceId";
+import { IOStyles } from "../../../components/core/variables/IOStyles";
 import WorkunitGenericFailure from "../../../components/error/WorkunitGenericFailure";
 import MessageDetailComponent from "../../../components/messages/paginated/MessageDetail";
 
@@ -133,14 +134,16 @@ const MessageDetailScreen = ({
           contextualHelpMarkdown={contextualHelpMarkdown}
           faqCategories={["messages_detail"]}
         >
-          <MessageDetailComponent
-            hasPaidBadge={hasPaidBadge}
-            message={message}
-            messageDetails={details}
-            service={service}
-            serviceMetadata={maybeServiceMetadata}
-            onServiceLinkPress={onServiceLinkPressHandler}
-          />
+          <SafeAreaView style={IOStyles.flex}>
+            <MessageDetailComponent
+              hasPaidBadge={hasPaidBadge}
+              message={message}
+              messageDetails={details}
+              service={service}
+              serviceMetadata={maybeServiceMetadata}
+              onServiceLinkPress={onServiceLinkPressHandler}
+            />
+          </SafeAreaView>
         </BaseScreenComponent>
       ),
       () => renderLoadingState(),

--- a/ts/utils/device.ts
+++ b/ts/utils/device.ts
@@ -4,7 +4,7 @@
  */
 import DeviceInfo from "react-native-device-info";
 
-export const getDeviceId = (): string => DeviceInfo.getUniqueId();
+export const getDeviceId = (): string => DeviceInfo.getUniqueIdSync();
 
 export const getFontScale = (): Promise<number> => DeviceInfo.getFontScale();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13809,10 +13809,10 @@ react-native-config@^1.4.5:
   resolved "https://registry.yarnpkg.com/react-native-config/-/react-native-config-1.4.5.tgz#6fe5895410b75e44fe4f4bf00caaf894a0981f3a"
   integrity sha512-5oiAsoW88SOYDg/0cleJ2vJDqv98FJUbFQYEnH4sdMtEn3AAT3lb7BkTGW8HO/t3Vk9VOruwxUUnO4tzuxzCsw==
 
-react-native-device-info@^8.3.3:
-  version "8.3.3"
-  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-8.3.3.tgz#05c1900602d174b58c6ac927d748a785d76d0898"
-  integrity sha512-l8/3MHq6O9PRWSrKwy63WvDCnt8IXOce86AEkJFVVtKR9cAGLLaFyXUGyqIc5T/kpCyOqofOattVDjZGUn/zAQ==
+react-native-device-info@^10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-10.3.0.tgz#6bab64d84d3415dd00cc446c73ec5e2e61fddbe7"
+  integrity sha512-/ziZN1sA1REbJTv5mQZ4tXggcTvSbct+u5kCaze8BmN//lbxcTvWsU6NQd4IihLt89VkbX+14IGc9sVApSxd/w==
 
 react-native-drawer@2.5.1:
   version "2.5.1"


### PR DESCRIPTION
## Short description
On iPhone 14, the CTA inside `MessageDetailScreen` component (`MessageDetailScreen.tsx`) does not respect the Safe Area and it's too much near the "Home Indicator".

| iPhone 14 |
| - |
| <img src="https://user-images.githubusercontent.com/16268789/207027955-b9ebeeb9-e442-4955-b695-c5998f76c277.png" width="150" /> |

## List of changes proposed in this pull request
- Bump `react-native-device-info` to `10.3.0` to have the right behavior of `hasNotch()` against iPhone 14.
   This brings along a new patch file `react-native-device-info+8.3.3.patch` for the library. The old `react-native-device-info+8.3.3.patch` file didn't work anymore.
- Wrap `MessageDetailComponent` inside `MessageDetailScreen.tsx` with `SafeAreaView` to handle safe area the right way both for CTA and message content, the latter with or without the CTA.

| &nbsp; | CTA | Message | Message with CTA |
| - | - | - | - | 
| ❌ | <img src="https://user-images.githubusercontent.com/16268789/207031229-6806c148-050c-4d3d-af3c-47570d5e04d5.png" width="150" /> | <img src="https://user-images.githubusercontent.com/16268789/207031965-49600a37-7e90-4092-aaa1-453ec48335cc.png" width="150" /> | <img src="https://user-images.githubusercontent.com/16268789/207033075-25f8d0ee-caaa-4cc8-bc0b-c7e39141f279.png" width="150" /> | 
| ✅ | <img src="https://user-images.githubusercontent.com/16268789/207032190-0ff51c63-946e-4ff9-935f-1e1e59abef8c.png" width="150" /> | <img src="https://user-images.githubusercontent.com/16268789/207031576-ce912da2-fd8c-49b6-afc7-d6e72092ce9a.png" width="150" /> | <img src="https://user-images.githubusercontent.com/16268789/207033107-4d3ae170-8e5b-4e02-a2c4-a2fc76f037fd.png" width="150" /> | 

| Android: Pixel 3a - iOS: iPhone SE, iPhone 13, iPhone 14  |
| - |
| <img src="https://user-images.githubusercontent.com/16268789/207032523-83176747-9951-4b03-a3c3-594711e59731.png" width="600" /> |

## How to test
1. Clone the repo and run the App on different emulators:
    - iPhone with the notch (both iPhone 13 and 14)
    - iPhone without the notch (e.g. iPhone SE) 
    
    And check that on all the devices above the message detail screen is rendered correctly.

2. Check if the new patch file `react-native-device-info+8.3.3.patch` for `react-native-device-info` is applied correctly.
