### PR TITLE
fix: [IOCOM-759] Remove the section title if there are no attachments

### DIFF
--- a/ts/components/messages/MessageDetail/index.tsx
+++ b/ts/components/messages/MessageDetail/index.tsx
@@ -9,7 +9,9 @@ import {
 import { useNavigation } from "@react-navigation/native";
 import { IOColors, IOStyles, VSpacer } from "@pagopa/io-app-design-system";
 import * as pot from "@pagopa/ts-commons/lib/pot";
+import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
+import * as RA from "fp-ts/lib/ReadonlyArray";
 import I18n from "../../../i18n";
 import { OrganizationFiscalCode } from "../../../../definitions/backend/OrganizationFiscalCode";
 import { ServiceMetadata } from "../../../../definitions/backend/ServiceMetadata";
@@ -151,9 +153,15 @@ const MessageDetailsComponent = ({
   const thirdPartyDataPot = useIOSelector(state =>
     thirdPartyFromIdSelector(state, messageId)
   );
-  const thirdPartyMessagePotOrUndefined = pot.toUndefined(thirdPartyDataPot);
-  const hasThirdPartyDataAttachments =
-    !!thirdPartyMessagePotOrUndefined?.third_party_message.attachments;
+  const hasThirdPartyDataAttachments = pipe(
+    thirdPartyDataPot,
+    pot.toOption,
+    O.chainNullableK(
+      thirdPartyData => thirdPartyData.third_party_message.attachments
+    ),
+    O.map(RA.isNonEmpty),
+    O.getOrElse(() => false)
+  );
 
   const messageMarkdown =
     useIOSelector(state => messageMarkdownSelector(state, messageId)) ??


### PR DESCRIPTION
## Short description
This PR avoids displaying the section title if there are no attachments.

<details open><summary>Details</summary>
<p>

| before | after |
| - | - |
| <img src="https://github.com/pagopa/io-app/assets/29163287/4ef8ba82-5b04-44c6-8809-bbe6b543e109" width="300" /> | <img src="https://github.com/pagopa/io-app/assets/29163287/25ced45a-a47a-4257-a98c-de9f23508d3f" width="300" /> | 

</p>
</details> 

## List of changes proposed in this pull request
- updated `hasThirdPartyDataAttachments` in order to not display the section title

## How to test
Using io-dev-api-server, generate a message without attachments. Open the message detail and check that the section title is not displayed.