### PR TITLE
fix: [IABT-1447] Revert: services logos not updating on Android devices

### DIFF
--- a/ts/components/IdpsGrid.tsx
+++ b/ts/components/IdpsGrid.tsx
@@ -20,7 +20,8 @@ import themeVariables from "../theme/variables";
 import { GlobalState } from "../store/reducers/types";
 import { idpsStateSelector } from "../store/reducers/content";
 import { LocalIdpsFallback } from "../utils/idps";
-import { toAndroidCacheTimestamp } from "../utils/dates";
+import { localeDateFormat } from "../utils/locale";
+import I18n from "../i18n";
 import { VSpacer } from "./core/spacer/Spacer";
 import { IOColors } from "./core/variables/IOColors";
 
@@ -79,7 +80,10 @@ const keyExtractor = (idp: LocalIdpsFallback): string => idp.id;
 // Image cache forced refresh for Android by appending
 // the `ts` query parameter as DDMMYYYY to simulate a 24h TTL.
 const androidIdpLogoForcedRefreshed = () => {
-  const timestampValue = toAndroidCacheTimestamp();
+  const timestampValue = localeDateFormat(
+    new Date(),
+    I18n.t("global.dateFormats.shortFormat").replace(/\//g, "")
+  );
   return Platform.OS === "android" ? `?ts=${timestampValue}` : "";
 };
 

--- a/ts/components/ui/MultiImage.tsx
+++ b/ts/components/ui/MultiImage.tsx
@@ -4,14 +4,8 @@ import {
   Image,
   ImageProps,
   ImageRequireSource,
-  ImageURISource,
-  Platform
+  ImageURISource
 } from "react-native";
-import { pipe } from "fp-ts/lib/function";
-import * as B from "fp-ts/boolean";
-import * as T from "io-ts";
-import * as E from "fp-ts/Either";
-import { toAndroidCacheTimestamp } from "../../utils/dates";
 
 interface Props extends Omit<ImageProps, "source"> {
   source: ReadonlyArray<ImageURISource | ImageRequireSource>;
@@ -42,31 +36,7 @@ export class MultiImage extends React.PureComponent<Props, State> {
     if (sourceIndex === undefined) {
       return null;
     }
-
-    const atIndex = this.props.source[sourceIndex];
-
-    // Workaround for invalidating the Android cache of the Image component.
-    const source: ImageURISource | ImageRequireSource = pipe(
-      Platform.OS === "android",
-      B.fold(
-        () => atIndex,
-        () =>
-          pipe(
-            atIndex,
-            T.number.decode,
-            E.fold(
-              () => ({
-                ...(atIndex as ImageURISource),
-                uri: `${
-                  (atIndex as ImageURISource).uri
-                }?ts=${toAndroidCacheTimestamp()}`
-              }),
-              () => atIndex
-            )
-          )
-      )
-    );
-
+    const source = this.props.source[sourceIndex];
     const onError = () => {
       // if current image fails loading, move to next
       this.setState((_, props) => ({

--- a/ts/utils/dates.ts
+++ b/ts/utils/dates.ts
@@ -295,15 +295,3 @@ export const getTranslatedShortNumericMonthYear = (
     I18n.t("global.dateFormats.shortNumericMonthYear")
   );
 };
-
-/**
- * Generates a locale formatted timestamp,
- * used to force the refresh of the Image component cache for Android devices
- * every 24 hours.
- * @returns the actual locale date short format without slashes.
- */
-export const toAndroidCacheTimestamp = () =>
-  localeDateFormat(
-    new Date(),
-    I18n.t("global.dateFormats.shortFormat").replace(/\//g, "")
-  );


### PR DESCRIPTION
This PR  reverts pagopa/io-app#4458 because we have found we didn't manage `undefined` values the right way.