### PR TITLE
chore: [IOBP-218] Add LogoPaymentWithFallback to AvailableInitiativesListScreen

### DIFF
--- a/ts/features/idpay/wallet/screens/AvailableInitiativesListScreen.tsx
+++ b/ts/features/idpay/wallet/screens/AvailableInitiativesListScreen.tsx
@@ -4,12 +4,12 @@ import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
 import React from "react";
 import { ScrollView, StyleSheet, View } from "react-native";
-import { IOLogoPaymentType, LogoPayment } from "@pagopa/io-app-design-system";
 import { HSpacer, VSpacer } from "../../../../components/core/spacer/Spacer";
 import { H1 } from "../../../../components/core/typography/H1";
 import { H4 } from "../../../../components/core/typography/H4";
 import { IOStyles } from "../../../../components/core/variables/IOStyles";
 import BaseScreenComponent from "../../../../components/screens/BaseScreenComponent";
+import { LogoPaymentWithFallback } from "../../../../components/ui/utils/components/LogoPaymentWithFallback";
 import TypedI18n from "../../../../i18n";
 import { IOStackNavigationRouteProps } from "../../../../navigation/params/AppParamsList";
 import { WalletParamsList } from "../../../../navigation/params/WalletParamsList";
@@ -30,20 +30,6 @@ type Props = IOStackNavigationRouteProps<
   WalletParamsList,
   "WALLET_IDPAY_INITIATIVE_LIST"
 >;
-
-const brandToLogoPaymentMap: Record<string, IOLogoPaymentType> = {
-  MASTERCARD: "mastercard",
-  VISA: "visa",
-  AMEX: "amex",
-  DINERS: "diners",
-  MAESTRO: "maestro",
-  VISAELECTRON: "visa",
-  POSTEPAY: "postepay",
-  UNIONPAY: "unionPay",
-  DISCOVER: "discover",
-  JCB: "jcb",
-  JCB15: "jcb"
-};
 
 export const IdPayInitiativeListScreen = (props: Props) => {
   const { idWallet } = props.route.params;
@@ -80,7 +66,7 @@ export const IdPayInitiativeListScreen = (props: Props) => {
         <VSpacer size={16} />
         {maskedPan && (
           <View style={[IOStyles.row, { paddingVertical: 8 }]}>
-            <LogoPayment name={brandToLogoPaymentMap[brand]} />
+            <LogoPaymentWithFallback brand={brand} />
             <HSpacer size={8} />
             <H4>•••• {maskedPan}</H4>
           </View>


### PR DESCRIPTION
## Short description
addition of said component to said screen, both for cleanliness and because some methods sent the whole screen in an error state because their brand does not appear in the payment methods' logo list.
<img width="250" alt="Screenshot 2023-09-07 at 12 02 25" src="https://github.com/pagopa/io-app/assets/60693085/d06a26d9-1b0a-4e14-b8a8-98edd3c7b1d6">

## List of changes proposed in this pull request
see short description

## How to test
navigate to a payment method's details screen, then to its connected initiatives (if there are none, check another method, `io-dev-api-server` is your friend here 😉 ) , and then once more to the "view all" page, in order to show the full initiatives list, then make sure nothing breaks.
