### PR TITLE
feat: [IOBP-480] Remove holder name from wallet payment confirm screen

### DIFF
--- a/ts/features/walletV3/payment/components/WalletPaymentConfirmContent.tsx
+++ b/ts/features/walletV3/payment/components/WalletPaymentConfirmContent.tsx
@@ -138,10 +138,7 @@ const getPaymentSubtitle = (cardDetails: WalletInfoDetails) => {
   switch (cardDetails.type) {
     case TypeEnum.CARDS:
       const cardsDetail = cardDetails as WalletInfoDetails1;
-      return `${cardsDetail.holder} · ${format(
-        cardsDetail.expiryDate,
-        "MM/YY"
-      )}`;
+      return `${format(cardsDetail.expiryDate, "MM/YY")}`;
     case TypeEnum.PAYPAL:
       return I18n.t("wallet.onboarding.paypal.name");
     case TypeEnum.BANCOMATPAY:


### PR DESCRIPTION
## Short description
This PR removes the cardholder information into `WalletPaymentConfirmScreen` if the user chooses a payment with cards.

## List of changes proposed in this pull request
- Into `WalletPaymentConfirmContent` the user holder as payment subtitle has been removed.

## How to test
- Start a payment flow through the `New wallet Playground`;
- Select a credit card as payment method;
- When you reach the end of the payment, you should be able to see only the expiration date of the card

## Preview

|Before|After|
|-|-|
|<img src="https://github.com/pagopa/io-app/assets/34343582/1270f0c3-b485-42c2-8bd1-952ad602de78)" width="300" /> | <img src="https://github.com/pagopa/io-app/assets/34343582/fd1fb805-d8a8-45f4-8543-8183cf91197f)" width="300" /> 
