### PR TITLE
fix: a11y into `TransactionSummaryRow` component

### DIFF
--- a/ts/screens/wallet/payment/components/TransactionSummary.tsx
+++ b/ts/screens/wallet/payment/components/TransactionSummary.tsx
@@ -25,6 +25,7 @@ import {
 import { usePaymentAmountInfoBottomSheet } from "../hooks/usePaymentAmountInfoBottomSheet";
 import { getRecepientName } from "../../../../utils/strings";
 import { format } from "../../../../utils/dates";
+import { getAccessibleAmountText } from "../../../../utils/accessibility";
 
 const styles = StyleSheet.create({
   spacer: {
@@ -66,10 +67,14 @@ export const TransactionSummaryRow = (
     return null;
   }
 
+  const accessibilityLabel = value
+    ? `${title}, ${getAccessibleAmountText(value)}`
+    : title;
+
   return (
     <React.Fragment>
       <ListItemInfo
-        accessibilityLabel={title}
+        accessibilityLabel={accessibilityLabel}
         icon={icon}
         label={title}
         value={


### PR DESCRIPTION
## Short description
This PR fixes the correct voice over pronunciation for the `TransactionSummaryRow`, previously it read only the title text omitting the value.

## List of changes proposed in this pull request
- Added a custom accessibilityLabel for the `ListItemInfo` used into `TransactionSummaryRow` component.

## How to test
With VoiceOver turned on, go to the transaction summary screen from qrcode scan page and then check that the list item value is read correctly.