### PR TITLE
chore(IT Wallet): [SIW-511] Change payments screen title

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1040,7 +1040,7 @@ wallet:
       title: Vuoi pagare in app?
       content: Scopri quali sono i metodi che puoi aggiungere al tuo portafoglio.
       cta: Scopri di più
-  wallet: Wallet
+  wallet: Payments
   refreshWallet: Refresh the Wallet
   favourite:
     setFavoriteTitle: Use as favorite

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1057,7 +1057,7 @@ wallet:
       title: Vuoi pagare in app?
       content: Scopri quali sono i metodi che puoi aggiungere al tuo portafoglio.
       cta: Scopri di più
-  wallet: Portafoglio
+  wallet: Pagamenti
   refreshWallet: Aggiorna il Portafoglio
   favourite:
     setFavoriteTitle: Usa come preferito


### PR DESCRIPTION
## Short description
This PR changes the screen title for the payments home screen, namely WALLET_HOME.
| Before | After |
|--------|--------|
| <img src="https://github.com/pagopa/io-app/assets/12371664/4d4bf862-78b0-4a33-b3d1-41c1498766d7" height="300"> | <img src="https://github.com/pagopa/io-app/assets/12371664/a0c808b2-3ee4-4fd5-b95c-e111d09fddfa" height="300"> | 

## List of changes proposed in this pull request
- Updates the locale used to show the title.

## How to test
Start the app and open the payments section, the title should be "Pagamenti" or "Payments".
