### PR TITLE
chore(IT Wallet): [SIW-535] Refactor title card component

### DIFF
--- a/ts/features/it-wallet/components/ItwCredentialCard.tsx
+++ b/ts/features/it-wallet/components/ItwCredentialCard.tsx
@@ -7,13 +7,13 @@ import {
   ImageSourcePropType
 } from "react-native";
 import { H3, H6, IOColors } from "@pagopa/io-app-design-system";
-import I18n from "../../../i18n";
 import customVariables from "../../../theme/variables";
 
 /**
  * Props for the component which consists of the name and fiscal code to be render on the card.
  */
 type Props = {
+  credential: string;
   name: string;
   fiscalCode: string;
   backgroundImage: ImageSourcePropType;
@@ -66,7 +66,12 @@ const styles = StyleSheet.create({
  * Renders a card for the PID credential with the name and fiscal code of the owner.
  * @param props - props of the screen containg name and fiscal code.
  */
-const ItwCredentialCard = ({ name, fiscalCode, backgroundImage }: Props) => (
+const ItwCredentialCard = ({
+  credential,
+  name,
+  fiscalCode,
+  backgroundImage
+}: Props) => (
   <View>
     <Image source={backgroundImage} style={styles.cardBackground} />
     <H3
@@ -74,7 +79,7 @@ const ItwCredentialCard = ({ name, fiscalCode, backgroundImage }: Props) => (
       accessibilityLabel={name}
       style={[styles.text, styles.titleText]}
     >
-      {I18n.t("features.itWallet.verifiableCredentials.type.digitalCredential")}
+      {credential}
     </H3>
     <H6
       style={[styles.text, styles.nameText]}

--- a/ts/features/it-wallet/components/ItwCredentialCard.tsx
+++ b/ts/features/it-wallet/components/ItwCredentialCard.tsx
@@ -10,10 +10,10 @@ import { H3, H6, IOColors } from "@pagopa/io-app-design-system";
 import customVariables from "../../../theme/variables";
 
 /**
- * Props for the component which consists of the name and fiscal code to be render on the card.
+ * Props for the component.
  */
 type Props = {
-  credential: string;
+  title: string;
   name: string;
   fiscalCode: string;
   backgroundImage: ImageSourcePropType;
@@ -64,10 +64,13 @@ const styles = StyleSheet.create({
 
 /**
  * Renders a card for the PID credential with the name and fiscal code of the owner.
- * @param props - props of the screen containg name and fiscal code.
+ * @param title - the credential title.
+ * @param name - the name of the owner.
+ * @param fiscalCode - the fiscal code of the owner.
+ * @param backgroundImage - the background image of the card.
  */
 const ItwCredentialCard = ({
-  credential,
+  title,
   name,
   fiscalCode,
   backgroundImage
@@ -79,7 +82,7 @@ const ItwCredentialCard = ({
       accessibilityLabel={name}
       style={[styles.text, styles.titleText]}
     >
-      {credential}
+      {title}
     </H3>
     <H6
       style={[styles.text, styles.nameText]}

--- a/ts/features/it-wallet/screens/ItwHomeScreen.tsx
+++ b/ts/features/it-wallet/screens/ItwHomeScreen.tsx
@@ -93,6 +93,9 @@ const ItwHomeScreen = () => {
           }
         >
           <ItwCredentialCard
+            credential={I18n.t(
+              "features.itWallet.verifiableCredentials.type.digitalCredential"
+            )}
             name={`${decodedPid?.pid.claims.givenName} ${decodedPid?.pid.claims.familyName}`}
             fiscalCode={decodedPid?.pid.claims.taxIdCode as string}
             backgroundImage={require("../assets/img/pidCredentialCard.png")}

--- a/ts/features/it-wallet/screens/ItwHomeScreen.tsx
+++ b/ts/features/it-wallet/screens/ItwHomeScreen.tsx
@@ -93,7 +93,7 @@ const ItwHomeScreen = () => {
           }
         >
           <ItwCredentialCard
-            credential={I18n.t(
+            title={I18n.t(
               "features.itWallet.verifiableCredentials.type.digitalCredential"
             )}
             name={`${decodedPid?.pid.claims.givenName} ${decodedPid?.pid.claims.familyName}`}

--- a/ts/features/it-wallet/screens/credentials/ItwPidDetails.tsx
+++ b/ts/features/it-wallet/screens/credentials/ItwPidDetails.tsx
@@ -49,7 +49,7 @@ const ItwPidDetails = () => {
         <VSpacer />
         <View style={IOStyles.horizontalContentPadding}>
           <ItwCredentialCard
-            credential={I18n.t(
+            title={I18n.t(
               "features.itWallet.verifiableCredentials.type.digitalCredential"
             )}
             name={`${decodedPid.pid.claims.givenName} ${decodedPid.pid.claims.familyName}`}

--- a/ts/features/it-wallet/screens/credentials/ItwPidDetails.tsx
+++ b/ts/features/it-wallet/screens/credentials/ItwPidDetails.tsx
@@ -49,6 +49,9 @@ const ItwPidDetails = () => {
         <VSpacer />
         <View style={IOStyles.horizontalContentPadding}>
           <ItwCredentialCard
+            credential={I18n.t(
+              "features.itWallet.verifiableCredentials.type.digitalCredential"
+            )}
             name={`${decodedPid.pid.claims.givenName} ${decodedPid.pid.claims.familyName}`}
             fiscalCode={decodedPid.pid.claims.taxIdCode as string}
             backgroundImage={require("../../assets/img/pidCredentialCard.png")}

--- a/ts/features/it-wallet/screens/issuing/ItwPidPreviewScreen.tsx
+++ b/ts/features/it-wallet/screens/issuing/ItwPidPreviewScreen.tsx
@@ -82,7 +82,7 @@ const ItwPidPreviewScreen = () => {
           <VSpacer />
           <View style={IOStyles.horizontalContentPadding}>
             <ItwCredentialCard
-              credential={I18n.t(
+              title={I18n.t(
                 "features.itWallet.verifiableCredentials.type.digitalCredential"
               )}
               name={name}

--- a/ts/features/it-wallet/screens/issuing/ItwPidPreviewScreen.tsx
+++ b/ts/features/it-wallet/screens/issuing/ItwPidPreviewScreen.tsx
@@ -82,6 +82,9 @@ const ItwPidPreviewScreen = () => {
           <VSpacer />
           <View style={IOStyles.horizontalContentPadding}>
             <ItwCredentialCard
+              credential={I18n.t(
+                "features.itWallet.verifiableCredentials.type.digitalCredential"
+              )}
               name={name}
               fiscalCode={fiscalCode}
               backgroundImage={require("../../assets/img/pidCredentialCard.png")}


### PR DESCRIPTION
## Short description
This PR adds customizable credential title to the `ItwCredentialCard.tsx` component which was left out by mistake in #5086, hence why the same ticket number.

## List of changes proposed in this pull request
- Adds `title` props in `ItwCredentialCards.tsx` component;
- Updates usage accordingly.

## How to test
Check for any regression in the issuing flow which uses a PID card and also in the wallet section after obtaining a PID.
