### PR TITLE
chore: [IOPID-1182] Chore: enable all FL related local FF in production"

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -84,17 +84,17 @@ CIE_SPID_INFORMATION_URL='https://identitadigitale.gov.it'
 # Pin/Puk help url
 PIN_PUK_HELP_URL='https://www.cartaidentita.interno.gov.it/info-utili/codici-di-sicurezza-pin-e-puk'
 # Fast Login feature
-FAST_LOGIN_ENABLED=YES
+FAST_LOGIN_ENABLED=NO
 # Native Login feature
 NATIVE_LOGIN_ENABLED=NO
 # Fast login max retries
 FAST_LOGIN_MAX_RETRIES=3
 # Fast login bypass opt-in
-FAST_LOGIN_OPTIN=YES
+FAST_LOGIN_OPTIN=NO
 # Enable CIE login flow with emulator and dev server
 CIE_LOGIN_WITH_DEV_SERVER_ENABLED=NO
 # Enable CDU flow new screen
-CDU_NEW_FLOW=YES
+CDU_NEW_FLOW=NO
 # Relay State for SPID
 SPID_RELAY_STATE='appio'
 # Wallet RESTful API


### PR DESCRIPTION
Reverts pagopa/io-app#5353

This PR disables all related FL remote FF if we need to make a deploy before the launch of FL.