### PR TITLE
fix: [PE-494] CGN test ids for e2e tests

### DIFF
--- a/ts/features/bonus/cgn/screens/activation/CgnAlreadyActiveScreen.tsx
+++ b/ts/features/bonus/cgn/screens/activation/CgnAlreadyActiveScreen.tsx
@@ -34,7 +34,8 @@ const CgnAlreadyActiveScreen = (props: Props): React.ReactElement => (
           buttonProps: {
             onPress: props.navigateToDetail,
             label: I18n.t("bonus.cgn.cta.goToDetail"),
-            accessibilityLabel: I18n.t("bonus.cgn.cta.goToDetail")
+            accessibilityLabel: I18n.t("bonus.cgn.cta.goToDetail"),
+            testID: "cgnConfirmButtonTestId"
           }
         }}
       />


### PR DESCRIPTION
## Short description
This PR fixes some CGN e2e test regression after the massive refactor adding a missing test id to a button.

## List of changes proposed in this pull request
- Added a missing test id to a button