### PR TITLE
feat: [IOPID-1391] Fix tablet compatibility alert displaying

### DIFF
--- a/ts/navigation/AuthenticationNavigator.tsx
+++ b/ts/navigation/AuthenticationNavigator.tsx
@@ -10,7 +10,7 @@ import CiePinScreen from "../screens/authentication/cie/CiePinScreen";
 import CieWrongCiePinScreen from "../screens/authentication/cie/CieWrongCiePinScreen";
 import IdpLoginScreen from "../screens/authentication/IdpLoginScreen";
 import IdpSelectionScreen from "../screens/authentication/IdpSelectionScreen";
-import LandingScreen from "../screens/authentication/LandingScreen";
+import { LandingScreen } from "../screens/authentication/LandingScreen";
 import TestAuthenticationScreen from "../screens/authentication/TestAuthenticationScreen";
 import MarkdownScreen from "../screens/development/MarkdownScreen";
 import { AuthSessionPage } from "../screens/authentication/idpAuthSessionHandler";

--- a/ts/screens/authentication/LandingScreen.tsx
+++ b/ts/screens/authentication/LandingScreen.tsx
@@ -167,6 +167,10 @@ export const LandingScreen = () => {
   const [isRootedOrJailbroken, setIsRootedOrJailbroken] = React.useState<
     O.Option<boolean>
   >(O.none);
+  const [
+    hasTabletCompatibilityAlertAlreadyShown,
+    setHasTabletCompatibilityAlertAlreadyShown
+  ] = React.useState<boolean>(false);
 
   const store = useStore();
 
@@ -206,18 +210,22 @@ export const LandingScreen = () => {
 
   const { hideModal, showAnimatedModal } = React.useContext(LightModalContext);
 
-  const displayTabletAlert = () =>
-    Alert.alert(
-      "",
-      I18n.t("tablet.message"),
-      [
-        {
-          text: I18n.t("global.buttons.continue"),
-          style: "cancel"
-        }
-      ],
-      { cancelable: true }
-    );
+  const displayTabletAlert = () => {
+    if (!hasTabletCompatibilityAlertAlreadyShown) {
+      setHasTabletCompatibilityAlertAlreadyShown(true);
+      Alert.alert(
+        "",
+        I18n.t("tablet.message"),
+        [
+          {
+            text: I18n.t("global.buttons.continue"),
+            style: "cancel"
+          }
+        ],
+        { cancelable: true }
+      );
+    }
+  };
 
   const navigateToMarkdown = React.useCallback(
     () =>

--- a/ts/screens/authentication/LandingScreen.tsx
+++ b/ts/screens/authentication/LandingScreen.tsx
@@ -10,8 +10,9 @@ import { Content, Text as NBButtonText } from "native-base";
 import * as React from "react";
 import { View, Alert, StyleSheet } from "react-native";
 import DeviceInfo from "react-native-device-info";
-import { connect } from "react-redux";
+import { useDispatch, useStore } from "react-redux";
 import { IOColors, Icon, HSpacer, VSpacer } from "@pagopa/io-app-design-system";
+import { useNavigation } from "@react-navigation/native";
 import sessionExpiredImg from "../../../img/landing/session_expired.png";
 import ButtonDefaultOpacity from "../../components/ButtonDefaultOpacity";
 import CieNotSupported from "../../components/cie/CieNotSupported";
@@ -19,7 +20,6 @@ import ContextualInfo from "../../components/ContextualInfo";
 import { Link } from "../../components/core/typography/Link";
 import { IOStyles } from "../../components/core/variables/IOStyles";
 import { DevScreenButton } from "../../components/DevScreenButton";
-import { withLightModalContext } from "../../components/helpers/withLightModalContext";
 import { HorizontalScroll } from "../../components/HorizontalScroll";
 import { renderInfoRasterImage } from "../../components/infoScreen/imageRendering";
 import { InfoScreenComponent } from "../../components/infoScreen/InfoScreenComponent";
@@ -29,28 +29,19 @@ import BaseScreenComponent, {
   ContextualHelpPropsMarkdown
 } from "../../components/screens/BaseScreenComponent";
 import SectionStatusComponent from "../../components/SectionStatus";
-import { LightModalContextInterface } from "../../components/ui/LightModal";
 import I18n from "../../i18n";
 import { mixpanelTrack } from "../../mixpanel";
-import {
-  AppParamsList,
-  IOStackNavigationRouteProps
-} from "../../navigation/params/AppParamsList";
 import ROUTES from "../../navigation/routes";
 import {
   idpSelected,
   resetAuthenticationState
 } from "../../store/actions/authentication";
-import { continueWithRootOrJailbreak } from "../../store/actions/persistedPreferences";
-import { Dispatch } from "../../store/actions/types";
-import { isSessionExpiredSelector } from "../../store/reducers/authentication";
 import {
   hasApiLevelSupportSelector,
   hasNFCFeatureSelector,
   isCieSupportedSelector
 } from "../../store/reducers/cie";
 import { continueWithRootOrJailbreakSelector } from "../../store/reducers/persistedPreferences";
-import { GlobalState } from "../../store/reducers/types";
 import variables from "../../theme/variables";
 import { ComponentProps } from "../../types/react";
 import { isDevEnv } from "../../utils/environment";
@@ -64,23 +55,16 @@ import {
 } from "../../features/fastLogin/store/selectors";
 import { isCieLoginUatEnabledSelector } from "../../features/cieLogin/store/selectors";
 import { cieFlowForDevServerEnabled } from "../../features/cieLogin/utils";
+import { useOnFirstRender } from "../../utils/hooks/useOnFirstRender";
+import { useIOSelector } from "../../store/hooks";
+import { isSessionExpiredSelector } from "../../store/reducers/authentication";
+import { LightModalContext } from "../../components/ui/LightModal";
+import { continueWithRootOrJailbreak } from "../../store/actions/persistedPreferences";
 import {
   trackCieLoginSelected,
   trackMethodInfo,
   trackSpidLoginSelected
 } from "./analytics";
-
-type NavigationProps = IOStackNavigationRouteProps<AppParamsList, "INGRESS">;
-
-type Props = NavigationProps &
-  LightModalContextInterface &
-  ReturnType<typeof mapStateToProps> &
-  ReturnType<typeof mapDispatchToProps>;
-
-type State = {
-  isRootedOrJailbroken: O.Option<boolean>;
-  isSessionExpired: boolean;
-};
 
 const getCards = (
   isCIEAvailable: boolean
@@ -179,26 +163,50 @@ export const IdpCIE: SpidIdp = {
   profileUrl: ""
 };
 
-class LandingScreen extends React.PureComponent<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = { isRootedOrJailbroken: O.none, isSessionExpired: false };
-  }
+export const LandingScreen = () => {
+  const [isRootedOrJailbroken, setIsRootedOrJailbroken] = React.useState<
+    O.Option<boolean>
+  >(O.none);
 
-  private isCieSupported = () =>
-    cieFlowForDevServerEnabled || this.props.isCieSupported;
-  private isCieUatEnabled = () => this.props.isCieUatEnabled;
+  const store = useStore();
 
-  public async componentDidMount() {
+  const dispatch = useDispatch();
+  const navigation = useNavigation();
+
+  const isSessionExpired = useIOSelector(isSessionExpiredSelector);
+
+  const isContinueWithRootOrJailbreak = useIOSelector(
+    continueWithRootOrJailbreakSelector
+  );
+
+  const isFastLoginEnabled = useIOSelector(isFastLoginEnabledSelector);
+  const isFastLoginOptInFFEnabled = useIOSelector(fastLoginOptInFFEnabled);
+
+  const isCIEAuthenticationSupported = useIOSelector(isCieSupportedSelector);
+  const hasApiLevelSupport = useIOSelector(hasApiLevelSupportSelector);
+  const hasCieApiLevelSupport = pot.getOrElse(hasApiLevelSupport, false);
+  const hasNFCFeature = useIOSelector(hasNFCFeatureSelector);
+  const hasCieNFCFeature = pot.getOrElse(hasNFCFeature, false);
+
+  const isCieSupported = React.useCallback(
+    () =>
+      cieFlowForDevServerEnabled ||
+      pot.getOrElse(isCIEAuthenticationSupported, false),
+    [isCIEAuthenticationSupported]
+  );
+  const isCieUatEnabled = useIOSelector(isCieLoginUatEnabledSelector);
+
+  useOnFirstRender(async () => {
     const isRootedOrJailbroken = await JailMonkey.isJailBroken();
-    this.setState({ isRootedOrJailbroken: O.some(isRootedOrJailbroken) });
-    if (this.props.isSessionExpired) {
-      this.setState({ isSessionExpired: true });
-      this.props.resetState();
+    setIsRootedOrJailbroken(O.some(isRootedOrJailbroken));
+    if (isSessionExpired) {
+      dispatch(resetAuthenticationState());
     }
-  }
+  });
 
-  private displayTabletAlert() {
+  const { hideModal, showAnimatedModal } = React.useContext(LightModalContext);
+
+  const displayTabletAlert = () =>
     Alert.alert(
       "",
       I18n.t("tablet.message"),
@@ -210,93 +218,103 @@ class LandingScreen extends React.PureComponent<Props, State> {
       ],
       { cancelable: true }
     );
-  }
 
-  private openUnsupportedCIEModal = () => {
-    this.props.showAnimatedModal(
-      <ContextualInfo
-        onClose={this.props.hideModal}
-        title={I18n.t("authentication.landing.cie_unsupported.title")}
-        body={() => (
-          <CieNotSupported
-            hasCieApiLevelSupport={this.props.hasCieApiLevelSupport}
-            hasCieNFCFeature={this.props.hasCieNFCFeature}
-          />
-        )}
-      />
-    );
-  };
+  const navigateToMarkdown = React.useCallback(
+    () =>
+      navigation.navigate(ROUTES.AUTHENTICATION, {
+        screen: ROUTES.MARKDOWN
+      }),
+    [navigation]
+  );
 
-  private navigateToMarkdown = () =>
-    this.props.navigation.navigate(ROUTES.AUTHENTICATION, {
-      screen: ROUTES.MARKDOWN
-    });
-
-  private navigateToIdpSelection = () => {
+  const navigateToIdpSelection = React.useCallback(() => {
     trackSpidLoginSelected();
-    if (this.props.isFastLoginOptInFFEnabled) {
-      this.props.navigation.navigate(ROUTES.AUTHENTICATION, {
+    if (isFastLoginOptInFFEnabled) {
+      navigation.navigate(ROUTES.AUTHENTICATION, {
         screen: ROUTES.AUTHENTICATION_OPT_IN,
         params: { identifier: "SPID" }
       });
     } else {
-      this.props.navigation.navigate(ROUTES.AUTHENTICATION, {
+      navigation.navigate(ROUTES.AUTHENTICATION, {
         screen: ROUTES.AUTHENTICATION_IDP_SELECTION
       });
     }
-  };
+  }, [isFastLoginOptInFFEnabled, navigation]);
 
-  private navigateToCiePinScreen = () => {
-    if (this.isCieSupported()) {
-      void trackCieLoginSelected(this.props.state);
-      this.props.dispatchIdpCieSelected();
-      if (this.props.isFastLoginOptInFFEnabled) {
-        this.props.navigation.navigate(ROUTES.AUTHENTICATION, {
+  const navigateToCiePinScreen = React.useCallback(() => {
+    const openUnsupportedCIEModal = () => {
+      showAnimatedModal(
+        <ContextualInfo
+          onClose={hideModal}
+          title={I18n.t("authentication.landing.cie_unsupported.title")}
+          body={() => (
+            <CieNotSupported
+              hasCieApiLevelSupport={hasCieApiLevelSupport}
+              hasCieNFCFeature={hasCieNFCFeature}
+            />
+          )}
+        />
+      );
+    };
+
+    if (isCieSupported()) {
+      void trackCieLoginSelected(store.getState());
+      dispatch(idpSelected(IdpCIE));
+      if (isFastLoginOptInFFEnabled) {
+        navigation.navigate(ROUTES.AUTHENTICATION, {
           screen: ROUTES.AUTHENTICATION_OPT_IN,
           params: { identifier: "CIE" }
         });
       } else {
-        this.props.navigation.navigate(ROUTES.AUTHENTICATION, {
+        navigation.navigate(ROUTES.AUTHENTICATION, {
           screen: ROUTES.CIE_PIN_SCREEN
         });
       }
     } else {
-      this.openUnsupportedCIEModal();
+      openUnsupportedCIEModal();
     }
-  };
+  }, [
+    dispatch,
+    hasCieApiLevelSupport,
+    hasCieNFCFeature,
+    hideModal,
+    isCieSupported,
+    isFastLoginOptInFFEnabled,
+    navigation,
+    showAnimatedModal,
+    store
+  ]);
 
-  private navigateToSpidCieInformationRequest = () => {
+  const navigateToSpidCieInformationRequest = () => {
     trackMethodInfo();
     openWebUrl(cieSpidMoreInfoUrl);
   };
 
-  private navigateToCieUatSelectionScreen = () => {
-    if (this.isCieSupported()) {
-      this.props.navigation.navigate(ROUTES.AUTHENTICATION, {
+  const navigateToCieUatSelectionScreen = React.useCallback(() => {
+    if (isCieSupported()) {
+      navigation.navigate(ROUTES.AUTHENTICATION, {
         screen: ROUTES.CIE_LOGIN_CONFIG_SCREEN
       });
     }
-  };
+  }, [isCieSupported, navigation]);
 
-  private renderCardComponents = () => {
-    const cardProps = getCards(this.isCieSupported());
+  const renderCardComponents = () => {
+    const cardProps = getCards(isCieSupported());
     return cardProps.map(p => (
       <LandingCardComponent key={`card-${p.id}`} {...p} />
     ));
   };
 
-  private handleContinueWithRootOrJailbreak = (continueWith: boolean) => {
-    this.props.dispatchContinueWithRootOrJailbreak(continueWith);
+  const handleContinueWithRootOrJailbreak = (continueWith: boolean) => {
+    dispatch(continueWithRootOrJailbreak(continueWith));
   };
 
   // eslint-disable-next-line sonarjs/cognitive-complexity
-  private renderLandingScreen = () => {
-    const isCieSupported = this.isCieSupported();
-    const isCieUatEnabled = this.isCieUatEnabled();
+  const renderLandingScreen = () => {
     const firstButtonStyle = isCieUatEnabled
       ? styles.uatCie
       : styles.fullOpacity;
-    const secondButtonStyle = isCieSupported
+    const secondButtonStyle = isCieSupported()
       ? styles.fullOpacity
       : styles.noCie;
     return (
@@ -304,22 +322,22 @@ class LandingScreen extends React.PureComponent<Props, State> {
         appLogo
         contextualHelpMarkdown={contextualHelpMarkdown}
         faqCategories={
-          isCieSupported ? ["landing_SPID", "landing_CIE"] : ["landing_SPID"]
+          isCieSupported() ? ["landing_SPID", "landing_CIE"] : ["landing_SPID"]
         }
       >
-        {isDevEnv && <DevScreenButton onPress={this.navigateToMarkdown} />}
+        {isDevEnv && <DevScreenButton onPress={navigateToMarkdown} />}
 
-        {this.state.isSessionExpired ? (
+        {isSessionExpired ? (
           <InfoScreenComponent
             title={I18n.t("authentication.landing.session_expired.title")}
             body={I18n.t("authentication.landing.session_expired.body", {
-              days: this.props.isFastLoginEnabled ? "365" : "30"
+              days: isFastLoginEnabled ? "365" : "30"
             })}
             image={renderInfoRasterImage(sessionExpiredImg)}
           />
         ) : (
           <Content contentContainerStyle={styles.flex} noPadded={true}>
-            <HorizontalScroll cards={this.renderCardComponents()} />
+            <HorizontalScroll cards={renderCardComponents()} />
           </Content>
         )}
 
@@ -330,31 +348,32 @@ class LandingScreen extends React.PureComponent<Props, State> {
             primary={true}
             iconLeft={true}
             onPress={
-              isCieSupported
-                ? this.navigateToCiePinScreen
-                : this.navigateToIdpSelection
+              isCieSupported() ? navigateToCiePinScreen : navigateToIdpSelection
             }
             onLongPress={() =>
-              isCieSupported ? this.navigateToCieUatSelectionScreen() : ""
+              isCieSupported() ? navigateToCieUatSelectionScreen() : ""
             }
             accessibilityRole="button"
             accessible={true}
             style={firstButtonStyle}
             accessibilityLabel={
-              isCieSupported
+              isCieSupported()
                 ? I18n.t("authentication.landing.loginCie")
                 : I18n.t("authentication.landing.loginSpid")
             }
             testID={
-              isCieSupported
+              isCieSupported()
                 ? "landing-button-login-cie"
                 : "landing-button-login-spid"
             }
           >
-            <Icon name={isCieSupported ? "cie" : "navProfile"} color="white" />
+            <Icon
+              name={isCieSupported() ? "cie" : "navProfile"}
+              color="white"
+            />
             <HSpacer size={8} />
             <NBButtonText>
-              {isCieSupported
+              {isCieSupported()
                 ? I18n.t("authentication.landing.loginCie")
                 : I18n.t("authentication.landing.loginSpid")}
             </NBButtonText>
@@ -362,7 +381,7 @@ class LandingScreen extends React.PureComponent<Props, State> {
           <VSpacer size={16} />
           <ButtonDefaultOpacity
             accessibilityLabel={
-              this.isCieSupported()
+              isCieSupported()
                 ? I18n.t("authentication.landing.loginSpid")
                 : I18n.t("authentication.landing.loginCie")
             }
@@ -373,23 +392,21 @@ class LandingScreen extends React.PureComponent<Props, State> {
             primary={true}
             iconLeft={true}
             onPress={
-              this.isCieSupported()
-                ? this.navigateToIdpSelection
-                : this.navigateToCiePinScreen
+              isCieSupported() ? navigateToIdpSelection : navigateToCiePinScreen
             }
             testID={
-              this.isCieSupported()
+              isCieSupported()
                 ? "landing-button-login-spid"
                 : "landing-button-login-cie"
             }
           >
             <Icon
-              name={this.isCieSupported() ? "navProfile" : "cie"}
+              name={isCieSupported() ? "navProfile" : "cie"}
               color="white"
             />
             <HSpacer size={8} />
             <NBButtonText>
-              {this.isCieSupported()
+              {isCieSupported()
                 ? I18n.t("authentication.landing.loginSpid")
                 : I18n.t("authentication.landing.loginCie")}
             </NBButtonText>
@@ -397,9 +414,9 @@ class LandingScreen extends React.PureComponent<Props, State> {
           <VSpacer size={16} />
           <Link
             style={styles.link}
-            onPress={this.navigateToSpidCieInformationRequest}
+            onPress={navigateToSpidCieInformationRequest}
           >
-            {this.isCieSupported()
+            {isCieSupported()
               ? I18n.t("authentication.landing.nospid-nocie")
               : I18n.t("authentication.landing.nospid")}
           </Link>
@@ -409,70 +426,39 @@ class LandingScreen extends React.PureComponent<Props, State> {
   };
 
   // Screen displayed during the async loading of the JailMonkey.isJailBroken()
-  private renderLoadingScreen = () => (
+  const renderLoadingScreen = () => (
     <View style={{ flex: 1 }}>
       <LoadingSpinnerOverlay isLoading={true} />
     </View>
   );
 
-  private chooseScreenToRender = (isRootedOrJailbroken: boolean) => {
+  const chooseScreenToRender = (isRootedOrJailbroken: boolean) => {
     // if the device is compromised and the user didn't allow to continue
     // show a blocking modal
-    if (isRootedOrJailbroken && !this.props.continueWithRootOrJailbreak) {
+    if (isRootedOrJailbroken && !isContinueWithRootOrJailbreak) {
       void mixpanelTrack("SHOW_ROOTED_OR_JAILBROKEN_MODAL");
       return (
         <RootedDeviceModal
-          onContinue={() => this.handleContinueWithRootOrJailbreak(true)}
-          onCancel={() => this.handleContinueWithRootOrJailbreak(false)}
+          onContinue={() => handleContinueWithRootOrJailbreak(true)}
+          onCancel={() => handleContinueWithRootOrJailbreak(false)}
         />
       );
     }
     // In case of Tablet, display an alert to inform the user
     if (DeviceInfo.isTablet()) {
-      this.displayTabletAlert();
+      displayTabletAlert();
     }
     // standard rendering of the landing screen
-    return this.renderLandingScreen();
+    return renderLandingScreen();
   };
 
-  public render() {
-    // If the async loading of the isRootedOrJailbroken is not ready, display a loading
-    return pipe(
-      this.state.isRootedOrJailbroken,
-      O.fold(
-        () => this.renderLoadingScreen(),
-        // when the value isRootedOrJailbroken is ready, display the right screen based on a set of rule
-        rootedOrJailbroken => this.chooseScreenToRender(rootedOrJailbroken)
-      )
-    );
-  }
-}
-
-const mapStateToProps = (state: GlobalState) => {
-  const isCIEAuthenticationSupported = isCieSupportedSelector(state);
-  const hasApiLevelSupport = hasApiLevelSupportSelector(state);
-  const hasNFCFeature = hasNFCFeatureSelector(state);
-  return {
-    isFastLoginEnabled: isFastLoginEnabledSelector(state),
-    isSessionExpired: isSessionExpiredSelector(state),
-    isFastLoginOptInFFEnabled: fastLoginOptInFFEnabled(state),
-    continueWithRootOrJailbreak: continueWithRootOrJailbreakSelector(state),
-    isCieSupported: pot.getOrElse(isCIEAuthenticationSupported, false),
-    hasCieApiLevelSupport: pot.getOrElse(hasApiLevelSupport, false),
-    hasCieNFCFeature: pot.getOrElse(hasNFCFeature, false),
-    isCieUatEnabled: isCieLoginUatEnabledSelector(state),
-    state
-  };
+  // If the async loading of the isRootedOrJailbroken is not ready, display a loading
+  return pipe(
+    isRootedOrJailbroken,
+    O.fold(
+      () => renderLoadingScreen(),
+      // when the value isRootedOrJailbroken is ready, display the right screen based on a set of rule
+      rootedOrJailbroken => chooseScreenToRender(rootedOrJailbroken)
+    )
+  );
 };
-
-const mapDispatchToProps = (dispatch: Dispatch) => ({
-  resetState: () => dispatch(resetAuthenticationState()),
-  dispatchIdpCieSelected: () => dispatch(idpSelected(IdpCIE)),
-  dispatchContinueWithRootOrJailbreak: (continueWith: boolean) =>
-    dispatch(continueWithRootOrJailbreak(continueWith))
-});
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(withLightModalContext(LandingScreen));


### PR DESCRIPTION
## Short description
This PR fixes the continuously displaying of the Tablet compatibility alert during the login flow. It took the chance to refactor the `LandingScreen` from `PureComponent` to `FunctionComponent`. 

<details open><summary>Details</summary>
<p>

| ❌ | ✅ |
| - | - |
| <video src="https://github.com/pagopa/io-app/assets/16268789/68836f13-88f9-41a5-98a6-eceea56de750" />  | <video src="https://github.com/pagopa/io-app/assets/16268789/0e6e24ff-31a2-4aef-958e-0402564629e6" /> |

</p>

</details> 

## How to test
Launch the app on an Android Tablet and check that the Alert is shown only at every first render of `LandingScreen`.
