### PR TITLE
fix: [IOBP-296] A11y reading acronyms in idpay code onboarding screen

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3378,7 +3378,7 @@ idpay:
     cie:
       bottomSheet:
         title: "Come funziona?"
-        featureOne: "Puoi pagare presso tutti gli esercenti convenzionati: ti basterà appoggiare la carta d'identità elettronica sul POS."
+        featureOne: "Puoi pagare presso tutti gli esercenti convenzionati: ti basterà appoggiare sul POS la tua carta d’identità elettronica."
         featureTwo: "Per autorizzare il pagamento, inserisci sul POS il tuo codice di sicurezza. Lo crei in app una volta sola e vale per qualsiasi iniziativa welfare compatibile."
         featureThree: "Se dimentichi il codice, puoi generarne un altro in ogni momento in Profilo > Sicurezza."
   onboarding:

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3378,7 +3378,7 @@ idpay:
     cie:
       bottomSheet:
         title: "Come funziona?"
-        featureOne: "Puoi pagare presso tutti gli esercenti convenzionati: ti basterà appoggiare la carta d'identità elettronica sul POS."
+        featureOne: "Puoi pagare presso tutti gli esercenti convenzionati: ti basterà appoggiare sul POS la tua carta d’identità elettronica."
         featureTwo: "Per autorizzare il pagamento, inserisci sul POS il tuo codice di sicurezza. Lo crei in app una volta sola e vale per qualsiasi iniziativa welfare compatibile."
         featureThree: "Se dimentichi il codice, puoi generarne un altro in ogni momento in Profilo > Sicurezza."
   onboarding:


### PR DESCRIPTION
## Short description
fixed voiceover reading `POS` as "position"
<img src="https://github.com/pagopa/io-app/assets/60693085/2a1c6c2f-78d5-454d-a7dc-33d513584919"
width=200
/>

## List of changes proposed in this pull request
- updated I18n to avoid the problem

This is a change that should in my opinion occur in the `FeatureInfo` component, but is being fixed here for now.

## How to test
With the idpay flag active, navigate to idpay code's onboarding test page in the profile section and make sure that the bottom sheet is correctly read by voiceover
