### PR TITLE
feat: [IOCOM-717] Update error message in the `MessageRouterScreen`

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1797,6 +1797,9 @@ messageDetails:
   sendEmail: Send email
   write: Write
   id: "ID:"
+  remoteContentError:
+    title: "Non è stato possibile recuperare i dettagli del messaggio"
+    body: "Abbiamo riscontrato un errore nelle informazioni fornite dall'Ente. Riprova tra qualche minuto. Se il problema persiste, contatta l’assistenza."
   attachments:
     loading: "Loading document..."
     badFormat: "The attachment format is not supported. Please contact the sender"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1797,6 +1797,9 @@ messageDetails:
   sendEmail: Manda email
   write: Scrivi
   id: "ID:"
+  remoteContentError:
+    title: "Non è stato possibile recuperare i dettagli del messaggio"
+    body: "Abbiamo riscontrato un errore nelle informazioni fornite dall'Ente. Riprova tra qualche minuto. Se il problema persiste, contatta l’assistenza."
   attachments:
     loading: "Caricamento del documento..."
     badFormat: "Il formato dell'allegato non è supportato. Contatta l'ente mittente"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "italia-app",
   "version": "2.48.0-rc.0",
-  "io_backend_api": "https://raw.githubusercontent.com/pagopa/io-backend/v13.23.0-RELEASE/api_backend.yaml",
+  "io_backend_api": "https://raw.githubusercontent.com/pagopa/io-backend/c4118dd7ddf28a69447259b323db1648fc6d2772/api_backend.yaml",
   "io_public_api": "https://raw.githubusercontent.com/pagopa/io-backend/v13.23.0-RELEASE/api_public.yaml",
   "io_content_specs": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.28/definitions.yml",
   "io_bonus_vacanze_specs": "https://raw.githubusercontent.com/pagopa/io-backend/v13.23.0-RELEASE/api_bonus.yaml",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "italia-app",
   "version": "2.48.0-rc.0",
-  "io_backend_api": "https://raw.githubusercontent.com/pagopa/io-backend/c4118dd7ddf28a69447259b323db1648fc6d2772/api_backend.yaml",
+  "io_backend_api": "https://raw.githubusercontent.com/pagopa/io-backend/v13.23.0-RELEASE/api_backend.yaml",
   "io_public_api": "https://raw.githubusercontent.com/pagopa/io-backend/v13.23.0-RELEASE/api_public.yaml",
   "io_content_specs": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.28/definitions.yml",
   "io_bonus_vacanze_specs": "https://raw.githubusercontent.com/pagopa/io-backend/v13.23.0-RELEASE/api_bonus.yaml",

--- a/ts/components/screens/GenericErrorComponent.tsx
+++ b/ts/components/screens/GenericErrorComponent.tsx
@@ -103,6 +103,7 @@ export default class GenericErrorComponent extends React.PureComponent<Props> {
                   ? this.props.text
                   : I18n.t("wallet.errors.GENERIC_ERROR")}
               </H2>
+              <VSpacer size={16} />
               <Body accessible={subTextAccessible}>
                 {this.props.subText !== undefined
                   ? this.props.subText

--- a/ts/sagas/messages/watchThirdPartyMessageSaga.ts
+++ b/ts/sagas/messages/watchThirdPartyMessageSaga.ts
@@ -60,7 +60,7 @@ function* getThirdPartyMessage(
       );
     } else {
       const reason = `Response status ${result.right.status} - ${
-        result.right.value?.detail || "UNKNOWN"
+        result.right.value?.detail || "no detail field provided"
       }`;
       throw new Error(reason);
     }

--- a/ts/sagas/messages/watchThirdPartyMessageSaga.ts
+++ b/ts/sagas/messages/watchThirdPartyMessageSaga.ts
@@ -59,7 +59,9 @@ function* getThirdPartyMessage(
         loadThirdPartyMessage.success({ id, content: thirdPartyMessage })
       );
     } else {
-      const reason = `Response status ${result.right.status}`;
+      const reason = `Response status ${result.right.status} - ${
+        result.right.value?.detail || "UNKNOWN"
+      }`;
       throw new Error(reason);
     }
   } catch (error) {

--- a/ts/screens/messages/MessageRouterScreen.tsx
+++ b/ts/screens/messages/MessageRouterScreen.tsx
@@ -13,7 +13,8 @@ import { trackOpenMessage } from "../../features/messages/analytics";
 import {
   blockedFromPushNotificationSelector,
   messageSuccessDataSelector,
-  showSpinnerFromMessageGetStatusSelector
+  showSpinnerFromMessageGetStatusSelector,
+  thirdPartyMessageDetailsErrorSelector
 } from "../../store/reducers/entities/messages/messageGetStatus";
 import {
   cancelGetMessageDataAction,
@@ -42,6 +43,9 @@ export const MessageRouterScreen = (
   const navigation = useNavigation();
   const isFirstRendering = useRef(true);
   const showSpinner = useIOSelector(showSpinnerFromMessageGetStatusSelector);
+  const thirdPartyMessageDetailsError = useIOSelector(
+    thirdPartyMessageDetailsErrorSelector
+  );
   const messageSuccessDataOrUndefined = useIOSelector(
     messageSuccessDataSelector
   );
@@ -144,7 +148,16 @@ export const MessageRouterScreen = (
       contextualHelp={emptyContextualHelp}
     >
       <LoadingErrorComponent
-        errorText={I18n.t("global.genericError")}
+        errorText={
+          thirdPartyMessageDetailsError
+            ? I18n.t("messageDetails.remoteContentError.title")
+            : I18n.t("global.genericError")
+        }
+        errorSubText={
+          thirdPartyMessageDetailsError
+            ? I18n.t("messageDetails.remoteContentError.body")
+            : undefined
+        }
         isLoading={showSpinner}
         loadingCaption={I18n.t("messageDetails.loadingText")}
         onAbort={onCancelCallback}

--- a/ts/screens/messages/__tests__/__snapshots__/MessageRouterScreen.test.tsx.snap
+++ b/ts/screens/messages/__tests__/__snapshots__/MessageRouterScreen.test.tsx.snap
@@ -1962,6 +1962,13 @@ exports[`MessageRouterScreen should match snapshot on message data retrieval fai
                                   >
                                     There is a temporary problem, please try again.
                                   </Text>
+                                  <View
+                                    style={
+                                      Object {
+                                        "height": 16,
+                                      }
+                                    }
+                                  />
                                   <Text
                                     accessible={false}
                                     color="bluegrey"

--- a/ts/store/reducers/entities/messages/messageGetStatus.ts
+++ b/ts/store/reducers/entities/messages/messageGetStatus.ts
@@ -68,7 +68,14 @@ export const messageGetStatusReducer = (
 
 export const showSpinnerFromMessageGetStatusSelector = (state: GlobalState) =>
   state.entities.messages.messageGetStatus.status !== "error";
+
+export const thirdPartyMessageDetailsErrorSelector = (state: GlobalState) =>
+  state.entities.messages.messageGetStatus.status === "error" &&
+  state.entities.messages.messageGetStatus.failurePhase ===
+    "thirdPartyMessageDetails";
+
 export const messageSuccessDataSelector = (state: GlobalState) =>
   state.entities.messages.messageGetStatus.successData;
+
 export const blockedFromPushNotificationSelector = (state: GlobalState) =>
   state.entities.messages.messageGetStatus.status === "blocked";


### PR DESCRIPTION
## Short description
This PR updates the error message in the `MessageRouterScreen` if `getThirdPartyMessage` fails.

## List of changes proposed in this pull request
- updated error message in the `MessageRouterScreen`
- updated locales

## How to test
Using `io-dev-api-server` generate a message with remote content that fails. Open the message detail, check that the error message is correctly displayed
