### PR TITLE
fix(IT Wallet): [SIW-695] Fix credentials issuing checks error navigation

### DIFF
--- a/ts/features/it-wallet/screens/credential/issuing/ItwCredentialsCatalogScreen.tsx
+++ b/ts/features/it-wallet/screens/credential/issuing/ItwCredentialsCatalogScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect } from "react";
 import { FlatList, SafeAreaView, View } from "react-native";
 import {
   Badge,
@@ -38,6 +38,11 @@ const ItwCredentialCatalogScreen = () => {
   const [loadingIndex, setLoadingIndex] = React.useState<number>(NONE_LOADING);
   const catalog = getCredentialsCatalog();
 
+  const navigateToResultScreen = useCallback(() => {
+    navigation.navigate(ITW_ROUTES.CREDENTIAL.ISSUING.CHECKS);
+    setLoadingIndex(NONE_LOADING);
+  }, [navigation]);
+
   /**
    * Side effect to navigate to the credential checks screen when the preliminaryChecks pot
    * transitions to a non loading state and not none state.
@@ -51,15 +56,10 @@ const ItwCredentialCatalogScreen = () => {
    * when the user goes back from the credential checks screen.
    */
   useEffect(() => {
-    if (
-      loadingIndex !== NONE_LOADING &&
-      !pot.isLoading(preliminaryChecks) &&
-      !pot.isNone(preliminaryChecks)
-    ) {
-      setLoadingIndex(-1);
-      navigation.navigate(ITW_ROUTES.CREDENTIAL.ISSUING.CHECKS);
+    if (loadingIndex !== NONE_LOADING && !pot.isLoading(preliminaryChecks)) {
+      navigateToResultScreen();
     }
-  }, [loadingIndex, navigation, preliminaryChecks]);
+  }, [loadingIndex, navigateToResultScreen, preliminaryChecks]);
 
   const onCredentialSelect = ({
     type: credentialType,

--- a/ts/features/it-wallet/screens/credential/issuing/ItwCredentialsCatalogScreen.tsx
+++ b/ts/features/it-wallet/screens/credential/issuing/ItwCredentialsCatalogScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useEffect } from "react";
 import { FlatList, SafeAreaView, View } from "react-native";
 import {
   Badge,
@@ -38,11 +38,6 @@ const ItwCredentialCatalogScreen = () => {
   const [loadingIndex, setLoadingIndex] = React.useState<number>(NONE_LOADING);
   const catalog = getCredentialsCatalog();
 
-  const navigateToResultScreen = useCallback(() => {
-    navigation.navigate(ITW_ROUTES.CREDENTIAL.ISSUING.CHECKS);
-    setLoadingIndex(NONE_LOADING);
-  }, [navigation]);
-
   /**
    * Side effect to navigate to the credential checks screen when the preliminaryChecks pot
    * transitions to a non loading state and not none state.
@@ -57,9 +52,10 @@ const ItwCredentialCatalogScreen = () => {
    */
   useEffect(() => {
     if (loadingIndex !== NONE_LOADING && !pot.isLoading(preliminaryChecks)) {
-      navigateToResultScreen();
+      navigation.navigate(ITW_ROUTES.CREDENTIAL.ISSUING.CHECKS);
+      setLoadingIndex(NONE_LOADING);
     }
-  }, [loadingIndex, navigateToResultScreen, preliminaryChecks]);
+  }, [loadingIndex, navigation, preliminaryChecks]);
 
   const onCredentialSelect = ({
     type: credentialType,


### PR DESCRIPTION
## Short description
This PR proposes a fix for the credential catalog screen not navigating to the checks result screen on error.
The issue comes from the condition on the navigation `pot.isNone` which evaluates to true when the pot is in `NoneError` state, thus preventing the navigation to the result screen. 

## List of changes proposed in this pull request
- Removes the `pot.isNone` condition leaving only `pot.isLoading`. This is sufficient because we only want to navigate when the pot is not in a loading state and the loading index is not `-1`. 
If the pot is `none`, when the user opens the catalog, the condition will still fail due to the loading index being none. 
If the pot is `noneError` after the user selects a credential, then the navigation happens due to the loading index being different from none. However, if the pot is `noneError` because an error occurred and the user lands again in the credential catalog, the navigation won't happen because the loading index is being none.

## How to test
Check if obtaining a credential still works properly and also check if the "already existing credential" error is shown.
