### PR TITLE
chore(IT Wallet): [SIW-300] Add wallet reset

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3267,6 +3267,13 @@ features:
         personal: "Personal"
         cgn: "Carta giovani"
         payments: "Payments methods"
+      reset: 
+        label: "Reset"
+        bottomSheet: 
+          title: "Do you want to reset IT Wallet?"
+          body: "By deactivating IT Wallet, you will lose your Digital Identity and return to the initial state. You can reactivate it later."
+          confirm: "Confirm reset"
+          cancel: "Cancel"
     infoAuthScreen:
       title: "Log in with CIE + PIN and save your digital identity"
       subTitle: "To activate IT Wallet you need to authenticate yourself using your Electronic Identity Card (CIE) + PIN."

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3291,6 +3291,14 @@ features:
         personal: "Personali"
         cgn: "Carta giovani"
         payments: "Metodi di pagamento"
+      reset: 
+        label: "Resetta"
+        bottomSheet: 
+          title: "Vuoi resettare IT Wallet?"
+          body: "Perderai l’Identità Digitale e tornerai allo stato iniziale disattivando
+        IT Wallet. Potrai riattivarlo in un secondo momento."
+          confirm: "Conferma reset"
+          cancel: "Annulla"
     infoAuthScreen:
       title: "Accedi con CIE + PIN e salva la tua identità digitale"
       subTitle: "Per attivare IT Wallet è necessario autenticarti utilizzando la tua Carta di Identità Elettronica (CIE) + PIN."

--- a/ts/features/it-wallet/hooks/useItwResetFlow.tsx
+++ b/ts/features/it-wallet/hooks/useItwResetFlow.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { View } from "react-native";
+import { useDispatch } from "react-redux";
+import { useIOBottomSheetModal } from "../../../utils/hooks/bottomSheet";
+import { IOStyles } from "../../../components/core/variables/IOStyles";
+import FooterWithButtons from "../../../components/ui/FooterWithButtons";
+import I18n from "../../../i18n";
+import { H4 } from "../../../components/core/typography/H4";
+import { itwCredentialsReset } from "../store/actions";
+import { IOColors } from "../../../components/core/variables/IOColors";
+
+/**
+ * A hook that returns a function to present the reset wallet bottom sheet in the wallet home screen.
+ */
+export const useItwResetFlow = () => {
+  const dispatch = useDispatch();
+  const BottomSheetBody = () => (
+    <View style={IOStyles.flex}>
+      <H4 color={"bluegreyDark"} weight={"Regular"}>
+        {I18n.t("features.itWallet.homeScreen.reset.bottomSheet.body")}
+      </H4>
+    </View>
+  );
+  const Footer = () => (
+    <FooterWithButtons
+      type={"TwoButtonsInlineHalf"}
+      leftButton={{
+        onPressWithGestureHandler: true,
+        bordered: true,
+        onPress: () => dismiss(),
+        title: I18n.t("features.itWallet.homeScreen.reset.bottomSheet.cancel")
+      }}
+      rightButton={{
+        onPress: () => {
+          dispatch(itwCredentialsReset());
+          dismiss();
+        },
+        primary: true,
+        labelColor: IOColors.white,
+        title: I18n.t("features.itWallet.homeScreen.reset.bottomSheet.confirm")
+      }}
+    />
+  );
+  const { present, bottomSheet, dismiss } = useIOBottomSheetModal({
+    title: I18n.t("features.itWallet.homeScreen.reset.bottomSheet.title"),
+    component: <BottomSheetBody />,
+    snapPoint: [300],
+    footer: <Footer />
+  });
+
+  return {
+    dismiss,
+    present,
+    bottomSheet
+  };
+};

--- a/ts/features/it-wallet/store/actions/index.ts
+++ b/ts/features/it-wallet/store/actions/index.ts
@@ -33,10 +33,18 @@ export const itwCredentialsAddPid = createAsyncAction(
 )<PidMockType, PidMockType, ItWalletError>();
 
 /**
+ * Resets the ITW state, deactivating it and deleting all credentials.
+ */
+export const itwCredentialsReset = createStandardAction(
+  "ITW_CREDENTIALS_RESET"
+)<void>();
+
+/**
  * Action types for the IT Wallet feature
  */
 export type ItWalletActions =
   | ActionType<typeof itwActivationStart>
   | ActionType<typeof itwRequirementsRequest>
   | ActionType<typeof itwCredentialsAddPid>
+  | ActionType<typeof itwCredentialsReset>
   | ItwCieAuthenticationActions;

--- a/ts/features/it-wallet/store/reducers/itwCredentials.ts
+++ b/ts/features/it-wallet/store/reducers/itwCredentials.ts
@@ -1,7 +1,7 @@
 import { getType } from "typesafe-actions";
 import * as pot from "@pagopa/ts-commons/lib/pot";
 import { Action } from "../../../../store/actions/types";
-import { itwCredentialsAddPid } from "../actions";
+import { itwCredentialsAddPid, itwCredentialsReset } from "../actions";
 import { PidMockType } from "../../utils/mocks";
 import { ItWalletError } from "../../utils/errors/itwErrors";
 import { GlobalState } from "../../../../store/reducers/types";
@@ -37,6 +37,8 @@ const reducer = (
       });
     case getType(itwCredentialsAddPid.failure):
       return pot.toError(state, action.payload);
+    case getType(itwCredentialsReset):
+      return emptyState;
   }
   return state;
 };


### PR DESCRIPTION
## Short description
This PR adds a reset button in the wallet home screen.

## List of changes proposed in this pull request
- `locales/en/index.yml` & `locales/it/index.yml`: Adds necessary locales;
- `ts/features/it-wallet/hooks/useItwResetFlow.tsx`: Adds an hook to display the bottom sheet to reset the wallet;
- `ts/features/it-wallet/screens/ItwHomeScreen.tsx`: Adds a reset button when the wallet is active;
- `ts/features/it-wallet/store/actions/index.ts`: Adds the reset action;
- `ts/features/it-wallet/store/reducers/itwCredentials.ts`: Adds the new action to the reducer which resets the state to the initial one.

## How to test
Active the IT Wallet, then open the wallet section and try to reset it. 
