### PR TITLE
[IOCOM-716] Clear message details and third party message caches on reloadAllMessage.request

### DIFF
--- a/ts/store/reducers/entities/messages/detailsById.ts
+++ b/ts/store/reducers/entities/messages/detailsById.ts
@@ -3,7 +3,10 @@ import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
 import { getType } from "typesafe-actions";
 
-import { loadMessageDetails } from "../../../actions/messages";
+import {
+  loadMessageDetails,
+  reloadAllMessages
+} from "../../../actions/messages";
 import { clearCache } from "../../../actions/profile";
 import { Action } from "../../../actions/types";
 import { GlobalState } from "../../types";
@@ -52,6 +55,7 @@ const reducer = (
     }
 
     case getType(clearCache):
+    case getType(reloadAllMessages.request):
       return INITIAL_STATE;
 
     default:

--- a/ts/store/reducers/entities/messages/thirdPartyById.ts
+++ b/ts/store/reducers/entities/messages/thirdPartyById.ts
@@ -19,6 +19,7 @@ import {
 } from "../../../../store/reducers/IndexedByIdPot";
 import { GlobalState } from "../../../../store/reducers/types";
 import { RemoteContentDetails } from "../../../../../definitions/backend/RemoteContentDetails";
+import { reloadAllMessages } from "../../../actions/messages";
 import { attachmentFromThirdPartyMessage } from "./transformers";
 
 export type ThirdPartyById = IndexedById<
@@ -43,6 +44,8 @@ export const thirdPartyByIdReducer = (
       return toSome(action.payload.id, state, action.payload.content);
     case getType(loadThirdPartyMessage.failure):
       return toError(action.payload.id, state, action.payload.error);
+    case getType(reloadAllMessages.request):
+      return initialState;
   }
   return state;
 };


### PR DESCRIPTION
## Short description
This PR clears both caches of message details by id and third party message by id upon receiving an action of type reloadAllMessage.request 

## List of changes proposed in this pull request
- Both reducers includes a new case where they return their respective initial state in response to action reloadAllMessage.request

## How to test
Using the io-dev-api-server, access a remote content message details. Go back and manually refresh the message list. Reselect the same message and check that both getMessageDetails and getThirdPartyData API calls are invoked.
