### PR TITLE
feat(IT Wallet): [SIW-319] Add profile button to main screens

### DIFF
--- a/ts/components/screens/DarkLayout.tsx
+++ b/ts/components/screens/DarkLayout.tsx
@@ -18,8 +18,9 @@ import { FAQsCategoriesType } from "../../utils/faq";
 import { VSpacer } from "../core/spacer/Spacer";
 import { IOColors, getGradientColorValues } from "../core/variables/IOColors";
 import { IOStyles } from "../core/variables/IOStyles";
+import { ComponentProps } from "../../types/react";
 import AnimatedScreenContent from "./AnimatedScreenContent";
-import {
+import BaseScreenComponent, {
   ContextualHelpProps,
   ContextualHelpPropsMarkdown
 } from "./BaseScreenComponent";
@@ -52,7 +53,8 @@ type Props = Readonly<{
   referenceToContentScreen?: (
     c: ScreenContentRoot
   ) => ScreenContentRoot | React.LegacyRef<Content>;
-}>;
+}> &
+  Pick<ComponentProps<typeof BaseScreenComponent>, "isProfileAvailable">;
 
 const styles = StyleSheet.create({
   headerContents: {
@@ -115,6 +117,7 @@ export default class DarkLayout extends React.Component<Props> {
         contextualHelpMarkdown={this.props.contextualHelpMarkdown}
         faqCategories={this.props.faqCategories}
         titleColor={"white"}
+        isProfileAvailable={this.props.isProfileAvailable}
       >
         <FocusAwareStatusBar
           backgroundColor={IOColors.bluegrey}

--- a/ts/components/wallet/WalletLayout.tsx
+++ b/ts/components/wallet/WalletLayout.tsx
@@ -25,6 +25,7 @@ import { VSpacer } from "../core/spacer/Spacer";
 import { Body } from "../core/typography/Body";
 import { IOStyles } from "../core/variables/IOStyles";
 import { ScreenContentRoot } from "../screens/ScreenContent";
+import { ComponentProps } from "../../types/react";
 
 type Props = Readonly<{
   accessibilityLabel?: string;
@@ -47,7 +48,8 @@ type Props = Readonly<{
   referenceToContentScreen?: (
     c: ScreenContentRoot
   ) => ScreenContentRoot | React.LegacyRef<Content>;
-}>;
+}> &
+  Pick<ComponentProps<typeof DarkLayout>, "isProfileAvailable">;
 
 const styles = StyleSheet.create({
   whiteBg: {
@@ -124,6 +126,7 @@ export default class WalletLayout extends React.Component<Props> {
         gradientHeader={this.props.gradientHeader}
         headerPaddingMin={this.props.headerPaddingMin}
         referenceToContentScreen={this.props.referenceToContentScreen}
+        isProfileAvailable={this.props.isProfileAvailable}
       >
         {this.props.children}
       </DarkLayout>

--- a/ts/screens/services/ServicesHomeScreen.tsx
+++ b/ts/screens/services/ServicesHomeScreen.tsx
@@ -102,6 +102,7 @@ import {
 } from "../../utils/profile";
 import { showToast } from "../../utils/showToast";
 import { Icon } from "../../components/core/icons";
+import ROUTES from "../../navigation/routes";
 import { ServiceDetailsScreenNavigationParams } from "./ServiceDetailsScreen";
 
 type OwnProps = IOStackNavigationRouteProps<AppParamsList>;
@@ -361,6 +362,13 @@ class ServicesHomeScreen extends React.Component<Props, State> {
             appLogo={true}
             contextualHelpMarkdown={contextualHelpMarkdown}
             faqCategories={["services"]}
+            isProfileAvailable={{
+              enabled: true,
+              onProfileTap: () =>
+                this.props.navigation
+                  .getParent()
+                  ?.navigate(ROUTES.PROFILE_NAVIGATOR)
+            }}
           >
             {this.renderErrorContent() ? (
               this.renderErrorContent()

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -106,6 +106,7 @@ import { isStrictSome } from "../../utils/pot";
 import { showToast } from "../../utils/showToast";
 import { Icon } from "../../components/core/icons";
 import { IOStyles } from "../../components/core/variables/IOStyles";
+import ROUTES from "../../navigation/routes";
 
 export type WalletHomeNavigationParams = Readonly<{
   newMethodAdded: boolean;
@@ -549,6 +550,13 @@ class WalletHomeScreen extends React.PureComponent<Props, State> {
         gradientHeader={true}
         headerPaddingMin={true}
         footerFullWidth={<SectionStatusComponent sectionKey={"wallets"} />}
+        isProfileAvailable={{
+          enabled: true,
+          onProfileTap: () =>
+            this.props.navigation
+              .getParent()
+              ?.navigate(ROUTES.PROFILE_NAVIGATOR)
+        }}
       >
         <BpdOptInPaymentMethodsContainer />
         <>


### PR DESCRIPTION
## Short description
This pull request introduces the profile button to main screens, including payments and services.

## List of changes proposed in this pull request
- `ts/components/screens/DarkLayout.tsx`: Prop drilling;
- `ts/components/wallet/WalletLayout.tsx`: Prop drilling;
- `ts/screens/services/ServicesHomeScreen.tsx`: Adds the profile button to the services screen;
- `ts/screens/wallet/WalletHomeScreen.tsx`: Adds the profile button to the payments screen;

## How to test
Run the application.
Check if the profile button is displayed in the top bar on each main screen, including payments and services.
