### PR TITLE
[IABT-1383] Email already in use - bug

### DIFF
--- a/ts/screens/onboarding/EmailInsertScreen.tsx
+++ b/ts/screens/onboarding/EmailInsertScreen.tsx
@@ -241,6 +241,7 @@ class EmailInsertScreen extends React.PureComponent<Props, State> {
           this.state.email,
           O.map(e => {
             this.props.updateEmail(e as EmailString);
+            this.setState({ email: O.some(EMPTY_EMAIL) })
           })
         );
       } else {


### PR DESCRIPTION
## Short description
Cleared a property, after the email update request, to prevent incorrect alert from showing.

## The problem
An alert indicating "email already in use" (generated by the comparison of the old and new email), shows up when the user changes the email and lands on the email verification reminder page.

## List of changes proposed in this pull request
- ts/screens/onboarding/EmailInsertScreen.tsx: set the email state to "empty".

## How to test
Change the email and verify that no wrong alert is shown when you reach the email verification reminder page.

