### PR TITLE
[IOBP-292] idpay details monitoring payment method count not handling voiceover correctly

### DIFF
--- a/ts/features/idpay/details/components/InitiativeDiscountSettingsComponent.tsx
+++ b/ts/features/idpay/details/components/InitiativeDiscountSettingsComponent.tsx
@@ -50,27 +50,31 @@ const InitiativeDiscountSettingsComponent = (props: Props) => {
           onPress={() => null}
         />
       ),
-      initiative => (
-        <ListItemNav
-          value={I18n.t(
-            "idpay.initiative.details.initiativeDetailsScreen.configured.settings.associatedPaymentMethods"
-          )}
-          description={I18n.t(
-            `idpay.initiative.details.initiativeDetailsScreen.configured.settings.methods`,
-            {
-              defaultValue: I18n.t(
-                `idpay.initiative.details.initiativeDetailsScreen.configured.settings.methods.other`,
-                { count: initiative.nInstr }
-              ),
-              count: initiative.nInstr
-            }
-          )}
-          onPress={() => navigateToInstrumentsConfiguration(initiative)}
-          accessibilityLabel={I18n.t(
-            "idpay.initiative.details.initiativeDetailsScreen.configured.settings.associatedPaymentMethods"
-          )}
-        />
-      )
+      initiative => {
+        const methodCountString = I18n.t(
+          `idpay.initiative.details.initiativeDetailsScreen.configured.settings.methods`,
+          {
+            defaultValue: I18n.t(
+              `idpay.initiative.details.initiativeDetailsScreen.configured.settings.methods.other`,
+              { count: initiative.nInstr }
+            ),
+            count: initiative.nInstr
+          }
+        );
+        return (
+          <ListItemNav
+            value={I18n.t(
+              "idpay.initiative.details.initiativeDetailsScreen.configured.settings.associatedPaymentMethods"
+            )}
+            description={methodCountString}
+            onPress={() => navigateToInstrumentsConfiguration(initiative)}
+            accessibilityLabel={`${I18n.t(
+              "idpay.initiative.details.initiativeDetailsScreen.configured.settings.associatedPaymentMethods"
+            )}
+         ${methodCountString}`}
+          />
+        );
+      }
     )
   );
 

--- a/ts/features/idpay/details/components/InitiativeRefundSettingsComponent.tsx
+++ b/ts/features/idpay/details/components/InitiativeRefundSettingsComponent.tsx
@@ -67,25 +67,27 @@ const InitiativeRefundSettingsComponent = (props: Props) => {
       ),
       ({ initiativeId, nInstr, status }) => {
         // between ListItemNav and ListItemNavAlert, ListItemNavAlert is the least inclusive one
+        const methodCountString = I18n.t(
+          `idpay.initiative.details.initiativeDetailsScreen.configured.settings.methods`,
+          {
+            defaultValue: I18n.t(
+              `idpay.initiative.details.initiativeDetailsScreen.configured.settings.methods.other`,
+              { count: nInstr }
+            ),
+            count: nInstr
+          }
+        );
         const listItemOptions: ListItemNavAlert = {
           value: I18n.t(
             "idpay.initiative.details.initiativeDetailsScreen.configured.settings.associatedPaymentMethods"
           ),
-          description: I18n.t(
-            `idpay.initiative.details.initiativeDetailsScreen.configured.settings.methods`,
-            {
-              defaultValue: I18n.t(
-                `idpay.initiative.details.initiativeDetailsScreen.configured.settings.methods.other`,
-                { count: nInstr }
-              ),
-              count: nInstr
-            }
-          ),
+          description: methodCountString,
 
           onPress: () => navigateToInstrumentsConfiguration(initiativeId),
-          accessibilityLabel: I18n.t(
+          accessibilityLabel: `${I18n.t(
             "idpay.initiative.details.initiativeDetailsScreen.configured.settings.associatedPaymentMethods"
-          )
+          )}
+          ${methodCountString}`
         };
         const areActionsRequired =
           status === InitiativeStatusEnum.NOT_REFUNDABLE_ONLY_IBAN ||


### PR DESCRIPTION
## Short description
added correct voiceover handling of `ListItemNav` components in said screen

## List of changes proposed in this pull request
- added body to AccessibilityLabel for the payment methods count in both discount and refund type initiatives

## How to test
with idpay flag active, navigate to an initiative's detail page, activate voiceover and make sure the voiceover correctly reads both the header and the body of the payment methods count, with a slight pause in between (e.g. "payment methods: 2 methods") 
