### PR TITLE
feat: [IOCOM-559] Enable the PN flag for cancelled notification's handling

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -100,4 +100,4 @@ WALLETV3_API_UAT_BASEURL='http://169.254.191.117:3000'
 # Enable CIE login flow with emulator and dev server
 CIE_LOGIN_WITH_DEV_SERVER_ENABLED=NO
 # Redesign of the PN message details screen
-NEW_PN_MESSAGE_DETAILS_ENABLED=NO
+NEW_PN_MESSAGE_DETAILS_ENABLED=YES

--- a/ts/features/pn/components/PnMessageDetails.tsx
+++ b/ts/features/pn/components/PnMessageDetails.tsx
@@ -80,6 +80,7 @@ export const PnMessageDetails = ({
   const viewRef = createRef<View>();
   const frontendUrl = useIOSelector(pnFrontendUrlSelector);
 
+  const hasAttachment = message.attachments && message.attachments.length > 0;
   const isCancelled = message.isCancelled ?? false;
   const completedPaymentNoticeCode =
     isCancelled && message.completedPayments
@@ -187,7 +188,7 @@ export const PnMessageDetails = ({
             </DSFullWidthComponent>
           </>
         )}
-        {message.attachments && (
+        {hasAttachment && (
           <PnMessageDetailsSection
             title={I18n.t("features.pn.details.attachmentsSection.title")}
           >


### PR DESCRIPTION
## Short description
This PR enables the FF flag for using the new PN screens (that handles the cancelled notification).
It also fixes the PN message details UI, when there are no attachments by not showing the related section's title.

## List of changes proposed in this pull request
- env.production has the flag turned on
- PnMessageDetails checks for at least one attachment before displaying the related section's title

## How to test
Using the various io-dev-api-server PN's configurations, check that all data are properly handled and displayed
