### PR TITLE
chore: [IOBP-266] IDPay configuration wallet instruments filter

### DIFF
--- a/ts/features/idpay/configuration/xstate/services.ts
+++ b/ts/features/idpay/configuration/xstate/services.ts
@@ -6,6 +6,7 @@ import { PreferredLanguageEnum } from "../../../../../definitions/backend/Prefer
 import { IbanListDTO } from "../../../../../definitions/idpay/IbanListDTO";
 import { InitiativeDTO } from "../../../../../definitions/idpay/InitiativeDTO";
 import { InstrumentDTO } from "../../../../../definitions/idpay/InstrumentDTO";
+import { TypeEnum } from "../../../../../definitions/pagopa/Wallet";
 import { PaymentManagerClient } from "../../../../api/pagopa";
 import { PaymentManagerToken, Wallet } from "../../../../types/pagopa";
 import { SessionManager } from "../../../../utils/SessionManager";
@@ -156,7 +157,11 @@ const createServicesImplementation = (
               const wallet = pipe(
                 value.data,
                 O.fromNullable,
-                O.map(_ => _.map(convertWalletV2toWalletV1)),
+                O.map(_ =>
+                  _.map(convertWalletV2toWalletV1).filter(
+                    el => el.type === TypeEnum.CREDIT_CARD
+                  )
+                ),
                 O.getOrElse(() => [] as ReadonlyArray<Wallet>)
               );
 


### PR DESCRIPTION
## Short description
This PR adds a filter into `loadWalletInstruments` method to filter all the instruments of type `CREDIT_CARD`

## List of changes proposed in this pull request
- Added a filter into pipe that filters only wallets instruments of type `CREDIT_CARD`

## How to test
Navigate into an initiative and check inside the instruments list that there is only available instruments of type credit card.
