### PR TITLE
chore(IT Wallet): [SIW-365] Remove hardcoded strings from info screen 

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3301,6 +3301,8 @@ features:
       confirm: "Continue with CIE + PIN"
       footerBox: "Before continuing, make sure you have the Electronic Identity Card (CIE) with you and remember the PIN [Read more](https://www.cartaidentita.interno.gov.it)"
       readMoreUrl: "https://identitadigitale.gov.it/"
+      noCieInfo: "If you don't have CIE "
+      noCieCta: "find out how to get it."
       errors:
         nfc:
           title: "Your device does not support NFC which is required to enable IT Wallet"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3326,6 +3326,8 @@ features:
       confirm: "Continua con CIE + PIN"
       footerBox: "Prima di continua, assicurati di avere con te la Carta d’Identità Elettronica (CIE) e ricordare il PIN [Per saperne di più](https://www.cartaidentita.interno.gov.it)"
       readMoreUrl: "https://identitadigitale.gov.it/"
+      noCieInfo: "Non hai la CIE? "
+      noCieCta: "Scopri come ottenerla"
       errors:
         nfc:
           title: "Il tuo dispositivo non supporta la funzione NFC necessaria per attivare IT Wallet"

--- a/ts/features/it-wallet/screens/issuing/ItwPidAuthInfoScreen.tsx
+++ b/ts/features/it-wallet/screens/issuing/ItwPidAuthInfoScreen.tsx
@@ -126,7 +126,7 @@ const ItwPidAuthInfoScreen = () => {
         >
           <View style={IOStyles.horizontalContentPadding}>
             <H4 weight={"Regular"} color={"bluegrey"}>
-              {"Non hai la CIE? "}
+              {I18n.t("features.itWallet.infoAuthScreen.noCieInfo")}
               <Link
                 onPress={() =>
                   openWebUrl(
@@ -134,7 +134,7 @@ const ItwPidAuthInfoScreen = () => {
                   )
                 }
               >
-                {"Scopri come ottenerla"}
+                {I18n.t("features.itWallet.infoAuthScreen.noCieCta")}
               </Link>
             </H4>
 


### PR DESCRIPTION
## Short description
This PR removes hardcoded strings from the `ItwPidAuthInfoScreen.tsx` and moves them to the translations files.

## How to test
Test an activation flow and the replaced strings should be displayed properly.