### PR TITLE
fix: [IOPID-1261] Fix fast login opt-in selector

### DIFF
--- a/ts/features/fastLogin/store/selectors/__tests__/fastLogin.test.ts
+++ b/ts/features/fastLogin/store/selectors/__tests__/fastLogin.test.ts
@@ -5,6 +5,7 @@ import { baseRawBackendStatus } from "../../../../../store/reducers/__mock__/bac
 import { GlobalState } from "../../../../../store/reducers/types";
 import { getAppVersion } from "../../../../../utils/appVersion";
 import { isFastLoginEnabledSelector } from "..";
+import { FastLoginConfigOpt_in } from "../../../../../../definitions/content/FastLoginConfig";
 
 jest.mock("react-native-device-info", () => ({
   getReadableVersion: jest.fn().mockReturnValue("1.2.3.4"),
@@ -12,7 +13,8 @@ jest.mock("react-native-device-info", () => ({
 }));
 
 jest.mock("../../../../../config", () => ({
-  fastLoginEnabled: true
+  fastLoginEnabled: true,
+  fastLoginOptIn: true
 }));
 
 const currentAppVersion = getAppVersion();
@@ -91,14 +93,16 @@ describe("FastLogin remote flag test", () => {
 
   function checkIfFastLoginFlagIsEnableForThisAppVersion(
     minAppVersion: string | undefined,
-    expectedValue: boolean
+    expectedValue: boolean,
+    optInStatus: FastLoginConfigOpt_in | undefined,
+    optInSelection: boolean | undefined
   ) {
     const customStore = {
       features: {
         loginFeatures: {
           fastLogin: {
             optIn: {
-              enabled: true
+              enabled: optInSelection
             }
           }
         }
@@ -112,7 +116,8 @@ describe("FastLogin remote flag test", () => {
               min_app_version: {
                 android: minAppVersion,
                 ios: minAppVersion
-              }
+              },
+              opt_in: optInStatus
             }
           }
         })
@@ -126,7 +131,9 @@ describe("FastLogin remote flag test", () => {
   function checkFastLoginFlagTest(
     minAppVersion: string | undefined,
     currentAppVersion: string,
-    expectedValue: boolean
+    expectedValue: boolean,
+    optInStatus: FastLoginConfigOpt_in | undefined,
+    optInSelection: boolean | undefined
   ) {
     const testTitle = `FastLogin${
       expectedValue ? "" : " NOT"
@@ -134,12 +141,14 @@ describe("FastLogin remote flag test", () => {
     it(testTitle, () => {
       checkIfFastLoginFlagIsEnableForThisAppVersion(
         minAppVersion,
-        expectedValue
+        expectedValue,
+        optInStatus,
+        optInSelection
       );
     });
   }
 
-  describe("FastLogin flag test for different config values", () => {
+  describe("FastLogin flag test for different config values with NO opt-in", () => {
     [
       Tuple2("0", false),
       Tuple2("0.0", false),
@@ -159,7 +168,118 @@ describe("FastLogin remote flag test", () => {
       Tuple2(undefined, false),
       Tuple2("?$&&/!@", false)
     ].forEach((t: ITuple2<string | undefined, boolean>) =>
-      checkFastLoginFlagTest(t.e1, currentAppVersion, t.e2)
+      checkFastLoginFlagTest(
+        t.e1,
+        currentAppVersion,
+        t.e2,
+        undefined,
+        undefined
+      )
+    );
+  });
+
+  describe("FastLogin flag test for different config values with undefined opt-in", () => {
+    [
+      Tuple2("0", false),
+      Tuple2("0.0", false),
+      Tuple2("0.0.0", false),
+      Tuple2("0.0.0.0", false),
+      Tuple2("1", true),
+      Tuple2("1.2", true),
+      Tuple2("1.2.3", true),
+      Tuple2("1.2.3.0", true),
+      Tuple2("1.2.3.1", true),
+      Tuple2("1.2.3.2", true),
+      Tuple2("1.2.3.3", true),
+      Tuple2("1.2.3.4", true),
+      Tuple2("-1", false),
+      Tuple2("1.2.3.5", false),
+      Tuple2("", false),
+      Tuple2(undefined, false),
+      Tuple2("?$&&/!@", false)
+    ].forEach((t: ITuple2<string | undefined, boolean>) =>
+      checkFastLoginFlagTest(
+        t.e1,
+        currentAppVersion,
+        t.e2,
+        {
+          min_app_version: {
+            android: t.e1,
+            ios: t.e1
+          }
+        },
+        undefined
+      )
+    );
+  });
+
+  describe("FastLogin flag test for different config values with opt-in selected", () => {
+    [
+      Tuple2("0", false),
+      Tuple2("0.0", false),
+      Tuple2("0.0.0", false),
+      Tuple2("0.0.0.0", false),
+      Tuple2("1", true),
+      Tuple2("1.2", true),
+      Tuple2("1.2.3", true),
+      Tuple2("1.2.3.0", true),
+      Tuple2("1.2.3.1", true),
+      Tuple2("1.2.3.2", true),
+      Tuple2("1.2.3.3", true),
+      Tuple2("1.2.3.4", true),
+      Tuple2("-1", false),
+      Tuple2("1.2.3.5", false),
+      Tuple2("", false),
+      Tuple2(undefined, false),
+      Tuple2("?$&&/!@", false)
+    ].forEach((t: ITuple2<string | undefined, boolean>) =>
+      checkFastLoginFlagTest(
+        t.e1,
+        currentAppVersion,
+        t.e2,
+        {
+          min_app_version: {
+            android: t.e1,
+            ios: t.e1
+          }
+        },
+        true
+      )
+    );
+  });
+
+  describe("FastLogin flag test for different config values, with opt-in not selected", () => {
+    [
+      Tuple2("0", false),
+      Tuple2("0.0", false),
+      Tuple2("0.0.0", false),
+      Tuple2("0.0.0.0", false),
+      Tuple2("1", false),
+      Tuple2("1.2", false),
+      Tuple2("1.2.3", false),
+      Tuple2("1.2.3.0", false),
+      Tuple2("1.2.3.1", false),
+      Tuple2("1.2.3.2", false),
+      Tuple2("1.2.3.3", false),
+      Tuple2("1.2.3.4", false),
+      Tuple2("-1", false),
+      Tuple2("1.2.3.5", false),
+      Tuple2("", false),
+      Tuple2(undefined, false),
+      Tuple2("?$&&/!@", false)
+    ].forEach((t: ITuple2<string | undefined, boolean>) =>
+      checkFastLoginFlagTest(
+        t.e1,
+        currentAppVersion,
+        t.e2,
+        {
+          min_app_version: {
+            android: t.e1,
+            ios: t.e1
+          }
+        },
+        false
+      )
     );
   });
 });

--- a/ts/features/fastLogin/store/selectors/index.ts
+++ b/ts/features/fastLogin/store/selectors/index.ts
@@ -55,7 +55,7 @@ const isFastLoginOptInEnabledSelector = createSelector(
   fastLoginOptInSelector,
   (featureFlag, optIn) => {
     if (featureFlag) {
-      return optIn.enabled;
+      return optIn.enabled ?? true;
     }
     return true;
   }
@@ -85,7 +85,7 @@ export const isFastLoginFFEnabledSelector = createSelector(
 export const isFastLoginEnabledSelector = createSelector(
   isFastLoginFFEnabledSelector,
   isFastLoginOptInEnabledSelector,
-  (fastloginFFEnabled, optInEnabled) => fastloginFFEnabled && !!optInEnabled
+  (fastloginFFEnabled, optInEnabled) => fastloginFFEnabled && optInEnabled
 );
 
 const fastLoginTokenRefreshHandlerSelector = (state: GlobalState) =>


### PR DESCRIPTION
## Short description
This PR fixes a bug that happens when a user has logged in with FL while the opt-in FF was disable and then the FF it's been enabled. In this case the app return that FL is not enabled.

| ❌ | ✅ |
| - | - | 
| <video src="https://github.com/pagopa/io-app/assets/16268789/5cf18c3f-d374-4446-844c-ec1886e09fee" /> | <video src="https://github.com/pagopa/io-app/assets/16268789/e13f1ccb-f694-4ccb-a56f-7249a8aeb93c" />

## How to test
...
