### PR TITLE
fix: [IOPID-1267] Chore: fix toast

### DIFF
--- a/ts/screens/profile/CduEmailInsertScreen.tsx
+++ b/ts/screens/profile/CduEmailInsertScreen.tsx
@@ -24,8 +24,7 @@ import {
   LabelSmall,
   VSpacer,
   Alert as AlertComponent,
-  FooterWithButtons,
-  IOToast
+  FooterWithButtons
 } from "@pagopa/io-app-design-system";
 import { H1 } from "../../components/core/typography/H1";
 import { LabelledItem } from "../../components/LabelledItem";
@@ -61,6 +60,7 @@ import {
 import { getFlowType } from "../../utils/analytics";
 import { emailValidationSelector } from "../../store/reducers/emailValidation";
 import { emailAcknowledged } from "../../store/actions/onboarding";
+import { showToast } from "../../utils/showToast";
 
 export type CduEmailInsertScreenNavigationParams = Readonly<{
   isOnboarding: boolean;
@@ -256,7 +256,7 @@ const CduEmailInsertScreen = (props: Props) => {
             ]
           );
         } else {
-          IOToast.error(I18n.t("email.edit.upsert_ko"));
+          showToast(I18n.t("email.edit.upsert_ko"));
         }
         // display a toast with error
       } else if (pot.isSome(profile) && !pot.isUpdating(profile)) {


### PR DESCRIPTION
## Short description
This PR fixes the missing error toast inside `CduEmailInsertScreen`.

<details open><summary>Details</summary>
<p>

<video src="https://github.com/pagopa/io-app/assets/16268789/961b10ab-0694-4bfe-9fee-a6d283a6c2ca" />

</p>
</details> 


## How to test
Modify your profile email simulating an HTTP error (with proxyman or io-dev-api-server) and check that an error snackbar is shown.
