### PR TITLE
[IODPAY-197] fix infinite loading in card detail

### DIFF
--- a/ts/features/idpay/wallet/store/reducers/index.ts
+++ b/ts/features/idpay/wallet/store/reducers/index.ts
@@ -122,9 +122,14 @@ export const idPayEnabledInitiativesFromInstrumentSelector = createSelector(
     isIdpayEnabled ? pot.getOrElse(initiatives, []) : []
 );
 
-export const idPayAreInitiativesFromInstrumentLoadingSelector = (
-  state: GlobalState
-) => pot.isLoading(state.features.idPay.wallet.initiativesWithInstrument);
+const idPayInitiativesFromInstrumentPotSelector = (state: GlobalState) =>
+  state.features.idPay.wallet.initiativesWithInstrument;
+
+export const idPayAreInitiativesFromInstrumentLoadingSelector = createSelector(
+  [isIdPayEnabledSelector, idPayInitiativesFromInstrumentPotSelector],
+  (isIDPayEnabled, initiativesPot) =>
+    isIDPayEnabled ? pot.isLoading(initiativesPot) : false
+);
 export const idPayAreInitiativesFromInstrumentErrorSelector = (
   state: GlobalState
 ) => pot.isError(state.features.idPay.wallet.initiativesWithInstrument);


### PR DESCRIPTION
## Short description
added a missing check for idpay's feature flag state in the loading selector creditCardDetailScreen relies on

## List of changes proposed in this pull request

- initiativesFromInstrumentPotSelector
- updated the loading selector to check for idpay's FF state

## How to test
with IDPay's test FF set to off, navigate to a card's detail screen and make sure that:
- it correctly loads
- does not render idpay's initiative list
- does not display any loading spinner
