### PR TITLE
fix(IDPay): [IODPAY-159] Show loader when enrollment request in progress

### DIFF
--- a/ts/features/idpay/initiative/configuration/xstate/machine.ts
+++ b/ts/features/idpay/initiative/configuration/xstate/machine.ts
@@ -806,6 +806,8 @@ const createIDPayInitiativeConfigurationMachine = () =>
           if (context.instrumentToEnroll === undefined) {
             return {};
           }
+
+          // We fallback to `pot.none` if it's the first time we are enrolling the instrument
           const currentStatus =
             context.instrumentStatuses[context.instrumentToEnroll.idWallet] ||
             p.none;

--- a/ts/features/idpay/initiative/configuration/xstate/machine.ts
+++ b/ts/features/idpay/initiative/configuration/xstate/machine.ts
@@ -807,11 +807,8 @@ const createIDPayInitiativeConfigurationMachine = () =>
             return {};
           }
           const currentStatus =
-            context.instrumentStatuses[context.instrumentToEnroll.idWallet];
-
-          if (currentStatus === undefined) {
-            return {};
-          }
+            context.instrumentStatuses[context.instrumentToEnroll.idWallet] ||
+            p.none;
 
           return {
             instrumentStatuses: {


### PR DESCRIPTION
## Short description
Set a proper pot state when the request is in progress

## List of changes proposed in this pull request
- Set a proper pot state when the request is in progress

## How to test
Try to enable an instrument for an initiative and check if the spinner appears
