### PR TITLE
chore: [LLK-55] Removed user-agent during Spid login

### DIFF
--- a/ts/sagas/startup/__tests__/checkProfileEmailSaga.test.tsx
+++ b/ts/sagas/startup/__tests__/checkProfileEmailSaga.test.tsx
@@ -15,7 +15,7 @@ import { appReducer } from "../../../store/reducers";
 import { renderScreenFakeNavRedux } from "../../../utils/testWrapper";
 import { checkAcknowledgedEmailSaga } from "../checkAcknowledgedEmailSaga";
 
-describe("checkAcceptedTosSaga", () => {
+describe("checkAcknowledgedEmailSaga", () => {
   beforeEach(() => {
     const globalState = appReducer(undefined, applicationChangeState("active"));
     const store = createStore(appReducer, globalState as any);

--- a/ts/screens/authentication/IdpLoginScreen.tsx
+++ b/ts/screens/authentication/IdpLoginScreen.tsx
@@ -45,7 +45,6 @@ import { assistanceToolConfigSelector } from "../../store/reducers/backendStatus
 import { idpContextualHelpDataFromIdSelector } from "../../store/reducers/content";
 import { GlobalState } from "../../store/reducers/types";
 import { SessionToken } from "../../types/SessionToken";
-import { getAppVersion } from "../../utils/appVersion";
 import {
   getIdpLoginUri,
   getIntentFallbackUrl,
@@ -57,7 +56,6 @@ import {
   handleSendAssistanceLog
 } from "../../utils/supportAssistance";
 import { getUrlBasepath } from "../../utils/url";
-import { lollipopLoginEnabled } from "../../config";
 import { trackLollipopIdpLoginFailure } from "../../utils/analytics";
 import { originSchemasWhiteList } from "./originSchemasWhiteList";
 
@@ -116,11 +114,6 @@ const styles = StyleSheet.create({
   },
   webViewWrapper: { flex: 1 }
 });
-
-// TODO if left as it is, this would cause some IDP to offer limited login capabilities.
-// See: https://pagopa.atlassian.net/browse/IOAPPCIT-46
-const getUserAgentForWebView = () =>
-  lollipopLoginEnabled ? `IO-App/${getAppVersion()}` : undefined;
 
 /**
  * A screen that allows the user to login with an IDP.
@@ -441,7 +434,6 @@ const IdpLoginScreen = (props: Props) => {
             androidMicrophoneAccessDisabled={true}
             textZoom={100}
             originWhitelist={originSchemasWhiteList}
-            userAgent={getUserAgentForWebView()}
             source={webviewSource}
             onError={handleLoadingError}
             javaScriptEnabled={true}


### PR DESCRIPTION
🤚 This PR depends on [137](https://github.com/pagopa/io-spid-commons/pull/137) 🤚

## Short description
This PR removes the user-agent that was sent during Spid login and fixes an unrelated typo in tests

## List of changes proposed in this pull request
- `ts/screens/authentication/IdpLoginScreen.tsx`: removed the code that was generating and setting the user agent
- `ts/sagas/startup/__tests__/checkProfileEmailSaga.test.tsx`: fixed a typo in the parameter of the `describe` method invocation

## How to test
- Test that both LolliPoP Spid login and non-LolliPop Spid login work (using the LOLLIPOP property in the `.env` file). If you're using the dev-server, make sure that you are on the branch with no user-agent checking