### PR TITLE
chore: [IOAPPFD0-145] Add the new `PictogramBleed` component

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   "dependencies": {
     "@babel/plugin-transform-regenerator": "^7.18.6",
     "@gorhom/bottom-sheet": "^4.1.5",
-    "@pagopa/io-app-design-system": "^1.6.1",
+    "@pagopa/io-app-design-system": "^1.7.0",
     "@pagopa/io-pagopa-commons": "^3.1.0",
     "@pagopa/io-react-native-crypto": "^0.2.1",
     "@pagopa/io-react-native-login-utils": "^0.2.0",

--- a/ts/components/Banner/index.tsx
+++ b/ts/components/Banner/index.tsx
@@ -15,6 +15,11 @@ import Animated, {
   useSharedValue,
   withSpring
 } from "react-native-reanimated";
+import {
+  IOPictogramSizeScale,
+  IOPictogramsBleed,
+  PictogramBleed
+} from "@pagopa/io-app-design-system";
 import { WithTestID } from "../../types/WithTestID";
 // Design System components
 import { IOColors } from "../core/variables/IOColors";
@@ -27,11 +32,6 @@ import {
   IOBannerSmallVSpacing
 } from "../core/variables/IOSpacing";
 import ButtonLink from "../ui/ButtonLink";
-import {
-  IOPictogramsBleed,
-  IOPictogramSizeScale,
-  Pictogram
-} from "../core/pictograms";
 import { LabelSmall } from "../core/typography/LabelSmall";
 import { NewH6 } from "../core/typography/NewH6";
 import IconButton from "../ui/IconButton";
@@ -228,7 +228,7 @@ export const Banner = ({
         )}
       </View>
       <View style={[styles.bleedPictogram, IOStyles.selfCenter]}>
-        <Pictogram
+        <PictogramBleed
           name={pictogramName}
           size={size === "big" ? sizePictogramBig : sizePictogramSmall}
         />

--- a/ts/components/screens/__tests__/__snapshots__/OperationResultScreenContent.test.tsx.snap
+++ b/ts/components/screens/__tests__/__snapshots__/OperationResultScreenContent.test.tsx.snap
@@ -612,19 +612,19 @@ exports[`OperationResultScreenContent should match the snapshot with default pro
                                                     Array [
                                                       Object {
                                                         "alignItems": "center",
-                                                        "borderRadius": 8,
+                                                        "borderRadius": 4,
                                                         "elevation": 0,
                                                         "flexDirection": "row",
                                                         "justifyContent": "center",
-                                                        "paddingHorizontal": 24,
+                                                        "paddingHorizontal": 16,
                                                         "textAlignVertical": "center",
                                                       },
                                                       false,
                                                       Object {
-                                                        "height": 48,
+                                                        "height": 40,
                                                       },
                                                       Object {
-                                                        "backgroundColor": "#0B3EE3",
+                                                        "backgroundColor": "#0073E6",
                                                       },
                                                       Object {
                                                         "backgroundColor": undefined,
@@ -640,7 +640,6 @@ exports[`OperationResultScreenContent should match the snapshot with default pro
                                                   <Text
                                                     color="white"
                                                     ellipsizeMode="tail"
-                                                    font="ReadexPro"
                                                     numberOfLines={1}
                                                     style={
                                                       Array [
@@ -655,13 +654,13 @@ exports[`OperationResultScreenContent should match the snapshot with default pro
                                                         undefined,
                                                         Object {
                                                           "color": "#FFFFFF",
-                                                          "fontFamily": "Readex Pro",
+                                                          "fontFamily": "Titillium Web",
                                                           "fontStyle": "normal",
-                                                          "fontWeight": "400",
+                                                          "fontWeight": "700",
                                                         },
                                                       ]
                                                     }
-                                                    weight="Regular"
+                                                    weight="Bold"
                                                   >
                                                     Action
                                                   </Text>
@@ -739,13 +738,13 @@ exports[`OperationResultScreenContent should match the snapshot with default pro
                                                     style={
                                                       Array [
                                                         Object {
-                                                          "fontFamily": "Readex Pro",
+                                                          "fontFamily": "Titillium Web",
                                                           "fontSize": 16,
                                                           "fontStyle": "normal",
-                                                          "fontWeight": "400",
+                                                          "fontWeight": "700",
                                                         },
                                                         Object {
-                                                          "color": "#0B3EE3",
+                                                          "color": "#0073E6",
                                                         },
                                                         Object {
                                                           "color": undefined,

--- a/ts/features/design-system/components/DSAssetViewerBox.tsx
+++ b/ts/features/design-system/components/DSAssetViewerBox.tsx
@@ -49,6 +49,12 @@ const styles = StyleSheet.create({
     borderColor: hexToRgba(IOColors.black, 0.1),
     borderWidth: 1
   },
+  assetItemBleed: {
+    paddingRight: 0,
+    paddingLeft: 8,
+    paddingVertical: 4,
+    justifyContent: "flex-end"
+  },
   assetItemSmall: {
     padding: 24
   },
@@ -72,13 +78,19 @@ const styles = StyleSheet.create({
   pillRaster: {
     backgroundColor: IOColors.yellow,
     color: IOColors.black
+  },
+  pillBleed: {
+    backgroundColor: IOColors["success-500"],
+    color: IOColors.white
   }
 });
 
 type DSAssetViewerBoxProps = {
   name: string;
   image: React.ReactNode;
-  type?: "vector" | "raster";
+  /* "bleed" shows the pictogram without padding
+  "hasBleed" shows the pictgram label on top right */
+  type?: "vector" | "raster" | "bleed" | "hasBleed";
   size?: "small" | "medium";
   colorMode?: "light" | "dark";
 };
@@ -96,6 +108,10 @@ const pillMap = {
   raster: {
     style: styles.pillRaster,
     text: "Png"
+  },
+  hasBleed: {
+    style: styles.pillBleed,
+    text: "Bleed"
   }
 };
 
@@ -116,6 +132,7 @@ export const DSAssetViewerBox = ({
       style={[
         styles.assetItem,
         size === "small" ? styles.assetItemSmall : {},
+        type === "bleed" ? styles.assetItemBleed : {},
         colorMode === "dark" ? styles.assetItemDark : {}
       ]}
     >
@@ -124,17 +141,18 @@ export const DSAssetViewerBox = ({
         source={FakeTransparentBg}
       />
       {image}
-      {type !== "vector" && (
-        <Text
-          style={[
-            styles.pill,
-            size === "small" ? styles.pillSmall : {},
-            pillMap[type].style
-          ]}
-        >
-          {pillMap[type].text}
-        </Text>
-      )}
+      {type === "raster" ||
+        (type === "hasBleed" && (
+          <Text
+            style={[
+              styles.pill,
+              size === "small" ? styles.pillSmall : {},
+              pillMap[type].style
+            ]}
+          >
+            {pillMap[type].text}
+          </Text>
+        ))}
     </View>
     <View
       style={{

--- a/ts/features/design-system/core/DSAdvice.tsx
+++ b/ts/features/design-system/core/DSAdvice.tsx
@@ -182,7 +182,7 @@ const renderBanner = () => {
               color={color}
               size="big"
               title="Banner title"
-              pictogramName="donation"
+              pictogramName="charity"
               action="Action text"
               onPress={onLinkPress}
             />
@@ -194,7 +194,7 @@ const renderBanner = () => {
               content={
                 "Fai una donazione alle organizzazioni umanitarie che assistono le vittime civile della crisi in Ucraina"
               }
-              pictogramName="donation"
+              pictogramName="charity"
             />
             <VSpacer size={24} />
             <Banner
@@ -204,7 +204,7 @@ const renderBanner = () => {
               content={
                 "Fai una donazione alle organizzazioni umanitarie che assistono le vittime civile della crisi in Ucraina"
               }
-              pictogramName="donation"
+              pictogramName="charity"
               action="Dona anche tu"
               onPress={onLinkPress}
             />
@@ -217,7 +217,7 @@ const renderBanner = () => {
               content={
                 "Fai una donazione alle organizzazioni umanitarie che assistono le vittime civile della crisi in Ucraina"
               }
-              pictogramName="donation"
+              pictogramName="charity"
             />
             <VSpacer size={24} />
             <Banner
@@ -228,7 +228,7 @@ const renderBanner = () => {
               content={
                 "Fai una donazione alle organizzazioni umanitarie che assistono le vittime civile della crisi in Ucraina"
               }
-              pictogramName="donation"
+              pictogramName="charity"
               action="Dona anche tu"
               onPress={onLinkPress}
             />
@@ -244,7 +244,7 @@ const renderBanner = () => {
               content={
                 "Fai una donazione alle organizzazioni umanitarie che assistono le vittime civile della crisi in Ucraina"
               }
-              pictogramName="donation"
+              pictogramName="charity"
               onClose={onClose}
               labelClose="Nascondi questo banner"
             />
@@ -258,7 +258,7 @@ const renderBanner = () => {
               }
               action="Dona anche tu"
               onPress={onLinkPress}
-              pictogramName="donation"
+              pictogramName="charity"
               onClose={onClose}
               labelClose="Nascondi questo banner"
             />
@@ -272,7 +272,7 @@ const renderBanner = () => {
               content={
                 "Fai una donazione alle organizzazioni umanitarie che assistono le vittime civile della crisi in Ucraina"
               }
-              pictogramName="donation"
+              pictogramName="charity"
               action="Dona anche tu"
               onPress={onLinkPress}
             />
@@ -286,7 +286,7 @@ const renderBanner = () => {
               }
               action="Dona anche tu"
               onPress={onLinkPress}
-              pictogramName="donation"
+              pictogramName="charity"
             />
             <VSpacer size={24} />
             <Banner
@@ -296,7 +296,7 @@ const renderBanner = () => {
               content={
                 "Fai una donazione alle organizzazioni umanitarie che assistono le vittime civile della crisi in Ucraina"
               }
-              pictogramName="donation"
+              pictogramName="charity"
             />
           </DSComponentViewerBox>
         </React.Fragment>

--- a/ts/features/design-system/core/DSPictograms.tsx
+++ b/ts/features/design-system/core/DSPictograms.tsx
@@ -1,11 +1,21 @@
 import * as React from "react";
 import { View, StyleSheet } from "react-native";
 import {
+  IOPictograms,
+  IOPictogramsBleed,
+  IOPictogramsLegacy,
+  IOThemeContext,
+  IOVisualCostants,
+  Pictogram,
+  PictogramBleed,
+  SVGPictogramProps
+} from "@pagopa/io-app-design-system";
+import { useContext } from "react";
+import {
   DSAssetViewerBox,
   assetItemGutter
 } from "../components/DSAssetViewerBox";
 import { H2 } from "../../../components/core/typography/H2";
-import { Pictogram, IOPictograms } from "../../../components/core/pictograms";
 import { DesignSystemScreen } from "../components/DesignSystemScreen";
 
 const styles = StyleSheet.create({
@@ -19,21 +29,110 @@ const styles = StyleSheet.create({
   }
 });
 
-export const DSPictograms = () => (
-  <DesignSystemScreen title={"Pictograms"}>
-    <H2 color={"bluegrey"} weight={"SemiBold"} style={{ marginBottom: 16 }}>
-      Pictograms
-    </H2>
-    <View style={styles.itemsWrapper}>
-      {Object.entries(IOPictograms).map(([pictogramItemName]) => (
-        <DSAssetViewerBox
-          key={pictogramItemName}
-          name={pictogramItemName}
-          image={
-            <Pictogram name={pictogramItemName as IOPictograms} size="100%" />
-          }
-        />
-      ))}
-    </View>
-  </DesignSystemScreen>
+// Filter the main object, removing already displayed pictograms in the other sets
+type PictogramSubsetObject = Record<
+  string,
+  ({ size }: SVGPictogramProps) => JSX.Element
+>;
+interface PictogramSetObject {
+  [key: string]: ({ size }: SVGPictogramProps) => JSX.Element;
+}
+
+const filterPictogramSet = (
+  pictogramSubsetObject: PictogramSubsetObject,
+  pictogramSetObject: PictogramSetObject
+): PictogramSetObject =>
+  Object.fromEntries(
+    Object.entries(pictogramSetObject).filter(
+      ([key]) => !Object.keys(pictogramSubsetObject).includes(key)
+    )
+  );
+
+const filteredIOPictograms = filterPictogramSet(
+  {
+    ...IOPictogramsLegacy
+  },
+  IOPictograms
 );
+
+export const DSPictograms = () => {
+  const theme = useContext(IOThemeContext);
+  return (
+    <DesignSystemScreen title={"Pictograms"}>
+      <H2
+        color={theme["textHeading-default"]}
+        weight={"SemiBold"}
+        style={{
+          marginBottom: 16
+        }}
+      >
+        Pictograms
+      </H2>
+      <View style={styles.itemsWrapper}>
+        {Object.entries(filteredIOPictograms).map(([pictogramItemName]) => (
+          <DSAssetViewerBox
+            key={pictogramItemName}
+            name={pictogramItemName}
+            type={
+              Object.keys(IOPictogramsBleed).includes(pictogramItemName)
+                ? "hasBleed"
+                : "vector"
+            }
+            image={
+              <Pictogram name={pictogramItemName as IOPictograms} size="100%" />
+            }
+          />
+        ))}
+      </View>
+
+      <H2
+        color={theme["textHeading-default"]}
+        weight={"SemiBold"}
+        style={{
+          marginBottom: 16,
+          paddingTop: IOVisualCostants.appMarginDefault
+        }}
+      >
+        Bleed Pictograms
+      </H2>
+      <View style={styles.itemsWrapper}>
+        {Object.entries(IOPictogramsBleed).map(([pictogramItemName]) => (
+          <DSAssetViewerBox
+            type="bleed"
+            key={pictogramItemName}
+            name={pictogramItemName}
+            size="small"
+            image={
+              <PictogramBleed
+                name={pictogramItemName as IOPictogramsBleed}
+                size="100%"
+              />
+            }
+          />
+        ))}
+      </View>
+
+      <H2
+        color={theme["textHeading-default"]}
+        weight={"SemiBold"}
+        style={{
+          marginBottom: 16,
+          paddingTop: IOVisualCostants.appMarginDefault
+        }}
+      >
+        Legacy Pictograms
+      </H2>
+      <View style={styles.itemsWrapper}>
+        {Object.entries(IOPictogramsLegacy).map(([pictogramItemName]) => (
+          <DSAssetViewerBox
+            key={pictogramItemName}
+            name={pictogramItemName}
+            image={
+              <Pictogram name={pictogramItemName as IOPictograms} size="100%" />
+            }
+          />
+        ))}
+      </View>
+    </DesignSystemScreen>
+  );
+};

--- a/ts/features/idpay/initiative/details/screens/InitiativeDetailsScreen.tsx
+++ b/ts/features/idpay/initiative/details/screens/InitiativeDetailsScreen.tsx
@@ -6,13 +6,13 @@ import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
 import * as React from "react";
 import { StyleSheet, View } from "react-native";
+import { Pictogram } from "@pagopa/io-app-design-system";
 import {
   InitiativeDTO,
   InitiativeRewardTypeEnum,
   StatusEnum as InitiativeStatusEnum
 } from "../../../../../../definitions/idpay/InitiativeDTO";
 import { ContentWrapper } from "../../../../../components/core/ContentWrapper";
-import { Pictogram } from "../../../../../components/core/pictograms";
 import { VSpacer } from "../../../../../components/core/spacer/Spacer";
 import { Body } from "../../../../../components/core/typography/Body";
 import { H3 } from "../../../../../components/core/typography/H3";
@@ -189,7 +189,7 @@ const InitiativeDetailsScreen = () => {
               if (initiativeNeedsConfiguration) {
                 return (
                   <View style={styles.newInitiativeMessageContainer}>
-                    <Pictogram name="setup" size={72} />
+                    <Pictogram name="empty" size={72} />
                     <VSpacer size={16} />
                     <H3>
                       {I18n.t(

--- a/ts/features/wallet/bancomat/screen/BancomatDetailScreen.tsx
+++ b/ts/features/wallet/bancomat/screen/BancomatDetailScreen.tsx
@@ -75,7 +75,7 @@ const BancomatDetailScreen = ({ route }: Props) => {
       headerTitle="PagoBANCOMAT"
       content={
         <Banner
-          pictogramName="focusOn"
+          pictogramName="help"
           size="big"
           color="neutral"
           viewRef={bannerViewRef}

--- a/ts/features/wallet/cobadge/screen/CobadgeDetailScreen.tsx
+++ b/ts/features/wallet/cobadge/screen/CobadgeDetailScreen.tsx
@@ -77,7 +77,7 @@ const CobadgeDetailScreen = (props: Props) => {
       headerTitle={I18n.t("wallet.methodDetails.cobadgeTitle")}
       content={
         <Banner
-          pictogramName="focusOn"
+          pictogramName="help"
           size="big"
           color="neutral"
           viewRef={bannerViewRef}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3122,10 +3122,10 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@pagopa/io-app-design-system@^1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-app-design-system/-/io-app-design-system-1.6.1.tgz#32107f822658a872f6ff38e9268e73ba0abe8e5e"
-  integrity sha512-Wmej+digK56dQsmAtqdS/qoZ8+D+2MIn4o84DpJJatgULFarCtLnTQTkFefVMfUWD/lb8+59YZRzO3SvljzQ7w==
+"@pagopa/io-app-design-system@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-app-design-system/-/io-app-design-system-1.7.0.tgz#40a8705fb2767e4a5595645ea4153ed1f7e1e986"
+  integrity sha512-UGd1+zDCewbjugY0MkNSse3+eX1QnuwBD0tdbFx2tH3dbnbl2uEFwVHZDEyZdeuhmxSF1b5TNoCR4UdNpRQOmg==
   dependencies:
     "@expo/vector-icons" "^13.0.0"
     "@pagopa/ts-commons" "^12.0.0"


### PR DESCRIPTION
## Short description
This PR adds the new `PictogramBleed` component. It also replaces some keys used in some `Pictogram` components that no longer exist.

To learn more, please refer to:
* https://github.com/pagopa/io-app-design-system/pull/63

## List of changes proposed in this pull request
- Update `io-app-design-system` to the `1.7.0` version
- Update `Banner` component to use the new `PictogramBleed` component
- Replaces some `Pictogram` keys that no longer exist
- Add the new **Bleed pictograms** section to the **Pictograms** page

> [!WARNING]
> This update breaks the `OperationResultScreenContent` because the snapshot was generated with the new variant of `ButtonSolid`. The new version of `io-app-design-system` restores the legacy variant when the DS toggle is set to off.

### Preview

https://github.com/pagopa/io-app/assets/1255491/0ecb8615-ab16-4a7c-a35d-c0de8003d734



## How to test
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
