### PR TITLE
fix: [LLK-71] Fix test login

### DIFF
--- a/ts/features/lollipop/__tests__/login.test.ts
+++ b/ts/features/lollipop/__tests__/login.test.ts
@@ -41,6 +41,10 @@ const DATA_FROM_SERVER: DataFromServerType = {
   }
 };
 
+jest.mock("../../../store/reducers/authentication", () => ({
+  isLoggedOutWithoutIdpSelector: () => false
+}));
+
 const mockedSessionInvalid: StaticProvider = [put(sessionInvalid()), true];
 const mockedRestartCleanApplication: StaticProvider = [
   call(restartCleanApplication),

--- a/ts/features/lollipop/saga/index.ts
+++ b/ts/features/lollipop/saga/index.ts
@@ -73,7 +73,7 @@ export function* checkLollipopSessionAssertionAndInvalidateIfNeeded(
   maybePublicKey: O.Option<PublicKey>,
   maybeSessionInformation: O.Option<PublicSession>
 ) {
-  // The actual function is called after the login.
+  // The actual function is called after a successful login.
   // For the test idp we don't store any authentication data.
   // If we are logged with the test idp we don't need to check the lollipop assertion.
   const areWeLoggedWithTestIdp = yield* select(isLoggedOutWithoutIdpSelector);

--- a/ts/features/lollipop/saga/index.ts
+++ b/ts/features/lollipop/saga/index.ts
@@ -76,7 +76,7 @@ export function* checkLollipopSessionAssertionAndInvalidateIfNeeded(
   // When using the test idp to login, no authentication data nor lollipop key are saved / used / sent.
   // Therefore, we must not check for the lollipop assertion,
   // when this function is called after a successful test idp login,
-  // otherwise the (test) user is immediately logged-out".
+  // otherwise the (test) user is immediately logged-out.
   // TODO: this is a temporary workaround, we should find a better way to handle test accounts.
   // See: https://pagopa.atlassian.net/browse/LLK-72
   const areWeLoggedWithTestIdp = yield* select(isLoggedOutWithoutIdpSelector);

--- a/ts/features/lollipop/saga/index.ts
+++ b/ts/features/lollipop/saga/index.ts
@@ -31,6 +31,7 @@ import {
   trackLollipopKeyGenerationSuccess
 } from "../../../utils/analytics";
 import { PublicSession } from "../../../../definitions/backend/PublicSession";
+import { isLoggedOutWithoutIdpSelector } from "../../../store/reducers/authentication";
 
 export function* generateLollipopKeySaga() {
   const maybeOldKeyTag = yield* select(lollipopKeyTagSelector);
@@ -72,6 +73,14 @@ export function* checkLollipopSessionAssertionAndInvalidateIfNeeded(
   maybePublicKey: O.Option<PublicKey>,
   maybeSessionInformation: O.Option<PublicSession>
 ) {
+  // The actual function is called after the login.
+  // For the test idp we don't store any authentication data.
+  // If we are logged with the test idp we don't need to check the lollipop assertion.
+  const areWeLoggedWithTestIdp = yield* select(isLoggedOutWithoutIdpSelector);
+  if (areWeLoggedWithTestIdp) {
+    return;
+  }
+
   const lollipopCheckResult = pipe(
     maybeSessionInformation,
     O.chainNullableK(

--- a/ts/features/lollipop/saga/index.ts
+++ b/ts/features/lollipop/saga/index.ts
@@ -73,9 +73,12 @@ export function* checkLollipopSessionAssertionAndInvalidateIfNeeded(
   maybePublicKey: O.Option<PublicKey>,
   maybeSessionInformation: O.Option<PublicSession>
 ) {
-  // The actual function is called after a successful login.
-  // For the test idp we don't store any authentication data.
-  // If we are logged with the test idp we don't need to check the lollipop assertion.
+  // When using the test idp to login, no authentication data nor lollipop key are saved / used / sent.
+  // Therefore, we must not check for the lollipop assertion,
+  // when this function is called after a successful test idp login,
+  // otherwise the (test) user is immediately logged-out".a
+  // TODO: this is a temporary workaround, we should find a better way to handle test accounts.
+  // See: https://pagopa.atlassian.net/browse/LLK-72
   const areWeLoggedWithTestIdp = yield* select(isLoggedOutWithoutIdpSelector);
   if (areWeLoggedWithTestIdp) {
     return;

--- a/ts/features/lollipop/saga/index.ts
+++ b/ts/features/lollipop/saga/index.ts
@@ -76,7 +76,7 @@ export function* checkLollipopSessionAssertionAndInvalidateIfNeeded(
   // When using the test idp to login, no authentication data nor lollipop key are saved / used / sent.
   // Therefore, we must not check for the lollipop assertion,
   // when this function is called after a successful test idp login,
-  // otherwise the (test) user is immediately logged-out".a
+  // otherwise the (test) user is immediately logged-out".
   // TODO: this is a temporary workaround, we should find a better way to handle test accounts.
   // See: https://pagopa.atlassian.net/browse/LLK-72
   const areWeLoggedWithTestIdp = yield* select(isLoggedOutWithoutIdpSelector);

--- a/ts/store/reducers/authentication.ts
+++ b/ts/store/reducers/authentication.ts
@@ -100,7 +100,7 @@ export const INITIAL_STATE: LoggedOutWithoutIdp = {
 
 // Type guards
 
-export function isLoggedOutWithoutIdp(
+function isLoggedOutWithoutIdp(
   state: AuthenticationState
 ): state is LoggedOutWithoutIdp {
   return state.kind === "LoggedOutWithoutIdp";

--- a/ts/store/reducers/authentication.ts
+++ b/ts/store/reducers/authentication.ts
@@ -100,6 +100,12 @@ export const INITIAL_STATE: LoggedOutWithoutIdp = {
 
 // Type guards
 
+export function isLoggedOutWithoutIdp(
+  state: AuthenticationState
+): state is LoggedOutWithoutIdp {
+  return state.kind === "LoggedOutWithoutIdp";
+}
+
 export function isLoggedOutWithIdp(
   state: AuthenticationState
 ): state is LoggedOutWithIdp {
@@ -133,6 +139,9 @@ export function isSessionExpired(
 }
 
 // Selectors
+
+export const isLoggedOutWithoutIdpSelector = (state: GlobalState) =>
+  isLoggedOutWithoutIdp(state.authentication);
 
 export const isLogoutRequested = (state: GlobalState) =>
   state.authentication.kind === "LogoutRequested";


### PR DESCRIPTION
## Short description
This PR fixes the test login. After the addition of the `assertionRef`, it's now impossible to successfully login with a test account.

## List of changes proposed in this pull request
- ts/store/reducers/authentication.ts: adds type guards and selectors to check the logged-out state.
- ts/features/lollipop/saga/index.ts: disables `assertionRef` check if we are logged-in with a test account.

## How to test
You should succeed while logging in with a test login.
