### PR TITLE
fix: [IOAPPCOM-35] Fix bottom sheets not opening (on a PN message)

### DIFF
--- a/ts/components/messages/paginated/hooks/useMessageOpening.tsx
+++ b/ts/components/messages/paginated/hooks/useMessageOpening.tsx
@@ -1,15 +1,15 @@
 import { useNavigation } from "@react-navigation/native";
 import { useCallback } from "react";
-import { UIMessage } from "../../../../store/reducers/entities/messages/types";
-import ROUTES from "../../../../navigation/routes";
 import { TagEnum } from "../../../../../definitions/backend/MessageCategoryPN";
 import { usePnOpenConfirmationBottomSheet } from "../../../../features/pn/components/PnOpenConfirmationBottomSheet";
 import {
   AppParamsList,
   IOStackNavigationProp
 } from "../../../../navigation/params/AppParamsList";
-import { isPnEnabledSelector } from "../../../../store/reducers/backendStatus";
+import ROUTES from "../../../../navigation/routes";
 import { useIOSelector } from "../../../../store/hooks";
+import { isPnEnabledSelector } from "../../../../store/reducers/backendStatus";
+import { UIMessage } from "../../../../store/reducers/entities/messages/types";
 
 export const useMessageOpening = () => {
   const navigation = useNavigation<IOStackNavigationProp<AppParamsList>>();
@@ -58,6 +58,6 @@ export const useMessageOpening = () => {
 
   return {
     openMessage,
-    bottomSheets: [pnBottomSheet.bottomSheet]
+    bottomSheet: pnBottomSheet.bottomSheet
   };
 };

--- a/ts/screens/messages/paginated/MessagesArchiveScreen.tsx
+++ b/ts/screens/messages/paginated/MessagesArchiveScreen.tsx
@@ -8,7 +8,7 @@ import { UIMessage } from "../../../store/reducers/entities/messages/types";
 
 const MessagesArchiveScreen = () => {
   const archive = useIOSelector(allArchiveMessagesSelector);
-  const { openMessage, bottomSheets } = useMessageOpening();
+  const { openMessage, bottomSheet } = useMessageOpening();
 
   const dispatch = useIODispatch();
 
@@ -32,7 +32,7 @@ const MessagesArchiveScreen = () => {
         navigateToMessageDetail={openMessage}
         unarchiveMessages={messages => setArchived(false, messages)}
       />
-      {bottomSheets}
+      {bottomSheet}
     </>
   );
 };

--- a/ts/screens/messages/paginated/MessagesArchiveScreen.tsx
+++ b/ts/screens/messages/paginated/MessagesArchiveScreen.tsx
@@ -8,7 +8,7 @@ import { UIMessage } from "../../../store/reducers/entities/messages/types";
 
 const MessagesArchiveScreen = () => {
   const archive = useIOSelector(allArchiveMessagesSelector);
-  const { openMessage } = useMessageOpening();
+  const { openMessage, bottomSheets } = useMessageOpening();
 
   const dispatch = useIODispatch();
 
@@ -26,11 +26,14 @@ const MessagesArchiveScreen = () => {
     );
 
   return (
-    <MessagesArchive
-      messages={archive}
-      navigateToMessageDetail={openMessage}
-      unarchiveMessages={messages => setArchived(false, messages)}
-    />
+    <>
+      <MessagesArchive
+        messages={archive}
+        navigateToMessageDetail={openMessage}
+        unarchiveMessages={messages => setArchived(false, messages)}
+      />
+      {bottomSheets}
+    </>
   );
 };
 

--- a/ts/screens/messages/paginated/MessagesHomeScreen.tsx
+++ b/ts/screens/messages/paginated/MessagesHomeScreen.tsx
@@ -106,7 +106,7 @@ const MessagesHomeScreen = ({
     );
   }, [latestMessageOperation]);
 
-  const { openMessage, bottomSheets } = useMessageOpening();
+  const { openMessage, bottomSheet } = useMessageOpening();
 
   const isScreenReaderEnabled = useScreenReaderEnabled();
 
@@ -179,7 +179,7 @@ const MessagesHomeScreen = ({
           ))
         )}
       {!isScreenReaderEnabled && statusComponent}
-      {bottomSheets}
+      {bottomSheet}
     </TopScreenComponent>
   );
 };

--- a/ts/screens/messages/paginated/MessagesHomeScreen.tsx
+++ b/ts/screens/messages/paginated/MessagesHomeScreen.tsx
@@ -179,7 +179,7 @@ const MessagesHomeScreen = ({
           ))
         )}
       {!isScreenReaderEnabled && statusComponent}
-      {bottomSheets.map(_ => _)}
+      {bottomSheets}
     </TopScreenComponent>
   );
 };

--- a/ts/screens/messages/paginated/MessagesInboxScreen.tsx
+++ b/ts/screens/messages/paginated/MessagesInboxScreen.tsx
@@ -8,7 +8,7 @@ import { UIMessage } from "../../../store/reducers/entities/messages/types";
 
 const MessagesInboxScreen = () => {
   const inbox = useIOSelector(allInboxMessagesSelector);
-  const { openMessage } = useMessageOpening();
+  const { openMessage, bottomSheets } = useMessageOpening();
 
   const dispatch = useIODispatch();
 
@@ -26,11 +26,14 @@ const MessagesInboxScreen = () => {
     );
 
   return (
-    <MessagesInbox
-      messages={inbox}
-      navigateToMessageDetail={openMessage}
-      archiveMessages={messages => setArchived(true, messages)}
-    />
+    <>
+      <MessagesInbox
+        messages={inbox}
+        navigateToMessageDetail={openMessage}
+        archiveMessages={messages => setArchived(true, messages)}
+      />
+      {bottomSheets}
+    </>
   );
 };
 

--- a/ts/screens/messages/paginated/MessagesInboxScreen.tsx
+++ b/ts/screens/messages/paginated/MessagesInboxScreen.tsx
@@ -8,7 +8,7 @@ import { UIMessage } from "../../../store/reducers/entities/messages/types";
 
 const MessagesInboxScreen = () => {
   const inbox = useIOSelector(allInboxMessagesSelector);
-  const { openMessage, bottomSheets } = useMessageOpening();
+  const { openMessage, bottomSheet } = useMessageOpening();
 
   const dispatch = useIODispatch();
 
@@ -32,7 +32,7 @@ const MessagesInboxScreen = () => {
         navigateToMessageDetail={openMessage}
         archiveMessages={messages => setArchived(true, messages)}
       />
-      {bottomSheets}
+      {bottomSheet}
     </>
   );
 };


### PR DESCRIPTION
## Short description
This PR fixes the bottom sheet that does not open when selecting a PN message

## List of changes proposed in this pull request
- Added the bottom Sheet component reference to both `MessagesArchiveScreen.tsx` and `MessagesInboxScreen.tsx`
- Removed a redundant `map` call on the `bottomSheets` instance in `MessagesHomeScreen.tsx`

## How to test
Enable `includePn` in the [dev server config](https://github.com/pagopa/io-dev-api-server/blob/master/src/config.ts#L122) and increment `pnCount` in the [dev server config](https://github.com/pagopa/io-dev-api-server/blob/master/src/config.ts#L78). 
Start the application and select a PN message. A bottom sheet should open (try to close it and to also navigate to the message).
Repeat the same test for a normal message (in this case, the bottom sheet should not open)
