### PR TITLE
chore: [IOAPPFD0-21] Remove nesting between ScrollView and FlatList on Idp selection screen

### DIFF
--- a/ts/components/IdpsGrid.tsx
+++ b/ts/components/IdpsGrid.tsx
@@ -3,7 +3,14 @@
  * array property. When an Identity Provider is selected a callback function is called.
  */
 import * as React from "react";
-import { FlatList, Image, ListRenderItemInfo, StyleSheet } from "react-native";
+import {
+  FlatList,
+  Image,
+  ListRenderItemInfo,
+  StyleProp,
+  StyleSheet,
+  ViewStyle
+} from "react-native";
 
 import { Button } from "native-base";
 import { connect } from "react-redux";
@@ -14,6 +21,11 @@ import { LocalIdpsFallback } from "../utils/idps";
 import ButtonDefaultOpacity from "./ButtonDefaultOpacity";
 
 type OwnProps = {
+  columnWrapperStyle?: StyleProp<ViewStyle>;
+  contentContainerStyle?: StyleProp<ViewStyle>;
+  footerComponent?: React.ReactNode;
+  headerComponentStyle?: StyleProp<ViewStyle>;
+  headerComponent?: React.ReactNode;
   // Array of Identity Provider to show in the grid.
   idps: ReadonlyArray<LocalIdpsFallback>;
   // A callback function called when an Identity Provider is selected
@@ -89,6 +101,11 @@ const IdpsGrid: React.FunctionComponent<Props> = (props: Props) => (
     numColumns={2}
     keyExtractor={keyExtractor}
     renderItem={renderItem(props)}
+    columnWrapperStyle={props.columnWrapperStyle}
+    contentContainerStyle={props.contentContainerStyle}
+    ListHeaderComponentStyle={props.headerComponentStyle}
+    ListHeaderComponent={props.headerComponent}
+    ListFooterComponent={props.footerComponent}
   />
 );
 

--- a/ts/screens/authentication/IdpSelectionScreen.tsx
+++ b/ts/screens/authentication/IdpSelectionScreen.tsx
@@ -1,7 +1,7 @@
-import { Content, Text as NBText, View } from "native-base";
+import { Text as NBText } from "native-base";
 import * as React from "react";
 import { useNavigation } from "@react-navigation/native";
-import { StyleSheet } from "react-native";
+import { StyleSheet, View } from "react-native";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { useEffect, useState } from "react";
@@ -39,9 +39,26 @@ const TAPS_TO_OPEN_TESTIDP = 5;
 
 const styles = StyleSheet.create({
   gridContainer: {
-    padding: variables.contentPadding,
-    flex: 1,
+    flex: 1
+  },
+  footerAdviceContainer: {
+    backgroundColor: IOColors.white,
+    paddingHorizontal: variables.contentPadding,
+    paddingVertical: variables.spacerExtralargeHeight,
+    marginTop: variables.contentPadding
+  },
+  footerCancelButton: {
+    marginTop: variables.spacerHeight,
+    marginHorizontal: variables.contentPadding
+  },
+  ipdsGridColumnStyle: {
+    paddingHorizontal: variables.contentPadding
+  },
+  ipdsGridContentContainerStyle: {
     backgroundColor: IOColors.greyUltraLight
+  },
+  ipdsGridHeaderComponentStyle: {
+    marginTop: variables.contentPadding
   }
 });
 
@@ -93,6 +110,28 @@ const IdpSelectionScreen = (props: Props): React.ReactElement => {
     }
   }, [counter, setSelectedIdp, navigation]);
 
+  const headerComponent = () => <View />;
+
+  const footerComponent = () => (
+    <View>
+      <ButtonDefaultOpacity
+        block={true}
+        light={true}
+        bordered={true}
+        onPress={navigation.goBack}
+        style={styles.footerCancelButton}
+      >
+        <NBText>{I18n.t("global.buttons.cancel")}</NBText>
+      </ButtonDefaultOpacity>
+      <View style={styles.footerAdviceContainer}>
+        <AdviceComponent
+          text={I18n.t("login.expiration_info")}
+          iconColor={"black"}
+        />
+      </View>
+    </View>
+  );
+
   return (
     <BaseScreenComponent
       contextualHelpMarkdown={contextualHelpMarkdown}
@@ -101,34 +140,20 @@ const IdpSelectionScreen = (props: Props): React.ReactElement => {
       headerTitle={I18n.t("authentication.idp_selection.headerTitle")}
     >
       <LoadingSpinnerOverlay isLoading={props.isIdpsLoading}>
-        <Content noPadded={true} overScrollMode={"never"} bounces={false}>
-          <ScreenContentHeader
-            title={I18n.t("authentication.idp_selection.contentTitle")}
+        <ScreenContentHeader
+          title={I18n.t("authentication.idp_selection.contentTitle")}
+        />
+        <View style={styles.gridContainer}>
+          <IdpsGrid
+            idps={[...props.idps, testIdp]}
+            onIdpSelected={onIdpSelected}
+            columnWrapperStyle={styles.ipdsGridColumnStyle}
+            contentContainerStyle={styles.ipdsGridContentContainerStyle}
+            headerComponent={headerComponent}
+            headerComponentStyle={styles.ipdsGridHeaderComponentStyle}
+            footerComponent={footerComponent}
           />
-          <View style={styles.gridContainer} testID={"idps-view"}>
-            <IdpsGrid
-              idps={[...props.idps, testIdp]}
-              onIdpSelected={onIdpSelected}
-            />
-
-            <View spacer={true} />
-            <ButtonDefaultOpacity
-              block={true}
-              light={true}
-              bordered={true}
-              onPress={navigation.goBack}
-            >
-              <NBText>{I18n.t("global.buttons.cancel")}</NBText>
-            </ButtonDefaultOpacity>
-          </View>
-          <View style={{ padding: variables.contentPadding }}>
-            <View spacer={true} />
-            <AdviceComponent
-              text={I18n.t("login.expiration_info")}
-              iconColor={"black"}
-            />
-          </View>
-        </Content>
+        </View>
       </LoadingSpinnerOverlay>
     </BaseScreenComponent>
   );


### PR DESCRIPTION
## Short description
This PR removes a nesting between a ScrollView and a FlatList on the Idp selection screen (which caused a silent error)

## List of changes proposed in this pull request
- `Content` component (native base) has been replaced with a `View` (react native) in `ts/screens/authentication/IdpSelectionScreen.tsc` and all the scrolling has been delegated to the `FlatList` component.
- To preserve the same UI and UX, all previous views below the `IdpsGrid` have been grouped in a Flat List Footer (and Header) given (with styles) to the `IdpsGrid` component

## How to test
Start the application from scratch and check that the UI and UX of the Idp selection view is the same as before on different devices (see attached screenshots): check on different display size like 3.6", 4.0", 5.0"+ and/or on different OSs (_e.g._, iPhone 6s and iPhone 13/14, Nexus 5, ...). 

Make sure that no error like below appears in the console (when transitioning from login to idp selection screen):

` ERROR  VirtualizedLists should never be nested inside plain ScrollViews with the same orientation because it can break windowing and other functionality - use another VirtualizedList-backed container instead. `

iPhone 6s
![iPhone6s](https://user-images.githubusercontent.com/5150343/211365441-0ba24a5a-ab8c-4c86-b62e-bc84023e5248.png)

iPhone 13/14
<img width="433" alt="iPhone14" src="https://user-images.githubusercontent.com/5150343/211365465-a95363e1-5863-42c7-a1a1-89dddb3d54be.png">

Moto X 2013
![MotoX2013](https://user-images.githubusercontent.com/5150343/211365509-b03df402-68eb-4535-a0b6-a8a5d338e071.png)

Pixel 5
<img width="414" alt="Pixel5" src="https://user-images.githubusercontent.com/5150343/211365545-37cc9247-f8ce-4e88-be9f-abb44fda2557.png">
