### PR TITLE
fix(IT Wallet): [SIW-322] Add vertical spacer in discovery screens

### DIFF
--- a/ts/features/it-wallet/screens/discovery/ItwActivationDetailsScreen.tsx
+++ b/ts/features/it-wallet/screens/discovery/ItwActivationDetailsScreen.tsx
@@ -65,6 +65,7 @@ const ItwActivationDetailsScreen = () => {
           <ItwFooterInfoBox
             content={I18n.t("features.itWallet.activationScreen.tos")}
           />
+          <VSpacer />
         </ScreenContent>
         <FooterWithButtons
           type={"TwoButtonsInlineThird"}

--- a/ts/features/it-wallet/screens/issuing/ItwActivationInfoAuthScreen.tsx
+++ b/ts/features/it-wallet/screens/issuing/ItwActivationInfoAuthScreen.tsx
@@ -23,6 +23,7 @@ import { InfoScreenComponent } from "../../../fci/components/InfoScreenComponent
 import { Pictogram } from "../../../../components/core/pictograms";
 import { mapRequirementsError } from "../../utils/errors/itwErrorsMapping";
 import { ITW_ROUTES } from "../../navigation/routes";
+import { VSpacer } from "../../../../components/core/spacer/Spacer";
 
 const ItwActivationInfoAuthScreen = () => {
   const navigation = useNavigation();
@@ -114,6 +115,7 @@ const ItwActivationInfoAuthScreen = () => {
             content={I18n.t("features.itWallet.infoAuthScreen.footerBox")}
             infoIcon
           />
+          <VSpacer />
         </ScreenContent>
         <FooterWithButtons
           type={"SingleButton"}


### PR DESCRIPTION
## Short description
This PR adds a vertical spacer in discovery screens. 

## List of changes proposed in this pull request
- `ts/features/it-wallet/screens/discovery/ItwActivationDetailsScreen.tsx`: Add vertical spacer;
- `ts/features/it-wallet/screens/issuing/ItwActivationInfoAuthScreen.tsx`: Add vertical spacer.

## How to test
| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/pagopa/io-app/assets/12371664/acffebc8-f2b1-4c00-8da2-8d7686f0967c" height="400">  |  <img src="https://github.com/pagopa/io-app/assets/12371664/26dc9f41-4c2d-43ba-8880-2531c4531a81" height="400">|


