### PR TITLE
fix: [IOBP-158] Removal of municipality icons in wallet transactions

### DIFF
--- a/ts/components/wallet/TransactionsList.tsx
+++ b/ts/components/wallet/TransactionsList.tsx
@@ -14,10 +14,8 @@ import I18n from "../../i18n";
 import variables from "../../theme/variables";
 import { Transaction } from "../../types/pagopa";
 import { format } from "../../utils/dates";
-import { isImageUri } from "../../utils/url";
 import ButtonDefaultOpacity from "../ButtonDefaultOpacity";
 import ItemSeparatorComponent from "../ItemSeparatorComponent";
-import { Icon } from "../core/icons";
 import { Body } from "../core/typography/Body";
 import { H3 } from "../core/typography/H3";
 import { IOColors } from "../core/variables/IOColors";
@@ -72,12 +70,6 @@ export const TransactionsList = (props: Props) => {
   }
 
   // ------------------ components + utils ------------------
-  const MunicipalityPlaceholder = () => (
-    <View style={styles.municipalityPlaceholder}>
-      <Icon color="grey-450" name="institution" size={"100%"} />
-    </View>
-  );
-
   const shouldShowFooterComponent = (
     ListEmptyComponent?: React.ReactElement
   ): ListEmptyComponent is React.ReactElement =>
@@ -121,14 +113,8 @@ export const TransactionsList = (props: Props) => {
 
     const amount = formatNumberCurrencyCents(item.amount.amount);
     const datetime: string = format(item.created, "DD MMM YYYY, HH:mm");
-    const recipientLogo = isImageUri(recipient) ? (
-      recipient
-    ) : (
-      <MunicipalityPlaceholder />
-    );
     return (
       <ListItemTransaction
-        paymentLogoIcon={recipientLogo}
         title={recipient}
         subtitle={datetime}
         onPress={() => props.navigateToTransactionDetails(item)}
@@ -189,14 +175,5 @@ const styles = StyleSheet.create({
     alignSelf: "center",
     width: screenWidth - variables.contentPadding * 2,
     backgroundColor: IOColors.white
-  },
-  municipalityPlaceholder: {
-    width: 44,
-    height: 44,
-    borderRadius: 100,
-    backgroundColor: IOColors["grey-100"],
-    justifyContent: "center",
-    alignItems: "center",
-    padding: 12
   }
 });


### PR DESCRIPTION
## Short description

after a discussion with @thisisjp , it was decided it's best to remove the municipality logo from wallet transactions for now, to then add them later in future evolutives

<img width="200" alt="Screenshot 2023-07-28 at 16 00 37" src="https://github.com/pagopa/io-app/assets/60693085/0d627a0a-0a85-4159-8ee0-f7d54177e873">


## List of changes proposed in this pull request
- removed municipality logos from wallet transactions

## How to test
navigate to the wallet screen, click on the "show transactions" button and make sure listItems render correctly and with no icons.