### PR TITLE
fix: [IOBP-330] Fix manual input modal in Barcode Scan screen

### DIFF
--- a/ts/features/barcode/screens/BarcodeScanScreen.tsx
+++ b/ts/features/barcode/screens/BarcodeScanScreen.tsx
@@ -179,6 +179,14 @@ const BarcodeScanScreen = () => {
     title: ""
   });
 
+  const handleManualInputPressed = () => {
+    if (isIdPayEnabled) {
+      manualInputModal.present();
+    } else {
+      handlePagoPACodeInput();
+    }
+  };
+
   const enabledFormats = IO_BARCODE_ALL_FORMATS.filter(format => {
     switch (format) {
       case "DATA_MATRIX":
@@ -204,7 +212,7 @@ const BarcodeScanScreen = () => {
         barcodeTypes={enabledTypes}
         onBarcodeSuccess={handleBarcodeSuccess}
         onBarcodeError={handleBarcodeError}
-        onManualInputPressed={manualInputModal.present}
+        onManualInputPressed={handleManualInputPressed}
         contextualHelp={emptyContextualHelp}
       />
       {manualInputModal.bottomSheet}


### PR DESCRIPTION
## Short description
This PR fixes an issue with the modal dialog in the Barcode Scan screen, which causes ID Pay manual input to appear even if it is not enabled by the FF.

## List of changes proposed in this pull request
- [ts/features/barcode/screens/BarcodeScanScreen.tsx](https://github.com/pagopa/io-app/compare/IOBP-330-tap-su-autorizza-una-transazione-senza-una-azione-collegata?expand=1#diff-12570b34029e534a64b24f1cb81383d99557273c4b2f34ad4ced82685fa017f6): added IDPay FF check

## How to test
With the Experimental Design System enabled, navigate to the scan screen and check that the manual input modal is not displayed if IDPay is not enabled.