### PR TITLE
fix: [IABT-1389] On Android IdP logo never refresh when it's changed

### DIFF
--- a/ts/components/IdpsGrid.tsx
+++ b/ts/components/IdpsGrid.tsx
@@ -7,6 +7,7 @@ import {
   FlatList,
   Image,
   ListRenderItemInfo,
+  Platform,
   Pressable,
   StyleProp,
   StyleSheet,
@@ -92,7 +93,18 @@ const renderItem =
           testID={`idp-${item.id}-button`}
         >
           <Image
-            source={item.localLogo ? item.localLogo : { uri: item.logo }}
+            source={
+              item.localLogo
+                ? item.localLogo
+                : {
+                    // https://github.com/facebook/react-native/issues/12606
+                    // Image cache is disable for Android by appending
+                    // the `ts` query parameter.
+                    uri:
+                      item.logo +
+                      (Platform.OS === "android" ? `?ts=${Date.now()}` : "")
+                  }
+            }
             style={styles.idpLogo}
           />
         </Pressable>

--- a/ts/components/IdpsGrid.tsx
+++ b/ts/components/IdpsGrid.tsx
@@ -77,9 +77,9 @@ const styles = StyleSheet.create({
 const keyExtractor = (idp: LocalIdpsFallback): string => idp.id;
 
 // https://github.com/facebook/react-native/issues/12606
-// Image cache is disable for Android by appending
-// the `ts` query parameter as DDMMYYYY to simulate a 24h TTL
-const disableAndroidImageCache = () => {
+// Image cache forced refresh for Android by appending
+// the `ts` query parameter as DDMMYYYY to simulate a 24h TTL.
+const androidIdpLogoForcedRefreshed = () => {
   const timestampValue = localeDateFormat(
     new Date(),
     I18n.t("global.dateFormats.shortFormat").replace(/\//g, "")
@@ -110,7 +110,7 @@ const renderItem =
               item.localLogo
                 ? item.localLogo
                 : {
-                    uri: `${item.logo}${disableAndroidImageCache()}`
+                    uri: `${item.logo}${androidIdpLogoForcedRefreshed()}`
                   }
             }
             style={styles.idpLogo}

--- a/ts/components/IdpsGrid.tsx
+++ b/ts/components/IdpsGrid.tsx
@@ -20,6 +20,8 @@ import themeVariables from "../theme/variables";
 import { GlobalState } from "../store/reducers/types";
 import { idpsStateSelector } from "../store/reducers/content";
 import { LocalIdpsFallback } from "../utils/idps";
+import { localeDateFormat } from "../utils/locale";
+import I18n from "../i18n";
 import { VSpacer } from "./core/spacer/Spacer";
 import { IOColors } from "./core/variables/IOColors";
 
@@ -74,6 +76,17 @@ const styles = StyleSheet.create({
 
 const keyExtractor = (idp: LocalIdpsFallback): string => idp.id;
 
+// https://github.com/facebook/react-native/issues/12606
+// Image cache is disable for Android by appending
+// the `ts` query parameter as DDMMYYYY to simulate a 24h TTL
+const disableAndroidImageCache = () => {
+  const timestampValue = localeDateFormat(
+    new Date(),
+    I18n.t("global.dateFormats.shortFormat").replace(/\//g, "")
+  );
+  return Platform.OS === "android" ? `?ts=${timestampValue}` : "";
+};
+
 const renderItem =
   (props: Props) =>
   (info: ListRenderItemInfo<LocalIdpsFallback>): React.ReactElement => {
@@ -97,12 +110,7 @@ const renderItem =
               item.localLogo
                 ? item.localLogo
                 : {
-                    // https://github.com/facebook/react-native/issues/12606
-                    // Image cache is disable for Android by appending
-                    // the `ts` query parameter.
-                    uri:
-                      item.logo +
-                      (Platform.OS === "android" ? `?ts=${Date.now()}` : "")
+                    uri: `${item.logo}${disableAndroidImageCache()}`
                   }
             }
             style={styles.idpLogo}


### PR DESCRIPTION
## Short description
This PR fixes the issue present on Android about IdP logo caching. 

When an IdP logo is changed — its URI remains the same and on Android — the image never changes but remains the first ever downloaded.

This is a known [RN issue](https://github.com/facebook/react-native/issues/12606).


## List of changes proposed in this pull request
- ts/components/IdpsGrid.tsx: Add a timestamp query param on Android on IdP URI to simulate a TTL of 24h.

## How to test
Run the app without this fix against the dev server, and after the first IdPs Selection Screen render, change an IdP logo and restart the server. Load the IdP Selection Screen again and see that the logo remains the same. Apply this fix, run the app, and check that the logo has changed.
