### PR TITLE
fix: [IOAPPFD0-47] Remove extra properties from new buttons

### DIFF
--- a/ts/components/core/variables/IOStyles.ts
+++ b/ts/components/core/variables/IOStyles.ts
@@ -84,10 +84,6 @@ export const IOButtonStyles = StyleSheet.create({
   /* Widths */
   dimensionsDefault: {
     alignSelf: "flex-start"
-  },
-  dimensionsFullWidth: {
-    flex: 1,
-    alignSelf: "auto"
   }
 });
 

--- a/ts/components/ui/ButtonOutline.tsx
+++ b/ts/components/ui/ButtonOutline.tsx
@@ -229,11 +229,7 @@ export const ButtonOutline = ({
       onPressOut={onPressOut}
       accessible={true}
       disabled={disabled}
-      style={
-        fullWidth
-          ? IOButtonStyles.dimensionsFullWidth
-          : IOButtonStyles.dimensionsDefault
-      }
+      style={!fullWidth ? IOButtonStyles.dimensionsDefault : {}}
     >
       <Animated.View
         style={[

--- a/ts/components/ui/ButtonSolid.tsx
+++ b/ts/components/ui/ButtonSolid.tsx
@@ -146,11 +146,7 @@ export const ButtonSolid = ({
       onPressOut={onPressOut}
       accessible={true}
       disabled={disabled}
-      style={
-        fullWidth
-          ? IOButtonStyles.dimensionsFullWidth
-          : IOButtonStyles.dimensionsDefault
-      }
+      style={!fullWidth ? IOButtonStyles.dimensionsDefault : {}}
     >
       <Animated.View
         style={[

--- a/ts/features/design-system/core/DSButtons.tsx
+++ b/ts/features/design-system/core/DSButtons.tsx
@@ -47,22 +47,26 @@ export const DSButtons = () => (
       ButtonSolid
     </H2>
     <DSComponentViewerBox name="ButtonSolid · Primary Variant (using Pressable API)">
-      <View>
+      <ButtonSolid
+        accessibilityLabel="Tap to trigger test alert"
+        label={"Primary button"}
+        onPress={onButtonPress}
+      />
+      <VSpacer size={16} />
+      <View style={{ alignSelf: "center" }}>
         <ButtonSolid
           accessibilityLabel="Tap to trigger test alert"
-          label={"Primary button"}
+          label={"Primary button (centered)"}
           onPress={onButtonPress}
         />
       </View>
       <VSpacer size={16} />
-      <View>
-        <ButtonSolid
-          small
-          label={"Primary Button (Small)"}
-          accessibilityLabel="Tap to trigger test alert"
-          onPress={onButtonPress}
-        />
-      </View>
+      <ButtonSolid
+        small
+        label={"Primary Button (Small)"}
+        accessibilityLabel="Tap to trigger test alert"
+        onPress={onButtonPress}
+      />
     </DSComponentViewerBox>
     <DSComponentViewerBox name="ButtonSolid · Primary, Full width">
       <View>
@@ -263,26 +267,36 @@ export const DSButtons = () => (
       ButtonOutline
     </H2>
     <DSComponentViewerBox name="ButtonOutline · Primary Variant (using Pressable API)">
-      <View>
-        <ButtonOutline
-          accessibilityLabel="Tap to trigger test alert"
-          label={"Primary button"}
-          onPress={() => {
-            alert("Action triggered");
-          }}
-        />
-      </View>
+      <ButtonOutline
+        accessibilityLabel="Tap to trigger test alert"
+        label={"Primary button"}
+        onPress={() => {
+          alert("Action triggered");
+        }}
+      />
+
       <VSpacer size={16} />
-      <View>
+
+      <View style={{ alignSelf: "center" }}>
         <ButtonOutline
-          small
-          label={"Primary Button (Small)"}
           accessibilityLabel="Tap to trigger test alert"
+          label={"Primary button (centered)"}
           onPress={() => {
             alert("Action triggered");
           }}
         />
       </View>
+
+      <VSpacer size={16} />
+
+      <ButtonOutline
+        small
+        label={"Primary Button (Small)"}
+        accessibilityLabel="Tap to trigger test alert"
+        onPress={() => {
+          alert("Action triggered");
+        }}
+      />
     </DSComponentViewerBox>
     <DSComponentViewerBox name="ButtonOutline · Primary, Full width">
       <View>

--- a/ts/features/design-system/core/DSButtons.tsx
+++ b/ts/features/design-system/core/DSButtons.tsx
@@ -69,24 +69,22 @@ export const DSButtons = () => (
       />
     </DSComponentViewerBox>
     <DSComponentViewerBox name="ButtonSolid · Primary, Full width">
-      <View>
-        <ButtonSolid
-          fullWidth
-          accessibilityLabel="Tap to trigger test alert"
-          label={"Primary button (Full Width)"}
-          onPress={onButtonPress}
-        />
-      </View>
+      <ButtonSolid
+        fullWidth
+        accessibilityLabel="Tap to trigger test alert"
+        label={"Primary button (Full Width)"}
+        onPress={onButtonPress}
+      />
+
       <VSpacer size={16} />
-      <View>
-        <ButtonSolid
-          small
-          fullWidth
-          accessibilityLabel="Tap to trigger test alert"
-          label={"Primary Button (Small, Full Width)"}
-          onPress={onButtonPress}
-        />
-      </View>
+
+      <ButtonSolid
+        small
+        fullWidth
+        accessibilityLabel="Tap to trigger test alert"
+        label={"Primary Button (Small, Full Width)"}
+        onPress={onButtonPress}
+      />
     </DSComponentViewerBox>
     <DSComponentViewerBox name="ButtonSolid · Primary, disabled">
       <View>


### PR DESCRIPTION
## Short description
This PR removes the `dimensionsFullWidth` class with relative style properties, as they are redundant. There's no need to specify the `flex: 1` property because React Native makes the button fill the entire horizontal space by default.
When developing specific layouts, these additional properties caused some annoyance.
 
## List of changes proposed in this pull request
- Remove `dimensionsFullWidth` from `ButtonSolid` and `ButtonOutline` components

## How to test
Go to the `Profile → Design System → Buttons`