### PR TITLE
chore(IT Wallet): [SIW-614] Update error screens DS in credential issuing and presentation

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3426,7 +3426,7 @@ features:
           alreadyExisting: 
             title: "You already have this credential."
             subtitle: "This credential is already in your wallet. If you don't see it, contact us."
-            cta: "Go to the Wallet"
+            actionLabel: "Go to the Wallet"
       credentialAddScreen:
         loading:
           title: "We're adding your credential to your walleto"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3450,7 +3450,7 @@ features:
           alreadyExisting: 
             title: "Hai già questa tessera"
             subtitle: "La tessera si trova già nel tuo Portafoglio. Se non la vedi, scrivici."
-            cta: "Vai al Portafoglio"
+            actionLabel: "Vai al Portafoglio"
       credentialAddScreen:
         loading:
           title: "Stiamo aggiungendo la tua credenziale al portafoglio"

--- a/ts/features/it-wallet/components/ItwKoView.tsx
+++ b/ts/features/it-wallet/components/ItwKoView.tsx
@@ -3,6 +3,7 @@ import {
   ButtonSolid,
   H3,
   IOPictograms,
+  IOStyles,
   LabelSmall,
   Pictogram,
   VSpacer,
@@ -39,6 +40,7 @@ const ItwKoView = ({
     centerContent={true}
     contentContainerStyle={[
       styles.wrapper,
+      IOStyles.horizontalContentPadding,
       /* Android fallback because `centerContent` is only an iOS property */
       Platform.OS === "android" && styles.wrapper_android
     ]}

--- a/ts/features/it-wallet/screens/credentials/ItwAddCredentialsCheckScreen.tsx
+++ b/ts/features/it-wallet/screens/credentials/ItwAddCredentialsCheckScreen.tsx
@@ -8,9 +8,11 @@ import { useIODispatch, useIOSelector } from "../../../../store/hooks";
 import ItwLoadingSpinnerOverlay from "../../components/ItwLoadingSpinnerOverlay";
 import I18n from "../../../../i18n";
 import { itwCredentialsChecks } from "../../store/actions/itwCredentialsActions";
-import ItwErrorView from "../../components/ItwErrorView";
-import { cancelButtonProps } from "../../utils/itwButtonsUtils";
-import { ItWalletError } from "../../utils/errors/itwErrors";
+import {
+  ItWalletError,
+  ItWalletErrorTypes,
+  ItwErrorMapping
+} from "../../utils/errors/itwErrors";
 import { CredentialCatalogItem } from "../../utils/mocks";
 import { ItwParamsList } from "../../navigation/ItwParamsList";
 import {
@@ -24,6 +26,8 @@ import ItwContinueScreen from "../../components/ItwResultComponent";
 import ROUTES from "../../../../navigation/routes";
 import { ITW_ROUTES } from "../../navigation/ItwRoutes";
 import { showCancelAlert } from "../../utils/alert";
+import ItwKoView from "../../components/ItwKoView";
+import { getItwGenerciMappedError } from "../../utils/errors/itwErrorsMapping";
 
 /**
  * ItwAddCredentialsCheckScreen screen navigation params.
@@ -67,6 +71,39 @@ const ItwAddCredentialsCheckScreen = () => {
     navigation.navigate(ROUTES.MAIN, { screen: ROUTES.MESSAGES_HOME });
   };
 
+  /**
+   * Error mapping function which takes an error and returns a mapped error object which can be used to render {@link ItwKoView}.
+   * @param error - an ItWalletError instance.
+   * @returns an object of type {@link ItwKoViewProps}.
+   */
+  const mapError: ItwErrorMapping = (error: ItWalletError) => {
+    const onPress = () =>
+      navigation.navigate(ROUTES.MAIN, { screen: ROUTES.ITWALLET_HOME });
+    switch (error.code) {
+      case ItWalletErrorTypes.CREDENTIAL_ALREADY_EXISTING_ERROR:
+        return {
+          title: I18n.t(
+            "features.itWallet.issuing.credentialsChecksScreen.failure.alreadyExisting.title"
+          ),
+          subtitle: I18n.t(
+            "features.itWallet.issuing.credentialsChecksScreen.failure.alreadyExisting.subtitle"
+          ),
+          action: {
+            accessibilityLabel: I18n.t(
+              "features.itWallet.issuing.credentialsChecksScreen.failure.alreadyExisting.actionLabel"
+            ),
+            label: I18n.t(
+              "features.itWallet.issuing.credentialsChecksScreen.failure.alreadyExisting.actionLabel"
+            ),
+            onPress
+          },
+          pictogram: "identityCheck"
+        };
+      default:
+        return getItwGenerciMappedError(onPress);
+    }
+  };
+
   const LoadingView = () => (
     <ItwLoadingSpinnerOverlay
       captionTitle={I18n.t(
@@ -103,13 +140,10 @@ const ItwAddCredentialsCheckScreen = () => {
     </BaseScreenComponent>
   );
 
-  const ErrorView = ({ error }: { error: ItWalletError }) => (
-    <ItwErrorView
-      error={error}
-      type="SingleButton"
-      leftButton={cancelButtonProps(navigation.goBack)}
-    />
-  );
+  const ErrorView = ({ error }: { error: ItWalletError }) => {
+    const mappedError = mapError(error);
+    return <ItwKoView {...mappedError} />;
+  };
 
   const RenderMask = () =>
     pot.fold(

--- a/ts/features/it-wallet/screens/credentials/ItwAddCredentialsCheckScreen.tsx
+++ b/ts/features/it-wallet/screens/credentials/ItwAddCredentialsCheckScreen.tsx
@@ -27,7 +27,7 @@ import ROUTES from "../../../../navigation/routes";
 import { ITW_ROUTES } from "../../navigation/ItwRoutes";
 import { showCancelAlert } from "../../utils/alert";
 import ItwKoView from "../../components/ItwKoView";
-import { getItwGenerciMappedError } from "../../utils/errors/itwErrorsMapping";
+import { getItwGenericMappedError } from "../../utils/errors/itwErrorsMapping";
 
 /**
  * ItwAddCredentialsCheckScreen screen navigation params.
@@ -100,7 +100,7 @@ const ItwAddCredentialsCheckScreen = () => {
           pictogram: "identityCheck"
         };
       default:
-        return getItwGenerciMappedError(onPress);
+        return getItwGenericMappedError(onPress);
     }
   };
 

--- a/ts/features/it-wallet/screens/credentials/ItwCredentialIssuingInfoScreen.tsx
+++ b/ts/features/it-wallet/screens/credentials/ItwCredentialIssuingInfoScreen.tsx
@@ -22,8 +22,6 @@ import BaseScreenComponent from "../../../../components/screens/BaseScreenCompon
 import { emptyContextualHelp } from "../../../../utils/emptyContextualHelp";
 import { useIOSelector } from "../../../../store/hooks";
 import { itwDecodedPidValueSelector } from "../../store/reducers/itwPidDecodeReducer";
-import ItwErrorView from "../../components/ItwErrorView";
-import { cancelButtonProps } from "../../utils/itwButtonsUtils";
 import { IOStackNavigationProp } from "../../../../navigation/params/AppParamsList";
 import { ItwParamsList } from "../../navigation/ItwParamsList";
 import ItwFooterInfoBox from "../../components/ItwFooterInfoBox";
@@ -35,6 +33,8 @@ import { ItwCredentialsCheckCredentialSelector } from "../../store/reducers/itwC
 import { showCancelAlert } from "../../utils/alert";
 import ROUTES from "../../../../navigation/routes";
 import { ITW_ROUTES } from "../../navigation/ItwRoutes";
+import ItwKoView from "../../components/ItwKoView";
+import { getItwGenerciMappedError } from "../../utils/errors/itwErrorsMapping";
 
 type ContentViewParams = {
   decodedPid: PidWithToken;
@@ -160,16 +160,17 @@ const ItwCredentialIssuingInfoScreen = () => {
     </SafeAreaView>
   );
 
+  const ErrorView = () => {
+    const onPress = () => navigation.goBack();
+    const mappedError = getItwGenerciMappedError(onPress);
+    return <ItwKoView {...mappedError} />;
+  };
+
   const DecodedPidOrErrorView = () =>
     pipe(
       sequenceS(O.Applicative)({ decodedPid, credential }),
       O.fold(
-        () => (
-          <ItwErrorView
-            type="SingleButton"
-            leftButton={cancelButtonProps(navigation.goBack)}
-          />
-        ),
+        () => <ErrorView />,
         some => <ContentView {...some} />
       )
     );

--- a/ts/features/it-wallet/screens/credentials/ItwCredentialIssuingInfoScreen.tsx
+++ b/ts/features/it-wallet/screens/credentials/ItwCredentialIssuingInfoScreen.tsx
@@ -34,7 +34,7 @@ import { showCancelAlert } from "../../utils/alert";
 import ROUTES from "../../../../navigation/routes";
 import { ITW_ROUTES } from "../../navigation/ItwRoutes";
 import ItwKoView from "../../components/ItwKoView";
-import { getItwGenerciMappedError } from "../../utils/errors/itwErrorsMapping";
+import { getItwGenericMappedError } from "../../utils/errors/itwErrorsMapping";
 
 type ContentViewParams = {
   decodedPid: PidWithToken;
@@ -162,7 +162,7 @@ const ItwCredentialIssuingInfoScreen = () => {
 
   const ErrorView = () => {
     const onPress = () => navigation.goBack();
-    const mappedError = getItwGenerciMappedError(onPress);
+    const mappedError = getItwGenericMappedError(onPress);
     return <ItwKoView {...mappedError} />;
   };
 

--- a/ts/features/it-wallet/screens/credentials/ItwCredentialPreviewScreen.tsx
+++ b/ts/features/it-wallet/screens/credentials/ItwCredentialPreviewScreen.tsx
@@ -30,7 +30,7 @@ import ROUTES from "../../../../navigation/routes";
 import { itwCredentialsAddCredential } from "../../store/actions/itwCredentialsActions";
 import { itwCredentialsSelector } from "../../store/reducers/itwCredentialsReducer";
 import ItwKoView from "../../components/ItwKoView";
-import { getItwGenerciMappedError } from "../../utils/errors/itwErrorsMapping";
+import { getItwGenericMappedError } from "../../utils/errors/itwErrorsMapping";
 
 /**
  * Type for the content view component props.
@@ -192,7 +192,7 @@ const ItwCredentialPreviewScreen = () => {
 
   const ErrorView = () => {
     const onPress = () => navigation.goBack();
-    const mappedError = getItwGenerciMappedError(onPress);
+    const mappedError = getItwGenericMappedError(onPress);
     return <ItwKoView {...mappedError} />;
   };
 

--- a/ts/features/it-wallet/screens/credentials/ItwCredentialPreviewScreen.tsx
+++ b/ts/features/it-wallet/screens/credentials/ItwCredentialPreviewScreen.tsx
@@ -21,8 +21,6 @@ import { emptyContextualHelp } from "../../../../utils/emptyContextualHelp";
 import { ItwParamsList } from "../../navigation/ItwParamsList";
 import { IOStackNavigationProp } from "../../../../navigation/params/AppParamsList";
 import { useIODispatch, useIOSelector } from "../../../../store/hooks";
-import ItwErrorView from "../../components/ItwErrorView";
-import { cancelButtonProps } from "../../utils/itwButtonsUtils";
 import { ItwCredentialsCheckCredentialSelector } from "../../store/reducers/itwCredentialsChecksReducer";
 import { CredentialCatalogItem } from "../../utils/mocks";
 import ItwCredentialClaimsList from "../../components/ItwCredentialClaimsList";
@@ -31,6 +29,8 @@ import { showCancelAlert } from "../../utils/alert";
 import ROUTES from "../../../../navigation/routes";
 import { itwCredentialsAddCredential } from "../../store/actions/itwCredentialsActions";
 import { itwCredentialsSelector } from "../../store/reducers/itwCredentialsReducer";
+import ItwKoView from "../../components/ItwKoView";
+import { getItwGenerciMappedError } from "../../utils/errors/itwErrorsMapping";
 
 /**
  * Type for the content view component props.
@@ -190,6 +190,12 @@ const ItwCredentialPreviewScreen = () => {
     );
   };
 
+  const ErrorView = () => {
+    const onPress = () => navigation.goBack();
+    const mappedError = getItwGenerciMappedError(onPress);
+    return <ItwKoView {...mappedError} />;
+  };
+
   /**
    * Checks if credential is some or none and renders the content of the screen or an error view.
    * @returns the content of the screen if the credential is some, an error view otherwise.
@@ -198,12 +204,7 @@ const ItwCredentialPreviewScreen = () => {
     pipe(
       credential,
       O.fold(
-        () => (
-          <ItwErrorView
-            type="SingleButton"
-            leftButton={cancelButtonProps(navigation.goBack)}
-          />
-        ),
+        () => <ErrorView />,
         credential => <ContentView credential={credential} />
       )
     );

--- a/ts/features/it-wallet/screens/presentation/crossdevice/new/ItwPresentationChecksScreen.tsx
+++ b/ts/features/it-wallet/screens/presentation/crossdevice/new/ItwPresentationChecksScreen.tsx
@@ -20,7 +20,7 @@ import { ItwParamsList } from "../../../../navigation/ItwParamsList";
 import { rpMock } from "../../../../utils/mocks";
 import { ITW_ROUTES } from "../../../../navigation/ItwRoutes";
 import ItwKoView from "../../../../components/ItwKoView";
-import { getItwGenerciMappedError } from "../../../../utils/errors/itwErrorsMapping";
+import { getItwGenericMappedError } from "../../../../utils/errors/itwErrorsMapping";
 
 /**
  * This screen is used to perform different checks before initiating the presentation flow.
@@ -58,7 +58,7 @@ const ItwPresentationChecksScreen = () => {
 
   const ErrorView = () => {
     const onPress = () => navigation.goBack();
-    const mappedError = getItwGenerciMappedError(onPress);
+    const mappedError = getItwGenericMappedError(onPress);
     return <ItwKoView {...mappedError} />;
   };
 

--- a/ts/features/it-wallet/screens/presentation/crossdevice/new/ItwPresentationChecksScreen.tsx
+++ b/ts/features/it-wallet/screens/presentation/crossdevice/new/ItwPresentationChecksScreen.tsx
@@ -8,9 +8,6 @@ import { itwPresentationChecksSelector } from "../../../../store/reducers/new/it
 import { useIODispatch, useIOSelector } from "../../../../../../store/hooks";
 import { useOnFirstRender } from "../../../../../../utils/hooks/useOnFirstRender";
 import ItwLoadingSpinnerOverlay from "../../../../components/ItwLoadingSpinnerOverlay";
-import ItwErrorView from "../../../../components/ItwErrorView";
-import { cancelButtonProps } from "../../../../utils/itwButtonsUtils";
-import { ItWalletError } from "../../../../utils/errors/itwErrors";
 import ItwContinueScreen from "../../../../components/ItwResultComponent";
 import I18n from "../../../../../../i18n";
 import { showCancelAlert } from "../../../../utils/alert";
@@ -22,6 +19,8 @@ import {
 import { ItwParamsList } from "../../../../navigation/ItwParamsList";
 import { rpMock } from "../../../../utils/mocks";
 import { ITW_ROUTES } from "../../../../navigation/ItwRoutes";
+import ItwKoView from "../../../../components/ItwKoView";
+import { getItwGenerciMappedError } from "../../../../utils/errors/itwErrorsMapping";
 
 /**
  * This screen is used to perform different checks before initiating the presentation flow.
@@ -57,13 +56,11 @@ const ItwPresentationChecksScreen = () => {
     </ItwLoadingSpinnerOverlay>
   );
 
-  const ErrorView = ({ error }: { error: ItWalletError }) => (
-    <ItwErrorView
-      error={error}
-      type="SingleButton"
-      leftButton={cancelButtonProps(navigation.goBack)}
-    />
-  );
+  const ErrorView = () => {
+    const onPress = () => navigation.goBack();
+    const mappedError = getItwGenerciMappedError(onPress);
+    return <ItwKoView {...mappedError} />;
+  };
 
   const SuccessView = () => (
     <SafeAreaView style={IOStyles.flex}>
@@ -93,11 +90,11 @@ const ItwPresentationChecksScreen = () => {
       () => <LoadingView />,
       () => <LoadingView />,
       () => <LoadingView />,
-      err => <ErrorView error={err} />,
+      _ => <ErrorView />,
       _ => <SuccessView />,
       () => <LoadingView />,
       () => <LoadingView />,
-      (_, err) => <ErrorView error={err} />
+      _ => <ErrorView />
     );
 
   return <RenderMask />;

--- a/ts/features/it-wallet/screens/presentation/crossdevice/new/ItwPresentationDataScreen.tsx
+++ b/ts/features/it-wallet/screens/presentation/crossdevice/new/ItwPresentationDataScreen.tsx
@@ -32,15 +32,15 @@ import ROUTES from "../../../../../../navigation/routes";
 import I18n from "../../../../../../i18n";
 import ItwBulletList from "../../../../components/ItwBulletList";
 import ItwFooterInfoBox from "../../../../components/ItwFooterInfoBox";
-import ItwErrorView from "../../../../components/ItwErrorView";
 import BaseScreenComponent from "../../../../../../components/screens/BaseScreenComponent";
 import { emptyContextualHelp } from "../../../../../../utils/emptyContextualHelp";
-import { cancelButtonProps } from "../../../../utils/itwButtonsUtils";
 import ItwOptionalClaimsList from "../../../../components/ItwOptionalClaimsList";
 import { ITW_ROUTES } from "../../../../navigation/ItwRoutes";
 import { useItwInfoBottomSheet } from "../../../../hooks/useItwInfoBottomSheet";
 import { rpMock } from "../../../../utils/mocks";
 import { showCancelAlert } from "../../../../utils/alert";
+import ItwKoView from "../../../../components/ItwKoView";
+import { getItwGenerciMappedError } from "../../../../utils/errors/itwErrorsMapping";
 
 type ContentViewParams = {
   decodedPid: PidWithToken;
@@ -203,16 +203,17 @@ const ItwPresentationDataScreen = () => {
     </SafeAreaView>
   );
 
+  const ErrorView = () => {
+    const onPress = () => navigation.goBack();
+    const mappedError = getItwGenerciMappedError(onPress);
+    return <ItwKoView {...mappedError} />;
+  };
+
   const DecodedPidOrErrorView = () =>
     pipe(
       decodedPid,
       O.fold(
-        () => (
-          <ItwErrorView
-            type="SingleButton"
-            leftButton={cancelButtonProps(navigation.goBack)}
-          />
-        ),
+        () => <ErrorView />,
         some => <ContentView decodedPid={some} />
       )
     );

--- a/ts/features/it-wallet/screens/presentation/crossdevice/new/ItwPresentationDataScreen.tsx
+++ b/ts/features/it-wallet/screens/presentation/crossdevice/new/ItwPresentationDataScreen.tsx
@@ -40,7 +40,7 @@ import { useItwInfoBottomSheet } from "../../../../hooks/useItwInfoBottomSheet";
 import { rpMock } from "../../../../utils/mocks";
 import { showCancelAlert } from "../../../../utils/alert";
 import ItwKoView from "../../../../components/ItwKoView";
-import { getItwGenerciMappedError } from "../../../../utils/errors/itwErrorsMapping";
+import { getItwGenericMappedError } from "../../../../utils/errors/itwErrorsMapping";
 
 type ContentViewParams = {
   decodedPid: PidWithToken;
@@ -205,7 +205,7 @@ const ItwPresentationDataScreen = () => {
 
   const ErrorView = () => {
     const onPress = () => navigation.goBack();
-    const mappedError = getItwGenerciMappedError(onPress);
+    const mappedError = getItwGenericMappedError(onPress);
     return <ItwKoView {...mappedError} />;
   };
 

--- a/ts/features/it-wallet/screens/presentation/crossdevice/new/ItwPresentationResultScreen.tsx
+++ b/ts/features/it-wallet/screens/presentation/crossdevice/new/ItwPresentationResultScreen.tsx
@@ -17,7 +17,7 @@ import {
 import { ItwParamsList } from "../../../../navigation/ItwParamsList";
 import { rpMock } from "../../../../utils/mocks";
 import ItwKoView from "../../../../components/ItwKoView";
-import { getItwGenerciMappedError } from "../../../../utils/errors/itwErrorsMapping";
+import { getItwGenericMappedError } from "../../../../utils/errors/itwErrorsMapping";
 
 /**
  * This screen is used to perform different checks before initiating the presentation flow.
@@ -48,7 +48,7 @@ const ItwPresentationResultScreen = () => {
 
   const ErrorView = () => {
     const onPress = () => navigation.goBack();
-    const mappedError = getItwGenerciMappedError(onPress);
+    const mappedError = getItwGenericMappedError(onPress);
     return <ItwKoView {...mappedError} />;
   };
 

--- a/ts/features/it-wallet/screens/presentation/crossdevice/new/ItwPresentationResultScreen.tsx
+++ b/ts/features/it-wallet/screens/presentation/crossdevice/new/ItwPresentationResultScreen.tsx
@@ -8,9 +8,6 @@ import { itwPresentationChecksSelector } from "../../../../store/reducers/new/it
 import { useIODispatch, useIOSelector } from "../../../../../../store/hooks";
 import { useOnFirstRender } from "../../../../../../utils/hooks/useOnFirstRender";
 import ItwLoadingSpinnerOverlay from "../../../../components/ItwLoadingSpinnerOverlay";
-import ItwErrorView from "../../../../components/ItwErrorView";
-import { cancelButtonProps } from "../../../../utils/itwButtonsUtils";
-import { ItWalletError } from "../../../../utils/errors/itwErrors";
 import I18n from "../../../../../../i18n";
 import ROUTES from "../../../../../../navigation/routes";
 import {
@@ -20,6 +17,7 @@ import {
 import { ItwParamsList } from "../../../../navigation/ItwParamsList";
 import { rpMock } from "../../../../utils/mocks";
 import ItwKoView from "../../../../components/ItwKoView";
+import { getItwGenerciMappedError } from "../../../../utils/errors/itwErrorsMapping";
 
 /**
  * This screen is used to perform different checks before initiating the presentation flow.
@@ -48,13 +46,11 @@ const ItwPresentationResultScreen = () => {
     </ItwLoadingSpinnerOverlay>
   );
 
-  const ErrorView = ({ error }: { error: ItWalletError }) => (
-    <ItwErrorView
-      error={error}
-      type="SingleButton"
-      leftButton={cancelButtonProps(navigation.goBack)}
-    />
-  );
+  const ErrorView = () => {
+    const onPress = () => navigation.goBack();
+    const mappedError = getItwGenerciMappedError(onPress);
+    return <ItwKoView {...mappedError} />;
+  };
 
   const SuccessView = () => (
     <SafeAreaView style={IOStyles.flex}>
@@ -85,11 +81,11 @@ const ItwPresentationResultScreen = () => {
       () => <LoadingView />,
       () => <LoadingView />,
       () => <LoadingView />,
-      err => <ErrorView error={err} />,
+      _ => <ErrorView />,
       _ => <SuccessView />,
       () => <LoadingView />,
       () => <LoadingView />,
-      (_, err) => <ErrorView error={err} />
+      _ => <ErrorView />
     );
 
   return <RenderMask />;

--- a/ts/features/it-wallet/utils/errors/itwErrors.ts
+++ b/ts/features/it-wallet/utils/errors/itwErrors.ts
@@ -1,3 +1,5 @@
+import ItwKoView from "../../components/ItwKoView";
+
 /**
  * Type for errors which might occur during the it-wallet flow.
  * These errors are a superset of HTTP errors with custom error codes.
@@ -14,6 +16,14 @@ export type ItWalletMappedError = {
   title: string;
   body: string;
 };
+
+/**
+ * Type for error mapping functions which map an error to a component to be displayed to the user.
+ * The function must takes an {@link ItWalletError} and returns a {@link ItwKoViewProps}
+ */
+export type ItwErrorMapping = (
+  error: ItWalletError
+) => React.ComponentProps<typeof ItwKoView>;
 
 /**
  * Requirements error codes

--- a/ts/features/it-wallet/utils/errors/itwErrorsMapping.ts
+++ b/ts/features/it-wallet/utils/errors/itwErrorsMapping.ts
@@ -9,14 +9,14 @@ import {
 /**
  * Getter for a generic error title and body.
  * @returns a generic ItWalletMappedError.
- * @deprecated use {@link getItwGenerciMappedError} instead.
+ * @deprecated use {@link getItwGenericMappedError} instead.
  */
 export const getItwGenericError = (): ItWalletMappedError => ({
   title: I18n.t("features.itWallet.generic.error.title"),
   body: I18n.t("features.itWallet.generic.error.body")
 });
 
-export const getItwGenerciMappedError = (
+export const getItwGenericMappedError = (
   onPress: () => any
 ): React.ComponentProps<typeof ItwKoView> => ({
   title: I18n.t("features.itWallet.generic.error.title"),

--- a/ts/features/it-wallet/utils/errors/itwErrorsMapping.ts
+++ b/ts/features/it-wallet/utils/errors/itwErrorsMapping.ts
@@ -1,4 +1,5 @@
 import I18n from "../../../../i18n";
+import ItwKoView from "../../components/ItwKoView";
 import {
   ItWalletError,
   ItWalletErrorTypes,
@@ -12,6 +13,19 @@ import {
 export const getItwGenericError = (): ItWalletMappedError => ({
   title: I18n.t("features.itWallet.generic.error.title"),
   body: I18n.t("features.itWallet.generic.error.body")
+});
+
+export const getItwGenerciMappedError = (
+  onPress: () => any
+): React.ComponentProps<typeof ItwKoView> => ({
+  title: I18n.t("features.itWallet.generic.error.title"),
+  subtitle: I18n.t("features.itWallet.generic.error.body"),
+  action: {
+    accessibilityLabel: I18n.t("global.buttons.back"),
+    label: I18n.t("global.buttons.back"),
+    onPress
+  },
+  pictogram: "fatalError"
 });
 
 /**

--- a/ts/features/it-wallet/utils/errors/itwErrorsMapping.ts
+++ b/ts/features/it-wallet/utils/errors/itwErrorsMapping.ts
@@ -9,6 +9,7 @@ import {
 /**
  * Getter for a generic error title and body.
  * @returns a generic ItWalletMappedError.
+ * @deprecated use {@link getItwGenerciMappedError} instead.
  */
 export const getItwGenericError = (): ItWalletMappedError => ({
   title: I18n.t("features.itWallet.generic.error.title"),
@@ -32,6 +33,7 @@ export const getItwGenerciMappedError = (
  * Maps an ItWalletError to an ItWalletMappedError to display an error message to the user.
  * @param error an instance of ItWalletError containg the code to be translated.
  * @returns a title and a body messages to be displayed to the user if the error is known, otherwise a generic error title and body.
+ * @deprecated use {@link ItwErrorMapping} prototype and implemend your own mapping function directly in the component.
  */
 export const mapItwError = (error: ItWalletError): ItWalletMappedError => {
   switch (error.code) {


### PR DESCRIPTION
## Short description
This PR updates the design system in error screens related to credential issuing and presentation flows. 
It also moves the credential mapping from a monolitic util function to the related screen. 

## List of changes proposed in this pull request
- Adds horizontal padding in `ItwKoView.tsx`;
- Defines a `ItwErrorMapping` function interface type which can be used in screens to implement a dedicated error mapping function; 
- Defines a new `getItwGenerciMappedError` function to get a generic error view;
- Replaces legacy error view to the new `ItwKoView.tsx` in credential issuing and presentation screens; 
- Sets old error mapping functions helpers to deprecated.

Note: this could be improved by strictly type-checking each possible error in a view but that's up for another PR.

## How to test
Test the credential issuing and presentation flow. Errors can be forced from the related sagas or it can be triggered when adding an already existing credential.
