### PR TITLE
chore: [IOAPPFD0-153] Remove `@react-navigation/drawer` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     "@react-native-picker/picker": "^2.4.1",
     "@react-navigation/bottom-tabs": "^5.11.15",
     "@react-navigation/compat": "^5.3.20",
-    "@react-navigation/drawer": "^5.12.9",
     "@react-navigation/material-top-tabs": "^5.x",
     "@react-navigation/native": "^5.9.8",
     "@react-navigation/stack": "^5.14.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3543,14 +3543,6 @@
     query-string "^6.13.6"
     react-is "^16.13.0"
 
-"@react-navigation/drawer@^5.12.9":
-  version "5.12.9"
-  resolved "https://registry.yarnpkg.com/@react-navigation/drawer/-/drawer-5.12.9.tgz#b07d7391a6fea4ce07cd7a7421fdbaea37cdbb46"
-  integrity sha512-SYb2BCEAn+BiEwC6WBfCzs1VlWD+ZdQbxmsim6vo1o+ndPW2e+kiq7FXKRs0vUXhQRZVl2oOB3vBn0c3YCllQg==
-  dependencies:
-    color "^3.1.3"
-    react-native-iphone-x-helper "^1.3.0"
-
 "@react-navigation/material-top-tabs@^5.x":
   version "5.3.19"
   resolved "https://registry.yarnpkg.com/@react-navigation/material-top-tabs/-/material-top-tabs-5.3.19.tgz#64f3a933f5d7e86e99f3d57d9f0c1e833ffa7e4f"


### PR DESCRIPTION
## Short description
This PR removes `@react-navigation/drawer` dependency, not referenced anymore.

## How to test
N/A