### PR TITLE
fix(Firma con IO): [SFEQS-1489] Update footer on document preview component with right label

### DIFF
--- a/ts/features/fci/components/DocumentViewer.tsx
+++ b/ts/features/fci/components/DocumentViewer.tsx
@@ -42,7 +42,7 @@ const renderFooter = (url: string, filePath: string) =>
       type={"SingleButton"}
       leftButton={confirmButtonProps(() => {
         ReactNativeBlobUtil.ios.presentOptionsMenu(filePath);
-      }, I18n.t("features.mvl.details.attachments.pdfPreview.singleBtn"))}
+      }, I18n.t("features.mvl.details.attachments.pdfPreview.open"))}
     />
   ) : (
     <FooterWithButtons


### PR DESCRIPTION
## Short description
This PR fix the copy of the footer in `DocumentPreview` component. So the copy is the same of the message with attachments.

| iOS  |Android |
| ------------- | ------------- |
| <img width="150" alt="Screenshot 2023-03-07 at 10 44 20" src="https://user-images.githubusercontent.com/49342144/223436270-38a50e2f-ec12-4836-953e-18a50a3c9456.png"> | <img width="150" alt="Screenshot 2023-03-07 at 10 44 20" src="https://user-images.githubusercontent.com/49342144/223436341-ba083725-6d99-4968-8a2b-495faa89bc5e.png"> |

## List of changes proposed in this pull request
- Update `DocumentPreview`

## How to test
Start a signing flow using io-dev-server or if not merged this [branch](https://github.com/pagopa/io-dev-api-server/pull/190) and on the provider page try to open a linked document. 