### PR TITLE
chore(IDPay): [IODPAY-167] Show amount on PAID_REFUND operation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "pagopa_privative_configuration": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.24/pagopa/privative/definitions.yml",
   "idpay_onboarding": "https://raw.githubusercontent.com/pagopa/cstar-infrastructure/v2.12.1/src/domains/idpay-app/api/idpay_onboarding_workflow/openapi.onboarding.yml",
   "idpay_wallet": "https://raw.githubusercontent.com/pagopa/cstar-infrastructure/v2.17.0/src/domains/idpay-app/api/idpay_wallet/openapi.wallet.yml",
-  "idpay_timeline": "https://raw.githubusercontent.com/pagopa/cstar-infrastructure/v2.22.0/src/domains/idpay-app/api/idpay_timeline/openapi.timeline.yml",
+  "idpay_timeline": "https://raw.githubusercontent.com/pagopa/cstar-infrastructure/v2.24.1/src/domains/idpay-app/api/idpay_timeline/openapi.timeline.yml",
   "idpay_iban": "https://raw.githubusercontent.com/pagopa/cstar-infrastructure/v1.101.0/src/domains/idpay-app/api/idpay_iban/openapi.iban.yml",
   "private": true,
   "scripts": {

--- a/ts/features/idpay/initiative/details/components/TimelineOperationListItem.tsx
+++ b/ts/features/idpay/initiative/details/components/TimelineOperationListItem.tsx
@@ -80,7 +80,7 @@ const OperationAmount = ({ operation }: OperationComponentProps) => {
     case RefundOperationTypeEnum.PAID_REFUND:
       return (
         <H4 color="greenLight">
-          {`${formatNumberAmount(operation.accrued, false)} €`}
+          {`${formatNumberAmount(operation.amount, false)} €`}
         </H4>
       );
     default:


### PR DESCRIPTION
## Short description
In the operations timeline use the amount on operation of PAID_REFUND type.

## List of changes proposed in this pull request
Use the amount instead of the accrued value on operation of type PAID_REFUND

## How to test
Check the timeline with an operation of PAID_REFUND type.