### PR TITLE
fix: [IOAPPCIT-46] Fixes the missing PosteID rapid access missing choice on IdP credential screen

### DIFF
--- a/ts/screens/authentication/IdpLoginScreen.tsx
+++ b/ts/screens/authentication/IdpLoginScreen.tsx
@@ -116,6 +116,8 @@ const styles = StyleSheet.create({
   webViewWrapper: { flex: 1 }
 });
 
+// TODO if left as it is, this would cause some IDP to offer limited login capabilities.
+// See: https://pagopa.atlassian.net/browse/IOAPPCIT-46
 const getUserAgentForWebView = () =>
   lollipopLoginEnabled ? `IO-App/${getAppVersion()}` : undefined;
 

--- a/ts/screens/authentication/IdpLoginScreen.tsx
+++ b/ts/screens/authentication/IdpLoginScreen.tsx
@@ -58,6 +58,7 @@ import {
 } from "../../utils/supportAssistance";
 import { getUrlBasepath } from "../../utils/url";
 import { originSchemasWhiteList } from "./originSchemasWhiteList";
+import { lollipopLoginEnabled } from "../../config";
 
 type NavigationProps = IOStackNavigationRouteProps<
   AuthenticationParamsList,
@@ -115,7 +116,8 @@ const styles = StyleSheet.create({
   webViewWrapper: { flex: 1 }
 });
 
-const getUserAgentForWebView = () => `IO-App/${getAppVersion()}`;
+const getUserAgentForWebView = () =>
+  lollipopLoginEnabled ? `IO-App/${getAppVersion()}` : undefined;
 
 /**
  * A screen that allows the user to login with an IDP.

--- a/ts/screens/authentication/IdpLoginScreen.tsx
+++ b/ts/screens/authentication/IdpLoginScreen.tsx
@@ -57,8 +57,8 @@ import {
   handleSendAssistanceLog
 } from "../../utils/supportAssistance";
 import { getUrlBasepath } from "../../utils/url";
-import { originSchemasWhiteList } from "./originSchemasWhiteList";
 import { lollipopLoginEnabled } from "../../config";
+import { originSchemasWhiteList } from "./originSchemasWhiteList";
 
 type NavigationProps = IOStackNavigationRouteProps<
   AuthenticationParamsList,


### PR DESCRIPTION
## Short description
This PR fixes the missing PosteID rapid access missing choice on IdP credential screen

| ❌ | ✅ | 
| - | - |
| <img src="https://user-images.githubusercontent.com/16268789/219661773-dff9d091-f05d-4cd4-b763-c38a9d2c2069.PNG" width="150" /> | <img src="https://user-images.githubusercontent.com/16268789/219661780-a566307a-e9fe-4423-9d46-efcb3b3ff9b4.PNG" width="150" /> |
