### PR TITLE
chore(IT Wallet): [SIW-486] Add incoming badge to spid item into info provider screen

### DIFF
--- a/ts/features/it-wallet/screens/discovery/ItwDiscoveryProviderInfoScreen.tsx
+++ b/ts/features/it-wallet/screens/discovery/ItwDiscoveryProviderInfoScreen.tsx
@@ -57,23 +57,27 @@ const ItwDiscoveryProviderInfoScreen = () => {
     }
   ];
 
-  const FEATURES_LIST_MAIN: ReadonlyArray<ListItemNav> = [
-    {
-      value: I18n.t("features.itWallet.featuresInfoScreen.list.spid"),
-      description: I18n.t(
-        "features.itWallet.featuresInfoScreen.list.spidSubTitle"
-      ),
-      icon: "spid",
-      onPress: () => undefined,
-      accessibilityLabel: I18n.t(
-        "features.itWallet.featuresInfoScreen.list.spid"
-      )
-    }
-  ];
+  const FEATURES_LIST_MAIN: ReadonlyArray<ListItemNav> = [];
 
   // Here we have a different type of list item because not
   // all the components are available yet. See comment below.
   const FEATURES_LIST_COMING: ReadonlyArray<ListItemInfo> = [
+    {
+      label: I18n.t("features.itWallet.featuresInfoScreen.list.spid"),
+      value: I18n.t("features.itWallet.featuresInfoScreen.list.spidSubTitle"),
+      icon: "spid",
+      action: (
+        <Badge
+          text={I18n.t(
+            "features.itWallet.featuresInfoScreen.list.incomingFeature"
+          )}
+          variant="default"
+        />
+      ),
+      accessibilityLabel: I18n.t(
+        "features.itWallet.featuresInfoScreen.list.spid"
+      )
+    },
     {
       label: I18n.t("features.itWallet.featuresInfoScreen.list.cieId"),
       value: I18n.t("features.itWallet.featuresInfoScreen.list.cieIdSubTitle"),


### PR DESCRIPTION
## Short description
This PR adds incoming badge to the SPID item in `ItwDiscoveryProviderInfoScreen`.

![Simulator Screenshot - iPhone 14 Pro - 2023-09-19 at 13 08 38](https://github.com/pagopa/io-app/assets/49342144/97bf5bb6-08be-4f07-9730-fc86f1299623)

## List of changes proposed in this pull request
- Update `ItwDiscoveryProviderInfoScreen`

## How to test
Start activation flow. In the Provider Info screen the SPID item should have incoming badge.