### PR TITLE
fix: [IOPID-377] iOS crash while reading CIE with NFC

### DIFF
--- a/ts/components/cie/CieNotSupported.tsx
+++ b/ts/components/cie/CieNotSupported.tsx
@@ -1,12 +1,13 @@
-import { Body, List, ListItem } from "native-base";
+import { List, ListItem } from "native-base";
 import * as React from "react";
 import { useState } from "react";
 import { Platform, View } from "react-native";
 import I18n from "../../i18n";
-import { VSpacer } from "../core/spacer/Spacer";
+import { HSpacer, VSpacer } from "../core/spacer/Spacer";
 import Markdown from "../ui/Markdown";
 import { IOIcons, Icon } from "../core/icons";
 import { IOColors } from "../core/variables/IOColors";
+import { Body } from "../core/typography/Body";
 
 type Props = {
   hasCieApiLevelSupport: boolean;
@@ -43,6 +44,7 @@ const CieNotSupported: React.FunctionComponent<Props> = props => {
                   name={props.hasCieApiLevelSupport ? okIcon : koIcon}
                   color={props.hasCieApiLevelSupport ? okColor : koColor}
                 />
+                <HSpacer size={8} />
                 <Body>
                   {I18n.t(
                     "authentication.landing.cie_unsupported.os_version_unsupported"
@@ -57,6 +59,7 @@ const CieNotSupported: React.FunctionComponent<Props> = props => {
                     color={props.hasCieNFCFeature ? okColor : koColor}
                   />
                 </View>
+                <HSpacer size={8} />
                 <Body>
                   {I18n.t(
                     "authentication.landing.cie_unsupported.nfc_incompatible"

--- a/ts/components/cie/CieRequestAuthenticationOverlay.tsx
+++ b/ts/components/cie/CieRequestAuthenticationOverlay.tsx
@@ -183,8 +183,7 @@ const CieWebView = (props: Props) => {
     ) {
       // avoid redirect and follow the 'happy path'
       if (webView.current !== null) {
-        const authUrl = url.replace("nextUrl=", "OpenApp?nextUrl=");
-        setInternalState(state => generateFoundAuthUrlState(authUrl, state));
+        setInternalState(state => generateFoundAuthUrlState(url, state));
       }
       return false;
     }

--- a/ts/screens/authentication/cie/CieConsentDataUsageScreen.tsx
+++ b/ts/screens/authentication/cie/CieConsentDataUsageScreen.tsx
@@ -167,7 +167,7 @@ class CieConsentDataUsageScreen extends React.Component<Props, State> {
           androidMicrophoneAccessDisabled={true}
           textZoom={100}
           originWhitelist={originSchemasWhiteList}
-          source={{ uri: this.cieAuthorizationUri }}
+          source={{ uri: decodeURIComponent(this.cieAuthorizationUri) }}
           javaScriptEnabled={true}
           onShouldStartLoadWithRequest={this.handleShouldStartLoading}
           renderLoading={() => loaderComponent}


### PR DESCRIPTION
## Short description
This PR fixes the CIE Login flow.

## List of changes proposed in this pull request
* [ts/components/cie/CieNotSupported.tsx](https://github.com/pagopa/io-app/blob/0944df5cbab1a63eaa8d9e385a85b372dbd5b01b/ts%2Fcomponents%2Fcie%2FCieNotSupported.tsx): Fixes UI to avoid crash.
* [ts/components/cie/CieRequestAuthenticationOverlay.tsx](https://github.com/pagopa/io-app/blob/0944df5cbab1a63eaa8d9e385a85b372dbd5b01b/ts%2Fcomponents%2Fcie%2FCieRequestAuthenticationOverlay.tsx): Removes replace.
* [ts/screens/authentication/cie/CieConsentDataUsageScreen.tsx](https://github.com/pagopa/io-app/blob/0944df5cbab1a63eaa8d9e385a85b372dbd5b01b/ts%2Fscreens%2Fauthentication%2Fcie%2FCieConsentDataUsageScreen.tsx): Uses `decodeURIComponent` to allow the `WebView` to navigate to the obtain auth url.

## How to test
- Run `yarn cie-ios:prod` and run the app on a physical device on both Android and iOS.
- Test CIE login.
