### PR TITLE
fix: [IOBP-127] Add swipe back gesture navigation in transaction code input screen

### DIFF
--- a/ts/features/idpay/payment/navigation/navigator.tsx
+++ b/ts/features/idpay/payment/navigation/navigator.tsx
@@ -44,6 +44,7 @@ export const IDPayPaymentNavigator = () => (
       <Stack.Screen
         name={IDPayPaymentRoutes.IDPAY_PAYMENT_CODE_INPUT}
         component={IDPayPaymentCodeInputScreen}
+        options={{ gestureEnabled: true }}
       />
       <Stack.Screen
         name={IDPayPaymentRoutes.IDPAY_PAYMENT_AUTHORIZATION}


### PR DESCRIPTION
## Short description
This PR adds the gesture navigation in the transaction code manual input screen.

## List of changes proposed in this pull request
- [ts/features/idpay/payment/navigation/navigator.tsx](https://github.com/pagopa/io-app/pull/4787/files#diff-db3bd7a286b3c1c1c1d256147d82387d23b714bafaba4d9ceba25a685bd2c27e): enabled gesture navigation

## How to test
Navigate to the transazione code input screen and try to navigate back with a swipe gesture.
