### PR TITLE
chore(Firma con IO): [SFEQS-1409] Update fci specs to add service id selector from remote config

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.26.0-rc.3",
   "io_backend_api": "https://raw.githubusercontent.com/pagopa/io-backend/v9.2.0-RELEASE/api_backend.yaml",
   "io_public_api": "https://raw.githubusercontent.com/pagopa/io-backend/v9.2.0-RELEASE/api_public.yaml",
-  "io_content_specs": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.24/definitions.yml",
+  "io_content_specs": "https://raw.githubusercontent.com/pagopa/io-services-metadata/SFEQS-1406-adding-service-id-fci/definitions.yml",
   "io_bonus_vacanze_specs": "https://raw.githubusercontent.com/pagopa/io-backend/v9.2.0-RELEASE/api_bonus.yaml",
   "io_cgn_specs": "https://raw.githubusercontent.com/pagopa/io-backend/v9.2.0-RELEASE/api_cgn.yaml",
   "io_cgn_merchants_specs": "https://raw.githubusercontent.com/pagopa/io-backend/v9.2.0-RELEASE/api_cgn_operator_search.yaml",

--- a/ts/store/reducers/backendStatus.ts
+++ b/ts/store/reducers/backendStatus.ts
@@ -408,6 +408,19 @@ export const isFciEnabledSelector = createSelector(
     )
 );
 
+/**
+ * Return the remote config about FCI service ID
+ */
+export const fciServiceIDSelector = createSelector(
+  backendStatusSelector,
+  (backendStatus): string | undefined =>
+    pipe(
+      backendStatus,
+      O.map(bs => bs.config.fci.service_id),
+      O.toUndefined
+    )
+);
+
 export const isIdPayEnabledSelector = createSelector(
   backendStatusSelector,
   (backendStatus): boolean =>


### PR DESCRIPTION
## Short description
This PR update FCI specs to add a new service-id selector from backend status

## List of changes proposed in this pull request
- Update fci specs in package.json
- Add service-id selector for FCI

## How to test
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
