### PR TITLE
fix(IDPay): [IODPAY-160] Update ListItem import to follow design

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "pagopa_privative_configuration": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.24/pagopa/privative/definitions.yml",
   "idpay_onboarding": "https://raw.githubusercontent.com/pagopa/cstar-infrastructure/v2.12.1/src/domains/idpay-app/api/idpay_onboarding_workflow/openapi.onboarding.yml",
   "idpay_wallet": "https://raw.githubusercontent.com/pagopa/cstar-infrastructure/v2.17.0/src/domains/idpay-app/api/idpay_wallet/openapi.wallet.yml",
-  "idpay_timeline": "https://raw.githubusercontent.com/pagopa/cstar-infrastructure/v2.17.0/src/domains/idpay-app/api/idpay_timeline/openapi.timeline.yml",
+  "idpay_timeline": "https://raw.githubusercontent.com/pagopa/cstar-infrastructure/v2.22.0/src/domains/idpay-app/api/idpay_timeline/openapi.timeline.yml",
   "idpay_iban": "https://raw.githubusercontent.com/pagopa/cstar-infrastructure/v1.101.0/src/domains/idpay-app/api/idpay_iban/openapi.iban.yml",
   "private": true,
   "scripts": {

--- a/ts/features/design-system/core/DSListItems.tsx
+++ b/ts/features/design-system/core/DSListItems.tsx
@@ -212,7 +212,8 @@ export const DSListItems = () => (
           operationDate: new Date(),
           brandLogo: "",
           maskedPan: "****",
-          amount: -100,
+          amount: 100,
+          accrued: 50,
           circuitType: "MasterCard"
         }}
       />

--- a/ts/features/idpay/initiative/details/components/TimelineOperationListItem.tsx
+++ b/ts/features/idpay/initiative/details/components/TimelineOperationListItem.tsx
@@ -72,19 +72,19 @@ const OperationIcon = ({ operation }: OperationComponentProps) => {
   }
 };
 const OperationAmount = ({ operation }: OperationComponentProps) => {
-  const hasAmount = "amount" in operation;
-  if (!hasAmount) {
+  const hasAccrued = "accrued" in operation;
+  if (!hasAccrued) {
     return null;
   }
   switch (operation.operationType) {
     case TransactionOperationTypeEnum.TRANSACTION:
-      return <H4>{`–${formatNumberAmount(operation.amount, false)} €`}</H4>;
+      return <H4>{`–${formatNumberAmount(operation.accrued, false)} €`}</H4>;
     case TransactionOperationTypeEnum.REVERSAL:
-      return <H4>{`+${formatNumberAmount(operation.amount, false)} €`}</H4>;
+      return <H4>{`+${formatNumberAmount(operation.accrued, false)} €`}</H4>;
     case RefundOperationTypeEnum.PAID_REFUND:
       return (
         <H4 color="greenLight">
-          {`${formatNumberAmount(operation.amount, false)} €`}
+          {`${formatNumberAmount(operation.accrued, false)} €`}
         </H4>
       );
     default:

--- a/ts/features/idpay/initiative/details/components/TimelineOperationListItem.tsx
+++ b/ts/features/idpay/initiative/details/components/TimelineOperationListItem.tsx
@@ -72,10 +72,6 @@ const OperationIcon = ({ operation }: OperationComponentProps) => {
   }
 };
 const OperationAmount = ({ operation }: OperationComponentProps) => {
-  const hasAccrued = "accrued" in operation;
-  if (!hasAccrued) {
-    return null;
-  }
   switch (operation.operationType) {
     case TransactionOperationTypeEnum.TRANSACTION:
       return <H4>{`–${formatNumberAmount(operation.accrued, false)} €`}</H4>;

--- a/ts/features/idpay/initiative/details/store/__test__/store.test.ts
+++ b/ts/features/idpay/initiative/details/store/__test__/store.test.ts
@@ -116,6 +116,7 @@ const mockTimelineResponseSuccess: TimelineDTO = {
       operationType: TransactionOperationType.TRANSACTION,
       operationDate: new Date("2020-05-20T09:00:00.000Z"),
       amount: 100,
+      accrued: 50,
       brandLogo: "https://www.google.com",
       maskedPan: "1234567890",
       circuitType: "CREDIT_CARD"


### PR DESCRIPTION
## Short description
Updated ListItem to follow design
<img src="https://user-images.githubusercontent.com/60693085/221547663-9393c588-0355-48fa-9e54-9c50ac2442d8.png" width=200/>


## List of changes proposed in this pull request
- the number in `ListItem`'s right now shows `accrued` instead of `amount`
- updated definitions to correctly serialize data

## How to test
navigate to an initiative's detail page, possibly also to the timeline page and make sure the `ListItem`s correctly display the accrued amount only in the right section
