### PR TITLE
chore: [IOAPPFD0-48] Remove shuffled archived message from E2E tests

### DIFF
--- a/scripts/api-config.json
+++ b/scripts/api-config.json
@@ -20,6 +20,7 @@
     "withValidDueDateCount": 1,
     "withInValidDueDateCount": 1,
     "standardMessageCount": 1,
+    "archivedMessageCount": 0,
     "allowRandomValues": false
   },
   "wallet": {


### PR DESCRIPTION
## Short description
This pull request updates the `api-config.js` file utilized in the E2E tests by assigning a value of `0` to `archivedMessageCount`. This is to prevent possible conflicts between the E2E tests and the selected message.

## How to test
To perform the test, run the development server using this configuration, and verify that no message in the inbox is moved to the archived section.
