### PR TITLE
[IOBP-59] update discount-type beneficiary details page 

### DIFF
--- a/ts/features/idpay/initiative/details/components/BeneficiaryDetailsContent.tsx
+++ b/ts/features/idpay/initiative/details/components/BeneficiaryDetailsContent.tsx
@@ -10,6 +10,7 @@ import {
   InitiativeRewardTypeEnum
 } from "../../../../../../definitions/idpay/InitiativeDTO";
 import { InitiativeDetailDTO } from "../../../../../../definitions/idpay/InitiativeDetailDTO";
+import { RewardValueTypeEnum } from "../../../../../../definitions/idpay/RewardValueDTO";
 import { VSpacer } from "../../../../../components/core/spacer/Spacer";
 import { LabelSmall } from "../../../../../components/core/typography/LabelSmall";
 import { Link } from "../../../../../components/core/typography/Link";
@@ -82,13 +83,30 @@ const BeneficiaryDetailsContent = (props: BeneficiaryDetailsProps) => {
     O.getOrElse(() => "-")
   );
 
-  const rewardPercentageString = pipe(
-    beneficiaryDetails.refundRule?.accumulatedAmount?.refundThreshold,
-    O.fromNullable,
-    O.map(percentage => `${percentage}%`),
-    O.getOrElse(() => "-")
-  );
-
+  const getRewardTypeDependantString = () => {
+    if (
+      initiativeDetails.initiativeRewardType === InitiativeRewardTypeEnum.REFUND
+    ) {
+      return pipe(
+        beneficiaryDetails.refundRule?.accumulatedAmount?.refundThreshold,
+        O.fromNullable,
+        O.map(percentage => `${percentage}%`),
+        O.getOrElse(() => "-")
+      );
+    }
+    return pipe(
+      beneficiaryDetails.rewardRule?.rewardValue,
+      O.fromNullable,
+      O.fold(
+        () => "-",
+        value =>
+          beneficiaryDetails.rewardRule?.rewardValueType ===
+          RewardValueTypeEnum.PERCENTAGE
+            ? `${value}%`
+            : "-" // will be added once the ABSOLUTE reward type is supported
+      )
+    );
+  };
   const lastUpdateString = pipe(
     beneficiaryDetails.updateDate,
     O.fromNullable,
@@ -187,7 +205,7 @@ const BeneficiaryDetailsContent = (props: BeneficiaryDetailsProps) => {
             label: I18n.t(
               "idpay.initiative.beneficiaryDetails.spendPercentage"
             ),
-            value: rewardPercentageString
+            value: getRewardTypeDependantString()
           }
         ]}
       />


### PR DESCRIPTION
## Short description
updated discount-type beneficiary details page to display the correct data in the reward percentage field

## List of changes proposed in this pull request
- updated the aforementioned's datum mapping function

## How to test
( usual `io-dev-server` slander ), navigate to an initiative's detail page, click on the ( i ) icon in the top right, and make sure the reward percentage field renders correctly, it should:
- render a percentage in case of a `PERCENTAGE` initiative
- render "-" in case of an `ABSOLUTE` initiative, since there is no copy for that yet

