### PR TITLE
feat(IT Wallet): [SIW-355] Bypass CIE login during activation

### DIFF
--- a/ts/features/it-wallet/saga/wia.ts
+++ b/ts/features/it-wallet/saga/wia.ts
@@ -7,6 +7,7 @@ import { itwWiaRequest } from "../store/actions";
 import { ItWalletErrorTypes } from "../utils/errors/itwErrors";
 import { getWia } from "../utils/wia";
 import { isCIEAuthenticationSupported } from "../utils/cie";
+import { isIos } from "../../../utils/platform";
 
 /*
  * This saga handles the wallet instance attestation issuing.
@@ -17,7 +18,7 @@ export function* handleWiaRequest(): SagaIterator {
   const idp = yield* select(idpSelector);
   const hasLoggedInWithCie = isSome(idp) && idp.value.name === "cie";
   const isCieSupported = yield* call(isCIEAuthenticationSupported);
-  if (hasLoggedInWithCie || isCieSupported) {
+  if ((hasLoggedInWithCie || isCieSupported) && !isIos) {
     try {
       const wia = yield* call(getWia);
       yield* put(itwWiaRequest.success(wia));

--- a/ts/features/it-wallet/saga/wia.ts
+++ b/ts/features/it-wallet/saga/wia.ts
@@ -2,12 +2,12 @@ import { SagaIterator } from "redux-saga";
 import { put, select, call } from "typed-redux-saga/macro";
 import { isSome } from "fp-ts/lib/Option";
 import { Errors } from "@pagopa/io-react-native-wallet";
+import DeviceInfo from "react-native-device-info";
 import { idpSelector } from "../../../store/reducers/authentication";
 import { itwWiaRequest } from "../store/actions";
 import { ItWalletErrorTypes } from "../utils/errors/itwErrors";
 import { getWia } from "../utils/wia";
 import { isCIEAuthenticationSupported } from "../utils/cie";
-import { isIos } from "../../../utils/platform";
 
 /*
  * This saga handles the wallet instance attestation issuing.
@@ -18,7 +18,8 @@ export function* handleWiaRequest(): SagaIterator {
   const idp = yield* select(idpSelector);
   const hasLoggedInWithCie = isSome(idp) && idp.value.name === "cie";
   const isCieSupported = yield* call(isCIEAuthenticationSupported);
-  if ((hasLoggedInWithCie || isCieSupported) && !isIos) {
+  const isEmulator = yield* call(DeviceInfo.isEmulator);
+  if (hasLoggedInWithCie || isCieSupported || isEmulator) {
     try {
       const wia = yield* call(getWia);
       yield* put(itwWiaRequest.success(wia));

--- a/ts/features/it-wallet/screens/issuing/ItwActivationInfoAuthScreen.tsx
+++ b/ts/features/it-wallet/screens/issuing/ItwActivationInfoAuthScreen.tsx
@@ -32,6 +32,7 @@ import {
 } from "../../../../store/reducers/profile";
 import { pidDataMock } from "../../utils/mocks";
 import { formatDateToYYYYMMDD } from "../../../../utils/dates";
+import { isIos } from "../../../../utils/platform";
 
 /**
  * Delay in milliseconds to bypass the CIE authentication process.
@@ -112,6 +113,7 @@ const ItwActivationInfoAuthScreen = () => {
       block: true,
       primary: true,
       onPress: () => navigation.navigate(ITW_ROUTES.ACTIVATION.CIE_PIN_SCREEN),
+      disabled: isIos,
       title: I18n.t("features.itWallet.infoAuthScreen.confirm")
     };
     return (

--- a/ts/features/it-wallet/utils/mocks.ts
+++ b/ts/features/it-wallet/utils/mocks.ts
@@ -3,40 +3,12 @@ import I18n from "../../../i18n";
 
 export const ISSUER_URL = "https://www.interno.gov.it/pid/";
 
-export type PidMockType = ReturnType<typeof getPidMock>;
-
-export const getPidMock = (pidData?: PidData) => ({
-  verified_claims: {
-    verification: {
-      trust_framework: "eidas",
-      assurance_level: "high",
-      evidence: [
-        {
-          type: "electronic_record",
-          record: {
-            type: "eidas.it.cie",
-            source: {
-              organization_name: "Ministero dell'Interno",
-              organization_id: "m_it",
-              country_code: "IT"
-            }
-          }
-        }
-      ]
-    },
-    claims: {
-      unique_id: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-      given_name: pidData?.name ?? "Anna",
-      family_name: pidData?.surname ?? "Verdi",
-      birthdate: pidData?.birthDate ?? "1978-12-30",
-      place_of_birth: {
-        country: "IT",
-        locality: "Rome"
-      },
-      tax_id_number: pidData?.fiscalCode ?? "VRDBNC80A41H501X"
-    }
-  }
-});
+export const pidDataMock: PidData = {
+  name: "Mario",
+  surname: "Rossi",
+  fiscalCode: "RSSMRA80L05F593A",
+  birthDate: "1980-01-10"
+};
 
 enum AssuranceLevel {
   HIGH = "high"

--- a/ts/store/reducers/profile.ts
+++ b/ts/store/reducers/profile.ts
@@ -76,6 +76,30 @@ export const profileNameSelector = createSelector(
 );
 
 /**
+ * Return the surname of the profile if some, else undefined
+ */
+export const profileSurnameSelector = createSelector(
+  profileSelector,
+  (profile: ProfileState): string | undefined =>
+    pot.getOrElse(
+      pot.map(profile, p => capitalize(p.family_name)),
+      undefined
+    )
+);
+
+/**
+ * Return the birth date of the profile if some, else undefined
+ */
+export const profileBirthDateSelector = createSelector(
+  profileSelector,
+  (profile: ProfileState): Date | undefined =>
+    pot.getOrElse(
+      pot.map(profile, p => p.date_of_birth),
+      undefined
+    )
+);
+
+/**
  * Return the fiscal code of the profile if some, else undefined
  */
 export const profileFiscalCodeSelector = createSelector(

--- a/ts/utils/dates.ts
+++ b/ts/utils/dates.ts
@@ -307,3 +307,15 @@ export const toAndroidCacheTimestamp = () =>
     new Date(),
     I18n.t("global.dateFormats.shortFormat").replace(/\//g, "")
   );
+
+/**
+ * Formats a Date object to YYYY/MM/DD format.
+ * @param date - The Date object to format.
+ * @returns a date string in the format YYYY/MM/DD.
+ */
+export const formatDateToYYYYMMDD = (date: Date, separator: string = "-") => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}${separator}${month}${separator}${day}`;
+};


### PR DESCRIPTION
## Short description
This PR introduces feature which allows users to bypass the CIE login process during the ITW activation. It completely disables the flow on iOS devices. The data required for issuing the PID is retrieved directly from the user profile or from a mock if not available. The bypass can be activated by long-pressing the image on this screen: 
<img src="https://github.com/pagopa/io-app/assets/12371664/d09800ef-d623-4cb8-a4c5-b4ffa4ca564e" height="450">

## List of changes proposed in this pull request
- `ts/features/it-wallet/saga/wia.ts`: Checks if the platform is iOS in order to disable the CIE login flow on iOS but keep it enabled during tests;
- `ts/features/it-wallet/saga/wia.ts`: Checks the `isEmulator` flag to disabled the NFC process and enable the iOS simulator to skip the CIE login flow;
- `ts/features/it-wallet/screens/issuing/ItwActivationInfoAuthScreen.tsx`: Adds the bypass pressable component and logic. Also disables the `Continue` button on iOS due to the missing SDK;
- `ts/features/it-wallet/utils/mocks.ts`: Replaces full PID mocked data with mocked personal data;
- `ts/store/reducers/profile.ts`: Adds selector for selecting the profile surname and birth date;
- `ts/utils/dates.ts`: Adds an util function which converts a Date object into a YYYY-MM-DD string;

## How to test
 To test, both the bypass and complete flows should be tested on Android, whereas on iOS, only the bypass flow should be available due to the disabled Continue button.
