### PR TITLE
fix: [IOBP-122] Available initiatives label alignment 

### DIFF
--- a/ts/features/wallet/component/features/PaymentMethodInitiatives.tsx
+++ b/ts/features/wallet/component/features/PaymentMethodInitiatives.tsx
@@ -1,14 +1,10 @@
 import * as React from "react";
 
 import { useFocusEffect, useNavigation } from "@react-navigation/native";
-import { StyleSheet, View } from "react-native";
+import { View } from "react-native";
 import { connect } from "react-redux";
 import { Dispatch } from "redux";
-import Initiative from "../../../../../img/wallet/initiatives.svg";
-import { HSpacer } from "../../../../components/core/spacer/Spacer";
 import { Body } from "../../../../components/core/typography/Body";
-import { H3 } from "../../../../components/core/typography/H3";
-import { IOColors } from "../../../../components/core/variables/IOColors";
 import I18n from "../../../../i18n";
 import { IOStackNavigationProp } from "../../../../navigation/params/AppParamsList";
 import { WalletParamsList } from "../../../../navigation/params/WalletParamsList";
@@ -21,17 +17,14 @@ import {
   idPayInitiativesFromInstrumentRefreshStop
 } from "../../../idpay/wallet/store/actions";
 import { idPayEnabledInitiativesFromInstrumentSelector } from "../../../idpay/wallet/store/reducers";
+import { IOStyles } from "../../../../components/core/variables/IOStyles";
+import SectionHeader from "../../../../components/services/SectionHeader";
 
 type OwnProps = {
   paymentMethod: PaymentMethod;
 } & Pick<React.ComponentProps<typeof View>, "style">;
 
 type Props = ReturnType<typeof mapDispatchToProps> & OwnProps;
-
-const styles = StyleSheet.create({
-  icon: { alignSelf: "center" },
-  row: { flex: 1, flexDirection: "row" }
-});
 
 /**
  * This component enlists the different initiatives active on the payment methods
@@ -67,17 +60,8 @@ const PaymentMethodInitiatives = (props: Props): React.ReactElement | null => {
 
   return initiativesList.length > 0 ? (
     <View testID="idPayInitiativesList" style={props.style}>
-      <View style={styles.row}>
-        <View style={styles.row}>
-          <Initiative
-            width={20}
-            height={20}
-            stroke={IOColors.bluegreyDark}
-            style={styles.icon}
-          />
-          <HSpacer size={16} />
-          <H3 color={"bluegrey"}>{I18n.t("wallet.capability.title")}</H3>
-        </View>
+      <View style={[IOStyles.rowSpaceBetween, IOStyles.alignCenter]}>
+        <SectionHeader iconName="initiatives" title="wallet.capability.title" />
         <Body
           weight="SemiBold"
           color="blue"


### PR DESCRIPTION
## Short description
This PR fixes a label alignment of "Iniziative disponibili" label into credit card details

## List of changes proposed in this pull request
- Replaced the previous implementation with the `SectionHeader` component that aligns label correctly (It will be replaced as soon as the new `SectionDivider` component will become available into Design System) 

## How to test
Into wallet tab section, press on a credit card and go into credit card details

## Preview

|Before|After|
|-|-|
| <img width="350" src="https://github.com/pagopa/io-app/assets/34343582/8a533315-47f6-473c-a392-f6a1804fa46f"  /> | <img width="350" src="https://github.com/pagopa/io-app/assets/34343582/a45edc89-c1df-4cf3-9099-b0c5bfeeff67" /> |
