### PR TITLE
fix: [IABT-1435] Fix unwrap text info box

### DIFF
--- a/ts/features/zendesk/components/ZendeskSupportComponent.tsx
+++ b/ts/features/zendesk/components/ZendeskSupportComponent.tsx
@@ -3,13 +3,14 @@ import { useNavigation } from "@react-navigation/native";
 import * as O from "fp-ts/lib/Option";
 import * as React from "react";
 import { InitializedProfile } from "../../../../definitions/backend/InitializedProfile";
-import AdviceComponent from "../../../components/AdviceComponent";
+import { InfoBox } from "../../../components/box/InfoBox";
 import ButtonDefaultOpacity from "../../../components/ButtonDefaultOpacity";
 import { VSpacer } from "../../../components/core/spacer/Spacer";
 import { H3 } from "../../../components/core/typography/H3";
 import { H4 } from "../../../components/core/typography/H4";
 import { Label } from "../../../components/core/typography/Label";
 import { Link } from "../../../components/core/typography/Link";
+import { IOColors } from "../../../components/core/variables/IOColors";
 import { zendeskPrivacyUrl } from "../../../config";
 import I18n from "../../../i18n";
 import { mixpanelTrack } from "../../../mixpanel";
@@ -75,9 +76,11 @@ const ZendeskSupportComponent = ({
         </Link>
       </H4>
       <VSpacer size={24} />
-      <AdviceComponent
-        text={I18n.t("support.helpCenter.supportComponent.adviceMessage")}
-      />
+      <InfoBox iconName={"io-notice"} iconColor={IOColors.blue} iconSize={18}>
+        <Label color={"bluegrey"} weight={"Regular"}>
+          {I18n.t("support.helpCenter.supportComponent.adviceMessage")}
+        </Label>
+      </InfoBox>
       <VSpacer size={16} />
 
       <ButtonDefaultOpacity

--- a/ts/features/zendesk/screens/ZendeskSupportHelpCenter.tsx
+++ b/ts/features/zendesk/screens/ZendeskSupportHelpCenter.tsx
@@ -231,6 +231,7 @@ const ZendeskSupportHelpCenter = () => {
             assistanceForPayment={assistanceForPayment}
             assistanceForCard={assistanceForCard}
           />
+          <VSpacer size={16} />
         </ScrollView>
       </SafeAreaView>
     </BaseScreenComponent>


### PR DESCRIPTION
## Short description
This PR fixes the text displayed inside the box and adds space under the buttons. 

| Before  | After  | 
| ------------- | ------------- | 
| ![android-before](https://user-images.githubusercontent.com/29163287/221159900-134e6c0c-6672-4345-aec7-b7ee447edcd0.png)  | ![android-after](https://user-images.githubusercontent.com/29163287/221159929-72e80813-a9ef-47ed-a3fa-fdf3f4b97411.png)  |

## List of changes proposed in this pull request
- updated `ZendeskSupportComponent.tsx`
- updated `ZendeskSupportHelpCenter.tsx`

## How to test
- Start dev server
- Perform a login
- Browse to message list
- Open contextual help