### PR TITLE
feat(IDPay): [IODPAY-74] Add ability to remove payment instruments from an IDPay initiative

### DIFF
--- a/ts/features/idpay/initiative/configuration/components/InstrumentEnrollmentSwitch.tsx
+++ b/ts/features/idpay/initiative/configuration/components/InstrumentEnrollmentSwitch.tsx
@@ -1,0 +1,148 @@
+import { Badge, ListItem, View } from "native-base";
+import { default as React } from "react";
+import { StyleSheet } from "react-native";
+import {
+  InstrumentDTO,
+  StatusEnum
+} from "../../../../../../definitions/idpay/wallet/InstrumentDTO";
+import { Body } from "../../../../../components/core/typography/Body";
+import { H4 } from "../../../../../components/core/typography/H4";
+import { LabelSmall } from "../../../../../components/core/typography/LabelSmall";
+import { IOColors } from "../../../../../components/core/variables/IOColors";
+import FooterWithButtons from "../../../../../components/ui/FooterWithButtons";
+import Switch from "../../../../../components/ui/Switch";
+import I18n from "../../../../../i18n";
+import { Wallet } from "../../../../../types/pagopa";
+import { useIOBottomSheetModal } from "../../../../../utils/hooks/bottomSheet";
+import { instrumentStatusLabels } from "../../../common/labels";
+import { useConfigurationMachineService } from "../xstate/provider";
+
+type InstrumentEnrollmentSwitchProps = {
+  instrument: Wallet;
+  status: InstrumentDTO["status"];
+  isDisabled?: boolean;
+};
+
+/**
+ * A component to enable/disable the enrollment of an instrument
+ */
+const InstrumentEnrollmentSwitch = (props: InstrumentEnrollmentSwitchProps) => {
+  const configurationMachine = useConfigurationMachineService();
+
+  const { instrument, status, isDisabled } = props;
+
+  const [switchStatus, setSwitchStatus] = React.useState(
+    status === StatusEnum.ACTIVE
+  );
+
+  const sendEnrollInstrument = (): void => {
+    configurationMachine.send("ENROLL_INSTRUMENT", {
+      instrumentId: instrument.idWallet
+    });
+  };
+
+  const sendDeleteInstrument = (): void => {
+    configurationMachine.send("DELETE_INSTRUMENT", {
+      instrumentId: instrument.idWallet
+    });
+  };
+
+  const enrollmentBottomSheetModal = useIOBottomSheetModal(
+    <Body>
+      {I18n.t("idpay.initiative.configuration.bottomSheet.bodyFirst")}
+      <Body weight="SemiBold">
+        {I18n.t("idpay.initiative.configuration.bottomSheet.bodyBold") + "\n"}
+      </Body>
+      {I18n.t("idpay.initiative.configuration.bottomSheet.bodyLast")}
+    </Body>,
+
+    I18n.t("idpay.initiative.configuration.bottomSheet.header"),
+    270,
+
+    <FooterWithButtons
+      type="TwoButtonsInlineThird"
+      rightButton={{
+        onPress: () => {
+          sendEnrollInstrument();
+          enrollmentBottomSheetModal.dismiss();
+        },
+        block: true,
+        bordered: false,
+        title: I18n.t(
+          "idpay.initiative.configuration.bottomSheet.footer.buttonActivate"
+        )
+      }}
+      leftButton={{
+        onPress: () => {
+          setSwitchStatus(false);
+          enrollmentBottomSheetModal.dismiss();
+        },
+        block: true,
+        bordered: true,
+        title: I18n.t(
+          "idpay.initiative.configuration.bottomSheet.footer.buttonCancel"
+        )
+      }}
+    />
+  );
+
+  const handleSwitch = () => {
+    if (switchStatus) {
+      sendDeleteInstrument();
+    } else {
+      setSwitchStatus(true);
+      enrollmentBottomSheetModal.present();
+    }
+  };
+
+  const renderControl = () => {
+    if (
+      status === StatusEnum.PENDING_ENROLLMENT_REQUEST ||
+      status === StatusEnum.PENDING_DEACTIVATION_REQUEST
+    ) {
+      return (
+        <Badge style={styles.badge}>
+          <LabelSmall color="white">
+            {instrumentStatusLabels[status]}
+          </LabelSmall>
+        </Badge>
+      );
+    }
+
+    return (
+      <Switch
+        value={switchStatus}
+        onChange={handleSwitch}
+        disabled={isDisabled}
+      />
+    );
+  };
+
+  return (
+    <>
+      <ListItem>
+        <View style={styles.listItemContainer}>
+          <H4>{instrument.idWallet}</H4>
+          {renderControl()}
+        </View>
+      </ListItem>
+      {enrollmentBottomSheetModal.bottomSheet}
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  listItemContainer: {
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "space-between"
+  },
+  badge: {
+    height: 24,
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: IOColors.blue
+  }
+});
+
+export { InstrumentEnrollmentSwitch };

--- a/ts/features/idpay/initiative/configuration/components/InstrumentEnrollmentSwitch.tsx
+++ b/ts/features/idpay/initiative/configuration/components/InstrumentEnrollmentSwitch.tsx
@@ -16,14 +16,14 @@ import Switch from "../../../../../components/ui/Switch";
 import I18n from "../../../../../i18n";
 import { Wallet } from "../../../../../types/pagopa";
 import { useIOBottomSheetModal } from "../../../../../utils/hooks/bottomSheet";
-
 import { instrumentStatusLabels } from "../../../common/labels";
-import { useConfigurationMachineService } from "../xstate/provider";
 
 type InstrumentEnrollmentSwitchProps = {
   wallet: Wallet;
   instrument?: InstrumentDTO;
   isDisabled?: boolean;
+  onEnrollInstrument: (walletId: number) => void;
+  onDeleteInstrument: (instrumentId: string) => void;
 };
 
 type InstrumentInfo = {
@@ -35,30 +35,19 @@ type InstrumentInfo = {
  * A component to enable/disable the enrollment of an instrument
  */
 const InstrumentEnrollmentSwitch = (props: InstrumentEnrollmentSwitchProps) => {
-  const configurationMachine = useConfigurationMachineService();
-
-  const { wallet, instrument, isDisabled } = props;
+  const {
+    wallet,
+    instrument,
+    isDisabled,
+    onEnrollInstrument,
+    onDeleteInstrument
+  } = props;
 
   const status = instrument?.status;
 
   const [switchStatus, setSwitchStatus] = React.useState(
     status === StatusEnum.ACTIVE
   );
-
-  const sendEnrollInstrument = (): void => {
-    configurationMachine.send("ENROLL_INSTRUMENT", {
-      instrumentId: wallet.idWallet
-    });
-  };
-
-  const sendDeleteInstrument = (): void => {
-    if (instrument === undefined) {
-      return;
-    }
-    configurationMachine.send("DELETE_INSTRUMENT", {
-      instrumentId: instrument.instrumentId
-    });
-  };
 
   const enrollmentBottomSheetModal = useIOBottomSheetModal(
     <Body>
@@ -76,7 +65,7 @@ const InstrumentEnrollmentSwitch = (props: InstrumentEnrollmentSwitchProps) => {
       type="TwoButtonsInlineThird"
       rightButton={{
         onPress: () => {
-          sendEnrollInstrument();
+          onEnrollInstrument(wallet.idWallet);
           enrollmentBottomSheetModal.dismiss();
         },
         block: true,
@@ -101,7 +90,9 @@ const InstrumentEnrollmentSwitch = (props: InstrumentEnrollmentSwitchProps) => {
 
   const handleSwitch = () => {
     if (switchStatus) {
-      sendDeleteInstrument();
+      if (instrument !== undefined) {
+        onDeleteInstrument(instrument.instrumentId);
+      }
     } else {
       setSwitchStatus(true);
       enrollmentBottomSheetModal.present();

--- a/ts/features/idpay/initiative/configuration/components/InstrumentEnrollmentSwitch.tsx
+++ b/ts/features/idpay/initiative/configuration/components/InstrumentEnrollmentSwitch.tsx
@@ -20,10 +20,10 @@ import { instrumentStatusLabels } from "../../../common/labels";
 
 type InstrumentEnrollmentSwitchProps = {
   wallet: Wallet;
-  instrument?: InstrumentDTO;
+  status?: InstrumentDTO["status"];
   isDisabled?: boolean;
-  onEnrollInstrument: (walletId: number) => void;
-  onDeleteInstrument: (instrumentId: string) => void;
+  onEnrollInstrument?: (walletId: number) => void;
+  onDeleteInstrument?: (walletId: number) => void;
 };
 
 type InstrumentInfo = {
@@ -35,15 +35,8 @@ type InstrumentInfo = {
  * A component to enable/disable the enrollment of an instrument
  */
 const InstrumentEnrollmentSwitch = (props: InstrumentEnrollmentSwitchProps) => {
-  const {
-    wallet,
-    instrument,
-    isDisabled,
-    onEnrollInstrument,
-    onDeleteInstrument
-  } = props;
-
-  const status = instrument?.status;
+  const { wallet, status, isDisabled, onEnrollInstrument, onDeleteInstrument } =
+    props;
 
   const [switchStatus, setSwitchStatus] = React.useState(
     status === StatusEnum.ACTIVE
@@ -65,7 +58,9 @@ const InstrumentEnrollmentSwitch = (props: InstrumentEnrollmentSwitchProps) => {
       type="TwoButtonsInlineThird"
       rightButton={{
         onPress: () => {
-          onEnrollInstrument(wallet.idWallet);
+          if (onEnrollInstrument) {
+            onEnrollInstrument(wallet.idWallet);
+          }
           enrollmentBottomSheetModal.dismiss();
         },
         block: true,
@@ -88,10 +83,10 @@ const InstrumentEnrollmentSwitch = (props: InstrumentEnrollmentSwitchProps) => {
     />
   );
 
-  const handleSwitch = () => {
+  const handleChange = () => {
     if (switchStatus) {
-      if (instrument !== undefined) {
-        onDeleteInstrument(instrument.instrumentId);
+      if (onDeleteInstrument !== undefined) {
+        onDeleteInstrument(wallet.idWallet);
       }
     } else {
       setSwitchStatus(true);
@@ -128,7 +123,7 @@ const InstrumentEnrollmentSwitch = (props: InstrumentEnrollmentSwitchProps) => {
     return (
       <Switch
         value={switchStatus}
-        onChange={handleSwitch}
+        onChange={handleChange}
         disabled={isDisabled}
       />
     );

--- a/ts/features/idpay/initiative/configuration/screens/InstrumentsEnrollmentScreen.tsx
+++ b/ts/features/idpay/initiative/configuration/screens/InstrumentsEnrollmentScreen.tsx
@@ -65,15 +65,21 @@ const InstrumentsEnrollmentScreen = () => {
     });
   };
 
-  const sendEnrollInstrument = (idWallet: number): void => {
+  const sendEnrollInstrument = (walletId: number): void => {
     configurationMachine.send("ENROLL_INSTRUMENT", {
-      instrumentId: idWallet
+      instrumentId: walletId
     });
   };
 
-  const sendDeleteInstrument = (instrumentId: string): void => {
+  const sendDeleteInstrument = (walletId: number): void => {
+    const instrument = idPayInstrumentsByIdWallet[walletId];
+
+    if (instrument === undefined) {
+      return;
+    }
+
     configurationMachine.send("DELETE_INSTRUMENT", {
-      instrumentId
+      instrumentId: instrument.instrumentId
     });
   };
 
@@ -109,8 +115,9 @@ const InstrumentsEnrollmentScreen = () => {
                 <InstrumentEnrollmentSwitch
                   key={pagoPAInstrument.idWallet}
                   wallet={pagoPAInstrument}
-                  instrument={
+                  status={
                     idPayInstrumentsByIdWallet[pagoPAInstrument.idWallet]
+                      ?.status
                   }
                   isDisabled={isUpserting}
                   onEnrollInstrument={sendEnrollInstrument}

--- a/ts/features/idpay/initiative/configuration/screens/InstrumentsEnrollmentScreen.tsx
+++ b/ts/features/idpay/initiative/configuration/screens/InstrumentsEnrollmentScreen.tsx
@@ -1,15 +1,20 @@
 import { RouteProp, useRoute } from "@react-navigation/native";
 import { useSelector } from "@xstate/react";
 import { List, Text, View } from "native-base";
-import React from "react";
+import React, { useRef } from "react";
 import { SafeAreaView, ScrollView } from "react-native";
+import { Body } from "../../../../../components/core/typography/Body";
 import { H1 } from "../../../../../components/core/typography/H1";
 import { IOStyles } from "../../../../../components/core/variables/IOStyles";
 import LoadingSpinnerOverlay from "../../../../../components/LoadingSpinnerOverlay";
 import BaseScreenComponent from "../../../../../components/screens/BaseScreenComponent";
 import FooterWithButtons from "../../../../../components/ui/FooterWithButtons";
 import I18n from "../../../../../i18n";
-import { InstrumentEnrollmentSwitch } from "../components/InstrumentEnrollmentSwitch";
+import { useIOBottomSheetModal } from "../../../../../utils/hooks/bottomSheet";
+import {
+  InstrumentEnrollmentSwitch,
+  InstrumentEnrollmentSwitchRef
+} from "../components/InstrumentEnrollmentSwitch";
 import { IDPayConfigurationParamsList } from "../navigation/navigator";
 import { ConfigurationMode } from "../xstate/context";
 import { useConfigurationMachineService } from "../xstate/provider";
@@ -34,6 +39,23 @@ const InstrumentsEnrollmentScreen = () => {
   const { initiativeId } = route.params;
 
   const configurationMachine = useConfigurationMachineService();
+
+  // See more in the docs: https://beta.reactjs.org/learn/manipulating-the-dom-with-refs#how-to-manage-a-list-of-refs-using-a-ref-callback
+  const instrumentItemsRef = useRef<Map<number, InstrumentEnrollmentSwitchRef>>(
+    new Map<number, InstrumentEnrollmentSwitchRef>()
+  );
+  const getInstrumentItemsMap = () => {
+    if (!instrumentItemsRef.current) {
+      // eslint-disable-next-line functional/immutable-data
+      instrumentItemsRef.current = new Map<
+        number,
+        InstrumentEnrollmentSwitchRef
+      >();
+    }
+    return instrumentItemsRef.current;
+  };
+
+  const selectedInstrumentIdRef = useRef<number | undefined>(undefined);
 
   const isLoading = useSelector(configurationMachine, isLoadingSelector);
 
@@ -93,62 +115,131 @@ const InstrumentsEnrollmentScreen = () => {
     }
   }, [configurationMachine, initiativeId]);
 
+  const enrollmentBottomSheetModal = useIOBottomSheetModal(
+    <Body>
+      {I18n.t("idpay.initiative.configuration.bottomSheet.bodyFirst")}
+      <Body weight="SemiBold">
+        {I18n.t("idpay.initiative.configuration.bottomSheet.bodyBold") + "\n"}
+      </Body>
+      {I18n.t("idpay.initiative.configuration.bottomSheet.bodyLast")}
+    </Body>,
+
+    I18n.t("idpay.initiative.configuration.bottomSheet.header"),
+    270,
+
+    <FooterWithButtons
+      type="TwoButtonsInlineThird"
+      rightButton={{
+        onPress: () => {
+          sendEnrollInstrument(selectedInstrumentIdRef.current as number);
+          enrollmentBottomSheetModal.dismiss();
+        },
+        block: true,
+        bordered: false,
+        title: I18n.t(
+          "idpay.initiative.configuration.bottomSheet.footer.buttonActivate"
+        )
+      }}
+      leftButton={{
+        onPress: () => {
+          revertInstrumentSwitch(selectedInstrumentIdRef.current as number);
+          enrollmentBottomSheetModal.dismiss();
+        },
+        block: true,
+        bordered: true,
+        title: I18n.t(
+          "idpay.initiative.configuration.bottomSheet.footer.buttonCancel"
+        )
+      }}
+    />
+  );
+
+  const revertInstrumentSwitch = (walletId: number): void => {
+    const node = getInstrumentItemsMap().get(walletId);
+    if (node) {
+      node.setSwitchStatus(false);
+    }
+  };
+
+  const handleInstrumentSwitch = (
+    walletId: number,
+    isEnrolling: boolean
+  ): void => {
+    if (isEnrolling) {
+      // eslint-disable-next-line functional/immutable-data
+      selectedInstrumentIdRef.current = walletId;
+      enrollmentBottomSheetModal.present();
+    } else {
+      sendDeleteInstrument(walletId);
+    }
+  };
+
   return (
-    <BaseScreenComponent
-      goBack={handleBackPress}
-      headerTitle={I18n.t("idpay.configuration.headerTitle")}
-    >
-      <LoadingSpinnerOverlay isLoading={isLoading} loadingOpacity={1}>
-        <View spacer />
-        <View style={[IOStyles.flex, IOStyles.horizontalContentPadding]}>
-          <H1>{I18n.t("idpay.initiative.configuration.header")}</H1>
-          <View spacer small />
-          <Text>
-            {I18n.t("idpay.initiative.configuration.subHeader", {
-              initiativeName: "18app"
-            })}
-          </Text>
+    <>
+      <BaseScreenComponent
+        goBack={handleBackPress}
+        headerTitle={I18n.t("idpay.configuration.headerTitle")}
+      >
+        <LoadingSpinnerOverlay isLoading={isLoading} loadingOpacity={1}>
           <View spacer />
-          <ScrollView>
-            <List>
-              {pagoPAInstruments.map(pagoPAInstrument => (
-                <InstrumentEnrollmentSwitch
-                  key={pagoPAInstrument.idWallet}
-                  wallet={pagoPAInstrument}
-                  status={
-                    idPayInstrumentsByIdWallet[pagoPAInstrument.idWallet]
-                      ?.status
-                  }
-                  isDisabled={isUpserting}
-                  onEnrollInstrument={sendEnrollInstrument}
-                  onDeleteInstrument={sendDeleteInstrument}
-                />
-              ))}
-            </List>
-            <Text>{I18n.t("idpay.initiative.configuration.footer")}</Text>
-          </ScrollView>
-        </View>
-        <SafeAreaView>
-          <FooterWithButtons
-            type="TwoButtonsInlineHalf"
-            leftButton={{
-              title: I18n.t(
-                "idpay.initiative.configuration.buttonFooter.noneCta"
-              ),
-              bordered: true,
-              disabled: true
-            }}
-            rightButton={{
-              title: I18n.t(
-                "idpay.initiative.configuration.buttonFooter.continueCta"
-              ),
-              disabled: isUpserting || !hasSelectedInstruments,
-              onPress: handleContinueButton
-            }}
-          />
-        </SafeAreaView>
-      </LoadingSpinnerOverlay>
-    </BaseScreenComponent>
+          <View style={[IOStyles.flex, IOStyles.horizontalContentPadding]}>
+            <H1>{I18n.t("idpay.initiative.configuration.header")}</H1>
+            <View spacer small />
+            <Text>
+              {I18n.t("idpay.initiative.configuration.subHeader", {
+                initiativeName: "18app"
+              })}
+            </Text>
+            <View spacer />
+            <ScrollView>
+              <List>
+                {pagoPAInstruments.map(pagoPAInstrument => (
+                  <InstrumentEnrollmentSwitch
+                    ref={node => {
+                      const map = getInstrumentItemsMap();
+                      if (node) {
+                        map.set(pagoPAInstrument.idWallet, node);
+                      } else {
+                        map.delete(pagoPAInstrument.idWallet);
+                      }
+                    }}
+                    key={pagoPAInstrument.idWallet}
+                    wallet={pagoPAInstrument}
+                    status={
+                      idPayInstrumentsByIdWallet[pagoPAInstrument.idWallet]
+                        ?.status
+                    }
+                    isDisabled={isUpserting}
+                    onSwitch={handleInstrumentSwitch}
+                  />
+                ))}
+              </List>
+              <Text>{I18n.t("idpay.initiative.configuration.footer")}</Text>
+            </ScrollView>
+          </View>
+          <SafeAreaView>
+            <FooterWithButtons
+              type="TwoButtonsInlineHalf"
+              leftButton={{
+                title: I18n.t(
+                  "idpay.initiative.configuration.buttonFooter.noneCta"
+                ),
+                bordered: true,
+                disabled: true
+              }}
+              rightButton={{
+                title: I18n.t(
+                  "idpay.initiative.configuration.buttonFooter.continueCta"
+                ),
+                disabled: isUpserting || !hasSelectedInstruments,
+                onPress: handleContinueButton
+              }}
+            />
+          </SafeAreaView>
+        </LoadingSpinnerOverlay>
+      </BaseScreenComponent>
+      {enrollmentBottomSheetModal.bottomSheet}
+    </>
   );
 };
 export type { InstrumentsEnrollmentScreenRouteParams };

--- a/ts/features/idpay/initiative/configuration/screens/InstrumentsEnrollmentScreen.tsx
+++ b/ts/features/idpay/initiative/configuration/screens/InstrumentsEnrollmentScreen.tsx
@@ -1,23 +1,15 @@
 import { RouteProp, useRoute } from "@react-navigation/native";
 import { useSelector } from "@xstate/react";
-import { Badge, List, ListItem, Text, View } from "native-base";
-import React, { useRef } from "react";
-import { SafeAreaView, ScrollView, StyleSheet } from "react-native";
-import { InstrumentDTO } from "../../../../../../definitions/idpay/wallet/InstrumentDTO";
-import { Body } from "../../../../../components/core/typography/Body";
+import { List, Text, View } from "native-base";
+import React from "react";
+import { SafeAreaView, ScrollView } from "react-native";
 import { H1 } from "../../../../../components/core/typography/H1";
-import { H4 } from "../../../../../components/core/typography/H4";
-import { LabelSmall } from "../../../../../components/core/typography/LabelSmall";
-import { IOColors } from "../../../../../components/core/variables/IOColors";
 import { IOStyles } from "../../../../../components/core/variables/IOStyles";
 import LoadingSpinnerOverlay from "../../../../../components/LoadingSpinnerOverlay";
 import BaseScreenComponent from "../../../../../components/screens/BaseScreenComponent";
 import FooterWithButtons from "../../../../../components/ui/FooterWithButtons";
-import Switch from "../../../../../components/ui/Switch";
 import I18n from "../../../../../i18n";
-import { Wallet } from "../../../../../types/pagopa";
-import { useIOBottomSheetModal } from "../../../../../utils/hooks/bottomSheet";
-import { instrumentStatusLabels } from "../../../common/labels";
+import { InstrumentEnrollmentSwitch } from "../components/InstrumentEnrollmentSwitch";
 import { IDPayConfigurationParamsList } from "../navigation/navigator";
 import { ConfigurationMode } from "../xstate/context";
 import { useConfigurationMachineService } from "../xstate/provider";
@@ -37,74 +29,11 @@ type InstrumentsEnrollmentScreenRouteProps = RouteProp<
   "IDPAY_CONFIGURATION_INSTRUMENTS_ENROLLMENT"
 >;
 
-const styles = StyleSheet.create({
-  listItemContainer: {
-    flex: 1,
-    flexDirection: "row",
-    justifyContent: "space-between"
-  },
-  badge: {
-    height: 24,
-    flexDirection: "row",
-    alignItems: "center",
-    backgroundColor: IOColors.blue
-  }
-});
-
-type InstrumentEnrollmentSwitcher = {
-  instrument: Wallet;
-  idPayStatus: InstrumentDTO["status"];
-  onSwitch: (idWallet: number) => void;
-  isDisabled?: boolean;
-};
-
-/**
- * A component to enable/disable the enrollment of an instrument
- */
-const InstrumentEnrollmentSwitcher = ({
-  instrument,
-  idPayStatus,
-  onSwitch,
-  isDisabled
-}: InstrumentEnrollmentSwitcher) => {
-  const [switchStatus, setSwitchStatus] = React.useState(false);
-  const handleSwitch = () => {
-    setSwitchStatus(_ => !_);
-    onSwitch(instrument.idWallet);
-  };
-
-  return (
-    <ListItem>
-      <View style={styles.listItemContainer}>
-        <H4>{instrument.idWallet}</H4>
-        {idPayStatus === undefined ? (
-          <Switch
-            value={switchStatus}
-            onChange={handleSwitch}
-            disabled={isDisabled}
-          />
-        ) : (
-          <Badge style={styles.badge}>
-            <LabelSmall color="white">
-              {instrumentStatusLabels[idPayStatus]}
-            </LabelSmall>
-          </Badge>
-        )}
-      </View>
-    </ListItem>
-  );
-};
-
 const InstrumentsEnrollmentScreen = () => {
   const route = useRoute<InstrumentsEnrollmentScreenRouteProps>();
   const { initiativeId } = route.params;
 
-  const selectedCardRef = useRef<number | undefined>(undefined);
   const configurationMachine = useConfigurationMachineService();
-
-  const handleBackPress = () => {
-    configurationMachine.send({ type: "BACK" });
-  };
 
   const isLoading = useSelector(configurationMachine, isLoadingSelector);
 
@@ -112,6 +41,7 @@ const InstrumentsEnrollmentScreen = () => {
     configurationMachine,
     selectorPagoPAIntruments
   );
+
   const idPayInstrumentsByIdWallet = useSelector(
     configurationMachine,
     selectorIDPayInstrumentsByIdWallet
@@ -125,22 +55,14 @@ const InstrumentsEnrollmentScreen = () => {
   const hasSelectedInstruments =
     Object.keys(idPayInstrumentsByIdWallet).length > 0;
 
-  const sendAddInstrument = (): void => {
-    configurationMachine.send("ADD_INSTRUMENT", {
-      walletId: selectedCardRef.current
-    });
+  const handleBackPress = () => {
+    configurationMachine.send({ type: "BACK" });
   };
 
   const handleContinueButton = () => {
     configurationMachine.send({
       type: "NEXT"
     });
-  };
-
-  const onSwitchHandler = (idWallet: number | undefined) => {
-    // eslint-disable-next-line functional/immutable-data
-    selectedCardRef.current = idWallet;
-    present();
   };
 
   React.useEffect(() => {
@@ -153,101 +75,60 @@ const InstrumentsEnrollmentScreen = () => {
     }
   }, [configurationMachine, initiativeId]);
 
-  const { present, bottomSheet, dismiss } = useIOBottomSheetModal(
-    <Body>
-      {I18n.t("idpay.initiative.configuration.bottomSheet.bodyFirst")}
-      <Body weight="SemiBold">
-        {I18n.t("idpay.initiative.configuration.bottomSheet.bodyBold") + "\n"}
-      </Body>
-      {I18n.t("idpay.initiative.configuration.bottomSheet.bodyLast")}
-    </Body>,
-
-    I18n.t("idpay.initiative.configuration.bottomSheet.header"),
-    270,
-
-    <FooterWithButtons
-      type="TwoButtonsInlineThird"
-      rightButton={{
-        onPress: () => {
-          sendAddInstrument();
-          dismiss();
-        },
-        block: true,
-        bordered: false,
-        title: I18n.t(
-          "idpay.initiative.configuration.bottomSheet.footer.buttonActivate"
-        )
-      }}
-      leftButton={{
-        onPress: () => dismiss(),
-        block: true,
-        bordered: true,
-        title: I18n.t(
-          "idpay.initiative.configuration.bottomSheet.footer.buttonCancel"
-        )
-      }}
-    />
-  );
-
   return (
-    <>
-      <BaseScreenComponent
-        goBack={handleBackPress}
-        headerTitle={I18n.t("idpay.configuration.headerTitle")}
-      >
-        <LoadingSpinnerOverlay isLoading={isLoading} loadingOpacity={1}>
+    <BaseScreenComponent
+      goBack={handleBackPress}
+      headerTitle={I18n.t("idpay.configuration.headerTitle")}
+    >
+      <LoadingSpinnerOverlay isLoading={isLoading} loadingOpacity={1}>
+        <View spacer />
+        <View style={[IOStyles.flex, IOStyles.horizontalContentPadding]}>
+          <H1>{I18n.t("idpay.initiative.configuration.header")}</H1>
+          <View spacer small />
+          <Text>
+            {I18n.t("idpay.initiative.configuration.subHeader", {
+              initiativeName: "18app"
+            })}
+          </Text>
           <View spacer />
-          <View style={[IOStyles.flex, IOStyles.horizontalContentPadding]}>
-            <H1>{I18n.t("idpay.initiative.configuration.header")}</H1>
-            <View spacer small />
-            <Text>
-              {I18n.t("idpay.initiative.configuration.subHeader", {
-                initiativeName: "18app"
-              })}
-            </Text>
-            <View spacer />
-            <ScrollView>
-              <List>
-                {pagoPAInstruments.map(pagoPAInstrument => (
-                  <InstrumentEnrollmentSwitcher
-                    key={pagoPAInstrument.idWallet}
-                    instrument={pagoPAInstrument}
-                    idPayStatus={
-                      idPayInstrumentsByIdWallet[pagoPAInstrument.idWallet]
-                        ?.status
-                    }
-                    onSwitch={onSwitchHandler}
-                    isDisabled={isUpserting}
-                  />
-                ))}
-              </List>
-              <Text>{I18n.t("idpay.initiative.configuration.footer")}</Text>
-            </ScrollView>
-          </View>
-          <SafeAreaView>
-            <FooterWithButtons
-              type="TwoButtonsInlineHalf"
-              leftButton={{
-                title: I18n.t(
-                  "idpay.initiative.configuration.buttonFooter.noneCta"
-                ),
-                bordered: true,
-                disabled: true
-              }}
-              rightButton={{
-                title: I18n.t(
-                  "idpay.initiative.configuration.buttonFooter.continueCta"
-                ),
-                disabled: isUpserting || !hasSelectedInstruments,
-                onPress: handleContinueButton
-              }}
-            />
-          </SafeAreaView>
-        </LoadingSpinnerOverlay>
-      </BaseScreenComponent>
-
-      {bottomSheet}
-    </>
+          <ScrollView>
+            <List>
+              {pagoPAInstruments.map(pagoPAInstrument => (
+                <InstrumentEnrollmentSwitch
+                  key={pagoPAInstrument.idWallet}
+                  instrument={pagoPAInstrument}
+                  status={
+                    idPayInstrumentsByIdWallet[pagoPAInstrument.idWallet]
+                      ?.status
+                  }
+                  isDisabled={isUpserting}
+                />
+              ))}
+            </List>
+            <Text>{I18n.t("idpay.initiative.configuration.footer")}</Text>
+          </ScrollView>
+        </View>
+        <SafeAreaView>
+          <FooterWithButtons
+            type="TwoButtonsInlineHalf"
+            leftButton={{
+              title: I18n.t(
+                "idpay.initiative.configuration.buttonFooter.noneCta"
+              ),
+              bordered: true,
+              disabled: true
+            }}
+            rightButton={{
+              title: I18n.t(
+                "idpay.initiative.configuration.buttonFooter.continueCta"
+              ),
+              disabled: isUpserting || !hasSelectedInstruments,
+              onPress: handleContinueButton
+            }}
+          />
+        </SafeAreaView>
+      </LoadingSpinnerOverlay>
+    </BaseScreenComponent>
   );
 };
 export type { InstrumentsEnrollmentScreenRouteParams };

--- a/ts/features/idpay/initiative/configuration/screens/InstrumentsEnrollmentScreen.tsx
+++ b/ts/features/idpay/initiative/configuration/screens/InstrumentsEnrollmentScreen.tsx
@@ -96,10 +96,9 @@ const InstrumentsEnrollmentScreen = () => {
               {pagoPAInstruments.map(pagoPAInstrument => (
                 <InstrumentEnrollmentSwitch
                   key={pagoPAInstrument.idWallet}
-                  instrument={pagoPAInstrument}
-                  status={
+                  wallet={pagoPAInstrument}
+                  instrument={
                     idPayInstrumentsByIdWallet[pagoPAInstrument.idWallet]
-                      ?.status
                   }
                   isDisabled={isUpserting}
                 />

--- a/ts/features/idpay/initiative/configuration/screens/InstrumentsEnrollmentScreen.tsx
+++ b/ts/features/idpay/initiative/configuration/screens/InstrumentsEnrollmentScreen.tsx
@@ -65,6 +65,18 @@ const InstrumentsEnrollmentScreen = () => {
     });
   };
 
+  const sendEnrollInstrument = (idWallet: number): void => {
+    configurationMachine.send("ENROLL_INSTRUMENT", {
+      instrumentId: idWallet
+    });
+  };
+
+  const sendDeleteInstrument = (instrumentId: string): void => {
+    configurationMachine.send("DELETE_INSTRUMENT", {
+      instrumentId
+    });
+  };
+
   React.useEffect(() => {
     if (initiativeId) {
       configurationMachine.send({
@@ -101,6 +113,8 @@ const InstrumentsEnrollmentScreen = () => {
                     idPayInstrumentsByIdWallet[pagoPAInstrument.idWallet]
                   }
                   isDisabled={isUpserting}
+                  onEnrollInstrument={sendEnrollInstrument}
+                  onDeleteInstrument={sendDeleteInstrument}
                 />
               ))}
             </List>

--- a/ts/features/idpay/initiative/configuration/xstate/events.ts
+++ b/ts/features/idpay/initiative/configuration/xstate/events.ts
@@ -7,9 +7,14 @@ type E_START_CONFIGURATION = {
   mode: ConfigurationMode;
 };
 
-type E_ADD_INSTRUMENT = {
-  type: "ADD_INSTRUMENT";
-  walletId: string;
+type E_ENROLL_INSTRUMENT = {
+  type: "ENROLL_INSTRUMENT";
+  instrumentId: string;
+};
+
+type E_DELETE_INSTRUMENT = {
+  type: "DELETE_INSTRUMENT";
+  instrumentId: string;
 };
 
 type E_NEW_IBAN_ONBOARDING = {
@@ -47,7 +52,8 @@ type E_QUIT = {
 
 export type Events =
   | E_START_CONFIGURATION
-  | E_ADD_INSTRUMENT
+  | E_ENROLL_INSTRUMENT
+  | E_DELETE_INSTRUMENT
   | E_NEW_IBAN_ONBOARDING
   | E_CONFIRM_IBAN
   | E_ENROLL_IBAN

--- a/ts/features/idpay/initiative/configuration/xstate/machine.ts
+++ b/ts/features/idpay/initiative/configuration/xstate/machine.ts
@@ -281,6 +281,10 @@ const createIDPayInitiativeConfigurationMachine = () =>
                 onDone: {
                   target: "DISPLAYING_INSTRUMENTS",
                   actions: "enrollInstrumentSuccess"
+                },
+                onError: {
+                  target: "DISPLAYING_INSTRUMENTS",
+                  actions: "enrollInstrumentFailure"
                 }
               }
             },
@@ -292,6 +296,10 @@ const createIDPayInitiativeConfigurationMachine = () =>
                 onDone: {
                   target: "DISPLAYING_INSTRUMENTS",
                   actions: "deleteInstrumentSuccess"
+                },
+                onError: {
+                  target: "DISPLAYING_INSTRUMENTS",
+                  actions: "deleteInstrumentFailure"
                 }
               }
             },

--- a/ts/features/idpay/initiative/configuration/xstate/machine.ts
+++ b/ts/features/idpay/initiative/configuration/xstate/machine.ts
@@ -283,8 +283,7 @@ const createIDPayInitiativeConfigurationMachine = () =>
                   actions: "enrollInstrumentSuccess"
                 },
                 onError: {
-                  target: "DISPLAYING_INSTRUMENTS",
-                  actions: "enrollInstrumentFailure"
+                  target: "DISPLAYING_INSTRUMENTS"
                 }
               }
             },
@@ -298,8 +297,7 @@ const createIDPayInitiativeConfigurationMachine = () =>
                   actions: "deleteInstrumentSuccess"
                 },
                 onError: {
-                  target: "DISPLAYING_INSTRUMENTS",
-                  actions: "deleteInstrumentFailure"
+                  target: "DISPLAYING_INSTRUMENTS"
                 }
               }
             },

--- a/ts/features/idpay/initiative/configuration/xstate/selectors.ts
+++ b/ts/features/idpay/initiative/configuration/xstate/selectors.ts
@@ -30,7 +30,8 @@ const selectIsLoadingInstruments = (state: StateWithContext) =>
   state.matches("CONFIGURING_INSTRUMENTS.LOADING_INSTRUMENTS");
 
 const selectIsUpsertingInstrument = (state: StateWithContext) =>
-  state.matches("CONFIGURING_INSTRUMENTS.ADDING_INSTRUMENT");
+  state.matches("CONFIGURING_INSTRUMENTS.ENROLLING_INSTRUMENT") ||
+  state.matches("CONFIGURING_INSTRUMENTS.DELETING_INSTRUMENT");
 
 const selectPagoPAInstruments = (state: StateWithContext) =>
   state.context.pagoPAInstruments;

--- a/ts/features/idpay/initiative/configuration/xstate/services.ts
+++ b/ts/features/idpay/initiative/configuration/xstate/services.ts
@@ -198,7 +198,7 @@ const createServicesImplementation = (
     }
   };
 
-  const addInstrument = async (context: Context) => {
+  const enrollInstrument = async (context: Context) => {
     if (context.initiativeId === undefined) {
       return Promise.reject("initiativeId is undefined");
     }
@@ -222,7 +222,35 @@ const createServicesImplementation = (
       return Promise.reject("error enrolling instruments");
     }
 
-    // After updating the list of instruments, we need to reload the list of enrloled instruments
+    // After updating the list of instruments, we need to reload the list of enrolled instruments
+    return loadIDPayInstruments(context.initiativeId);
+  };
+
+  const deleteInstrument = async (context: Context) => {
+    if (context.initiativeId === undefined) {
+      return Promise.reject("initiativeId is undefined");
+    }
+
+    if (context.selectedInstrumentId === undefined) {
+      return Promise.reject("selectedInstrumentId is undefined");
+    }
+
+    const response = await walletClient.deleteInstrument({
+      initiativeId: context.initiativeId,
+      instrumentId: context.selectedInstrumentId,
+      bearerAuth: bearerToken,
+      "Accept-Language": language
+    });
+
+    if (E.isLeft(response)) {
+      return Promise.reject("error deleting instrument");
+    }
+
+    if (response.right.status !== 200) {
+      return Promise.reject("error deleting instrument");
+    }
+
+    // After updating the list of instruments, we need to reload the list of enrolled instruments
     return loadIDPayInstruments(context.initiativeId);
   };
 
@@ -232,7 +260,8 @@ const createServicesImplementation = (
     enrollIban,
     confirmIban,
     loadInstruments,
-    addInstrument
+    enrollInstrument,
+    deleteInstrument
   };
 };
 


### PR DESCRIPTION
## Short description
This PR adds the ability to remove enrolled payment instruments from an initiative.

https://user-images.githubusercontent.com/6160324/211323521-eb52abc3-ee89-49f9-9bb4-48ca579f95ca.mp4


## List of changes proposed in this pull request
- Added events and handlers to the XState machine
- Refactoring of `InstrumentEnrollmentSwitch` in order to support the cancel method

## How to test
Open the details of an initiative and go to the payment instrument configuration screen. Try to add and remove instruments using the switches in the list.
