### PR TITLE
feat: [IOCOM-740] Update `tosVersion` to 4.7

### DIFF
--- a/ts/config.ts
+++ b/ts/config.ts
@@ -125,7 +125,7 @@ export const remindersOptInEnabled = Config.REMINDERS_OPT_IN_ENABLED === "YES";
 export const isNewCduFlow = Config.CDU_NEW_FLOW === "YES";
 
 // version of ToS
-export const tosVersion: NonNegativeNumber = 4.5 as NonNegativeNumber;
+export const tosVersion: NonNegativeNumber = 4.7 as NonNegativeNumber;
 
 export const fetchTimeout = pipe(
   parseInt(Config.FETCH_TIMEOUT_MS, 10),


### PR DESCRIPTION
## Short description
This PR is going to update the `tosVersion` config to 4.7 in order to forcefully show the ToS screen to the user.

## List of changes proposed in this pull request
- Bumped `tosVersion` to `4.7`

## How to test
The ToS screen should be visible after opening the app
