### PR TITLE
fix(IDPay): [IODPAY-157] Add correct amount to initiative card

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3305,7 +3305,7 @@ idpay:
     details:
       initiativeCard:
         availableAmount: Disponibile
-        validUntil: Valido fino al
+        validUntil: Valido fino al {{expiryDate}}
         toRefund: da rimborsare
       initiativeDetailsScreen:
         notConfigured:

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3329,7 +3329,7 @@ idpay:
     details:
       initiativeCard:
         availableAmount: Disponibile
-        validUntil: Valido fino al
+        validUntil: Valido fino al {{expiryDate}}
         toRefund: da rimborsare
       initiativeDetailsScreen:
         notConfigured:

--- a/ts/features/idpay/initiative/details/components/InitiativeCardComponent.tsx
+++ b/ts/features/idpay/initiative/details/components/InitiativeCardComponent.tsx
@@ -1,29 +1,31 @@
 import { Text } from "native-base";
 import * as React from "react";
-import { View, Image, ImageBackground, StyleSheet } from "react-native";
+import { Image, ImageBackground, StyleSheet, View } from "react-native";
 import { widthPercentageToDP } from "react-native-responsive-screen";
-import { StatusEnum } from "../../../../../../definitions/idpay/wallet/InitiativeDTO";
+import {
+  InitiativeDTO,
+  StatusEnum
+} from "../../../../../../definitions/idpay/wallet/InitiativeDTO";
+import bonusVacanzeWhiteLogo from "../../../../../../img/bonus/bonusVacanze/logo_BonusVacanze_White.png";
+import cardBg from "../../../../../../img/features/idpay/card_full.png";
 import { makeFontStyleObject } from "../../../../../components/core/fonts";
+import { HSpacer, VSpacer } from "../../../../../components/core/spacer/Spacer";
 import { H2 } from "../../../../../components/core/typography/H2";
 import { H5 } from "../../../../../components/core/typography/H5";
 import { IOColors } from "../../../../../components/core/variables/IOColors";
-import TypedI18n from "../../../../../i18n";
-import { formatDateAsLocal } from "../../../../../utils/dates";
-import bonusVacanzeWhiteLogo from "../../../../../../img/bonus/bonusVacanze/logo_BonusVacanze_White.png";
-import { formatNumberAmount } from "../../../../../utils/stringBuilder";
 import { IOStyles } from "../../../../../components/core/variables/IOStyles";
-import cardBg from "../../../../../../img/features/idpay/card_full.png";
-import { HSpacer, VSpacer } from "../../../../../components/core/spacer/Spacer";
+import I18n from "../../../../../i18n";
+import { formatDateAsLocal } from "../../../../../utils/dates";
+import { formatNumberAmount } from "../../../../../utils/stringBuilder";
 
 type Props = {
-  status: StatusEnum;
-  endDate: Date;
-  initiativeName?: string;
-  amount?: number;
-  accrued?: number;
+  initiative: InitiativeDTO;
 };
 
 const styles = StyleSheet.create({
+  fullHeight: {
+    height: "100%"
+  },
   cardContainer: {
     height: 230,
     width: widthPercentageToDP(100)
@@ -73,78 +75,70 @@ const styles = StyleSheet.create({
 });
 
 const InitiativeCardComponent = (props: Props) => {
-  const renderFullCard = () => {
-    const isInitiativeConfigured = props.status === StatusEnum.REFUNDABLE;
-    return (
-      <View style={[styles.row, styles.spaced, IOStyles.flex]}>
-        <View
-          style={[
-            {
-              height: "100%"
-            },
-            styles.spaced
-          ]}
-        >
-          <View>
-            <VSpacer size={8} />
+  const { initiativeName, endDate, status, amount, accrued, refunded } =
+    props.initiative;
 
-            <H2 color="white">{props.initiativeName}</H2>
-            <Text style={{ color: IOColors.white }}>{`${TypedI18n.t(
-              "idpay.initiative.details.initiativeCard.validUntil"
-            )} ${formatDateAsLocal(props.endDate, true)}`}</Text>
-          </View>
-          <View style={styles.row}>
-            <View>
-              <Text
-                bold={true}
-                style={[
-                  !isInitiativeConfigured ? styles.consumedOpacity : {},
-                  styles.amount
-                ]}
-              >
-                {formatNumberAmount(props.amount || 0, true)}
-              </Text>
-              <H5 color="white">
-                {TypedI18n.t(
-                  "idpay.initiative.details.initiativeCard.availableAmount"
-                )}
-              </H5>
-            </View>
+  const isInitiativeConfigured = status === StatusEnum.REFUNDABLE;
+  const toBeRepaidAmount = (accrued || 0) - (refunded || 0);
 
-            <HSpacer size={8} />
-
-            <View>
-              <Text
-                bold={true}
-                style={[
-                  !isInitiativeConfigured ? styles.consumedOpacity : {},
-                  styles.amount
-                ]}
-              >
-                {formatNumberAmount(props.accrued || 0, true)}
-              </Text>
-
-              <H5 color="white">
-                {TypedI18n.t(
-                  "idpay.initiative.details.initiativeCard.toRefund"
-                )}
-              </H5>
-            </View>
-          </View>
-        </View>
+  const renderFullCard = () => (
+    <View style={[styles.row, styles.spaced, IOStyles.flex]}>
+      <View style={[styles.fullHeight, styles.spaced]}>
         <View>
-          <View
-            style={styles.bottomInitiativeIcon}
-            accessible={true}
-            importantForAccessibility={"no-hide-descendants"}
-            accessibilityElementsHidden={true}
-          >
-            <Image source={bonusVacanzeWhiteLogo} style={styles.logo} />
+          <VSpacer size={8} />
+          <H2 color="white">{initiativeName}</H2>
+          <Text style={{ color: IOColors.white }}>
+            {I18n.t("idpay.initiative.details.initiativeCard.validUntil", {
+              expiryDate: formatDateAsLocal(endDate, true)
+            })}
+          </Text>
+        </View>
+        <View style={styles.row}>
+          <View>
+            <Text
+              bold={true}
+              style={[
+                !isInitiativeConfigured ? styles.consumedOpacity : {},
+                styles.amount
+              ]}
+            >
+              {formatNumberAmount(amount || 0, true)}
+            </Text>
+            <H5 color="white">
+              {I18n.t(
+                "idpay.initiative.details.initiativeCard.availableAmount"
+              )}
+            </H5>
+          </View>
+          <HSpacer size={8} />
+          <View>
+            <Text
+              bold={true}
+              style={[
+                !isInitiativeConfigured ? styles.consumedOpacity : {},
+                styles.amount
+              ]}
+            >
+              {formatNumberAmount(toBeRepaidAmount, true)}
+            </Text>
+            <H5 color="white">
+              {I18n.t("idpay.initiative.details.initiativeCard.toRefund")}
+            </H5>
           </View>
         </View>
       </View>
-    );
-  };
+      <View>
+        <View
+          style={styles.bottomInitiativeIcon}
+          accessible={true}
+          importantForAccessibility={"no-hide-descendants"}
+          accessibilityElementsHidden={true}
+        >
+          <Image source={bonusVacanzeWhiteLogo} style={styles.logo} />
+        </View>
+      </View>
+    </View>
+  );
 
   return (
     <View style={styles.card} testID={"card-component"}>

--- a/ts/features/idpay/initiative/details/screens/InitiativeDetailsScreen.tsx
+++ b/ts/features/idpay/initiative/details/screens/InitiativeDetailsScreen.tsx
@@ -134,13 +134,7 @@ export const InitiativeDetailsScreen = () => {
               style={[IOStyles.horizontalContentPadding, { height: 149 }]}
             />
           </LinearGradient>
-          <InitiativeCardComponent
-            endDate={initiativeData.endDate}
-            status={initiativeData.status}
-            accrued={initiativeData.accrued}
-            amount={initiativeData.amount}
-            initiativeName={initiativeData.initiativeName}
-          />
+          <InitiativeCardComponent initiative={initiativeData} />
           <View
             style={[
               IOStyles.flex,


### PR DESCRIPTION
## Short description
This PR fixes display issues in the initiative details card.

## List of changes proposed in this pull request
- Refactoring of the InitiativeCardComponent:
  - Changed props to only one prop  `initiative: InitiativeDTO`
  - I18n refactoring with params
- The amount to be repaid now displays correct amount in the initiative details card

## How to test
- Navigate to the initiative details screen.
- Check if the amount to be repaid in the card displays the correct value. The correct value should be `accrued - refunded` where `accrued` is the total amount accumulated since the start of the initiative and `refunded` is the amount already refunded to the enrolled IBAN.
