### PR TITLE
fix(IDPay): [IODPAY-183] Singular for payment methods i18n in initiative details page 

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3336,8 +3336,9 @@ idpay:
             showMore: Vedi tutte
             header: Impostazioni
             associatedPaymentMethods: Metodi di pagamento associati
-            methodsPlural: metodi 
-            methodsSingular: metodo 
+            methods:
+              one: "1 metodo"
+              other: "{{count}} metodi"
             selectedIBAN: IBAN per l'accredito
             actionsRequired: Azioni richieste 
           startConfigurationCTA: Inizia

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3336,7 +3336,8 @@ idpay:
             showMore: Vedi tutte
             header: Impostazioni
             associatedPaymentMethods: Metodi di pagamento associati
-            methodsi18n: metodi 
+            methodsPlural: metodi 
+            methodsSingular: metodo 
             selectedIBAN: IBAN per l'accredito
             actionsRequired: Azioni richieste 
           startConfigurationCTA: Inizia

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3360,8 +3360,9 @@ idpay:
             showMore: Vedi tutte
             header: Impostazioni
             associatedPaymentMethods: Metodi di pagamento associati
-            methodsPlural: metodi 
-            methodsSingular: metodo 
+            methods:
+              one: "1 metodo"
+              other: "{{count}} metodi"
             selectedIBAN: IBAN per l'accredito
             actionsRequired: Azioni richieste 
           startConfigurationCTA: Inizia

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3360,7 +3360,8 @@ idpay:
             showMore: Vedi tutte
             header: Impostazioni
             associatedPaymentMethods: Metodi di pagamento associati
-            methodsi18n: metodi 
+            methodsPlural: metodi 
+            methodsSingular: metodo 
             selectedIBAN: IBAN per l'accredito
             actionsRequired: Azioni richieste 
           startConfigurationCTA: Inizia

--- a/ts/features/idpay/initiative/details/components/InitiativeSettingsComponent.tsx
+++ b/ts/features/idpay/initiative/details/components/InitiativeSettingsComponent.tsx
@@ -98,9 +98,14 @@ export const InitiativeSettingsComponent = (props: Props) => {
           title={I18n.t(
             "idpay.initiative.details.initiativeDetailsScreen.configured.settings.associatedPaymentMethods"
           )}
-          subTitle={`${initiative.nInstr} ${I18n.t(
-            "idpay.initiative.details.initiativeDetailsScreen.configured.settings.methodsi18n"
-          )}`}
+          subTitle={
+            `${initiative.nInstr} ` +
+            I18n.t(
+              `idpay.initiative.details.initiativeDetailsScreen.configured.settings.${
+                initiative.nInstr === 1 ? "methodsSingular" : "methodsPlural"
+              }`
+            )
+          }
           onPress={navigateToInstrumentsConfiguration}
           hasWarnings={
             initiative.status === StatusEnum.NOT_REFUNDABLE_ONLY_IBAN

--- a/ts/features/idpay/initiative/details/components/InitiativeSettingsComponent.tsx
+++ b/ts/features/idpay/initiative/details/components/InitiativeSettingsComponent.tsx
@@ -98,14 +98,16 @@ export const InitiativeSettingsComponent = (props: Props) => {
           title={I18n.t(
             "idpay.initiative.details.initiativeDetailsScreen.configured.settings.associatedPaymentMethods"
           )}
-          subTitle={
-            `${initiative.nInstr} ` +
-            I18n.t(
-              `idpay.initiative.details.initiativeDetailsScreen.configured.settings.${
-                initiative.nInstr === 1 ? "methodsSingular" : "methodsPlural"
-              }`
-            )
-          }
+          subTitle={I18n.t(
+            `idpay.initiative.details.initiativeDetailsScreen.configured.settings.methods`,
+            {
+              defaultValue: I18n.t(
+                `idpay.initiative.details.initiativeDetailsScreen.configured.settings.methods.other`,
+                { count: initiative.nInstr }
+              ),
+              count: initiative.nInstr
+            }
+          )}
           onPress={navigateToInstrumentsConfiguration}
           hasWarnings={
             initiative.status === StatusEnum.NOT_REFUNDABLE_ONLY_IBAN


### PR DESCRIPTION
## Short description
added missing i18n and rendering logic

## List of changes proposed in this pull request
see description

## How to test
opening up an initiative's details while having a single method connected should now render "1 method" instead of "1 methods"