### PR TITLE
chore: [IOAPPFD0-33] Add the new color palette

### DIFF
--- a/ts/components/core/variables/IOColors.ts
+++ b/ts/components/core/variables/IOColors.ts
@@ -33,50 +33,92 @@ export const hexToRgba = (hexCode: string, opacity: number = 1) => {
 
 export const IOColors = asIOColors({
   white: "#FFFFFF",
+  grey50: "#F4F5F8",
+  grey100: "#E8EBF1",
+  grey200: "#D2D6E3",
+  grey450: "#99A3C1",
+  grey650: "#636B82",
+  grey700: "#555C70",
+  grey850: "#2B2E38",
+  blackNew: "#0E0F13",
+  blueNew: "#0B3EE3",
+  blueDark: "#031344",
+  blueLight: "#B6C5F7",
+  blue50: "#E7ECFC",
+  blue100: "#CED8F9",
+  blue200: "#9DB2F4",
+  blue600: "#0932B6",
+  turquoise: "#00C5CA",
+  turquoiseDark: "#003B3D",
+  turquoiseLight: "#AAEEEF",
+  turquoise50: "#DBF9FA",
+  turquoise100: "#C2F3F4",
+  error: "#FE6666",
+  errorGraphic: "#D75252",
+  errorDark: "#761F1F",
+  errorLight: "#FFD1D1",
+  warning: "#FFC824",
+  warningGraphic: "#A5822A",
+  warningDark: "#614C15",
+  warningLight: "#FFF5DA",
+  success: "#6CC66A",
+  successGraphic: "#427940",
+  successDark: "#224021",
+  successLight: "#D3EED2",
+  info: "#6BCFFB",
+  infoGraphic: "#418DAF",
+  infoDark: "#215C76",
+  infoLight: "#E1F5FE",
+  cobalt: "#2C489D" /* used in the `Bonus Vacanze` only */,
+  blueItalia: "#0066CC" /* pagoPA service */,
+  /* LEGACY */
   greyUltraLight: "#F5F6F7",
-  /* ↳ ALIAS TOKEN: tabUnderlineColor → greyUltraLight */
   greyLight: "#E6E9F2",
-  /* ↳ ALIAS TOKEN: headerIconLight → greyLight */
   bluegreyLight: "#CCD4DC",
-  /* ↳ ALIAS TOKEN: colorSkeleton → bluegreyLight */
-  /* ↳ ALIAS TOKEN: itemSeparator → bluegreyLight */
   grey: "#909DA8",
-  /* ↳ ALIAS TOKEN: btnLightBorderColor → grey */
-  /* ↳ ALIAS TOKEN: disabledService → grey, not referenced though */
   milderGray: "#5F6F80",
-  /* ↳ ALIAS TOKEN: headerIconDark → milderGray */
   bluegrey: "#475A6D",
-  /* ↳ ALIAS TOKEN: textColor → bluegrey */
-  /* ↳ ALIAS TOKEN: topTabBarTextColor → bluegrey */
-  /* ↳ ALIAS TOKEN: unselectedColor → bluegrey */
   bluegreyDark: "#17324D",
-  /* ↳ ALIAS TOKEN: textColorDark → bluegreyDark */
-  /* ↳ ALIAS TOKEN: cardTextColor → bluegreyDark */
   black: "#000000",
-  /* ↳ ALIAS TOKEN: footerShadowColor → black */
-  noCieButton:
-    "#789CCD" /* Background of half-disabled noCIE CTA, from LandingScreen.tsx */,
+  noCieButton: "#789CCD" /* Half-disabled noCIE CTA BG, LandingScreen.tsx */,
   blue: "#0073E6",
-  /* ↳ ALIAS TOKEN: topTabBarActiveTextColor → blue */
-  /* ↳ ALIAS TOKEN: selectedColor → blue */
-  /* ↳ ALIAS TOKEN: contentPrimaryBackground → blue */
-  /* ↳ ALIAS TOKEN: textLinkColor → blue */
   blueUltraLight: "#99CCFF" /* Almost deprecated, avoid if possible */,
   aqua: "#00C5CA",
-  /* ↳ ALIAS TOKEN: colorHighlight → aqua */
   aquaUltraLight: "#C1F4F2",
-  /* ↳ ALIAS TOKEN: toastColor → aquaUltraLight */
-  cobalt: "#2C489D" /* used in the `Bonus Vacanze` only */,
-  antiqueFuchsia:
-    "#9B5897" /* used in the CgnDiscountValueBox component only */,
+  antiqueFuchsia: "#9B5897" /* used in the CgnDiscountValueBox only */,
   yellow: "#FFC824" /* Almost deprecated, used in `PaymentHistoryList` only */,
   orange: "#EA7614",
   red: "#C02927",
-  /* ↳ ALIAS TOKEN: brandDanger → red */
-  /* ↳ ALIAS TOKEN: calendarExpirableColor → red */
-  green: "#005C3C"
-  /* ↳ ALIAS TOKEN: brandSuccess → green */
+  green: "#005C3C",
+  greenLight: "#5CA85A"
 });
+
+/*
+REFERENCEs USEFUL FOR REFACTORING
+Alias tokens:
+*/
+/* ↳ tabUnderlineColor → greyUltraLight */
+/* ↳ headerIconLight → greyLight */
+/* ↳ colorSkeleton → bluegreyLight */
+/* ↳ itemSeparator → bluegreyLight */
+/* ↳ btnLightBorderColor → grey */
+/* ↳ disabledService → grey, not referenced though */
+/* ↳ headerIconDark → milderGray */
+/* ↳ textColor → bluegrey */
+/* ↳ topTabBarTextColor → bluegrey */
+/* ↳ unselectedColor → bluegrey */
+/* ↳ textColorDark → bluegreyDark */
+/* ↳ cardTextColor → bluegreyDark */
+/* ↳ footerShadowColor → black */
+/* ↳ topTabBarActiveTextColor → blue */
+/* ↳ selectedColor → blue */
+/* ↳ contentPrimaryBackground → blue */
+/* ↳ textLinkColor → blue */
+/* ↳ colorHighlight → aqua */
+/* ↳ toastColor → aquaUltraLight */
+/* ↳ brandDanger → red */
+/* ↳ calendarExpirableColor → red */
+/* ↳ brandSuccess → green */
 
 export const IOColorGradients = asIOColorGradients({
   appLaunch: ["#0C00D3", "#0073E6"],
@@ -105,3 +147,145 @@ export const getGradientColorValues = (
 
 export type IOColorType = keyof typeof IOColors;
 export type IOColorGradientType = keyof typeof IOColorGradients;
+
+const {
+  white,
+  greyUltraLight,
+  greyLight,
+  bluegreyLight,
+  grey,
+  milderGray,
+  bluegrey,
+  bluegreyDark,
+  black,
+  noCieButton,
+  blue,
+  blueUltraLight,
+  aqua,
+  aquaUltraLight,
+  cobalt,
+  antiqueFuchsia,
+  yellow,
+  orange,
+  red,
+  green
+} = IOColors;
+
+export const IOColorsLegacy = {
+  white,
+  greyUltraLight,
+  greyLight,
+  bluegreyLight,
+  grey,
+  milderGray,
+  bluegrey,
+  bluegreyDark,
+  black,
+  noCieButton,
+  blue,
+  blueUltraLight,
+  aqua,
+  aquaUltraLight,
+  cobalt,
+  antiqueFuchsia,
+  yellow,
+  orange,
+  red,
+  green
+};
+
+const {
+  grey50,
+  grey100,
+  grey200,
+  grey450,
+  grey650,
+  grey700,
+  grey850,
+  blackNew
+} = IOColors;
+
+export const IOColorsNeutral = {
+  white,
+  grey50,
+  grey100,
+  grey200,
+  grey450,
+  grey650,
+  grey700,
+  grey850,
+  blackNew
+};
+
+const {
+  blueNew,
+  blueDark,
+  blueLight,
+  blue50,
+  blue100,
+  blue600,
+  turquoise,
+  turquoiseDark,
+  turquoiseLight,
+  turquoise100,
+  turquoise50
+} = IOColors;
+
+export const IOColorsTints = {
+  blueDark,
+  blue600,
+  blueNew,
+  blueLight,
+  blue100,
+  blue50,
+  turquoiseDark,
+  turquoise,
+  turquoiseLight,
+  turquoise100,
+  turquoise50
+};
+
+const {
+  error,
+  errorGraphic,
+  errorDark,
+  errorLight,
+  warning,
+  warningGraphic,
+  warningDark,
+  warningLight,
+  success,
+  successGraphic,
+  successDark,
+  successLight,
+  info,
+  infoGraphic,
+  infoDark,
+  infoLight
+} = IOColors;
+
+export const IOColorsStatus = {
+  errorDark,
+  errorGraphic,
+  error,
+  errorLight,
+  warningDark,
+  warningGraphic,
+  warning,
+  warningLight,
+  successDark,
+  successGraphic,
+  success,
+  successLight,
+  infoDark,
+  infoGraphic,
+  info,
+  infoLight
+};
+
+const { blueItalia } = IOColors;
+
+export const IOColorsExtra = {
+  cobalt,
+  blueItalia
+};

--- a/ts/components/core/variables/IOColors.ts
+++ b/ts/components/core/variables/IOColors.ts
@@ -93,33 +93,6 @@ export const IOColors = asIOColors({
   greenLight: "#5CA85A"
 });
 
-/*
-REFERENCEs USEFUL FOR REFACTORING
-Alias tokens:
-*/
-/* ↳ tabUnderlineColor → greyUltraLight */
-/* ↳ headerIconLight → greyLight */
-/* ↳ colorSkeleton → bluegreyLight */
-/* ↳ itemSeparator → bluegreyLight */
-/* ↳ btnLightBorderColor → grey */
-/* ↳ disabledService → grey, not referenced though */
-/* ↳ headerIconDark → milderGray */
-/* ↳ textColor → bluegrey */
-/* ↳ topTabBarTextColor → bluegrey */
-/* ↳ unselectedColor → bluegrey */
-/* ↳ textColorDark → bluegreyDark */
-/* ↳ cardTextColor → bluegreyDark */
-/* ↳ footerShadowColor → black */
-/* ↳ topTabBarActiveTextColor → blue */
-/* ↳ selectedColor → blue */
-/* ↳ contentPrimaryBackground → blue */
-/* ↳ textLinkColor → blue */
-/* ↳ colorHighlight → aqua */
-/* ↳ toastColor → aquaUltraLight */
-/* ↳ brandDanger → red */
-/* ↳ calendarExpirableColor → red */
-/* ↳ brandSuccess → green */
-
 export const IOColorGradients = asIOColorGradients({
   appLaunch: ["#0C00D3", "#0073E6"],
   appIcon: ["#1D51DF", "#1723D5"],
@@ -296,3 +269,51 @@ export const IOColorsExtra = {
   blueItalia
 };
 export type IOColorsExtra = keyof typeof IOColorsExtra;
+
+/*
+REFERENCES
+Alias tokens:
+*/
+/* 
+tabUnderlineColor → greyUltraLight
+headerIconLight → greyLight
+colorSkeleton → bluegreyLight
+itemSeparator → bluegreyLight
+btnLightBorderColor → grey
+disabledService → grey, not referenced though
+headerIconDark → milderGray
+textColor → bluegrey
+topTabBarTextColor → bluegrey
+unselectedColor → bluegrey
+textColorDark → bluegreyDark
+cardTextColor → bluegreyDark
+footerShadowColor → black
+topTabBarActiveTextColor → blue
+selectedColor → blue
+contentPrimaryBackground → blue
+textLinkColor → blue
+colorHighlight → aqua
+toastColor → aquaUltraLight
+brandDanger → red
+calendarExpirableColor → red
+brandSuccess → green
+*/
+
+/* NEW PALETTE → OLD PALETTE
+That is, which color replaces the other? */
+/*
+`blackNew` replaces `black`
+`grey50` → `greyUltraLight`
+`grey100` → `greyLight`
+`grey200` → `blueGreyLight`
+`grey450` → `grey`
+`grey650` → `milderGrey`
+`grey700` → `bluegrey`
+`grey850` → `bluegreyDark`
+`blueNew` → `blue`
+`turquoise` → `aqua`
+`turquoiseLight` → `aquaUltraLight`
+`warning` → `yellow`
+`error` → `red`
+`success` → `green`
+*/

--- a/ts/components/core/variables/IOColors.ts
+++ b/ts/components/core/variables/IOColors.ts
@@ -168,7 +168,8 @@ const {
   yellow,
   orange,
   red,
-  green
+  green,
+  greenLight
 } = IOColors;
 
 export const IOColorsLegacy = {
@@ -191,8 +192,10 @@ export const IOColorsLegacy = {
   yellow,
   orange,
   red,
-  green
+  green,
+  greenLight
 };
+export type IOColorLegacy = keyof typeof IOColorsLegacy;
 
 const {
   grey50,
@@ -216,6 +219,7 @@ export const IOColorsNeutral = {
   grey850,
   blackNew
 };
+export type IOColorsNeutral = keyof typeof IOColorsNeutral;
 
 const {
   blueNew,
@@ -244,6 +248,7 @@ export const IOColorsTints = {
   turquoise100,
   turquoise50
 };
+export type IOColorsTints = keyof typeof IOColorsTints;
 
 const {
   error,
@@ -282,6 +287,7 @@ export const IOColorsStatus = {
   info,
   infoLight
 };
+export type IOColorsStatus = keyof typeof IOColorsStatus;
 
 const { blueItalia } = IOColors;
 
@@ -289,3 +295,4 @@ export const IOColorsExtra = {
   cobalt,
   blueItalia
 };
+export type IOColorsExtra = keyof typeof IOColorsExtra;

--- a/ts/features/design-system/core/DSColors.tsx
+++ b/ts/features/design-system/core/DSColors.tsx
@@ -1,19 +1,26 @@
 import * as React from "react";
 import { Text, View, ColorValue, StyleSheet } from "react-native";
 import LinearGradient from "react-native-linear-gradient";
+import { VSpacer } from "../../../components/core/spacer/Spacer";
 import { H2 } from "../../../components/core/typography/H2";
 import { H5 } from "../../../components/core/typography/H5";
+import { LabelSmall } from "../../../components/core/typography/LabelSmall";
 import {
+  IOColorsLegacy,
   IOColors,
   IOColorGradients,
-  hexToRgba
+  hexToRgba,
+  IOColorsNeutral,
+  IOColorsTints,
+  IOColorsStatus,
+  IOColorsExtra
 } from "../../../components/core/variables/IOColors";
 import { DesignSystemScreen } from "../components/DesignSystemScreen";
 
 const colorItemGutter = 16;
 const sectionTitleMargin = 16;
 const colorItemBorder = hexToRgba(IOColors.black, 0.1);
-const colorPillBg = hexToRgba(IOColors.black, 0.3);
+const colorPillBg = hexToRgba(IOColors.black, 0.2);
 
 const styles = StyleSheet.create({
   itemsWrapper: {
@@ -25,6 +32,10 @@ const styles = StyleSheet.create({
     marginBottom: 16
   },
   colorWrapper: {
+    justifyContent: "flex-start",
+    marginBottom: 16
+  },
+  gradientWrapper: {
     width: "50%",
     justifyContent: "flex-start",
     marginBottom: 16,
@@ -32,7 +43,6 @@ const styles = StyleSheet.create({
   },
   colorItem: {
     width: "100%",
-    aspectRatio: 4 / 1,
     padding: 8,
     borderRadius: 4,
     alignItems: "flex-end",
@@ -58,24 +68,39 @@ const styles = StyleSheet.create({
   }
 });
 
+const renderColorGroup = (
+  name: string,
+  colorObject: Record<string, ColorValue>
+) => (
+  <View style={{ marginBottom: 40 }}>
+    {name && (
+      <H2
+        color={"bluegrey"}
+        weight={"SemiBold"}
+        style={{ marginBottom: sectionTitleMargin }}
+      >
+        {name}
+      </H2>
+    )}
+
+    {Object.entries(colorObject).map(([name, colorValue]) => (
+      <ColorBox key={name} name={name} color={colorValue} />
+    ))}
+  </View>
+);
+
 export const DSColors = () => (
   <DesignSystemScreen title={"Colors"}>
-    <H2
-      color={"bluegrey"}
-      weight={"SemiBold"}
-      style={{ marginBottom: sectionTitleMargin }}
-    >
-      Plain
-    </H2>
-    <View style={styles.itemsWrapper}>
-      {Object.entries(IOColors).map(colorEntry => (
-        <ColorBox
-          key={colorEntry[0]}
-          name={colorEntry[0]}
-          color={colorEntry[1]}
-        />
-      ))}
-    </View>
+    {/* Neutrals */}
+    {renderColorGroup("Neutrals", IOColorsNeutral)}
+    {/* Tints */}
+    {renderColorGroup("Main tints", IOColorsTints)}
+    {/* Status */}
+    {renderColorGroup("Status", IOColorsStatus)}
+    {/* Extra */}
+    {renderColorGroup("Extra", IOColorsExtra)}
+
+    {/* Gradients */}
     <H2
       color={"bluegrey"}
       weight={"SemiBold"}
@@ -84,14 +109,27 @@ export const DSColors = () => (
       Gradients
     </H2>
     <View style={styles.itemsWrapper}>
-      {Object.entries(IOColorGradients).map(colorEntry => (
-        <GradientBox
-          key={colorEntry[0]}
-          name={colorEntry[0]}
-          colors={colorEntry[1]}
-        />
+      {Object.entries(IOColorGradients).map(([name, colorValues]) => (
+        <GradientBox key={name} name={name} colors={colorValues} />
       ))}
     </View>
+
+    <VSpacer size={40} />
+
+    {/* Legacy */}
+    <View style={{ marginBottom: sectionTitleMargin }}>
+      <H2 color={"bluegrey"} weight={"SemiBold"}>
+        Legacy palette (†2023)
+      </H2>
+      <LabelSmall weight={"Regular"} color="bluegrey">
+        Not moved to the &ldquo;Legacy&rdquo; category yet, because it&apos;s
+        currently used everywhere
+      </LabelSmall>
+    </View>
+    {Object.entries(IOColorsLegacy).map(([name, colorValue]) => (
+      <ColorBox key={name} name={name} color={colorValue} />
+    ))}
+    <VSpacer size={40} />
   </DesignSystemScreen>
 );
 
@@ -116,9 +154,9 @@ const ColorBox = (props: ColorBoxProps) => (
       {props.color && <Text style={styles.colorPill}>{props.color}</Text>}
     </View>
     {props.name && (
-      <H5 color={"bluegrey"} weight={"Regular"}>
+      <LabelSmall color={"bluegrey"} weight={"Regular"}>
         {props.name}
-      </H5>
+      </LabelSmall>
     )}
   </View>
 );
@@ -126,7 +164,7 @@ const ColorBox = (props: ColorBoxProps) => (
 const GradientBox = (props: GradientBoxProps) => {
   const [first, last] = props.colors;
   return (
-    <View style={styles.colorWrapper}>
+    <View style={styles.gradientWrapper}>
       <LinearGradient
         colors={props.colors}
         useAngle={true}


### PR DESCRIPTION
## Short description
This PR adds the new color palette, the foundation of the new visual language that will be gradually introduced over the next few months.

### Preview

https://user-images.githubusercontent.com/1255491/218756279-3ea4ef6e-d07e-444e-9589-8ad77214f3e0.mp4



## List of changes proposed in this pull request
- Add the new color values to the existing `IOColors` object to avoid disruption on the current components
- Separate the different color values into different groups: `IOColorsLegacy`, `IOColorsNeutral`, `IOColorsTints`, `IOColorsStatus`, `IOColorsExtra` (the mentioned names might change over the time)
- Change `DSColors` grid from two columns to single one.

## How to test
Go to the `Profile → Design System → Colors`