### PR TITLE
fix: [IOBP-331] Remove torch button in Barcode Scan screen if camera permission is not granted

### DIFF
--- a/ts/features/barcode/components/BarcodeScanBaseScreenComponent.tsx
+++ b/ts/features/barcode/components/BarcodeScanBaseScreenComponent.tsx
@@ -194,6 +194,17 @@ const BarcodeScanBaseScreenComponent = ({
     );
   };
 
+  const shouldDisplayTorchButton =
+    cameraPermissionStatus === "authorized" && hasTorch;
+
+  const torchIconButton: React.ComponentProps<
+    typeof BaseHeader
+  >["customRightIcon"] = {
+    iconName: isTorchOn ? "lightFilled" : "light",
+    accessibilityLabel: "torch",
+    onPress: toggleTorch
+  };
+
   return (
     <View style={[styles.screen, { paddingBottom: insets.bottom }]}>
       <View style={styles.cameraContainer}>{renderCameraView()}</View>
@@ -233,13 +244,7 @@ const BarcodeScanBaseScreenComponent = ({
             customGoBack={customGoBack}
             onShowHelp={canShowHelpButton() ? onShowHelp() : undefined}
             customRightIcon={
-              hasTorch
-                ? {
-                    iconName: isTorchOn ? "lightFilled" : "light",
-                    accessibilityLabel: "torch",
-                    onPress: toggleTorch
-                  }
-                : undefined
+              shouldDisplayTorchButton ? torchIconButton : undefined
             }
           />
           {/* This overrides BaseHeader status bar configuration */}


### PR DESCRIPTION
## Short description
This PR removed the torch icon from the Barcode Scan screen when camera permission is not granted.

## List of changes proposed in this pull request
- [ts/features/barcode/components/BarcodeScanBaseScreenComponent.tsx](https://github.com/pagopa/io-app/compare/IOBP-331-nella-pagina-di-richiesta-consnso-fotocamera-e-presente-licona-torcia?expand=1#diff-1e4e400edd0a8debdd16a6c728d260d849b977083ea5aa108a5ba43ce25ac4c2): added checks to display torch icon

## How to test
Navigate to the barcode scan screen, check that the torch icon is not displayed when camera permission is not granted.
