### PR TITLE
[IAI-275] Fix `BaseHeader` UI regression

### DIFF
--- a/ts/components/screens/BaseHeader.tsx
+++ b/ts/components/screens/BaseHeader.tsx
@@ -231,23 +231,17 @@ class BaseHeaderComponent extends React.PureComponent<Props, State> {
         */}
         {!isSearchEnabled && (
           <NBBody style={goBack || customGoBack ? styles.body : styles.noLeft}>
-            <NBBody
-              style={goBack || customGoBack ? styles.body : styles.noLeft}
-            >
-              {this.state.isScreenReaderActive &&
-              O.isSome(maybeAccessibilityLabel) ? (
-                this.renderBodyLabel(
-                  maybeAccessibilityLabel.value,
-                  this.firstElementRef
-                )
-              ) : (
-                <View ref={this.firstElementRef} accessible={true}>
-                  {body
-                    ? body
-                    : headerTitle && this.renderBodyLabel(headerTitle)}
-                </View>
-              )}
-            </NBBody>
+            {this.state.isScreenReaderActive &&
+            O.isSome(maybeAccessibilityLabel) ? (
+              this.renderBodyLabel(
+                maybeAccessibilityLabel.value,
+                this.firstElementRef
+              )
+            ) : (
+              <View ref={this.firstElementRef} accessible={true}>
+                {body ? body : headerTitle && this.renderBodyLabel(headerTitle)}
+              </View>
+            )}
           </NBBody>
         )}
 


### PR DESCRIPTION
## Short description
This PR fixes the UI regression caused by #4321

### Preview
| Before | After
| - | - |
| <img src="https://user-images.githubusercontent.com/1255491/230376360-2c14f1df-2cce-4da1-a8ab-3e9472b7cec3.png" width="350" /> | <img src="https://user-images.githubusercontent.com/1255491/230376155-cd149dba-8106-45e0-b2de-e9daec7cd5a7.png" width="350" />


## List of changes proposed in this pull request
- Remove double `NBBody` container added by mistake