### PR TITLE
fix: [IOBP-364] Disable gesture in ID Pay onboarding completed screen

### DIFF
--- a/ts/features/idpay/onboarding/navigation/navigator.tsx
+++ b/ts/features/idpay/onboarding/navigation/navigator.tsx
@@ -65,6 +65,7 @@ export const IDPayOnboardingNavigator = () => (
       <Stack.Screen
         name={IDPayOnboardingRoutes.IDPAY_ONBOARDING_COMPLETION}
         component={CompletionScreen}
+        options={{ gestureEnabled: false }}
       />
       <Stack.Screen
         name={IDPayOnboardingRoutes.IDPAY_ONBOARDING_FAILURE}


### PR DESCRIPTION
## Short description
This PR fixes the navigation in the ID Pay Onboarding completed screen, disabling the back navigation gesture if the flow is completed.

| Before | After |
| --- | --- |
|  <video src="https://github.com/pagopa/io-app/assets/6160324/c997b92c-0e04-4524-ade8-b26173877b6f" /> |  <video src="https://github.com/pagopa/io-app/assets/6160324/e7653c8d-d1c7-49a0-835b-116251cf66f1" />  |

## List of changes proposed in this pull request
- [ts/features/idpay/onboarding/navigation/navigator.tsx](https://github.com/pagopa/io-app/compare/IOBP-364-fix-idpay-onboarding-navigation?expand=1#diff-01b5ae5ce43bd13eb4995f7b94f39e84f2b77491d85513f111a2582d06e06115): added `gestureEnabled: false` to `IDPayOnboardingRoutes.IDPAY_ONBOARDING_COMPLETION` route
- Feature B

## How to test
Try to complete an ID Pay onboarding flow, in the final step, try to navigate back with a gesture. You should not be allowed to return to the previous screen.
