### PR TITLE
fix: [IOAPPFD0-88] Keychain error event tracked without reason parameter

### DIFF
--- a/ts/utils/analytics.ts
+++ b/ts/utils/analytics.ts
@@ -159,7 +159,9 @@ export function trackLollipopIdpLoginFailure(reason: string) {
 // workaround to send keychainError for Pixel devices
 // TODO: REMOVE AFTER FIXING https://pagopa.atlassian.net/jira/software/c/projects/IABT/boards/92?modal=detail&selectedIssue=IABT-1441
 export function trackKeychainGetFailure(reason: string | undefined) {
-  void mixpanelTrack("KEY_CHAIN_GET_GENERIC_PASSWORD_FAILURE", {
-    reason: reason ?? ""
-  });
+  if (reason) {
+    void mixpanelTrack("KEY_CHAIN_GET_GENERIC_PASSWORD_FAILURE", {
+      reason
+    });
+  }
 }


### PR DESCRIPTION
## Short description
This PR fixes an issue which makes the app track a `KEY_CHAIN_GET_GENERIC_PASSWORD_FAILURE`, introduced in [this PR](https://github.com/pagopa/io-app/pull/4494), even when there's no error at all. 

We couldn't reproduce the error so we weren't sure wether or not the stack trace was being capture. Given that we know for sure that the tracking event is indeed working and the stack track is properly captured, we can now narrow the tracking function only when the `reason` parameter is defined.

## List of changes proposed in this pull request
- ts/utils/analytics.ts: Checks if the `reason` parameter is defined before sending the event to Mixpanel.

## How to test
- Start the app and the error shouldn't be tracked when you're logging in or reopening the app;
- In order to "force" an error, you can refer to [this PR](https://github.com/pagopa/io-app/pull/4494) instructions on how to do so. You can also just throw a new error in `ts/store/storages/keychain.ts/createSecureStorage` function just after the `Keychain.getGenericPassword()` call. 
