### PR TITLE
fix(IT Wallet): [SIW-471] Move loading animation to native thread

### DIFF
--- a/ts/features/it-wallet/components/ItwLoadingSpinner.tsx
+++ b/ts/features/it-wallet/components/ItwLoadingSpinner.tsx
@@ -44,7 +44,7 @@ const startRotationAnimation = (
       toValue: 360,
       duration: durationMs,
       easing: Easing.linear,
-      useNativeDriver: false
+      useNativeDriver: true
     })
   ).start();
 };


### PR DESCRIPTION
## Short description
This PR moves the loading animation on the `ItwLoadingSpinner.tsx` component to the native thread. 
This change improves the framerate of the animation and doesn't block it when the JS thread is busy. 

## List of changes proposed in this pull request
- Sets the `useNativeDriver` to true as explained in the official [React Native documentation](https://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated).

## How to test
Test a PID issuing flow and a presentation flow from a pyshical device to value the difference.
