### PR TITLE
fix: [IOBP-467] Add correct details component in ID Pay timeline transaction item

### DIFF
--- a/ts/features/idpay/timeline/components/TimelineDetailsBottomSheet.tsx
+++ b/ts/features/idpay/timeline/components/TimelineDetailsBottomSheet.tsx
@@ -85,16 +85,17 @@ const useTimelineDetailsBottomSheet = (
       O.map(details => {
         switch (details.operationType) {
           case TransactionOperationTypeEnum.TRANSACTION:
-            if (details.channel === ChannelEnum.QRCODE) {
+            if (details.channel === ChannelEnum.RTD) {
               return (
-                <TimelineDiscountTransactionDetailsComponent
-                  transaction={details}
-                />
+                <TimelineTransactionDetailsComponent transaction={details} />
               );
             }
             return (
-              <TimelineTransactionDetailsComponent transaction={details} />
+              <TimelineDiscountTransactionDetailsComponent
+                transaction={details}
+              />
             );
+
           case TransactionOperationTypeEnum.REVERSAL:
             return (
               <TimelineTransactionDetailsComponent transaction={details} />


### PR DESCRIPTION
## Short description
This PR fixes an issue with the visualization of the correct details component in ID Pay timeline item.

## List of changes proposed in this pull request
- [ts/features/idpay/timeline/components/TimelineDetailsBottomSheet.tsx](https://github.com/pagopa/io-app/compare/IOBP-467-3-sp-nel-dettaglio-del-pagamento-visualizziamo-un-messaggio-non-corretto?expand=1#diff-290dfda62f62d0a913eb406f4e342bfd3b05c46736f47193e32eed53fae9a073): added correct check in conditional rendering

## How to test
With the `io-dev-api-server`, navigate to the details screen of an initiative, check that `RTD` channel transactions are displayed correctly.
