### PR TITLE
feat(Firma con IO): [SFEQS-1044] Add bottom sheet to check/activate service preferences

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3214,6 +3214,11 @@ features:
       content: "Do you want to cancel the documents signing process?"
       cancel: "Cancel signing"
       confirm: "Keep signing"
+    checkService:
+      title: "Turn on messages"
+      content: "To receive signed documents you must activate the option that allows the service to send you messages. If you don't activate it, you can complete the signature but you won't receive the signed documents."
+      cancel: "Not now"
+      confirm: "Turn on"
     signatureFields:
       title: "Sign here"
       showOnDocument: "See on document"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3238,6 +3238,11 @@ features:
       content: "Vuoi annullare la firma dei documenti?"
       cancel: "Annulla la firma"
       confirm: "Continua a firmare"
+    checkService:
+      title: "Attiva i messaggi"
+      content: "Per ricevere i documenti firmati devi attivare l’opzione che consente al servizio di inviarti messaggi. Se non la attivi, puoi completare la firma ma non riceverai i documenti firmati."
+      cancel: "Non ora"
+      confirm: "Attiva"
     signatureFields:
       title: "Firma qui"
       showOnDocument: "Vedi sul documento"

--- a/ts/features/fci/hooks/useFciCheckService.tsx
+++ b/ts/features/fci/hooks/useFciCheckService.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+import { StyleSheet, View } from "react-native";
+import * as pot from "@pagopa/ts-commons/lib/pot";
+import { useIOBottomSheetModal } from "../../../utils/hooks/bottomSheet";
+import { IOStyles } from "../../../components/core/variables/IOStyles";
+import { H3 } from "../../../components/core/typography/H3";
+import FooterWithButtons from "../../../components/ui/FooterWithButtons";
+import I18n from "../../../i18n";
+import customVariables from "../../../theme/variables";
+import { confirmButtonProps } from "../../bonus/bonusVacanze/components/buttons/ButtonConfigurations";
+import { H4 } from "../../../components/core/typography/H4";
+import { useIODispatch, useIOSelector } from "../../../store/hooks";
+import { fciStartSigningRequest } from "../store/actions";
+import { upsertServicePreference } from "../../../store/actions/services/servicePreference";
+import { ServiceId } from "../../../../definitions/backend/ServiceId";
+import { isServicePreferenceResponseSuccess } from "../../../types/services/ServicePreferenceResponse";
+import { servicePreferenceSelector } from "../../../store/reducers/entities/services/servicePreference";
+import { fciMetadataServiceIdSelector } from "../store/reducers/fciMetadata";
+
+const styles = StyleSheet.create({
+  verticalPad: {
+    paddingVertical: customVariables.spacerHeight
+  }
+});
+
+/**
+ * A hook that returns a function to present the abort signature flow bottom sheet
+ */
+export const useFciCheckService = () => {
+  const dispatch = useIODispatch();
+  const fciServiceId = useIOSelector(fciMetadataServiceIdSelector);
+  const servicePreference = useIOSelector(servicePreferenceSelector);
+  const servicePreferenceValue = pot.getOrElse(servicePreference, undefined);
+  const { present, bottomSheet, dismiss } = useIOBottomSheetModal(
+    <View style={styles.verticalPad}>
+      <H4 weight={"Regular"}>{I18n.t("features.fci.checkService.content")}</H4>
+    </View>,
+    <View style={IOStyles.flex}>
+      <H3 color={"bluegreyDark"} weight={"SemiBold"}>
+        {I18n.t("features.fci.checkService.title")}
+      </H3>
+    </View>,
+    280,
+    <FooterWithButtons
+      type={"TwoButtonsInlineThird"}
+      leftButton={{
+        onPressWithGestureHandler: true,
+        bordered: true,
+        onPress: () => {
+          dispatch(fciStartSigningRequest());
+          dismiss();
+        },
+        title: I18n.t("features.fci.checkService.cancel")
+      }}
+      rightButton={{
+        ...confirmButtonProps(() => {
+          if (
+            fciServiceId &&
+            servicePreferenceValue &&
+            isServicePreferenceResponseSuccess(servicePreferenceValue)
+          ) {
+            const sp = { ...servicePreferenceValue.value, inbox: true };
+            dispatch(
+              upsertServicePreference.request({
+                id: fciServiceId as ServiceId,
+                ...sp
+              })
+            );
+          }
+          dispatch(fciStartSigningRequest());
+          dismiss();
+        }, I18n.t("features.fci.checkService.confirm")),
+        onPressWithGestureHandler: true
+      }}
+    />
+  );
+
+  return {
+    dismiss,
+    present,
+    bottomSheet
+  };
+};

--- a/ts/features/fci/screens/valid/FciQtspClausesScreen.tsx
+++ b/ts/features/fci/screens/valid/FciQtspClausesScreen.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { SafeAreaView, FlatList, View } from "react-native";
 import { useSelector } from "react-redux";
 import { useNavigation } from "@react-navigation/native";
+import * as pot from "@pagopa/ts-commons/lib/pot";
 import { constNull } from "fp-ts/lib/function";
 import { H1 } from "../../../../components/core/typography/H1";
 import { IOStyles } from "../../../../components/core/variables/IOStyles";
@@ -30,9 +31,18 @@ import GenericErrorComponent from "../../components/GenericErrorComponent";
 import LinkedText from "../../components/LinkedText";
 import { H4 } from "../../../../components/core/typography/H4";
 import { VSpacer } from "../../../../components/core/spacer/Spacer";
+import { servicePreferenceSelector } from "../../../../store/reducers/entities/services/servicePreference";
+import { loadServicePreference } from "../../../../store/actions/services/servicePreference";
+import { ServiceId } from "../../../../../definitions/backend/ServiceId";
+import { useFciCheckService } from "../../hooks/useFciCheckService";
+import { isServicePreferenceResponseSuccess } from "../../../../types/services/ServicePreferenceResponse";
+import { fciMetadataServiceIdSelector } from "../../store/reducers/fciMetadata";
 
 const FciQtspClausesScreen = () => {
+  const dispatch = useIODispatch();
+  const navigation = useNavigation();
   const [clausesChecked, setClausesChecked] = React.useState(0);
+  const servicePreference = useSelector(servicePreferenceSelector);
   const qtspClausesSelector = useSelector(fciQtspClausesSelector);
   const qtspPrivacyTextSelector = useSelector(fciQtspPrivacyTextSelector);
   const qtspPrivacyUrlSelector = useSelector(fciQtspPrivacyUrlSelector);
@@ -42,11 +52,25 @@ const FciQtspClausesScreen = () => {
   const fciPollFilledDocumentError = useSelector(
     fciPollFilledDocumentErrorSelector
   );
+  const fciServiceId = useSelector(fciMetadataServiceIdSelector);
 
-  const navigation = useNavigation();
-  const dispatch = useIODispatch();
+  const servicePreferenceValue = pot.getOrElse(servicePreference, undefined);
 
-  const { present, bottomSheet: fciAbortSignature } =
+  const isServiceActive =
+    servicePreferenceValue &&
+    isServicePreferenceResponseSuccess(servicePreferenceValue) &&
+    servicePreferenceValue.value.inbox;
+
+  React.useEffect(() => {
+    if (fciServiceId) {
+      dispatch(loadServicePreference.request(fciServiceId as ServiceId));
+    }
+  }, [dispatch, fciServiceId]);
+
+  const { present: showCheckService, bottomSheet: fciCheckService } =
+    useFciCheckService();
+
+  const { present: showAbort, bottomSheet: fciAbortSignature } =
     useFciAbortSignatureFlow();
 
   const openUrl = (url: string) => {
@@ -122,7 +146,7 @@ const FciQtspClausesScreen = () => {
     block: true,
     light: false,
     bordered: true,
-    onPress: present,
+    onPress: showAbort,
     title: I18n.t("global.buttons.cancel")
   };
 
@@ -130,7 +154,8 @@ const FciQtspClausesScreen = () => {
     block: true,
     primary: true,
     disabled: clausesChecked !== qtspClausesSelector.length,
-    onPress: () => dispatch(fciStartSigningRequest()),
+    onPress: () =>
+      isServiceActive ? dispatch(fciStartSigningRequest()) : showCheckService(),
     title: I18n.t("global.buttons.continue")
   };
 
@@ -157,6 +182,7 @@ const FciQtspClausesScreen = () => {
         />
       </SafeAreaView>
       {fciAbortSignature}
+      {fciCheckService}
     </BaseScreenComponent>
   );
 };

--- a/ts/features/fci/store/reducers/fciMetadata.ts
+++ b/ts/features/fci/store/reducers/fciMetadata.ts
@@ -1,5 +1,6 @@
 import * as pot from "@pagopa/ts-commons/lib/pot";
 import { getType } from "typesafe-actions";
+import { createSelector } from "reselect";
 import { Action } from "../../../../store/actions/types";
 import { GlobalState } from "../../../../store/reducers/types";
 import { NetworkError } from "../../../../utils/errors";
@@ -32,5 +33,11 @@ const reducer = (
 export const fciMetadataSelector = (
   state: GlobalState
 ): FciMetadataRequestState => state.features.fci.metadata;
+
+export const fciMetadataServiceIdSelector = createSelector(
+  fciMetadataSelector,
+  fciMetadata =>
+    pot.isSome(fciMetadata) ? fciMetadata.value.serviceId : undefined
+);
 
 export default reducer;


### PR DESCRIPTION
## Short description
This PR adds a BS and a check on the inbox status of the service preference giving the serviceId of FCI.

https://user-images.githubusercontent.com/49342144/229453496-9757b75c-b873-4ce6-966b-724c3f199a64.mp4

## List of changes proposed in this pull request
- Add check service bs
- Update `FciQtspClausesScreen`

## How to test

1.  start `io-dev-api-server`
2. go to the service panel -> Firma con IO and disable "Contattarti in app"
3. tap on a `WAIT_FOR_SIGNATURE` message and start a signing flow
4. on the QTSP clauses screen try to tap to continue and should appear a BS

NOTE: tapping on "Attiva ora" or "Non ora" are a non blocking CTA. The signing flow should continue in any case. The BS gives to the user the availability to activate "Contattarti in app" without go in the service preference screen.