### PR TITLE
[IOAPPFD0-133] Remove the pagoPA test indicator from the first level header

### DIFF
--- a/ts/RootContainer.tsx
+++ b/ts/RootContainer.tsx
@@ -24,10 +24,14 @@ import { applicationChangeState } from "./store/actions/application";
 import { setDebugCurrentRouteName } from "./store/actions/debug";
 import { navigateBack } from "./store/actions/navigation";
 import { isDebugModeEnabledSelector } from "./store/reducers/debug";
-import { preferredLanguageSelector } from "./store/reducers/persistedPreferences";
+import {
+  preferredLanguageSelector,
+  isPagoPATestEnabledSelector
+} from "./store/reducers/persistedPreferences";
 import { GlobalState } from "./store/reducers/types";
 import customVariables from "./theme/variables";
 import { isStringNullyOrEmpty } from "./utils/strings";
+import PagoPATestIndicatorOverlay from "./components/PagoPATestIndicatorOverlay";
 
 type Props = ReturnType<typeof mapStateToProps> & typeof mapDispatchToProps;
 
@@ -102,6 +106,11 @@ class RootContainer extends React.PureComponent<Props> {
         <IONavigationContainer />
 
         {this.props.isDebugModeEnabled && <DebugInfoOverlay />}
+        {/* Just show the pagoPA test indicator if
+        debug mode is disabled */}
+        {this.props.isPagoPATestEnabled && !this.props.isDebugModeEnabled && (
+          <PagoPATestIndicatorOverlay />
+        )}
         {!isStringNullyOrEmpty(testOverlayCaption) && (
           <BetaTestingOverlay
             title={`🛠️ TEST VERSION 🛠️`}
@@ -117,6 +126,7 @@ class RootContainer extends React.PureComponent<Props> {
 
 const mapStateToProps = (state: GlobalState) => ({
   preferredLanguage: preferredLanguageSelector(state),
+  isPagoPATestEnabled: isPagoPATestEnabledSelector(state),
   isDebugModeEnabled: isDebugModeEnabledSelector(state)
 });
 

--- a/ts/RootContainer.tsx
+++ b/ts/RootContainer.tsx
@@ -15,7 +15,7 @@ import configurePushNotifications from "./boot/configurePushNotification";
 import { BetaTestingOverlay } from "./components/BetaTestingOverlay";
 import FlagSecureComponent from "./components/FlagSecure";
 import { LightModalRoot } from "./components/ui/LightModal";
-import VersionInfoOverlay from "./components/VersionInfoOverlay";
+import DebugInfoOverlay from "./components/DebugInfoOverlay";
 import { testOverlayCaption } from "./config";
 import { setLocale } from "./i18n";
 import { IONavigationContainer } from "./navigation/AppStackNavigator";
@@ -101,7 +101,7 @@ class RootContainer extends React.PureComponent<Props> {
 
         <IONavigationContainer />
 
-        {this.props.isDebugModeEnabled && <VersionInfoOverlay />}
+        {this.props.isDebugModeEnabled && <DebugInfoOverlay />}
         {!isStringNullyOrEmpty(testOverlayCaption) && (
           <BetaTestingOverlay
             title={`🛠️ TEST VERSION 🛠️`}

--- a/ts/components/DebugInfoOverlay.tsx
+++ b/ts/components/DebugInfoOverlay.tsx
@@ -20,8 +20,8 @@ import PagoPATestIndicator from "./PagoPATestIndicator";
 
 type Props = ReturnType<typeof mapStateToProps> & ReduxProps;
 
-export const debugItemBgColor = hexToRgba(IOColors.white, 0.4);
-export const debugItemBorderColor = hexToRgba(IOColors.black, 0.1);
+const debugItemBgColor = hexToRgba(IOColors.white, 0.4);
+const debugItemBorderColor = hexToRgba(IOColors.black, 0.1);
 
 const styles = StyleSheet.create({
   versionContainer: {

--- a/ts/components/DebugInfoOverlay.tsx
+++ b/ts/components/DebugInfoOverlay.tsx
@@ -6,7 +6,6 @@ import { widthPercentageToDP } from "react-native-responsive-screen";
 import {
   HSpacer,
   IOStyles,
-  Icon,
   makeFontStyleObject
 } from "@pagopa/io-app-design-system";
 import { ReduxProps } from "../store/actions/types";
@@ -17,11 +16,12 @@ import { clipboardSetStringWithFeedback } from "../utils/clipboard";
 import { useIOSelector } from "../store/hooks";
 import { isPagoPATestEnabledSelector } from "../store/reducers/persistedPreferences";
 import { IOColors, hexToRgba } from "./core/variables/IOColors";
+import PagoPATestIndicator from "./PagoPATestIndicator";
 
 type Props = ReturnType<typeof mapStateToProps> & ReduxProps;
 
-const bgColor = hexToRgba(IOColors.white, 0.4);
-const itemBorderColor = hexToRgba(IOColors.black, 0.1);
+export const debugItemBgColor = hexToRgba(IOColors.white, 0.4);
+export const debugItemBorderColor = hexToRgba(IOColors.black, 0.1);
 
 const styles = StyleSheet.create({
   versionContainer: {
@@ -45,27 +45,19 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
-    borderColor: itemBorderColor,
+    borderColor: debugItemBorderColor,
     borderWidth: 1,
     paddingHorizontal: 4,
     borderRadius: 8,
-    backgroundColor: bgColor
-  },
-  pagoPaTestText: {
-    letterSpacing: 0.2,
-    marginLeft: 4,
-    fontSize: 9,
-    textTransform: "uppercase",
-    color: IOColors["grey-850"],
-    ...makeFontStyleObject("SemiBold")
+    backgroundColor: debugItemBgColor
   },
   routeText: {
-    borderColor: itemBorderColor,
+    borderColor: debugItemBorderColor,
     borderWidth: 1,
     borderRadius: 8,
     maxWidth: widthPercentageToDP(80),
     paddingHorizontal: 8,
-    backgroundColor: bgColor,
+    backgroundColor: debugItemBgColor,
     marginTop: 4
   }
 });
@@ -87,10 +79,7 @@ const DebugInfoOverlay: React.FunctionComponent<Props> = (props: Props) => {
         {isPagoPATestEnabled && (
           <>
             <HSpacer size={4} />
-            <View style={styles.versionTextWrapper}>
-              <Icon name="productPagoPA" color="grey-850" size={20} />
-              <Text style={styles.pagoPaTestText}>Test</Text>
-            </View>
+            <PagoPATestIndicator />
           </>
         )}
       </View>

--- a/ts/components/DebugInfoOverlay.tsx
+++ b/ts/components/DebugInfoOverlay.tsx
@@ -1,15 +1,22 @@
 import * as React from "react";
-import { StyleSheet, Pressable, SafeAreaView } from "react-native";
+import { StyleSheet, Pressable, SafeAreaView, View, Text } from "react-native";
 import { connect } from "react-redux";
 import { useState } from "react";
 import { widthPercentageToDP } from "react-native-responsive-screen";
+import {
+  HSpacer,
+  IOStyles,
+  Icon,
+  makeFontStyleObject
+} from "@pagopa/io-app-design-system";
 import { ReduxProps } from "../store/actions/types";
 import { currentRouteSelector } from "../store/reducers/navigation";
 import { GlobalState } from "../store/reducers/types";
 import { getAppVersion } from "../utils/appVersion";
 import { clipboardSetStringWithFeedback } from "../utils/clipboard";
-import { IOColors, hexToRgba } from "../components/core/variables/IOColors";
-import { H5 } from "./core/typography/H5";
+import { useIOSelector } from "../store/hooks";
+import { isPagoPATestEnabledSelector } from "../store/reducers/persistedPreferences";
+import { IOColors, hexToRgba } from "./core/variables/IOColors";
 
 type Props = ReturnType<typeof mapStateToProps> & ReduxProps;
 
@@ -24,11 +31,33 @@ const styles = StyleSheet.create({
     zIndex: 1000
   },
   versionText: {
+    fontSize: 12,
+    color: IOColors["grey-850"],
+    ...makeFontStyleObject("SemiBold")
+  },
+  screenDebugText: {
+    fontSize: 12,
+    color: IOColors["grey-850"],
+    ...makeFontStyleObject("Regular")
+  },
+  versionTextWrapper: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
     borderColor: itemBorderColor,
     borderWidth: 1,
-    paddingHorizontal: 8,
+    paddingHorizontal: 4,
     borderRadius: 8,
     backgroundColor: bgColor
+  },
+  pagoPaTestText: {
+    letterSpacing: 0.2,
+    marginLeft: 4,
+    fontSize: 9,
+    textTransform: "uppercase",
+    color: IOColors["grey-850"],
+    ...makeFontStyleObject("SemiBold")
   },
   routeText: {
     borderColor: itemBorderColor,
@@ -41,26 +70,36 @@ const styles = StyleSheet.create({
   }
 });
 
-const VersionInfoOverlay: React.FunctionComponent<Props> = (props: Props) => {
+const DebugInfoOverlay: React.FunctionComponent<Props> = (props: Props) => {
   const appVersion = getAppVersion();
   const [showRootName, setShowRootName] = useState(true);
+  const isPagoPATestEnabled = useIOSelector(isPagoPATestEnabledSelector);
 
   return (
     <SafeAreaView style={styles.versionContainer} pointerEvents="box-none">
-      <Pressable
-        style={styles.versionText}
-        onPress={() => setShowRootName(prevState => !prevState)}
-      >
-        <H5 weight="SemiBold" color="bluegreyDark">{`v: ${appVersion}`}</H5>
-      </Pressable>
+      <View style={IOStyles.row}>
+        <Pressable
+          style={styles.versionTextWrapper}
+          onPress={() => setShowRootName(prevState => !prevState)}
+        >
+          <Text style={styles.versionText}>{`v. ${appVersion}`}</Text>
+        </Pressable>
+        {isPagoPATestEnabled && (
+          <>
+            <HSpacer size={4} />
+            <View style={styles.versionTextWrapper}>
+              <Icon name="productPagoPA" color="grey-850" size={20} />
+              <Text style={styles.pagoPaTestText}>Test</Text>
+            </View>
+          </>
+        )}
+      </View>
       {showRootName && (
         <Pressable
           style={styles.routeText}
           onPress={() => clipboardSetStringWithFeedback(props.screenNameDebug)}
         >
-          <H5 weight="Regular" color="bluegreyDark">
-            {props.screenNameDebug}
-          </H5>
+          <Text style={styles.screenDebugText}>{props.screenNameDebug}</Text>
         </Pressable>
       )}
     </SafeAreaView>
@@ -73,4 +112,4 @@ const mapStateToProps = (state: GlobalState) => ({
   screenNameDebug: currentRouteSelector(state)
 });
 
-export default connect(mapStateToProps)(VersionInfoOverlay);
+export default connect(mapStateToProps)(DebugInfoOverlay);

--- a/ts/components/PagoPATestIndicator.tsx
+++ b/ts/components/PagoPATestIndicator.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import { StyleSheet, Text, View } from "react-native";
+import {
+  IOColors,
+  Icon,
+  makeFontStyleObject
+} from "@pagopa/io-app-design-system";
+import { debugItemBgColor, debugItemBorderColor } from "./DebugInfoOverlay";
+
+const styles = StyleSheet.create({
+  indicatoWrapper: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    borderColor: debugItemBorderColor,
+    borderWidth: 1,
+    paddingHorizontal: 6,
+    borderRadius: 8,
+    backgroundColor: debugItemBgColor
+  },
+  testText: {
+    letterSpacing: 0.2,
+    marginLeft: 4,
+    fontSize: 9,
+    textTransform: "uppercase",
+    color: IOColors["grey-850"],
+    ...makeFontStyleObject("SemiBold")
+  }
+});
+
+const PagoPATestIndicator = () => (
+  <View style={styles.indicatoWrapper}>
+    <Icon name="productPagoPA" color="grey-850" size={20} />
+    <Text style={styles.testText}>Test</Text>
+  </View>
+);
+
+export default PagoPATestIndicator;

--- a/ts/components/PagoPATestIndicator.tsx
+++ b/ts/components/PagoPATestIndicator.tsx
@@ -3,9 +3,12 @@ import { StyleSheet, Text, View } from "react-native";
 import {
   IOColors,
   Icon,
+  hexToRgba,
   makeFontStyleObject
 } from "@pagopa/io-app-design-system";
-import { debugItemBgColor, debugItemBorderColor } from "./DebugInfoOverlay";
+
+const debugItemBgColor = hexToRgba(IOColors.white, 0.4);
+const debugItemBorderColor = hexToRgba(IOColors.black, 0.1);
 
 const styles = StyleSheet.create({
   indicatoWrapper: {

--- a/ts/components/PagoPATestIndicatorOverlay.tsx
+++ b/ts/components/PagoPATestIndicatorOverlay.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { SafeAreaView, StyleSheet } from "react-native";
+import PagoPATestIndicator from "./PagoPATestIndicator";
+
+const styles = StyleSheet.create({
+  indicatorContainer: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: "flex-start",
+    alignItems: "center",
+    zIndex: 1000
+  }
+});
+
+const PagoPATestIndicatorOverlay = () => (
+  <SafeAreaView style={styles.indicatorContainer} pointerEvents="box-none">
+    <PagoPATestIndicator />
+  </SafeAreaView>
+);
+
+export default PagoPATestIndicatorOverlay;

--- a/ts/components/screens/BaseHeader.tsx
+++ b/ts/components/screens/BaseHeader.tsx
@@ -18,7 +18,6 @@ import I18n from "../../i18n";
 import { navigateBack } from "../../store/actions/navigation";
 import { Dispatch } from "../../store/actions/types";
 import { assistanceToolConfigSelector } from "../../store/reducers/backendStatus";
-import { isPagoPATestEnabledSelector } from "../../store/reducers/persistedPreferences";
 import { isSearchEnabledSelector } from "../../store/reducers/search";
 import { GlobalState } from "../../store/reducers/types";
 import variables from "../../theme/variables";
@@ -324,13 +323,9 @@ class BaseHeaderComponent extends React.PureComponent<Props, State> {
   };
 
   private renderAppLogo = () => {
-    const { isPagoPATestEnabled, primary, dark } = this.props;
+    const { primary, dark } = this.props;
 
-    const iconColor: IOColors = isPagoPATestEnabled
-      ? "aqua"
-      : primary || dark
-      ? "white"
-      : "blue";
+    const iconColor: IOColors = primary || dark ? "white" : "blue";
     return (
       <Left>
         <View
@@ -361,7 +356,6 @@ class BaseHeaderComponent extends React.PureComponent<Props, State> {
 
 const mapStateToProps = (state: GlobalState) => ({
   isSearchEnabled: isSearchEnabledSelector(state),
-  isPagoPATestEnabled: isPagoPATestEnabledSelector(state),
   assistanceToolConfig: assistanceToolConfigSelector(state)
 });
 


### PR DESCRIPTION
## Short description
This PR removes the pagoPA test indicator from the first level header. This change is necessary because the next version of the first level header won't have the IO app logo anymore. Since the previous indicator was simply a color change of the logo, the new indicator also clearly explains its function.

## List of changes proposed in this pull request
- Add the new `PagoPATestIndicator` and relative `PagoPATestIndicatorOverlay` wrapper component
  - `PagoPATestIndicatorOverlay` is shown just when debug mode is disabled
- Add the `PagoPATestIndicator` to the `DebugInfoOverlay` when debug mode is enabled

### Preview
| Before | After |
|--------|--------|
| ![Simulator Screen Shot - iPhone 13 - 2023-08-04 at 16 13 51](https://github.com/pagopa/io-app/assets/1255491/e4816ab6-0737-4328-b2a7-f42338895793) | ![Simulator Screen Shot - iPhone 13 - 2023-08-04 at 16 10 14](https://github.com/pagopa/io-app/assets/1255491/eeb350ac-8dbc-4dd1-9d04-001002eb5760) | 


## How to test
Just run the app and try different combinations:
- Debug mode enabled, PagoPA Test mode enabled
- Debug mode disabled, PagoPA Test mode disabled