### PR TITLE
fix(IT Wallet): [SIW-730] Fix credential issuance error not shown

### DIFF
--- a/ts/features/it-wallet/saga/new/itwIssuanceSaga.ts
+++ b/ts/features/it-wallet/saga/new/itwIssuanceSaga.ts
@@ -206,7 +206,7 @@ export function* handleIssuanceGetCredential(): SagaIterator {
   } catch (e) {
     const res = toError(e);
     yield* put(
-      itwIssuanceChecks.failure({
+      itwIssuanceGetCredential.failure({
         code: ItWalletErrorTypes.CREDENTIAL_CHECKS_GENERIC_ERROR,
         message: res.message
       })


### PR DESCRIPTION
## Short description
This PR fixes an error which prevents the UI to show an error view while issuing a credential.
The issue is cased by a wrong dispatched action.

## List of changes proposed in this pull request
- Replaces the wrong action with the right one.

## How to test
Static checks.