### PR TITLE
fix: [IOBP-286] Fix ID Pay instruments and unsubscription bottom sheets

### DIFF
--- a/ts/features/idpay/configuration/screens/InstrumentsEnrollmentScreen.tsx
+++ b/ts/features/idpay/configuration/screens/InstrumentsEnrollmentScreen.tsx
@@ -1,4 +1,9 @@
-import { IOColors, IOStyles, VSpacer } from "@pagopa/io-app-design-system";
+import {
+  FooterWithButtons,
+  IOColors,
+  IOStyles,
+  VSpacer
+} from "@pagopa/io-app-design-system";
 import { RouteProp, useRoute } from "@react-navigation/native";
 import { useSelector } from "@xstate/react";
 import React from "react";
@@ -8,7 +13,7 @@ import LoadingSpinnerOverlay from "../../../../components/LoadingSpinnerOverlay"
 import { Body } from "../../../../components/core/typography/Body";
 import { H1 } from "../../../../components/core/typography/H1";
 import BaseScreenComponent from "../../../../components/screens/BaseScreenComponent";
-import FooterWithButtons from "../../../../components/ui/FooterWithButtons";
+import LegacyFooterWithButtons from "../../../../components/ui/FooterWithButtons";
 import { useNavigationSwipeBackListener } from "../../../../hooks/useNavigationSwipeBackListener";
 import I18n from "../../../../i18n";
 import { Wallet } from "../../../../types/pagopa";
@@ -132,25 +137,31 @@ const InstrumentsEnrollmentScreen = () => {
       footer: (
         <FooterWithButtons
           type="TwoButtonsInlineThird"
-          rightButton={{
-            onPress: handleEnrollConfirm,
-            block: true,
-            bordered: false,
-            labelColor: IOColors.white,
-            title: I18n.t(
-              "idpay.configuration.instruments.enrollmentSheet.buttons.activate"
-            )
+          primary={{
+            type: "Solid",
+            buttonProps: {
+              label: I18n.t(
+                "idpay.configuration.instruments.enrollmentSheet.buttons.activate"
+              ),
+              accessibilityLabel: I18n.t(
+                "idpay.configuration.instruments.enrollmentSheet.buttons.activate"
+              ),
+              onPress: handleEnrollConfirm
+            }
           }}
-          leftButton={{
-            onPress: () => {
-              enrollmentBottomSheetModal.dismiss();
-            },
-            block: true,
-            bordered: true,
-            labelColor: IOColors.blue,
-            title: I18n.t(
-              "idpay.configuration.instruments.enrollmentSheet.buttons.cancel"
-            )
+          secondary={{
+            type: "Outline",
+            buttonProps: {
+              label: I18n.t(
+                "idpay.configuration.instruments.enrollmentSheet.buttons.cancel"
+              ),
+              accessibilityLabel: I18n.t(
+                "idpay.configuration.instruments.enrollmentSheet.buttons.cancel"
+              ),
+              onPress: () => {
+                enrollmentBottomSheetModal.dismiss();
+              }
+            }
           }}
         />
       ),
@@ -158,7 +169,7 @@ const InstrumentsEnrollmentScreen = () => {
         setStagedWalletId(undefined);
       }
     },
-    150
+    175
   );
 
   React.useEffect(() => {
@@ -172,7 +183,7 @@ const InstrumentsEnrollmentScreen = () => {
   const renderFooterButtons = () => {
     if (isInstrumentsOnlyMode) {
       return (
-        <FooterWithButtons
+        <LegacyFooterWithButtons
           type="SingleButton"
           leftButton={{
             title: I18n.t("idpay.configuration.instruments.buttons.addMethod"),
@@ -184,7 +195,7 @@ const InstrumentsEnrollmentScreen = () => {
     }
 
     return (
-      <FooterWithButtons
+      <LegacyFooterWithButtons
         type="TwoButtonsInlineHalf"
         leftButton={{
           title: I18n.t("idpay.configuration.instruments.buttons.skip"),

--- a/ts/features/idpay/unsubscription/screens/UnsubscriptionConfirmationScreen.tsx
+++ b/ts/features/idpay/unsubscription/screens/UnsubscriptionConfirmationScreen.tsx
@@ -1,19 +1,19 @@
+import {
+  ContentWrapper,
+  FooterWithButtons,
+  IconButton,
+  VSpacer
+} from "@pagopa/io-app-design-system";
 import { useSelector } from "@xstate/react";
 import React from "react";
 import { SafeAreaView, View } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
-import {
-  IconButton,
-  IOColors,
-  VSpacer,
-  ContentWrapper
-} from "@pagopa/io-app-design-system";
 import LoadingSpinnerOverlay from "../../../../components/LoadingSpinnerOverlay";
 import { Body } from "../../../../components/core/typography/Body";
 import { H1 } from "../../../../components/core/typography/H1";
 import { IOStyles } from "../../../../components/core/variables/IOStyles";
 import BaseScreenComponent from "../../../../components/screens/BaseScreenComponent";
-import FooterWithButtons from "../../../../components/ui/FooterWithButtons";
+import LegacyFooterWithButtons from "../../../../components/ui/FooterWithButtons";
 import { useConfirmationChecks } from "../../../../hooks/useConfirmationChecks";
 import I18n from "../../../../i18n";
 import { emptyContextualHelp } from "../../../../utils/emptyContextualHelp";
@@ -66,30 +66,34 @@ const UnsubscriptionConfirmationScreen = () => {
       footer: (
         <FooterWithButtons
           type="TwoButtonsInlineHalf"
-          leftButton={{
-            onPress: () => {
-              confirmModal.dismiss();
-              handleConfirmPress();
-            },
-            block: true,
-            bordered: true,
-            title: I18n.t("idpay.unsubscription.button.continue"),
-            danger: true,
-            labelColor: IOColors.red
+          primary={{
+            type: "Outline",
+            buttonProps: {
+              label: I18n.t("idpay.unsubscription.button.continue"),
+              accessibilityLabel: I18n.t(
+                "idpay.unsubscription.button.continue"
+              ),
+              onPress: () => {
+                confirmModal.dismiss();
+                handleConfirmPress();
+              },
+              color: "danger"
+            }
           }}
-          rightButton={{
-            onPress: () => {
-              confirmModal.dismiss();
-            },
-            block: true,
-            bordered: true,
-            title: I18n.t("global.buttons.cancel"),
-            labelColor: IOColors.blue
+          secondary={{
+            type: "Outline",
+            buttonProps: {
+              label: I18n.t("global.buttons.cancel"),
+              accessibilityLabel: I18n.t("global.buttons.cancel"),
+              onPress: () => {
+                confirmModal.dismiss();
+              }
+            }
           }}
         />
       )
     },
-    150
+    175
   );
 
   const body = (
@@ -113,7 +117,7 @@ const UnsubscriptionConfirmationScreen = () => {
           <VSpacer size={48} />
         </ContentWrapper>
       </ScrollView>
-      <FooterWithButtons
+      <LegacyFooterWithButtons
         type={"TwoButtonsInlineHalf"}
         leftButton={{
           bordered: true,


### PR DESCRIPTION
## Short description
This PR fixes the bottom sheets inside the ID Pay instruments configuration and unsubscription screens.

## List of changes proposed in this pull request
- [ts/features/idpay/configuration/screens/InstrumentsEnrollmentScreen.tsx](https://github.com/pagopa/io-app/compare/IOBP-286-fix-idpay-bottom-sheets?expand=1#diff-7bcfebf445dd9574f6d78c786ca8832a4559e3ce28dbb5d9d540de80a64ba8aa): incremented to 175 the bottom sheets bottom padding
- [ts/features/idpay/unsubscription/screens/UnsubscriptionConfirmationScreen.tsx](https://github.com/pagopa/io-app/compare/IOBP-286-fix-idpay-bottom-sheets?expand=1#diff-7a2a5467f073e83a63b580443c564027a011c278100741fc17914d098862f0f3): incremented to 175 the bottom sheets bottom padding

## How to test
Navigate to the instruments configuration screen and/or the initiative unsubscription screen and check that the bottom sheets are displayed correctly.
