### PR TITLE
feat: [IOCOM-461] Add F24 Mixpanel events

### DIFF
--- a/ts/features/messages/components/MessageAttachmentPreview.tsx
+++ b/ts/features/messages/components/MessageAttachmentPreview.tsx
@@ -32,7 +32,7 @@ import { confirmButtonProps } from "../../bonus/bonusVacanze/components/buttons/
 type Props = {
   messageId: UIMessageId;
   attachment: UIAttachment;
-  skipDownloadAttachment?: boolean;
+  enableDownloadAttachment?: boolean;
   onLoadComplete?: () => void;
   onPDFError?: () => void;
   onShare?: () => void;
@@ -79,7 +79,7 @@ const renderError = (title: string, body: string) => (
 const renderPDF = (
   downloadPath: string,
   isPDFError: boolean,
-  props: Omit<Props, "skipDownloadAttachment">,
+  props: Omit<Props, "enableDownloadAttachment">,
   onPDFLoadingError: () => void
 ) => (
   <>
@@ -183,7 +183,7 @@ const renderFooter = (
   );
 
 export const MessageAttachmentPreview = ({
-  skipDownloadAttachment = true,
+  enableDownloadAttachment = true,
   ...props
 }: Props): React.ReactElement => {
   const dispatch = useIODispatch();
@@ -209,7 +209,7 @@ export const MessageAttachmentPreview = ({
   // blob data is present or if there was a previous error in
   // downloading the data
   const shouldDownloadAttachment =
-    skipDownloadAttachment &&
+    enableDownloadAttachment &&
     isFirstRendering.current &&
     (isStrictNone(downloadPot) || pot.isError(downloadPot));
 
@@ -226,7 +226,7 @@ export const MessageAttachmentPreview = ({
   // since PN attachments are downloaded before entering this component)
   const customGoBack = useCallback(() => {
     if (
-      skipDownloadAttachment &&
+      enableDownloadAttachment &&
       (pot.isLoading(downloadPot) || pot.isUpdating(downloadPot))
     ) {
       dispatch(cancelPreviousAttachmentDownload());
@@ -234,7 +234,7 @@ export const MessageAttachmentPreview = ({
     // eslint-disable-next-line functional/immutable-data
     autoBackOnErrorHandled.current = true;
     navigation.goBack();
-  }, [downloadPot, dispatch, skipDownloadAttachment, navigation]);
+  }, [downloadPot, dispatch, enableDownloadAttachment, navigation]);
 
   useEffect(() => {
     // eslint-disable-next-line functional/immutable-data
@@ -248,7 +248,7 @@ export const MessageAttachmentPreview = ({
       );
     } else if (
       !autoBackOnErrorHandled.current &&
-      skipDownloadAttachment &&
+      enableDownloadAttachment &&
       pot.isError(downloadPot)
     ) {
       // eslint-disable-next-line functional/immutable-data
@@ -261,7 +261,7 @@ export const MessageAttachmentPreview = ({
     attachment,
     downloadPot,
     dispatch,
-    skipDownloadAttachment,
+    enableDownloadAttachment,
     navigation,
     shouldDownloadAttachment
   ]);

--- a/ts/features/messages/hooks/useAttachmentDownload.tsx
+++ b/ts/features/messages/hooks/useAttachmentDownload.tsx
@@ -105,7 +105,7 @@ export const useAttachmentDownload = (
     const download = pot.toUndefined(downloadPot);
 
     if (pot.isError(downloadPot)) {
-      trackPNAttachmentDownloadFailure();
+      trackPNAttachmentDownloadFailure(attachment.category);
       showToast(i18n.t("messageDetails.attachments.failing.details"));
     } else if (download) {
       const { path, attachment } = download;
@@ -116,7 +116,7 @@ export const useAttachmentDownload = (
         await taskDownloadFileIntoAndroidPublicFolder(attachment, path)();
       }
     }
-  }, [downloadPot, openPreview]);
+  }, [downloadPot, openPreview, attachment.category]);
 
   useEffect(() => {
     const wasLoading = isLoading;

--- a/ts/features/pn/analytics/index.ts
+++ b/ts/features/pn/analytics/index.ts
@@ -88,48 +88,60 @@ export function trackPNAttachmentDownloadFailure() {
   );
 }
 
-export function trackPNAttachmentSave() {
+export function trackPNAttachmentSave(category?: string) {
   void mixpanelTrack(
     "PN_ATTACHMENT_SAVE",
-    buildEventProperties("UX", "action")
+    buildEventProperties("UX", "action", {
+      category
+    })
   );
 }
 
-export function trackPNAttachmentShare() {
+export function trackPNAttachmentShare(category?: string) {
   void mixpanelTrack(
     "PN_ATTACHMENT_SHARE",
-    buildEventProperties("UX", "action")
+    buildEventProperties("UX", "action", {
+      category
+    })
   );
 }
 
-export function trackPNAttachmentSaveShare() {
+export function trackPNAttachmentSaveShare(category?: string) {
   void mixpanelTrack(
     "PN_ATTACHMENT_SAVE_SHARE",
-    buildEventProperties("UX", "action")
+    buildEventProperties("UX", "action", {
+      category
+    })
   );
 }
 
-export function trackPNAttachmentOpen() {
+export function trackPNAttachmentOpen(category?: string) {
   void mixpanelTrack(
     "PN_ATTACHMENT_OPEN",
-    buildEventProperties("UX", "action")
+    buildEventProperties("UX", "action", {
+      category
+    })
   );
 }
 
-export function trackPNAttachmentOpening() {
+export function trackPNAttachmentOpening(category?: string) {
   void mixpanelTrack(
     "PN_ATTACHMENT_OPENING",
-    buildEventProperties("UX", "action")
+    buildEventProperties("UX", "action", {
+      category
+    })
   );
 }
 
 export function trackPNAttachmentOpeningSuccess(
-  previewStatus: "displayer" | "error"
+  previewStatus: "displayer" | "error",
+  category?: string
 ) {
   void mixpanelTrack(
     "PN_ATTACHMENT_OPENING_SUCCESS",
     buildEventProperties("UX", "screen_view", {
-      PREVIEW_STATUS: previewStatus
+      PREVIEW_STATUS: previewStatus,
+      category
     })
   );
 }
@@ -255,4 +267,8 @@ export function trackPNUxSuccess(
       contains_f24: "no"
     })
   );
+}
+
+export function trackPNShowF24() {
+  void mixpanelTrack("PN_SHOW_F24", buildEventProperties("UX", "action"));
 }

--- a/ts/features/pn/analytics/index.ts
+++ b/ts/features/pn/analytics/index.ts
@@ -81,10 +81,12 @@ export const trackPNServiceStatusChangeError = (currentStatus?: boolean) =>
     })
   );
 
-export function trackPNAttachmentDownloadFailure() {
+export function trackPNAttachmentDownloadFailure(category?: string) {
   void mixpanelTrack(
     "PN_ATTACHMENT_DOWNLOAD_FAILURE",
-    buildEventProperties("TECH", undefined)
+    buildEventProperties("TECH", undefined, {
+      category
+    })
   );
 }
 

--- a/ts/features/pn/analytics/index.ts
+++ b/ts/features/pn/analytics/index.ts
@@ -254,7 +254,8 @@ export function legacyTrackPNUxSuccess(
 export function trackPNUxSuccess(
   paymentCount: number,
   firstTimeOpening: boolean,
-  isCancelled: boolean
+  isCancelled: boolean,
+  containsF24: boolean
 ) {
   void mixpanelTrack(
     "PN_UX_SUCCESS",
@@ -264,7 +265,7 @@ export function trackPNUxSuccess(
       notification_status: isCancelled ? "cancelled" : "active",
       contains_multipayment: numberToYesNoOnThreshold(paymentCount, 1),
       count_payment: paymentCount,
-      contains_f24: "no"
+      contains_f24: containsF24
     })
   );
 }

--- a/ts/features/pn/components/MessageDetails.tsx
+++ b/ts/features/pn/components/MessageDetails.tsx
@@ -94,6 +94,7 @@ export const MessageDetails = ({
 
   const maxVisiblePaymentCount = maxVisiblePaymentCountGenerator();
   const scrollViewRef = React.createRef<ScrollView>();
+
   return (
     <>
       <ScrollView
@@ -147,12 +148,12 @@ export const MessageDetails = ({
           presentPaymentsBottomSheetRef={presentPaymentsBottomSheetRef}
         />
 
-        {RA.isNonEmpty(f24List) && (
+        {!isCancelled && RA.isNonEmpty(f24List) ? (
           <>
             <MessageF24 attachments={f24List} openPreview={openAttachment} />
             <VSpacer size={24} />
           </>
-        )}
+        ) : null}
 
         <PnMessageDetailsSection
           title={I18n.t("features.pn.details.infoSection.title")}

--- a/ts/features/pn/components/MessageDetails.tsx
+++ b/ts/features/pn/components/MessageDetails.tsx
@@ -82,7 +82,7 @@ export const MessageDetails = ({
 
   const openAttachment = useCallback(
     (attachment: UIAttachment) => {
-      trackPNAttachmentOpening();
+      trackPNAttachmentOpening(attachment.category);
       NavigationService.navigate(PN_ROUTES.MESSAGE_ATTACHMENT, {
         messageId,
         attachmentId: attachment.id,

--- a/ts/features/pn/components/MessageF24.tsx
+++ b/ts/features/pn/components/MessageF24.tsx
@@ -7,10 +7,11 @@ import {
   VSpacer
 } from "@pagopa/io-app-design-system";
 import I18n from "../../../i18n";
+import { trackPNShowF24 } from "../analytics";
 import { UIAttachment } from "../../../store/reducers/entities/messages/types";
 import { useF24BottomSheet } from "../hooks/useF24BottomSheet";
 import { MessageAttachments } from "../../messages/components/MessageAttachments";
-import { PnMessageDetailsSection } from "./PnMessageDetailsSection";
+import { MessageDetailsSection } from "./MessageDetailsSection";
 
 type Props = {
   attachments: ReadonlyArray<UIAttachment>;
@@ -39,7 +40,10 @@ const MessageF24Content = ({ attachments, openPreview }: Props) => {
         <ButtonLink
           accessibilityLabel={showAllLabel}
           label={showAllLabel}
-          onPress={present}
+          onPress={() => {
+            trackPNShowF24();
+            present();
+          }}
         />
       </View>
       {bottomSheet}
@@ -48,7 +52,7 @@ const MessageF24Content = ({ attachments, openPreview }: Props) => {
 };
 
 export const MessageF24 = (props: Props) => (
-  <PnMessageDetailsSection
+  <MessageDetailsSection
     title={I18n.t("features.pn.details.f24Section.title")}
     testID={"pn-f24-section"}
   >
@@ -58,5 +62,5 @@ export const MessageF24 = (props: Props) => (
     </Body>
     <VSpacer />
     <MessageF24Content {...props} />
-  </PnMessageDetailsSection>
+  </MessageDetailsSection>
 );

--- a/ts/features/pn/screens/AttachmentPreviewScreen.tsx
+++ b/ts/features/pn/screens/AttachmentPreviewScreen.tsx
@@ -23,7 +23,7 @@ import { isIos } from "../../../utils/platform";
 export type AttachmentPreviewScreenNavigationParams = Readonly<{
   messageId: UIMessageId;
   attachmentId: UIAttachmentId;
-  category: string;
+  category?: string;
 }>;
 
 type AttachmentPreviewScreenProps = IOStackNavigationRouteProps<
@@ -35,7 +35,7 @@ export const AttachmentPreviewScreen = ({
   navigation,
   route
 }: AttachmentPreviewScreenProps) => {
-  const { messageId, attachmentId } = route.params;
+  const { messageId, attachmentId, category } = route.params;
   // This ref is needed otherwise the auto back on the useEffect will fire multiple
   // times, since its dependencies change during the back navigation
   const autoBackOnErrorHandled = useRef(false);
@@ -56,15 +56,23 @@ export const AttachmentPreviewScreen = ({
   return O.isSome(maybePnMessageAttachment) ? (
     <MessageAttachmentPreview
       messageId={messageId}
-      skipDownloadAttachment={false}
+      enableDownloadAttachment={false}
       attachment={maybePnMessageAttachment.value}
-      onOpen={trackPNAttachmentOpen}
+      onOpen={() => trackPNAttachmentOpen(category)}
       onShare={() =>
-        pipe(isIos, B.fold(trackPNAttachmentShare, trackPNAttachmentSaveShare))
+        pipe(
+          isIos,
+          B.fold(
+            () => trackPNAttachmentShare(category),
+            () => trackPNAttachmentSaveShare(category)
+          )
+        )
       }
-      onDownload={trackPNAttachmentSave}
-      onLoadComplete={() => trackPNAttachmentOpeningSuccess("displayer")}
-      onPDFError={() => trackPNAttachmentOpeningSuccess("error")}
+      onDownload={() => trackPNAttachmentSave(category)}
+      onLoadComplete={() =>
+        trackPNAttachmentOpeningSuccess("displayer", category)
+      }
+      onPDFError={() => trackPNAttachmentOpeningSuccess("error", category)}
     />
   ) : (
     <></>

--- a/ts/features/pn/screens/MessageDetailsScreen.tsx
+++ b/ts/features/pn/screens/MessageDetailsScreen.tsx
@@ -26,6 +26,7 @@ import { NotificationPaymentInfo } from "../../../../definitions/pn/Notification
 import { cancelPreviousAttachmentDownload } from "../../../store/actions/messages";
 import { profileFiscalCodeSelector } from "../../../store/reducers/profile";
 import {
+  containsF24FromPNMessagePot,
   isCancelledFromPNMessagePot,
   paymentsFromPNMessagePot
 } from "../utils";
@@ -83,7 +84,6 @@ export const MessageDetailsScreen = (
 
   const dispatch = useIODispatch();
   const navigation = useNavigation();
-  const uxEventTracked = React.useRef(false);
 
   const service = pot.toUndefined(
     useIOSelector(state => serviceByIdSelector(serviceId)(state)) ?? pot.none
@@ -109,13 +109,21 @@ export const MessageDetailsScreen = (
     loadContent();
   });
 
-  if (!uxEventTracked.current && isStrictSome(message)) {
-    // eslint-disable-next-line functional/immutable-data
-    uxEventTracked.current = true;
-    const paymentCount = payments?.length ?? 0;
-    const isCancelled = isCancelledFromPNMessagePot(message);
-    trackPNUxSuccess(paymentCount, firstTimeOpening, isCancelled);
-  }
+  useOnFirstRender(
+    () => {
+      const paymentCount = payments?.length ?? 0;
+      const isCancelled = isCancelledFromPNMessagePot(message);
+      const containsF24 = containsF24FromPNMessagePot(message);
+
+      trackPNUxSuccess(
+        paymentCount,
+        firstTimeOpening,
+        isCancelled,
+        containsF24
+      );
+    },
+    () => isStrictSome(message)
+  );
 
   const store = useStore();
   useFocusEffect(

--- a/ts/features/pn/screens/PnAttachmentPreview.tsx
+++ b/ts/features/pn/screens/PnAttachmentPreview.tsx
@@ -54,7 +54,7 @@ export const PnAttachmentPreview = (
   return O.isSome(maybePnMessageAttachment) ? (
     <MessageAttachmentPreview
       messageId={messageId}
-      skipDownloadAttachment={false}
+      enableDownloadAttachment={false}
       attachment={maybePnMessageAttachment.value}
       onOpen={trackPNAttachmentOpen}
       onShare={() =>

--- a/ts/features/pn/utils/index.ts
+++ b/ts/features/pn/utils/index.ts
@@ -144,8 +144,7 @@ export const containsF24FromPNMessagePot = (
     pot.getOrElse(potMessage, O.none),
     O.chainNullableK(message => message.attachments),
     O.getOrElse<ReadonlyArray<UIAttachment>>(() => []),
-    RA.findFirst(attachment => attachment.category === ATTACHMENT_CATEGORY.F24),
-    O.isSome
+    RA.some(attachment => attachment.category === ATTACHMENT_CATEGORY.F24)
   );
 
 export const initializeAndNavigateToWalletForPayment = (

--- a/ts/features/pn/utils/index.ts
+++ b/ts/features/pn/utils/index.ts
@@ -18,6 +18,8 @@ import { paymentInitializeState } from "../../../store/actions/wallet/payment";
 import NavigationService from "../../../navigation/NavigationService";
 import ROUTES from "../../../navigation/routes";
 import { setSelectedPayment } from "../store/actions";
+import { ATTACHMENT_CATEGORY } from "../../messages/types/attachmentCategory";
+import { UIAttachment } from "../../../store/reducers/entities/messages/types";
 
 export function getNotificationStatusInfo(status: NotificationStatus) {
   return I18n.t(`features.pn.details.timeline.status.${status}`, {
@@ -133,6 +135,17 @@ export const isCancelledFromPNMessagePot = (
     pot.getOrElse(potMessage, O.none),
     O.chainNullableK(message => message.isCancelled),
     O.getOrElse(() => false)
+  );
+
+export const containsF24FromPNMessagePot = (
+  potMessage: pot.Pot<O.Option<PNMessage>, Error>
+) =>
+  pipe(
+    pot.getOrElse(potMessage, O.none),
+    O.chainNullableK(message => message.attachments),
+    O.getOrElse<ReadonlyArray<UIAttachment>>(() => []),
+    RA.findFirst(attachment => attachment.category === ATTACHMENT_CATEGORY.F24),
+    O.isSome
   );
 
 export const initializeAndNavigateToWalletForPayment = (


### PR DESCRIPTION
## Short description
This PR adds F24 Mixpanel events

## List of changes proposed in this pull request
- added the `category` property to the events:
    - `PN_ATTACHMENT_OPENING`
    - `PN_ATTACHMENT_OPENING_SUCCESS`
    - `PN_ATTACHMENT_SHARE`
    - `PN_ATTACHMENT_SAVE`
    - `PN_ATTACHMENT_OPEN`
    - `PN_ATTACHMENT_SAVE_SHARE`
    - `PN_ATTACHMENT_DOWNLOAD_FAILURE`
- added event: `PN_SHOW_F24`
- added `contains_f24` property to `PN_UX_SUCCESS`
- renamed `skipDownloadAttachment` to `enableDownloadAttachment`

## How to test
Using `io-dev-api-server`, check that events are generated with the correct properties
