### PR TITLE
feat(IT Wallet): [SIW-242] Disable min app version check if FF is enabled

### DIFF
--- a/ts/screens/modal/RootModal.tsx
+++ b/ts/screens/modal/RootModal.tsx
@@ -9,6 +9,7 @@ import { isDeviceSupportedSelector } from "../../features/lollipop/store/reducer
 import { mixpanelTrack } from "../../mixpanel";
 import { isBackendServicesStatusOffSelector } from "../../store/reducers/backendStatus";
 import { GlobalState } from "../../store/reducers/types";
+import { itWalletEnabled } from "../../config";
 import IdentificationModal from "./IdentificationModal";
 import SystemOffModal from "./SystemOffModal";
 import UpdateAppModal from "./UpdateAppModal";
@@ -30,7 +31,7 @@ const RootModal: React.FunctionComponent<Props> = (props: Props) => {
     return <SystemOffModal />;
   }
   // if the app is out of date, force a screen to update it
-  if (!props.isAppSupported) {
+  if (!props.isAppSupported && !itWalletEnabled) {
     void mixpanelTrack("UPDATE_APP_MODAL", {
       minVersioniOS: props.versionInfo?.min_app_version.ios,
       minVersionAndroid: props.versionInfo?.min_app_version.android


### PR DESCRIPTION
## Short description
This PR disables the minimum app version check if the IT-WALLET feature flag is enabled.

## List of changes proposed in this pull request
- `ts/screens/modal/RootModal.tsx`: Checks if the IT-WALLET FF is enabled to bypass the minimum app version check.

## How to test
Login should be successful while targeting the dev server.