### PR TITLE
chore: [IOAPPFD0-144] Add `IconContained` example to DS

### DIFF
--- a/ts/features/design-system/core/DSIcons.tsx
+++ b/ts/features/design-system/core/DSIcons.tsx
@@ -12,12 +12,16 @@ import {
   IOIconSizeScale,
   IOSystemIcons,
   IOThemeContext,
-  IOColors
+  IOColors,
+  IconContained,
+  HSpacer,
+  IOStyles
 } from "@pagopa/io-app-design-system";
 import { DSIconViewerBox, iconItemGutter } from "../components/DSIconViewerBox";
 import { H2 } from "../../../components/core/typography/H2";
 import { H3 } from "../../../components/core/typography/H3";
 import { DesignSystemScreen } from "../components/DesignSystemScreen";
+import { DSComponentViewerBox } from "../components/DSComponentViewerBox";
 
 // Filter the main object, removing already displayed icons in the other sets
 type IconSubsetObject = Record<
@@ -207,6 +211,22 @@ export const DSIcons = () => (
             />
           ))}
         </View>
+
+        <H3
+          color={theme["textHeading-default"]}
+          weight={"SemiBold"}
+          style={{ marginBottom: 12 }}
+        >
+          IconContained
+        </H3>
+        <DSComponentViewerBox name="IconContained · Tonal variant, neutral color">
+          <View style={IOStyles.row}>
+            <IconContained icon="device" variant="tonal" color="neutral" />
+            <HSpacer size={8} />
+            <IconContained icon="institution" variant="tonal" color="neutral" />
+          </View>
+        </DSComponentViewerBox>
+
         <H3
           color={theme["textHeading-default"]}
           weight={"SemiBold"}


### PR DESCRIPTION
## Short description
This PR adds an example of `IconContained` to the `Icons` page

## List of changes proposed in this pull request
- Add the default (and currently unique) variant of `IconContained`

### Preview
<img src="https://github.com/pagopa/io-app/assets/1255491/ae4aa00a-bf6e-4f1c-8049-45aea0331876" width="300" />

## How to test
Go to the **Design System → Icons (Foundation)**