### PR TITLE
feat: [IA-362,IA-367] -- Accessibility doesn't recognise CIE/SPID login button

### DIFF
--- a/ts/screens/authentication/LandingScreen.tsx
+++ b/ts/screens/authentication/LandingScreen.tsx
@@ -268,6 +268,13 @@ class LandingScreen extends React.PureComponent<Props, State> {
                 ? this.navigateToCiePinScreen
                 : this.navigateToIdpSelection
             }
+            accessibilityRole="button"
+            accessible={true}
+            accessibilityLabel={
+              isCieSupported
+                ? I18n.t("authentication.landing.loginCie")
+                : I18n.t("authentication.landing.loginSpid")
+            }
             testID={
               isCieSupported
                 ? "landing-button-login-cie"
@@ -286,6 +293,13 @@ class LandingScreen extends React.PureComponent<Props, State> {
           </ButtonDefaultOpacity>
           <VSpacer size={16} />
           <ButtonDefaultOpacity
+            accessibilityLabel={
+              this.isCieSupported()
+                ? I18n.t("authentication.landing.loginSpid")
+                : I18n.t("authentication.landing.loginCie")
+            }
+            accessibilityRole="button"
+            accessible={true}
             style={secondButtonStyle}
             block={true}
             primary={true}


### PR DESCRIPTION
## Short description
Added the right role to the buttons

## List of changes proposed in this pull request
- ts/screens/authentication/LandingScreen.tsx: added the right role and label to the buttons.

## How to test
iOS:
Run app, VoiceOver, disable CIE support and verify if the login buttons are read properly;
Run app, VoiceOver, enable CIE support and verify if the login buttons are read properly;
Android:
Run app, TalkBack, disable CIE support and verify if the login buttons are read properly;
Run app, TalkBack, enable CIE support and verify if the login buttons are read properly;
