### PR TITLE
[IAI-258] Add SVG pictograms to transaction error screens

### DIFF
--- a/ts/components/InfoAltScreenComponent/InfoAltScreenComponent.tsx
+++ b/ts/components/InfoAltScreenComponent/InfoAltScreenComponent.tsx
@@ -1,0 +1,73 @@
+import { NavigationEvents } from "@react-navigation/compat";
+import { View as NBView } from "native-base";
+import * as React from "react";
+import { StyleSheet, Text, View } from "react-native";
+import themeVariables from "../../theme/variables";
+import { setAccessibilityFocus } from "../../utils/accessibility";
+import { IOPictogramType, Pictogram } from "../core/pictograms";
+import { Body } from "../core/typography/Body";
+import { H2 } from "../core/typography/H2";
+
+type Props = {
+  image: IOPictogramType;
+  title: string;
+  body?: string | React.ReactNode;
+};
+
+const styles = StyleSheet.create({
+  main: {
+    padding: themeVariables.contentPadding,
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center"
+  },
+  textAlignCenter: {
+    textAlign: "center"
+  }
+});
+
+const renderNode = (body: string | React.ReactNode) => {
+  if (typeof body === "string") {
+    return (
+      <Body testID="InfoAltScreenBody" style={styles.textAlignCenter}>
+        {body}
+      </Body>
+    );
+  }
+
+  return body;
+};
+
+/**
+ * A base screen that displays one illustration (through the Pictogram component),
+ * text, and one bottom button. It's an alternative to the InfoScreenComponent
+ * that accepts a generic raster image.
+ *
+ * @param props
+ * @constructor
+ */
+export const InfoAltScreenComponent = ({ image, title, body }: Props) => {
+  const elementRef = React.createRef<Text>();
+
+  return (
+    <View style={styles.main} testID="InfoAltScreenComponent">
+      <NavigationEvents onWillFocus={() => setAccessibilityFocus(elementRef)} />
+      <Pictogram name={image} />
+      <NBView spacer={true} large={true} />
+      <H2
+        testID="infoScreenTitle"
+        accessible
+        ref={elementRef}
+        style={styles.textAlignCenter}
+      >
+        {title}
+      </H2>
+      {body && (
+        <React.Fragment>
+          <NBView spacer={true} />
+          {renderNode(body)}
+        </React.Fragment>
+      )}
+    </View>
+  );
+};

--- a/ts/components/infoScreen/InfoScreenComponent.tsx
+++ b/ts/components/infoScreen/InfoScreenComponent.tsx
@@ -1,7 +1,7 @@
 import { NavigationEvents } from "@react-navigation/compat";
-import { View } from "native-base";
+import { View as NBView } from "native-base";
 import * as React from "react";
-import { StyleSheet, Text } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
 import themeVariables from "../../theme/variables";
 import { setAccessibilityFocus } from "../../utils/accessibility";
 import { Body } from "../core/typography/Body";
@@ -50,7 +50,7 @@ export const InfoScreenComponent: React.FunctionComponent<Props> = props => {
     <View style={styles.main} testID="InfoScreenComponent">
       <NavigationEvents onWillFocus={() => setAccessibilityFocus(elementRef)} />
       {props.image}
-      <View spacer={true} large={true} />
+      <NBView spacer={true} large={true} />
       <H2
         testID="infoScreenTitle"
         accessible
@@ -59,7 +59,7 @@ export const InfoScreenComponent: React.FunctionComponent<Props> = props => {
       >
         {props.title}
       </H2>
-      <View spacer={true} />
+      <NBView spacer={true} />
       {renderNode(props.body)}
     </View>
   );

--- a/ts/screens/wallet/payment/TransactionErrorScreen.tsx
+++ b/ts/screens/wallet/payment/TransactionErrorScreen.tsx
@@ -10,7 +10,7 @@ import * as t from "io-ts";
 import { View } from "native-base";
 import * as React from "react";
 import { ComponentProps } from "react";
-import { Image, ImageSourcePropType, SafeAreaView } from "react-native";
+import { SafeAreaView } from "react-native";
 import { connect } from "react-redux";
 import { Detail_v2Enum } from "../../../../definitions/backend/PaymentProblemJson";
 import { ToolEnum } from "../../../../definitions/content/AssistanceToolConfig";
@@ -18,7 +18,6 @@ import { ZendeskCategory } from "../../../../definitions/content/ZendeskCategory
 import CopyButtonComponent from "../../../components/CopyButtonComponent";
 import { H4 } from "../../../components/core/typography/H4";
 import { IOStyles } from "../../../components/core/variables/IOStyles";
-import { InfoScreenComponent } from "../../../components/infoScreen/InfoScreenComponent";
 import BaseScreenComponent from "../../../components/screens/BaseScreenComponent";
 import {
   cancelButtonProps,
@@ -64,6 +63,8 @@ import {
   zendeskCategoryId,
   zendeskPaymentCategory
 } from "../../../utils/supportAssistance";
+import { IOPictogramType } from "../../../components/core/pictograms/Pictogram";
+import { InfoAltScreenComponent } from "../../../components/InfoAltScreenComponent/InfoAltScreenComponent";
 
 export type TransactionErrorScreenNavigationParams = {
   error: O.Option<
@@ -86,17 +87,15 @@ type Props = OwnProps &
   ReturnType<typeof mapStateToProps> &
   ReturnType<typeof mapDispatchToProps>;
 
-const baseIconPath = "../../../../img/";
-
-const imageMapping: Record<ErrorTypes, ImageSourcePropType> = {
-  DATA: require(baseIconPath + "pictograms/doubt.png"),
-  DUPLICATED: require(baseIconPath + "pictograms/fireworks.png"),
-  EC: require(baseIconPath + "wallet/errors/payment-unavailable-icon.png"),
-  EXPIRED: require(baseIconPath + "servicesStatus/error-detail-icon.png"),
-  ONGOING: require(baseIconPath + "pictograms/hourglass.png"),
-  REVOKED: require(baseIconPath + "servicesStatus/error-detail-icon.png"),
-  UNCOVERED: require(baseIconPath + "/wallet/errors/generic-error-icon.png"),
-  TECHNICAL: require(baseIconPath + "servicesStatus/error-detail-icon.png")
+const imageMapping: Record<ErrorTypes, IOPictogramType> = {
+  DATA: "question",
+  DUPLICATED: "fireworks",
+  EC: "notAvailable",
+  ONGOING: "hourglass",
+  UNCOVERED: "umbrella",
+  REVOKED: "error",
+  EXPIRED: "error",
+  TECHNICAL: "error"
 };
 
 const requestZendeskAssistanceForPaymentFailure = (
@@ -118,7 +117,7 @@ const requestZendeskAssistanceForPaymentFailure = (
   }
 };
 type ScreenUIContents = {
-  image: ImageSourcePropType;
+  image: IOPictogramType;
   title: string;
   subtitle?: React.ReactNode;
   footerButtons?: ComponentProps<typeof FooterStackButton>["buttons"];
@@ -208,8 +207,7 @@ export const errorTransactionUIElements = (
 
   if (errorORUndefined === "PAYMENT_ID_TIMEOUT") {
     return {
-      image: require(baseIconPath +
-        "wallet/errors/missing-payment-id-icon.png"),
+      image: "inProgress",
       title: I18n.t("wallet.errors.MISSING_PAYMENT_ID"),
       footerButtons: [...closeButtonCancel]
     };
@@ -230,9 +228,7 @@ export const errorTransactionUIElements = (
     )
   );
 
-  const image = errorMacro
-    ? imageMapping[errorMacro]
-    : require(baseIconPath + "/wallet/errors/generic-error-icon.png");
+  const image = errorMacro ? imageMapping[errorMacro] : "error";
 
   switch (errorMacro) {
     case "TECHNICAL":
@@ -370,11 +366,7 @@ const TransactionErrorScreen = (props: Props) => {
   return (
     <BaseScreenComponent>
       <SafeAreaView style={IOStyles.flex}>
-        <InfoScreenComponent
-          image={<Image source={image} />}
-          title={title}
-          body={subtitle}
-        />
+        <InfoAltScreenComponent image={image} title={title} body={subtitle} />
         {footerButtons && <FooterStackButton buttons={footerButtons} />}
       </SafeAreaView>
     </BaseScreenComponent>


### PR DESCRIPTION
## Short description
This PR adds SVG pictograms to `TransactionErrorScreen` instead of raster assets (*.png, etc…)

## List of changes proposed in this pull request
- Refactor `TransactionErrorScreen` to accept `IOPictogramType`
- Add the new `InfoAltScreenComponent` that accepts `IOPictogramType` as `image` prop

## How to test
N/A