### PR TITLE
fix: Back Button not working in IdentificationModal (#2764)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -340,7 +340,7 @@ task copyDownloadableDepsToLibs(type: Copy) {
 }
 
 // Add the following line to the bottom of the file:
-apply plugin: 'com.google.gms.google-services'  // Google Play services Gradle plugin
+// apply plugin: 'com.google.gms.google-services'  // Google Play services Gradle plugin
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
 
 def isNewArchitectureEnabled() {

--- a/package.json
+++ b/package.json
@@ -317,5 +317,9 @@
     "scripts": {
       "postchangelog": "node scripts/changelog/add_pivotal_stories.js"
     }
+  },
+  "volta": {
+    "node": "16.19.0",
+    "yarn": "1.22.19"
   }
 }

--- a/ts/screens/modal/IdentificationModal.tsx
+++ b/ts/screens/modal/IdentificationModal.tsx
@@ -3,7 +3,7 @@ import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
 import { Content, Text as NBText } from "native-base";
 import * as React from "react";
-import { View, Alert, Modal, StatusBar, StyleSheet } from "react-native";
+import { View, Alert, Modal, StatusBar, StyleSheet, BackHandler } from "react-native";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
 import { Link } from "../../components/core/typography/Link";
@@ -72,7 +72,9 @@ const checkPinInterval = 100 as Millisecond;
 // the threshold of attempts after which it is necessary to activate the timer check
 const checkTimerThreshold = maxAttempts - freeAttempts;
 
-const onRequestCloseHandler = () => undefined;
+const onRequestCloseHandler = () => {
+  BackHandler.exitApp();
+};
 
 const styles = StyleSheet.create({
   header: {


### PR DESCRIPTION
## Short description
Chiude #2764. Permette la chiusura dell'app su Android premendo il tasto indietro quando si è nella Schermata di Inserimento del PIN proprio come avviene nelle altre schermate.

## How to test
Ho testato il comportamento del pulsante indietro nelle altre schermate ed è il medesimo.

## Notes
Mi piacerebbe modificare il comportamento del pulsante "indietro" nelle altre schermate per fare in modo che venga richiesto il doppio tap per uscire (come proposto [qui](https://github.com/pagopa/io-app/issues/2764#issue-798212875) da @drsurfer). Non trovo, però, il codice dove viene gestita l'uscita nelle altre schermate (forse è un comportamento di default di React Native - che non ho mai utilizzato prima - o forse è la mia pigrizia domenicale che non ha aiutato). Mi piacerebbero le vostre opinioni rispetto a questa potenziale modifica e, eventualmente, degli indizi su cosa e dove modificare.