### PR TITLE
fix(IT Wallet): [SIW-741] PID detail screen error after app restart

### DIFF
--- a/ts/features/it-wallet/screens/presentation/ItwPrPidDetails.tsx
+++ b/ts/features/it-wallet/screens/presentation/ItwPrPidDetails.tsx
@@ -32,8 +32,6 @@ export type ContentViewParams = {
   decodedPid: PidWithToken;
 };
 
-const SPACER_SIZE = 32;
-
 /**
  * Renders a preview screen which displays a visual representation and the claims contained in the PID.
  * This screen should be generalized for any verifiable crediential but for now it's only used for the PID.
@@ -44,6 +42,7 @@ const ItwPrPidDetails = () => {
   const pid = useIOSelector(ItwCredentialsPidSelector);
   const pidDisplayData = getPidDisplayData();
   const bannerViewRef = React.createRef<View>();
+  const spacerSize = 32;
 
   const presentationButton: BlockButtonProps = {
     type: "Solid",
@@ -86,7 +85,7 @@ const ItwPrPidDetails = () => {
                 issuerInfo
               />
             </ItwClaimsWrapper>
-            <VSpacer size={SPACER_SIZE} />
+            <VSpacer size={spacerSize} />
             <Banner
               testID={"ItwBannerTestID"}
               viewRef={bannerViewRef}
@@ -107,7 +106,7 @@ const ItwPrPidDetails = () => {
               }
             />
           </View>
-          <VSpacer size={SPACER_SIZE} />
+          <VSpacer size={spacerSize} />
         </ScrollView>
         <FooterWithButtons type={"SingleButton"} primary={presentationButton} />
       </SafeAreaView>


### PR DESCRIPTION
## Short description
This PR fixes an issue which causes an error screen in the PID detail screen after an app restart.
The issue is caused by a wrong selector which should provide the encoded PID value but instead of selecting it from the persisted state it's being selected from the issuing flow state.

## List of changes proposed in this pull request
- Replaces the wrong selector with the correct one which gets the encoded PID value from the persisted state.

## How to test
Obtain a PID and then try to open the PID detail from the wallet home screen. Then restart the app and open the PID detail again. It should not show an error screen in both cases.