### PR TITLE
chore(IT Wallet): [SIW-772] Add `BLE` permissions for `iOS` and `Android`

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -44,6 +44,27 @@
   <!-- Required for local notifications -->
   <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
+  <!-- Request legacy Bluetooth permissions on older devices. -->
+  <uses-permission android:name="android.permission.BLUETOOTH"
+                   android:maxSdkVersion="30" />
+  <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
+                   android:maxSdkVersion="30" />
+
+  <!-- Needed only if your app looks for Bluetooth devices.
+       If your app doesn't use Bluetooth scan results to derive physical
+       location information, you can
+       <a href="#assert-never-for-location">strongly assert that your app
+       doesn't derive physical location</a>. -->
+  <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+
+  <!-- Needed only if your app makes the device discoverable to Bluetooth
+       devices. -->
+  <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+
+  <!-- Needed only if your app communicates with already-paired Bluetooth
+       devices. -->
+  <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
   <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:usesCleartextTraffic="true" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:requestLegacyExternalStorage="true" android:theme="@style/AppTheme">
 
     <!-- START Required by react-native-push-notification -->

--- a/ios/ItaliaApp/Info.plist
+++ b/ios/ItaliaApp/Info.plist
@@ -62,9 +62,9 @@
     <key>NSAppleMusicUsageDescription</key>
     <string>The app needs NSAppleMusicUsageDescription permission</string>
     <key>NSBluetoothAlwaysUsageDescription</key>
-    <string>The app needs NSBluetoothAlwaysUsageDescription permission</string>
+    <string>IO needs access to Bluetooth to allow you to search and exchange data with the verification app</string>
     <key>NSBluetoothPeripheralUsageDescription</key>
-    <string>The app needs NSBluetoothPeripheralUsageDescription permission</string>
+    <string>IO need access to Bluetooth to allow you to search and exchange data with the verification app</string>
     <key>NSCalendarsUsageDescription</key>
     <string>So that you’ll be able to add deadlines to your calendar and set a reminder.</string>
     <key>NSCameraUsageDescription</key>

--- a/ios/ItaliaApp/Info.plist
+++ b/ios/ItaliaApp/Info.plist
@@ -89,6 +89,8 @@
     <string>You’ll be able to save bonuses, certificates and upload screenshots or payment notices.</string>
     <key>NSSpeechRecognitionUsageDescription</key>
     <string>The app needs NSSpeechRecognitionUsageDescription permission</string>
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>Our app uses bluetooth to find, connect and transfer data between different devices</string>
     <key>UIAppFonts</key>
     <array>
       <string>TitilliumWeb-Black.ttf</string>

--- a/ios/ItaliaApp/it.lproj/InfoPlist.strings
+++ b/ios/ItaliaApp/it.lproj/InfoPlist.strings
@@ -5,3 +5,4 @@
 "NSPhotoLibraryUsageDescription" = "Potrai salvare bonus e certificati, caricare screenshot e avvisi di pagamento.";
 "NSMicrophoneUsageDescription" = "IO ha necessità di accedere al microfono nel caso in cui desideri mandare una nota vocale";
 "NSPhotoLibraryAddUsageDescription" = "Potrai salvare immagini dall'app sul tuo dispositivo.";
+"NSBluetoothAlwaysUsageDescription" = "IO ha necessità di accedere al Bluetooth per permetterti di cercare e scambiare dati con app di verifica";


### PR DESCRIPTION
## Short description
This PR updates `Info.plist` and `AndroidManifest.xml` adding BLE permission as describe on [react-native-ble-manager](https://github.com/innoveit/react-native-ble-manager) repo.

- https://github.com/innoveit/react-native-ble-manager?tab=readme-ov-file#android---update-manifest
- https://github.com/innoveit/react-native-ble-manager?tab=readme-ov-file#ios---update-infoplist

## List of changes proposed in this pull request
- Update AndroidManifest.xml
- Update Info.plist

## How to test
Static checks should be enough 