### PR TITLE
fix: [IABT-1488] Fix crash on Android 6 when checking for notifications' permission

### DIFF
--- a/ts/utils/notification.ts
+++ b/ts/utils/notification.ts
@@ -14,19 +14,13 @@ export enum AuthorizationStatus {
   Provisional = 3
 }
 
-const isAndroid7NougatAPI24OrMore = (version: string | number) =>
-  pipe(
-    version,
-    version => (typeof version === "string" ? Number(version) : version),
-    numericVersion => numericVersion >= 24
-  );
-const successFullBooleanTaskEither = () => TE.fromEither(E.right(true));
+const isAndroid7NougatAPI24OrMore = (Platform.Version as number) >= 24;
+const successfulBooleanTaskEither = () => TE.fromEither(E.right(true));
 
 const checkPermissionAndroid = () =>
   pipe(
-    Platform.Version,
     isAndroid7NougatAPI24OrMore,
-    B.fold(successFullBooleanTaskEither, () =>
+    B.fold(successfulBooleanTaskEither, () =>
       TE.tryCatch(
         () =>
           PermissionsAndroid.check(
@@ -80,9 +74,8 @@ const requestPermissioniOS = () =>
 
 const requestPermissionAndroid = () =>
   pipe(
-    Platform.Version,
     isAndroid7NougatAPI24OrMore,
-    B.fold(successFullBooleanTaskEither, () =>
+    B.fold(successfulBooleanTaskEither, () =>
       pipe(
         TE.tryCatch(
           () =>

--- a/ts/utils/notification.ts
+++ b/ts/utils/notification.ts
@@ -3,7 +3,7 @@ import * as B from "fp-ts/lib/boolean";
 import * as E from "fp-ts/lib/Either";
 import * as T from "fp-ts/lib/Task";
 import * as TE from "fp-ts/lib/TaskEither";
-import { PermissionsAndroid } from "react-native";
+import { Platform, PermissionsAndroid } from "react-native";
 import PushNotificationIOS from "@react-native-community/push-notification-ios";
 import { isIos } from "./platform";
 
@@ -14,14 +14,26 @@ export enum AuthorizationStatus {
   Provisional = 3
 }
 
+const isAndroid7NougatAPI24OrMore = (version: string | number) =>
+  pipe(
+    version,
+    version => (typeof version === "string" ? Number(version) : version),
+    numericVersion => numericVersion >= 24
+  );
+const successFullBooleanTaskEither = () => TE.fromEither(E.right(true));
+
 const checkPermissionAndroid = () =>
   pipe(
-    TE.tryCatch(
-      () =>
-        PermissionsAndroid.check(
-          PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS
-        ),
-      E.toError
+    Platform.Version,
+    isAndroid7NougatAPI24OrMore,
+    B.fold(successFullBooleanTaskEither, () =>
+      TE.tryCatch(
+        () =>
+          PermissionsAndroid.check(
+            PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS
+          ),
+        E.toError
+      )
     )
   );
 
@@ -68,16 +80,22 @@ const requestPermissioniOS = () =>
 
 const requestPermissionAndroid = () =>
   pipe(
-    TE.tryCatch(
-      () =>
-        PermissionsAndroid.request(
-          PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS
+    Platform.Version,
+    isAndroid7NougatAPI24OrMore,
+    B.fold(successFullBooleanTaskEither, () =>
+      pipe(
+        TE.tryCatch(
+          () =>
+            PermissionsAndroid.request(
+              PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS
+            ),
+          E.toError
         ),
-      E.toError
-    ),
-    TE.map(
-      permissionStatus =>
-        permissionStatus === PermissionsAndroid.RESULTS.GRANTED
+        TE.map(
+          permissionStatus =>
+            permissionStatus === PermissionsAndroid.RESULTS.GRANTED
+        )
+      )
     )
   );
 


### PR DESCRIPTION
## Short description
This PR fixes a crash on devices running Android 6 Marshmallow, when checking for notifications' permission.

## List of changes proposed in this pull request
- notifications' checking methods for Android have been modified in order not to check but to return a given permission on devices running Android API level 23 (Android 6 Marshmallow). 
- This is needed since on such Android version, if a permission is requested that was not declared at the time of the Android release (such as the POST_NOTIFICATIONS permission string), the system throws an exception. This behaviour has been changed since Android 7 Nougat (API level 24) in order not to throw anything but return a default value.
- Also note that on any Android versions lower than 13 (API level 33), the notifications' permission is always given (there is no need to ask the user for it)

## How to test
Run this code on a device with Android 6, go through the login and land on the messages section. There should be no crash.
Run this code on a device with Android version between 7 and 12, and follow steps above. There should be no crash.
Run this code on a device with Android 13+ and follow steps above. Before landing on the message screen, the application should have asked the user for the notifications' permission