### PR TITLE
fix: [IOAPPFD0-50] Crash when navigating out of a WebView on Android

### DIFF
--- a/ts/components/services/LocalServicesWebView.tsx
+++ b/ts/components/services/LocalServicesWebView.tsx
@@ -3,7 +3,7 @@ import * as E from "fp-ts/lib/Either";
 import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
 import React from "react";
-import { StyleSheet, View } from "react-native";
+import { Platform, StyleSheet, View } from "react-native";
 import WebView, { WebViewMessageEvent } from "react-native-webview";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
@@ -130,7 +130,7 @@ const LocalServicesWebView = (props: Props) => {
         androidMicrophoneAccessDisabled={true}
         ref={webViewRef}
         injectedJavaScript={closeInjectedScript(AVOID_ZOOM_JS)}
-        style={{ flex: 1 }}
+        style={style.webView}
         textZoom={100}
         source={{
           uri: localServicesWebUrl
@@ -149,6 +149,13 @@ const LocalServicesWebView = (props: Props) => {
     </>
   );
 };
+
+const style = StyleSheet.create({
+  webView: {
+    flex: 1,
+    opacity: Platform.OS === "android" ? 0.99 : 1 // Android workaround to avoid crashing when navigating out of a WebView
+  }
+});
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   loadService: (serviceId: string) =>


### PR DESCRIPTION
## Short description
This PR implements a workaround for a potential crash that could occur when navigating out of a screen with a WebView on Android. It doesn't happen on iOS devices.
This is an [issue](https://github.com/react-native-webview/react-native-webview/issues/811#issuecomment-570813204) of possibly some versions of WebView as it doesn't always occur. 

## List of changes proposed in this pull request
- ts/components/services/LocalServicesWebView.tsx: Replaced the inline styling with a StyleSheet containing a conditional styling which applies an opacity of 0.99 for Android and the default one for iOS. 

## How to test
1. Select "services" in the bottom tab navigator and then "Local" in the tab navigator;
2. Select "National" in the tab navigator and then select any available service.
