### PR TITLE
fix(Firma con IO): [SFEQS-1317] Add item separator to tos screen

### DIFF
--- a/ts/features/fci/screens/valid/FciQtspClausesScreen.tsx
+++ b/ts/features/fci/screens/valid/FciQtspClausesScreen.tsx
@@ -94,11 +94,15 @@ const FciQtspClausesScreen = () => {
             />
           )}
           ListFooterComponent={
-            <LinkedText
-              text={qtspPrivacyTextSelector}
-              replacementUrl={qtspPrivacyUrlSelector}
-              onPress={openUrl}
-            />
+            <>
+              <ItemSeparatorComponent noPadded={true} />
+              <VSpacer size={24} />
+              <LinkedText
+                text={qtspPrivacyTextSelector}
+                replacementUrl={qtspPrivacyUrlSelector}
+                onPress={openUrl}
+              />
+            </>
           }
           keyboardShouldPersistTaps={"handled"}
           testID={"FciQtspClausesListTestID"}


### PR DESCRIPTION
## Short description
This PR adds an item separator component to the bottom of the qtsp tos screen.

Before            |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/49342144/221701693-e6516485-7ed4-431e-86c0-9b7aef95d741.png)  |  ![](https://user-images.githubusercontent.com/49342144/221701670-cd5bf3c8-9e53-41ca-b8f1-6e02a78d5f78.png)

## List of changes proposed in this pull request
- Update `FciQtspClausesScreen`

## How to test
Using `io-dev-server-api` try a signing flow, the qtsp clauses screen should have an item separator for all items