### PR TITLE
feat(IT Wallet): [SIW-497] Add ListItemItw component

### DIFF
--- a/ts/features/design-system/core/DSListItems.tsx
+++ b/ts/features/design-system/core/DSListItems.tsx
@@ -2,7 +2,12 @@ import * as React from "react";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
 import { Alert, ImageSourcePropType, View } from "react-native";
-import { IOThemeContext, Icon } from "@pagopa/io-app-design-system";
+import {
+  Badge,
+  IOThemeContext,
+  Icon,
+  Label
+} from "@pagopa/io-app-design-system";
 import { H2 } from "../../../components/core/typography/H2";
 
 import { DSComponentViewerBox } from "../components/DSComponentViewerBox";
@@ -37,6 +42,7 @@ import ListItemAction from "../../../components/ui/ListItemAction";
 import ListItemInfo from "../../../components/ui/ListItemInfo";
 import { ListItemIDP } from "../../../components/ui/ListItemIDP";
 import { ListItemTransaction } from "../../../components/ui/ListItemTransaction";
+import { ItwListItem } from "../../it-wallet/components/ItwListItem";
 
 const onButtonPress = () => {
   Alert.alert("Alert", "Action triggered");
@@ -319,7 +325,15 @@ export const DSListItems = () => (
             isNew={true}
           />
         </DSComponentViewerBox>
-        <VSpacer size={40} />
+        <DSComponentViewerBox name="ItWalletListItem">
+          <ItwListItem
+            label="Test"
+            icon="abacus"
+            onPress={() => Alert.alert("pressed")}
+            accessibilityLabel="test"
+            rightNode={<Badge variant="success" text="In arrivo" />}
+          />
+        </DSComponentViewerBox>
       </DesignSystemScreen>
     )}
   </IOThemeContext.Consumer>

--- a/ts/features/design-system/core/DSListItems.tsx
+++ b/ts/features/design-system/core/DSListItems.tsx
@@ -41,7 +41,7 @@ import ListItemAction from "../../../components/ui/ListItemAction";
 import ListItemInfo from "../../../components/ui/ListItemInfo";
 import { ListItemIDP } from "../../../components/ui/ListItemIDP";
 import { ListItemTransaction } from "../../../components/ui/ListItemTransaction";
-import { ItwListItem } from "../../it-wallet/components/ItwListItem";
+import { ListItemItw } from "../../it-wallet/components/ListItemItw";
 
 const onButtonPress = () => {
   Alert.alert("Alert", "Action triggered");
@@ -324,8 +324,8 @@ export const DSListItems = () => (
             isNew={true}
           />
         </DSComponentViewerBox>
-        <DSComponentViewerBox name="ItWalletListItem">
-          <ItwListItem
+        <DSComponentViewerBox name="ListItemItw">
+          <ListItemItw
             title="Title test"
             subTitle="Subtitle test"
             icon="abacus"

--- a/ts/features/design-system/core/DSListItems.tsx
+++ b/ts/features/design-system/core/DSListItems.tsx
@@ -6,7 +6,7 @@ import {
   Badge,
   IOThemeContext,
   Icon,
-  Label
+  VSpacer
 } from "@pagopa/io-app-design-system";
 import { H2 } from "../../../components/core/typography/H2";
 
@@ -32,7 +32,6 @@ import {
   StatusEnum
 } from "../../../../definitions/idpay/TransactionOperationDTO";
 import { DesignSystemScreen } from "../components/DesignSystemScreen";
-import { VSpacer } from "../../../components/core/spacer/Spacer";
 import ButtonLink from "../../../components/ui/ButtonLink";
 import IconButton from "../../../components/ui/IconButton";
 import ListItemNav from "../../../components/ui/ListItemNav";
@@ -334,6 +333,7 @@ export const DSListItems = () => (
             rightNode={<Badge variant="success" text="In arrivo" />}
           />
         </DSComponentViewerBox>
+        <VSpacer size={40} />
       </DesignSystemScreen>
     )}
   </IOThemeContext.Consumer>

--- a/ts/features/design-system/core/DSListItems.tsx
+++ b/ts/features/design-system/core/DSListItems.tsx
@@ -326,7 +326,8 @@ export const DSListItems = () => (
         </DSComponentViewerBox>
         <DSComponentViewerBox name="ItWalletListItem">
           <ItwListItem
-            label="Test"
+            title="Title test"
+            subTitle="Subtitle test"
             icon="abacus"
             onPress={() => Alert.alert("pressed")}
             accessibilityLabel="test"

--- a/ts/features/it-wallet/components/ItwListItem.tsx
+++ b/ts/features/it-wallet/components/ItwListItem.tsx
@@ -59,6 +59,11 @@ const styles = StyleSheet.create({
 
 const DISABLED_OPACITY = 0.5;
 
+/**
+ * Components which renders a list item for the IT-WALLET stream.
+ * It supports an optional left icon, a title, an optional subtitle and an optional right node.
+ * It also supports a disabled state which greys out the component and disables the onPress callback.
+ */
 export const ItwListItem = ({
   title,
   subTitle,

--- a/ts/features/it-wallet/components/ItwListItem.tsx
+++ b/ts/features/it-wallet/components/ItwListItem.tsx
@@ -10,6 +10,7 @@ import {
   IOSpringValues,
   IOStyles,
   Icon,
+  LabelSmall,
   WithTestID,
   useIOTheme
 } from "@pagopa/io-app-design-system";
@@ -31,7 +32,8 @@ import Animated, {
 } from "react-native-reanimated";
 
 type ItwListItem = WithTestID<{
-  label: string;
+  title: string;
+  subTitle?: string;
   numberOfLines?: number;
   onPress: (event: GestureResponderEvent) => void;
   icon?: IOIcons;
@@ -58,7 +60,8 @@ const styles = StyleSheet.create({
 const DISABLED_OPACITY = 0.5;
 
 export const ItwListItem = ({
-  label,
+  title,
+  subTitle,
   numberOfLines,
   onPress,
   icon,
@@ -101,10 +104,32 @@ export const ItwListItem = ({
     isPressed.value = 0;
   }, [isPressed]);
 
-  const infoCopyText = (
+  const renderTitle = (
     <H6 color={theme["interactiveElem-default"]} numberOfLines={numberOfLines}>
-      {label}
+      {title}
     </H6>
+  );
+
+  const renderSubTitle = subTitle && (
+    <LabelSmall weight="Regular" color={theme["textBody-tertiary"]}>
+      {subTitle}
+    </LabelSmall>
+  );
+
+  const renderRightNode = rightNode && (
+    <View style={{ marginLeft: IOListItemVisualParams.iconMargin }}>
+      {rightNode}
+    </View>
+  );
+
+  const renderIcon = icon && (
+    <View style={{ marginRight: IOListItemVisualParams.iconMargin }}>
+      <Icon
+        name={icon}
+        color="grey-450"
+        size={IOListItemVisualParams.iconSize}
+      />
+    </View>
   );
 
   return (
@@ -126,19 +151,12 @@ export const ItwListItem = ({
           disabled ? { opacity: DISABLED_OPACITY } : {}
         ]}
       >
-        {icon && (
-          <View style={{ marginRight: IOListItemVisualParams.iconMargin }}>
-            <Icon
-              name={icon}
-              color="grey-450"
-              size={IOListItemVisualParams.iconSize}
-            />
-          </View>
-        )}
-        <View style={IOStyles.flex}>{infoCopyText}</View>
-        <View style={{ marginLeft: IOListItemVisualParams.iconMargin }}>
-          {rightNode}
+        {renderIcon}
+        <View style={IOStyles.flex}>
+          {renderTitle}
+          {renderSubTitle}
         </View>
+        {renderRightNode}
       </Animated.View>
     </Pressable>
   );

--- a/ts/features/it-wallet/components/ItwListItem.tsx
+++ b/ts/features/it-wallet/components/ItwListItem.tsx
@@ -1,0 +1,147 @@
+import {
+  H6,
+  IOColors,
+  IOIcons,
+  IOListItemIDPHSpacing,
+  IOListItemIDPRadius,
+  IOListItemIDPVSpacing,
+  IOListItemVisualParams,
+  IOScaleValues,
+  IOSpringValues,
+  IOStyles,
+  Icon,
+  WithTestID,
+  useIOTheme
+} from "@pagopa/io-app-design-system";
+import * as React from "react";
+import { useCallback } from "react";
+import {
+  StyleSheet,
+  Pressable,
+  GestureResponderEvent,
+  View
+} from "react-native";
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+  useDerivedValue,
+  interpolate,
+  Extrapolate
+} from "react-native-reanimated";
+
+type ItwListItem = WithTestID<{
+  label: string;
+  numberOfLines?: number;
+  onPress: (event: GestureResponderEvent) => void;
+  icon?: IOIcons;
+  rightNode?: React.ReactNode;
+  disabled?: boolean;
+  // Accessibility
+  accessibilityLabel: string;
+}>;
+
+const styles = StyleSheet.create({
+  button: {
+    borderWidth: 1,
+    borderColor: IOColors["grey-300"],
+    borderRadius: IOListItemIDPRadius,
+    backgroundColor: IOColors.white,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: IOListItemIDPVSpacing,
+    paddingHorizontal: IOListItemIDPHSpacing
+  }
+});
+
+const DISABLED_OPACITY = 0.5;
+
+export const ItwListItem = ({
+  label,
+  numberOfLines,
+  onPress,
+  icon,
+  rightNode,
+  testID,
+  disabled = false,
+  // Accessibility
+  accessibilityLabel
+}: ItwListItem) => {
+  const isPressed: Animated.SharedValue<number> = useSharedValue(0);
+  const theme = useIOTheme();
+
+  // Scaling transformation applied when the button is pressed
+  const animationScaleValue = IOScaleValues?.magnifiedButton?.pressedState;
+
+  const scaleTraversed = useDerivedValue(() =>
+    withSpring(isPressed.value, IOSpringValues.button)
+  );
+
+  // Interpolate animation values from `isPressed` values
+  const animatedStyle = useAnimatedStyle(() => {
+    const scale = interpolate(
+      scaleTraversed.value,
+      [0, 1],
+      [1, animationScaleValue],
+      Extrapolate.CLAMP
+    );
+
+    return {
+      transform: [{ scale }]
+    };
+  });
+
+  const onPressIn = useCallback(() => {
+    // eslint-disable-next-line functional/immutable-data
+    isPressed.value = 1;
+  }, [isPressed]);
+  const onPressOut = useCallback(() => {
+    // eslint-disable-next-line functional/immutable-data
+    isPressed.value = 0;
+  }, [isPressed]);
+
+  const infoCopyText = (
+    <H6 color={theme["interactiveElem-default"]} numberOfLines={numberOfLines}>
+      {label}
+    </H6>
+  );
+
+  return (
+    <Pressable
+      onPress={onPress}
+      onPressIn={onPressIn}
+      onPressOut={onPressOut}
+      onTouchEnd={onPressOut}
+      accessible={true}
+      accessibilityRole={"button"}
+      accessibilityLabel={accessibilityLabel}
+      testID={testID}
+      disabled={disabled}
+    >
+      <Animated.View
+        style={[
+          styles.button,
+          animatedStyle,
+          disabled ? { opacity: DISABLED_OPACITY } : {}
+        ]}
+      >
+        {icon && (
+          <View style={{ marginRight: IOListItemVisualParams.iconMargin }}>
+            <Icon
+              name={icon}
+              color="grey-450"
+              size={IOListItemVisualParams.iconSize}
+            />
+          </View>
+        )}
+        <View style={IOStyles.flex}>{infoCopyText}</View>
+        <View style={{ marginLeft: IOListItemVisualParams.iconMargin }}>
+          {rightNode}
+        </View>
+      </Animated.View>
+    </Pressable>
+  );
+};
+
+export default ItwListItem;

--- a/ts/features/it-wallet/components/ListItemItw.tsx
+++ b/ts/features/it-wallet/components/ListItemItw.tsx
@@ -31,7 +31,7 @@ import Animated, {
   Extrapolate
 } from "react-native-reanimated";
 
-type ItwListItem = WithTestID<{
+type ListItemItw = WithTestID<{
   title: string;
   subTitle?: string;
   numberOfLines?: number;
@@ -64,7 +64,7 @@ const DISABLED_OPACITY = 0.5;
  * It supports an optional left icon, a title, an optional subtitle and an optional right node.
  * It also supports a disabled state which greys out the component and disables the onPress callback.
  */
-export const ItwListItem = ({
+export const ListItemItw = ({
   title,
   subTitle,
   numberOfLines,
@@ -75,7 +75,7 @@ export const ItwListItem = ({
   disabled = false,
   // Accessibility
   accessibilityLabel
-}: ItwListItem) => {
+}: ListItemItw) => {
   const isPressed: Animated.SharedValue<number> = useSharedValue(0);
   const theme = useIOTheme();
 
@@ -167,4 +167,4 @@ export const ItwListItem = ({
   );
 };
 
-export default ItwListItem;
+export default ListItemItw;


### PR DESCRIPTION
## Short description
This PR adds the `ListItemItw` component used in a few screens like the [credentials catalog ](https://www.figma.com/file/c80PUA6BYANkGPyaqsRBNA/IT-Wallet---Esperienza-in-IO?type=design&node-id=2035-41538&mode=design&t=SiPuRdgQeVDbj4iZ-0)and the[ accepted login methods](https://www.figma.com/file/c80PUA6BYANkGPyaqsRBNA/IT-Wallet---Esperienza-in-IO?type=design&node-id=2851-52986&mode=design&t=SiPuRdgQeVDbj4iZ-0).
It supports an optional left icon, a title, an optional subtitle, an optional right node and a disabled state which greys out the component and disables the onPress callback.

## List of changes proposed in this pull request
- Adds the `ListItemItw` component;
- Updates the `ListItem` section of the in-app Design System showroom.

## How to test
Open the Design System showroom, navigate to `ListItem` and scroll to the bottom to see the new component example. 
