### PR TITLE
fix: [IOBP-285] Fix navigation on IdPay CIE code failure

### DIFF
--- a/ts/features/idpay/code/screens/IdPayCodeDisplayScreen.tsx
+++ b/ts/features/idpay/code/screens/IdPayCodeDisplayScreen.tsx
@@ -51,7 +51,7 @@ const IdPayCodeDisplayScreen = () => {
 
   React.useEffect(() => {
     if (isFailure) {
-      navigation.navigate(IdPayCodeRoutes.IDPAY_CODE_MAIN, {
+      navigation.replace(IdPayCodeRoutes.IDPAY_CODE_MAIN, {
         screen: IdPayCodeRoutes.IDPAY_CODE_RESULT
       });
     }


### PR DESCRIPTION
## Short description
This PR fixes an issue when navigating to the failure screen of the ID Pay CIE code flow.

## List of changes proposed in this pull request
- [ts/features/idpay/code/screens/IdPayCodeDisplayScreen.tsx](https://github.com/pagopa/io-app/pull/5067/files#diff-d707cf1d996ad8193c4fb386857e18e3f1defbfe49e1820b361fd7cd9b357403): changed `navigate` to `replace` in navigation function.

## How to test
With the `io-dev-server`, navigate to **Profile -> ID Pay Code Playground**
