### PR TITLE
fix: [IOBP-425] Fix Mixpanel events in `BarcodeScanScreen`

### DIFF
--- a/ts/features/barcode/components/BarcodeScanBaseScreenComponent.tsx
+++ b/ts/features/barcode/components/BarcodeScanBaseScreenComponent.tsx
@@ -133,16 +133,18 @@ const BarcodeScanBaseScreenComponent = ({
   const canShowHelp = useIOSelector(canShowHelpSelector);
   const choosenTool = assistanceToolRemoteConfig(assistanceToolConfig);
 
-  useFocusEffect(() => {
-    trackBarcodeScanScreenView(barcodeAnalyticsFlow);
-  });
+  useFocusEffect(
+    React.useCallback(() => {
+      trackBarcodeScanScreenView(barcodeAnalyticsFlow);
+    }, [barcodeAnalyticsFlow])
+  );
 
   const onShowHelp = (): (() => void) | undefined => {
     switch (choosenTool) {
       case ToolEnum.zendesk:
-        trackZendeskSupport(route.name, barcodeAnalyticsFlow);
         // The navigation param assistanceForPayment is fixed to false because in this entry point we don't know the category yet.
         return () => {
+          trackZendeskSupport(route.name, barcodeAnalyticsFlow);
           resetCustomFields();
           dispatch(
             zendeskSupportStart({

--- a/ts/features/walletV3/payment/screens/WalletPaymentBarcodeChoiceScreen.tsx
+++ b/ts/features/walletV3/payment/screens/WalletPaymentBarcodeChoiceScreen.tsx
@@ -47,9 +47,11 @@ const WalletPaymentBarcodeChoiceScreen = () => {
   const dispatch = useIODispatch();
   const navigation = useNavigation<IOStackNavigationProp<AppParamsList>>();
 
-  useFocusEffect(() => {
-    analytics.trackBarcodeMultipleCodesScreenView();
-  });
+  useFocusEffect(
+    React.useCallback(() => {
+      analytics.trackBarcodeMultipleCodesScreenView();
+    }, [])
+  );
 
   const route =
     useRoute<


### PR DESCRIPTION
## Short description
This PR resolves an issue with some Mixpanel events that are being sent repeatedly in the `BarcodeScanScreen` component

## List of changes proposed in this pull request
- Added `useCallback` inside `useFocusEffect` hooks

## How to test
Navigating to the Barcode Scan screen, the corresponding screen view event `QRCODE_SCAN_SCREEN` should be sent only once, whenever the screen is focused. 
