### PR TITLE
fix: [IOBP-248] Fix IDPay decoded barcodes max length in barcode scan screen

### DIFF
--- a/ts/features/idpay/payment/screens/IDPayPaymentCodeScanScreen.tsx
+++ b/ts/features/idpay/payment/screens/IDPayPaymentCodeScanScreen.tsx
@@ -19,7 +19,7 @@ const IDPayPaymentCodeScanScreen = () => {
   const openDeepLink = useOpenDeepLink();
 
   const handleBarcodeSuccess = (barcodes: Array<IOBarcode>) => {
-    if (barcodes.length >= 1) {
+    if (barcodes.length > 1) {
       Alert.alert(
         I18n.t("barcodeScan.multipleResultsAlert.title"),
         I18n.t("barcodeScan.multipleResultsAlert.body"),


### PR DESCRIPTION
## Short description
This PR increases the max length of decoded barcodes in the barcode scan screen, which was causing a bug that would not allow IDPay barcodes to be scanned.

## List of changes proposed in this pull request
- ts/features/idpay/payment/screens/IDPayPaymentCodeScanScreen.tsx: incresed size of max scanned barcodes lenght

## How to test
Try to scan an IDPay transaction code from the barcode scan screen. 
