### PR TITLE
revert: Enable new qr code screen only with DS feature flag active

### DIFF
--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -69,6 +69,7 @@ import { IOStackNavigationRouteProps } from "../../navigation/params/AppParamsLi
 import { MainTabParamsList } from "../../navigation/params/MainTabParamsList";
 import {
   navigateBack,
+  navigateToPaymentScanQrCode,
   navigateToTransactionDetailsScreen,
   navigateToWalletAddPaymentMethod
 } from "../../store/actions/navigation";
@@ -472,9 +473,13 @@ class WalletHomeScreen extends React.PureComponent<Props, State> {
   }
 
   private navigateToPaymentScanQrCode = () => {
-    this.props.navigation.navigate(WalletBarcodeRoutes.WALLET_BARCODE_MAIN, {
-      screen: WalletBarcodeRoutes.WALLET_BARCODE_SCAN
-    });
+    if (this.props.isDesignSystemEnabled) {
+      this.props.navigation.navigate(WalletBarcodeRoutes.WALLET_BARCODE_MAIN, {
+        screen: WalletBarcodeRoutes.WALLET_BARCODE_SCAN
+      });
+    } else {
+      this.props.navigateToPaymentScanQrCode();
+    }
   };
 
   private footerButton(potWallets: pot.Pot<ReadonlyArray<Wallet>, Error>) {
@@ -588,6 +593,7 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
   loadIdPayWalletData: () => dispatch(idPayWalletGet.request()),
   navigateToWalletAddPaymentMethod: (keyFrom?: string) =>
     navigateToWalletAddPaymentMethod({ inPayment: O.none, keyFrom }),
+  navigateToPaymentScanQrCode: () => navigateToPaymentScanQrCode(),
   navigateToTransactionDetailsScreen: (transaction: Transaction) => {
     navigateToTransactionDetailsScreen({
       transaction,


### PR DESCRIPTION
## Short description
This PR restores the new QR code scan screen visible only with the DS feature flag enabled

## List of changes proposed in this pull request
- Added a DS feature flag check into `WalletHomeScreen`, is enabled it navigates to the new QR Code screen

## How to test
Open the wallet homepage, and press on the `Paga ora` button, if the DS feature flag toggle is enabled you should be able to see the new screen, otherwise the old one.

## Preview
https://github.com/pagopa/io-app/assets/34343582/96ac98ca-98bb-4828-9d6c-c8dba12d4df8

