### PR TITLE
fix: [IABT-1489] Mismatch in expireDate field on Payment Method details page

### DIFF
--- a/ts/components/ui/cards/payment/PaymentCardBig.tsx
+++ b/ts/components/ui/cards/payment/PaymentCardBig.tsx
@@ -1,22 +1,22 @@
 import {
   IOColors,
+  IOLogoPaymentExtType,
   IOStyles,
-  VSpacer,
   LogoPaymentExt,
-  IOLogoPaymentExtType
+  VSpacer
 } from "@pagopa/io-app-design-system";
-import { format } from "date-fns";
 import React from "react";
 import { StyleSheet, View } from "react-native";
 import Placeholder from "rn-placeholder";
 import I18n from "../../../../i18n";
 import { WithTestID } from "../../../../types/WithTestID";
+import { format } from "../../../../utils/dates";
+import { capitalize } from "../../../../utils/strings";
 import { LabelSmall } from "../../../core/typography/LabelSmall";
 import { NewH3 } from "../../../core/typography/NewH3";
+import { NewH6 } from "../../../core/typography/NewH6";
 import { LogoPaymentExtended } from "../../LogoPaymentExtended";
 import { LogoPaymentWithFallback } from "../../utils/components/LogoPaymentWithFallback";
-import { NewH6 } from "../../../core/typography/NewH6";
-import { capitalize } from "../../../../utils/strings";
 
 export const PaymentCardBig = (props: PaymentCardBigProps) => {
   if (props.isLoading) {

--- a/ts/features/wallet/bancomat/screen/BancomatDetailScreen.tsx
+++ b/ts/features/wallet/bancomat/screen/BancomatDetailScreen.tsx
@@ -56,7 +56,8 @@ const BancomatDetailScreen = ({ route }: Props) => {
       ...cardData,
       expirationDate: new Date(
         Number(cardData.expireYear),
-        Number(cardData.expireMonth)
+        // month is 0 based, BE res is not
+        Number(cardData.expireMonth) - 1
       )
     }))
   );

--- a/ts/features/wallet/cobadge/screen/CobadgeDetailScreen.tsx
+++ b/ts/features/wallet/cobadge/screen/CobadgeDetailScreen.tsx
@@ -58,7 +58,8 @@ const CobadgeDetailScreen = (props: Props) => {
       ...cardData,
       expirationDate: new Date(
         Number(cardData.expireYear),
-        Number(cardData.expireMonth)
+        // month is 0 based, BE response is not
+        Number(cardData.expireMonth) - 1
       )
     }))
   );

--- a/ts/features/wallet/creditCard/screen/CreditCardDetailScreen.tsx
+++ b/ts/features/wallet/creditCard/screen/CreditCardDetailScreen.tsx
@@ -70,7 +70,8 @@ const CreditCardDetailScreen = ({ route }: Props) => {
         ...cardData,
         expDate: new Date(
           Number(cardData.expireYear),
-          Number(cardData.expireMonth)
+          // month is 0 based, while BE response isn't
+          Number(cardData.expireMonth) - 1
         )
       }))
     );


### PR DESCRIPTION
## Short description
fixed a mismatch in the payment methods' displayed expire date .
this should fix the problem for Credit/debit cards, bancomat, cobadge

<img width="250" alt="Screenshot 2023-09-20 at 14 53 49" src="https://github.com/pagopa/io-app/assets/60693085/e73c8572-80bb-4886-bb15-7b1880542a53"><img width="400" alt="Screenshot 2023-09-20 at 14 53 32" src="https://github.com/pagopa/io-app/assets/60693085/97eb0e6e-f8bc-4d3a-9097-d4a23f3e1e50">


## List of changes proposed in this pull request
- updated date generation from backend data to follow the correct format

## How to test
navigate to the details screen of a payment method that has an expiration date, and make sure the displayed expiration date matches the one that is passed from BE