### PR TITLE
chore(IT Wallet): [SIW-624] Add navigation to missing feature screen

### DIFF
--- a/ts/features/it-wallet/screens/credential/ItwCredentialDetailsScreen.tsx
+++ b/ts/features/it-wallet/screens/credential/ItwCredentialDetailsScreen.tsx
@@ -8,7 +8,6 @@ import {
 } from "@pagopa/io-app-design-system";
 import { ScrollView } from "react-native-gesture-handler";
 import { SafeAreaView, View } from "react-native";
-import { constNull } from "fp-ts/lib/function";
 import ItwCredentialCard from "../../components/ItwCredentialCard";
 import { IOStyles } from "../../../../components/core/variables/IOStyles";
 import BaseScreenComponent from "../../../../components/screens/BaseScreenComponent";
@@ -82,7 +81,9 @@ const ItwCredentialDetailsScreen = () => {
               action={I18n.t(
                 "features.itWallet.issuing.credentialPreviewScreen.banner.actionTitle"
               )}
-              onPress={constNull}
+              onPress={() =>
+                navigation.navigate(ITW_ROUTES.GENERIC.NOT_AVAILABLE)
+              }
             />
             <VSpacer size={32} />
           </ScrollView>

--- a/ts/features/it-wallet/screens/credential/ItwCredentialDetailsScreen.tsx
+++ b/ts/features/it-wallet/screens/credential/ItwCredentialDetailsScreen.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { RouteProp, useRoute } from "@react-navigation/native";
+import { RouteProp, useNavigation, useRoute } from "@react-navigation/native";
 import {
   Banner,
   BlockButtonProps,
@@ -17,6 +17,8 @@ import { emptyContextualHelp } from "../../../../utils/emptyContextualHelp";
 import { ItwParamsList } from "../../navigation/ItwParamsList";
 import ItwCredentialClaimsList from "../../components/ItwCredentialClaimsList";
 import { StoredCredential } from "../../store/reducers/itwCredentialsReducer";
+import { IOStackNavigationProp } from "../../../../navigation/params/AppParamsList";
+import { ITW_ROUTES } from "../../navigation/ItwRoutes";
 
 export type ItwCredentialDetailsScreenNavigationParams = {
   credential: StoredCredential;
@@ -32,6 +34,7 @@ type ItwCredentialDetailscreenRouteProps = RouteProp<
  */
 const ItwCredentialDetailsScreen = () => {
   const route = useRoute<ItwCredentialDetailscreenRouteProps>();
+  const navigation = useNavigation<IOStackNavigationProp<ItwParamsList>>();
   const { credential } = route.params;
   const bannerViewRef = React.createRef<View>();
 
@@ -49,7 +52,7 @@ const ItwCredentialDetailsScreen = () => {
         accessibilityLabel: I18n.t(
           "features.itWallet.presentation.credentialDetails.buttons.qrCode"
         ),
-        onPress: () => null
+        onPress: () => navigation.navigate(ITW_ROUTES.GENERIC.NOT_AVAILABLE)
       }
     };
 

--- a/ts/features/it-wallet/screens/credential/ItwPidDetails.tsx
+++ b/ts/features/it-wallet/screens/credential/ItwPidDetails.tsx
@@ -21,6 +21,7 @@ import ItwPidClaimsList from "../../components/ItwPidClaimsList";
 import { BlockButtonProps } from "../../../../components/ui/BlockButtons";
 import ItwCredentialCard from "../../components/ItwCredentialCard";
 import { pidDisplayData } from "../../utils/mocks";
+import { ITW_ROUTES } from "../../navigation/ItwRoutes";
 
 export type ContentViewParams = {
   decodedPid: PidWithToken;
@@ -41,7 +42,7 @@ const ItwPidDetails = () => {
     ),
     iconName: "qrCode",
     iconColor: "white",
-    onPress: () => null
+    onPress: () => navigation.navigate(ITW_ROUTES.GENERIC.NOT_AVAILABLE)
   };
 
   const ContentView = ({ decodedPid }: ContentViewParams) => (
@@ -59,7 +60,9 @@ const ItwPidDetails = () => {
             claims={["givenName", "familyName", "taxIdCode"]}
             expiryDate
             securityLevel
-            onLinkPress={() => null}
+            onLinkPress={() =>
+              navigation.navigate(ITW_ROUTES.GENERIC.NOT_AVAILABLE)
+            }
             issuerInfo
           />
           <VSpacer size={spacerSize} />

--- a/ts/features/it-wallet/screens/issuing/ItwPidPreviewScreen.tsx
+++ b/ts/features/it-wallet/screens/issuing/ItwPidPreviewScreen.tsx
@@ -96,7 +96,9 @@ const ItwPidPreviewScreen = () => {
               claims={["givenName", "familyName", "taxIdCode"]}
               expiryDate
               securityLevel
-              onLinkPress={() => null}
+              onLinkPress={() =>
+                navigation.navigate(ITW_ROUTES.GENERIC.NOT_AVAILABLE)
+              }
               issuerInfo
             />
             <VSpacer />
@@ -123,7 +125,9 @@ const ItwPidPreviewScreen = () => {
               label={I18n.t(
                 "features.itWallet.verifiableCredentials.unrecognizedData.cta"
               )}
-              onPress={() => null}
+              onPress={() =>
+                navigation.navigate(ITW_ROUTES.GENERIC.NOT_AVAILABLE)
+              }
             />
             <VSpacer />
           </View>


### PR DESCRIPTION
## Short description
This PR adds a navigation to the missing feature screen where a feature is not implemented yet.

## List of changes proposed in this pull request
- Adds the navigation in [ItwCredentialDetailsScreen.tsx](https://github.com/pagopa/io-app/pull/5228/files#diff-94e935f2d7d760954fd0c0647b59f32cd163d70dac988b5588a985aadef0689b) when pressing the `Show QR Code` button and the banner;
- Adds the navigation in [ItwPidDetails.tsx](https://github.com/pagopa/io-app/pull/5228/files#diff-94e935f2d7d760954fd0c0647b59f32cd163d70dac988b5588a985aadef0689b) on the `Show QR Code` button and when tapping on the security level;
- Adds the navigation in [ts/features/it-wallet/screens/issuing/ItwPidPreviewScreen.tsx](https://github.com/pagopa/io-app/pull/5228/files#diff-1efa65eedbb4bea4a8d61f1d909912fa8a94af60a4df438f01730c624c2c9fca) when tapping on the security level.

## How to test
Check if the navigation happens properly in the aformentioned screens. Also check if there's any other unresponsive pressable element in any ITW related flow.