### PR TITLE
chore: [IOPID-1301] Bump ToS version from 4.7 to 4.8

### DIFF
--- a/ts/config.ts
+++ b/ts/config.ts
@@ -125,7 +125,7 @@ export const remindersOptInEnabled = Config.REMINDERS_OPT_IN_ENABLED === "YES";
 export const isNewCduFlow = Config.CDU_NEW_FLOW === "YES";
 
 // version of ToS
-export const tosVersion: NonNegativeNumber = 4.7 as NonNegativeNumber;
+export const tosVersion: NonNegativeNumber = 4.8 as NonNegativeNumber;
 
 export const fetchTimeout = pipe(
   parseInt(Config.FETCH_TIMEOUT_MS, 10),


### PR DESCRIPTION
## Short description
This PR bumps the ToS version from `4.7` to `4.8`

## How to test
Run the app against the dev server. Either on first onboarding/onboarding or after a successful identification, you should see the ToS screen to accept the new ToS.
