### PR TITLE
chore(IT Wallet): [SIW-737] Update io-react-native-jwt library to 1.1.0

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -140,7 +140,7 @@ PODS:
     - React-Core
   - pagopa-io-react-native-crypto (0.2.1):
     - React-Core
-  - pagopa-io-react-native-jwt (1.0.0):
+  - pagopa-io-react-native-jwt (1.1.0):
     - JOSESwift (~> 2.3)
     - React-Core
   - pagopa-io-react-native-login-utils (0.2.0):
@@ -950,7 +950,7 @@ SPEC CHECKSUMS:
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   pagopa-io-react-native-cie-pid: a3f213959fb23b82822a0bf987610831eb01a5fd
   pagopa-io-react-native-crypto: 644fece16966f2e1ea1f872344ee5a3c6c8761a1
-  pagopa-io-react-native-jwt: c97d8a1d137f34d3f2ab354fca8433fea5676b91
+  pagopa-io-react-native-jwt: 0b096d1b173e438a963cb81f251a33988b46f5fa
   pagopa-io-react-native-login-utils: 929e584c817572ce7a3e41e0c6f96c7990bd314d
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   Protobuf: 3724efa50cb2846d7ccebc8691c574e85fd74471

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@pagopa/io-pagopa-commons": "^3.1.0",
     "@pagopa/io-react-native-cie-pid": "^0.1.3",
     "@pagopa/io-react-native-crypto": "^0.2.1",
-    "@pagopa/io-react-native-jwt": "1.0.0",
+    "@pagopa/io-react-native-jwt": "1.1.0",
     "@pagopa/io-react-native-login-utils": "^0.2.0",
     "@pagopa/io-react-native-wallet": "^0.10.2",
     "@pagopa/react-native-cie": "1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3164,10 +3164,10 @@
   resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-crypto/-/io-react-native-crypto-0.2.1.tgz#3d62b0f0cf45b2a878e4ee0652239ea69089988e"
   integrity sha512-J+VP1kLXl1lQSJJYFMa+ljW9fWgMIYQskBJZFaVKPrtrZr8MJyrhNzlFUf2/EGwxm3kA+7o7budq6fPqdfVvvg==
 
-"@pagopa/io-react-native-jwt@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-jwt/-/io-react-native-jwt-1.0.0.tgz#958ab1b717bebe0066b8b431dbc42912785ef825"
-  integrity sha512-3av1Ccokyln0e+tJOqKgXe+bFfBgIealAu9POsh+Cy+IWQpfy9LLjJ292dSzzmak8fd8MnufLQOHxM4oxd+c6A==
+"@pagopa/io-react-native-jwt@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-jwt/-/io-react-native-jwt-1.1.0.tgz#9a8e99672a683a32a27785eb01a7f108561ca8dd"
+  integrity sha512-R/Cgiu3Qb/7LnzQstUTGkNnsKfQ5lc/O3eSAkzZPGQqQb4hoSch4N/2JgqXRZPeTNfFA2vDmYbV6fSidMDL2xA==
   dependencies:
     abab "^2.0.6"
     zod "^3.21.4"


### PR DESCRIPTION
## Short description
This PR updates `io-react-native-jwt` to the `1.1.0` version which fixes an issue during the credential issuing on Android. 
More on the issue in [this PR](https://github.com/pagopa/io-react-native-jwt/pull/22).

## List of changes proposed in this pull request
- Updates the dependency.

## How to test
Test the credential issuing flow on Android and it should work as expected.