### PR TITLE
feat: [IOPID-987] Add contextual help content

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -675,6 +675,8 @@ authentication:
     contentTitle: Don't have SPID?
     subtitle: SPID is safe
   opt-in:
+    contextualHelpTitle: Authentication
+    contextualHelpContent: Here you can find information on how to authenticate on IO and some security tips.
     news: News
     title: It's now faster to log into IO
     identity-check: You'll need to log in with SPID or CIE only once a year, or in case you log out.

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -675,6 +675,8 @@ authentication:
     contentTitle: Cos'è SPID?
     subtitle: SPID è sicuro
   opt-in:
+    contextualHelpTitle: Autenticazione
+    contextualHelpContent: Qui puoi trovare le informazioni sulle modalità di autenticazione su IO e alcuni consigli di sicurezza.
     news: novità
     title: Da oggi accedi a IO più velocemente
     identity-check: Ti chiederemo di autenticarti con SPID o CIE solo una volta all’anno o se ti disconnetti dall’app.

--- a/ts/screens/authentication/NewOptInScreen.tsx
+++ b/ts/screens/authentication/NewOptInScreen.tsx
@@ -28,8 +28,8 @@ import { TranslationKeys } from "../../../locales/locales";
 
 // FIXME -> insert correct contextual help and FAQ https://pagopa.atlassian.net/browse/IOPID-987
 const contextualHelpMarkdown: ContextualHelpPropsMarkdown = {
-  title: "authentication.landing.contextualHelpTitle",
-  body: "authentication.landing.contextualHelpContent"
+  title: "authentication.opt-in.contextualHelpTitle",
+  body: "authentication.opt-in.contextualHelpContent"
 };
 
 export type ChosenIdentifier = {

--- a/ts/screens/authentication/NewOptInScreen.tsx
+++ b/ts/screens/authentication/NewOptInScreen.tsx
@@ -26,7 +26,6 @@ import { setFastLoginOptIn } from "../../features/fastLogin/store/actions/optInA
 import { useIODispatch } from "../../store/hooks";
 import { TranslationKeys } from "../../../locales/locales";
 
-// FIXME -> insert correct contextual help and FAQ https://pagopa.atlassian.net/browse/IOPID-987
 const contextualHelpMarkdown: ContextualHelpPropsMarkdown = {
   title: "authentication.opt-in.contextualHelpTitle",
   body: "authentication.opt-in.contextualHelpContent"


### PR DESCRIPTION
## Short description
Add contextual help content 

https://github.com/pagopa/io-app/assets/83651704/e7edc293-a09d-4d8d-ae59-b998a1256429


## List of changes proposed in this pull request
- Add texts 
- Integrate texts

## How to test
In **.env file**  `FAST_LOGIN_ENABLED=YES` and `FAST_LOGIN_OPTIN=YES`
in io-dev-server-api in backend.ts file:

```ts
fastLogin: {
  min_app_version: {
    ios: "1.2.1",
    android: "0.0.0"
  },
  opt_in: {
    min_app_version: {
      ios: "1.2.1", 
      android: "0.0.0"
    }
  }
}
```
NB: if fastLogin is disabled (`0.0.0`) the opt-in is disabled too, but not the reverse. 
Run the application

