### PR TITLE
fix: [IOBP-95] Fix ultra wide angle camera being used in barcode scan screen

### DIFF
--- a/ts/components/BarcodeCamera.tsx
+++ b/ts/components/BarcodeCamera.tsx
@@ -138,7 +138,7 @@ type Props = {
 export const BarcodeCamera = (props: Props) => {
   const { onBarcodeScanned, disabled } = props;
   const prevDisabled = usePrevious(disabled);
-  const devices = useCameraDevices();
+  const devices = useCameraDevices("wide-angle-camera");
   const [permissionsGranted, setPermissionsGranted] = useState(false);
   const device = devices.back;
   const barcodeConfig = useIOSelector(barcodesScannerConfigSelector);

--- a/ts/features/barcode/hooks/useIOBarcodeCameraScanner.tsx
+++ b/ts/features/barcode/hooks/useIOBarcodeCameraScanner.tsx
@@ -1,3 +1,4 @@
+import { IOColors } from "@pagopa/io-app-design-system";
 import * as R from "fp-ts/ReadonlyRecord";
 import * as A from "fp-ts/lib/Array";
 import * as E from "fp-ts/lib/Either";
@@ -15,7 +16,6 @@ import {
   BarcodeFormat,
   useScanBarcodes
 } from "vision-camera-code-scanner";
-import { IOColors } from "@pagopa/io-app-design-system";
 import { usePrevious } from "../../../utils/hooks/usePrevious";
 import { AnimatedCameraMarker } from "../components/AnimatedCameraMarker";
 import { IOBarcode, IOBarcodeFormat, IOBarcodeType } from "../types/IOBarcode";
@@ -166,7 +166,7 @@ export const useIOBarcodeCameraScanner = ({
   );
 
   const prevDisabled = usePrevious(disabled);
-  const devices = useCameraDevices();
+  const devices = useCameraDevices("wide-angle-camera");
   const device = devices.back;
 
   // Checks that the device has a torch


### PR DESCRIPTION
## Short description
This PR replaces ultra wide angle camera with wide angle camera in barcode screen

## List of changes proposed in this pull request
- `ts/features/barcode/hooks/useIOBarcodeCameraScanner.tsx`: explicited the use of `wide-angle-camera` in `useCameraDevices` hook
- `ts/components/BarcodeCamera.tsx`: explicited the use of `wide-angle-camera` in `useCameraDevices` hook

## How to test
With a device, navigate to the barcode scan screen and check that the camera used is the wide angle camera.