### PR TITLE
[IOBP-441] Remove double header glitch from payment flow

### DIFF
--- a/ts/navigation/AuthenticatedStackNavigator.tsx
+++ b/ts/navigation/AuthenticatedStackNavigator.tsx
@@ -273,7 +273,8 @@ const AuthenticatedStackNavigator = () => {
         name={WalletPaymentRoutes.WALLET_PAYMENT_MAIN}
         component={WalletPaymentNavigator}
         options={{
-          gestureEnabled: isGestureEnabled
+          gestureEnabled: isGestureEnabled,
+          ...hideHeaderOptions
         }}
       />
       <Stack.Screen
@@ -293,7 +294,8 @@ const AuthenticatedStackNavigator = () => {
         component={WalletPaymentBarcodeScanScreen}
         options={{
           ...TransitionPresets.ModalSlideFromBottomIOS,
-          gestureEnabled: isGestureEnabled
+          gestureEnabled: isGestureEnabled,
+          ...hideHeaderOptions
         }}
       />
     </Stack.Navigator>


### PR DESCRIPTION
## Short description
This PR resolves a glitch in the payment flow which displays two headers

## List of changes proposed in this pull request
- Added `headerShown: false` in payment navigators

## How to test
Go to **Wallet > Pay an advice**, check that the header works as expected
