### PR TITLE
[IAI-270] Bump version of react-native-vision-camera from 2.15.1 to 2.15.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "react-native-tab-view": "^2.x",
     "react-native-vector-icons": "^7.0.0",
     "react-native-view-shot": "3.1.2",
-    "react-native-vision-camera": "2.15.1",
+    "react-native-vision-camera": "2.15.4",
     "react-native-webview": "^11.13.0",
     "react-native-xml2js": "^1.0.3",
     "react-redux": "7.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14481,10 +14481,10 @@ react-native-view-shot@3.1.2:
   resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-3.1.2.tgz#8c8e84c67a4bc8b603e697dbbd59dbc9b4f84825"
   integrity sha512-9u9fPtp6a52UMoZ/UCPrCjKZk8tnkI9To0Eh6yYnLKFEGkRZ7Chm6DqwDJbYJHeZrheCCopaD5oEOnRqhF4L2Q==
 
-react-native-vision-camera@2.15.1:
-  version "2.15.1"
-  resolved "https://registry.yarnpkg.com/react-native-vision-camera/-/react-native-vision-camera-2.15.1.tgz#2259cce3b4ff4ac6c8e9eb859a71a12731ceddf6"
-  integrity sha512-mvz9T6DRfHSee52dpwZxyIdhED8ebmMbVoIpAC2MwkAv1tAV2iZhScRNhpf3Pj9pbh9hpO7Kan0Kc+k7GQGhpw==
+react-native-vision-camera@2.15.4:
+  version "2.15.4"
+  resolved "https://registry.yarnpkg.com/react-native-vision-camera/-/react-native-vision-camera-2.15.4.tgz#821f0505fc8c63b87c1ae4697d2bb4f670333576"
+  integrity sha512-SJXSWH1pu4V3Kj4UuX/vSgOxc9d5wb5+nHqBHd+5iUtVyVLEp0F6Jbbaha7tDoU+kUBwonhlwr2o8oV6NZ7Ibg==
 
 react-native-webview@^11.13.0:
   version "11.13.0"


### PR DESCRIPTION
## Short description
This PR bumps version of react-native-vision-camera from 2.15.1 to 2.15.4 to avoid crashes when compiling the app with Xcode 14

## How to test
Compile the app with Xcode 14 and try reading a payment notice from a QR code with the camera.
