### PR TITLE
[IABT-1394] removal of surplus info in transaction summary

### DIFF
--- a/ts/screens/wallet/payment/components/TransactionSummary.tsx
+++ b/ts/screens/wallet/payment/components/TransactionSummary.tsx
@@ -24,8 +24,8 @@ import {
   centsToAmount,
   formatNumberAmount
 } from "../../../../utils/stringBuilder";
-import { formatTextRecipient } from "../../../../utils/strings";
 import { usePaymentAmountInfoBottomSheet } from "../hooks/usePaymentAmountInfoBottomSheet";
+import { EnteBeneficiario } from "../../../../../definitions/backend/EnteBeneficiario";
 
 const styles = StyleSheet.create({
   row: {
@@ -166,10 +166,20 @@ type Props = Readonly<{
 export const TransactionSummary = (props: Props): React.ReactElement => {
   const isLoading = pot.isLoading(props.paymentVerification);
 
+  const getRecepientName = (recipient: EnteBeneficiario) => {
+    const denomUnitOper = pipe(
+      recipient.denomUnitOperBeneficiario,
+      O.fromNullable,
+      O.map(d => ` - ${d}`),
+      O.getOrElse(() => "")
+    );
+    return `${recipient.denominazioneBeneficiario}${denomUnitOper}`.trim();
+  };
+
   const recipient = pipe(
     pot.toOption(props.paymentVerification),
     O.chainNullableK(_ => _.enteBeneficiario),
-    O.map(formatTextRecipient),
+    O.map(getRecepientName),
     O.toUndefined
   );
 


### PR DESCRIPTION
## Short description
 removal of surplus info in transaction summary

## List of changes proposed in this pull request
- removed recepient address from transaction summary


## How to test
try to open a new payment from the wallet sectieon, or look at the receipt of a past transaction where the address used to be displayed
