### PR TITLE
fix: [IOCOM-472] Fix canOpenUrl on Android which was not taking the host parameter into account

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,11 +4,11 @@
   <queries>
     <intent>
       <action android:name="android.intent.action.VIEW" />
-      <data android:scheme="http"/>
+      <data android:scheme="http" android:host="*" />
     </intent>
     <intent>
       <action android:name="android.intent.action.VIEW" />
-      <data android:scheme="https"/>
+      <data android:scheme="https" android:host="*" />
     </intent>
   </queries>
 


### PR DESCRIPTION
## Short description
This PR adds the `host` attribute into the queries intent filter in order for the canOpenUrl method to work with http/https url (which is used to check and open third-party apps).

## List of changes proposed in this pull request
- added `host` parameter to `queries` `intent` `data` in the Android manifest (for both `http` and `https` `data` `scheme`s)

## How to test
From a message with markdown, open an url that points to another installed application
