### PR TITLE
[IOBP-87] Fix IDPay transaction doce format

### DIFF
--- a/ts/features/idpay/payment/common/types.ts
+++ b/ts/features/idpay/payment/common/types.ts
@@ -4,7 +4,7 @@ interface IDPayTransactionCodeBrand {
   readonly IDPayTransactionCode: unique symbol;
 }
 
-const transactionCodePattern = /^[0-9]{8}$/;
+const transactionCodePattern = /^[A-Za-z0-9]{8}$/;
 export const IDPayTransactionCode = t.brand(
   t.string,
   (s: string): s is t.Branded<string, IDPayTransactionCodeBrand> =>

--- a/ts/features/idpay/payment/screens/IDPayPaymentCodeInputScreen.tsx
+++ b/ts/features/idpay/payment/screens/IDPayPaymentCodeInputScreen.tsx
@@ -57,8 +57,8 @@ const IDPayPaymentCodeInputScreen = () => {
             accessibilityLabel={I18n.t("idpay.payment.qrCode.manual.input")}
             inputMaskProps={{
               type: "custom",
-              options: { mask: "99999999" },
-              keyboardType: "numeric",
+              options: { mask: "SSSSSSSS" },
+              keyboardType: "default",
               returnKeyType: "done",
               value: inputState.value,
               autoCapitalize: "none",


### PR DESCRIPTION
## Short description
This PR modifies the transaction code format from 6 digits to 8 alphanumeric characters

## List of changes proposed in this pull request
- Feature A
- Feature B

## How to test
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
