### PR TITLE
chore: [IOAPPFD0-79] update e2e test for manual payments

### DIFF
--- a/ts/__e2e__/payment.e2e.ts
+++ b/ts/__e2e__/payment.e2e.ts
@@ -105,7 +105,7 @@ describe("Payment", () => {
         .withTimeout(e2eWaitRenderTimeout);
 
       await element(matchNoticeCodeInput).typeText("123123123123123123");
-      await element(by.id("EntityCodeInput")).typeText("12345678901");
+      await element(by.id("EntityCodeInputMask")).typeText("12345678901");
       // Close the keyboard
       await element(by.label("Done")).atIndex(0).tap();
 


### PR DESCRIPTION
## Short description
After merging #4480, e2e tests fail for the manual payment test. 

## List of changes proposed in this pull request
- Updates the testID for the `EntityCode` mask.

## How to test
- Run the payments E2E tests locally by following [these](https://github.com/pagopa/io-app/blob/master/TESTING_E2E.md) instructions. Tests should succeded.