### PR TITLE
chore: [IOBP-77] Remove entry point of PagoBANCOMAT flow

### DIFF
--- a/ts/screens/wallet/AddPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/AddPaymentMethodScreen.tsx
@@ -21,7 +21,6 @@ import PaymentBannerComponent from "../../components/wallet/PaymentBannerCompone
 import PaymentMethodsList, {
   IPaymentMethod
 } from "../../components/wallet/PaymentMethodsList";
-import { bpdEnabled } from "../../config";
 import { walletAddBancomatStart } from "../../features/wallet/onboarding/bancomat/store/actions";
 import { walletAddBPayStart } from "../../features/wallet/onboarding/bancomatPay/store/actions";
 import {
@@ -140,17 +139,6 @@ const getPaymentMethods = (
     onPress: props.startSatispayOnboarding,
     status: "notImplemented",
     section: "digital_payments"
-  },
-  {
-    name: I18n.t("wallet.methods.pagobancomat.name"),
-    description: I18n.t("wallet.methods.pagobancomat.description"),
-    icon: CreditCard,
-    onPress: props.startAddBancomat,
-    status:
-      bpdEnabled && !options.onlyPaymentMethodCanPay
-        ? "implemented"
-        : "notImplemented",
-    section: "bancomat"
   }
 ];
 


### PR DESCRIPTION
## Short description
This PR removes the entry point of PagoBANCOMAT flow from "Add new payment methods" screen;

## Preview
|Before|After|
|-|-|
| <img src="https://github.com/pagopa/io-app/assets/34343582/b619ffb9-978b-47af-9692-97c689acb2b3"  width="250"/>| <img src="https://github.com/pagopa/io-app/assets/34343582/41b91a83-056e-4abe-911a-c536310b980e" width="250" />

## List of changes proposed in this pull request
- Removed from screen list the data source of PagoBANCOMAT

## How to test
- Go into wallet tab;
- Press on top-right button "+ Aggiungi"
- Press on "New payment method"
- Inside the list there must not be visible PagoBANCOMAT item
