### PR TITLE
[IOCOM-476] Fix app opening from a tap on push notification on Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -338,6 +338,9 @@ dependencies {
     implementation project(':react-native-fingerprint-scanner')
     implementation project(':react-native-art')
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.3.41"
+    implementation('com.google.firebase:firebase-iid:21.1.0') {
+        because "Firebase messaging 22.0.0 removes Firebase Instance ID API but out current version of the mixpanel sdk requires it https://github.com/mixpanel/mixpanel-android/issues/744 https://firebase.google.com/support/release-notes/android#messaging_v22-0-0"
+    }
 }
 
 // Run this once to be able to run the application with BUCK

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        firebaseVersion = "17.6.0"
+        firebaseMessagingVersion = "23.2.1"
         kotlin_version = "1.7.0"
         buildToolsVersion = "33.0.2"
         minSdkVersion = 23


### PR DESCRIPTION
## Short description
This PR fixes the app opening from a received push notification on Android 12 and 13, with the app in background

## List of changes proposed in this pull request
- Firebase messaging version updated to latest one (to support both SDK 33 and fix the anomaly)
- Added Android dependency on Firebase IID library in order for Mixpanel to work (the latter has a strict dependency on Firebase API that was removed in Messaging 22.0.0. This library is needed for Mixpanel to work until we upgrade its SDK)

## How to test
Run the application on a device that can receive a push notification, send yourself a message that generates a push notification with the application in the background, tap the push notification and check that it opens the application.
