### PR TITLE
chore: [IAI-259] Remove width limit applied to the text in the Services' metadata

### DIFF
--- a/ts/components/services/ServiceMetadata/InformationRow.tsx
+++ b/ts/components/services/ServiceMetadata/InformationRow.tsx
@@ -13,13 +13,12 @@ const styles = StyleSheet.create({
     flexDirection: "column"
   },
   touchable: {
+    display: "flex",
     flexDirection: "row",
-    marginVertical: 24
+    marginVertical: 16
   },
-  label: {
-    flex: 1
-  },
-  alignToRight: {
+  value: {
+    flexGrow: 1,
     textAlign: "right"
   }
 });
@@ -28,6 +27,7 @@ type Props = {
   value: string;
   label: TranslationKeys;
   onPress: () => void;
+  isLast?: boolean;
   accessibilityLabel?: string;
 };
 
@@ -35,6 +35,7 @@ const InformationRow = ({
   value,
   label,
   onPress,
+  isLast,
   accessibilityLabel
 }: Props) => (
   <View style={styles.row}>
@@ -44,19 +45,12 @@ const InformationRow = ({
       accessibilityRole={"button"}
       accessibilityLabel={accessibilityLabel}
     >
-      <H4
-        style={styles.label}
-        ellipsizeMode={"tail"}
-        numberOfLines={1}
-        color={"bluegrey"}
-        weight={"Regular"}
-      >
+      <H4 numberOfLines={1} color={"bluegrey"} weight={"Regular"}>
         {capitalize(I18n.t(label))}
       </H4>
       <NBView hspacer={true} />
       <H4
-        style={[styles.label, styles.alignToRight]}
-        ellipsizeMode={"tail"}
+        style={styles.value}
         numberOfLines={1}
         color={"blue"}
         weight={"SemiBold"}
@@ -64,7 +58,7 @@ const InformationRow = ({
         {value}
       </H4>
     </TouchableDefaultOpacity>
-    <ItemSeparatorComponent noPadded />
+    {!isLast && <ItemSeparatorComponent noPadded />}
   </View>
 );
 

--- a/ts/components/services/ServiceMetadata/InformationRow.tsx
+++ b/ts/components/services/ServiceMetadata/InformationRow.tsx
@@ -9,16 +9,13 @@ import TouchableDefaultOpacity from "../../TouchableDefaultOpacity";
 import ItemSeparatorComponent from "../../ItemSeparatorComponent";
 
 const styles = StyleSheet.create({
-  row: {
-    flexDirection: "column"
-  },
   touchable: {
-    display: "flex",
     flexDirection: "row",
     marginVertical: 16
   },
   value: {
     flexGrow: 1,
+    flexShrink: 1,
     textAlign: "right"
   }
 });
@@ -38,7 +35,7 @@ const InformationRow = ({
   isLast,
   accessibilityLabel
 }: Props) => (
-  <View style={styles.row}>
+  <View>
     <TouchableDefaultOpacity
       onPress={onPress}
       style={styles.touchable}
@@ -52,6 +49,7 @@ const InformationRow = ({
       <H4
         style={styles.value}
         numberOfLines={1}
+        ellipsizeMode="tail"
         color={"blue"}
         weight={"SemiBold"}
       >

--- a/ts/components/services/ServiceMetadata/__tests__/__snapshots__/InformationRow.test.tsx.snap
+++ b/ts/components/services/ServiceMetadata/__tests__/__snapshots__/InformationRow.test.tsx.snap
@@ -1,13 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`the InformationRow component should match the snapshot 1`] = `
-<View
-  style={
-    Object {
-      "flexDirection": "column",
-    }
-  }
->
+<View>
   <View
     accessibilityLabel="Label"
     accessibilityRole="button"
@@ -24,14 +18,13 @@ exports[`the InformationRow component should match the snapshot 1`] = `
     style={
       Object {
         "flexDirection": "row",
-        "marginVertical": 24,
+        "marginVertical": 16,
         "opacity": 1,
       }
     }
   >
     <Text
       color="bluegrey"
-      ellipsizeMode="tail"
       font="TitilliumWeb"
       fontStyle={
         Object {
@@ -42,9 +35,6 @@ exports[`the InformationRow component should match the snapshot 1`] = `
       numberOfLines={1}
       style={
         Array [
-          Object {
-            "flex": 1,
-          },
           Object {
             "fontSize": 16,
             "lineHeight": 22,
@@ -79,14 +69,11 @@ exports[`the InformationRow component should match the snapshot 1`] = `
       numberOfLines={1}
       style={
         Array [
-          Array [
-            Object {
-              "flex": 1,
-            },
-            Object {
-              "textAlign": "right",
-            },
-          ],
+          Object {
+            "flexGrow": 1,
+            "flexShrink": 1,
+            "textAlign": "right",
+          },
           Object {
             "fontSize": 16,
             "lineHeight": 22,

--- a/ts/components/services/ServiceMetadata/index.tsx
+++ b/ts/components/services/ServiceMetadata/index.tsx
@@ -129,6 +129,7 @@ const ServiceMetadataComponent: React.FC<Props> = ({
             pec,
             I18n.t("messageDetails.sendEmail")
           )}
+          isLast
         />
       )}
       {isDebugModeEnabled && serviceId && (

--- a/ts/screens/services/ServiceDetailsScreen.tsx
+++ b/ts/screens/services/ServiceDetailsScreen.tsx
@@ -154,8 +154,6 @@ const ServiceDetailsScreen = (props: Props) => {
               />
 
               <EdgeBorderComponent />
-
-              <View spacer={true} extralarge={true} />
             </>
           )}
         </Content>


### PR DESCRIPTION
## Short description
This PR improves the text behaviour in the ServiceDetail's metadata section, removing the width limit set to 50%, applied to the keys/values. It doesn't change the default single line behaviour.

### Preview
| Before | After
| - | - |
| <img src="https://user-images.githubusercontent.com/1255491/211326019-799fd4b8-513a-4910-a0ff-9e9243ff84f7.png" width="350" /> | <img src="https://user-images.githubusercontent.com/1255491/211326072-1196454a-9ad7-4aac-94d3-9cffeaee8e28.png" width="350" />

## List of changes proposed in this pull request
- Remove flex properties that introduced that width limit
- Decrease the vertical margin because it was huge