### PR TITLE
fix: Fixes not working alpha promotion on release workflow for android

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           ./scripts/android-release.sh ./android/app
           yarn bundle:android-release
           cd android && bundle exec fastlane alpha
-          cd android && bundle exec fastlane promote_internal_to_alpha
+          bundle exec fastlane promote_internal_to_alpha
         shell: bash
         env:
           ENCODED_IOAPP_GOOGLE_SERVICES_JSON_FILE: ${{secrets.ENCODED_IOAPP_GOOGLE_SERVICES_JSON_FILE}}


### PR DESCRIPTION
## Short description
This PR fixes the last instructions on alpha promotion for release workflow

