### PR TITLE
[IGB-87] New feedback message displayed on a message attachment download failure

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1792,7 +1792,7 @@ messageDetails:
   attachments:
     badFormat: "The attachment format is not supported. Please contact the sender"
     corruptedFile: "The attachment is corrupt and can't be opened. Please contact the sender"
-    downloadFailed: "We couldn't open the attachment. Try again"
+    downloadFailed: "The attachment is currently not available. Please try again or contact the sender"
     showPreview: "See preview"
     unavailable:
       firstPart: "The attachments are no longer available. "

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1813,7 +1813,7 @@ messageDetails:
   attachments:
     badFormat: "Il formato dell'allegato non è supportato. Contatta l'ente mittente"
     corruptedFile: "L'allegato è danneggato e non può essere aperto. Contatta l'ente mittente"
-    downloadFailed: "L'allegato non si è aperto. Riprova"
+    downloadFailed: "L'allegato non è al momento disponibile. Riprova o contatta l'ente mittente"
     showPreview: "Visualizza anteprima"
     unavailable:
       firstPart: "Gli allegati non sono più disponibili. "


### PR DESCRIPTION
## Short description
This PR changes the italian and english translations of the message that is displayed when the download of a message attachment fails.

## List of changes proposed in this pull request
- locales/it/index.yml has the new italian translation
- locales/en/index.yml has the new english translations

## How to test
Simulate the download failure using the dev-server (return any http status code in range [400-599] but 415) and check that the message is correctly displayed in both italian and english languages
