### PR TITLE
fix: [IOAPPFD0-91] Message sender details not wrapping

### DIFF
--- a/ts/components/messages/MessageDetail/Content.tsx
+++ b/ts/components/messages/MessageDetail/Content.tsx
@@ -60,7 +60,7 @@ const Content = ({ message, goToServiceDetail, serviceContacts }: Props) => {
         <Body>{`${I18n.t("messageDetails.service")} `}</Body>
         <Link
           weight={"Bold"}
-          style={{ ...styles.textWrap, ...IOStyles.flex }}
+          style={styles.textWrap}
           onPress={goToServiceDetail}
         >
           {message.serviceName}

--- a/ts/components/messages/MessageDetail/Content.tsx
+++ b/ts/components/messages/MessageDetail/Content.tsx
@@ -17,6 +17,10 @@ const styles = StyleSheet.create({
   container: {
     backgroundColor: IOColors.greyUltraLight,
     padding: customVariables.contentPadding
+  },
+  textWrap: {
+    flex: 1,
+    flexWrap: "wrap"
   }
 });
 
@@ -38,20 +42,27 @@ const Content = ({ message, goToServiceDetail, serviceContacts }: Props) => {
   return (
     <View style={styles.container}>
       <View style={[IOStyles.flex, IOStyles.row]}>
-        <Body>{I18n.t("messageDetails.dateSending")}</Body>
-        <Label color="bluegrey">{` ${convertDateTimeToWordDistance(
-          message.createdAt
-        )}`}</Label>
+        <Body>{`${I18n.t("messageDetails.dateSending")} `}</Body>
+        <Label
+          style={styles.textWrap}
+          color="bluegrey"
+        >{`${convertDateTimeToWordDistance(message.createdAt)}`}</Label>
       </View>
 
       <View style={[IOStyles.flex, IOStyles.row]}>
-        <Body>{I18n.t("messageDetails.sender")}</Body>
-        <Label color="bluegrey">{` ${message.organizationName}`}</Label>
+        <Body>{`${I18n.t("messageDetails.sender")} `}</Body>
+        <Label style={styles.textWrap} color="bluegrey">
+          {message.organizationName}
+        </Label>
       </View>
 
       <View style={[IOStyles.flex, IOStyles.row]}>
         <Body>{`${I18n.t("messageDetails.service")} `}</Body>
-        <Link weight={"Bold"} style={IOStyles.flex} onPress={goToServiceDetail}>
+        <Link
+          weight={"Bold"}
+          style={{ ...styles.textWrap, ...IOStyles.flex }}
+          onPress={goToServiceDetail}
+        >
           {message.serviceName}
         </Link>
       </View>

--- a/ts/components/messages/MessageDetail/__tests__/__snapshots__/Content.test.tsx.snap
+++ b/ts/components/messages/MessageDetail/__tests__/__snapshots__/Content.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`MessageDetailData component when service's contact detail are not defin
       }
       weight="Regular"
     >
-      Date and time sending:
+      Date and time sending: 
     </Text>
     <Text
       color="bluegrey"
@@ -63,6 +63,10 @@ exports[`MessageDetailData component when service's contact detail are not defin
       style={
         Array [
           Object {
+            "flex": 1,
+            "flexWrap": "wrap",
+          },
+          Object {
             "fontSize": 16,
           },
           Object {
@@ -75,7 +79,7 @@ exports[`MessageDetailData component when service's contact detail are not defin
       }
       weight="Bold"
     >
-       18/10/2021, 16:00
+      18/10/2021, 16:00
     </Text>
   </View>
   <View
@@ -117,7 +121,7 @@ exports[`MessageDetailData component when service's contact detail are not defin
       }
       weight="Regular"
     >
-      Sender:
+      Sender: 
     </Text>
     <Text
       color="bluegrey"
@@ -132,6 +136,10 @@ exports[`MessageDetailData component when service's contact detail are not defin
       style={
         Array [
           Object {
+            "flex": 1,
+            "flexWrap": "wrap",
+          },
+          Object {
             "fontSize": 16,
           },
           Object {
@@ -144,7 +152,7 @@ exports[`MessageDetailData component when service's contact detail are not defin
       }
       weight="Bold"
     >
-       Ċentru tas-Saħħa
+      Ċentru tas-Saħħa
     </Text>
   </View>
   <View
@@ -205,6 +213,7 @@ exports[`MessageDetailData component when service's contact detail are not defin
         Array [
           Object {
             "flex": 1,
+            "flexWrap": "wrap",
           },
           Object {
             "fontSize": 16,


### PR DESCRIPTION
## Short description
This PR adds text wrapping to the sender of a message in the details screen. Closes #4563.

## List of changes proposed in this pull request
- ts/components/messages/MessageDetail/Content.tsx: Adds text wrapping to the sender details. Also moves the trailing space to the `Body` content to avoid issues with the `Label` wrapping.

<details>
<summary>PROD</summary>

| Before | After |
|--------|--------|
| ![IMG_0003 2](https://user-images.githubusercontent.com/12371664/234527155-4a5082c4-6084-441d-b989-cb93e482b4dc.PNG) | ![IMG_0002](https://user-images.githubusercontent.com/12371664/234527260-19fb5fae-c8e3-4b7c-b348-283b815f547c.PNG)  | 
</details>
 
<details>
<summary>DEV</summary>

| Before | After |
|--------|--------|
| ![Simulator Screen Shot - iPhone 13 - 2023-04-26 at 10 59 44](https://user-images.githubusercontent.com/12371664/234526283-7d541cc5-b5b2-4c19-babb-39d90b3242b1.png) | ![Simulator Screen Shot - iPhone 13 - 2023-04-26 at 11 00 37](https://user-images.githubusercontent.com/12371664/234526344-864445d1-dca9-4c26-b694-abc7be185dde.png)  | 
</details>


## How to test
- Point to the io-dev-api-server and make it return a message with very long sender details. Otherwise you can place a very long string by yourself.
- Point to production and if you have an enabled `CGN` you just have to check for a message from `PCM - Dipartimento per le Politiche Giovanili e il Servizio Civile Universale`.
- Also check if text which don't require wrapping is properly displayed.
