### PR TITLE
chore(IT Wallet): [SIW-519] Remove AdviceComponent from ITW CIE pin screen

### DIFF
--- a/ts/features/it-wallet/screens/issuing/cie/ItwCiePinScreen.tsx
+++ b/ts/features/it-wallet/screens/issuing/cie/ItwCiePinScreen.tsx
@@ -17,7 +17,6 @@ import {
 } from "react-native";
 import { connect } from "react-redux";
 import { IOColors, VSpacer } from "@pagopa/io-app-design-system";
-import AdviceComponent from "../../../../../components/AdviceComponent";
 import ButtonDefaultOpacity from "../../../../../components/ButtonDefaultOpacity";
 import CiePinpad from "../../../../../components/CiePinpad";
 import { Link } from "../../../../../components/core/typography/Link";
@@ -170,11 +169,6 @@ const ItwCiePinScreen: React.FC<Props> = props => {
             pinLength={CIE_PIN_LENGTH}
             onPinChanged={setPin}
             onSubmit={showModal}
-          />
-          <VSpacer size={16} />
-          <AdviceComponent
-            text={I18n.t("login.expiration_info")}
-            iconColor={"black"}
           />
         </View>
       </ScrollView>


### PR DESCRIPTION
## Short description
This PR removes the `AdviceComponent` from the ITW CIE pin screen which contained wrong copy information.
| Before | After |
|--------|--------|
| <img src="https://github.com/pagopa/io-app/assets/12371664/fb524e46-178f-4ea1-a69c-c4d5fb878f72" height="300"> | <img src="https://github.com/pagopa/io-app/assets/12371664/85a80ab7-a55e-44f5-8213-f17e66ab6bbd" height="300"> | 


## How to test
Test a PID issuing flow and check if the `AdviceComponent` has been removed.
