### PR TITLE
chore: [IOBP-150] Add identification request in IdPay transaction authorization

### DIFF
--- a/ts/features/idpay/payment/screens/IDPayPaymentAuthorizationScreen.tsx
+++ b/ts/features/idpay/payment/screens/IDPayPaymentAuthorizationScreen.tsx
@@ -35,6 +35,8 @@ import {
   selectIsPreAuthorizing,
   selectTransactionData
 } from "../xstate/selectors";
+import { useIODispatch } from "../../../../store/hooks";
+import { identificationRequest } from "../../../../store/actions/identification";
 
 export type IDPayPaymentAuthorizationScreenRouteParams = {
   trxCode?: string;
@@ -49,6 +51,8 @@ const IDPayPaymentAuthorizationScreen = () => {
   const route = useRoute<IDPayPaymentAuthorizationRouteProps>();
 
   const machine = usePaymentMachineService();
+  const dispatch = useIODispatch();
+
   const transactionData = useSelector(machine, selectTransactionData);
 
   const { trxCode } = route.params;
@@ -75,7 +79,20 @@ const IDPayPaymentAuthorizationScreen = () => {
   };
 
   const handleConfirm = () => {
-    machine.send("CONFIRM_AUTHORIZATION");
+    dispatch(
+      identificationRequest(
+        false,
+        true,
+        undefined,
+        {
+          label: I18n.t("global.buttons.cancel"),
+          onCancel: () => undefined
+        },
+        {
+          onSuccess: () => machine.send("CONFIRM_AUTHORIZATION")
+        }
+      )
+    );
   };
 
   const renderContent = () => {


### PR DESCRIPTION
## Short description
This PR adds the identification request before IdPay transaction authorization

https://github.com/pagopa/io-app/assets/6160324/dbd0f861-c984-442a-8faf-afb0217584bc

## List of changes proposed in this pull request
- `ts/features/idpay/payment/screens/IDPayPaymentAuthorizationScreen.tsx`: add `identificationRequest` dispatch before authorization action.

## How to test
Try to authorize an IdPay transaction, the identification request screen should appear.
