### PR TITLE
fix: [IOCOM-622] Fix padding around the `StatusContent` component on Android

### DIFF
--- a/ts/features/pn/components/MessageDetails.tsx
+++ b/ts/features/pn/components/MessageDetails.tsx
@@ -4,7 +4,11 @@ import * as O from "fp-ts/lib/Option";
 import React, { createRef, useCallback, useEffect, useState } from "react";
 import { View } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
-import { ListItemInfoCopy, VSpacer } from "@pagopa/io-app-design-system";
+import {
+  IOVisualCostants,
+  ListItemInfoCopy,
+  VSpacer
+} from "@pagopa/io-app-design-system";
 import { RptId } from "@pagopa/io-pagopa-commons/lib/pagopa";
 import { ServicePublic } from "../../../../definitions/backend/ServicePublic";
 import { H5 } from "../../../components/core/typography/H5";
@@ -20,7 +24,6 @@ import {
   UIAttachment,
   UIMessageId
 } from "../../../store/reducers/entities/messages/types";
-import customVariables from "../../../theme/variables";
 import { clipboardSetStringWithFeedback } from "../../../utils/clipboard";
 import { useOnFirstRender } from "../../../utils/hooks/useOnFirstRender";
 import { isDuplicatedPayment } from "../../../utils/payment";
@@ -156,7 +159,10 @@ export const MessageDetails = ({
         <TransactionSummaryStatus error={paymentVerificationError} />
       )}
       <ScrollView
-        style={{ padding: customVariables.contentPadding }}
+        contentContainerStyle={{
+          flexGrow: 1,
+          padding: IOVisualCostants.appMarginDefault
+        }}
         ref={scrollViewRef}
       >
         {service && <PnMessageDetailsHeader service={service} />}
@@ -211,12 +217,10 @@ export const MessageDetails = ({
             accessibilityLabel={I18n.t("features.pn.details.infoSection.iun")}
             label={I18n.t("features.pn.details.infoSection.iun")}
           />
-          <H5
-            color="bluegrey"
-            style={{ marginBottom: customVariables.spacerLargeHeight }}
-          >
+          <H5 color="bluegrey">
             {I18n.t("features.pn.details.timeline.title")}
           </H5>
+          <VSpacer size={24} />
           <PnMessageTimeline
             message={message}
             onExpand={() => {

--- a/ts/features/pn/components/PnMessageDetails.tsx
+++ b/ts/features/pn/components/PnMessageDetails.tsx
@@ -4,7 +4,11 @@ import * as O from "fp-ts/lib/Option";
 import React, { createRef, useCallback, useEffect, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { ScrollView } from "react-native-gesture-handler";
-import { ListItemInfoCopy, VSpacer } from "@pagopa/io-app-design-system";
+import {
+  IOVisualCostants,
+  ListItemInfoCopy,
+  VSpacer
+} from "@pagopa/io-app-design-system";
 import { RptId } from "@pagopa/io-pagopa-commons/lib/pagopa";
 import { ServicePublic } from "../../../../definitions/backend/ServicePublic";
 import { H5 } from "../../../components/core/typography/H5";
@@ -163,7 +167,10 @@ export const PnMessageDetails = ({
         <TransactionSummaryStatus error={paymentVerificationError} />
       )}
       <ScrollView
-        style={{ padding: customVariables.contentPadding }}
+        contentContainerStyle={{
+          flexGrow: 1,
+          paddingHorizontal: IOVisualCostants.appMarginDefault
+        }}
         ref={scrollViewRef}
       >
         {service && <PnMessageDetailsHeader service={service} />}
@@ -217,12 +224,10 @@ export const PnMessageDetails = ({
             accessibilityLabel={I18n.t("features.pn.details.infoSection.iun")}
             label={I18n.t("features.pn.details.infoSection.iun")}
           />
-          <H5
-            color="bluegrey"
-            style={{ marginBottom: customVariables.spacerLargeHeight }}
-          >
+          <H5 color="bluegrey">
             {I18n.t("features.pn.details.timeline.title")}
           </H5>
+          <VSpacer size={24} />
           <PnMessageTimeline
             message={message}
             onExpand={() => {


### PR DESCRIPTION
## Short description
This PR fixes the padding around the `StatusContent` component in PnMessageDetailsScreen.

### Preview

| Before | After |
| --- | --- |
| <img src="https://github.com/pagopa/io-app/assets/29163287/a2e7d0a0-2084-42ad-bf89-dc4ec1ec8702" width="300" /> | <img src="https://github.com/pagopa/io-app/assets/29163287/6e2669bd-f912-41f1-a445-0caef3072b0f" width="300" /> | 

## List of changes proposed in this pull request
- Moved padding to the scroll view content container

## How to test
Generate a **cancelled** PN notification using `io-dev-api-server`. Check that the banner is displayed correctly on android and ios.
