### PR TITLE
fix: [IABT-1436] Change the background activity timeout

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -11,7 +11,7 @@ DEBUG_REMOTE_PUSH_NOTIFICATION=NO
 # If set to "YES" an Alert is rendered when an error was received from the biometric identification
 DEBUG_BIOMETRIC_IDENTIFICATION=NO
 # Seconds of background activity before asking the unlock code login
-BACKGROUND_ACTIVITY_TIMEOUT_S=30
+BACKGROUND_ACTIVITY_TIMEOUT_S=120
 # timeout of fetch for calling the pagoPA SOAP APIs
 FETCH_PAGOPA_TIMEOUT_MS=60000
 # default timeout of fetch (in ms)

--- a/.env.production
+++ b/.env.production
@@ -11,7 +11,7 @@ DEBUG_REMOTE_PUSH_NOTIFICATION=NO
 # If set to "YES" an Alert is rendered when an error was received from the biometric identification
 DEBUG_BIOMETRIC_IDENTIFICATION=NO
 # Seconds of background activity before asking the unlock code login
-BACKGROUND_ACTIVITY_TIMEOUT_S=30
+BACKGROUND_ACTIVITY_TIMEOUT_S=120
 # timeout of fetch for calling the pagoPA SOAP APIs
 FETCH_PAGOPA_TIMEOUT_MS=60000
 # default timeout of fetch (in ms)


### PR DESCRIPTION
## Short description
Change the timeout from 30s to 120s.

## List of changes proposed in this pull request
Update the backgroundActivityTimeout from 30s to 120s. 

## How to test
Put the app in background for less than 120s and check that you are not required to insert the pin/biometric.
