### PR TITLE
fix: [IOCOM-761] Text wrapping for precondition's title text

### DIFF
--- a/ts/features/messages/components/PreconditionBottomSheet/PreconditionHeader.tsx
+++ b/ts/features/messages/components/PreconditionBottomSheet/PreconditionHeader.tsx
@@ -1,11 +1,18 @@
 import * as React from "react";
-import { View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import Placeholder from "rn-placeholder";
 import { IOColors } from "@pagopa/io-app-design-system";
 import HeaderImage from "../../../../../img/features/pn/pn_alert_header.svg";
 import customVariables from "../../../../theme/variables";
 import { IOStyles } from "../../../../components/core/variables/IOStyles";
 import { H3 } from "../../../../components/core/typography/H3";
+
+const styles = StyleSheet.create({
+  preconditionTitle: {
+    flex: 1,
+    flexWrap: "wrap"
+  }
+});
 
 type Props = {
   title: string;
@@ -19,7 +26,7 @@ export const PreconditionHeader = ({ title }: Props) => (
       fill={IOColors.blue}
       style={{ marginRight: customVariables.spacerWidth }}
     />
-    <H3>{title}</H3>
+    <H3 style={styles.preconditionTitle}>{title}</H3>
   </View>
 );
 


### PR DESCRIPTION
## Short description
This PR adjusts the right margin of the title text of the precondition bottom sheet.
![Simulator Screenshot - iPhone 14 - 2024-01-03 at 11 57 21](https://github.com/pagopa/io-app/assets/5150343/35ab2c63-3cfb-48fb-bfa3-2f02dabdfefc)

## List of changes proposed in this pull request
- Styles for the H3 element where the text is displayed

## How to test
Using the io-dev-api-server, check that the text wraps around the title assigned space
