### PR TITLE
fix: [IABT-1474] Avoid clearing contextual help data on logout

### DIFF
--- a/ts/store/reducers/index.ts
+++ b/ts/store/reducers/index.ts
@@ -24,7 +24,7 @@ import appStateReducer from "./appState";
 import assistanceToolsReducer from "./assistanceTools";
 import authenticationReducer, {
   AuthenticationState,
-  INITIAL_STATE as autenticationInitialState
+  INITIAL_STATE as authenticationInitialState
 } from "./authentication";
 import backendStatusReducer from "./backendStatus";
 import backoffErrorReducer from "./backoffError";
@@ -167,7 +167,7 @@ export function createRootReducer(
       state = state
         ? ({
             authentication: {
-              ...autenticationInitialState,
+              ...authenticationInitialState,
               // eslint-disable-next-line no-underscore-dangle
               _persist: state.authentication._persist
             },
@@ -175,7 +175,8 @@ export function createRootReducer(
             backendStatus: state.backendStatus,
             // keep servicesMetadata from content section
             content: {
-              ...contentInitialContentState
+              ...contentInitialContentState,
+              contextualHelp: state.content.contextualHelp
             },
             // keep hashed fiscal code
             crossSessions: state.crossSessions,


### PR DESCRIPTION
## Short description
This PR aims to prevent unintentional clear of the contextual help

## List of changes proposed in this pull request
- change rootReducer initialization

## How to test
1. Open the app 
2. login 
3. check the contextual help from messages home
4. logout
5. login without closing the app
6. check again the contextual help, data should not be missing.
