### PR TITLE
Iobp 439 fix payment method initiatives list refresh

### DIFF
--- a/ts/features/idpay/wallet/components/IdPayInstrumentInitiativesList.tsx
+++ b/ts/features/idpay/wallet/components/IdPayInstrumentInitiativesList.tsx
@@ -50,8 +50,8 @@ const IdPayInitiativeListItemSwitch = ({
   const dispatch = useIODispatch();
   const { initiativeName, status } = item;
 
-  const isInitiativeActive = useIOSelector(state =>
-    idPayInitiativeFromInstrumentPotSelector(state, item.initiativeId)
+  const isInitiativeActive = useIOSelector(
+    idPayInitiativeFromInstrumentPotSelector(item.initiativeId)
   );
 
   const handleSwitchValueChange = React.useCallback(

--- a/ts/features/idpay/wallet/saga/handleGetInitiativesFromInstrument.ts
+++ b/ts/features/idpay/wallet/saga/handleGetInitiativesFromInstrument.ts
@@ -61,13 +61,8 @@ export function* handleGetIDPayInitiativesFromInstrument(
 
 export function* handleInitiativesFromInstrumentRefresh(
   idWallet: string,
-  refreshDelay: number = 3000
+  refreshDelay: number = 5000
 ) {
-  yield* put(
-    idPayInitiativesFromInstrumentGet.request({
-      idWallet
-    })
-  );
   while (true) {
     yield* delay(refreshDelay);
     yield* put(

--- a/ts/features/idpay/wallet/screens/IdPayInstrumentInitiativesScreen.tsx
+++ b/ts/features/idpay/wallet/screens/IdPayInstrumentInitiativesScreen.tsx
@@ -34,6 +34,7 @@ type Props = IOStackNavigationRouteProps<
 export const IdPayInstrumentInitiativesScreen = (props: Props) => {
   const { idWallet } = props.route.params;
   const dispatch = useIODispatch();
+  const initiatives = useIOSelector(idPayInitiativesFromInstrumentSelector);
 
   React.useEffect(() => {
     dispatch(
@@ -46,7 +47,6 @@ export const IdPayInstrumentInitiativesScreen = (props: Props) => {
     };
   }, [idWallet, dispatch]);
 
-  const initiatives = useIOSelector(idPayInitiativesFromInstrumentSelector);
   const [maskedPan, brand, idpayInitiatives] = pipe(
     initiatives,
     pot.toOption,

--- a/ts/features/idpay/wallet/store/reducers/__test__/reducer.test.ts
+++ b/ts/features/idpay/wallet/store/reducers/__test__/reducer.test.ts
@@ -3,10 +3,9 @@ import { createStore } from "redux";
 import {
   idPayAreInitiativesFromInstrumentLoadingSelector,
   idPayEnabledInitiativesFromInstrumentSelector,
-  idPayInitiativeAwaitingUpdateSelector,
+  idPayInitiativesAwaitingUpdateSelector,
   idPayInitiativesFromInstrumentSelector,
-  idPayWalletInitiativeListSelector,
-  idPayWalletSelector
+  idPayWalletInitiativeListSelector
 } from "..";
 import { InitiativesWithInstrumentDTO } from "../../../../../../../definitions/idpay/InitiativesWithInstrumentDTO";
 import { WalletDTO } from "../../../../../../../definitions/idpay/WalletDTO";
@@ -44,7 +43,6 @@ describe("Test IDPay wallet/initiatives reducers and selectors", () => {
     expect(globalState.features.idPay.wallet.initiatives).toStrictEqual(
       pot.none
     );
-    expect(idPayWalletSelector(globalState)).toStrictEqual(pot.none);
     expect(idPayWalletInitiativeListSelector(globalState)).toStrictEqual(
       pot.none
     );
@@ -54,9 +52,6 @@ describe("Test IDPay wallet/initiatives reducers and selectors", () => {
     const store = createStore(appReducer, globalState as any);
     store.dispatch(idPayWalletGet.request());
     expect(store.getState().features.idPay.wallet.initiatives).toStrictEqual(
-      pot.noneLoading
-    );
-    expect(idPayWalletSelector(store.getState())).toStrictEqual(
       pot.noneLoading
     );
     expect(idPayWalletInitiativeListSelector(store.getState())).toStrictEqual(
@@ -71,9 +66,6 @@ describe("Test IDPay wallet/initiatives reducers and selectors", () => {
     expect(store.getState().features.idPay.wallet.initiatives).toStrictEqual(
       pot.some(mockResponseSuccess)
     );
-    expect(idPayWalletSelector(store.getState())).toStrictEqual(
-      pot.some(mockResponseSuccess)
-    );
     expect(idPayWalletInitiativeListSelector(store.getState())).toStrictEqual(
       pot.some(mockResponseSuccess.initiativeList)
     );
@@ -84,9 +76,6 @@ describe("Test IDPay wallet/initiatives reducers and selectors", () => {
     store.dispatch(idPayWalletGet.request());
     store.dispatch(idPayWalletGet.failure(mockFailure));
     expect(store.getState().features.idPay.wallet.initiatives).toStrictEqual(
-      pot.noneError(mockFailure)
-    );
-    expect(idPayWalletSelector(store.getState())).toStrictEqual(
       pot.noneError(mockFailure)
     );
     expect(idPayWalletInitiativeListSelector(store.getState())).toStrictEqual(
@@ -202,37 +191,49 @@ describe("test Idpay Initiative Enroll/Delete reducers and selectors", () => {
   it("adds the initiative to the data structure when enrolling", () => {
     const globalState = appReducer(undefined, applicationChangeState("active"));
     const store = createStore(appReducer, globalState as any);
+
+    const T_INITIATIVE_ID_1 = "initiative1";
+    const T_INITIATIVE_ID_2 = "initiative2";
+    const T_INITIATIVE_ID_3 = "initiative3";
+
     store.dispatch(
       idpayInitiativesInstrumentEnroll.request({
         idWallet: "MOCK",
-        initiativeId: "initiative"
+        initiativeId: T_INITIATIVE_ID_1
       })
     );
     store.dispatch(
       idpayInitiativesInstrumentEnroll.request({
         idWallet: "MOCK1",
-        initiativeId: "initiative1"
+        initiativeId: T_INITIATIVE_ID_2
       })
     );
     store.dispatch(
       idpayInitiativesInstrumentDelete.request({
         instrumentId: "MOCK2",
-        initiativeId: "initiative2"
+        initiativeId: T_INITIATIVE_ID_3
       })
     );
     expect(
       store.getState().features.idPay.wallet.initiativesAwaitingStatusUpdate
-    ).toStrictEqual({ initiative: true, initiative1: true, initiative2: true });
+    ).toStrictEqual({
+      [T_INITIATIVE_ID_1]: true,
+      [T_INITIATIVE_ID_2]: true,
+      [T_INITIATIVE_ID_3]: true
+    });
     expect(
       idPayEnabledInitiativesFromInstrumentSelector(store.getState())
     ).toStrictEqual(mockInitiativesWithInstrumentSuccess.initiativeList);
     expect(
-      idPayInitiativeAwaitingUpdateSelector(store.getState(), "initiative") &&
-        idPayInitiativeAwaitingUpdateSelector(
-          store.getState(),
-          "initiative1"
-        ) &&
-        idPayInitiativeAwaitingUpdateSelector(store.getState(), "initiative2")
+      idPayInitiativesAwaitingUpdateSelector(store.getState())[
+        T_INITIATIVE_ID_1
+      ] &&
+        idPayInitiativesAwaitingUpdateSelector(store.getState())[
+          T_INITIATIVE_ID_2
+        ] &&
+        idPayInitiativesAwaitingUpdateSelector(store.getState())[
+          T_INITIATIVE_ID_3
+        ]
     ).toStrictEqual(true);
   });
 });

--- a/ts/features/wallet/component/features/PaymentMethodInitiatives.tsx
+++ b/ts/features/wallet/component/features/PaymentMethodInitiatives.tsx
@@ -11,6 +11,7 @@ import { useIODispatch, useIOSelector } from "../../../../store/hooks";
 import { PaymentMethod } from "../../../../types/pagopa";
 import { IdPayInstrumentInitiativesList } from "../../../idpay/wallet/components/IdPayInstrumentInitiativesList";
 import {
+  idPayInitiativesFromInstrumentGet,
   idPayInitiativesFromInstrumentRefreshStart,
   idPayInitiativesFromInstrumentRefreshStop
 } from "../../../idpay/wallet/store/actions";
@@ -31,18 +32,23 @@ const PaymentMethodInitiatives = (props: Props): React.ReactElement | null => {
 
   const dispatch = useIODispatch();
 
-  const refresh = React.useCallback(() => {
-    dispatch(
-      idPayInitiativesFromInstrumentRefreshStart({
-        idWallet: idWalletString
-      })
-    );
-    return () => {
-      dispatch(idPayInitiativesFromInstrumentRefreshStop());
-    };
-  }, [idWalletString, dispatch]);
-
-  useFocusEffect(refresh);
+  useFocusEffect(
+    React.useCallback(() => {
+      dispatch(
+        idPayInitiativesFromInstrumentGet.request({
+          idWallet: idWalletString
+        })
+      );
+      dispatch(
+        idPayInitiativesFromInstrumentRefreshStart({
+          idWallet: idWalletString
+        })
+      );
+      return () => {
+        dispatch(idPayInitiativesFromInstrumentRefreshStop());
+      };
+    }, [idWalletString, dispatch])
+  );
 
   const initiativesList = useIOSelector(
     idPayEnabledInitiativesFromInstrumentSelector

--- a/ts/features/walletV3/common/components/WalletDetailsPaymentMethodInitiatives.tsx
+++ b/ts/features/walletV3/common/components/WalletDetailsPaymentMethodInitiatives.tsx
@@ -10,6 +10,7 @@ import ROUTES from "../../../../navigation/routes";
 import { useIODispatch, useIOSelector } from "../../../../store/hooks";
 import { IdPayInstrumentInitiativesList } from "../../../idpay/wallet/components/IdPayInstrumentInitiativesList";
 import {
+  idPayInitiativesFromInstrumentGet,
   idPayInitiativesFromInstrumentRefreshStart,
   idPayInitiativesFromInstrumentRefreshStop
 } from "../../../idpay/wallet/store/actions";
@@ -33,18 +34,23 @@ const WalletDetailsPaymentMethodInitiatives = (
 
   const dispatch = useIODispatch();
 
-  const refresh = React.useCallback(() => {
-    dispatch(
-      idPayInitiativesFromInstrumentRefreshStart({
-        idWallet: idWalletString
-      })
-    );
-    return () => {
-      dispatch(idPayInitiativesFromInstrumentRefreshStop());
-    };
-  }, [idWalletString, dispatch]);
-
-  useFocusEffect(refresh);
+  useFocusEffect(
+    React.useCallback(() => {
+      dispatch(
+        idPayInitiativesFromInstrumentGet.request({
+          idWallet: idWalletString
+        })
+      );
+      dispatch(
+        idPayInitiativesFromInstrumentRefreshStart({
+          idWallet: idWalletString
+        })
+      );
+      return () => {
+        dispatch(idPayInitiativesFromInstrumentRefreshStop());
+      };
+    }, [idWalletString, dispatch])
+  );
 
   const initiativesList = useIOSelector(
     idPayEnabledInitiativesFromInstrumentSelector


### PR DESCRIPTION
## Short description
This PR removes unnecessary initiatives refreshes in the payment method detail screen

| Before | After |
| --- | --- |
| <video src="https://github.com/pagopa/io-app/assets/6160324/fc93240d-689c-4afa-9c41-e2477c4c82da" /> |<video src="https://github.com/pagopa/io-app/assets/6160324/6f64c56a-46d4-4458-aab4-6e7afad8b310" /> |

## List of changes proposed in this pull request
- Removed unnecessary selectors
- Removed extra API call in [IdPayInstrumentInitiativesScreen.tsx](https://github.com/pagopa/io-app/compare/IOBP-439-fix-payment-method-initiatives-list-refresh?expand=1#diff-ebeb1ad0d49ec3ad8e8c582eb6dd4301a17731c7fc2b828f914f46d80c81a46e)

## How to test
Navigate to **Wallet > Select a Payment Method > ID Pay Initiatives list**
