### PR TITLE
chore: [IAI-262] Add `onDismiss` handler parameter to `useIOBottomSheetModal`

### DIFF
--- a/ts/utils/hooks/bottomSheet.tsx
+++ b/ts/utils/hooks/bottomSheet.tsx
@@ -88,6 +88,7 @@ export const bottomSheetContent = (
  * @param title
  * @param snapPoint
  * @param footer
+ * @param onDismiss callback to be called when the bottom sheet is dismissed
  */
 export const useIOBottomSheetModal = (
   component: React.ReactNode,

--- a/ts/utils/hooks/bottomSheet.tsx
+++ b/ts/utils/hooks/bottomSheet.tsx
@@ -93,7 +93,8 @@ export const useIOBottomSheetModal = (
   component: React.ReactNode,
   title: string | React.ReactNode,
   snapPoint: number,
-  footer?: React.ReactElement
+  footer?: React.ReactElement,
+  onDismiss?: () => void
 ): IOBottomSheetModal => {
   const { dismissAll } = useBottomSheetModal();
   const bottomSheetModalRef = React.useRef<BottomSheetModal>(null);
@@ -141,6 +142,7 @@ export const useIOBottomSheetModal = (
         accessible: false
       }}
       importantForAccessibility={"yes"}
+      onDismiss={onDismiss}
     >
       {screenReaderEnabled && Platform.OS === "android" ? (
         <Modal>


### PR DESCRIPTION
## Short description
This PR adds the ability to catch dismiss event on an bottom sheet presented by the `useIOBottomSheetModal` hook.

## List of changes proposed in this pull request
- Added optional `onDismiss` parameter to `useIOBottomSheetModal`

## How to test
Pass an handler to a bottom sheet and check if it is triggered when the bottom sheet closes
