### PR TITLE
chore(IT Wallet): [SIW-363] Add main banner translation

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3265,9 +3265,9 @@ features:
     title: "IT Wallet"
     actionBanner:
       title: "Novità IT Wallet"
-      description: "Da oggi puoi collezionare le tue credenziali digitali (come Licenza di Guida, Tessera Sanitaria, etc.) e accedere ai servizi online con IT Wallet."
-      action: "Attiva IT Wallet"
-      hideLabel: "Nascondi questo banner"
+      description: "Starting today, you can collect your digital credentials (such as Driver's License, Health Card, etc.) and access online services with IT Wallet."
+      action: "Enable IT Wallet"
+      hideLabel: "Hide this banner"
     innerActionBanner: 
       title: "Digital credential news"
       description: "Enable IT Wallet and add your digital credentials (e.g. driving license, health insurance card, etc.)"


### PR DESCRIPTION
## Short description
This PR introduces the English translation for the messages section banner.

## How to test
Set the application language to English. If the wallet has a reset option, perform a reset. Verify that the banner in the messages section is translated into English.
