### PR TITLE
chore(IT Wallet): [SIW-608] Add pictogram to error mapping type

### DIFF
--- a/ts/features/it-wallet/utils/errors/itwErrors.ts
+++ b/ts/features/it-wallet/utils/errors/itwErrors.ts
@@ -1,3 +1,5 @@
+import { IOPictograms } from "@pagopa/io-app-design-system";
+
 /**
  * Type for errors which might occur during the it-wallet flow.
  * These errors are a superset of HTTP errors with custom error codes.
@@ -13,6 +15,7 @@ export type ItWalletError = {
 export type ItWalletMappedError = {
   title: string;
   body: string;
+  pictogram?: IOPictograms;
 };
 
 /**


### PR DESCRIPTION
## Short description
This PR adds an optional `pictogram` prop to the `ItWalletMappedError` type.

## How to test
Static checks.
