### PR TITLE
chore(IT Wallet): [SIW-529] Remove tab navigator right horizontal padding in ITW home screen

### DIFF
--- a/ts/features/it-wallet/screens/ItwHomeScreen.tsx
+++ b/ts/features/it-wallet/screens/ItwHomeScreen.tsx
@@ -1,11 +1,15 @@
 import React, { useState } from "react";
 import { useNavigation } from "@react-navigation/native";
-import { Pressable, ScrollView, View } from "react-native";
+import { Pressable, ScrollView, StyleSheet, View } from "react-native";
 import * as pot from "@pagopa/ts-commons/lib/pot";
 import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
 import { PidWithToken } from "@pagopa/io-react-native-wallet/lib/typescript/pid/sd-jwt";
-import { ButtonLink, VSpacer } from "@pagopa/io-app-design-system";
+import {
+  ButtonLink,
+  IOVisualCostants,
+  VSpacer
+} from "@pagopa/io-app-design-system";
 import TopScreenComponent from "../../../components/screens/TopScreenComponent";
 import ROUTES from "../../../navigation/routes";
 import I18n from "../../../i18n";
@@ -149,7 +153,7 @@ const ItwHomeScreen = () => {
       }}
       sectionTitle={I18n.t("global.navigator.wallet")}
     >
-      <View style={IOStyles.horizontalContentPadding}>
+      <View style={styles.horizontalScroll}>
         <ScrollView horizontal showsHorizontalScrollIndicator={false}>
           {badgesLabels.map((label, idx) => (
             <BadgeButton
@@ -190,4 +194,11 @@ const ItwHomeScreen = () => {
     </TopScreenComponent>
   );
 };
+
+const styles = StyleSheet.create({
+  horizontalScroll: {
+    marginLeft: IOVisualCostants.appMarginDefault
+  }
+});
+
 export default ItwHomeScreen;


### PR DESCRIPTION
## Short description
This PR removes the right horizontal padding of the tab navigator component in the ITW home screen. 
The content should clip in the view on the right side.

Before: 
https://github.com/pagopa/io-app/assets/12371664/60f9588a-2c71-46fe-ba3f-9bbdf7dd11ea 
After: 
https://github.com/pagopa/io-app/assets/12371664/5e7a75a9-f3d6-4ae0-a171-1f5696be9a2d


## List of changes proposed in this pull request
- Replace the horizontal padding with a left only padding.

## How to test
Obtain a PID then open the ITW home screen and check the lateral scrolling of the tab navigator. The content should clip on the right.