### PR TITLE
[IOBP-173] Add IDPay transaction already authorized failure screen

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3683,6 +3683,8 @@ idpay:
         BUDGET_EXHAUSTED:
           title: Autorizzazione negata
           body: Non hai abbastanza soldi per autorizzare
+        AUTHORIZED:
+          title: L’operazione è stata già autorizzata!
     manualInput:
       title: Autorizza una transazione
       subtitle: Inserisci il codice di 8 caratteri riportato sotto al codice QR.

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3707,6 +3707,8 @@ idpay:
         BUDGET_EXHAUSTED:
           title: Autorizzazione negata
           body: Non hai abbastanza soldi per autorizzare
+        AUTHORIZED:
+          title: L’operazione è stata già autorizzata!
     manualInput:
       title: Autorizza una transazione
       subtitle: Inserisci il codice di 8 caratteri riportato sotto al codice QR.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "pagopa_api_walletv2": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.26/bonus/specs/bpd/pm/walletv2.json",
   "pagopa_cobadge_configuration": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.26/pagopa/cobadge/abi_definitions.yml",
   "pagopa_privative_configuration": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.26/pagopa/privative/definitions.yml",
-  "idpay_api": "https://raw.githubusercontent.com/pagopa/cstar-infrastructure/v2.114.1/src/domains/idpay-app/api/idpay_appio_full/openapi.appio.full.yml",
+  "idpay_api": "https://raw.githubusercontent.com/pagopa/cstar-infrastructure/v2.121.1/src/domains/idpay-app/api/idpay_appio_full/openapi.appio.full.yml",
   "lollipop_api": "https://raw.githubusercontent.com/pagopa/io-backend/v12.6.1-RELEASE/api_lollipop_first_consumer.yaml",
   "fast_login_api": "https://raw.githubusercontent.com/pagopa/io-backend/v12.6.1-RELEASE/openapi/generated/api_fast_login.yaml",
   "pagopa_api_walletv3": "https://raw.githubusercontent.com/pagopa/pagopa-infra/ca0f61d6c764dcc8a8594c1593d436dcdae58a7c/src/domains/wallet-app/api/wallet-service/v1/_openapi.json.tpl",

--- a/ts/components/screens/OperationResultScreenContent.tsx
+++ b/ts/components/screens/OperationResultScreenContent.tsx
@@ -1,5 +1,5 @@
 import {
-  Body,
+  ButtonLink,
   ButtonSolid,
   H3,
   IOPictograms,
@@ -7,65 +7,71 @@ import {
   Pictogram,
   VSpacer
 } from "@pagopa/io-app-design-system";
-import { useNavigation } from "@react-navigation/native";
 import * as React from "react";
-import { Platform, SafeAreaView, StyleSheet } from "react-native";
+import { Platform, SafeAreaView, StyleSheet, View } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
-import I18n from "../../i18n";
+import { LabelSmall } from "../core/typography/LabelSmall";
+
+type ActionProps = {
+  label: string;
+  accessibilityLabel: string;
+  onPress: () => void;
+};
 
 type OperationResultScreenContent = {
   pictogram?: IOPictograms;
   title: string;
   subTitle?: string;
-  actionLabel?: string;
-  actionAccessibilityLabel?: string;
-  action?: () => void;
+  action: ActionProps;
+  secondaryAction?: ActionProps;
 };
 
 const OperationResultScreenContent = ({
   pictogram,
   title,
   subTitle,
-  actionLabel = I18n.t("global.buttons.close"),
-  actionAccessibilityLabel = I18n.t("global.buttons.close"),
-  action
-}: OperationResultScreenContent) => {
-  const navigation = useNavigation();
-
-  return (
-    <SafeAreaView style={styles.container}>
-      <ScrollView
-        centerContent={true}
-        contentContainerStyle={[
-          styles.wrapper,
-          /* Android fallback because `centerContent` is only an iOS property */
-          Platform.OS === "android" && styles.wrapper_android
-        ]}
-      >
-        {pictogram && (
-          <>
-            <Pictogram name={pictogram} size={120} />
-            <VSpacer size={24} />
-          </>
-        )}
-        <H3 style={styles.text}>{title}</H3>
-        {subTitle && (
-          <>
-            <VSpacer size={8} />
-            <Body style={styles.text}>{subTitle}</Body>
-          </>
-        )}
-        <VSpacer size={24} />
-        <ButtonSolid
-          label={actionLabel}
-          accessibilityLabel={actionAccessibilityLabel}
-          onPress={action ?? navigation.goBack}
-          fullWidth={true}
-        />
-      </ScrollView>
-    </SafeAreaView>
-  );
-};
+  action,
+  secondaryAction
+}: OperationResultScreenContent) => (
+  <SafeAreaView style={styles.container}>
+    <ScrollView
+      centerContent={true}
+      contentContainerStyle={[
+        styles.wrapper,
+        /* Android fallback because `centerContent` is only an iOS property */
+        Platform.OS === "android" && styles.wrapper_android
+      ]}
+    >
+      {pictogram && (
+        <>
+          <Pictogram name={pictogram} size={120} />
+          <VSpacer size={24} />
+        </>
+      )}
+      <H3 style={styles.text}>{title}</H3>
+      {subTitle && (
+        <>
+          <VSpacer size={8} />
+          <LabelSmall style={styles.text} color="grey-650" weight="Regular">
+            {subTitle}
+          </LabelSmall>
+        </>
+      )}
+      <VSpacer size={24} />
+      <View>
+        <ButtonSolid {...action} />
+      </View>
+      {secondaryAction && (
+        <>
+          <VSpacer size={24} />
+          <View>
+            <ButtonLink {...secondaryAction} />
+          </View>
+        </>
+      )}
+    </ScrollView>
+  </SafeAreaView>
+);
 
 const styles = StyleSheet.create({
   container: {
@@ -73,6 +79,7 @@ const styles = StyleSheet.create({
     marginHorizontal: IOVisualCostants.appMarginDefault
   },
   wrapper: {
+    flex: 1,
     alignItems: "center",
     justifyContent: "center",
     alignContent: "center"

--- a/ts/components/screens/OperationResultScreenContent.tsx
+++ b/ts/components/screens/OperationResultScreenContent.tsx
@@ -5,7 +5,8 @@ import {
   IOPictograms,
   IOVisualCostants,
   Pictogram,
-  VSpacer
+  VSpacer,
+  WithTestID
 } from "@pagopa/io-app-design-system";
 import * as React from "react";
 import { Platform, SafeAreaView, StyleSheet, View } from "react-native";
@@ -21,19 +22,20 @@ type ActionProps = {
 type OperationResultScreenContent = {
   pictogram?: IOPictograms;
   title: string;
-  subTitle?: string;
-  action: ActionProps;
+  subtitle?: string;
+  action?: ActionProps;
   secondaryAction?: ActionProps;
 };
 
 const OperationResultScreenContent = ({
   pictogram,
   title,
-  subTitle,
+  subtitle,
   action,
-  secondaryAction
-}: OperationResultScreenContent) => (
-  <SafeAreaView style={styles.container}>
+  secondaryAction,
+  testID
+}: WithTestID<OperationResultScreenContent>) => (
+  <SafeAreaView style={styles.container} testID={testID}>
     <ScrollView
       centerContent={true}
       contentContainerStyle={[
@@ -49,18 +51,22 @@ const OperationResultScreenContent = ({
         </>
       )}
       <H3 style={styles.text}>{title}</H3>
-      {subTitle && (
+      {subtitle && (
         <>
           <VSpacer size={8} />
           <LabelSmall style={styles.text} color="grey-650" weight="Regular">
-            {subTitle}
+            {subtitle}
           </LabelSmall>
         </>
       )}
-      <VSpacer size={24} />
-      <View>
-        <ButtonSolid {...action} />
-      </View>
+      {action && (
+        <>
+          <VSpacer size={24} />
+          <View>
+            <ButtonSolid {...action} />
+          </View>
+        </>
+      )}
       {secondaryAction && (
         <>
           <VSpacer size={24} />

--- a/ts/features/design-system/core/DSScreenOperationResult.tsx
+++ b/ts/features/design-system/core/DSScreenOperationResult.tsx
@@ -10,7 +10,7 @@ const DSScreenOperationResult = () => {
     <OperationResultScreenContent
       pictogram="umbrellaNew"
       title="C’è un problema temporaneo, riprova."
-      subTitle="Premi a lungo uno o più messaggi per archiviarli."
+      subtitle="Premi a lungo uno o più messaggi per archiviarli."
       action={{
         label: I18n.t("global.buttons.close"),
         accessibilityLabel: I18n.t("global.buttons.close"),

--- a/ts/features/design-system/core/DSScreenOperationResult.tsx
+++ b/ts/features/design-system/core/DSScreenOperationResult.tsx
@@ -1,12 +1,28 @@
+import { useNavigation } from "@react-navigation/native";
 import React from "react";
 import { OperationResultScreenContent } from "../../../components/screens/OperationResultScreenContent";
 import I18n from "../../../i18n";
 
-const DSScreenOperationResult = () => (
-  <OperationResultScreenContent
-    pictogram="umbrellaNew"
-    title={I18n.t("idpay.payment.result.failure.GENERIC.title")}
-  />
-);
+const DSScreenOperationResult = () => {
+  const navigation = useNavigation();
+
+  return (
+    <OperationResultScreenContent
+      pictogram="umbrellaNew"
+      title="C’è un problema temporaneo, riprova."
+      subTitle="Premi a lungo uno o più messaggi per archiviarli."
+      action={{
+        label: I18n.t("global.buttons.close"),
+        accessibilityLabel: I18n.t("global.buttons.close"),
+        onPress: () => navigation.goBack()
+      }}
+      secondaryAction={{
+        label: I18n.t("global.buttons.retry"),
+        accessibilityLabel: I18n.t("global.buttons.retry"),
+        onPress: () => navigation.goBack()
+      }}
+    />
+  );
+};
 
 export { DSScreenOperationResult };

--- a/ts/features/idpay/payment/xstate/failure.ts
+++ b/ts/features/idpay/payment/xstate/failure.ts
@@ -7,6 +7,8 @@ export enum PaymentFailureEnum {
   REJECTED = "REJECTED",
   // User session expired
   EXPIRED = "EXPIRED",
+  // Transaction was already authorized
+  AUTHORIZED = "AUTHORIZED",
   // User does not have enough budget
   BUDGET_EXHAUSTED = "BUDGET_EXHAUSTED",
   // 429 Too Many Requests

--- a/ts/features/idpay/payment/xstate/services.ts
+++ b/ts/features/idpay/payment/xstate/services.ts
@@ -24,7 +24,8 @@ export const failureMap: Record<CodeEnum, PaymentFailureEnum> = {
   [CodeEnum.PAYMENT_USER_NOT_VALID]: PaymentFailureEnum.REJECTED,
   [CodeEnum.PAYMENT_STATUS_NOT_VALID]: PaymentFailureEnum.GENERIC,
   [CodeEnum.PAYMENT_GENERIC_ERROR]: PaymentFailureEnum.GENERIC,
-  [CodeEnum.PAYMENT_TOO_MANY_REQUESTS]: PaymentFailureEnum.TOO_MANY_REQUESTS
+  [CodeEnum.PAYMENT_TOO_MANY_REQUESTS]: PaymentFailureEnum.TOO_MANY_REQUESTS,
+  [CodeEnum.PAYMENT_ALREADY_AUTHORIZED]: PaymentFailureEnum.AUTHORIZED
 };
 
 /**


### PR DESCRIPTION
## Short description
This PR adds the failure screen for the transaction already authorized error in IDPay.

## List of changes proposed in this pull request
- Added `OperationResultScreenContent ` in `IDPayPaymentResultScreen.tsx`
- Extended `OperationResultScreenContent ` with secondary action and subtitle

## How to test
With the `io-dev-server`, try to authorize a transaction with code `00000088` and check that the correct screen is displayed.
