### PR TITLE
fix(IDPay): [IODPAY-192] Wrong copy in initiativeDetails' "lastUpdated"

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3366,6 +3366,7 @@ idpay:
           header: Configura l'iniziativa!
           footer: Aggiungi almeno un metodo per iniziare ad utilizzare {{initiative}}.
         configured:
+          lastUpdated: "Saldo aggiornato al "
           errorAlerts:
             NOT_REFUNDABLE_ONLY_IBAN:
               content: Inserisci un metodo di pagamento valido per effettuare transazioni 

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3390,6 +3390,7 @@ idpay:
           header: Configura l'iniziativa!
           footer: Aggiungi almeno un metodo per iniziare ad utilizzare {{initiative}}.
         configured:
+          lastUpdated: "Saldo aggiornato al " 
           errorAlerts:
             NOT_REFUNDABLE_ONLY_IBAN:
               content: Inserisci un metodo di pagamento valido per effettuare transazioni 

--- a/ts/features/idpay/initiative/details/screens/InitiativeDetailsScreen.tsx
+++ b/ts/features/idpay/initiative/details/screens/InitiativeDetailsScreen.tsx
@@ -94,7 +94,7 @@ const InitiativeDetailsScreen = () => {
       lastUpdated => (
         <LabelSmall style={styles.lastUpdate} color="bluegrey" weight="Regular">
           {I18n.t(
-            "idpay.initiative.details.initiativeDetailsScreen.configured.operationsList.lastUpdated"
+            "idpay.initiative.details.initiativeDetailsScreen.configured.lastUpdated"
           )}
           {lastUpdated}
         </LabelSmall>


### PR DESCRIPTION
## Short description
added separate I18n keys for an initiative's details' lastUpdated field

## List of changes proposed in this pull request
- new i18n keys
- updated initiative details to follow
## How to test
navigate to an initiative's details page and check that the small text under the card displays the correct text
