### PR TITLE
[IOAPPFD0-121] Add new `AppVersion` component

### DIFF
--- a/locales/de/index.yml
+++ b/locales/de/index.yml
@@ -427,7 +427,7 @@ profile:
       alertMessage: "Die App muss neu gestartet werden, damit die Änderungen wirksam werden."
     pnEnvironment:
       pnEnv: "PN-Testumgebung"
-    appVersion: "App-Version"
+    appVersion: "Version"
     backendVersion: "Backend-Version"
     debugMode: "Debug-Modus"
     designSystem: "Design System"

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -440,7 +440,7 @@ profile:
       idpayTest: Test IDPay
       idpayTestAlert: This change requires app reboot
     designSystemEnvironment: Experimental Design System
-    appVersion: App Version
+    appVersion: Version
     backendVersion: Backend Version
     debugMode: Debug mode
     designSystem: Design System

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -440,7 +440,7 @@ profile:
       idpayTest: Test IDPay
       idpayTestAlert: La modifica richiede il riavvio dell'app
     designSystemEnvironment: Design System sperimentale
-    appVersion: Versione App
+    appVersion: Versione
     backendVersion: Versione Backend
     debugMode: Modalità debug
     designSystem: Design System

--- a/ts/components/AppVersion.tsx
+++ b/ts/components/AppVersion.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import {
+  StyleSheet,
+  Pressable,
+  GestureResponderEvent,
+  View
+} from "react-native";
+import I18n from "i18n-js";
+import { getAppVersion } from "../utils/appVersion";
+import { WithTestID } from "../types/WithTestID";
+import { Icon } from "./core/icons";
+import { HSpacer } from "./core/spacer/Spacer";
+import { LabelSmall } from "./core/typography/LabelSmall";
+import { IOStyles } from "./core/variables/IOStyles";
+
+export type AppVersion = WithTestID<{
+  onPress: (event: GestureResponderEvent) => void;
+}>;
+
+const styles = StyleSheet.create({
+  versionButton: {
+    paddingVertical: 20,
+    alignSelf: "flex-start"
+  }
+});
+
+const AppVersion = ({ onPress, testID }: AppVersion) => {
+  const appVersion = getAppVersion();
+
+  return (
+    <Pressable onPress={onPress} testID={testID}>
+      <View style={[styles.versionButton, IOStyles.row, IOStyles.alignCenter]}>
+        <Icon name="productIOApp" size={20} color="grey-650" />
+        <HSpacer size={8} />
+        <LabelSmall numberOfLines={1} weight="SemiBold" color="grey-650">
+          {`${I18n.t("profile.main.appVersion")} ${appVersion}`}
+        </LabelSmall>
+      </View>
+    </Pressable>
+  );
+};
+
+export default AppVersion;

--- a/ts/screens/profile/ProfileMainScreen.tsx
+++ b/ts/screens/profile/ProfileMainScreen.tsx
@@ -1,13 +1,12 @@
 import { Millisecond } from "@pagopa/ts-commons/lib/units";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { List, ListItem, Toast } from "native-base";
+import { List, Toast } from "native-base";
 import * as React from "react";
-import { View, Alert, ScrollView, StyleSheet, Pressable } from "react-native";
+import { View, Alert, ScrollView, StyleSheet } from "react-native";
 import { connect } from "react-redux";
 import { TranslationKeys } from "../../../locales/locales";
 import ContextualInfo from "../../components/ContextualInfo";
 import { VSpacer } from "../../components/core/spacer/Spacer";
-import { Body } from "../../components/core/typography/Body";
 import { IOStyles } from "../../components/core/variables/IOStyles";
 import FiscalCodeComponent from "../../components/FiscalCodeComponent";
 import { withLightModalContext } from "../../components/helpers/withLightModalContext";
@@ -55,7 +54,6 @@ import {
   isPnTestEnabledSelector
 } from "../../store/reducers/persistedPreferences";
 import { GlobalState } from "../../store/reducers/types";
-import { getAppVersion } from "../../utils/appVersion";
 import { clipboardSetStringWithFeedback } from "../../utils/clipboard";
 import { getDeviceId } from "../../utils/device";
 import { isDevEnv } from "../../utils/environment";
@@ -65,6 +63,7 @@ import { Divider } from "../../components/core/Divider";
 import ListItemInfoCopy from "../../components/ui/ListItemInfoCopy";
 import ButtonSolid from "../../components/ui/ButtonSolid";
 import { SwitchListItem } from "../../components/ui/SwitchListItem";
+import AppVersion from "../../components/AppVersion";
 
 type Props = IOStackNavigationRouteProps<MainTabParamsList, "PROFILE_MAIN"> &
   LightModalContextInterface &
@@ -75,12 +74,6 @@ type Props = IOStackNavigationRouteProps<MainTabParamsList, "PROFILE_MAIN"> &
 type State = {
   tapsOnAppVersion: number;
 };
-
-const styles = StyleSheet.create({
-  noRightPadding: {
-    paddingRight: 0
-  }
-});
 
 const contextualHelpMarkdown: ContextualHelpPropsMarkdown = {
   title: "profile.main.contextualHelpTitle",
@@ -182,18 +175,6 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
           />
         )}
       </View>
-    );
-  }
-
-  private versionListItem(title: string, onPress: () => void) {
-    return (
-      <ListItem style={styles.noRightPadding}>
-        <Pressable onPress={onPress}>
-          <Body numberOfLines={1} weight="SemiBold">
-            {title}
-          </Body>
-        </Pressable>
-      </ListItem>
     );
   }
 
@@ -597,10 +578,8 @@ class ProfileMainScreen extends React.PureComponent<Props, State> {
             isLastItem={true}
           />
 
-          {this.versionListItem(
-            `${I18n.t("profile.main.appVersion")} ${getAppVersion()}`,
-            this.onTapAppVersion
-          )}
+          {/* Show the app version + Enable debug mode */}
+          <AppVersion onPress={this.onTapAppVersion} />
 
           {/* Developers Section */}
           {(this.props.isDebugModeEnabled || isDevEnv) &&


### PR DESCRIPTION
## Short description
This PR adds a small `AppVersion` component that is used in the main profile screen. Previously, this information was displayed as a list item, but it makes sense to render it as a specific UI fragment.

## List of changes proposed in this pull request
- Add the new `AppVersion`
- Change locales from `App Version` to `Version`

### Preview
<img src="https://github.com/pagopa/io-app/assets/1255491/9f376cc8-2681-41f1-9ce9-b0cf8a3dead8" width="350" />

(It includes new list items, not available in this PR)

## How to test
Go to the **Profile**