### PR TITLE
fix(Firma con IO): [SFEQS-1665] Update accessibilityLabel

### DIFF
--- a/ts/features/fci/components/QtspClauseListItem.tsx
+++ b/ts/features/fci/components/QtspClauseListItem.tsx
@@ -6,6 +6,7 @@ import TouchableDefaultOpacity from "../../../components/TouchableDefaultOpacity
 import { QtspClause } from "../../../../definitions/fci/QtspClause";
 import { fciQtspFilledDocumentUrlSelector } from "../store/reducers/fciQtspFilledDocument";
 import { Icon } from "../../../components/core/icons/Icon";
+import I18n from "../../../i18n";
 import LinkedText from "./LinkedText";
 
 type Props = {
@@ -48,7 +49,12 @@ const QtspClauseListItem = (props: Props) => {
       </View>
       <View style={IOStyles.horizontalContentPadding} />
       <TouchableDefaultOpacity
-        accessibilityRole={"radio"}
+        accessibilityLabel={
+          checked
+            ? I18n.t("features.fci.signatureFields.accessibility.selected")
+            : I18n.t("features.fci.signatureFields.accessibility.unselected")
+        }
+        accessibilityRole={"checkbox"}
         testID={"QtspClauseListItemButtonTestID"}
         onPress={() => {
           onChange(!checked);

--- a/ts/features/fci/components/SignatureFieldItem.tsx
+++ b/ts/features/fci/components/SignatureFieldItem.tsx
@@ -47,11 +47,11 @@ const SignatureFieldItem = (props: Props) => {
         </H4>
         <TouchableDefaultOpacity
           accessibilityRole={"checkbox"}
-          accessibilityValue={{
-            text: checked
+          accessibilityLabel={
+            checked
               ? I18n.t("features.fci.signatureFields.accessibility.selected")
               : I18n.t("features.fci.signatureFields.accessibility.unselected")
-          }}
+          }
           accessibilityState={{ selected: checked }}
           testID={"SignatureFieldItemButtonTestID"}
           onPress={() => {


### PR DESCRIPTION
## Short description
This PR fix accessibility label in QTSP clauses screen

## List of changes proposed in this pull request
- Add accessibilityLabel to QtspClauseListItem
- Update SignatureFieldItem

## How to test
Using io-dev-api-server start a signing flow. With Flipper or other dev tool try to check and uncheck QTSP clauses. The accessibilityLabel should change correctly.