### PR TITLE
chore: [IOBP-479] Add temporary missing methods error in method selection screen

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1667,6 +1667,11 @@ wallet:
       alert:
         body: "A causa dell’importo elevato, alcuni metodi non sono disponibili."
         cta: "Ok, ho capito!"
+      missingMethodsError:
+        title: Aggiungi un metodo per effettuare pagamenti in app
+        subtitle: Il metodo verrà salvato nel Portafoglio, così la prossima volta potrai pagare più facilmente.
+        addMethod: Aggiungi metodo
+        notNow: Non ora
     psp:
       title: Scegli chi gestirà il pagamento
       description: Ogni gestore propone una commissione.

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1667,6 +1667,11 @@ wallet:
       alert:
         body: "A causa dell’importo elevato, alcuni metodi non sono disponibili."
         cta: "Ok, ho capito!"
+      missingMethodsError:
+        title: Aggiungi un metodo per effettuare pagamenti in app
+        subtitle: Il metodo verrà salvato nel Portafoglio, così la prossima volta potrai pagare più facilmente.
+        addMethod: Aggiungi metodo
+        notNow: Non ora
     psp:
       title: Scegli chi gestirà il pagamento
       description: Ogni gestore propone una commissione.

--- a/ts/features/walletV3/payment/components/WalletPaymentMissingMethodsError.tsx
+++ b/ts/features/walletV3/payment/components/WalletPaymentMissingMethodsError.tsx
@@ -1,0 +1,49 @@
+import { useNavigation } from "@react-navigation/native";
+import React from "react";
+import { OperationResultScreenContent } from "../../../../components/screens/OperationResultScreenContent";
+import {
+  AppParamsList,
+  IOStackNavigationProp
+} from "../../../../navigation/params/AppParamsList";
+import { WalletOnboardingRoutes } from "../../onboarding/navigation/navigator";
+
+const WalletPaymentMissingMethodsError = () => {
+  const navigation = useNavigation<IOStackNavigationProp<AppParamsList>>();
+
+  React.useEffect(() => {
+    // This removes the header
+    navigation.setOptions({
+      header: () => undefined,
+      headerTransparent: true
+    });
+  }, [navigation]);
+
+  const handleAddMethod = () => {
+    navigation.replace(WalletOnboardingRoutes.WALLET_ONBOARDING_MAIN, {
+      screen: WalletOnboardingRoutes.WALLET_ONBOARDING_SELECT_PAYMENT_METHOD
+    });
+  };
+
+  const handleNotNow = () => {
+    navigation.pop();
+  };
+
+  return (
+    <OperationResultScreenContent
+      title="Aggiungi un metodo per effettuare pagamenti in app"
+      subtitle="Il metodo verrà salvato nel Portafoglio, così la prossima volta potrai pagare più facilmente."
+      action={{
+        label: "Aggiungi metodo",
+        accessibilityLabel: "Aggiungi metodo",
+        onPress: handleAddMethod
+      }}
+      secondaryAction={{
+        label: "Non ora",
+        accessibilityLabel: "Non ora",
+        onPress: handleNotNow
+      }}
+    />
+  );
+};
+
+export { WalletPaymentMissingMethodsError };

--- a/ts/features/walletV3/payment/components/WalletPaymentMissingMethodsError.tsx
+++ b/ts/features/walletV3/payment/components/WalletPaymentMissingMethodsError.tsx
@@ -30,6 +30,7 @@ const WalletPaymentMissingMethodsError = () => {
 
   return (
     <OperationResultScreenContent
+      pictogram="cardAdd"
       title={I18n.t("wallet.payment.methodSelection.missingMethodsError.title")}
       subtitle={I18n.t(
         "wallet.payment.methodSelection.missingMethodsError.subtitle"

--- a/ts/features/walletV3/payment/components/WalletPaymentMissingMethodsError.tsx
+++ b/ts/features/walletV3/payment/components/WalletPaymentMissingMethodsError.tsx
@@ -6,6 +6,7 @@ import {
   IOStackNavigationProp
 } from "../../../../navigation/params/AppParamsList";
 import { WalletOnboardingRoutes } from "../../onboarding/navigation/navigator";
+import I18n from "../../../../i18n";
 
 const WalletPaymentMissingMethodsError = () => {
   const navigation = useNavigation<IOStackNavigationProp<AppParamsList>>();
@@ -29,16 +30,26 @@ const WalletPaymentMissingMethodsError = () => {
 
   return (
     <OperationResultScreenContent
-      title="Aggiungi un metodo per effettuare pagamenti in app"
-      subtitle="Il metodo verrà salvato nel Portafoglio, così la prossima volta potrai pagare più facilmente."
+      title={I18n.t("wallet.payment.methodSelection.missingMethodsError.title")}
+      subtitle={I18n.t(
+        "wallet.payment.methodSelection.missingMethodsError.subtitle"
+      )}
       action={{
-        label: "Aggiungi metodo",
-        accessibilityLabel: "Aggiungi metodo",
+        label: I18n.t(
+          "wallet.payment.methodSelection.missingMethodsError.addMethod"
+        ),
+        accessibilityLabel: I18n.t(
+          "wallet.payment.methodSelection.missingMethodsError.addMethod"
+        ),
         onPress: handleAddMethod
       }}
       secondaryAction={{
-        label: "Non ora",
-        accessibilityLabel: "Non ora",
+        label: I18n.t(
+          "wallet.payment.methodSelection.missingMethodsError.notNow"
+        ),
+        accessibilityLabel: I18n.t(
+          "wallet.payment.methodSelection.missingMethodsError.notNow"
+        ),
         onPress: handleNotNow
       }}
     />

--- a/ts/features/walletV3/payment/components/WalletPaymentMissingMethodsError.tsx
+++ b/ts/features/walletV3/payment/components/WalletPaymentMissingMethodsError.tsx
@@ -11,7 +11,6 @@ const WalletPaymentMissingMethodsError = () => {
   const navigation = useNavigation<IOStackNavigationProp<AppParamsList>>();
 
   React.useEffect(() => {
-    // This removes the header
     navigation.setOptions({
       header: () => undefined,
       headerTransparent: true
@@ -19,7 +18,7 @@ const WalletPaymentMissingMethodsError = () => {
   }, [navigation]);
 
   const handleAddMethod = () => {
-    navigation.replace(WalletOnboardingRoutes.WALLET_ONBOARDING_MAIN, {
+    navigation.push(WalletOnboardingRoutes.WALLET_ONBOARDING_MAIN, {
       screen: WalletOnboardingRoutes.WALLET_ONBOARDING_SELECT_PAYMENT_METHOD
     });
   };

--- a/ts/features/walletV3/payment/screens/WalletPaymentPickMethodScreen.tsx
+++ b/ts/features/walletV3/payment/screens/WalletPaymentPickMethodScreen.tsx
@@ -95,7 +95,6 @@ const WalletPaymentPickMethodScreen = () => {
 
   useHeaderSecondLevel({
     title: "",
-    backAccessibilityLabel: I18n.t("global.buttons.back"),
     contextualHelp: emptyContextualHelp,
     faqCategories: ["payment"],
     supportRequest: true

--- a/ts/features/walletV3/payment/screens/WalletPaymentPickMethodScreen.tsx
+++ b/ts/features/walletV3/payment/screens/WalletPaymentPickMethodScreen.tsx
@@ -32,10 +32,7 @@ import { ComponentProps } from "../../../../types/react";
 import { emptyContextualHelp } from "../../../../utils/emptyContextualHelp";
 import { findFirstCaseInsensitive } from "../../../../utils/object";
 import { WalletPaymentRoutes } from "../navigation/routes";
-import {
-  walletPaymentGetAllMethods,
-  walletPaymentGetUserWallets
-} from "../store/actions/networking";
+import { walletPaymentGetUserWallets } from "../store/actions/networking";
 import { walletPaymentPickPaymentMethod } from "../store/actions/orchestration";
 import {
   walletPaymentAllMethodsSelector,
@@ -91,7 +88,7 @@ const WalletPaymentPickMethodScreen = () => {
 
   useFocusEffect(
     React.useCallback(() => {
-      dispatch(walletPaymentGetAllMethods.request());
+      // dispatch(walletPaymentGetAllMethods.request()); // currently we do not allow onboarding new methods in payment flow
       dispatch(walletPaymentGetUserWallets.request());
     }, [dispatch])
   );

--- a/ts/features/walletV3/payment/screens/WalletPaymentPickMethodScreen.tsx
+++ b/ts/features/walletV3/payment/screens/WalletPaymentPickMethodScreen.tsx
@@ -40,6 +40,7 @@ import {
   walletPaymentSavedMethodByIdSelector,
   walletPaymentUserWalletsSelector
 } from "../store/selectors";
+import { WalletPaymentMissingMethodsError } from "../components/WalletPaymentMissingMethodsError";
 
 type SavedMethodState = {
   kind: "saved";
@@ -80,7 +81,6 @@ const WalletPaymentPickMethodScreen = () => {
   useHeaderSecondLevel({
     title: "",
     backAccessibilityLabel: I18n.t("global.buttons.back"),
-    goBack: navigation.goBack,
     contextualHelp: emptyContextualHelp,
     faqCategories: ["payment"],
     supportRequest: true
@@ -166,7 +166,7 @@ const WalletPaymentPickMethodScreen = () => {
   }, [isLoading, genericMethodsListItems, savedMethodsListItems]);
 
   if (!isLoading && savedMethodsListItems.length === 0) {
-    return <></>;
+    return <WalletPaymentMissingMethodsError />;
   }
 
   return (

--- a/ts/features/walletV3/payment/store/selectors/index.ts
+++ b/ts/features/walletV3/payment/store/selectors/index.ts
@@ -1,5 +1,7 @@
-import { createSelector } from "reselect";
 import * as pot from "@pagopa/ts-commons/lib/pot";
+import * as O from "fp-ts/lib/Option";
+import { pipe } from "fp-ts/lib/function";
+import { createSelector } from "reselect";
 import { GlobalState } from "../../../../../store/reducers/types";
 
 const selectWalletPayment = (state: GlobalState) =>
@@ -20,17 +22,27 @@ export const walletPaymentAllMethodsSelector = createSelector(
 );
 export const walletPaymentGenericMethodByIdSelector = createSelector(
   walletPaymentAllMethodsSelector,
-  state => (id: string) =>
-    pot.map(state, methods => methods.find(_ => _.id === id))
+  methodsPot => (id: string) =>
+    pipe(
+      methodsPot,
+      pot.toOption,
+      O.chainNullableK(methods => methods.find(_ => _.id === id))
+    )
 );
+
 export const walletPaymentUserWalletsSelector = createSelector(
   selectWalletPayment,
   state => pot.map(state.userWallets, _ => _.wallets ?? [])
 );
+
 export const walletPaymentSavedMethodByIdSelector = createSelector(
   walletPaymentUserWalletsSelector,
-  state => (id: string) =>
-    pot.map(state, methods => methods.find(_ => _.walletId === id))
+  methodsPot => (id: string) =>
+    pipe(
+      methodsPot,
+      pot.toOption,
+      O.chainNullableK(methods => methods.find(_ => _.walletId === id))
+    )
 );
 
 export const walletPaymentPickedPaymentMethodSelector = createSelector(


### PR DESCRIPTION
## Short description
This PR adds the (temporary) missing methods error in methods selection screen

## List of changes proposed in this pull request
- Refactored `WalletPaymentPickMethodScreen` to allow the error to be displayed
- Added `WalletPaymentMissingMethodsError` component
- Added required locale keys

## How to test
With the `io-dev-api-server`, simulate an empty user wallet. Start a new payment from **Profile > New Wallet > Payment** and check if the error is displayed correctly and with working buttons.

## Preview

https://github.com/pagopa/io-app/assets/6160324/65f4d64f-6980-4d36-a82d-873ccf505b5e

