### PR TITLE
feat: [IA-362,IA-389,IA-344] Added accessibility support to switch components.

### DIFF
--- a/ts/components/core/selection/RemoteSwitch.tsx
+++ b/ts/components/core/selection/RemoteSwitch.tsx
@@ -15,7 +15,10 @@ type Props<E> = {
   value: pot.Pot<boolean, E>;
   onRetry?: () => void;
 } & TestID &
-  Pick<React.ComponentProps<typeof Switch>, "onValueChange">;
+  Pick<
+    React.ComponentProps<typeof Switch>,
+    "onValueChange" | "accessibilityLabel"
+  >;
 
 const iconSize = 24;
 const slop = calculateSlop(iconSize);
@@ -32,7 +35,7 @@ const LoadingVersion = (props: TestID) => (
 
 type SwitchProps = Pick<
   React.ComponentProps<typeof Switch>,
-  "testID" | "value" | "disabled" | "onValueChange"
+  "testID" | "value" | "disabled" | "onValueChange" | "accessibilityLabel"
 >;
 
 const SwitchVersion = (props: SwitchProps) => (
@@ -41,6 +44,7 @@ const SwitchVersion = (props: SwitchProps) => (
     value={props.value}
     disabled={props.disabled}
     onValueChange={props.onValueChange}
+    accessibilityLabel={props.accessibilityLabel}
   />
 );
 
@@ -80,6 +84,7 @@ export const RemoteSwitch = <E, _>(props: Props<E>): React.ReactElement => {
       testID={props.testID}
       value={value}
       onValueChange={props.onValueChange}
+      accessibilityLabel={props.accessibilityLabel}
     />
   );
 

--- a/ts/components/core/selection/__test__/__snapshots__/RemoteSwitch.test.tsx.snap
+++ b/ts/components/core/selection/__test__/__snapshots__/RemoteSwitch.test.tsx.snap
@@ -125,7 +125,6 @@ exports[`RemoteSwitch tests Snapshot for pot.noneUpdating 1`] = `
 
 exports[`RemoteSwitch tests Snapshot for pot.some 1`] = `
 <RCTSwitch
-  accessibilityLabel="Select to activate"
   accessibilityRole="switch"
   accessible={true}
   onChange={[Function]}
@@ -152,7 +151,6 @@ exports[`RemoteSwitch tests Snapshot for pot.some 1`] = `
 
 exports[`RemoteSwitch tests Snapshot for pot.some 2`] = `
 <RCTSwitch
-  accessibilityLabel="Select to activate"
   accessibilityRole="switch"
   accessible={true}
   onChange={[Function]}
@@ -179,7 +177,6 @@ exports[`RemoteSwitch tests Snapshot for pot.some 2`] = `
 
 exports[`RemoteSwitch tests Snapshot for pot.someError 1`] = `
 <RCTSwitch
-  accessibilityLabel="Select to activate"
   accessibilityRole="switch"
   accessible={true}
   onChange={[Function]}
@@ -206,7 +203,6 @@ exports[`RemoteSwitch tests Snapshot for pot.someError 1`] = `
 
 exports[`RemoteSwitch tests Snapshot for pot.someError 2`] = `
 <RCTSwitch
-  accessibilityLabel="Select to activate"
   accessibilityRole="switch"
   accessible={true}
   onChange={[Function]}
@@ -269,7 +265,6 @@ exports[`RemoteSwitch tests Snapshot for pot.someLoading 2`] = `
 
 exports[`RemoteSwitch tests Snapshot for pot.someUpdating 1`] = `
 <RCTSwitch
-  accessibilityLabel="Select to activate"
   accessibilityRole="switch"
   accessible={true}
   disabled={true}
@@ -297,7 +292,6 @@ exports[`RemoteSwitch tests Snapshot for pot.someUpdating 1`] = `
 
 exports[`RemoteSwitch tests Snapshot for pot.someUpdating 2`] = `
 <RCTSwitch
-  accessibilityLabel="Select to activate"
   accessibilityRole="switch"
   accessible={true}
   disabled={true}

--- a/ts/components/services/ContactPreferencesToggles/PreferenceToggleRow.tsx
+++ b/ts/components/services/ContactPreferencesToggles/PreferenceToggleRow.tsx
@@ -17,6 +17,7 @@ type Props = WithTestID<{
   graphicalState: "loading" | "error" | "ready";
   onReload: () => void;
   disabled?: boolean;
+  accessiblityLabel?: string;
 }>;
 
 const styles = StyleSheet.create({
@@ -67,6 +68,7 @@ const PreferenceToggleRow = ({
             disabled={disabled}
             accessibilityRole={"switch"}
             accessibilityState={{ checked: value, disabled }}
+            accessibilityLabel={label}
           />
         );
     }

--- a/ts/components/services/ContactPreferencesToggles/__test__/__snapshots__/PreferenceToggleRow.test.tsx.snap
+++ b/ts/components/services/ContactPreferencesToggles/__test__/__snapshots__/PreferenceToggleRow.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`PreferenceToggleRow component should match the snapshot 1`] = `
     </Text>
   </View>
   <RCTSwitch
-    accessibilityLabel="Select to activate"
+    accessibilityLabel="Push Notifications"
     accessibilityRole="switch"
     accessibilityState={
       Object {

--- a/ts/screens/profile/NotificationsPreferencesScreen.tsx
+++ b/ts/screens/profile/NotificationsPreferencesScreen.tsx
@@ -77,6 +77,12 @@ export const NotificationsPreferencesScreen = () => {
             rightElement={
               <RemoteSwitch
                 value={preview}
+                accessibilityLabel={
+                  I18n.t("profile.preferences.notifications.preview.title") +
+                  I18n.t(
+                    "profile.preferences.notifications.preview.description"
+                  )
+                }
                 onValueChange={(value: boolean) => {
                   trackNotificationsPreferencesPreviewStatus(value);
                   togglePreference<PushNotificationsContentTypeEnum>(
@@ -99,6 +105,12 @@ export const NotificationsPreferencesScreen = () => {
             rightElement={
               <RemoteSwitch
                 value={reminder}
+                accessibilityLabel={
+                  I18n.t("profile.preferences.notifications.reminders.title") +
+                  I18n.t(
+                    "profile.preferences.notifications.reminders.description"
+                  )
+                }
                 onValueChange={(value: boolean) => {
                   trackNotificationsPreferencesReminderStatus(value);
                   togglePreference<ReminderStatusEnum>(

--- a/ts/screens/profile/NotificationsPreferencesScreen.tsx
+++ b/ts/screens/profile/NotificationsPreferencesScreen.tsx
@@ -77,12 +77,11 @@ export const NotificationsPreferencesScreen = () => {
             rightElement={
               <RemoteSwitch
                 value={preview}
-                accessibilityLabel={
-                  I18n.t("profile.preferences.notifications.preview.title") +
-                  I18n.t(
-                    "profile.preferences.notifications.preview.description"
-                  )
-                }
+                accessibilityLabel={`${I18n.t(
+                  "profile.preferences.notifications.preview.title"
+                )}. ${I18n.t(
+                  "profile.preferences.notifications.preview.description"
+                )}`}
                 onValueChange={(value: boolean) => {
                   trackNotificationsPreferencesPreviewStatus(value);
                   togglePreference<PushNotificationsContentTypeEnum>(
@@ -105,12 +104,11 @@ export const NotificationsPreferencesScreen = () => {
             rightElement={
               <RemoteSwitch
                 value={reminder}
-                accessibilityLabel={
-                  I18n.t("profile.preferences.notifications.reminders.title") +
-                  I18n.t(
-                    "profile.preferences.notifications.reminders.description"
-                  )
-                }
+                accessibilityLabel={`${I18n.t(
+                  "profile.preferences.notifications.reminders.title"
+                )}. ${I18n.t(
+                  "profile.preferences.notifications.reminders.description"
+                )}`}
                 onValueChange={(value: boolean) => {
                   trackNotificationsPreferencesReminderStatus(value);
                   togglePreference<ReminderStatusEnum>(


### PR DESCRIPTION
## Short description
 Added accessibility support to switch elements.

## List of changes proposed in this pull request
- ts/components/core/selection/RemoteSwitch.tsx: added accessibility support to the component.
- ts/screens/profile/NotificationsPreferencesScreen.tsx: added accessibility label to RemoteSwitch(s).
- ts/components/services/ContactPreferencesToggles/PreferenceToggleRow.tsx: added accessibility support to Switch component.

## How to test
Run app, enable VoiceOver (or TalkBack) and verify wether, by highlighting a switch in profile settings or a switch in a specific service settings, the accessibilityLabel is read.
