### PR TITLE
feat: [IOCOM-667] Failure logging for messages' sagas

### DIFF
--- a/ts/features/messages/analytics/index.ts
+++ b/ts/features/messages/analytics/index.ts
@@ -163,3 +163,57 @@ export function trackNotificationRejected(tag: MessageCategory["tag"]) {
     buildEventProperties("UX", "exit")
   );
 }
+
+export function trackLoadMessageByIdFailure(reason: string) {
+  void mixpanelTrack(
+    "FAILURE_LOAD_MESSAGE_BY_ID",
+    buildEventProperties("TECH", undefined, {
+      reason
+    })
+  );
+}
+
+export function trackLoadMessageDetailsFailure(reason: string) {
+  void mixpanelTrack(
+    "FAILURE_LOAD_MESSAGE_DETAILS",
+    buildEventProperties("TECH", undefined, {
+      reason
+    })
+  );
+}
+
+export function trackLoadNextPageMessagesFailure(reason: string) {
+  void mixpanelTrack(
+    "FAILURE_LOAD_NEXT_PAGE_MESSAGES",
+    buildEventProperties("TECH", undefined, {
+      reason
+    })
+  );
+}
+
+export function trackLoadPreviousPageMessagesFailure(reason: string) {
+  void mixpanelTrack(
+    "FAILURE_LOAD_PREVIOUS_PAGE_MESSAGES",
+    buildEventProperties("TECH", undefined, {
+      reason
+    })
+  );
+}
+
+export function trackReloadAllMessagesFailure(reason: string) {
+  void mixpanelTrack(
+    "FAILURE_RELOAD_ALL_MESSAGES",
+    buildEventProperties("TECH", undefined, {
+      reason
+    })
+  );
+}
+
+export function trackUpsertMessageStatusAttributesFailure(reason: string) {
+  void mixpanelTrack(
+    "FAILURE_UPSERT_MESSAGE_STATUS_ATTRIBUTES",
+    buildEventProperties("TECH", undefined, {
+      reason
+    })
+  );
+}

--- a/ts/features/messages/utils/index.ts
+++ b/ts/features/messages/utils/index.ts
@@ -1,0 +1,10 @@
+import { pipe } from "fp-ts/lib/function";
+import { NetworkError, getNetworkError } from "../../../utils/errors";
+
+const networkErrorToError = (networkError: NetworkError) =>
+  networkError.kind === "timeout" ? new Error("timeout") : networkError.value;
+
+export const errorToReason = (error: Error) => error.message;
+
+export const unknownToReason = (e: unknown) =>
+  pipe(e, getNetworkError, networkErrorToError, error => error.message);

--- a/ts/features/messages/utils/index.ts
+++ b/ts/features/messages/utils/index.ts
@@ -7,4 +7,4 @@ const networkErrorToError = (networkError: NetworkError) =>
 export const errorToReason = (error: Error) => error.message;
 
 export const unknownToReason = (e: unknown) =>
-  pipe(e, getNetworkError, networkErrorToError, error => error.message);
+  pipe(e, getNetworkError, networkErrorToError, errorToReason);

--- a/ts/sagas/messages/watchLoadMessageById.ts
+++ b/ts/sagas/messages/watchLoadMessageById.ts
@@ -8,6 +8,8 @@ import { toUIMessage } from "../../store/reducers/entities/messages/transformers
 import { CreatedMessageWithContentAndAttachments } from "../../../definitions/backend/CreatedMessageWithContentAndAttachments";
 import { withRefreshApiCall } from "../../features/fastLogin/saga/utils";
 import { SagaCallReturnType } from "../../types/utils";
+import { errorToReason, unknownToReason } from "../../features/messages/utils";
+import { trackLoadMessageByIdFailure } from "../../features/messages/analytics";
 import { handleResponse } from "./utils";
 
 type LocalActionType = ActionType<(typeof loadMessageById)["request"]>;
@@ -36,12 +38,18 @@ function* handleLoadMessageById(
       response,
       (message: CreatedMessageWithContentAndAttachments) =>
         loadMessageById.success(toUIMessage(message)),
-      error => loadMessageById.failure({ id, error })
+      error => {
+        const reason = errorToReason(error);
+        trackLoadMessageByIdFailure(reason);
+        return loadMessageById.failure({ id, error });
+      }
     );
     if (nextAction) {
       yield* put(nextAction);
     }
   } catch (e) {
+    const reason = unknownToReason(e);
+    trackLoadMessageByIdFailure(reason);
     yield* put(
       loadMessageById.failure({ id, error: convertUnknownToError(e) })
     );

--- a/ts/sagas/messages/watchLoadPreviousPageMessages.ts
+++ b/ts/sagas/messages/watchLoadPreviousPageMessages.ts
@@ -8,6 +8,8 @@ import { PaginatedPublicMessagesCollection } from "../../../definitions/backend/
 import { isTestEnv } from "../../utils/environment";
 import { convertUnknownToError, getError } from "../../utils/errors";
 import { withRefreshApiCall } from "../../features/fastLogin/saga/utils";
+import { errorToReason, unknownToReason } from "../../features/messages/utils";
+import { trackLoadPreviousPageMessagesFailure } from "../../features/messages/analytics";
 import { handleResponse } from "./utils";
 
 type LocalActionType = ActionType<
@@ -48,17 +50,22 @@ function tryLoadPreviousPageMessages(getMessages: LocalBeClient) {
             pagination: { previous: prev },
             filter
           }),
-        error =>
-          loadPreviousPageMessagesAction.failure({
+        error => {
+          const reason = errorToReason(error);
+          trackLoadPreviousPageMessagesFailure(reason);
+          return loadPreviousPageMessagesAction.failure({
             error: getError(error),
             filter
-          })
+          });
+        }
       );
 
       if (nextAction) {
         yield* put(nextAction);
       }
     } catch (e) {
+      const reason = unknownToReason(e);
+      trackLoadPreviousPageMessagesFailure(reason);
       yield* put(
         loadPreviousPageMessagesAction.failure({
           error: convertUnknownToError(e),


### PR DESCRIPTION
## Short description
This PR adds some error logging to messages sagas.

## List of changes proposed in this pull request
Following sagas generate an analytics event when failing:
- watchLoadMessageById
- watchLoadMessageDetails
- watchLoadNextPageMessages
- watchLoadPreviousPageMessages
- watchReloadAllMessages
- watchUpsertMessageStatusAttribues

## How to test
Using the io-dev-api-server, check that failure events are reported with proper `reason` status.
