### PR TITLE
chore(IT Wallet): [SIW-773] Add patch to `cipher-base` package

### DIFF
--- a/patches/cipher-base+1.0.4.patch
+++ b/patches/cipher-base+1.0.4.patch
@@ -1,0 +1,11 @@
+diff --git a/node_modules/cipher-base/index.js b/node_modules/cipher-base/index.js
+index 6728005..16426bf 100644
+--- a/node_modules/cipher-base/index.js
++++ b/node_modules/cipher-base/index.js
+@@ -1,5 +1,5 @@
+ var Buffer = require('safe-buffer').Buffer
+-var Transform = require('stream').Transform
++var Transform = require('readable-stream').Transform
+ var StringDecoder = require('string_decoder').StringDecoder
+ var inherits = require('inherits')
+ 


### PR DESCRIPTION
## Short description
This PR adds a patch to `cipher-base` package to solve an "issue" during proximity verification flow. It could be related on how `io-app` do the bundle of sub-dependencies (like import/export issue). The patch is also related to these issues on other repositories:

- https://stackoverflow.com/questions/74413490/uncaught-typeerror-cannot-read-properties-of-undefined-reading-call-at-hash
- https://github.com/browserify/cipher-base/issues/10

## List of changes proposed in this pull request
- Add patch file using patch-package

## How to test
Static checks should be enough. 