### PR TITLE
chore: [IOBP-428] Replaced native-base toast into `clipboardSetStringWithFeedback` method

### DIFF
--- a/ts/utils/clipboard.ts
+++ b/ts/utils/clipboard.ts
@@ -1,7 +1,7 @@
-import { Toast } from "native-base";
 import Clipboard from "@react-native-clipboard/clipboard";
 
 import I18n from "../i18n";
+import { IOToast } from "../components/Toast";
 
 /**
  * Copy a text to the device clipboard and give a feedback.
@@ -9,7 +9,5 @@ import I18n from "../i18n";
 export const clipboardSetStringWithFeedback = (text: string) => {
   Clipboard.setString(text);
 
-  Toast.show({
-    text: I18n.t("clipboard.copyFeedback")
-  });
+  IOToast.success(I18n.t("clipboard.copyFeedback"));
 };


### PR DESCRIPTION
## Short description
This PR replaces the previous native-base toast provider into `clipboardSetStringWithFeedback` method with the new `IOToast` provider.

## List of changes proposed in this pull request
- Into `utils/clipboard.ts` has been replaced the previous native-base Toast with the new `IOToast`

## How to test
- Start a payment with a transaction summary and try to copy something, you should be able to see the new toast design

## Preview

https://github.com/pagopa/io-app/assets/34343582/14c193df-576a-4ba3-9353-1e3ce7147773


