### PR TITLE
chore: [LLK-35] Add mixpanel events for Lollipop failure

### DIFF
--- a/ts/features/lollipop/hooks/useLollipopLoginSource.tsx
+++ b/ts/features/lollipop/hooks/useLollipopLoginSource.tsx
@@ -1,8 +1,11 @@
+import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
+import * as TE from "fp-ts/lib/TaskEither";
 import { useCallback, useEffect, useState } from "react";
 import { lollipopLoginEnabled } from "../../../config";
 import { useIOSelector } from "../../../store/hooks";
 import { isLollipopEnabledSelector } from "../../../store/reducers/backendStatus";
+import { trackLollipopIdpLoginFailure } from "../../../utils/analytics";
 import { taskRegenerateKey } from "../../../utils/crypto";
 import { lollipopKeyTagSelector } from "../store/reducers/lollipop";
 import { LoginSourceAsync } from "../types/LollipopLoginSource";
@@ -37,6 +40,14 @@ export const useLollipopLoginSource = (loginUri?: string) => {
     }
 
     if (!useLollipopLogin || O.isNone(lollipopKeyTag)) {
+      if (useLollipopLogin) {
+        // We track missing key tag event only if lollipop is enabled
+        // (since the key tag is not used without lollipop)
+        trackLollipopIdpLoginFailure(
+          "Missing key tag while trying to login with lollipop"
+        );
+      }
+
       // Key generation may have failed. In that case, follow the old
       // non-lollipop login flow
       setDeprecatedLoginUri(loginUri);
@@ -48,12 +59,10 @@ export const useLollipopLoginSource = (loginUri?: string) => {
      * need to garantee the public key uniqueness on every login request.
      * https://pagopa.atlassian.net/browse/LLK-37
      */
-    taskRegenerateKey(lollipopKeyTag.value)
-      .then(key => {
-        if (!key) {
-          setDeprecatedLoginUri(loginUri);
-          return;
-        }
+    void pipe(
+      lollipopKeyTag.value,
+      taskRegenerateKey,
+      TE.map(key =>
         setLoginSource({
           kind: "ready",
           value: {
@@ -67,11 +76,13 @@ export const useLollipopLoginSource = (loginUri?: string) => {
             }
           },
           publicKey: O.some(key)
-        });
-      })
-      .catch(_ => {
+        })
+      ),
+      TE.mapLeft(error => {
+        trackLollipopIdpLoginFailure(error.message);
         setDeprecatedLoginUri(loginUri);
-      });
+      })
+    )();
   }, [useLollipopLogin, lollipopKeyTag, loginUri, setDeprecatedLoginUri]);
 
   return loginSource;

--- a/ts/features/lollipop/utils/login.ts
+++ b/ts/features/lollipop/utils/login.ts
@@ -10,7 +10,7 @@ export const lollipopSamlVerify = (
   urlEncodedSamlRequest: string,
   publicKey: PublicKey,
   onSuccess: () => void,
-  onFailure: () => void
+  onFailure: (reason: string) => void
 ) => {
   // SAMLRequest is URL encoded, so decode it
   const decodedSamlRequest = decodeURIComponent(urlEncodedSamlRequest);
@@ -32,7 +32,7 @@ export const lollipopSamlVerify = (
       const responseThumbprintWithHashAlgorithm = authnRequest?.$?.ID;
       if (!responseThumbprintWithHashAlgorithm) {
         // If the request did not include the ID, treat it as a failure
-        onFailure();
+        onFailure("Missing ID parameter in samlp:AuthnRequest");
         return;
       }
 
@@ -52,13 +52,13 @@ export const lollipopSamlVerify = (
       ) {
         // Hash signature from server did not match the
         // local one, so the response cannot be trusted
-        onFailure();
+        onFailure("Mismatch between local and remote ID parameter content");
         return;
       }
 
       onSuccess();
     })
     .catch(_ => {
-      onFailure();
+      onFailure("Unable to convert saml request from xml to json");
     });
 };

--- a/ts/sagas/startup/generateCryptoKeyPair.ts
+++ b/ts/sagas/startup/generateCryptoKeyPair.ts
@@ -12,7 +12,10 @@ import {
   getKeyGenerationInfo,
   KeyGenerationInfo
 } from "../../utils/crypto";
-import { mixpanelTrack } from "./../../mixpanel";
+import {
+  trackLollipopKeyGenerationFailure,
+  trackLollipopKeyGenerationSuccess
+} from "../../utils/analytics";
 
 /**
  * Generates a new crypto key pair.
@@ -35,17 +38,16 @@ export function* cryptoKeyGenerationSaga(
 export function* trackMixpanelCryptoKeyPairEvents(keyTag: string) {
   const keyInfo = yield* call(getKeyGenerationInfo, keyTag);
 
-  if (keyInfo && !keyInfo.errorCode) {
-    void mixpanelTrack("LOLLIPOP_KEY_GENERATION_SUCCESS", {
-      kty: keyInfo.keyType
-    });
+  if (!keyInfo) {
+    return;
   }
 
-  if (keyInfo && keyInfo.errorCode) {
-    void mixpanelTrack("LOLLIPOP_KEY_GENERATION_FAILURE", {
-      reason: keyInfo.errorCode
-    });
+  if (keyInfo.errorCode) {
+    trackLollipopKeyGenerationFailure(keyInfo);
+    return;
   }
+
+  trackLollipopKeyGenerationSuccess(keyInfo);
 }
 
 /**

--- a/ts/screens/authentication/IdpLoginScreen.tsx
+++ b/ts/screens/authentication/IdpLoginScreen.tsx
@@ -58,6 +58,7 @@ import {
 } from "../../utils/supportAssistance";
 import { getUrlBasepath } from "../../utils/url";
 import { lollipopLoginEnabled } from "../../config";
+import { trackLollipopIdpLoginFailure } from "../../utils/analytics";
 import { originSchemasWhiteList } from "./originSchemasWhiteList";
 
 type NavigationProps = IOStackNavigationRouteProps<
@@ -309,7 +310,8 @@ const IdpLoginScreen = (props: Props) => {
           });
           setWebviewSource({ uri: eventUrl });
         },
-        () => {
+        (reason: string) => {
+          trackLollipopIdpLoginFailure(reason);
           setLollipopCheckStatus({
             status: "untrusted",
             url: O.some(eventUrl)

--- a/ts/utils/analytics.ts
+++ b/ts/utils/analytics.ts
@@ -6,6 +6,7 @@ import { mixpanelTrack } from "../mixpanel";
 import { ReminderStatusEnum } from "../../definitions/backend/ReminderStatus";
 import { UIMessageId } from "../store/reducers/entities/messages/types";
 import { ServiceId } from "../../definitions/backend/ServiceId";
+import { KeyGenerationInfo } from "./crypto";
 
 const blackListRoutes: ReadonlyArray<string> = [];
 
@@ -137,3 +138,24 @@ export function trackThirdPartyMessageAttachmentUserAction(
 }
 
 // End of premium events
+
+// Lollipop events
+export function trackLollipopKeyGenerationSuccess(keyInfo: KeyGenerationInfo) {
+  void mixpanelTrack("LOLLIPOP_KEY_GENERATION_SUCCESS", {
+    kty: keyInfo.keyType
+  });
+}
+
+export function trackLollipopKeyGenerationFailure(keyInfo: KeyGenerationInfo) {
+  void mixpanelTrack("LOLLIPOP_KEY_GENERATION_FAILURE", {
+    reason: keyInfo.errorCode
+  });
+}
+
+export function trackLollipopIdpLoginFailure(reason: string) {
+  void mixpanelTrack("LOLLIPOP_IDP_LOGIN_FAILURE", {
+    reason
+  });
+}
+
+// End of lollipop events


### PR DESCRIPTION
## Short description
This PR adds Lollipop failure mixpanel events (described [here](https://docs.google.com/spreadsheets/d/1bXNRcTDKU-5l2RqCcwSbT7Y1M9QQTWtS_f-3-AIqSYk/edit#gid=1624395933))

Approved by the Privacy - [ticket](https://pagopa.atlassian.net/browse/LLK-47)

## List of changes proposed in this pull request
Following trackings have been added
* `LOLLIPOP_IDP_LOGIN_FAILURE { reason: string }` - Sent when there is a failure in the lollipop spid login.
Reason is one of the following:
    - "Missing key tag while trying to login with lollipop"
    - "Missing ID parameter in samlp:AuthnRequest"
    - "Mismatch between local and remote ID parameter content"
    - "Unable to convert saml request from xml to json"

refactored `taskRegenerateKey` to use fp-ts instead of promises

## How to test
Check that the events are received by mixpanel
