### PR TITLE
fix: [IOCOM-479] Strings for NSPhotoLibraryAddUsageDescription permission

### DIFF
--- a/ios/ItaliaApp/Info.plist
+++ b/ios/ItaliaApp/Info.plist
@@ -84,7 +84,7 @@
     <key>NSMotionUsageDescription</key>
     <string>The app needs NSMotionUsageDescription permission</string>
     <key>NSPhotoLibraryAddUsageDescription</key>
-    <string>The app needs NSPhotoLibraryAddUsageDescription permission</string>
+    <string>You will be able to save pictures from the app to your device.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>You’ll be able to save bonuses, certificates and upload screenshots or payment notices.</string>
     <key>NSSpeechRecognitionUsageDescription</key>

--- a/ios/ItaliaApp/it.lproj/InfoPlist.strings
+++ b/ios/ItaliaApp/it.lproj/InfoPlist.strings
@@ -4,3 +4,4 @@
 "NSFaceIDUsageDescription" = "IO ha necessità di accedere a Face ID per permetterti di effettuare un'autenticazione più veloce";
 "NSPhotoLibraryUsageDescription" = "Potrai salvare bonus e certificati, caricare screenshot e avvisi di pagamento.";
 "NSMicrophoneUsageDescription" = "IO ha necessità di accedere al microfono nel caso in cui desideri mandare una nota vocale";
+"NSPhotoLibraryAddUsageDescription" = "Potrai salvare immagini dall'app sul tuo dispositivo.";


### PR DESCRIPTION
## Short description
This PR adds proper description for the NSPhotoLibraryAddUsageDescription's permission (iOS only)

## List of changes proposed in this pull request
- Edited english translation in `ios/ItaliaApp/Info.plist`
- Added italian translation in `ios/ItaliaApp/it.lproj/InfoPlist.strings`

## How to test
Launch the app on an iOS device/simulator, navigate to a section where you can save an image to the device gallery (like the green pass) and check that the proper text is displayed (both italian and english translations)
