### PR TITLE
chore: [IOBP-328] Remove FF from new barcode scan screen access

### DIFF
--- a/ts/features/walletV3/payment/screens/WalletPaymentBarcodeScanScreen.tsx
+++ b/ts/features/walletV3/payment/screens/WalletPaymentBarcodeScanScreen.tsx
@@ -32,6 +32,7 @@ import {
   PagoPaBarcode
 } from "../../../barcode/types/IOBarcode";
 import { WalletPaymentRoutes } from "../navigation/routes";
+import { isDesignSystemEnabledSelector } from "../../../../store/reducers/persistedPreferences";
 
 const contextualHelpMarkdown: ContextualHelpPropsMarkdown = {
   title: "wallet.QRtoPay.contextualHelpTitle",
@@ -44,6 +45,7 @@ const WalletPaymentBarcodeScanScreen = () => {
   const { dataMatrixPosteEnabled } = useIOSelector(
     barcodesScannerConfigSelector
   );
+  const isDesignSystemEnabled = useIOSelector(isDesignSystemEnabledSelector);
 
   const barcodeFormats: Array<IOBarcodeFormat> = IO_BARCODE_ALL_FORMATS.filter(
     format => (format === "DATA_MATRIX" ? dataMatrixPosteEnabled : true)
@@ -128,9 +130,17 @@ const WalletPaymentBarcodeScanScreen = () => {
 
   const handleManualInputPressed = () => {
     analytics.trackBarcodeManualEntryPath("avviso");
-    navigation.navigate(WalletPaymentRoutes.WALLET_PAYMENT_MAIN, {
-      screen: WalletPaymentRoutes.WALLET_PAYMENT_INPUT_NOTICE_NUMBER
-    });
+
+    if (isDesignSystemEnabled) {
+      navigation.navigate(WalletPaymentRoutes.WALLET_PAYMENT_MAIN, {
+        screen: WalletPaymentRoutes.WALLET_PAYMENT_INPUT_NOTICE_NUMBER
+      });
+    } else {
+      navigation.navigate(ROUTES.WALLET_NAVIGATOR, {
+        screen: ROUTES.PAYMENT_MANUAL_DATA_INSERTION,
+        params: {}
+      });
+    }
   };
 
   const {

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -68,7 +68,6 @@ import { IOStackNavigationRouteProps } from "../../navigation/params/AppParamsLi
 import { MainTabParamsList } from "../../navigation/params/MainTabParamsList";
 import {
   navigateBack,
-  navigateToPaymentScanQrCode,
   navigateToTransactionDetailsScreen,
   navigateToWalletAddPaymentMethod
 } from "../../store/actions/navigation";
@@ -87,10 +86,7 @@ import {
   isIdPayEnabledSelector
 } from "../../store/reducers/backendStatus";
 import { paymentsHistorySelector } from "../../store/reducers/payments/history";
-import {
-  isDesignSystemEnabledSelector,
-  isPagoPATestEnabledSelector
-} from "../../store/reducers/persistedPreferences";
+import { isPagoPATestEnabledSelector } from "../../store/reducers/persistedPreferences";
 import { GlobalState } from "../../store/reducers/types";
 import { creditCardAttemptsSelector } from "../../store/reducers/wallet/creditCard";
 import {
@@ -454,13 +450,9 @@ class WalletHomeScreen extends React.PureComponent<Props, State> {
   }
 
   private navigateToPaymentScanQrCode = () => {
-    if (this.props.isDesignSystemEnabled) {
-      this.props.navigation.navigate(
-        WalletPaymentRoutes.WALLET_PAYMENT_BARCODE_SCAN
-      );
-    } else {
-      this.props.navigateToPaymentScanQrCode();
-    }
+    this.props.navigation.navigate(
+      WalletPaymentRoutes.WALLET_PAYMENT_BARCODE_SCAN
+    );
   };
 
   private footerButton(potWallets: pot.Pot<ReadonlyArray<Wallet>, Error>) {
@@ -564,8 +556,7 @@ const mapStateToProps = (state: GlobalState) => ({
   bancomatListVisibleInWallet: bancomatListVisibleInWalletSelector(state),
   coBadgeListVisibleInWallet: cobadgeListVisibleInWalletSelector(state),
   bpdConfig: bpdRemoteConfigSelector(state),
-  isIdPayEnabled: isIdPayEnabledSelector(state),
-  isDesignSystemEnabled: isDesignSystemEnabledSelector(state)
+  isIdPayEnabled: isIdPayEnabledSelector(state)
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
@@ -574,7 +565,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   loadIdPayWalletData: () => dispatch(idPayWalletGet.request()),
   navigateToWalletAddPaymentMethod: (keyFrom?: string) =>
     navigateToWalletAddPaymentMethod({ inPayment: O.none, keyFrom }),
-  navigateToPaymentScanQrCode: () => navigateToPaymentScanQrCode(),
   navigateToTransactionDetailsScreen: (transaction: Transaction) => {
     navigateToTransactionDetailsScreen({
       transaction,


### PR DESCRIPTION
## Short description
This PR removes the FF from the new barcode scan screen access, enabling it to be accessed without activating the new design system FF.
<video src="https://github.com/pagopa/io-app/assets/6160324/a4893357-1c56-472d-9ffa-cbaa248a3edb" width="200" />

## List of changes proposed in this pull request
- Removed `isDesignSystemEnabledSelector ` FF from `WalletHomeScreen` button
- Added `isDesignSystemEnabledSelector ` FF in `WalletPaymentBarcodeScanScreen` to use the old manual entry flow

## How to test
Navigate to the Wallet section and tap on the "Pay notice" button, check that the new screen is displayed
