### PR TITLE
fix(IT Wallet): [SIW-568,SIW-565] Decode PID at startup after PIN

### DIFF
--- a/ts/features/it-wallet/screens/ItwHomeScreen.tsx
+++ b/ts/features/it-wallet/screens/ItwHomeScreen.tsx
@@ -18,9 +18,8 @@ import { ContextualHelpPropsMarkdown } from "../../../components/screens/BaseScr
 import { ItwActionBanner } from "../components/ItwActionBanner";
 import { IOStyles } from "../../../components/core/variables/IOStyles";
 import BadgeButton from "../components/design/BadgeButton";
-import { useIODispatch, useIOSelector } from "../../../store/hooks";
+import { useIOSelector } from "../../../store/hooks";
 import { ITW_ROUTES } from "../navigation/ItwRoutes";
-import { useOnFirstRender } from "../../../utils/hooks/useOnFirstRender";
 import PidCredential from "../components/PidCredential";
 import { IOStackNavigationProp } from "../../../navigation/params/AppParamsList";
 import { ItwParamsList } from "../navigation/ItwParamsList";
@@ -30,7 +29,6 @@ import { cancelButtonProps } from "../utils/itwButtonsUtils";
 import { itwLifecycleIsOperationalSelector } from "../store/reducers/itwLifecycleReducer";
 import { ItwCredentialsPidSelector } from "../store/reducers/itwCredentialsReducer";
 import { ItwDecodedPidPotSelector } from "../store/reducers/itwPidDecodeReducer";
-import { itwDecodePid } from "../store/actions/itwCredentialsActions";
 import { useItwResetFlow } from "../hooks/useItwResetFlow";
 import { itWalletExperimentalEnabled } from "../../../config";
 
@@ -55,7 +53,6 @@ const ItwHomeScreen = () => {
   );
   const pid = useIOSelector(ItwCredentialsPidSelector);
   const decodedPidPot = useIOSelector(ItwDecodedPidPotSelector);
-  const dispatch = useIODispatch();
   const [selectedBadgeIdx, setSelectedBadgeIdx] = useState(0);
   const badgesLabels = [
     I18n.t("features.itWallet.homeScreen.categories.any"),
@@ -64,13 +61,6 @@ const ItwHomeScreen = () => {
     I18n.t("features.itWallet.homeScreen.categories.payments"),
     I18n.t("features.itWallet.homeScreen.categories.bonus")
   ];
-
-  /**
-   * Decodes the PID on first render since we don't know if the PID has been decoded yet.
-   */
-  useOnFirstRender(() => {
-    dispatch(itwDecodePid.request(pid));
-  });
 
   /**
    * Condionally navigate to the credentials catalog screen if the experimental feature flag is true.

--- a/ts/features/it-wallet/screens/issuing/ItwPidPreviewScreen.tsx
+++ b/ts/features/it-wallet/screens/issuing/ItwPidPreviewScreen.tsx
@@ -22,13 +22,16 @@ import { useItwAbortFlow } from "../../hooks/useItwAbortFlow";
 import { ITW_ROUTES } from "../../navigation/ItwRoutes";
 import { ItwParamsList } from "../../navigation/ItwParamsList";
 import { IOStackNavigationProp } from "../../../../navigation/params/AppParamsList";
-import { useIOSelector } from "../../../../store/hooks";
+import { useIODispatch, useIOSelector } from "../../../../store/hooks";
 import LoadingSpinnerOverlay from "../../../../components/LoadingSpinnerOverlay";
 import { ItwDecodedPidPotSelector } from "../../store/reducers/itwPidDecodeReducer";
 import ItwErrorView from "../../components/ItwErrorView";
 import { cancelButtonProps } from "../../utils/itwButtonsUtils";
 import { H4 } from "../../../../components/core/typography/H4";
 import ItwPidClaimsList from "../../components/ItwPidClaimsList";
+import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
+import { itwDecodePid } from "../../store/actions/itwCredentialsActions";
+import { itwPidValueSelector } from "../../store/reducers/itwPidReducer";
 
 type ContentViewProps = {
   decodedPid: PidWithToken;
@@ -40,7 +43,16 @@ type ContentViewProps = {
 const ItwPidPreviewScreen = () => {
   const { present, bottomSheet } = useItwAbortFlow();
   const navigation = useNavigation<IOStackNavigationProp<ItwParamsList>>();
+  const dispatch = useIODispatch();
+  const pid = useIOSelector(itwPidValueSelector);
   const decodedPidPot = useIOSelector(ItwDecodedPidPotSelector);
+
+  /**
+   * Dispatches the action to decode the PID on first render.
+   */
+  useOnFirstRender(() => {
+    dispatch(itwDecodePid.request(pid));
+  });
 
   /**
    * Renders the content of the screen if the PID is decoded.

--- a/ts/features/it-wallet/screens/issuing/ItwPidPreviewScreen.tsx
+++ b/ts/features/it-wallet/screens/issuing/ItwPidPreviewScreen.tsx
@@ -20,14 +20,11 @@ import ScreenContent from "../../../../components/screens/ScreenContent";
 import FooterWithButtons from "../../../../components/ui/FooterWithButtons";
 import { useItwAbortFlow } from "../../hooks/useItwAbortFlow";
 import { ITW_ROUTES } from "../../navigation/ItwRoutes";
-import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
 import { ItwParamsList } from "../../navigation/ItwParamsList";
 import { IOStackNavigationProp } from "../../../../navigation/params/AppParamsList";
-import { useIODispatch, useIOSelector } from "../../../../store/hooks";
+import { useIOSelector } from "../../../../store/hooks";
 import LoadingSpinnerOverlay from "../../../../components/LoadingSpinnerOverlay";
-import { itwPidValueSelector } from "../../store/reducers/itwPidReducer";
 import { ItwDecodedPidPotSelector } from "../../store/reducers/itwPidDecodeReducer";
-import { itwDecodePid } from "../../store/actions/itwCredentialsActions";
 import ItwErrorView from "../../components/ItwErrorView";
 import { cancelButtonProps } from "../../utils/itwButtonsUtils";
 import { H4 } from "../../../../components/core/typography/H4";
@@ -43,16 +40,7 @@ type ContentViewProps = {
 const ItwPidPreviewScreen = () => {
   const { present, bottomSheet } = useItwAbortFlow();
   const navigation = useNavigation<IOStackNavigationProp<ItwParamsList>>();
-  const dispatch = useIODispatch();
-  const pid = useIOSelector(itwPidValueSelector);
   const decodedPidPot = useIOSelector(ItwDecodedPidPotSelector);
-
-  /**
-   * Dispatches the action to decode the PID on first render.
-   */
-  useOnFirstRender(() => {
-    dispatch(itwDecodePid.request(pid));
-  });
 
   /**
    * Renders the content of the screen if the PID is decoded.

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -106,6 +106,9 @@ import {
 import { refreshSessionToken } from "../features/fastLogin/store/actions";
 import { enableWhatsNewCheck } from "../features/whatsnew/store/actions";
 import { watchItwSaga } from "../features/it-wallet/saga";
+import { itwLifecycleIsValidSelector } from "../features/it-wallet/store/reducers/itwLifecycleReducer";
+import { itwDecodePid } from "../features/it-wallet/store/actions/itwCredentialsActions";
+import { itwPidValueSelector } from "../features/it-wallet/store/reducers/itwPidReducer";
 import { startAndReturnIdentificationResult } from "./identification";
 import { previousInstallationDataDeleteSaga } from "./installation";
 import watchLoadMessageDetails from "./messages/watchLoadMessageDetails";
@@ -459,6 +462,16 @@ export function* initializeApplicationSaga(
       // If we are here the user had chosen to reset the unlock code
       yield* put(startApplicationInitialization());
       return;
+    }
+
+    /**
+     * If IT-Wallet is enabled and operational, then dispatch the PID decode request.
+     */
+    const isItWalletEnabled = itWalletEnabled;
+    const isItWalletValid = yield* select(itwLifecycleIsValidSelector);
+    if (isItWalletEnabled && isItWalletValid) {
+      const pid = yield* select(itwPidValueSelector);
+      yield* put(itwDecodePid.request(pid));
     }
 
     const isFastLoginEnabled = yield* select(isFastLoginEnabledSelector);

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -108,7 +108,7 @@ import { enableWhatsNewCheck } from "../features/whatsnew/store/actions";
 import { watchItwSaga } from "../features/it-wallet/saga";
 import { itwLifecycleIsValidSelector } from "../features/it-wallet/store/reducers/itwLifecycleReducer";
 import { itwDecodePid } from "../features/it-wallet/store/actions/itwCredentialsActions";
-import { itwPidValueSelector } from "../features/it-wallet/store/reducers/itwPidReducer";
+import { ItwCredentialsPidSelector } from "../features/it-wallet/store/reducers/itwCredentialsReducer";
 import { startAndReturnIdentificationResult } from "./identification";
 import { previousInstallationDataDeleteSaga } from "./installation";
 import watchLoadMessageDetails from "./messages/watchLoadMessageDetails";
@@ -464,16 +464,6 @@ export function* initializeApplicationSaga(
       return;
     }
 
-    /**
-     * If IT-Wallet is enabled and operational, then dispatch the PID decode request.
-     */
-    const isItWalletEnabled = itWalletEnabled;
-    const isItWalletValid = yield* select(itwLifecycleIsValidSelector);
-    if (isItWalletEnabled && isItWalletValid) {
-      const pid = yield* select(itwPidValueSelector);
-      yield* put(itwDecodePid.request(pid));
-    }
-
     const isFastLoginEnabled = yield* select(isFastLoginEnabledSelector);
     if (isFastLoginEnabled) {
       // At application startup, the state of the refresh token is "idle".
@@ -604,6 +594,12 @@ export function* initializeApplicationSaga(
   if (itWalletEnabled) {
     // Start watching for ITWallet actions
     yield* fork(watchItwSaga);
+    // If IT-Wallet is enabled and operational, then dispatch the PID decode request.
+    const isItWalletValid = yield* select(itwLifecycleIsValidSelector);
+    if (isItWalletValid) {
+      const pid = yield* select(ItwCredentialsPidSelector);
+      yield* put(itwDecodePid.request(pid));
+    }
   }
 
   // Load the user metadata


### PR DESCRIPTION
## Short description
This PR proposes a refactor to the PID decode process which is now decoded at startup after the user inserts its PIN. 

## List of changes proposed in this pull request
- Adds the PID decode action dispatch in the startup saga. This allows us to not worry about decoding the PID in each screen it needs to be decoded; 
- Removes the decoding from the `ItwHomeScreen.tsx` screen but keeps it in the `itwPidPreviewScreen.tsx`. That's necessary because the issuing happens after the startup saga if the wallet operational. 

We might rethink the PID state to be incorporated into the credentials state down the road.

## How to test
There a are few things that should be tested: 
1. Obtain a PID;
2. Authenticate on the RP demo website;
3. Close the app and open it again. You should still see the decoded PID in the wallet section;
4. Close the app and open it again. Start the RP flow without opening the wallet section, it should work as expected.
