### PR TITLE
feat: [IOBP-264] Addition of code regen screen in profile

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3371,6 +3371,16 @@ support:
     subTitle:
       category: "Help us understand how we can help you by selecting the topic of your problem: we will reply as soon as possible, during business hours."
 idpay:
+  code:
+    renew:
+      screen:
+        header: Codice ID Pay
+        body: Il codice per autorizzare i pagamenti effettuati con la tua carta d’identità elettronica
+        link: Come funziona?
+        generateCTA: Genera un nuovo codice
+      alert:
+        title: Vuoi generare un nuovo codice ID Pay?
+        body: Il codice attualmente in uso verrà sovrascritto.
   wallet:
     preview:
       validThrough: "Valid through {{endDate}}"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3395,6 +3395,16 @@ support:
     subTitle:
       category: "Aiutaci a capire meglio come possiamo aiutarti selezionando l’argomento del tuo problema: ti risponderemo il prima possibile, in orario lavorativo."
 idpay:
+  code:
+    renew:
+      alert:
+        title: Vuoi generare un nuovo codice ID Pay?
+        body: Il codice attualmente in uso verrà sovrascritto.
+      screen:
+        header: Codice ID Pay
+        body: Il codice per autorizzare i pagamenti effettuati con la tua carta d’identità elettronica
+        link: Come funziona?
+        generateCTA: Genera un nuovo codice
   wallet:
     preview:
       validThrough: "Valido fino al {{endDate}}"

--- a/ts/features/idpay/code/screens/IdPayCodeRenewScreen.tsx
+++ b/ts/features/idpay/code/screens/IdPayCodeRenewScreen.tsx
@@ -1,0 +1,80 @@
+import {
+  Body,
+  H2,
+  IOStyles,
+  ListItemAction,
+  VSpacer
+} from "@pagopa/io-app-design-system";
+import * as React from "react";
+import { Alert, View } from "react-native";
+import { Link } from "../../../../components/core/typography/Link";
+import TopScreenComponent from "../../../../components/screens/TopScreenComponent";
+import I18n from "../../../../i18n";
+import { identificationRequest } from "../../../../store/actions/identification";
+import { useIODispatch } from "../../../../store/hooks";
+import { emptyContextualHelp } from "../../../../utils/emptyContextualHelp";
+
+export const IdPayCodeRenewScreen = () => {
+  const dispatch = useIODispatch();
+
+  const handleConfirm = () => {
+    dispatch(
+      identificationRequest(
+        false,
+        true,
+        undefined,
+        {
+          label: I18n.t("global.buttons.cancel"),
+          onCancel: () => undefined
+        },
+        {
+          onSuccess: () => null // TODO: handle success
+        }
+      )
+    );
+  };
+
+  return (
+    <TopScreenComponent
+      customGoBack={false}
+      dark={false}
+      goBack={true}
+      contextualHelp={emptyContextualHelp}
+    >
+      <View style={IOStyles.horizontalContentPadding}>
+        <H2>{I18n.t("idpay.code.renew.screen.header")}</H2>
+        <VSpacer size={16} />
+        <Body>{I18n.t("idpay.code.renew.screen.body")}</Body>
+        <Link>{I18n.t("idpay.code.renew.screen.link")}</Link>
+        <VSpacer size={16} />
+        <ListItemAction
+          label={I18n.t("idpay.code.renew.screen.generateCTA")}
+          onPress={() => customAlert(handleConfirm)}
+          icon="reload" // becomes `change` once new DS is released
+          accessibilityLabel={I18n.t("idpay.code.renew.screen.generateCTA")}
+          variant="danger"
+        />
+      </View>
+    </TopScreenComponent>
+  );
+};
+
+// -------------------------- utils --------------------------
+
+const customAlert = (handleConfirm: () => void) =>
+  Alert.alert(
+    I18n.t("idpay.code.renew.alert.title"),
+
+    I18n.t("idpay.code.renew.alert.body"),
+    [
+      {
+        text: I18n.t("global.buttons.continue"),
+        onPress: handleConfirm,
+        style: "destructive"
+      },
+      {
+        text: I18n.t("global.buttons.cancel"),
+        style: "cancel"
+      }
+    ]
+  );

--- a/ts/screens/profile/playgrounds/IDPayCodePlayground.tsx
+++ b/ts/screens/profile/playgrounds/IDPayCodePlayground.tsx
@@ -1,10 +1,10 @@
 import { Divider, IOStyles, ListItemNav } from "@pagopa/io-app-design-system";
 import * as React from "react";
 import { View } from "react-native";
-import BaseScreenComponent from "../../../components/screens/BaseScreenComponent";
+import TopScreenComponent from "../../../components/screens/TopScreenComponent";
 
 export const IDPayCodePlayGround = () => (
-  <BaseScreenComponent goBack={true} headerTitle={"IDPay Code Playground"}>
+  <TopScreenComponent goBack={true} customGoBack={false} dark={false}>
     <View style={IOStyles.horizontalContentPadding}>
       <ListItemNav
         value={"Onboarding Start Screen"}
@@ -17,6 +17,12 @@ export const IDPayCodePlayGround = () => (
         accessibilityLabel="Result Screen"
         onPress={() => null}
       />
+      <Divider />
+      <ListItemNav
+        value={"Regenerate code"}
+        accessibilityLabel="regenerate code"
+        onPress={() => null} // navigate to code generation screen (IdPayCodeRenewScreen)
+      />
     </View>
-  </BaseScreenComponent>
+  </TopScreenComponent>
 );


### PR DESCRIPTION
## Short description

addition of said screen, with alert and biometric auth

<img width="200" alt="Screenshot 2023-09-22 at 15 32 31" src="https://github.com/pagopa/io-app/assets/60693085/f32fc546-aea9-4090-a0e4-926ef4494a35"><img width="200" alt="Screenshot 2023-09-22 at 15 32 37" src="https://github.com/pagopa/io-app/assets/60693085/644b7323-6a93-4e25-b41f-cac48d145c73"><img width="200" alt="Screenshot 2023-09-22 at 15 32 41" src="https://github.com/pagopa/io-app/assets/60693085/4d36cf10-a884-491b-8ef9-1736184ec2a7">

## List of changes proposed in this pull request
- addition of said screen
- addition of alert
- addition of biometric auth
- addition of entry in IdPay code playground
- update of IdPay code playground's screen to use `TopScreenComponent` instead of  `BaseScreenComponent` 

## How to test
swap out any entry in a navigator with the added screen 

---
    1) the navigator will be added in a future PR, so sadly the screen has to be tested/developed like this
    2) during development, line 105 of `navigation/ProfileNavigator.tsx` was modified to navigate to `IdPayCodeRenewScreen`
---

then navigate to it and make sure everything renders correctly.
The code will also be updated with future DS evolutions, since a new release will fix some pending problems there are in applying its current patch.
