### PR TITLE
chore: [IOBP-125] `ListItemTransaction` refinements

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -60,6 +60,7 @@ global:
     blocked: "Blocked"
     onGoing: "Ongoing"
     failed: "Failed"
+    cancelled: "Cancelled"
   password: Password
   username: Username
   unknown: unknown

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -60,6 +60,7 @@ global:
     blocked: "Bloccato"
     onGoing: "In corso"
     failed:  "Fallita"
+    cancelled: "Annullata"
   password: Password
   username: Username
   disclaimer_beta: Se riscontri problemi di accesso, segnalacelo!

--- a/ts/features/design-system/core/DSListItems.tsx
+++ b/ts/features/design-system/core/DSListItems.tsx
@@ -622,7 +622,7 @@ const renderListItemIDP = () => (
 const renderListItemTransaction = () => {
   const cdnPath = "https://assets.cdn.io.italia.it/logos/organizations/";
   const organizationLogoURI = {
-    imageSource: `${cdnPath}1199250158.png`,
+    imageSource: `${cdnPath}82003830161.png`,
     name: "Comune di Milano"
   };
   return (
@@ -639,14 +639,14 @@ const renderListItemTransaction = () => {
         <ListItemTransaction
           title="TITLE"
           subtitle="subtitle"
-          paymentLogoOrUrl={"amex"}
+          paymentLogoIcon={"amex"}
           transactionStatus="failure"
           onPress={onButtonPress}
         />
         <ListItemTransaction
           title="TITLE"
           subtitle="subtitle"
-          paymentLogoOrUrl={{ uri: organizationLogoURI.imageSource }}
+          paymentLogoIcon={{ uri: organizationLogoURI.imageSource }}
           transactionStatus="pending"
           onPress={onButtonPress}
         />
@@ -662,7 +662,7 @@ const renderListItemTransaction = () => {
           subtitle="subtitle"
           transactionStatus="success"
           transactionAmount="€ 1.000,00"
-          paymentLogoOrUrl={"mastercard"}
+          paymentLogoIcon={"mastercard"}
           onPress={onButtonPress}
         />
         <ListItemTransaction
@@ -677,15 +677,31 @@ const renderListItemTransaction = () => {
           title="This one is not clickable"
           subtitle="subtitle"
           transactionStatus="failure"
-          paymentLogoOrUrl={"postepay"}
+          paymentLogoIcon={"postepay"}
         />
         <ListItemTransaction
           title="This one is clickable but has a very long title"
           subtitle="very long subtitle, the kind of subtitle you'd never wish to see in the app, like a very long one"
           transactionAmount="€ 1.000,00"
-          paymentLogoOrUrl={"postepay"}
+          paymentLogoIcon={"postepay"}
           onPress={onButtonPress}
           transactionStatus="success"
+        />
+        <ListItemTransaction
+          title="Custom icon"
+          subtitle="This one has a custom icon on the left"
+          transactionStatus="success"
+          paymentLogoIcon={<Icon name="notice" color="red" />}
+          transactionAmount=""
+          onPress={onButtonPress}
+        />
+        <ListItemTransaction
+          title="Refunded transaction"
+          subtitle="This one has a custom icon and transaction amount with a green color"
+          transactionStatus="refunded"
+          paymentLogoIcon={<Icon name="refund" color="bluegrey" />}
+          transactionAmount="€ 100"
+          onPress={onButtonPress}
         />
       </View>
     </DSComponentViewerBox>


### PR DESCRIPTION
## Short description
In this PR:
- The icon behavior into `ListItemTransaction` component has been changed in order to add also a custom icon different from the `IOLogoPaymentType` and image uri.
- Has been done a design refinement following the [Redesign Portafoglio Figma](https://www.figma.com/file/nXyEtYEzfW4cnollwkgiXg/Redesign-Portafoglio?type=design&node-id=4-6089&mode=design&t=uB6svwBrSA52rREF-4) adding two more transaction statuses unhandled (_cancelled_, _refunded_)

## List of changes proposed in this pull request
- Changed the behavior into `ListItemTransaction`-> `LeftComponent`: Now it can show also a `React.ReactNode` (ideally an `Icon` component);
- Two more transaction statuses has been added into `ListItemTransaction` component: 
    - _cancelled_: It shows a right badge with a "Cancelled" text inside;
    - _refunded_: It sets the `transactionAmount` text color to greenLight;
    - For both statuses: Has been added a title and description opacity to `0.6`;
- Changed LeftComponent spacing following the redesign figma; 
- Added two more preview into Design System List items showcase;

## How to test
Go into Design System section -> List Items -> Scroll down until `ListItemTransaction` section

## Acknowledgement
@forrest57 

## Preview

https://github.com/pagopa/io-app/assets/34343582/1867dc0c-1009-4836-ae93-629c3e7b9138

