### PR TITLE
fix(IDPay): [IODPAY-104,IODPAY-105] Fix IDPay onboarding self declaration toggles

### DIFF
--- a/ts/features/idpay/onboarding/screens/BoolValuePrerequisitesScreen.tsx
+++ b/ts/features/idpay/onboarding/screens/BoolValuePrerequisitesScreen.tsx
@@ -18,15 +18,21 @@ import { useOnboardingMachineService } from "../xstate/provider";
 import {
   areAllSelfDeclarationsToggledSelector,
   boolRequiredCriteriaSelector,
-  selectIsLoading
+  selectIsLoading,
+  selectSelfDeclarationBoolAnswers
 } from "../xstate/selectors";
 
 const InitiativeSelfDeclarationsScreen = () => {
   const machine = useOnboardingMachineService();
 
   const isLoading = useSelector(machine, selectIsLoading);
+
   const selfCriteriaBool = useSelector(machine, boolRequiredCriteriaSelector);
-  const selfCriteriaAccepted = useSelector(
+  const selfCriteriaBoolAnswers = useSelector(
+    machine,
+    selectSelfDeclarationBoolAnswers
+  );
+  const areAllSelfCriteriaBoolAccepted = useSelector(
     machine,
     areAllSelfDeclarationsToggledSelector
   );
@@ -42,6 +48,9 @@ const InitiativeSelfDeclarationsScreen = () => {
         type: "TOGGLE_BOOL_CRITERIA",
         criteria: { ...criteria, value }
       });
+
+  const getSelfCriteriaBoolAnswer = (criteria: SelfDeclarationBoolDTO) =>
+    selfCriteriaBoolAnswers[criteria.code] ?? false;
 
   return (
     <BaseScreenComponent
@@ -63,9 +72,11 @@ const InitiativeSelfDeclarationsScreen = () => {
                   <ListItemComponent
                     key={index}
                     title={criteria.description}
-                    switchValue={criteria.value}
+                    switchValue={getSelfCriteriaBoolAnswer(criteria)}
                     accessibilityRole={"switch"}
-                    accessibilityState={{ checked: criteria.value }}
+                    accessibilityState={{
+                      checked: getSelfCriteriaBoolAnswer(criteria)
+                    }}
                     isLongPressEnabled={true}
                     onSwitchValueChanged={toggleCriteria(criteria)}
                   />
@@ -84,7 +95,7 @@ const InitiativeSelfDeclarationsScreen = () => {
             rightButton={{
               title: I18n.t("global.buttons.continue"),
               onPress: continueOnPress,
-              disabled: !selfCriteriaAccepted
+              disabled: !areAllSelfCriteriaBoolAccepted
             }}
           />
         </SafeAreaView>

--- a/ts/features/idpay/onboarding/screens/BoolValuePrerequisitesScreen.tsx
+++ b/ts/features/idpay/onboarding/screens/BoolValuePrerequisitesScreen.tsx
@@ -1,32 +1,47 @@
-import { useActor, useSelector } from "@xstate/react";
+import { useSelector } from "@xstate/react";
 import React from "react";
-import { View, SafeAreaView } from "react-native";
+import { SafeAreaView, View } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
+import { SelfDeclarationBoolDTO } from "../../../../../definitions/idpay/onboarding/SelfDeclarationBoolDTO";
+import { VSpacer } from "../../../../components/core/spacer/Spacer";
+import { Body } from "../../../../components/core/typography/Body";
 import { H1 } from "../../../../components/core/typography/H1";
+import { Link } from "../../../../components/core/typography/Link";
 import { IOStyles } from "../../../../components/core/variables/IOStyles";
 import LoadingSpinnerOverlay from "../../../../components/LoadingSpinnerOverlay";
 import BaseScreenComponent from "../../../../components/screens/BaseScreenComponent";
+import ListItemComponent from "../../../../components/screens/ListItemComponent";
+import FooterWithButtons from "../../../../components/ui/FooterWithButtons";
+import I18n from "../../../../i18n";
 import { emptyContextualHelp } from "../../../../utils/emptyContextualHelp";
 import { useOnboardingMachineService } from "../xstate/provider";
-import { Body } from "../../../../components/core/typography/Body";
-import { Link } from "../../../../components/core/typography/Link";
-import FooterWithButtons from "../../../../components/ui/FooterWithButtons";
-import ListItemComponent from "../../../../components/screens/ListItemComponent";
-import { LOADING_TAG } from "../../../../utils/xstate";
-import { boolRequiredCriteriaSelector } from "../xstate/selectors";
-import { VSpacer } from "../../../../components/core/spacer/Spacer";
-import I18n from "../../../../i18n";
+import {
+  areAllSelfDeclarationsToggledSelector,
+  boolRequiredCriteriaSelector,
+  selectIsLoading
+} from "../xstate/selectors";
 
 const InitiativeSelfDeclarationsScreen = () => {
   const machine = useOnboardingMachineService();
-  const [state, send] = useActor(machine);
 
-  const isLoading = state.tags.has(LOADING_TAG);
-
+  const isLoading = useSelector(machine, selectIsLoading);
   const selfCriteriaBool = useSelector(machine, boolRequiredCriteriaSelector);
+  const selfCriteriaAccepted = useSelector(
+    machine,
+    areAllSelfDeclarationsToggledSelector
+  );
 
-  const continueOnPress = () => send({ type: "ACCEPT_REQUIRED_BOOL_CRITERIA" });
-  const goBackOnPress = () => send({ type: "GO_BACK" });
+  const continueOnPress = () =>
+    machine.send({ type: "ACCEPT_REQUIRED_BOOL_CRITERIA" });
+
+  const goBackOnPress = () => machine.send({ type: "GO_BACK" });
+
+  const toggleCriteria =
+    (criteria: SelfDeclarationBoolDTO) => (value: boolean) =>
+      machine.send({
+        type: "TOGGLE_BOOL_CRITERIA",
+        criteria: { ...criteria, value }
+      });
 
   return (
     <BaseScreenComponent
@@ -48,10 +63,11 @@ const InitiativeSelfDeclarationsScreen = () => {
                   <ListItemComponent
                     key={index}
                     title={criteria.description}
-                    switchValue={true}
+                    switchValue={criteria.value}
                     accessibilityRole={"switch"}
-                    accessibilityState={{ checked: false }}
+                    accessibilityState={{ checked: criteria.value }}
                     isLongPressEnabled={true}
+                    onSwitchValueChanged={toggleCriteria(criteria)}
                   />
                   <VSpacer size={16} />
                 </View>
@@ -67,7 +83,8 @@ const InitiativeSelfDeclarationsScreen = () => {
             }}
             rightButton={{
               title: I18n.t("global.buttons.continue"),
-              onPress: continueOnPress
+              onPress: continueOnPress,
+              disabled: !selfCriteriaAccepted
             }}
           />
         </SafeAreaView>

--- a/ts/features/idpay/onboarding/xstate/machine.ts
+++ b/ts/features/idpay/onboarding/xstate/machine.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-underscore-dangle */
-import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
 import { assign, createMachine } from "xstate";
 import { InitiativeDto } from "../../../../../definitions/idpay/onboarding/InitiativeDto";
@@ -27,11 +26,13 @@ export type Context = {
   failure?: OnboardingFailureType;
   multiConsentsPage: number;
   multiConsentsAnswers: Record<number, SelfConsentMultiDTO>;
+  selfDeclarationBoolAnswers: Record<string, boolean>;
 };
 
 const INITIAL_CONTEXT: Context = {
   multiConsentsPage: 0,
-  multiConsentsAnswers: {}
+  multiConsentsAnswers: {},
+  selfDeclarationBoolAnswers: {}
 };
 
 // Events types
@@ -491,22 +492,10 @@ const createIDPayOnboardingMachine = () =>
           failure: event.data as OnboardingFailureType
         })),
         toggleBoolCriteria: assign((context, event) => ({
-          requiredCriteria: pipe(
-            context.requiredCriteria || O.none,
-            O.map(criteria => {
-              const index = criteria.selfDeclarationList.findIndex(
-                d => d.code === event.criteria.code
-              );
-              const newList = Object.assign([], criteria.selfDeclarationList, {
-                [index]: event.criteria
-              });
-
-              return {
-                ...criteria,
-                selfDeclarationList: newList
-              };
-            })
-          )
+          selfDeclarationBoolAnswers: {
+            ...context.selfDeclarationBoolAnswers,
+            [event.criteria.code]: event.criteria.value
+          }
         })),
         addMultiConsent: assign((context, event) => ({
           multiConsentsAnswers: {

--- a/ts/features/idpay/onboarding/xstate/selectors.ts
+++ b/ts/features/idpay/onboarding/xstate/selectors.ts
@@ -1,12 +1,13 @@
 /* eslint-disable no-underscore-dangle */
-import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
+import * as O from "fp-ts/lib/Option";
 import { createSelector } from "reselect";
 import { StateFrom } from "xstate";
 import { RequiredCriteriaDTO } from "../../../../../definitions/idpay/onboarding/RequiredCriteriaDTO";
 import { SelfDeclarationBoolDTO } from "../../../../../definitions/idpay/onboarding/SelfDeclarationBoolDTO";
 import { SelfDeclarationDTO } from "../../../../../definitions/idpay/onboarding/SelfDeclarationDTO";
 import { SelfDeclarationMultiDTO } from "../../../../../definitions/idpay/onboarding/SelfDeclarationMultiDTO";
+import { LOADING_TAG } from "../../../../utils/xstate";
 import { Context, IDPayOnboardingMachineType } from "./machine";
 
 type StateWithContext = StateFrom<IDPayOnboardingMachineType>;
@@ -94,6 +95,17 @@ const getBoolRequiredCriteriaFromContext = (context: Context) =>
     SelfDeclarationBoolDTO
   );
 
+const selectIsLoading = (state: StateWithContext) =>
+  state.tags.has(LOADING_TAG);
+
+const areAllSelfDeclarationsToggledSelector = createSelector(
+  boolRequiredCriteriaSelector,
+  boolSelfDeclarations =>
+    boolSelfDeclarations.filter(
+      selfDeclaration => selfDeclaration.value === false
+    ).length === 0
+);
+
 export {
   selectServiceId,
   multiRequiredCriteriaSelector,
@@ -102,5 +114,7 @@ export {
   getBoolRequiredCriteriaFromContext,
   criteriaToDisplaySelector,
   prerequisiteAnswerIndexSelector,
-  pdndCriteriaSelector
+  pdndCriteriaSelector,
+  selectIsLoading,
+  areAllSelfDeclarationsToggledSelector
 };

--- a/ts/features/idpay/onboarding/xstate/selectors.ts
+++ b/ts/features/idpay/onboarding/xstate/selectors.ts
@@ -12,13 +12,21 @@ import { Context, IDPayOnboardingMachineType } from "./machine";
 
 type StateWithContext = StateFrom<IDPayOnboardingMachineType>;
 
+const selectIsLoading = (state: StateWithContext) =>
+  state.tags.has(LOADING_TAG);
+
 const isUpsertingSelector = (state: StateWithContext) =>
   state.hasTag(UPSERTING_TAG as never);
 
 const selectRequiredCriteria = (state: StateWithContext) =>
   state.context.requiredCriteria;
+
+const selectSelfDeclarationBoolAnswers = (state: StateWithContext) =>
+  state.context.selfDeclarationBoolAnswers;
+
 const selectMultiConsents = (state: StateWithContext) =>
   state.context.multiConsentsAnswers;
+
 const selectCurrentPage = (state: StateWithContext) =>
   state.context.multiConsentsPage;
 
@@ -98,15 +106,12 @@ const getBoolRequiredCriteriaFromContext = (context: Context) =>
     SelfDeclarationBoolDTO
   );
 
-const selectIsLoading = (state: StateWithContext) =>
-  state.tags.has(LOADING_TAG);
-
 const areAllSelfDeclarationsToggledSelector = createSelector(
   boolRequiredCriteriaSelector,
-  boolSelfDeclarations =>
-    boolSelfDeclarations.filter(
-      selfDeclaration => selfDeclaration.value === false
-    ).length === 0
+  selectSelfDeclarationBoolAnswers,
+  (boolSelfDeclarations, answers) =>
+    boolSelfDeclarations.length ===
+    Object.values(answers).filter(answer => answer).length
 );
 
 export {
@@ -120,5 +125,6 @@ export {
   prerequisiteAnswerIndexSelector,
   pdndCriteriaSelector,
   selectIsLoading,
+  selectSelfDeclarationBoolAnswers,
   areAllSelfDeclarationsToggledSelector
 };


### PR DESCRIPTION
## Short description
This PR adds the ability to toggle (switch on and switch off) the self declarations in the IDPay onboarding flow.

https://user-images.githubusercontent.com/6160324/219682847-fbf07304-18e2-4812-893b-44a3171533a9.mp4

## List of changes proposed in this pull request
- Added `TOGGLE_BOOL_CRITERIA` event to the onboarding machine to mutate self declarations in the context
- Added selector to know if all the bool self declaration were set to true and the "continue" button should be enabled.

## How to test
- Start the onboarding for an IDPay initiative. The initiative should have a list of bool self declarations
- In the self declaration screen, try to switch on and off the self declaration toggles.
- Verify that the continue button is disabled if any of the toggles is off.
