### PR TITLE
fix: [IOBP-388] Android back button while success outcome payment screen showed

### DIFF
--- a/ts/navigation/WalletNavigator.tsx
+++ b/ts/navigation/WalletNavigator.tsx
@@ -182,6 +182,7 @@ const WalletNavigator = () => {
         component={AddCreditCardOutcomeCodeMessage}
       />
       <Stack.Screen
+        options={{ gestureEnabled: false }}
         name={ROUTES.PAYMENT_OUTCOMECODE_MESSAGE}
         component={PaymentOutcomeCodeMessage}
       />

--- a/ts/screens/wallet/payment/PaymentOutcomeCodeMessage.tsx
+++ b/ts/screens/wallet/payment/PaymentOutcomeCodeMessage.tsx
@@ -30,6 +30,7 @@ import { formatNumberCentsToAmount } from "../../../utils/stringBuilder";
 import { openWebUrl } from "../../../utils/url";
 import { mixpanelTrack } from "../../../mixpanel";
 import { backToEntrypointPayment } from "../../../store/actions/wallet/payment";
+import { useAvoidHardwareBackButton } from "../../../utils/useAvoidHardwareBackButton";
 
 export type PaymentOutcomeCodeMessageNavigationParams = Readonly<{
   fee: ImportoEuroCents;
@@ -131,6 +132,8 @@ const PaymentOutcomeCodeMessage: React.FC<Props> = (props: Props) => {
   const outcomeCode = O.toNullable(props.outcomeCode.outcomeCode);
   const learnMoreLink = "https://io.italia.it/faq/#pagamenti";
   const onLearnMore = () => openWebUrl(learnMoreLink);
+
+  useAvoidHardwareBackButton();
 
   const renderSuccessComponent = () => {
     if (pot.isSome(props.verifica)) {


### PR DESCRIPTION
## Short description
This PR fixes the strange behavior while pressing the android hardware back button while in success outcome payment screen showing an actionsheet to cancel the payment.

## List of changes proposed in this pull request
- Disabled the hardware back button into `PaymentOutcomeCodeMessage` screen;

## How to test
Complete a payment and when you reach the outcome success page, try to press the hardware back button on android

##Preview
|Before|After|
|-|-|
|<video src="https://github.com/pagopa/io-app/assets/34343582/c326d1e9-cfbf-426e-ae86-44ade62d13a0" />| <video src="https://github.com/pagopa/io-app/assets/34343582/534d31a4-4b4e-4a1e-a14f-1a0a8c791c35" />|


