### PR TITLE
[IOPID-1244] fix: fiscal code offsets

### DIFF
--- a/ts/components/FiscalCodeComponent.tsx
+++ b/ts/components/FiscalCodeComponent.tsx
@@ -63,7 +63,7 @@ const textLeftMarginF = 140 * fullScaleFactor + 6;
 const textGenderLeftMarginF = 800 * fullScaleFactor + 6;
 
 const cardHeightF = 546 * fullScaleFactor;
-const cardHeaderHeightF = 154 * fullScaleFactor;
+const cardHeaderHeightF = 194 * fullScaleFactor;
 const cardSpacerF = 16 * fullScaleFactor;
 const cardLargeSpacerF = 24 * fullScaleFactor;
 const cardLineHeightF = 26 * fullScaleFactor;
@@ -86,8 +86,8 @@ const dateHeightF = birthCityHeightF + cardLineHeightF + cardSpacerF;
 const landscapeScaleFactor = contentWidth / 546;
 const textLineHeightL = 28; // to solve misalignment on font, 28 is the fist value that seems to give text centered to line height
 const textFontSizeL = 21;
-const textLeftMarginL = 140 * landscapeScaleFactor + 8;
-const textGenderLeftMarginL = 800 * landscapeScaleFactor + 8;
+const textLeftMarginL = 170 * landscapeScaleFactor + 8;
+const textGenderLeftMarginL = 830 * landscapeScaleFactor + 8;
 
 const cardWidthL = 870 * landscapeScaleFactor;
 const cardHeaderHeightL = 154 * landscapeScaleFactor;
@@ -299,7 +299,7 @@ const styles = StyleSheet.create({
   },
 
   fullFacSimileText: {
-    marginTop: 310 * fullScaleFactor,
+    marginTop: 350 * fullScaleFactor,
     lineHeight: 38 * fullScaleFactor,
     position: "absolute",
     fontSize: textFontSizeF,


### PR DESCRIPTION
## Short description
This PR fixes offsets in `FiscalCodeScreen`

| iPhone 13 | iPhone 13 Land | iPhone 14 Pro Max | iPhone 14 Pro Max Land |
| - | - | - | - |
| <img src="https://github.com/pagopa/io-app/assets/16268789/f481dc7a-11dc-437a-9cd9-d45f560bd57a" height="200" />  | <img src="https://github.com/pagopa/io-app/assets/16268789/23487042-56a6-4434-a152-e590d7914176" height="200" /> | <img src="https://github.com/pagopa/io-app/assets/16268789/73c87073-c354-4464-bd54-394832e21541" height="200" /> | <img src="https://github.com/pagopa/io-app/assets/16268789/8ab0bc56-c226-4e7a-ae1b-3669d27f52b4" height="200" /> |

## How to test
Run the app both on Android and iOS and check if the fiscal code data are correctly centered.
