### PR TITLE
[IOPID-499]  Change the keyId format in the Lollipop Playground to be compliant with the new spec

### DIFF
--- a/ts/features/lollipop/playgrounds/LollipopPlayground.tsx
+++ b/ts/features/lollipop/playgrounds/LollipopPlayground.tsx
@@ -53,9 +53,7 @@ const LollipopPlayground = () => {
                 {
                   keyTag,
                   publicKey,
-                  publicKeyThumbprint: `${DEFAULT_LOLLIPOP_HASH_ALGORITHM_SERVER}-${toThumbprint(
-                    maybePublicKey
-                  )}`
+                  publicKeyThumbprint: toThumbprint(maybePublicKey)
                 },
                 { nonce: "aNonce", signBody }
               )


### PR DESCRIPTION
## Short description
This PR fixes the playground by following the new `keyId` BE specs.

## How to test
Run the application in production and test the Lollipop Playground
