### PR TITLE
fix: [IOBP-145] Fix navigation after IDPay transaction authorization

### DIFF
--- a/ts/features/idpay/payment/xstate/actions.ts
+++ b/ts/features/idpay/payment/xstate/actions.ts
@@ -31,12 +31,13 @@ const createActionsImplementation = (
   const exitAuthorization = (context: Context) => {
     pipe(
       context.transactionData,
-      O.map(({ initiativeId }) =>
-        navigation.replace(IDPayDetailsRoutes.IDPAY_DETAILS_MAIN, {
+      O.map(({ initiativeId }) => {
+        navigation.popToTop();
+        navigation.navigate(IDPayDetailsRoutes.IDPAY_DETAILS_MAIN, {
           screen: IDPayDetailsRoutes.IDPAY_DETAILS_MONITORING,
           params: { initiativeId }
-        })
-      ),
+        });
+      }),
       O.getOrElse(() => navigation.pop())
     );
   };


### PR DESCRIPTION
## Short description
This PR fixes the navigation behavior after an IDPay transaction authorization. 

## List of changes proposed in this pull request
- Added navigation reset on authorization exit

## How to test
With the `io-dev-server`, authorize an IDPay transaction and check that after the authorization you navigate back to the initiative screen.
