### PR TITLE
feat(IT Wallet): [SIW-587] Add credential to the check store

### DIFF
--- a/ts/features/it-wallet/saga/itwCredentialsSaga.ts
+++ b/ts/features/it-wallet/saga/itwCredentialsSaga.ts
@@ -65,8 +65,10 @@ export function* handleCredentialsAddPid(
 /**
  * This saga handles the required checks before adding a credential.
  * @param action the request dispatched action with a credential as payload.
- * action: ActionType<typeof itwCredentialsChecks.request>
  */
-export function* handleCredentialsChecks(): SagaIterator {
-  yield* put(itwCredentialsChecks.success());
+export function* handleCredentialsChecks(
+  action: ActionType<typeof itwCredentialsChecks.request>
+): SagaIterator {
+  // TODO: Implement the required checks. Currently it just returns the same credential as we are only handling a mocked credential.
+  yield* put(itwCredentialsChecks.success(action.payload));
 }

--- a/ts/features/it-wallet/store/actions/itwCredentialsActions.ts
+++ b/ts/features/it-wallet/store/actions/itwCredentialsActions.ts
@@ -40,7 +40,7 @@ export const itwCredentialsChecks = createAsyncAction(
   "ITW_CREDENTIALS_CHECKS_REQUEST",
   "ITW_CREDENTIALS_CHECKS_SUCCESS",
   "ITW_CREDENTIALS_CHECKS_FAILURE"
-)<CredentialCatalogItem, void, ItWalletError>();
+)<CredentialCatalogItem, CredentialCatalogItem, ItWalletError>();
 
 /**
  * Type for credentials related actions.

--- a/ts/features/it-wallet/store/reducers/itwCredentialsChecksReducer.ts
+++ b/ts/features/it-wallet/store/reducers/itwCredentialsChecksReducer.ts
@@ -1,11 +1,16 @@
 import { getType } from "typesafe-actions";
 import * as pot from "@pagopa/ts-commons/lib/pot";
+import * as O from "fp-ts/lib/Option";
 import { Action } from "../../../../store/actions/types";
 import { GlobalState } from "../../../../store/reducers/types";
 import { itwCredentialsChecks } from "../actions/itwCredentialsActions";
 import { ItWalletError } from "../../utils/errors/itwErrors";
+import { CredentialCatalogItem } from "../../utils/mocks";
 
-export type ItwCredentialsChecksState = pot.Pot<true, ItWalletError>;
+export type ItwCredentialsChecksState = pot.Pot<
+  O.Option<CredentialCatalogItem>,
+  ItWalletError
+>;
 
 const emptyState: ItwCredentialsChecksState = pot.none;
 
@@ -25,7 +30,7 @@ const reducer = (
     case getType(itwCredentialsChecks.request):
       return pot.toLoading(state);
     case getType(itwCredentialsChecks.success):
-      return pot.some(true);
+      return pot.some(O.some(action.payload));
     case getType(itwCredentialsChecks.failure):
       return pot.toError(state, action.payload);
   }
@@ -39,5 +44,13 @@ const reducer = (
  */
 export const ItwCredentialsChecksSelector = (state: GlobalState) =>
   state.features.itWallet.credentialsChecks;
+
+/**
+ * Selects the checked credential which is going to be added to the wallet.
+ * @param state - the global state
+ * @returns an Option containing the checked credential.
+ */
+export const ItwCredentialsCheckCredentialSelector = (state: GlobalState) =>
+  pot.getOrElse(state.features.itWallet.credentialsChecks, O.none);
 
 export default reducer;


### PR DESCRIPTION
## Short description
This PR adds a `CredentialCatalogItem` mock to the state and a selector to make it available during the issuing flow.

## How to test
Static checks.
