### PR TITLE
[IOCOM-328] FIMS handling of iosso:// protocol

### DIFF
--- a/ts/components/ui/Markdown/handlers/__test__/link.test.ts
+++ b/ts/components/ui/Markdown/handlers/__test__/link.test.ts
@@ -1,5 +1,5 @@
 import * as E from "fp-ts/lib/Either";
-import { deriveCustomHandledLink } from "../link";
+import { deriveCustomHandledLink, removeFIMSPrefixFromUrl } from "../link";
 
 const loadingCases: ReadonlyArray<
   [input: string, expectedResult: ReturnType<typeof deriveCustomHandledLink>]
@@ -67,11 +67,34 @@ const loadingCases: ReadonlyArray<
   ]
 ];
 
+const fimsCases: ReadonlyArray<
+  [input: string, expectedResult: ReturnType<typeof removeFIMSPrefixFromUrl>]
+> = [
+  [
+    "iosso://https://italia.io/main/messages?messageId=4&serviceId=5",
+    "https://italia.io/main/messages?messageId=4&serviceId=5"
+  ],
+  [
+    "iOsSo://https://italia.io/main/messages?messageId=4&serviceId=5",
+    "https://italia.io/main/messages?messageId=4&serviceId=5"
+  ]
+];
+
 describe("deriveCustomHandledLink", () => {
   test.each(loadingCases)(
     "given %p as argument, returns %p",
     (firstArg, expectedResult) => {
       const result = deriveCustomHandledLink(firstArg);
+      expect(result).toEqual(expectedResult);
+    }
+  );
+});
+
+describe("removeFIMSPrefixFromUrl", () => {
+  test.each(fimsCases)(
+    "given %p as argument, returns %p",
+    (firstArg, expectedResult) => {
+      const result = removeFIMSPrefixFromUrl(firstArg);
       expect(result).toEqual(expectedResult);
     }
   );

--- a/ts/components/ui/Markdown/handlers/link.ts
+++ b/ts/components/ui/Markdown/handlers/link.ts
@@ -3,10 +3,23 @@ import * as E from "fp-ts/lib/Either";
 import I18n from "../../../../i18n";
 import { showToast } from "../../../../utils/showToast";
 import { openWebUrl } from "../../../../utils/url";
-import { IO_INTERNAL_LINK_PREFIX } from "../../../../utils/navigation";
+import {
+  IO_INTERNAL_LINK_PREFIX,
+  IO_FIMS_LINK_PREFIX,
+  IO_FIMS_LINK_PROTOCOL
+} from "../../../../utils/navigation";
 
 export const isIoInternalLink = (href: string): boolean =>
   href.startsWith(IO_INTERNAL_LINK_PREFIX);
+
+export const isIoFIMSLink = (href: string): boolean =>
+  href.startsWith(IO_FIMS_LINK_PREFIX);
+
+export const removeFIMSPrefixFromUrl = (fimsUrlWithProtocol: string) => {
+  // eslint-disable-next-line no-useless-escape
+  const regexp = new RegExp(`^${IO_FIMS_LINK_PROTOCOL}\/\/`, "i");
+  return fimsUrlWithProtocol.replace(regexp, "");
+};
 
 /**
  * a dedicated codec for CustomHandledLink

--- a/ts/utils/navigation.ts
+++ b/ts/utils/navigation.ts
@@ -5,6 +5,9 @@ import { Platform } from "react-native";
 export const IO_INTERNAL_LINK_PROTOCOL = "ioit:";
 export const IO_INTERNAL_LINK_PREFIX = IO_INTERNAL_LINK_PROTOCOL + "//";
 
+export const IO_FIMS_LINK_PROTOCOL = "iosso:";
+export const IO_FIMS_LINK_PREFIX = IO_FIMS_LINK_PROTOCOL + "//";
+
 export const IO_UNIVERSAL_LINK_PREFIX = "https://continua.io.pagopa.it";
 
 export const convertUrlToNavigationLink = (path: string) =>


### PR DESCRIPTION
## Short description
This PR adds the iosso:// protocol handling for FIMS.

## List of changes proposed in this pull request
- Added `iosso://` protocol to valid protocols
- FIMS urls enabled for messages and services CTAs
- Tests for url validity

## How to test
Using the `io-dev-api-server`, change the `withCTA` configuration to generate a message with FIMS CTA and enable the [FIMS dev feature flag](https://github.com/pagopa/io-dev-api-server/blob/d5b746e445d545bb150660b96d6bcfa9132072f0/src/payloads/backend.ts#L45) in `src/payloads/backend.ts`.
Select such message, check that it has the FIMS CTA at the bottom, tap it and check that it navigates to an HTML page in a webview (such page content is not part of this PR)
