### PR TITLE
[IOAPPFD0-86] Add the new `IconButton`, rename the old one to `IconButtonContained`

### DIFF
--- a/ts/components/core/variables/IOStyles.ts
+++ b/ts/components/core/variables/IOStyles.ts
@@ -78,6 +78,8 @@ const btnSizeLarge = 56;
 // NEW Design System
 const btnBorderRadius = 8;
 const btnSizeDefault = 48;
+// TODO: Replace the number type with the new IOIconSizeScale
+const iconBtnSizeSmall: number = 24;
 
 export const IOButtonLegacyStyles = StyleSheet.create({
   /* BaseButton, used in the:
@@ -180,6 +182,10 @@ export const IOIconButtonStyles = StyleSheet.create({
     justifyContent: "center",
     // Reset default visual parameters
     elevation: 0
+  },
+  buttonSizeSmall: {
+    width: iconBtnSizeSmall,
+    height: iconBtnSizeSmall
   },
   buttonSizeDefault: {
     width: btnSizeDefault,

--- a/ts/components/ui/IconButtonContained.tsx
+++ b/ts/components/ui/IconButtonContained.tsx
@@ -19,7 +19,7 @@ import { WithTestID } from "../../types/WithTestID";
 import { useIOSelector } from "../../store/hooks";
 import { isDesignSystemEnabledSelector } from "../../store/reducers/persistedPreferences";
 
-export type IconButton = WithTestID<{
+export type IconButtonContained = WithTestID<{
   icon: IOIcons;
   color?: "primary" | "neutral" | "contrast";
   disabled?: boolean;
@@ -29,6 +29,11 @@ export type IconButton = WithTestID<{
 }>;
 
 type ColorStates = {
+  background: {
+    default: string;
+    pressed: string;
+    disabled: string;
+  };
   icon: {
     default: string;
     pressed: string;
@@ -46,30 +51,45 @@ get rid of legacy variant */
 /* ◀ REMOVE_LEGACY_COMPONENT: Start */
 
 const mapLegacyColorStates: Record<
-  NonNullable<IconButton["color"]>,
+  NonNullable<IconButtonContained["color"]>,
   ColorStates
 > = {
   // Primary button
   primary: {
+    background: {
+      default: hexToRgba(IOColors.blue, 0),
+      pressed: hexToRgba(IOColors.blue, 0.15),
+      disabled: "transparent"
+    },
     icon: {
       default: IOColors.blue,
-      pressed: IOColors["blue-600"],
+      pressed: IOColors.blue,
       disabled: hexToRgba(IOColors.blue, 0.25)
     }
   },
   // Neutral button
   neutral: {
+    background: {
+      default: IOColors.white,
+      pressed: IOColors.greyUltraLight,
+      disabled: "transparent"
+    },
     icon: {
-      default: IOColors.black,
-      pressed: IOColors.bluegreyDark,
+      default: IOColors.bluegrey,
+      pressed: IOColors.black,
       disabled: IOColors.grey
     }
   },
   // Contrast button
   contrast: {
+    background: {
+      default: hexToRgba(IOColors.white, 0),
+      pressed: hexToRgba(IOColors.white, 0.2),
+      disabled: "transparent"
+    },
     icon: {
       default: IOColors.white,
-      pressed: hexToRgba(IOColors.white, 0.85),
+      pressed: IOColors.white,
       disabled: hexToRgba(IOColors.white, 0.25)
     }
   }
@@ -77,9 +97,17 @@ const mapLegacyColorStates: Record<
 
 /* REMOVE_LEGACY_COMPONENT: End ▶ */
 
-const mapColorStates: Record<NonNullable<IconButton["color"]>, ColorStates> = {
+const mapColorStates: Record<
+  NonNullable<IconButtonContained["color"]>,
+  ColorStates
+> = {
   // Primary button
   primary: {
+    background: {
+      default: hexToRgba(IOColors["blueIO-500"], 0),
+      pressed: hexToRgba(IOColors["blueIO-500"], 0.15),
+      disabled: "transparent"
+    },
     icon: {
       default: IOColors["blueIO-500"],
       pressed: IOColors["blueIO-600"],
@@ -88,17 +116,27 @@ const mapColorStates: Record<NonNullable<IconButton["color"]>, ColorStates> = {
   },
   // Neutral button
   neutral: {
+    background: {
+      default: IOColors.white,
+      pressed: IOColors.greyUltraLight,
+      disabled: "transparent"
+    },
     icon: {
-      default: IOColors.black,
-      pressed: IOColors["grey-850"],
+      default: IOColors.bluegrey,
+      pressed: IOColors.black,
       disabled: IOColors.grey
     }
   },
   // Contrast button
   contrast: {
+    background: {
+      default: hexToRgba(IOColors.white, 0),
+      pressed: hexToRgba(IOColors.white, 0.2),
+      disabled: "transparent"
+    },
     icon: {
       default: IOColors.white,
-      pressed: hexToRgba(IOColors.white, 0.85),
+      pressed: IOColors.white,
       disabled: hexToRgba(IOColors.white, 0.25)
     }
   }
@@ -107,7 +145,7 @@ const mapColorStates: Record<NonNullable<IconButton["color"]>, ColorStates> = {
 const AnimatedIconClassComponent =
   Animated.createAnimatedComponent(IconClassComponent);
 
-export const IconButton = ({
+export const IconButtonContained = ({
   icon,
   color = "primary",
   disabled = false,
@@ -115,7 +153,7 @@ export const IconButton = ({
   accessibilityLabel,
   accessibilityHint,
   testID
-}: IconButton) => {
+}: IconButtonContained) => {
   const isPressed: Animated.SharedValue<number> = useSharedValue(0);
   const isDesignSystemEnabled = useIOSelector(isDesignSystemEnabledSelector);
 
@@ -130,6 +168,27 @@ export const IconButton = ({
   // Interpolate animation values from `isPressed` values
 
   const pressedAnimationStyle = useAnimatedStyle(() => {
+    // Link color states to the pressed states
+    /* ◀ REMOVE_LEGACY_COMPONENT: Remove the following condition */
+    const backgroundColor = isDesignSystemEnabled
+      ? interpolateColor(
+          progressPressed.value,
+          [0, 1],
+          [
+            mapColorStates[color].background.default,
+            mapColorStates[color].background.pressed
+          ]
+        )
+      : interpolateColor(
+          progressPressed.value,
+          [0, 1],
+          [
+            mapLegacyColorStates[color].background.default,
+            mapLegacyColorStates[color].background.pressed
+          ]
+        );
+    /* REMOVE_LEGACY_COMPONENT: End ▶ */
+
     // Scale down button slightly when pressed
     const scale = interpolate(
       progressPressed.value,
@@ -139,6 +198,7 @@ export const IconButton = ({
     );
 
     return {
+      backgroundColor,
       transform: [{ scale }]
     };
   });
@@ -191,7 +251,8 @@ export const IconButton = ({
     >
       <Animated.View
         style={[
-          IOIconButtonStyles.buttonSizeSmall,
+          IOIconButtonStyles.button,
+          IOIconButtonStyles.buttonSizeDefault,
           !disabled && pressedAnimationStyle
         ]}
       >
@@ -227,4 +288,4 @@ export const IconButton = ({
   );
 };
 
-export default IconButton;
+export default IconButtonContained;

--- a/ts/features/design-system/core/DSButtons.tsx
+++ b/ts/features/design-system/core/DSButtons.tsx
@@ -13,11 +13,12 @@ import { PaymentNoticeNumber } from "../../../../definitions/backend/PaymentNoti
 import { DSComponentViewerBox } from "../components/DSComponentViewerBox";
 import { DesignSystemScreen } from "../components/DesignSystemScreen";
 import { HSpacer, VSpacer } from "../../../components/core/spacer/Spacer";
-import IconButton from "../../../components/ui/IconButton";
+import IconButtonContained from "../../../components/ui/IconButtonContained";
 import { IOStyles } from "../../../components/core/variables/IOStyles";
 import IconButtonSolid from "../../../components/ui/IconButtonSolid";
 import { useIOSelector } from "../../../store/hooks";
 import { isDesignSystemEnabledSelector } from "../../../store/reducers/persistedPreferences";
+import IconButton from "../../../components/ui/IconButton";
 
 const styles = StyleSheet.create({
   primaryBlockLegacy: {
@@ -904,14 +905,20 @@ export const DSButtons = () => {
       >
         IconButton
       </H2>
-      <DSComponentViewerBox name="IconButton · Primary Variant (using Pressable API)">
+      <DSComponentViewerBox name="IconButton · Primary variant">
         <View style={IOStyles.row}>
           <IconButton
             accessibilityLabel="Tap to trigger test alert"
+            icon="search"
+            onPress={onButtonPress}
+          />
+
+          <HSpacer size={16} />
+
+          <IconButton
+            accessibilityLabel="Tap to trigger test alert"
             icon="help"
-            onPress={() => {
-              alert("Action triggered");
-            }}
+            onPress={onButtonPress}
           />
 
           <HSpacer size={16} />
@@ -920,22 +927,27 @@ export const DSButtons = () => {
             accessibilityLabel="Tap to trigger test alert"
             icon="help"
             disabled
-            onPress={() => {
-              alert("Action triggered");
-            }}
+            onPress={onButtonPress}
           />
         </View>
       </DSComponentViewerBox>
 
-      <DSComponentViewerBox name="IconButton · Neutral Variant, small">
+      <DSComponentViewerBox name="IconButton · Neutral variant">
         <View style={IOStyles.row}>
           <IconButton
             color="neutral"
             accessibilityLabel="Tap to trigger test alert"
+            icon="search"
+            onPress={onButtonPress}
+          />
+
+          <HSpacer size={16} />
+
+          <IconButton
+            color="neutral"
+            accessibilityLabel="Tap to trigger test alert"
             icon="help"
-            onPress={() => {
-              alert("Action triggered");
-            }}
+            onPress={onButtonPress}
           />
 
           <HSpacer size={16} />
@@ -945,9 +957,7 @@ export const DSButtons = () => {
             accessibilityLabel="Tap to trigger test alert"
             icon="help"
             disabled
-            onPress={() => {
-              alert("Action triggered");
-            }}
+            onPress={onButtonPress}
           />
         </View>
       </DSComponentViewerBox>
@@ -960,11 +970,20 @@ export const DSButtons = () => {
         }
       >
         <DSComponentViewerBox
-          name="IconButton · Neutral Variant, small"
+          name="IconButton · Contrast variant"
           colorMode="dark"
           last
         >
           <View style={IOStyles.row}>
+            <IconButton
+              color="contrast"
+              accessibilityLabel="Tap to trigger test alert"
+              icon="search"
+              onPress={onButtonPress}
+            />
+
+            <HSpacer size={16} />
+
             <IconButton
               color="contrast"
               accessibilityLabel="Tap to trigger test alert"
@@ -1028,7 +1047,7 @@ export const DSButtons = () => {
         }
       >
         <DSComponentViewerBox
-          name="IconButton · Contrast variant, large"
+          name="IconButtonSolid · Contrast variant, large"
           colorMode="dark"
           last
         >
@@ -1055,6 +1074,103 @@ export const DSButtons = () => {
 
       <VSpacer size={40} />
 
+      <H2
+        color={"bluegrey"}
+        weight={"SemiBold"}
+        style={{ marginBottom: 16, marginTop: 16 }}
+      >
+        IconButtonContained (Icebox)
+      </H2>
+      <DSComponentViewerBox name="IconButtonContained · Primary variant">
+        <View style={IOStyles.row}>
+          <IconButtonContained
+            accessibilityLabel="Tap to trigger test alert"
+            icon="help"
+            onPress={() => {
+              alert("Action triggered");
+            }}
+          />
+
+          <HSpacer size={16} />
+
+          <IconButtonContained
+            accessibilityLabel="Tap to trigger test alert"
+            icon="help"
+            disabled
+            onPress={() => {
+              alert("Action triggered");
+            }}
+          />
+        </View>
+      </DSComponentViewerBox>
+
+      <DSComponentViewerBox name="IconButtonContained · Neutral variant">
+        <View style={IOStyles.row}>
+          <IconButtonContained
+            color="neutral"
+            accessibilityLabel="Tap to trigger test alert"
+            icon="help"
+            onPress={() => {
+              alert("Action triggered");
+            }}
+          />
+
+          <HSpacer size={16} />
+
+          <IconButtonContained
+            color="neutral"
+            accessibilityLabel="Tap to trigger test alert"
+            icon="help"
+            disabled
+            onPress={() => {
+              alert("Action triggered");
+            }}
+          />
+        </View>
+      </DSComponentViewerBox>
+
+      <View
+        style={
+          isDesignSystemEnabled
+            ? styles.primaryBlock
+            : styles.primaryBlockLegacy
+        }
+      >
+        <DSComponentViewerBox
+          name="IconButtonContained · Contrast variant"
+          colorMode="dark"
+          last
+        >
+          <View style={IOStyles.row}>
+            <IconButtonContained
+              color="contrast"
+              accessibilityLabel="Tap to trigger test alert"
+              icon="help"
+              onPress={onButtonPress}
+            />
+
+            <HSpacer size={16} />
+
+            <IconButtonContained
+              color="contrast"
+              accessibilityLabel="Tap to trigger test alert"
+              icon="help"
+              disabled
+              onPress={onButtonPress}
+            />
+          </View>
+        </DSComponentViewerBox>
+      </View>
+
+      <VSpacer size={40} />
+
+      <H2
+        color={"bluegrey"}
+        weight={"SemiBold"}
+        style={{ marginBottom: 16, marginTop: 16 }}
+      >
+        ButtonExtendedOutline
+      </H2>
       <DSComponentViewerBox name="ButtonExtendedOutline (using Pressable API)">
         <View>
           <ButtonExtendedOutline
@@ -1077,7 +1193,7 @@ export const DSButtons = () => {
         </View>
       </DSComponentViewerBox>
 
-      <VSpacer size={24} />
+      <VSpacer size={40} />
 
       <H2
         color={"bluegrey"}


### PR DESCRIPTION
## Short description
This PR adds the new `IconButton` component with no background and a default size of `24`. The recently added `IconButton` has been renamed to `IconButtonContained` to avoid confusion with the new one.

## List of changes proposed in this pull request
- Add the new `IconButton`
- Rename the "old" `IconButton` to `IconButtonContained`
- Add the new `IconButton` to the Design System section

### Preview

https://user-images.githubusercontent.com/1255491/233034909-9df77628-449d-488f-be34-315418f87a98.mp4



## How to test
Go to **_Profile → Design System → Buttons (Components)_**