### PR TITLE
fix(Firma con IO): [SFEQS-1493] Use right pictogram for request already signed

### DIFF
--- a/ts/features/fci/components/SuccessComponent.tsx
+++ b/ts/features/fci/components/SuccessComponent.tsx
@@ -5,6 +5,7 @@ import { useIODispatch, useIOSelector } from "../../../store/hooks";
 import I18n from "../../../i18n";
 import imageExpired from "../../../../img/wallet/errors/payment-expired-icon.png";
 import hourglass from "../../../../img/pictograms/hourglass.png";
+import fireworks from "../../../../img/pictograms/fireworks.png";
 import { SignatureRequestDetailView } from "../../../../definitions/fci/SignatureRequestDetailView";
 import { isLollipopEnabledSelector } from "../../../store/reducers/backendStatus";
 import { fciEndRequest, fciStartRequest } from "../store/actions";
@@ -86,7 +87,7 @@ const SuccessComponent = (props: {
           title={I18n.t("features.fci.errors.signed.title")}
           subTitle={I18n.t("features.fci.errors.signed.subTitle")}
           onPress={() => dispatch(fciEndRequest())}
-          image={hourglass}
+          image={fireworks}
           testID={"SignedSignatureRequestTestID"}
         />
       );


### PR DESCRIPTION
## Short description
This PR adds the right pictogram in error screen for signature request already SIGNED.

![Simulator Screen Shot - iPhone 14 - 2023-04-07 at 11 30 11](https://user-images.githubusercontent.com/49342144/230584724-2f6ac244-4765-4b52-be3c-36d1335b413d.png)

## List of changes proposed in this pull request
- Update `SuccessComponent.tsx`

## How to test
Using `io-dev-api-server` a signature request in status SIGNED should show a screen as above with fireworks pictogram.