### PR TITLE
chore(IT Wallet): [SIW-722] Reintroduce CIE login bypass

### DIFF
--- a/ts/features/it-wallet/components/ItwContinueView.tsx
+++ b/ts/features/it-wallet/components/ItwContinueView.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, Pressable } from "react-native";
 import {
   ButtonLink,
   ButtonSolid,
@@ -23,7 +23,7 @@ type ItwContinueViewProps = {
   subtitle?: string;
   action?: ActionProps;
   secondaryAction?: ActionProps;
-  closeAction?: ActionProps["onPress"];
+  onPictogramPress?: ActionProps["onPress"]; // temporary workaround for the long press on the pictogram to be removed when the cie bypass will be removed.
 };
 
 /**
@@ -40,15 +40,16 @@ const ItwContinueView = ({
   pictogram,
   subtitle,
   action,
-  secondaryAction
+  secondaryAction,
+  onPictogramPress
 }: ItwContinueViewProps): React.ReactElement => (
   <View style={{ ...IOStyles.flex, ...IOStyles.horizontalContentPadding }}>
     <View style={styles.main} testID={"ItwContinueViewTestID"}>
       {pictogram && (
-        <>
+        <Pressable onLongPress={onPictogramPress}>
           <Pictogram name={pictogram} size={180} />
           <VSpacer size={24} />
-        </>
+        </Pressable>
       )}
       <H3 style={styles.text}>{title}</H3>
       {subtitle && (

--- a/ts/features/it-wallet/screens/issuing/pid/ItwIssuingPidAuthInfoScreen.tsx
+++ b/ts/features/it-wallet/screens/issuing/pid/ItwIssuingPidAuthInfoScreen.tsx
@@ -93,6 +93,7 @@ const ItwIssuingPidAuthInfoScreen = () => {
                 ? bypassCieLogin()
                 : navigation.navigate(ITW_ROUTES.ISSUING.PID.CIE.PIN_SCREEN)
           }}
+          onPictogramPress={() => bypassCieLogin()}
           secondaryAction={{
             label: I18n.t("features.itWallet.infoAuthScreen.noCieInfo"),
             accessibilityLabel: I18n.t(


### PR DESCRIPTION
## Short description
This PR reintroduces the CIE login bypass. It can be used by long pressing the pictogram in the following screen: 

<img src="https://github.com/pagopa/io-app/assets/12371664/eb007dac-9b9c-47f6-a297-ca90dae6b88e" height="400">

It still remains enabled by default on iOS when pressing the confirmation button.

## List of changes proposed in this pull request
- Add the `onPictogramPress` optional prop for `ItwContinueView.tsx`;
- Add the bypass in the relative screen.

## How to test
Test a PID issuing flow and try a long press on the pictogram in the aformentioned screen. It should bypass the CIE authentication. 
