### PR TITLE
chore(IDPay): Enable/disable all IDPay routes based on IDPAY_ENABLED feature flag

### DIFF
--- a/ts/navigation/AppStackNavigator.tsx
+++ b/ts/navigation/AppStackNavigator.tsx
@@ -19,7 +19,8 @@ import {
   bpdOptInPaymentMethodsEnabled,
   fimsEnabled,
   myPortalEnabled,
-  svEnabled
+  svEnabled,
+  idPayEnabled
 } from "../config";
 import BPD_ROUTES from "../features/bonus/bpd/navigation/routes";
 import { CdcStackNavigator } from "../features/bonus/cdc/navigation/CdcStackNavigator";
@@ -170,19 +171,22 @@ export const AppStackNavigator = () => {
         <Stack.Screen name={FCI_ROUTES.MAIN} component={FciStackNavigator} />
       )}
 
-      <Stack.Screen
-        name={IDPayOnboardingRoutes.IDPAY_ONBOARDING_MAIN}
-        component={IDPayOnboardingNavigator}
-      />
-      <Stack.Screen
-        name={ROUTES.IDPAY_INITIATIVE_DETAILS}
-        component={InitiativeDetailsScreen}
-      />
-
-      <Stack.Screen
-        name={IDPayConfigurationRoutes.IDPAY_CONFIGURATION_MAIN}
-        component={IDPayConfigurationNavigator}
-      />
+      {idPayEnabled && (
+        <>
+          <Stack.Screen
+            name={IDPayOnboardingRoutes.IDPAY_ONBOARDING_MAIN}
+            component={IDPayOnboardingNavigator}
+          />
+          <Stack.Screen
+            name={ROUTES.IDPAY_INITIATIVE_DETAILS}
+            component={InitiativeDetailsScreen}
+          />
+          <Stack.Screen
+            name={IDPayConfigurationRoutes.IDPAY_CONFIGURATION_MAIN}
+            component={IDPayConfigurationNavigator}
+          />
+        </>
+      )}
     </Stack.Navigator>
   );
 };


### PR DESCRIPTION
## Short description
This PR adds the `idPayEnabled` feature flag in the `AppStackNavigator` to  enable/disable all IDPay routes.
`idPayEnabled` is a flag loaded from `IDPAY_ENABLED` in the `.env` file.

## List of changes proposed in this pull request
N/A

## How to test
N/A
