### PR TITLE
fix: [IOAPPCIT-19,IABT-1406]  It's not clear that the notification shown inside the onboarding push notification preference screen is only an example when read by accessibility tools

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -833,6 +833,7 @@ onboarding:
     headerTitle: IO Settings
     continue: Continue
     preview:
+      accessibilityLabelPrefix: "Here's an example:"
       reminderOnPreviewOnTitle: You have a notice due soon
       reminderOnPreviewOnMessage: Log in to pay the notice issued by ACI
       reminderOffPreviewOnTitle: Comune di Ipazia

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -849,6 +849,7 @@ onboarding:
     headerTitle: Configura IO
     continue: Continua
     preview:
+      accessibilityLabelPrefix: "Ecco un esempio:"
       reminderOnPreviewOnTitle: Hai un avviso in scadenza
       reminderOnPreviewOnMessage: Entra nell’app e paga l’avviso emesso da ACI
       reminderOffPreviewOnTitle: Comune di Ipazia

--- a/ts/screens/onboarding/components/NotificationsPreferencesPreview.tsx
+++ b/ts/screens/onboarding/components/NotificationsPreferencesPreview.tsx
@@ -113,8 +113,16 @@ export const NotificationsPreferencesPreview = ({
           styles.notification,
           isFirstOnboarding && styles.notificationWhiteBg
         ]}
+        accessible={true}
+        accessibilityLabel={`${I18n.t(
+          "onboarding.notifications.preview.accessibilityLabelPrefix"
+        )} ${I18n.t(titleKey)} ${I18n.t(messageKey)}`}
       >
-        <View style={styles.box}>
+        <View
+          style={styles.box}
+          importantForAccessibility="no-hide-descendants"
+          accessibilityElementsHidden={true}
+        >
           <Image
             source={require("../../../../img/onboarding/notification_icon.png")}
           />


### PR DESCRIPTION
## Short description
This PR explicits that the notification shown inside the `OnboardingNotificationsPreferencesScreens` is only an example when read by accessibility tools like VoiceOver or TalkBack.

| iOS Example |
| - |
| <video src="https://user-images.githubusercontent.com/16268789/210255263-7406e6f5-7f8c-4382-9fb6-7d1fc343836f.mov" width="150" /> |

## List of changes proposed in this pull request
- `locales/en/index.yml`: added the custom accessibility label prefix for the example notification view.
- `locales/it/index.yml`: added the custom accessibility label prefix for the example notification view.
- `ts/screens/onboarding/components/NotificationsPreferencesPreview.tsx`: made the example notification view accessible with a custom label that explicits that this view is just an **example** notification and not an actual one. All this view children are marked to not be read by accessibility tools.

## How to test
- Run the application on an iOS or Android physical device and enable VoiceOver/TalkBack.
- Start from a logout state.
- Run an instance of [io-dev-api-server](https://github.com/pagopa/io-dev-api-server) with [`firstOnboarding` set to `true`](https://github.com/pagopa/io-dev-api-server/blob/9b381ef2438ae3b8e5d265afb2019c2561610852/src/config.ts#L67).
- Login to the application and navigate till the push notification preference screen. 
- Read accessibility information of the example push notification shown.
