### PR TITLE
fix(IT Wallet): [SIW-405] Fix JWT library crash

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -140,7 +140,7 @@ PODS:
     - React-Core
   - pagopa-io-react-native-crypto (0.2.1):
     - React-Core
-  - pagopa-io-react-native-jwt (0.6.0):
+  - pagopa-io-react-native-jwt (0.6.1):
     - JOSESwift (~> 2.3)
     - React-Core
   - pagopa-io-react-native-login-utils (0.2.0):
@@ -955,7 +955,7 @@ SPEC CHECKSUMS:
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   pagopa-io-react-native-cie-pid: a3f213959fb23b82822a0bf987610831eb01a5fd
   pagopa-io-react-native-crypto: 644fece16966f2e1ea1f872344ee5a3c6c8761a1
-  pagopa-io-react-native-jwt: e94e3193f3f0421e958666a788708d252e987cc7
+  pagopa-io-react-native-jwt: 5701afe65dc83d044866a3aef08b13ff8d0dd118
   pagopa-io-react-native-login-utils: 929e584c817572ce7a3e41e0c6f96c7990bd314d
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   Protobuf: 3724efa50cb2846d7ccebc8691c574e85fd74471

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@pagopa/io-pagopa-commons": "^3.1.0",
     "@pagopa/io-react-native-cie-pid": "^0.1.3",
     "@pagopa/io-react-native-crypto": "^0.2.1",
-    "@pagopa/io-react-native-jwt": "https://github.com/pagopa/io-react-native-jwt#SIW-405-fix-exports",
+    "@pagopa/io-react-native-jwt": "0.6.1",
     "@pagopa/io-react-native-login-utils": "^0.2.0",
     "@pagopa/io-react-native-wallet": "^0.2.8",
     "@pagopa/react-native-cie": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@pagopa/io-pagopa-commons": "^3.1.0",
     "@pagopa/io-react-native-cie-pid": "^0.1.3",
     "@pagopa/io-react-native-crypto": "^0.2.1",
-    "@pagopa/io-react-native-jwt": "^0.6.0",
+    "@pagopa/io-react-native-jwt": "https://github.com/pagopa/io-react-native-jwt#SIW-405-fix-exports",
     "@pagopa/io-react-native-login-utils": "^0.2.0",
     "@pagopa/io-react-native-wallet": "^0.2.8",
     "@pagopa/react-native-cie": "1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3163,9 +3163,10 @@
   resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-crypto/-/io-react-native-crypto-0.2.1.tgz#3d62b0f0cf45b2a878e4ee0652239ea69089988e"
   integrity sha512-J+VP1kLXl1lQSJJYFMa+ljW9fWgMIYQskBJZFaVKPrtrZr8MJyrhNzlFUf2/EGwxm3kA+7o7budq6fPqdfVvvg==
 
-"@pagopa/io-react-native-jwt@https://github.com/pagopa/io-react-native-jwt#SIW-405-fix-exports":
-  version "0.6.0"
-  resolved "https://github.com/pagopa/io-react-native-jwt#199cdc3d963c631f4dfa810102fd6e550d73d109"
+"@pagopa/io-react-native-jwt@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-jwt/-/io-react-native-jwt-0.6.1.tgz#85d7dca1a83a01e29d4116078972fc633c0c7f5d"
+  integrity sha512-5iVqnrXFnjdYG64PgsWoNSS2Z05WGgMfDe6WcHUhWJKPpT4oIzNc86GIqpavFWu1TibjFiYpNPh3YxcwxE52Aw==
   dependencies:
     abab "^2.0.6"
     zod "^3.21.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3163,10 +3163,9 @@
   resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-crypto/-/io-react-native-crypto-0.2.1.tgz#3d62b0f0cf45b2a878e4ee0652239ea69089988e"
   integrity sha512-J+VP1kLXl1lQSJJYFMa+ljW9fWgMIYQskBJZFaVKPrtrZr8MJyrhNzlFUf2/EGwxm3kA+7o7budq6fPqdfVvvg==
 
-"@pagopa/io-react-native-jwt@^0.6.0":
+"@pagopa/io-react-native-jwt@https://github.com/pagopa/io-react-native-jwt#SIW-405-fix-exports":
   version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-jwt/-/io-react-native-jwt-0.6.0.tgz#aba1515aad41d3e6fda57d757b277ce2db670486"
-  integrity sha512-6fKLPPB6p8LRWHZlr18ccgS0uWu9PQ4Ncfcsf/zADMTd2/Yo8GJo/QEtxWX31WtukFPG/nRT5LS91ZuAai01Mg==
+  resolved "https://github.com/pagopa/io-react-native-jwt#199cdc3d963c631f4dfa810102fd6e550d73d109"
   dependencies:
     abab "^2.0.6"
     zod "^3.21.4"


### PR DESCRIPTION
## Short description
This PR fixes a startup crash of the app due to the io-react-native-jwt library by updating it to the 0.6.1 version.

## How to test
The app should now run without crashing at startup.
