### PR TITLE
chore: [IOCOM-579] Replace the new pictograms with the old ones in the `PreconditionBottomSheet`

### DIFF
--- a/ts/features/messages/hooks/useMessageOpening.tsx
+++ b/ts/features/messages/hooks/useMessageOpening.tsx
@@ -61,7 +61,7 @@ const renderPreconditionContent = (
     ),
     () => (
       <MessageFeedback
-        pictogram="umbrellaNew"
+        pictogram="umbrella"
         title={I18n.t("global.genericError")}
       />
     )
@@ -127,7 +127,7 @@ export const useMessageOpening = () => {
     if (!pnSupported) {
       return (
         <MessageFeedback
-          pictogram="updateOS"
+          pictogram="umbrella"
           title={I18n.t("features.messages.updateBottomSheet.title")}
           subtitle={I18n.t("features.messages.updateBottomSheet.subtitle", {
             value: pnMinAppVersion


### PR DESCRIPTION
## Short description
This PR replaces the new pictograms with the old ones in the `PreconditionBottomSheet`.

## List of changes proposed in this pull request
See commit list

## How to test
After increasing the `min_app_version` for PN on the `io-dev-api-server`, open a PN message and verify that the old pictograms are visible.
