### PR TITLE
fix: [IOAPPFD0-109] Fix UI regression of the `Paid` badge in the message list

### DIFF
--- a/ts/components/messages/MessageDetail/__tests__/__snapshots__/MedicalPrescriptionDueDateBar.test.tsx.snap
+++ b/ts/components/messages/MessageDetail/__tests__/__snapshots__/MedicalPrescriptionDueDateBar.test.tsx.snap
@@ -1546,6 +1546,13 @@ exports[`MedicalPrescriptionDueDateBar component when payment info is expiring s
                                                 />
                                               </RNSVGGroup>
                                             </RNSVGSvgView>
+                                            <View
+                                              style={
+                                                Object {
+                                                  "width": 4,
+                                                }
+                                              }
+                                            />
                                             <Text
                                               style={
                                                 Array [
@@ -2413,6 +2420,13 @@ exports[`MedicalPrescriptionDueDateBar component when payment info is not expira
                                                 />
                                               </RNSVGGroup>
                                             </RNSVGSvgView>
+                                            <View
+                                              style={
+                                                Object {
+                                                  "width": 4,
+                                                }
+                                              }
+                                            />
                                             <Text
                                               style={
                                                 Array [
@@ -3280,6 +3294,13 @@ exports[`MedicalPrescriptionDueDateBar component when payment info is valid shou
                                                 />
                                               </RNSVGGroup>
                                             </RNSVGSvgView>
+                                            <View
+                                              style={
+                                                Object {
+                                                  "width": 4,
+                                                }
+                                              }
+                                            />
                                             <Text
                                               style={
                                                 Array [

--- a/ts/components/messages/MessageDetail/common/CalendarEventButton.tsx
+++ b/ts/components/messages/MessageDetail/common/CalendarEventButton.tsx
@@ -41,6 +41,7 @@ import { withLightModalContext } from "../../../helpers/withLightModalContext";
 import SelectCalendarModal from "../../../SelectCalendarModal";
 import { LightModalContextInterface } from "../../../ui/LightModal";
 import { Icon } from "../../../core/icons";
+import { HSpacer } from "../../../core/spacer/Spacer";
 
 type OwnProps = {
   message: CreatedMessageWithContentAndAttachments;
@@ -353,6 +354,7 @@ class CalendarEventButton extends React.PureComponent<Props, State> {
         {/* This condition doesn't make sense. We should replace it using
         a different component (e.g. ButtonOutline) */}
         <Icon name={iconName} color={disabled ? "white" : "blue"} />
+        <HSpacer size={4} />
         <NBButtonText style={styles.marginTop1}>{reminderText}</NBButtonText>
       </ButtonDefaultOpacity>
     );

--- a/ts/components/messages/MessageList/Item.tsx
+++ b/ts/components/messages/MessageList/Item.tsx
@@ -144,11 +144,13 @@ const itemBadgeToTagOrIcon = (itemBadge: ItemBadge): React.ReactNode => {
   switch (itemBadge) {
     case "paid":
       return (
-        <IOBadge
-          text={I18n.t("messages.badge.paid")}
-          variant="solid"
-          color="aqua"
-        />
+        <View style={{ alignSelf: "flex-start" }}>
+          <IOBadge
+            text={I18n.t("messages.badge.paid")}
+            variant="solid"
+            color="aqua"
+          />
+        </View>
       );
 
     case "qrcode":

--- a/ts/components/messages/MessageList/__tests__/__snapshots__/Item.test.tsx.snap
+++ b/ts/components/messages/MessageList/__tests__/__snapshots__/Item.test.tsx.snap
@@ -2473,43 +2473,51 @@ exports[`MessageList Item component when hasPaidBadge=true category=EU_COVID_CER
     </View>
     <View
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "borderRadius": 50,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 2.5,
-          },
-          false,
-          Object {
-            "backgroundColor": "#00C5CA",
-          },
-        ]
+        Object {
+          "alignSelf": "flex-start",
+        }
       }
     >
-      <Text
+      <View
         style={
           Array [
             Object {
-              "alignSelf": "center",
-              "fontFamily": "Titillium Web",
-              "fontStyle": "normal",
-              "fontWeight": "600",
-            },
-            Object {
-              "fontSize": 14,
-              "lineHeight": 20,
+              "alignItems": "center",
+              "borderRadius": 50,
+              "justifyContent": "center",
+              "paddingHorizontal": 20,
+              "paddingVertical": 2.5,
             },
             false,
             Object {
-              "color": "#17324D",
+              "backgroundColor": "#00C5CA",
             },
           ]
         }
       >
-        Paid
-      </Text>
+        <Text
+          style={
+            Array [
+              Object {
+                "alignSelf": "center",
+                "fontFamily": "Titillium Web",
+                "fontStyle": "normal",
+                "fontWeight": "600",
+              },
+              Object {
+                "fontSize": 14,
+                "lineHeight": 20,
+              },
+              false,
+              Object {
+                "color": "#17324D",
+              },
+            ]
+          }
+        >
+          Paid
+        </Text>
+      </View>
     </View>
   </View>
 </View>
@@ -2802,43 +2810,51 @@ exports[`MessageList Item component when hasPaidBadge=true category=GENERIC shou
     </View>
     <View
       style={
-        Array [
-          Object {
-            "alignItems": "center",
-            "borderRadius": 50,
-            "justifyContent": "center",
-            "paddingHorizontal": 20,
-            "paddingVertical": 2.5,
-          },
-          false,
-          Object {
-            "backgroundColor": "#00C5CA",
-          },
-        ]
+        Object {
+          "alignSelf": "flex-start",
+        }
       }
     >
-      <Text
+      <View
         style={
           Array [
             Object {
-              "alignSelf": "center",
-              "fontFamily": "Titillium Web",
-              "fontStyle": "normal",
-              "fontWeight": "600",
-            },
-            Object {
-              "fontSize": 14,
-              "lineHeight": 20,
+              "alignItems": "center",
+              "borderRadius": 50,
+              "justifyContent": "center",
+              "paddingHorizontal": 20,
+              "paddingVertical": 2.5,
             },
             false,
             Object {
-              "color": "#17324D",
+              "backgroundColor": "#00C5CA",
             },
           ]
         }
       >
-        Paid
-      </Text>
+        <Text
+          style={
+            Array [
+              Object {
+                "alignSelf": "center",
+                "fontFamily": "Titillium Web",
+                "fontStyle": "normal",
+                "fontWeight": "600",
+              },
+              Object {
+                "fontSize": 14,
+                "lineHeight": 20,
+              },
+              false,
+              Object {
+                "color": "#17324D",
+              },
+            ]
+          }
+        >
+          Paid
+        </Text>
+      </View>
     </View>
   </View>
 </View>


### PR DESCRIPTION
## Short description
This PR fixes the UI regression of the `Paid` badge in the message list, caused by the introduction of the new `IOBadge` component (see https://github.com/pagopa/io-app/pull/4337 for reference)

## List of changes proposed in this pull request
- Fix the UI regression
- [EXTRA] Add space between icon and text in the bottom CTA (Message Detail screen)

### Preview
| Before | After
| - | - |
| <img src="https://github.com/pagopa/io-app/assets/1255491/57eedfdc-80d6-423d-b2f5-cbd4e67bdd15" width="350" /> | <img src="https://github.com/pagopa/io-app/assets/1255491/bfbee193-0d06-4881-993f-720cec4cf3bc" width="350" />


## How to test
N/A