### PR TITLE
[SFEQS-1604] Add pagination to PDF components

### DIFF
--- a/ts/features/fci/components/DocumentViewer.tsx
+++ b/ts/features/fci/components/DocumentViewer.tsx
@@ -160,6 +160,7 @@ export const DocumentViewer = (props: Props): React.ReactElement => {
             onError={_ => {
               setIsError(true);
             }}
+            enablePaging
           />
           {renderFooter(documentUrl, fciDownloadPath)}
         </>

--- a/ts/features/fci/components/DocumentWithSignature.tsx
+++ b/ts/features/fci/components/DocumentWithSignature.tsx
@@ -225,6 +225,7 @@ const DocumentWithSignature = (props: Props) => {
       // TODO: add test for errors https://pagopa.atlassian.net/browse/SFEQS-1606
       onError={props.onError}
       onPressLink={constNull}
+      enablePaging
       style={styles.pdf}
     />
   );

--- a/ts/features/fci/screens/valid/FciDocumentsScreen.tsx
+++ b/ts/features/fci/screens/valid/FciDocumentsScreen.tsx
@@ -161,6 +161,7 @@ const FciDocumentsScreen = () => {
       onPageChanged={(page, _) => {
         setCurrentPage(page);
       }}
+      enablePaging
       style={styles.pdf}
     />
   );


### PR DESCRIPTION
## Short description
This PR adds pagination to the FCI `Pdf` components. This is needed because the component has a wrong behaviour when deciding which page is being shown in the viewport, thus making the `Continue` button not scrolling to the last page for landscape PDFs. It also causes the page counter to start from the wrong value.

## List of changes proposed in this pull request
- Adds the `enablePaging` prop to the `Pdf` components.

## How to test
- Download the PDF file which causes the issue from the Jira task;
- Replace it in the dev server under `io-dev-api-server/assets/fci/pdf/modulo_1.pdf`; 
- Start the dev server with the following configuration: 
`...
fci: {
      waitForSignatureCount: 1,
      rejectedCount: 0,
      expiredCount: 0,
      expired90Count: 0,
      waitForQtspCount: 0,
      signedCount: 0,
      noSignatureFieldsCount: 0
    },
...
`
- Start a signing flow in the application; 
- Check the page counter, it should indicate the first page;
- The `Continue` button while showing the document should take you to the latest page and a `Go to signature` button should appear;
- Check the page counter, it should indicate the last page;
- Test the signing flow with a proper document (restore the original asset in the dev server) and check if everything works as expected.
