### PR TITLE
[SIW-548] Crypto keys deletion while generating 

### DIFF
--- a/ts/features/it-wallet/utils/keychain.ts
+++ b/ts/features/it-wallet/utils/keychain.ts
@@ -7,6 +7,7 @@ import { generate, getPublicKey } from "@pagopa/io-react-native-crypto";
  * It does rejects the promise with a CryptoError if the key generation fails.
  * In the future we should change the generate function to reject with a CryptoError if the key already exists, thus allowing us
  * to better handle the error case and call getPublicKey only if generate fails due to an already existing key.
+ * TODO: IW-548-fix-keys-deletion
  * @returns the public key used to sign the WIA attestation.
  */
 export const generateCryptoKey = async (keyTag: string) =>

--- a/ts/features/it-wallet/utils/keychain.ts
+++ b/ts/features/it-wallet/utils/keychain.ts
@@ -1,22 +1,13 @@
-import {
-  CryptoError,
-  deleteKey,
-  generate
-} from "@pagopa/io-react-native-crypto";
+import { generate, getPublicKey } from "@pagopa/io-react-native-crypto";
 
 /**
  * Getter for the public key used to sign the WIA attestation.
- * This method tries to generate a new crypto key pair but if it already exists it returns already existing one.
+ * This method tries to generate a new crypto key pair but if it already exists it returns the already existing one.
+ * Note that at the moment the generate function rejects the promise without a CryptoError if the key already exists.
+ * It does rejects the promise with a CryptoError if the key generation fails.
+ * In the future we should change the generate function to reject with a CryptoError if the key already exists, thus allowing us
+ * to better handle the error case and call getPublicKey only if generate fails due to an already existing key.
  * @returns the public key used to sign the WIA attestation.
  */
-export const generateCryptoKey = async (keyTag: string) => {
-  try {
-    await deleteKey(keyTag);
-  } catch (e) {
-    const { message } = e as CryptoError;
-    if (message !== "PUBLIC_KEY_NOT_FOUND") {
-      throw e;
-    }
-  }
-  return await generate(keyTag);
-};
+export const generateCryptoKey = async (keyTag: string) =>
+  generate(keyTag).catch(_ => getPublicKey(keyTag));


### PR DESCRIPTION
## Short description
This PR fixes the crpyto key generation function, namely `generateCryptoKey`.
Currently the function deletes the existing key before generating a new one. In this PR the function tried to generate it first and if an error occurs it tries to get the already existing key. 
As noted in the code documentation, at the moment the generate function rejects the promise without a CryptoError if the key already exists. In the future we should change the generate function to reject with a CryptoError if the key already exists, thus allowing us to better handle errors.
This implementation calls getPublicKey unconditionally, even if generate fails for reasons other than an already existing key, resulting in another failure. 

## How to test
Test a full issuing flow, try to reset the wallet and test it again.
