### PR TITLE
fix(Firma con IO): [SFEQS-1437] Fix empty attributes when document to sign not has signature fields or coordinates

### DIFF
--- a/ts/features/fci/utils/signature.ts
+++ b/ts/features/fci/utils/signature.ts
@@ -4,6 +4,7 @@ import * as A from "fp-ts/lib/Array";
 import { pipe } from "fp-ts/lib/function";
 import * as TE from "fp-ts/lib/TaskEither";
 import * as E from "fp-ts/lib/Either";
+import * as S from "fp-ts/lib/string";
 import ReactNativeBlobUtil from "react-native-blob-util";
 import { QtspClauses } from "../../../../definitions/fci/QtspClauses";
 import { DocumentToSign } from "../../../../definitions/fci/DocumentToSign";
@@ -75,7 +76,7 @@ export const getCustomSignature = (
             )
             .join("+");
           // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-          return hash + "+" + attributes;
+          return S.isEmpty(attributes) ? hash : hash + "+" + attributes;
         })
       )
     ),


### PR DESCRIPTION
## Short description
This PR fixes custom signature creation by checking attribute string for empty state.

## List of changes proposed in this pull request
- Update `getCustomSignature`

## How to test
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
