### PR TITLE
chore(IT Wallet): [SIW-366] Bypass with CTA on iOS

### DIFF
--- a/ts/features/it-wallet/screens/issuing/ItwActivationInfoAuthScreen.tsx
+++ b/ts/features/it-wallet/screens/issuing/ItwActivationInfoAuthScreen.tsx
@@ -112,8 +112,10 @@ const ItwActivationInfoAuthScreen = () => {
     const continueButtonProps = {
       block: true,
       primary: true,
-      onPress: () => navigation.navigate(ITW_ROUTES.ACTIVATION.CIE_PIN_SCREEN),
-      disabled: isIos,
+      onPress: () =>
+        isIos
+          ? bypassCieLogin()
+          : navigation.navigate(ITW_ROUTES.ACTIVATION.CIE_PIN_SCREEN),
       title: I18n.t("features.itWallet.infoAuthScreen.confirm")
     };
     return (


### PR DESCRIPTION
## Short description
This PR re-enables the CIE login CTA on iOS which now automatically bypasses the whole process, using the profile data to get the PID.

## List of changes proposed in this pull request
- In the [ts/features/it-wallet/screens/issuing/ItwActivationInfoAuthScreen.tsx](https://github.com/pagopa/io-app/pull/4882/files#diff-9a825d7b18edf875ff691f385e0500af4b0b127f7389586e0a5c8f9b52174ad6) remove the disabled flag when on iOS and call `bypassCieLogin` on press instead.

## How to test
Test the flow on both iOS and Android. Android should show the CIE login process, iOS should display the PID preview after pressing the CTA button.