### PR TITLE
feat: [IA-362,IA-369] Accessibility: unlock code forgotten not recognised as button

### DIFF
--- a/ts/components/Pinpad/index.tsx
+++ b/ts/components/Pinpad/index.tsx
@@ -307,6 +307,10 @@ class Pinpad extends React.PureComponent<Props, State> {
               <NBText
                 underlined={true}
                 white={this.props.buttonType === "primary"}
+                accessibilityLabel={I18n.t(
+                  "identification.unlockCode.reset.code"
+                )}
+                accessibilityRole="button"
               >
                 {I18n.t("identification.unlockCode.reset.code")}
               </NBText>


### PR DESCRIPTION
## Short description
Added accessibility info to the component to fix the problem.

## List of changes proposed in this pull request
- ts/components/Pinpad/index.tsx: added accessibility info to the component 

## How to test
Run app, enable VoiceOver (or TalkBack) and verify if the button is properly read.