### PR TITLE
[IODPAY-161] Navigate to initiative details from message CTA 

### DIFF
--- a/ts/features/idpay/common/navigation/linking.ts
+++ b/ts/features/idpay/common/navigation/linking.ts
@@ -1,0 +1,19 @@
+import { PathConfigMap } from "@react-navigation/native";
+import { IDPayDetailsRoutes } from "../../initiative/details/navigation";
+import { IDPayOnboardingRoutes } from "../../onboarding/navigation/navigator";
+
+export const idPayLinkingOptions: PathConfigMap = {
+  [IDPayOnboardingRoutes.IDPAY_ONBOARDING_MAIN]: {
+    path: "idpay",
+    screens: {
+      [IDPayOnboardingRoutes.IDPAY_ONBOARDING_INITIATIVE_DETAILS]:
+        "onboarding/:serviceId"
+    }
+  },
+  [IDPayDetailsRoutes.IDPAY_DETAILS_MAIN]: {
+    path: "idpay",
+    screens: {
+      [IDPayDetailsRoutes.IDPAY_DETAILS_MONITORING]: "initiative/:initiativeId"
+    }
+  }
+};

--- a/ts/features/idpay/common/navigation/linking.ts
+++ b/ts/features/idpay/common/navigation/linking.ts
@@ -4,16 +4,15 @@ import { IDPayOnboardingRoutes } from "../../onboarding/navigation/navigator";
 
 export const idPayLinkingOptions: PathConfigMap = {
   [IDPayOnboardingRoutes.IDPAY_ONBOARDING_MAIN]: {
-    path: "idpay",
+    path: "idpay/onboarding",
     screens: {
-      [IDPayOnboardingRoutes.IDPAY_ONBOARDING_INITIATIVE_DETAILS]:
-        "onboarding/:serviceId"
+      [IDPayOnboardingRoutes.IDPAY_ONBOARDING_INITIATIVE_DETAILS]: "/:serviceId"
     }
   },
   [IDPayDetailsRoutes.IDPAY_DETAILS_MAIN]: {
-    path: "idpay",
+    path: "idpay/initiative",
     screens: {
-      [IDPayDetailsRoutes.IDPAY_DETAILS_MONITORING]: "initiative/:initiativeId"
+      [IDPayDetailsRoutes.IDPAY_DETAILS_MONITORING]: "/:initiativeId"
     }
   }
 };

--- a/ts/features/idpay/onboarding/navigation/navigator.tsx
+++ b/ts/features/idpay/onboarding/navigation/navigator.tsx
@@ -1,11 +1,7 @@
+import { ParamListBase, RouteProp } from "@react-navigation/native";
 import {
-  ParamListBase,
-  PathConfigMap,
-  RouteProp
-} from "@react-navigation/native";
-import {
-  StackNavigationProp,
-  createStackNavigator
+  createStackNavigator,
+  StackNavigationProp
 } from "@react-navigation/stack";
 import React from "react";
 import BoolValuePrerequisitesScreen from "../screens/BoolValuePrerequisitesScreen";
@@ -39,16 +35,6 @@ export type IDPayOnboardingParamsList = {
 };
 
 const Stack = createStackNavigator<IDPayOnboardingParamsList>();
-
-export const idPayOnboardingLinkingOptions: PathConfigMap = {
-  [IDPayOnboardingRoutes.IDPAY_ONBOARDING_MAIN]: {
-    path: "idpay",
-    screens: {
-      [IDPayOnboardingRoutes.IDPAY_ONBOARDING_INITIATIVE_DETAILS]:
-        "onboarding/:serviceId"
-    }
-  }
-};
 
 export const IDPayOnboardingNavigator = () => (
   <IDPayOnboardingMachineProvider>

--- a/ts/navigation/AppStackNavigator.tsx
+++ b/ts/navigation/AppStackNavigator.tsx
@@ -42,12 +42,16 @@ import {
   FimsNavigator
 } from "../features/fims/navigation/navigator";
 import FIMS_ROUTES from "../features/fims/navigation/routes";
+import { idPayLinkingOptions } from "../features/idpay/common/navigation/linking";
 import {
   IDPayConfigurationNavigator,
   IDPayConfigurationRoutes
 } from "../features/idpay/initiative/configuration/navigation/navigator";
 import {
-  idPayOnboardingLinkingOptions,
+  IDpayDetailsNavigator,
+  IDPayDetailsRoutes
+} from "../features/idpay/initiative/details/navigation";
+import {
   IDPayOnboardingNavigator,
   IDPayOnboardingRoutes
 } from "../features/idpay/onboarding/navigation/navigator";
@@ -69,10 +73,6 @@ import {
 } from "../store/reducers/backendStatus";
 import { isTestEnv } from "../utils/environment";
 import { IO_INTERNAL_LINK_PREFIX } from "../utils/navigation";
-import {
-  IDPayDetailsRoutes,
-  IDpayDetailsNavigator
-} from "../features/idpay/initiative/details/navigation";
 import authenticationNavigator from "./AuthenticationNavigator";
 import { MessagesStackNavigator } from "./MessagesNavigator";
 import NavigationService, { navigationRef } from "./NavigationService";
@@ -274,7 +274,7 @@ const InnerNavigationContainer = (props: { children: React.ReactElement }) => {
         ...(isFimsEnabled ? fimsLinkingOptions : {}),
         ...(cgnEnabled ? cgnLinkingOptions : {}),
         ...(isFciEnabled ? fciLinkingOptions : {}),
-        ...(isIdPayEnabled ? idPayOnboardingLinkingOptions : {}),
+        ...(isIdPayEnabled ? idPayLinkingOptions : {}),
         [UADONATION_ROUTES.WEBVIEW]: "uadonations-webview",
         [ROUTES.WORKUNIT_GENERIC_FAILURE]: "*"
       }


### PR DESCRIPTION
## Short description
This PR enables navigation to an IDPay initiative details screen from message CTAs.

https://user-images.githubusercontent.com/6160324/221604205-9986acd9-d1b6-40a1-ad74-8a5309f08f7e.mp4


## List of changes proposed in this pull request
- Added linking options for `ioit://idpay/initiative/:initiativeId`

## How to test
- Open a message with a CTA with the implemented route 
- Click on the CTA and see if the app navigates to the initiative details screen.