### PR TITLE
fix: [IABT-1473] Fix contextual help when user is not authenticated

### DIFF
--- a/ts/navigation/NotAuthenticatedStackNavigator.tsx
+++ b/ts/navigation/NotAuthenticatedStackNavigator.tsx
@@ -1,5 +1,10 @@
 import * as React from "react";
-import { createStackNavigator } from "@react-navigation/stack";
+import {
+  TransitionPresets,
+  createStackNavigator
+} from "@react-navigation/stack";
+import ZENDESK_ROUTES from "../features/zendesk/navigation/routes";
+import { ZendeskStackNavigator } from "../features/zendesk/navigation/navigator";
 import { AppParamsList } from "./params/AppParamsList";
 import ROUTES from "./routes";
 import AuthenticationNavigator from "./AuthenticationNavigator";
@@ -14,6 +19,12 @@ const NotAuthenticatedStackNavigator = () => (
     <Stack.Screen
       name={ROUTES.AUTHENTICATION}
       component={AuthenticationNavigator}
+    />
+
+    <Stack.Screen
+      name={ZENDESK_ROUTES.MAIN}
+      component={ZendeskStackNavigator}
+      options={{ ...TransitionPresets.ModalSlideFromBottomIOS }}
     />
   </Stack.Navigator>
 );


### PR DESCRIPTION
## Short description
This PR updates `NotAuthenticatedStackNavigator` adding `ZendeskStackNavigator`. It should possibile to open contextual help when user is not authenticated tap on question mark.

## List of changes proposed in this pull request
- Update `NotAuthenticatedStackNavigator`

## How to test
Using io-dev-api-server in the `AUTHENTICATION_LANDING ` screen after tap on question mark a contextual help should appear.