### PR TITLE
chore: [IOPID-1298,IOPID-1396] `Main` stack navigator - `startup` saga synch

### DIFF
--- a/ts/navigation/AppStackNavigator.tsx
+++ b/ts/navigation/AppStackNavigator.tsx
@@ -1,5 +1,9 @@
 /* eslint-disable functional/immutable-data */
-import { LinkingOptions, NavigationContainer } from "@react-navigation/native";
+import {
+  LinkingOptions,
+  NavigationContainer,
+  NavigationContainerProps
+} from "@react-navigation/native";
 import * as React from "react";
 import { useRef } from "react";
 import { View } from "react-native";
@@ -38,9 +42,21 @@ import { useStoredExperimentalDesign } from "../common/context/DSExperimentalCon
 import { IONavigationLightTheme } from "../theme/navigations";
 import { MESSAGES_ROUTES } from "../features/messages/navigation/routes";
 import AuthenticatedStackNavigator from "./AuthenticatedStackNavigator";
-import NavigationService, { navigationRef } from "./NavigationService";
+import NavigationService, {
+  navigationRef,
+  setMainNavigatorReady
+} from "./NavigationService";
 import NotAuthenticatedStackNavigator from "./NotAuthenticatedStackNavigator";
 import ROUTES from "./routes";
+
+type OnStateChangeStateType = Parameters<
+  NonNullable<NavigationContainerProps["onStateChange"]>
+>[0];
+const isMainNavigatorReady = (state: OnStateChangeStateType) =>
+  state &&
+  state.routes &&
+  state.routes.length > 0 &&
+  state.routes[0].name === ROUTES.MAIN;
 
 export const AppStackNavigator = (): React.ReactElement => {
   // This hook is used since we are in a child of the Context Provider
@@ -153,7 +169,10 @@ const InnerNavigationContainer = (props: { children: React.ReactElement }) => {
         NavigationService.setNavigationReady();
         routeNameRef.current = navigationRef.current?.getCurrentRoute()?.name;
       }}
-      onStateChange={async () => {
+      onStateChange={async state => {
+        if (isMainNavigatorReady(state)) {
+          setMainNavigatorReady();
+        }
         const previousRouteName = routeNameRef.current;
         const currentRouteName = navigationRef.current?.getCurrentRoute()?.name;
         if (currentRouteName !== undefined) {

--- a/ts/navigation/NavigationService.ts
+++ b/ts/navigation/NavigationService.ts
@@ -10,6 +10,13 @@ export const navigationRef = React.createRef<NavigationContainerRef>();
 // eslint-disable-next-line functional/no-let
 let isNavigationReady: boolean = false;
 
+// eslint-disable-next-line functional/no-let
+let isMainNavigatorReady = false;
+
+export const setMainNavigatorReady = () => {
+  isMainNavigatorReady = true;
+};
+
 export const setNavigationReady = () => {
   // eslint-disable-next-line functional/immutable-data
   isNavigationReady = true;
@@ -44,6 +51,8 @@ const dispatchNavigationAction = (action: NavigationAction) => {
   navigationRef.current?.dispatch(action);
 };
 
+const getIsMainNavigatorReady = () => isMainNavigatorReady;
+
 const getCurrentRouteName = (): string | undefined =>
   navigationRef.current?.getCurrentRoute()?.name;
 
@@ -66,5 +75,6 @@ export default {
   getCurrentRoute,
   getCurrentState,
   getIsNavigationReady,
-  setNavigationReady
+  setNavigationReady,
+  getIsMainNavigatorReady
 };

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -426,13 +426,11 @@ export function* initializeApplicationSaga(
   const watchAbortOnboardingSagaTask = yield* fork(watchAbortOnboardingSaga);
 
   yield* put(startupLoadSuccess(StartupStatusEnum.ONBOARDING));
-  // FIXME IOPID-1298: find any better way to handle this
-  // We need this workaround to let the inner AppStackNavigator stack be ready,
-  // before continuing with any other navigation action to avoid:
-  // Error: The 'navigation' object hasn't been initialized yet...
-  // Here the navigationRef is ready, but because we changed the navigation inner stack
-  // based on StartupStatusEnum value, we need to wait for the new stack to be ready.
-  yield* delay(0 as Millisecond);
+  if (!handleSessionExpiration) {
+    yield* call(waitForMainNavigator);
+  }
+
+  // yield* delay(0 as Millisecond);
   const hasPreviousSessionAndPin =
     previousSessionToken && O.isSome(maybeStoredPin);
   if (hasPreviousSessionAndPin && showIdentificationModal) {
@@ -517,9 +515,6 @@ export function* initializeApplicationSaga(
   yield* call(updateInstallationSaga, backendClient.createOrUpdateInstallation);
 
   yield* put(startupLoadSuccess(StartupStatusEnum.AUTHENTICATED));
-  // FIXME IOPID-1298: find any better way to handle this
-  // As above for StartupStatusEnum.ONBOARDING
-  yield* delay(0 as Millisecond);
   //
   // User is autenticated, session token is valid
   //
@@ -691,6 +686,33 @@ function* waitForNavigatorServiceInitialization() {
   const initTime = performance.now() - startTime;
 
   yield* call(mixpanelTrack, "NAVIGATION_SERVICE_INITIALIZATION_COMPLETED", {
+    elapsedTime: initTime
+  });
+}
+
+function* waitForMainNavigator() {
+  // eslint-disable-next-line functional/no-let
+  let isMainNavReady = yield* call(NavigationService.getIsMainNavigatorReady);
+
+  // eslint-disable-next-line functional/no-let
+  let timeoutLogged = false;
+  const startTime = performance.now();
+
+  // before continuing we must wait for the main navigator tack to be ready
+  while (!isMainNavReady) {
+    const elapsedTime = performance.now() - startTime;
+    if (!timeoutLogged && elapsedTime >= warningWaitNavigatorTime) {
+      timeoutLogged = true;
+
+      yield* call(mixpanelTrack, "MAIN_NAVIGATOR_STACK_READY_TIMEOUT");
+    }
+    yield* delay(navigatorPollingTime);
+    isMainNavReady = yield* call(NavigationService.getIsMainNavigatorReady);
+  }
+
+  const initTime = performance.now() - startTime;
+
+  yield* call(mixpanelTrack, "MAIN_NAVIGATOR_STACK_READY_OK", {
     elapsedTime: initTime
   });
 }


### PR DESCRIPTION
## Short description
This PR tries to synchronize the Main stack navigator with the startup saga business logic.

## List of changes proposed in this pull request
It uses the `waitForMainNavigator` generator function that acts like `waitForNavigatorServiceInitialization`.

## How to test
- Run the app and during a first onboarding, before reaching the pin creation screen, re-launch the app. You'd navigate to the last screen where you was before re-launching the app. 
- Try different login flows, you'd be reach the messages home all the times.
