### PR TITLE
fix: [IABT-1494] Fix camera not working on Android devices

### DIFF
--- a/ts/components/BarcodeCamera.tsx
+++ b/ts/components/BarcodeCamera.tsx
@@ -1,15 +1,16 @@
+import { IOColors } from "@pagopa/io-app-design-system";
 import { ParamListBase, useNavigation } from "@react-navigation/native";
 import { StackNavigationProp } from "@react-navigation/stack/lib/typescript/src/types";
 import React, { useEffect, useState } from "react";
 import { Dimensions, StyleSheet, View } from "react-native";
 import "react-native-reanimated";
-import { Camera, useCameraDevices } from "react-native-vision-camera";
+import { Camera } from "react-native-vision-camera";
 import {
   Barcode,
   BarcodeFormat,
   useScanBarcodes
 } from "vision-camera-code-scanner";
-import { IOColors } from "@pagopa/io-app-design-system";
+import { useWideAngleCameraDevice } from "../features/barcode/hooks/useWindeAngleCameraDevice";
 import I18n from "../i18n";
 import { useIOSelector } from "../store/hooks";
 import { barcodesScannerConfigSelector } from "../store/reducers/backendStatus";
@@ -138,9 +139,8 @@ type Props = {
 export const BarcodeCamera = (props: Props) => {
   const { onBarcodeScanned, disabled } = props;
   const prevDisabled = usePrevious(disabled);
-  const devices = useCameraDevices("wide-angle-camera");
+  const device = useWideAngleCameraDevice();
   const [permissionsGranted, setPermissionsGranted] = useState(false);
-  const device = devices.back;
   const barcodeConfig = useIOSelector(barcodesScannerConfigSelector);
   const navigation = useNavigation<StackNavigationProp<ParamListBase>>();
 

--- a/ts/features/barcode/hooks/useIOBarcodeCameraScanner.tsx
+++ b/ts/features/barcode/hooks/useIOBarcodeCameraScanner.tsx
@@ -6,11 +6,7 @@ import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
 import React from "react";
 import { Linking, StyleSheet, View } from "react-native";
-import {
-  Camera,
-  CameraPermissionStatus,
-  useCameraDevices
-} from "react-native-vision-camera";
+import { Camera, CameraPermissionStatus } from "react-native-vision-camera";
 import {
   Barcode,
   BarcodeFormat,
@@ -21,6 +17,7 @@ import { AnimatedCameraMarker } from "../components/AnimatedCameraMarker";
 import { IOBarcode, IOBarcodeFormat, IOBarcodeType } from "../types/IOBarcode";
 import { decodeIOBarcode } from "../types/decoders";
 import { BarcodeFailure } from "../types/failure";
+import { useWideAngleCameraDevice } from "./useWindeAngleCameraDevice";
 
 type IOBarcodeFormatsType = {
   [K in IOBarcodeFormat]: BarcodeFormat;
@@ -166,8 +163,7 @@ export const useIOBarcodeCameraScanner = ({
   );
 
   const prevDisabled = usePrevious(disabled);
-  const devices = useCameraDevices("wide-angle-camera");
-  const device = devices.back;
+  const device = useWideAngleCameraDevice();
 
   // Checks that the device has a torch
   const hasTorch = !!device?.hasTorch;

--- a/ts/features/barcode/hooks/useWindeAngleCameraDevice.tsx
+++ b/ts/features/barcode/hooks/useWindeAngleCameraDevice.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Camera, CameraDevice } from "react-native-vision-camera";
+
+/**
+ * This function returns the best match of back camera, excuding the ultra-wide-camera
+ * @param devices Array of {@see CameraDevice}
+ * @returns A {@see CameraDevice} or undefined, if a valid camera cannot be found
+ */
+const getWideAngleCameraOrDefault = (
+  devices: Array<CameraDevice>
+): CameraDevice | undefined => {
+  const defaultBackDevice = devices.find(d => d.position === "back");
+  const wideAngleDevice = devices.find(
+    d => !d.devices.includes("ultra-wide-angle-camera")
+  );
+  return wideAngleDevice || defaultBackDevice;
+};
+
+/**
+ * This hook tries to return a react-native-vision-camera with
+ * wide-angle-camera format. If not present, returns the default one as fallback
+ * FIXME: remove this when react-native-vision-camera is updated to 3.x
+ */
+const useWideAngleCameraDevice = (): CameraDevice | undefined => {
+  const [device, setDevice] = React.useState<CameraDevice>();
+
+  React.useEffect(() => {
+    Camera.getAvailableCameraDevices()
+      .then(devices => {
+        const bestMatchDevice = getWideAngleCameraOrDefault(devices);
+        setDevice(bestMatchDevice);
+      })
+      .catch(() => setDevice(undefined));
+  }, []);
+
+  return device;
+};
+
+export { useWideAngleCameraDevice };

--- a/ts/features/barcode/hooks/useWindeAngleCameraDevice.tsx
+++ b/ts/features/barcode/hooks/useWindeAngleCameraDevice.tsx
@@ -11,7 +11,8 @@ const getWideAngleCameraOrDefault = (
 ): CameraDevice | undefined => {
   const defaultBackDevice = devices.find(d => d.position === "back");
   const wideAngleDevice = devices.find(
-    d => !d.devices.includes("ultra-wide-angle-camera")
+    d =>
+      d.position !== "front" && !d.devices.includes("ultra-wide-angle-camera")
   );
   return wideAngleDevice || defaultBackDevice;
 };


### PR DESCRIPTION
## Short description
This PR fixes an issue where `wide-angle-camera` is not available on some Android devices, which causes the camera to not work properly.

## List of changes proposed in this pull request
- Added custom hook `useWideAngleCameraDevice` which handles the logic to select the best matching camera

## How to test
This PR should be tested on a physical device. Check that the camera is working and it's not an Ultra Wide Angle camera on both Android and iOS devices. 
A list of devices where the issue has been identified is:
- Samsung S22-S23
- Xiaomi 12 Lite, Xiaomi Redmi 10
- Huawei P30 Lite
