### PR TITLE
fix: [IABT-1447] Services logos not updating on Android devices

### DIFF
--- a/ts/components/IdpsGrid.tsx
+++ b/ts/components/IdpsGrid.tsx
@@ -22,6 +22,7 @@ import { idpsStateSelector } from "../store/reducers/content";
 import { LocalIdpsFallback } from "../utils/idps";
 import { localeDateFormat } from "../utils/locale";
 import I18n from "../i18n";
+import { toAndroidCacheTimestamp } from "../utils/dates";
 import { VSpacer } from "./core/spacer/Spacer";
 import { IOColors } from "./core/variables/IOColors";
 
@@ -80,10 +81,7 @@ const keyExtractor = (idp: LocalIdpsFallback): string => idp.id;
 // Image cache forced refresh for Android by appending
 // the `ts` query parameter as DDMMYYYY to simulate a 24h TTL.
 const androidIdpLogoForcedRefreshed = () => {
-  const timestampValue = localeDateFormat(
-    new Date(),
-    I18n.t("global.dateFormats.shortFormat").replace(/\//g, "")
-  );
+  const timestampValue = toAndroidCacheTimestamp();
   return Platform.OS === "android" ? `?ts=${timestampValue}` : "";
 };
 

--- a/ts/components/IdpsGrid.tsx
+++ b/ts/components/IdpsGrid.tsx
@@ -20,8 +20,6 @@ import themeVariables from "../theme/variables";
 import { GlobalState } from "../store/reducers/types";
 import { idpsStateSelector } from "../store/reducers/content";
 import { LocalIdpsFallback } from "../utils/idps";
-import { localeDateFormat } from "../utils/locale";
-import I18n from "../i18n";
 import { toAndroidCacheTimestamp } from "../utils/dates";
 import { VSpacer } from "./core/spacer/Spacer";
 import { IOColors } from "./core/variables/IOColors";

--- a/ts/components/ui/MultiImage.tsx
+++ b/ts/components/ui/MultiImage.tsx
@@ -55,11 +55,10 @@ export class MultiImage extends React.PureComponent<Props, State> {
             atIndex,
             T.number.decode,
             E.fold(
-              () => {
-                const { uri, ...others } = atIndex as ImageURISource;
-                const timestampValue = toAndroidCacheTimestamp();
-                return { uri: `${uri}?ts=${timestampValue}`, ...others };
-              },
+              () => ({
+                uri: `${(atIndex as ImageURISource).uri}?ts=${new Date()}`,
+                ...(atIndex as ImageURISource)
+              }),
               () => atIndex
             )
           )

--- a/ts/components/ui/MultiImage.tsx
+++ b/ts/components/ui/MultiImage.tsx
@@ -56,7 +56,9 @@ export class MultiImage extends React.PureComponent<Props, State> {
             T.number.decode,
             E.fold(
               () => ({
-                uri: `${(atIndex as ImageURISource).uri}?ts=${new Date()}`,
+                uri: `${
+                  (atIndex as ImageURISource).uri
+                }?ts=${toAndroidCacheTimestamp()}`,
                 ...(atIndex as ImageURISource)
               }),
               () => atIndex

--- a/ts/components/ui/MultiImage.tsx
+++ b/ts/components/ui/MultiImage.tsx
@@ -45,7 +45,7 @@ export class MultiImage extends React.PureComponent<Props, State> {
 
     const atIndex = this.props.source[sourceIndex];
 
-    // Workaround for invalidating the Android chance of the Image component.
+    // Workaround for invalidating the Android cache of the Image component.
     const source: ImageURISource | ImageRequireSource = pipe(
       Platform.OS === "android",
       B.fold(

--- a/ts/components/ui/MultiImage.tsx
+++ b/ts/components/ui/MultiImage.tsx
@@ -11,8 +11,6 @@ import { pipe } from "fp-ts/lib/function";
 import * as B from "fp-ts/boolean";
 import * as T from "io-ts";
 import * as E from "fp-ts/Either";
-import { localeDateFormat } from "../../utils/locale";
-import I18n from "../../i18n";
 import { toAndroidCacheTimestamp } from "../../utils/dates";
 
 interface Props extends Omit<ImageProps, "source"> {
@@ -48,19 +46,20 @@ export class MultiImage extends React.PureComponent<Props, State> {
     const atIndex = this.props.source[sourceIndex];
 
     const source: ImageURISource | ImageRequireSource = pipe(
-      Platform.OS === 'android',
+      Platform.OS === "android",
       B.fold(
         () => atIndex,
-        () => pipe(
-            atIndex, 
+        () =>
+          pipe(
+            atIndex,
             T.number.decode,
             E.fold(
               () => {
-                const {uri, ...others} = atIndex as ImageURISource;
+                const { uri, ...others } = atIndex as ImageURISource;
                 const timestampValue = toAndroidCacheTimestamp();
-                return {uri: `${uri}?ts=${timestampValue}`, ...others};
+                return { uri: `${uri}?ts=${timestampValue}`, ...others };
               },
-              () => atIndex, 
+              () => atIndex
             )
           )
       )

--- a/ts/components/ui/MultiImage.tsx
+++ b/ts/components/ui/MultiImage.tsx
@@ -56,10 +56,10 @@ export class MultiImage extends React.PureComponent<Props, State> {
             T.number.decode,
             E.fold(
               () => ({
+                ...(atIndex as ImageURISource),
                 uri: `${
                   (atIndex as ImageURISource).uri
-                }?ts=${toAndroidCacheTimestamp()}`,
-                ...(atIndex as ImageURISource)
+                }?ts=${toAndroidCacheTimestamp()}`
               }),
               () => atIndex
             )

--- a/ts/components/ui/MultiImage.tsx
+++ b/ts/components/ui/MultiImage.tsx
@@ -45,6 +45,7 @@ export class MultiImage extends React.PureComponent<Props, State> {
 
     const atIndex = this.props.source[sourceIndex];
 
+    // Workaround for invalidating the Android chance of the Image component.
     const source: ImageURISource | ImageRequireSource = pipe(
       Platform.OS === "android",
       B.fold(

--- a/ts/components/ui/MultiImage.tsx
+++ b/ts/components/ui/MultiImage.tsx
@@ -4,8 +4,16 @@ import {
   Image,
   ImageProps,
   ImageRequireSource,
-  ImageURISource
+  ImageURISource,
+  Platform
 } from "react-native";
+import { pipe } from "fp-ts/lib/function";
+import * as B from "fp-ts/boolean";
+import * as T from "io-ts";
+import * as E from "fp-ts/Either";
+import { localeDateFormat } from "../../utils/locale";
+import I18n from "../../i18n";
+import { toAndroidCacheTimestamp } from "../../utils/dates";
 
 interface Props extends Omit<ImageProps, "source"> {
   source: ReadonlyArray<ImageURISource | ImageRequireSource>;
@@ -36,7 +44,28 @@ export class MultiImage extends React.PureComponent<Props, State> {
     if (sourceIndex === undefined) {
       return null;
     }
-    const source = this.props.source[sourceIndex];
+
+    const atIndex = this.props.source[sourceIndex];
+
+    const source: ImageURISource | ImageRequireSource = pipe(
+      Platform.OS === 'android',
+      B.fold(
+        () => atIndex,
+        () => pipe(
+            atIndex, 
+            T.number.decode,
+            E.fold(
+              () => {
+                const {uri, ...others} = atIndex as ImageURISource;
+                const timestampValue = toAndroidCacheTimestamp();
+                return {uri: `${uri}?ts=${timestampValue}`, ...others};
+              },
+              () => atIndex, 
+            )
+          )
+      )
+    );
+
     const onError = () => {
       // if current image fails loading, move to next
       this.setState((_, props) => ({

--- a/ts/utils/dates.ts
+++ b/ts/utils/dates.ts
@@ -295,3 +295,14 @@ export const getTranslatedShortNumericMonthYear = (
     I18n.t("global.dateFormats.shortNumericMonthYear")
   );
 };
+
+/**
+ * Generates a locale formatted timestamp, 
+ * used to force the refresh of the Image component cache for Android devices
+ * every 24 hours.
+ * @returns the actual locale date short format.
+ */
+export const toAndroidCacheTimestamp = () => localeDateFormat(
+    new Date(),
+    I18n.t("global.dateFormats.shortFormat").replace(/\//g, "")
+  );

--- a/ts/utils/dates.ts
+++ b/ts/utils/dates.ts
@@ -300,7 +300,7 @@ export const getTranslatedShortNumericMonthYear = (
  * Generates a locale formatted timestamp,
  * used to force the refresh of the Image component cache for Android devices
  * every 24 hours.
- * @returns the actual locale date short format.
+ * @returns the actual locale date short format without slashes.
  */
 export const toAndroidCacheTimestamp = () =>
   localeDateFormat(

--- a/ts/utils/dates.ts
+++ b/ts/utils/dates.ts
@@ -297,12 +297,13 @@ export const getTranslatedShortNumericMonthYear = (
 };
 
 /**
- * Generates a locale formatted timestamp, 
+ * Generates a locale formatted timestamp,
  * used to force the refresh of the Image component cache for Android devices
  * every 24 hours.
  * @returns the actual locale date short format.
  */
-export const toAndroidCacheTimestamp = () => localeDateFormat(
+export const toAndroidCacheTimestamp = () =>
+  localeDateFormat(
     new Date(),
     I18n.t("global.dateFormats.shortFormat").replace(/\//g, "")
   );


### PR DESCRIPTION
## Short description
This PR implements a workaround for the aggressive ```Image``` component caching on Android which prevents the services logos from refreshing when changed.
The implemented workaround is the same as [this PR](https://github.com/pagopa/io-app/pull/4360). 

## List of changes proposed in this pull request
- ```ts/utils/dates.ts```: added the ```toAndroidCacheTimestamp``` function to return the locale formatted timestamp;
- ```ts/components/ui/MultiImage.tsx```: added a timestamp to the URI on Android by using ```toAndroidCacheTimestamp```. This component is used to render services logos;
- ```ts/components/IdpsGrid.tsx```: added a timestamp to the URI on Android by using ```toAndroidCacheTimestamp```.

## How to test
Using the dev server: 
1. Open any national service detail screen in the app;
2. Replace the service logo at ```pagopa/io-dev-api-server/assets/imgs/logos/services/service_1.png``` with another image;
3. Wait until midnight and the logo should be properly updated on Android. To speed up the process, change the emulator date time or edit the ```toAndroidCacheTimestamp``` function in ```ts/utils/dates.ts``` to return a random string, such as ```new Date()```. This will cause the image to refresh immediately upon changes;
4. Go back to the national services screen and then open the same service detail screen.
