### PR TITLE
fix: [IOBP-290 , IOBP-289] Voiceover fixes in BarcodeScanScreen

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1,6 +1,10 @@
 ---
 accessibility:
   doubleTapToActivateHint: "Double tap to activate"
+  buttons:
+    torch:
+      turnOn: "Accendi la torcia"
+      turnOff: "Spegni la torcia"
 date:
   formats:
     default: "%d/%m/%Y"
@@ -3817,6 +3821,10 @@ barcodeScan:
     scan: Inquadra
     upload: Carica
     input: Digita
+    a11y:
+      scan: Inquadra, 1 di 3
+      upload: Carica, 2 di 3
+      input: Digita, 3 di 3
   upload:
     image: Carica un'immagine
     file: Carica un file

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1,6 +1,10 @@
 ---
 accessibility:
   doubleTapToActivateHint: "Tocca due volte per attivare"
+  buttons:
+    torch:
+      turnOn: "Accendi la torcia"
+      turnOff: "Spegni la torcia"
 date:
   formats:
     default: "%d/%m/%Y"
@@ -3841,6 +3845,10 @@ barcodeScan:
     scan: Inquadra
     upload: Carica
     input: Digita
+    a11y:
+      scan: Inquadra, 1 di 3
+      upload: Carica, 2 di 3
+      input: Digita, 3 di 3
   upload:
     image: Carica un'immagine
     file: Carica un file

--- a/ts/features/barcode/components/BarcodeScanBaseScreenComponent.tsx
+++ b/ts/features/barcode/components/BarcodeScanBaseScreenComponent.tsx
@@ -201,16 +201,16 @@ const BarcodeScanBaseScreenComponent = ({
         <TabNavigation tabAlignment="stretch" selectedIndex={0} color="dark">
           <TabItem
             label={I18n.t("barcodeScan.tabs.scan")}
-            accessibilityLabel={I18n.t("barcodeScan.tabs.scan")}
+            accessibilityLabel={I18n.t("barcodeScan.tabs.a11y.scan")}
           />
           <TabItem
             label={I18n.t("barcodeScan.tabs.upload")}
-            accessibilityLabel={I18n.t("barcodeScan.tabs.upload")}
+            accessibilityLabel={I18n.t("barcodeScan.tabs.a11y.upload")}
             onPress={showFilePicker}
           />
           <TabItem
             label={I18n.t("barcodeScan.tabs.input")}
-            accessibilityLabel={I18n.t("barcodeScan.tabs.input")}
+            accessibilityLabel={I18n.t("barcodeScan.tabs.a11y.input")}
             onPress={onManualInputPressed}
           />
         </TabNavigation>
@@ -236,7 +236,9 @@ const BarcodeScanBaseScreenComponent = ({
               hasTorch
                 ? {
                     iconName: isTorchOn ? "lightFilled" : "light",
-                    accessibilityLabel: "torch",
+                    accessibilityLabel: isTorchOn
+                      ? I18n.t("accessibility.buttons.torch.turnOff")
+                      : I18n.t("accessibility.buttons.torch.turnOn"),
                     onPress: toggleTorch
                   }
                 : undefined


### PR DESCRIPTION
## Short description
fixed a couple of wrong a11y voiceover hints in said screen

## List of changes proposed in this pull request
- bottom tab navitgation now reads "x of 3"
- flashlight icon now reads "tap to turn the flashlight on/off"

## How to test
With voiceover active, navigate to a discount-type initiative, then tap the bottom button and make sure that what is listed in the "proposed changes" section actually happens.