### PR TITLE
chore(IT Wallet): [SIW-347] Update io-react-native-wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@pagopa/io-react-native-crypto": "^0.2.1",
     "@pagopa/io-react-native-jwt": "^0.4.1",
     "@pagopa/io-react-native-login-utils": "^0.2.0",
-    "@pagopa/io-react-native-wallet": "^0.2.1",
+    "@pagopa/io-react-native-wallet": "^0.2.2",
     "@pagopa/react-native-cie": "^1.1.5",
     "@pagopa/ts-commons": "^10.15.0",
     "@react-native-async-storage/async-storage": "^1.17.10",

--- a/ts/features/it-wallet/components/ClaimsList.tsx
+++ b/ts/features/it-wallet/components/ClaimsList.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Linking } from "react-native";
-import { VerifyResult } from "@pagopa/io-react-native-wallet/lib/typescript/pid/sd-jwt";
+import { PidWithToken } from "@pagopa/io-react-native-wallet/lib/typescript/pid/sd-jwt";
 import { ISSUER_URL, mapAssuranceLevel } from "../utils/mocks";
 import ListItemComponent from "../../../components/screens/ListItemComponent";
 import I18n from "../../../i18n";
@@ -14,7 +14,7 @@ import ButtonOutline from "../../../components/ui/ButtonOutline";
  * Contains the claims to be displayed, currenly only PID claims are supported.
  */
 type ClaimsListProps = {
-  decodedPid: VerifyResult;
+  decodedPid: PidWithToken;
 };
 
 /**

--- a/ts/features/it-wallet/screens/ItwCredentialDetails.tsx
+++ b/ts/features/it-wallet/screens/ItwCredentialDetails.tsx
@@ -3,7 +3,7 @@ import { View } from "native-base";
 import { SafeAreaView, ScrollView } from "react-native";
 import { PID } from "@pagopa/io-react-native-wallet";
 import * as O from "fp-ts/lib/Option";
-import { VerifyResult } from "@pagopa/io-react-native-wallet/lib/typescript/pid/sd-jwt";
+import { PidWithToken } from "@pagopa/io-react-native-wallet/lib/typescript/pid/sd-jwt";
 import FooterWithButtons from "../../../components/ui/FooterWithButtons";
 import I18n from "../../../i18n";
 import BaseScreenComponent from "../../../components/screens/BaseScreenComponent";
@@ -23,7 +23,7 @@ import LoadingSpinnerOverlay from "../../../components/LoadingSpinnerOverlay";
  */
 const ItwCredentialDetails = () => {
   const pid = useIOSelector(ItwCredentialsPidSelector);
-  const [decodedPid, setDecodedPid] = useState<VerifyResult>();
+  const [decodedPid, setDecodedPid] = useState<PidWithToken>();
   const spacerSize = 32;
 
   useOnFirstRender(() => {
@@ -57,7 +57,7 @@ const ItwCredentialDetails = () => {
           fiscalCode={decodedPid?.pid.claims.taxIdCode as string}
         />
         <VSpacer />
-        <ClaimsList decodedPid={decodedPid as VerifyResult} />
+        <ClaimsList decodedPid={decodedPid as PidWithToken} />
         <VSpacer size={spacerSize} />
       </View>
       <FooterWithButtons

--- a/ts/features/it-wallet/screens/ItwHomeScreen.tsx
+++ b/ts/features/it-wallet/screens/ItwHomeScreen.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
 import { useNavigation } from "@react-navigation/native";
 import { Pressable, ScrollView, View } from "react-native";
-import { VerifyResult } from "@pagopa/io-react-native-wallet/lib/typescript/pid/sd-jwt";
 import { PID } from "@pagopa/io-react-native-wallet";
 import * as O from "fp-ts/lib/Option";
+import { PidWithToken } from "@pagopa/io-react-native-wallet/lib/typescript/pid/sd-jwt";
 import TopScreenComponent from "../../../components/screens/TopScreenComponent";
 import ROUTES from "../../../navigation/routes";
 import I18n from "../../../i18n";
@@ -35,7 +35,7 @@ const ItwHomeScreen = () => {
   );
   const [selectedBadgeIdx, setSelectedBadgeIdx] = useState(0);
   const pid = useIOSelector(ItwCredentialsPidSelector);
-  const [decodedPid, setDecodedPid] = useState<VerifyResult>();
+  const [decodedPid, setDecodedPid] = useState<PidWithToken>();
   const { present, bottomSheet } = useItwResetFlow();
   const badgesLabels = [
     I18n.t("features.itWallet.homeScreen.categories.any"),

--- a/ts/features/it-wallet/store/actions/credentials.ts
+++ b/ts/features/it-wallet/store/actions/credentials.ts
@@ -1,7 +1,7 @@
 import { PidResponse } from "@pagopa/io-react-native-wallet/lib/typescript/pid/issuing";
 import { ActionType, createAsyncAction } from "typesafe-actions";
-import { VerifyResult } from "@pagopa/io-react-native-wallet/lib/typescript/pid/sd-jwt";
 import { PidData } from "@pagopa/io-react-native-cie-pid";
+import { PidWithToken } from "@pagopa/io-react-native-wallet/lib/typescript/pid/sd-jwt";
 import { ItWalletError } from "../../utils/errors/itwErrors";
 
 /**
@@ -9,7 +9,7 @@ import { ItWalletError } from "../../utils/errors/itwErrors";
  */
 type ItwCredentialsPidSuccessType = {
   pid: PidResponse;
-  decodedPid: VerifyResult;
+  decodedPid: PidWithToken;
 };
 
 /**

--- a/ts/features/it-wallet/store/reducers/itwPid.ts
+++ b/ts/features/it-wallet/store/reducers/itwPid.ts
@@ -2,7 +2,7 @@ import { getType } from "typesafe-actions";
 import * as pot from "@pagopa/ts-commons/lib/pot";
 import * as O from "fp-ts/lib/Option";
 import { PidResponse } from "@pagopa/io-react-native-wallet/lib/typescript/pid/issuing";
-import { VerifyResult } from "@pagopa/io-react-native-wallet/lib/typescript/pid/sd-jwt";
+import { PidWithToken } from "@pagopa/io-react-native-wallet/lib/typescript/pid/sd-jwt";
 import { Action } from "../../../../store/actions/types";
 import { ItWalletError } from "../../utils/errors/itwErrors";
 import { GlobalState } from "../../../../store/reducers/types";
@@ -10,7 +10,7 @@ import { itwPid } from "../actions/credentials";
 
 export type ItwPidType = {
   pid: O.Option<PidResponse>;
-  decodedPid: O.Option<VerifyResult>;
+  decodedPid: O.Option<PidWithToken>;
 };
 
 export type ItwPidState = pot.Pot<ItwPidType, ItWalletError>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3075,7 +3075,7 @@
   resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-login-utils/-/io-react-native-login-utils-0.2.0.tgz#4a9b55d84c6d77622e95de4511e4c422a862b27d"
   integrity sha512-mZ0Z7SAhWhbYIK/GvaeuecIyQPikj/D7pmejOrAiLA1KxIqO3UGH6p6LC2pZhN0JPHTcXbBiNHJRQtrqTHCfew==
 
-"@pagopa/io-react-native-wallet@^0.2.1":
+"@pagopa/io-react-native-wallet@^0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-wallet/-/io-react-native-wallet-0.2.2.tgz#f36c8d2a673974b4793622991c2111388b96d18a"
   integrity sha512-30dQ7p0XfK/QvvOXFZ1saSk19T5f4OKEQyPw4LPn7YiSR8qOYsZzf+FaEAmT6ltOqgUMSzKsq303YlGHjQz+3Q==


### PR DESCRIPTION
## Short description
This PR updates `io-react-native-wallet` dependency to the `0.2.2` version and also replaces the `VerifyResult` type with `PidWithToken` which wasn't exposed in the `0.2.1` version. 

## List of changes proposed in this pull request
- `package.json && yarn.lock`: Updates the dependency; 
- `ts/features/it-wallet/components/ClaimsList.tsx`: Replaces the `VerifyResult` type with `PidWithToken`;
- `ts/features/it-wallet/screens/ItwCredentialDetails.tsx`: As above;
- `ts/features/it-wallet/screens/ItwCredentialDetails.tsx`: As above;
- `ts/features/it-wallet/screens/ItwHomeScreen.tsx`: As above;
- `ts/features/it-wallet/store/actions/credentials.ts`: As above;
- `ts/features/it-wallet/store/reducers/itwPid.ts`: As above;

## How to test
The PID issuing flow should still work as expected.