### PR TITLE
fix: [IOBP-117] Remove "in progress" state handling for AUTHORIZED transactions

### DIFF
--- a/ts/features/idpay/initiative/details/components/TimelineOperationListItem.tsx
+++ b/ts/features/idpay/initiative/details/components/TimelineOperationListItem.tsx
@@ -86,17 +86,8 @@ const getDiscountInitiativeTransactionLabel = (
           )}
         />
       );
-    case TransactionStatusEnum.AUTHORIZED:
-      return (
-        <IOBadge
-          color="blue"
-          variant="solid"
-          text={I18n.t(
-            "idpay.initiative.operationDetails.discount.labels.AUTHORIZED"
-          )}
-        />
-      );
     case TransactionStatusEnum.REWARDED:
+    case TransactionStatusEnum.AUTHORIZED:
       return (
         <H4>{`-${formatAbsNumberAmountOrDefault(operation.amount)} €`}</H4>
       );

--- a/ts/features/idpay/initiative/timeline/components/TimelineDiscountTransactionDetailsComponent.tsx
+++ b/ts/features/idpay/initiative/timeline/components/TimelineDiscountTransactionDetailsComponent.tsx
@@ -44,19 +44,6 @@ const TimelineDiscountTransactionDetailsComponent = (props: Props) => {
               <VSpacer size={16} />
             </>
           );
-        case TransactionStatusEnum.AUTHORIZED:
-          return (
-            <>
-              <Alert
-                viewRef={alertViewRef}
-                variant="info"
-                content={I18n.t(
-                  "idpay.initiative.operationDetails.discount.details.alerts.AUTHORIZED"
-                )}
-              />
-              <VSpacer size={16} />
-            </>
-          );
         default:
           return null;
       }


### PR DESCRIPTION
## Short description
This PR removes the “in progress" badge and Alert info from an authorized transaction into IDPay timeline;

## List of changes proposed in this pull request
- Edited into `TimelineOperationListItem.tsx` the switch-case of an `AUTHORIZED` transaction doing the same behavior of a `REWARDED` transaction (showing amount instead badge); 
- Removed into `TimelineDiscountTransactionDetailsComponent.tsx` the case about the `AUTHORIZED` state;

## How to test
Go into a IDPay discount initiative details and check if there is not present the `in corso` badge if the transaction state is `AUTHORIZED`; 