### PR TITLE
[SFEQS-1600] added english translation

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3183,30 +3183,30 @@ features:
     errors:
       expiredAfterSigned:
         title: The documents are no longer available
-        subTitle: If you need a copy, contact the issuer
+        subTitle: If you need a copy, contact the institution
       expired:
-        title: The signature request is expired
-        subTitle: If you need help contact the issuer
+        title: The signature request has expired
+        subTitle: If you need help, contact the institution
       waitForQtsp:
-        title: The document is being processed
-        subTitle: Please wait, you will soon receive the signed contract in the app.
+        title: The signature is being processed
+        subTitle: You will receive a message with the signed documents as soon as they are ready.
       generic:
         default:
-          title: There is a problem
-          subTitle: To proceed with the signature, check that you have updated the IO app to the latest version.
+          title: There's a problem on our systems
+          subTitle: Try again in a few minutes. If it happens again, contact support.
         update:
           title: Update the app
-          subTitle: Check that you have installed the latest version of IO or log in again.
+          subTitle: Make sure you have installed the latest version of IO and log in again with SPID or CIE.
         rejected:
-          title: The signing failed
-          subTitle: The sender will contact you in the next few days to get you to re-sign. If this doesn't happen, write to    
+          title: The signature failed
+          subTitle: The institution will contact you in the next few days to get you to sign again. If this doesn't happen, please e-mail    
         signing:
-          title: The signing failed
-          subTitle: Due to a technical problem, the signing was not successful. If the problem persists, contact support.   
+          title: The signature failed
+          subTitle: Due to a technical problem, the signature failed. If the problem persists, contact support.   
     abort:
-      title: "Cancel signing flow"
-      content: "Do you want to cancel the documents signing process?"
-      cancel: "Cancel signing"
+      title: "Quit signing"
+      content: "Do you want to quit signing the documents?"
+      cancel: "Quit signing"
       confirm: "Keep signing"
     signatureFields:
       title: "Sign here"
@@ -3220,21 +3220,21 @@ features:
       titleLeft: Document {{currentDoc}} of {{totalDocs}}
       titleRight: Page {{currentPage}} of {{totalPages}}
     shareDataScreen:
-      title: "Do you want to share these data?"
-      content: "These will be shared with the digital signature provider. If you cancel, you will not be able to complete the signing."
+      title: "Share these data?"
+      content: "They will be shared with the digital signature provider. If you cancel, you won't be able to complete the signature."
       cancel: "Cancel"
       confirm: "Ok"
-      alertText: "Want to change or update your email address?"
+      alertText: "Do you want to change or update your e-mail address?"
       alertLink: "Go here"
       name: "Name"
-      familyName: "Family name"
+      familyName: "Surname"
       birthDate: "Date of birth"
     thankYouPage:
       title: "Done!"
       content: "You will shortly receive a message with the signed documents."
       cta: "Close"
     qtspTos:
-      title: "We are almost there!"
+      title: "Almost there!"
       subTitle: "To sign, you must accept the terms and conditions of the service and confirm that you have read the privacy policy of the signature provider."
       show: "View"
     documents:

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3207,26 +3207,26 @@ features:
     errors:
       expiredAfterSigned:
         title: I documenti non sono più disponibili
-        subTitle: Se hai bisogno di una copia conttatta l'ente
+        subTitle: Se hai bisogno di una copia, contatta l'ente
       expired:
         title: La richiesta di firma è scaduta
-        subTitle: Per assistenza contattare l'ente
+        subTitle: Se hai bisogno di assistenza, contatta l'ente
       waitForQtsp:
-        title: Il documento è in elaborazione
-        subTitle: Ti preghiamo di attendere, presto riceverai il contratto firmato in app.
+        title: La firma è in elaborazione
+        subTitle: Riceverai un messaggio con i documenti firmati non appena saranno pronti.
       generic:
         default:
           title: C’è un problema sui nostri sistemi
           subTitle: Riprova tra qualche minuto. Se si ripete, contatta l’assistenza.
         update:
           title: Aggiorna l’app
-          subTitle: Verifica di avere installato l’ultima versione di IO oppure rifai il login. 
+          subTitle: Verifica di avere installato l’ultima versione di IO e accedi di nuovo con SPID o CIE.
         rejected:
           title: La firma non è andata a buon fine
-          subTitle: L’ente mittente ti contatterà nei prossimi giorni per farti firmare di nuovo. Se ciò non dovesse succedere, scrivi a
+          subTitle: L’ente ti contatterà nei prossimi giorni per farti firmare di nuovo. Se non dovesse succedere, scrivi a
         signing:
           title: La firma non è andata a buon fine
-          subTitle: A causa di un problema tecnico, la firma non è andata a buon fine. Se il problema si ripete contatta l’assistenza.
+          subTitle: A causa di un problema tecnico, la firma non è andata a buon fine. Se il problema si ripete, contatta l’assistenza.
     abort:
       title: "Annulla la firma"
       content: "Vuoi annullare la firma dei documenti?"
@@ -3236,7 +3236,7 @@ features:
       title: "Firma qui"
       showOnDocument: "Vedi sul documento"
       accessibility:
-        fieldDetailHint: "Vai alla pagina per visualizzare il campo firma"
+        fieldDetailHint: "Visualizza sul documento dove metterai la firma"
         selected: "Campo selezionato"
         unselected: "Campo non selezionato"
     title: "Firma con IO"
@@ -3248,7 +3248,7 @@ features:
       content: "Verranno condivisi con il fornitore della firma digitale. Se annulli, non potrai completare la firma."
       cancel: "Annulla"
       confirm: "Ok, va bene"
-      alertText: "Vuoi modificare o aggiornare il tuo indirizzo email?"
+      alertText: "Vuoi modificare o aggiornare il tuo indirizzo e-mail?"
       alertLink: "Vai qui"
       name: "Nome"
       familyName: "Cognome"


### PR DESCRIPTION
added english translation and amended some copy in the Italian version as well.

@hevelius I've noticed a minor difference in how some error messages are handled: "expiredAfterSigned" and "expired" feature the copy "contatta l'ente", while rejected features the copy "scrivi a". Are they handled differently in the BE or should the copy be the same?

I also think I branched the master before the "signed" error and "checkService" were added to the master, so I will have to make a further PR to add these after this is approved.

