### PR TITLE
feat: [IOAPPCOM-40] Fix synchronization between in-memory state and stored one (after logout and login)

### DIFF
--- a/ts/components/screens/LogoutScreen.tsx
+++ b/ts/components/screens/LogoutScreen.tsx
@@ -41,7 +41,7 @@ const LogoutScreen = (props: Props) => {
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   // hard-logout
-  logout: () => dispatch(logoutRequest({ keepUserData: false }))
+  logout: () => dispatch(logoutRequest())
 });
 
 export default connect(undefined, mapDispatchToProps)(LogoutScreen);

--- a/ts/features/messages/saga/attachments.ts
+++ b/ts/features/messages/saga/attachments.ts
@@ -42,10 +42,8 @@ export function* watchMessageAttachmentsSaga(
   // clear cache when user explicitly logs out
   yield* takeEvery(
     logoutSuccess,
-    function* (action: ActionType<typeof logoutSuccess>) {
-      if (!action.payload.keepUserData) {
-        yield* call(clearAllAttachments);
-      }
+    function* (_: ActionType<typeof logoutSuccess>) {
+      yield* call(clearAllAttachments);
     }
   );
 }

--- a/ts/sagas/__tests__/notifications.test.ts
+++ b/ts/sagas/__tests__/notifications.test.ts
@@ -125,10 +125,7 @@ describe("updateInstallationSaga", () => {
 
     describe("and the user did logout", () => {
       it("should send the push notification token", () => {
-        const localState = updateState(
-          [logoutRequest({ keepUserData: false })],
-          globalState
-        );
+        const localState = updateState([logoutRequest()], globalState);
         const createOrUpdateInstallation = jest.fn();
         return expectSaga(updateInstallationSaga, createOrUpdateInstallation)
           .withState(localState)

--- a/ts/sagas/startup/__tests__/watchLogoutSaga.test.ts
+++ b/ts/sagas/startup/__tests__/watchLogoutSaga.test.ts
@@ -10,11 +10,10 @@ const logout = jest.fn();
 
 const takeCancellableAction = [logoutRequest, logoutSuccess, logoutFailure];
 
-const logoutRequestAct = logoutRequest({ keepUserData: true });
-const logoutSuccessAct = logoutSuccess({ keepUserData: true });
+const logoutRequestAct = logoutRequest();
+const logoutSuccessAct = logoutSuccess();
 const logoutFailureAct = logoutFailure({
-  error: new Error(),
-  options: { keepUserData: true }
+  error: new Error()
 });
 
 describe("watchLogoutSaga", () => {

--- a/ts/sagas/startup/watchLogoutSaga.ts
+++ b/ts/sagas/startup/watchLogoutSaga.ts
@@ -17,7 +17,7 @@ import { resetAssistanceData } from "../../utils/supportAssistance";
 
 export function* logoutSaga(
   logout: ReturnType<typeof BackendClient>["logout"],
-  action: ActionType<typeof logoutRequest>
+  _: ActionType<typeof logoutRequest>
 ) {
   // Issue a logout request to the backend, asking to delete the session
   // FIXME: if there's no connectivity to the backend, this request will
@@ -26,7 +26,7 @@ export function* logoutSaga(
     const response: SagaCallReturnType<typeof logout> = yield* call(logout, {});
     if (E.isRight(response)) {
       if (response.right.status === 200) {
-        yield* put(logoutSuccess(action.payload));
+        yield* put(logoutSuccess());
       } else {
         // We got a error, send a LOGOUT_FAILURE action so we can log it using Mixpanel
         const error = Error(
@@ -34,26 +34,24 @@ export function* logoutSaga(
             ? response.right.value.title
             : "Unknown error"
         );
-        yield* put(logoutFailure({ error, options: action.payload }));
+        yield* put(logoutFailure({ error }));
       }
     } else {
       const logoutError = {
-        error: Error(readableReport(response.left)),
-        options: action.payload
+        error: Error(readableReport(response.left))
       };
       yield* put(logoutFailure(logoutError));
     }
   } catch (e) {
     const logoutError = {
-      error: convertUnknownToError(e),
-      options: action.payload
+      error: convertUnknownToError(e)
     };
     yield* put(logoutFailure(logoutError));
   } finally {
     // clean up any assistance data
     resetAssistanceData();
-    // If keepUserData is false, startApplicationInitialization is
-    // dispatched within the componentDidMount of IngressScreen
+    // startApplicationInitialization is dispatched
+    // within the componentDidMount of IngressScreen
     resetToAuthenticationRoute();
     yield* put(startApplicationInitialization());
   }

--- a/ts/screens/profile/RemoveAccountSuccessScreen.tsx
+++ b/ts/screens/profile/RemoveAccountSuccessScreen.tsx
@@ -66,7 +66,7 @@ const RemoveAccountSuccess: React.FunctionComponent<Props> = props => {
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   // hard-logout
-  logout: () => dispatch(logoutRequest({ keepUserData: false }))
+  logout: () => dispatch(logoutRequest())
 });
 
 export default connect(undefined, mapDispatchToProps)(RemoveAccountSuccess);

--- a/ts/store/actions/authentication.ts
+++ b/ts/store/actions/authentication.ts
@@ -15,13 +15,8 @@ import { SessionToken } from "../../types/SessionToken";
 import { SupportToken } from "../../../definitions/backend/SupportToken";
 import { SpidIdp } from "../../../definitions/content/SpidIdp";
 
-export type LogoutOption = {
-  keepUserData: boolean;
-};
-
 export type LogoutError = {
   error: Error;
-  options: LogoutOption;
 };
 
 export type CheckSessionResult = {
@@ -51,11 +46,9 @@ export const loginFailure = createStandardAction("LOGIN_FAILURE")<{
   idp: string;
 }>();
 
-export const logoutRequest =
-  createStandardAction("LOGOUT_REQUEST")<LogoutOption>();
+export const logoutRequest = createStandardAction("LOGOUT_REQUEST")();
 
-export const logoutSuccess =
-  createStandardAction("LOGOUT_SUCCESS")<LogoutOption>();
+export const logoutSuccess = createStandardAction("LOGOUT_SUCCESS")();
 
 export const logoutFailure = createAction(
   "LOGOUT_FAILURE",

--- a/ts/store/reducers/__tests__/persistedPreferences.test.ts
+++ b/ts/store/reducers/__tests__/persistedPreferences.test.ts
@@ -36,10 +36,8 @@ describe("persistedPreferences reducer/selectors", () => {
     let noChangesState: GlobalState = notEnabledState;
     // for these actions isMixpanelEnabled must not change
     [
-      logoutRequest({ keepUserData: true }),
-      logoutRequest({ keepUserData: false }),
-      logoutSuccess({ keepUserData: true }),
-      logoutSuccess({ keepUserData: false }),
+      logoutRequest(),
+      logoutSuccess(),
       sessionExpired(),
       sessionInvalid(),
       clearCache()

--- a/ts/store/reducers/identification.ts
+++ b/ts/store/reducers/identification.ts
@@ -79,7 +79,7 @@ const INITIAL_PROGRESS_STATE: IdentificationUnidentifiedState = {
   kind: "unidentified"
 };
 
-const INITIAL_STATE: IdentificationState = {
+export const INITIAL_STATE: IdentificationState = {
   progress: INITIAL_PROGRESS_STATE,
   fail: undefined
 };

--- a/ts/store/reducers/index.ts
+++ b/ts/store/reducers/index.ts
@@ -150,7 +150,7 @@ export function createRootReducer(
     ) {
       // Purge the stored redux-persist state
       persistConfigs.forEach(persistConfig => purgeStoredState(persistConfig));
-      
+
       /**
        * We can't return undefined for nested persist reducer, we need to return
        * the basic redux persist content.

--- a/ts/store/reducers/index.ts
+++ b/ts/store/reducers/index.ts
@@ -35,7 +35,10 @@ import entitiesReducer, {
   entitiesPersistConfig,
   EntitiesState
 } from "./entities";
-import identificationReducer, { IdentificationState } from "./identification";
+import identificationReducer, {
+  IdentificationState,
+  INITIAL_STATE as identificationInitialState
+} from "./identification";
 import installationReducer from "./installation";
 import { navigationReducer } from "./navigation";
 import notificationsReducer from "./notifications";
@@ -51,6 +54,7 @@ import { GlobalState } from "./types";
 import userDataProcessingReducer from "./userDataProcessing";
 import userMetadataReducer from "./userMetadata";
 import walletReducer from "./wallet";
+import { WALLETS_INITIAL_STATE as walletsInitialState } from "./wallet/wallets";
 
 // A custom configuration to store the authentication into the Keychain
 export const authenticationPersistConfig: PersistConfig = {
@@ -146,55 +150,78 @@ export function createRootReducer(
     ) {
       // Purge the stored redux-persist state
       persistConfigs.forEach(persistConfig => purgeStoredState(persistConfig));
-
+      
       /**
        * We can't return undefined for nested persist reducer, we need to return
        * the basic redux persist content.
        */
       // for retro-compatibility
       // eslint-disable-next-line no-param-reassign
-      state =
-        state &&
-        ((isActionOf(logoutSuccess, action) && !action.payload.keepUserData) ||
-          (isActionOf(logoutFailure, action) &&
-            !action.payload.options.keepUserData))
-          ? ({
-              authentication: {
-                ...autenticationInitialState,
+      state = state
+        ? ({
+            authentication: {
+              ...autenticationInitialState,
+              // eslint-disable-next-line no-underscore-dangle
+              _persist: state.authentication._persist
+            },
+            // backend status must be kept
+            backendStatus: state.backendStatus,
+            // keep servicesMetadata from content section
+            content: {
+              ...contentInitialContentState
+            },
+            // keep hashed fiscal code
+            crossSessions: state.crossSessions,
+            // data should be kept across multiple sessions
+            entities: {
+              services: state.entities.services,
+              organizations: state.entities.organizations,
+              messagesStatus: state.entities.messagesStatus,
+              paymentByRptId: state.entities.paymentByRptId,
+              calendarEvents: state.entities.calendarEvents,
+              transactionsRead: state.entities.transactionsRead,
+              // eslint-disable-next-line no-underscore-dangle
+              _persist: state.entities._persist
+            },
+            features: {
+              mvl: {
                 // eslint-disable-next-line no-underscore-dangle
-                _persist: state.authentication._persist
+                _persist: state.features.mvl._persist
               },
-              // data should be kept across multiple sessions
-              entities: {
-                services: state.entities.services,
-                organizations: state.entities.organizations,
-                messagesStatus: state.entities.messagesStatus,
-                paymentByRptId: state.entities.paymentByRptId,
-                calendarEvents: state.entities.calendarEvents,
-                transactionsRead: state.entities.transactionsRead
+              pn: {
+                // eslint-disable-next-line no-underscore-dangle
+                _persist: state.features.pn._persist
               },
-              // backend status must be kept
-              backendStatus: state.backendStatus,
-              crossSessions: state.crossSessions,
-              // keep servicesMetadata from content section
-              content: {
-                ...contentInitialContentState
-              },
-              // isMixpanelEnabled must be kept
-              persistedPreferences: {
-                ...initialPreferencesState,
-                isMixpanelEnabled: state.persistedPreferences.isMixpanelEnabled
-              },
-              // notifications must be kept
-              notifications: {
-                ...state.notifications
-              },
-              // payments must be kept
-              payments: {
-                ...state.payments
+              // eslint-disable-next-line no-underscore-dangle
+              _persist: state.features._persist
+            },
+            identification: {
+              ...identificationInitialState,
+              // eslint-disable-next-line no-underscore-dangle
+              _persist: state.identification._persist
+            },
+            // notifications must be kept
+            notifications: {
+              ...state.notifications
+            },
+            // payments must be kept
+            payments: {
+              ...state.payments
+            },
+            // isMixpanelEnabled must be kept
+            persistedPreferences: {
+              ...initialPreferencesState,
+              isMixpanelEnabled: state.persistedPreferences.isMixpanelEnabled
+            },
+            wallet: {
+              wallets: {
+                ...walletsInitialState,
+                // eslint-disable-next-line no-underscore-dangle
+                _persist: state.wallet.wallets._persist
               }
-            } as GlobalState)
-          : state;
+            }
+          } as GlobalState)
+        : state;
     }
 
     return appReducer(state, action);

--- a/ts/store/reducers/wallet/wallets.ts
+++ b/ts/store/reducers/wallet/wallets.ts
@@ -90,7 +90,7 @@ export type WalletsState = Readonly<{
 
 export type PersistedWalletsState = WalletsState & PersistPartial;
 
-const WALLETS_INITIAL_STATE: WalletsState = {
+export const WALLETS_INITIAL_STATE: WalletsState = {
   walletById: pot.none,
   creditCardAddWallet: pot.none,
   deleteAllByFunction: remoteUndefined,


### PR DESCRIPTION
## Short description
This PR fixes the in-memory state not being persisted after logout/login with the same user (with respect to the linked issue, the "Paid" badge not showing up if the app is killed after logout and restarted, logging in with the same user).
It also removes the `keepUserData` parameter in the logout actions.
Detailed explanation of the issue [here](https://pagopa.atlassian.net/wiki/spaces/IOAPP/pages/605454598/IOAPPCOM-40+Out-of-synch+between+in-memory+and+persisted+state).

## List of changes proposed in this pull request
- Edited main reducer (`ts/store/reducers/index.ts`) in order to include the added `_persist` property (from redux-persist) when the state is recreated after a logout (for any reducer that includes a persisting configuration);
- Parameter `keepUserData` has been removed from Success and Failure logout actions.

## How to test
In order to test this PR you have to have some messages with the 'Paid' badge. To achieve this, you should edit the runtime state to populate `state.entities.paymentByRptId`, including the category's `rptId` of the messages where you want to see such badge. At this point:
- logout and log back in with the same user. The 'Paid' badge should be there;
- logout and log back in with the same user. Kill the application and restart it. The 'Paid' badge should be there;
- logout, kill the application and log back in with the same user. The 'Paid' badge should be there;
- logout, kill the application and log back in with the same user. Kill the application and restart it. The 'Paid' badge should be there;
- Repeat the same tests with a different user. The 'Paid' badge should not appear.

Take note that this PR edits the main recreated state so check that other sections of the application still work as they are supposed to.