### PR TITLE
[IOCOM-694] Support for remote content on standard messages

### DIFF
--- a/ts/components/messages/MessageDetail/index.tsx
+++ b/ts/components/messages/MessageDetail/index.tsx
@@ -148,12 +148,15 @@ const MessageDetailsComponent = ({
   // prescription attachments and third party data. That is why, later in the
   // code, the UI rendering is guarded by opposite checks on prescription and
   // third party attachments
-  const { prescriptionAttachments, markdown, prescriptionData } =
-    messageDetails;
+  const {
+    prescriptionAttachments,
+    markdown,
+    prescriptionData,
+    hasThirdPartyData
+  } = messageDetails;
   const isPrescription = prescriptionData !== undefined;
 
   const { id: messageId, title } = message;
-  const hasThirdPartyDataAttachments = messageDetails.hasThirdPartyData;
   const thirdPartyDataPot = useIOSelector(state =>
     thirdPartyFromIdSelector(state, messageId)
   );
@@ -161,7 +164,7 @@ const MessageDetailsComponent = ({
   // first rendering of this component. We want to send the request only if
   // we have never retrieved data or if there was an error
   const shouldDownloadThirdPartyDataAttachmentList =
-    hasThirdPartyDataAttachments &&
+    hasThirdPartyData &&
     isFirstRendering.current &&
     (isStrictNone(thirdPartyDataPot) || pot.isError(thirdPartyDataPot));
 
@@ -253,7 +256,7 @@ const MessageDetailsComponent = ({
 
         <VSpacer size={24} />
         {prescriptionAttachments &&
-          !hasThirdPartyDataAttachments &&
+          !hasThirdPartyData &&
           isContentLoadCompleted && (
             <>
               <MedicalPrescriptionAttachments
@@ -264,7 +267,7 @@ const MessageDetailsComponent = ({
               <VSpacer size={24} />
             </>
           )}
-        {hasThirdPartyDataAttachments && isContentLoadCompleted && (
+        {hasThirdPartyData && isContentLoadCompleted && (
           <>
             <H2 color="bluegrey" style={styles.attachmentsTitle}>
               {I18n.t("features.pn.details.attachmentsSection.title")}

--- a/ts/components/messages/MessageDetail/index.tsx
+++ b/ts/components/messages/MessageDetail/index.tsx
@@ -1,7 +1,4 @@
-import * as pot from "@pagopa/ts-commons/lib/pot";
-import * as React from "react";
-import * as O from "fp-ts/lib/Option";
-import { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import {
   ActivityIndicator,
   ScrollView,
@@ -11,6 +8,9 @@ import {
 } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import { IOColors, VSpacer } from "@pagopa/io-app-design-system";
+import { pipe } from "fp-ts/lib/function";
+import * as pot from "@pagopa/ts-commons/lib/pot";
+import * as O from "fp-ts/lib/Option";
 import I18n from "../../../i18n";
 import { OrganizationFiscalCode } from "../../../../definitions/backend/OrganizationFiscalCode";
 import { ServiceMetadata } from "../../../../definitions/backend/ServiceMetadata";
@@ -18,7 +18,11 @@ import { ThirdPartyMessageWithContent } from "../../../../definitions/backend/Th
 import { LegacyMessageAttachments } from "../../../features/messages/components/LegacyMessageAttachments";
 import { loadThirdPartyMessage } from "../../../features/messages/store/actions";
 import { useIODispatch, useIOSelector } from "../../../store/hooks";
-import { thirdPartyFromIdSelector } from "../../../store/reducers/entities/messages/thirdPartyById";
+import {
+  messageMarkdownSelector,
+  messageTitleSelector,
+  thirdPartyFromIdSelector
+} from "../../../store/reducers/entities/messages/thirdPartyById";
 import {
   UIAttachment,
   UIMessage,
@@ -49,8 +53,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: variables.contentPadding
   },
   webview: {
-    marginLeft: variables.contentPadding,
-    marginRight: variables.contentPadding
+    marginHorizontal: variables.contentPadding
   },
   attachmentsTitle: {
     paddingHorizontal: variables.spacerLargeHeight,
@@ -149,7 +152,7 @@ const MessageDetailsComponent = ({
     messageDetails;
   const isPrescription = prescriptionData !== undefined;
 
-  const messageId = message.id;
+  const { id: messageId, title } = message;
   const hasThirdPartyDataAttachments = messageDetails.hasThirdPartyData;
   const thirdPartyDataPot = useIOSelector(state =>
     thirdPartyFromIdSelector(state, messageId)
@@ -161,6 +164,18 @@ const MessageDetailsComponent = ({
     hasThirdPartyDataAttachments &&
     isFirstRendering.current &&
     (isStrictNone(thirdPartyDataPot) || pot.isError(thirdPartyDataPot));
+
+  const messageMarkdown = pipe(
+    useIOSelector(state => messageMarkdownSelector(state, messageId)),
+    O.fromNullable,
+    O.getOrElse(() => markdown)
+  );
+
+  const messageTitle = pipe(
+    useIOSelector(state => messageTitleSelector(state, messageId)),
+    O.fromNullable,
+    O.getOrElse(() => title)
+  );
 
   const openAttachment = useCallback(
     (attachment: UIAttachment) => {
@@ -218,7 +233,7 @@ const MessageDetailsComponent = ({
 
           <VSpacer size={24} />
 
-          <MessageTitle title={message.title} isPrescription={isPrescription} />
+          <MessageTitle title={messageTitle} isPrescription={isPrescription} />
 
           <VSpacer size={16} />
         </View>
@@ -226,13 +241,14 @@ const MessageDetailsComponent = ({
           hasPaidBadge={hasPaidBadge}
           messageDetails={messageDetails}
         />
+
         <MessageMarkdown
           webViewStyle={styles.webview}
           onLoadEnd={() => {
             setIsContentLoadCompleted(true);
           }}
         >
-          {cleanMarkdownFromCTAs(markdown)}
+          {cleanMarkdownFromCTAs(messageMarkdown)}
         </MessageMarkdown>
 
         <VSpacer size={24} />

--- a/ts/store/reducers/entities/messages/__tests__/thirdPartyById.test.ts
+++ b/ts/store/reducers/entities/messages/__tests__/thirdPartyById.test.ts
@@ -77,17 +77,6 @@ describe("messageTitleSelector", () => {
     const messageTitle = messageTitleSelector(state, messageId);
     expect(messageTitle).toBeUndefined();
   });
-  it("Should return the message title for a loaded matching message", () => {
-    const messageId = "m1" as UIMessageId;
-    const subject = "message subject";
-    const loadMessageDetailsSuccess = loadMessageDetails.success({
-      id: messageId,
-      subject
-    } as UIMessageDetails);
-    const state = appReducer(undefined, loadMessageDetailsSuccess);
-    const messageTitle = messageTitleSelector(state, messageId);
-    expect(messageTitle).toBe(subject);
-  });
   it("Should return undefined for a loading matching third party message", () => {
     const messageId = "m1" as UIMessageId;
     const loadThirdPartyMessageRequest =
@@ -192,17 +181,6 @@ describe("messageMarkdownSelector", () => {
     const state = appReducer(undefined, loadMessageDetailsRequest);
     const messageMarkdown = messageMarkdownSelector(state, messageId);
     expect(messageMarkdown).toBeUndefined();
-  });
-  it("Should return the message title for a loaded matching message", () => {
-    const messageId = "m1" as UIMessageId;
-    const markdown = "message markdown";
-    const loadMessageDetailsSuccess = loadMessageDetails.success({
-      id: messageId,
-      markdown
-    } as UIMessageDetails);
-    const state = appReducer(undefined, loadMessageDetailsSuccess);
-    const messageMarkdown = messageMarkdownSelector(state, messageId);
-    expect(messageMarkdown).toBe(markdown);
   });
   it("Should return undefined for a loading matching third party message", () => {
     const messageId = "m1" as UIMessageId;


### PR DESCRIPTION
## Short description
This PR adds support for remote content on standard messages.

## List of changes proposed in this pull request
- removed fallback logic in `messageContentSelector` selector
- added logic with fallback for retrieving remote `title` and `markdown`
- updated tests

## How to test
Using `io-dev-api-server` generate a message with or without remote content. Open the message detail and check that the content is displayed correctly.
