### PR TITLE
[IOCOM-358] iOS button label changed to 'Open or Share' on PDF preview

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1793,7 +1793,7 @@ messageDetails:
       details: "An error occurred while downloading the attachment. Retry or create a ticket"
 messagePDFPreview:
   title: "PDF Preview"
-  singleBtn: "Save, print, or share"
+  singleBtn: "Save or share"
   open: "Open"
   save: "Save"
   savedAtLocation: "Document {{name}} was successfully saved in your Download folder."

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1814,7 +1814,7 @@ messageDetails:
       details: "Non sono riuscito a scaricare l’allegato. Riprova o apri una segnalazione"
 messagePDFPreview:
   title: "Anteprima PDF"
-  singleBtn: "Salva, stampa o condividi"
+  singleBtn: "Salva o condividi"
   open: "Apri"
   save: "Salva"
   savedAtLocation: "Il documento {{name}} è stato salvato nella cartella Download."

--- a/ts/features/messages/components/MessageAttachmentPreview.tsx
+++ b/ts/features/messages/components/MessageAttachmentPreview.tsx
@@ -77,7 +77,6 @@ const renderError = (title: string, body: string) => (
 
 const renderPDF = (
   downloadPath: string,
-  isGenericAttachment: boolean,
   isPDFError: boolean,
   props: Props,
   onPDFLoadingError: () => void
@@ -98,7 +97,6 @@ const renderPDF = (
     {renderFooter(
       props.attachment,
       downloadPath,
-      isGenericAttachment,
       props.onShare,
       props.onOpen,
       props.onDownload
@@ -109,7 +107,6 @@ const renderPDF = (
 const renderFooter = (
   attachment: UIAttachment,
   downloadPath: string,
-  isGenericAttachment: boolean,
   onShare?: () => void,
   onOpen?: () => void,
   onDownload?: () => void
@@ -120,7 +117,7 @@ const renderFooter = (
       leftButton={confirmButtonProps(() => {
         onShare?.();
         ReactNativeBlobUtil.ios.presentOptionsMenu(downloadPath);
-      }, I18n.t(isGenericAttachment ? "messagePDFPreview.open" : "messagePDFPreview.singleBtn"))}
+      }, I18n.t("messagePDFPreview.singleBtn"))}
     />
   ) : (
     <FooterWithButtons
@@ -278,7 +275,6 @@ export const MessageAttachmentPreview = (props: Props): React.ReactElement => {
         {shouldDisplayPDFPreview &&
           renderPDF(
             downloadPot.value.path,
-            isGenericAttachment,
             isPDFError,
             props,
             internalOnPDFError


### PR DESCRIPTION
## Short description
This PR updates the label on the bottom bar button, when displaying a PDF Preview in iOS

## List of changes proposed in this pull request
- removed unnecessary property (since the label is now unique between general and PN attachments)
- label content changed to "Apri o condividi" / "Open or share"

## How to test
Using the io-dev-api-server, generate a standard message with attachments. Pick such message and select one of its attachment to see the button's label
