### PR TITLE
fix: [IOPLT-304] HeaderFirstLevelHandler logic on current route selector instead of local status

### DIFF
--- a/ts/navigation/TabNavigator.tsx
+++ b/ts/navigation/TabNavigator.tsx
@@ -53,10 +53,6 @@ export const MainTabNavigator = () => {
   const isDesignSystemEnabled = useIOSelector(isDesignSystemEnabledSelector);
   const navigation = useNavigation<IOStackNavigationProp<AppParamsList>>();
 
-  const [currentRoute, setCurrentRoute] = React.useState<
-    keyof MainTabParamsList
-  >(ROUTES.MESSAGES_HOME);
-
   const navigateToBarcodeScanScreen = () => {
     navigation.navigate(ROUTES.BARCODE_SCAN);
   };
@@ -66,7 +62,7 @@ export const MainTabNavigator = () => {
       isLoading={startupLoaded === StartupStatusEnum.ONBOARDING}
       loadingOpacity={1}
     >
-      <HeaderFirstLevelHandler currentRoute={currentRoute} />
+      <HeaderFirstLevelHandler />
       <Tab.Navigator
         tabBarOptions={{
           labelStyle: {
@@ -93,11 +89,6 @@ export const MainTabNavigator = () => {
         <Tab.Screen
           name={ROUTES.MESSAGES_HOME}
           component={MessagesHomeScreen}
-          listeners={{
-            tabPress: _ => {
-              setCurrentRoute(ROUTES.MESSAGES_HOME);
-            }
-          }}
           options={{
             title: I18n.t("global.navigator.messages"),
             tabBarIcon: ({ color, focused }) => (
@@ -115,11 +106,6 @@ export const MainTabNavigator = () => {
         <Tab.Screen
           name={ROUTES.WALLET_HOME}
           component={WalletHomeScreen}
-          listeners={{
-            tabPress: _ => {
-              setCurrentRoute(ROUTES.WALLET_HOME);
-            }
-          }}
           options={{
             title: I18n.t("global.navigator.wallet"),
             tabBarIcon: ({ color, focused }) => (
@@ -158,11 +144,6 @@ export const MainTabNavigator = () => {
         <Tab.Screen
           name={ROUTES.SERVICES_HOME}
           component={ServicesHomeScreen}
-          listeners={{
-            tabPress: _ => {
-              setCurrentRoute(ROUTES.SERVICES_HOME);
-            }
-          }}
           options={{
             title: I18n.t("global.navigator.services"),
             tabBarIcon: ({ color, focused }) => (
@@ -180,11 +161,6 @@ export const MainTabNavigator = () => {
         <Tab.Screen
           name={ROUTES.PROFILE_MAIN}
           component={ProfileMainScreen}
-          listeners={{
-            tabPress: _ => {
-              setCurrentRoute(ROUTES.PROFILE_MAIN);
-            }
-          }}
           options={{
             title: I18n.t("global.navigator.profile"),
             tabBarIcon: ({ color, focused }) => (

--- a/ts/navigation/components/HeaderFirstLevelHandler.tsx
+++ b/ts/navigation/components/HeaderFirstLevelHandler.tsx
@@ -1,8 +1,9 @@
 import React, { ComponentProps, useEffect, useMemo } from "react";
 import { ActionProp, HeaderFirstLevel } from "@pagopa/io-app-design-system";
 import { useNavigation } from "@react-navigation/native";
-import ROUTES from "../routes";
-import { useIODispatch } from "../../store/hooks";
+import * as O from "fp-ts/lib/Option";
+import { pipe } from "fp-ts/lib/function";
+import { useIODispatch, useIOSelector } from "../../store/hooks";
 import { MainTabParamsList } from "../params/MainTabParamsList";
 import { useWalletHomeHeaderBottomSheet } from "../../components/wallet/WalletHomeHeader";
 import {
@@ -12,16 +13,24 @@ import {
 import I18n from "../../i18n";
 import { navigateToServicePreferenceScreen } from "../../store/actions/navigation";
 import { searchMessagesEnabled } from "../../store/actions/search";
+import { currentRouteSelector } from "../../store/reducers/navigation";
 
 type HeaderFirstLevelProps = ComponentProps<typeof HeaderFirstLevel>;
-type TabRoutes = keyof MainTabParamsList;
-type Props = {
-  currentRoute: TabRoutes;
-};
+type TabRoutes =
+  | Exclude<keyof MainTabParamsList, "MESSAGES_HOME">
+  | "MESSAGES_INBOX"
+  | "MESSAGES_ARCHIVE";
 
 const headerHelpByRoute: Record<TabRoutes, SupportRequestParams> = {
   BARCODE_SCAN: {},
-  MESSAGES_HOME: {
+  MESSAGES_ARCHIVE: {
+    faqCategories: ["messages"],
+    contextualHelpMarkdown: {
+      title: "messages.contextualHelpTitle",
+      body: "messages.contextualHelpContent"
+    }
+  },
+  MESSAGES_INBOX: {
     faqCategories: ["messages"],
     contextualHelpMarkdown: {
       title: "messages.contextualHelpTitle",
@@ -57,16 +66,22 @@ const headerHelpByRoute: Record<TabRoutes, SupportRequestParams> = {
  * THIS COMPONENT IS NOT MEANT TO BE USED OUTSIDE THE NAVIGATION.
  * THIS COMPONENT WILL BE REMOVED ONCE REACT NAVIGATION WILL BE UPGRADED TO V6
  */
-export const HeaderFirstLevelHandler = ({
-  currentRoute = ROUTES.MESSAGES_HOME
-}: Props) => {
+export const HeaderFirstLevelHandler = () => {
   const dispatch = useIODispatch();
   const navigation = useNavigation();
 
+  const currentRouteName = useIOSelector(currentRouteSelector);
+  // console.log("currentRouteName", currentRouteName);
   const requestParams = useMemo(
-    () => headerHelpByRoute[currentRoute],
-    [currentRoute]
+    () =>
+      pipe(
+        headerHelpByRoute[currentRouteName as TabRoutes],
+        O.fromNullable,
+        O.getOrElse(() => ({}))
+      ),
+    [currentRouteName]
   );
+
   const {
     bottomSheet: WalletHomeHeaderBottomSheet,
     present: presentWalletHomeHeaderBottomsheet
@@ -84,7 +99,7 @@ export const HeaderFirstLevelHandler = ({
     [startSupportRequest]
   );
   const headerProps: HeaderFirstLevelProps = useMemo(() => {
-    switch (currentRoute) {
+    switch (currentRouteName) {
       case "SERVICES_HOME":
         return {
           title: I18n.t("services.title"),
@@ -105,7 +120,9 @@ export const HeaderFirstLevelHandler = ({
           type: "singleAction",
           firstAction: helpAction
         };
-      case "MESSAGES_HOME":
+      case "MESSAGES_INBOX":
+      case "MESSAGES_ARCHIVE":
+      default:
         return {
           title: I18n.t("messages.contentTitle"),
           type: "twoActions",
@@ -132,13 +149,18 @@ export const HeaderFirstLevelHandler = ({
           }
         };
     }
-  }, [currentRoute, helpAction, presentWalletHomeHeaderBottomsheet, dispatch]);
+  }, [
+    currentRouteName,
+    helpAction,
+    presentWalletHomeHeaderBottomsheet,
+    dispatch
+  ]);
 
   useEffect(() => {
     navigation.setOptions({
       header: () => <HeaderFirstLevel {...headerProps} />
     });
-  }, [headerProps, navigation, currentRoute]);
+  }, [headerProps, navigation, currentRouteName]);
 
   return <>{WalletHomeHeaderBottomSheet}</>;
 };


### PR DESCRIPTION
## Short description
This PR fixes an issue that showed the wrong header while navigating to any home section 

## List of changes proposed in this pull request
- Change the logic of `HeaderFirstLevelHandler` to check the current route stored on redux
- removes listeners on tab navigator

## How to test
Check flows like payment starting from a message, once completed reach the wallet home screen, the header should be correct
