### PR TITLE
chore(IT Wallet): [SIW-693,SIW-691] Add released by and issued by claims bottom sheet

### DIFF
--- a/ts/features/it-wallet/screens/issuing/credential/ItwCredentialPreviewScreen.tsx
+++ b/ts/features/it-wallet/screens/issuing/credential/ItwCredentialPreviewScreen.tsx
@@ -21,7 +21,6 @@ import { ItwParamsList } from "../../../navigation/ItwParamsList";
 import { IOStackNavigationProp } from "../../../../../navigation/params/AppParamsList";
 import { useIODispatch, useIOSelector } from "../../../../../store/hooks";
 import ItwCredentialClaimsList from "../../../components/ItwCredentialClaimsList";
-import { useItwInfoBottomSheet } from "../../../hooks/useItwInfoBottomSheet";
 import { showCancelAlert } from "../../../utils/alert";
 import ROUTES from "../../../../../navigation/routes";
 import ItwKoView from "../../../components/ItwKoView";
@@ -31,15 +30,13 @@ import {
   itwConfirmStoreCredential,
   itwIssuanceGetCredential
 } from "../../../store/actions/new/itwIssuanceActions";
-import {
-  itwIssuanceResultDataSelector,
-  itwIssuanceResultSelector
-} from "../../../store/reducers/new/itwIssuanceReducer";
+import { itwIssuanceResultSelector } from "../../../store/reducers/new/itwIssuanceReducer";
 import { ItWalletError } from "../../../utils/errors/itwErrors";
 import ItwLoadingSpinnerOverlay from "../../../components/ItwLoadingSpinnerOverlay";
 import { ForceScrollDownView } from "../../../../../components/ForceScrollDownView";
 import ItwFooterVerticalButtons from "../../../components/ItwFooterVerticalButtons";
 import { StoredCredential } from "../../../store/reducers/itwCredentialsReducer";
+import { ITW_ROUTES } from "../../../navigation/ItwRoutes";
 
 /**
  * Renders a preview screen which displays a visual representation and the claims contained in the credential.
@@ -47,7 +44,6 @@ import { StoredCredential } from "../../../store/reducers/itwCredentialsReducer"
 const ItwCredentialPreviewScreen = () => {
   const navigation = useNavigation<IOStackNavigationProp<ItwParamsList>>();
   const issuanceResult = useIOSelector(itwIssuanceResultSelector);
-  const issuanceResultData = useIOSelector(itwIssuanceResultDataSelector);
   const bannerViewRef = React.createRef<View>();
   const toast = useIOToast();
   const dispatch = useIODispatch();
@@ -57,39 +53,6 @@ const ItwCredentialPreviewScreen = () => {
    */
   useOnFirstRender(() => {
     dispatch(itwIssuanceGetCredential.request());
-  });
-
-  /**
-   * Bottom sheet with the issuer information.
-   */
-  const { present, bottomSheet } = useItwInfoBottomSheet({
-    title: pipe(
-      issuanceResultData,
-      O.fold(
-        () => I18n.t("features.itWallet.generic.placeholders.organizationName"),
-        some =>
-          some.issuerConf.federation_entity.organization_name ||
-          I18n.t("features.itWallet.generic.placeholders.organizationName")
-      )
-    ),
-    content: [
-      {
-        title: I18n.t(
-          "features.itWallet.issuing.credentialPreviewScreen.bottomSheet.about.title"
-        ),
-        body: I18n.t(
-          "features.itWallet.issuing.credentialPreviewScreen.bottomSheet.about.subtitle"
-        )
-      },
-      {
-        title: I18n.t(
-          "features.itWallet.issuing.credentialPreviewScreen.bottomSheet.data.title"
-        ),
-        body: I18n.t(
-          "features.itWallet.issuing.credentialPreviewScreen.bottomSheet.data.subtitle"
-        )
-      }
-    ]
   });
 
   /**
@@ -166,7 +129,9 @@ const ItwCredentialPreviewScreen = () => {
                 action={I18n.t(
                   "features.itWallet.issuing.credentialPreviewScreen.banner.actionTitle"
                 )}
-                onPress={present}
+                onPress={() =>
+                  navigation.navigate(ITW_ROUTES.GENERIC.NOT_AVAILABLE)
+                }
               />
               <VSpacer size={32} />
             </View>
@@ -204,31 +169,27 @@ const ItwCredentialPreviewScreen = () => {
     </ItwLoadingSpinnerOverlay>
   );
 
-  const RenderMask = pot.fold(
-    issuanceResult,
-    () => <LoadingView />,
-    () => <LoadingView />,
-    () => <ErrorView />,
-    () => <ErrorView />,
-    data =>
-      pipe(
-        data,
-        O.fold(
-          () => <ErrorView />,
-          some => <ContentView data={some} />
-        )
-      ),
-    () => <LoadingView />,
-    () => <ErrorView />,
-    (_, error) => <ErrorView error={error} />
-  );
+  const RenderMask = () =>
+    pot.fold(
+      issuanceResult,
+      () => <LoadingView />,
+      () => <LoadingView />,
+      () => <ErrorView />,
+      () => <ErrorView />,
+      data =>
+        pipe(
+          data,
+          O.fold(
+            () => <ErrorView />,
+            some => <ContentView data={some} />
+          )
+        ),
+      () => <LoadingView />,
+      () => <ErrorView />,
+      (_, error) => <ErrorView error={error} />
+    );
 
-  return (
-    <>
-      {RenderMask}
-      {bottomSheet}
-    </>
-  );
+  return <RenderMask />;
 };
 
 export default ItwCredentialPreviewScreen;


### PR DESCRIPTION
## Short description
This PR introduces the bottom sheet for the `issued by` and `released by` claims in the preview and details screen of a credential. It also removes it from the `assistance` banner which now navigates to the not available screen.

## List of changes proposed in this pull request
- Adds two bottom sheets for each claim;
- Removes the bottom sheet from the `assistance` banner and adds a navigation the not available screen.

## How to test
Try to obtain a new credential and test the bottom sheets for the two claims in the preview screen. Also test the navigation when pressing on the assistance banner. Then test them in the credential preview screen by single pressing it in the wallet home screen.
