### PR TITLE
chore: Clean-up Podfile.lock

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -373,8 +373,6 @@ PODS:
     - React-Core
   - react-native-cameraroll (5.6.1):
     - React-Core
-  - react-native-cie (1.2.0):
-    - React
   - react-native-config (1.4.5):
     - react-native-config/App (= 1.4.5)
   - react-native-config/App (1.4.5):
@@ -642,7 +640,6 @@ DEPENDENCIES:
   - react-native-background-timer (from `../node_modules/react-native-background-timer`)
   - react-native-blob-util (from `../node_modules/react-native-blob-util`)
   - "react-native-cameraroll (from `../node_modules/@react-native-camera-roll/camera-roll`)"
-  - "react-native-cie (from `../node_modules/@pagopa/react-native-cie`)"
   - react-native-config (from `../node_modules/react-native-config`)
   - "react-native-cookies (from `../node_modules/@react-native-cookies/cookies`)"
   - react-native-document-picker (from `../node_modules/react-native-document-picker`)
@@ -799,8 +796,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-blob-util"
   react-native-cameraroll:
     :path: "../node_modules/@react-native-camera-roll/camera-roll"
-  react-native-cie:
-    :path: "../node_modules/@pagopa/react-native-cie"
   react-native-config:
     :path: "../node_modules/react-native-config"
   react-native-cookies:
@@ -966,7 +961,6 @@ SPEC CHECKSUMS:
   react-native-background-timer: 1b6e6b4e10f1b74c367a1fdc3c72b67c619b222b
   react-native-blob-util: a5d3561045ed98cfb2fb80cbbff600fae0e8edee
   react-native-cameraroll: 2f08db1ecc9b73dbc01f89335d6d5179fac2894c
-  react-native-cie: 5ac9bf64badfe6c7224c362b278de00ff2ca720c
   react-native-config: 6502b1879f97ed5ac570a029961fc35ea606cd14
   react-native-cookies: f54fcded06bb0cda05c11d86788020b43528a26c
   react-native-document-picker: 2b8f18667caee73a96708a82b284a4f40b30a156


### PR DESCRIPTION
## Short description
This PR cleans up the `Podfile.lock` removing the reference to `react-native-cie`.  This specific pod is added at built time with the script `cie-ios:prod`.

