### PR TITLE
chore: [IOBP-486] Add hardware button back navigation in Barcode scan screen for Android devices

### DIFF
--- a/ts/features/barcode/screens/BarcodeScanScreen.tsx
+++ b/ts/features/barcode/screens/BarcodeScanScreen.tsx
@@ -39,12 +39,18 @@ import {
 import { BarcodeFailure } from "../types/failure";
 import { getIOBarcodesByType } from "../utils/getBarcodesByType";
 import { WalletBarcodeRoutes } from "../../walletV3/barcode/navigation/routes";
+import { useHardwareBackButton } from "../../../hooks/useHardwareBackButton";
 
 const BarcodeScanScreen = () => {
   const navigation = useNavigation<IOStackNavigationProp<AppParamsList>>();
   const dispatch = useIODispatch();
   const openDeepLink = useOpenDeepLink();
   const isIdPayEnabled = useIOSelector(isIdPayEnabledSelector);
+
+  useHardwareBackButton(() => {
+    navigation.goBack();
+    return true;
+  });
 
   const { dataMatrixPosteEnabled } = useIOSelector(
     barcodesScannerConfigSelector


### PR DESCRIPTION
## Short description
This PR enables the back navigation using hardware buttons on Android

## List of changes proposed in this pull request
- `ts/features/barcode/screens/BarcodeScanScreen.tsx`: added `useHardwareBackButton`

## How to test
Within the Barcode scan screen, try to navigate back using Android hardware back button.
