### PR TITLE
chore(IT Wallet): [SIW-510] Make ItwActionBanner component non dismissible

### DIFF
--- a/ts/components/messages/MessagesInbox.tsx
+++ b/ts/components/messages/MessagesInbox.tsx
@@ -94,7 +94,6 @@ const MessagesInbox = ({
                 title={I18n.t("features.itWallet.actionBanner.title")}
                 content={I18n.t("features.itWallet.actionBanner.description")}
                 action={I18n.t("features.itWallet.actionBanner.action")}
-                labelClose={I18n.t("features.itWallet.actionBanner.hideLabel")}
               />
             ) : (
               <UaDonationsBanner />

--- a/ts/features/it-wallet/components/ItwActionBanner.tsx
+++ b/ts/features/it-wallet/components/ItwActionBanner.tsx
@@ -1,16 +1,27 @@
 import * as React from "react";
-import { View } from "react-native";
+import { GestureResponderEvent, View } from "react-native";
 import { VSpacer } from "@pagopa/io-app-design-system";
 import { Banner } from "../../../components/Banner";
 import { useIODispatch } from "../../../store/hooks";
 import { itwActivationStart } from "../store/actions/itwActivationActions";
 
-export type ItwActionBannerProps = {
+/**
+ * Common props for the component which are always required.
+ */
+type CommonProps = {
   title: string;
   content: string;
   action: string;
-  labelClose: string;
 };
+
+/**
+ * Discriminated union props for the component which make the onClose callback optional and labelClose required if onClose is defined.
+ */
+type TruncateProps =
+  | { onClose?: (event: GestureResponderEvent) => void; labelClose?: never }
+  | { onClose: (event: GestureResponderEvent) => void; labelClose: string };
+
+type ItwActionBannerProps = CommonProps & TruncateProps;
 
 /**
  * The base graphical component, take a text as input and dispatch onPress when pressed
@@ -20,6 +31,7 @@ export const ItwActionBanner = ({
   title,
   content,
   action,
+  onClose,
   labelClose
 }: ItwActionBannerProps): React.ReactElement => {
   const viewRef = React.createRef<View>();
@@ -34,13 +46,11 @@ export const ItwActionBanner = ({
         size="big"
         title={title}
         content={content}
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         pictogramName={"itWallet"}
         action={action}
         labelClose={labelClose}
         onPress={() => dispatch(itwActivationStart())}
-        onClose={() => null}
+        onClose={onClose}
       />
     </>
   );

--- a/ts/features/it-wallet/screens/ItwHomeScreen.tsx
+++ b/ts/features/it-wallet/screens/ItwHomeScreen.tsx
@@ -178,9 +178,6 @@ const ItwHomeScreen = () => {
                 "features.itWallet.innerActionBanner.description"
               )}
               action={I18n.t("features.itWallet.innerActionBanner.action")}
-              labelClose={I18n.t(
-                "features.itWallet.innerActionBanner.hideLabel"
-              )}
             />
           </View>
         ) : (selectedBadgeIdx === 0 || selectedBadgeIdx === 1) && pid ? (


### PR DESCRIPTION
## Short description
This PR introduces a change to the `ItwActionBanner` component, making it non-dismissible. 

## List of changes proposed in this pull request
- Updates `ItwActionBanner` component props to accept an optional `onClose` prop and a required `labelClose` prop only if `onClose` is provided by using a discriminated union. When both props are not provided the banner is non-dimissable.
- Updates the usage in both `ItwHomeScreen` and `MessagesInbox` by removing the `labelClose` prop to make the banner non dismissable.

## How to test
Start the app, reset the wallet (if necessary) and check the banner in both screen. It shouldn't be dismissible while retaining its functionality.
