### PR TITLE
fix: [PE-498] CGN OTP code timer issue

### DIFF
--- a/ts/features/bonus/cgn/components/merchants/discount/OtpCodeComponent.tsx
+++ b/ts/features/bonus/cgn/components/merchants/discount/OtpCodeComponent.tsx
@@ -156,11 +156,13 @@ export const OtpCodeComponent = (props: Props) => {
       toValue: endPercentage,
       duration: currentDuration as number,
       easing: Easing.linear
-    }).start(() => {
+    }).start(({ finished }) => {
       // when animation end
-      setElapsedSeconds(cv => cv + 1);
-      stopInterval();
-      onEnd();
+      if (finished) {
+        setElapsedSeconds(cv => cv + 1);
+        stopInterval();
+        onEnd();
+      }
     });
     // eslint-disable-next-line functional/immutable-data
     intervalRef.current = setInterval(() => {


### PR DESCRIPTION
## Short description
This PR fixes OTP code timer issue for a CGN discount

## List of changes proposed in this pull request
- Added a check `finished` into Animated.timing function callback in order to check if the animation has reached the end

## How to test
Open a CGN discount with an OTP and try to generate it, you should be able to show the code for some minutes

## Preview
|Before|After|
|-|-|
| <video src="https://github.com/pagopa/io-app/assets/34343582/2a29e8a7-0e42-45c3-b205-80dab2ab2037" /> | <video src="https://github.com/pagopa/io-app/assets/34343582/3fc4ef33-b0a5-46e4-a260-201d18be86af" />


