### PR TITLE
feat: [IABT-1417,IOAPPCIT-35,IOAPPCIT-36] Added password autofill feature to ios devices

### DIFF
--- a/ios/ItaliaApp-Bridging-Header.h
+++ b/ios/ItaliaApp-Bridging-Header.h
@@ -2,3 +2,9 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 //
 
+#import "React/RCTBridgeModule.h"
+#import <UIKit/UIKit.h>
+
+@interface secureLogin : NSObject <UIApplicationDelegate, RCTBridgeModule>
+@end
+

--- a/ios/ItaliaApp.xcodeproj/project.pbxproj
+++ b/ios/ItaliaApp.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		9975E38DE95949D28D07A275 /* RobotoMono-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B7088D9B42BA4275A767BEFF /* RobotoMono-Bold.ttf */; };
 		9AA4918716C04270861750C9 /* io-icon-font.ttf in Resources */ = {isa = PBXBuildFile; fileRef = FB6C250A30844C039ED2913E /* io-icon-font.ttf */; };
 		A87A3CD6B126B5D47C610EFC /* libPods-ItaliaApp.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 76292B57C7589DC2DB43BB9F /* libPods-ItaliaApp.a */; };
+		BDE8DCA1297E863700F26850 /* secureLogin.m in Sources */ = {isa = PBXBuildFile; fileRef = BDE8DCA0297E863700F26850 /* secureLogin.m */; };
 		BE1A42156484487BABBC4DED /* TitilliumWeb-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 309BA0207AA24FE9A0EBE61C /* TitilliumWeb-Bold.ttf */; };
 		C2CF038002D24FEEAB41B336 /* RobotoMono-LightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 640E574519CA4183B230AF22 /* RobotoMono-LightItalic.ttf */; };
 		D18E075B28304466B6CA2381 /* TitilliumWeb-LightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B65D221FCB5A461FBC44285D /* TitilliumWeb-LightItalic.ttf */; };
@@ -101,6 +102,7 @@
 		B021D4CC17ED4D54B7944FED /* TitilliumWeb-SemiBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "TitilliumWeb-SemiBold.ttf"; path = "../assets/fonts/TitilliumWeb/TitilliumWeb-SemiBold.ttf"; sourceTree = "<group>"; };
 		B65D221FCB5A461FBC44285D /* TitilliumWeb-LightItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "TitilliumWeb-LightItalic.ttf"; path = "../assets/fonts/TitilliumWeb/TitilliumWeb-LightItalic.ttf"; sourceTree = "<group>"; };
 		B7088D9B42BA4275A767BEFF /* RobotoMono-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "RobotoMono-Bold.ttf"; path = "../assets/fonts/RobotoMono/RobotoMono-Bold.ttf"; sourceTree = "<group>"; };
+		BDE8DCA0297E863700F26850 /* secureLogin.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = secureLogin.m; sourceTree = "<group>"; };
 		C576763326D1F8C31CF3ABC8 /* libPods-ItaliaApp-ItaliaAppTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ItaliaApp-ItaliaAppTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CED8B1FF1E254583BB3F285F /* TitilliumWeb-SemiBoldItalic.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "TitilliumWeb-SemiBoldItalic.ttf"; path = "../assets/fonts/TitilliumWeb/TitilliumWeb-SemiBoldItalic.ttf"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
@@ -173,6 +175,7 @@
 				F09FEB0D231818E3007071DB /* Localizable.strings */,
 				13B07FB71A68108700A75B9A /* main.m */,
 				2AFAC65324C9B7C300E85199 /* ItaliaApp-Bridging-Header.h */,
+				BDE8DCA0297E863700F26850 /* secureLogin.m */,
 			);
 			name = ItaliaApp;
 			sourceTree = "<group>";
@@ -764,6 +767,7 @@
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				BDE8DCA1297E863700F26850 /* secureLogin.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/secureLogin.m
+++ b/ios/secureLogin.m
@@ -1,0 +1,62 @@
+#import <Foundation/Foundation.h>
+#import "ItaliaApp-Bridging-Header.h"
+#import <React/RCTUtils.h>
+#import <React/RCTLog.h>
+#import <AuthenticationServices/ASWebAuthenticationSession.h>
+#import <AuthenticationServices/AuthenticationServices.h>
+
+
+@interface secureLogin() <ASWebAuthenticationPresentationContextProviding>
+
+@property (nonatomic,strong) ASWebAuthenticationSession *authSession;
+@end
+
+@implementation secureLogin
+RCT_EXPORT_MODULE()
+
+- (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession *)session API_AVAILABLE(ios(13.0)){
+  return UIApplication.sharedApplication.keyWindow;
+}
+
+- (dispatch_queue_t)methodQueue
+{
+  return dispatch_get_main_queue();
+}
+
+RCT_EXPORT_METHOD(signIn:(NSURL *)url urlScheme:(NSString *)urlScheme callback:(RCTResponseSenderBlock)callback)
+{
+  if (!url || !urlScheme) {
+    RCTLogError(@"Missing params");
+    return;
+  }
+  if(@available(iOS 13.0, *)){
+   
+    self.authSession =
+    [[ASWebAuthenticationSession alloc] initWithURL:url
+                                  callbackURLScheme: urlScheme
+                                  completionHandler:^(NSURL * _Nullable callbackUrl,
+                                                      NSError * _Nullable error) {
+      self.authSession = nil;
+      if (callbackUrl) {
+        NSString *callbackUrlString = callbackUrl.absoluteString;
+        callback(@[callbackUrlString]);
+      }
+      else {
+        NSString *errorString = error.domain;
+        callback(@[errorString]);
+      }
+    }];
+    
+   
+    self.authSession.prefersEphemeralWebBrowserSession = true;
+    self.authSession.presentationContextProvider = self;
+    [self.authSession start];
+    
+  }else{
+    RCTLogError(@"This iOS version is not supported");
+    return;
+  }
+  
+}
+
+@end

--- a/ts/navigation/params/AuthenticationParamsList.ts
+++ b/ts/navigation/params/AuthenticationParamsList.ts
@@ -1,13 +1,14 @@
 import { CieCardReaderScreenNavigationParams } from "../../screens/authentication/cie/CieCardReaderScreen";
 import { CieConsentDataUsageScreenNavigationParams } from "../../screens/authentication/cie/CieConsentDataUsageScreen";
 import { CieWrongCiePinScreenNavigationParams } from "../../screens/authentication/cie/CieWrongCiePinScreen";
+import { navigationLoginUri } from "../../screens/authentication/IdpSelectionScreen";
 import ROUTES from "../routes";
 
 export type AuthenticationParamsList = {
   [ROUTES.AUTHENTICATION_LANDING]: undefined;
   [ROUTES.AUTHENTICATION_IDP_SELECTION]: undefined;
   [ROUTES.AUTHENTICATION_CIE]: undefined;
-  [ROUTES.AUTHENTICATION_IDP_LOGIN]: undefined;
+  [ROUTES.AUTHENTICATION_IDP_LOGIN]: navigationLoginUri;
   [ROUTES.AUTHENTICATION_IDP_TEST]: undefined;
   [ROUTES.AUTHENTICATION_SPID_INFORMATION]: undefined;
   [ROUTES.AUTHENTICATION_SPID_CIE_INFORMATION]: undefined;

--- a/ts/utils/login.ts
+++ b/ts/utils/login.ts
@@ -40,12 +40,11 @@ export const getIntentFallbackUrl = (intentUrl: string): O.Option<string> => {
 };
 
 // Prefixes for LOGIN SUCCESS/ERROR
-const LOGIN_SUCCESS_PAGE = "profile.html";
-const LOGIN_FAILURE_PAGE = "error.html";
+export const LOGIN_SUCCESS_PAGE = "profile.html";
+export const LOGIN_FAILURE_PAGE = "error.html";
 
 export const extractLoginResult = (url: string): LoginResult | undefined => {
   const urlParse = new URLParse(url, true);
-
   // LOGIN_SUCCESS
   if (urlParse.pathname.includes(LOGIN_SUCCESS_PAGE)) {
     const token = urlParse.query.token;

--- a/ts/utils/navigation.ts
+++ b/ts/utils/navigation.ts
@@ -15,6 +15,7 @@ export const isOnboardingCompleted = () => {
 };
 
 // Prefix to match deeplink uri like `ioit://PROFILE_MAIN`
+export const IO_INTERNAL_LINK = "ioit";
 export const IO_INTERNAL_LINK_PROTOCOL = "ioit:";
 export const IO_INTERNAL_LINK_PREFIX = IO_INTERNAL_LINK_PROTOCOL + "//";
 

--- a/ts/utils/platform.ts
+++ b/ts/utils/platform.ts
@@ -2,3 +2,11 @@ import { Platform } from "react-native";
 
 export const isIos = Platform.OS === "ios";
 export const isAndroid = Platform.OS === "android";
+
+export const getMajorIosVersion = (): number => {
+  if (Platform.OS !== "ios") {
+    throw Error("Platform is not iOS");
+  }
+
+  return parseInt(Platform.Version, 10);
+};


### PR DESCRIPTION
## Short description
Modified login method with a native component, to allow the credentials to be autocompleted for iOS devices ( iOS >=13.0).

## List of changes proposed in this pull request
- [ios/ItaliaApp-Bridging-Header.h, ios/ItaliaApp.xcodeproj/project.pbxproj, ios/secureLogin.m]: added support for ASWebAuthenticationSession native component.
- ts/navigation/params/AuthenticationParamsList.ts: edited AuthenticationParamsList type to allow params for the login route.
- ts/utils/login.ts: exported consts that allow you to understand the result of the login phase.
- ts/utils/platform.ts: added a function to get the ios major version.
- ts/screens/authentication/IdpSelectionScreen.tsx: added native component execution when an idp is selected. This is only supported by iOS devices >=13.0.
- ts/screens/authentication/IdpLoginScreen.tsx: 
        - edited to take the login url (or login response, depending on whether or not the native component was used) as a 
           navigation parameter.
        - modified response screen button in case of login with native component that receives an error.
- ts/utils/navigation.ts: added a const that represent the application urlScheme.

## How to test
First of all, to ensure that the login phase properly works, use a version of the dev server that contains the branch:
[IOAPPCIT-35,36 Update-dev-server-flow-to-support-autocomplete-login](https://github.com/pagopa/io-dev-api-server/tree/IOAPPCIT-35%2C36--Update-dev-server-flow-to-support-autocomplete-login)

- Run android simulator and verify that login (success and error) works correctly in a web view.
- Run iOS simulator with iOS version <13 and verify that login (success and error) works correctly in a web view.
- Run iOS simulator with iOS version >=13 and verify that login (success and error) works correctly through the new native component.