### PR TITLE
fix: [IOPID-1408] Fix cdu email insert screen logic 

### DIFF
--- a/ts/screens/profile/CduEmailInsertScreen.tsx
+++ b/ts/screens/profile/CduEmailInsertScreen.tsx
@@ -220,7 +220,7 @@ const CduEmailInsertScreen = (props: Props) => {
      *    the CIT does not need his email to be compared with another one,
      *    so the areSameEmails will always be false.
      * 3. Not first onboarding => if the CIT write the same email as the one
-     *    he already send, he is blocked.
+     *    he already has, he is blocked.
      */
     if (isFirstOnBoarding) {
       setAreSameEmails(

--- a/ts/screens/profile/CduEmailInsertScreen.tsx
+++ b/ts/screens/profile/CduEmailInsertScreen.tsx
@@ -214,10 +214,11 @@ const CduEmailInsertScreen = (props: Props) => {
   const handleOnChangeEmailText = (value: string) => {
     /**
      * SCENARIOS:
-     * 1. first onboarding and email already taken => if the CIT write
-     *    the same email as the one he has to modify, he is blocked
-     * 2. first onboarding and NOT email already taken => the email
-     *    with which he/she is logged in is valid and the CIT is not blocked
+     * 1. first onboarding and email already taken => if the CIT writes
+     *    the same email as the one he has to modify, he is blocked.
+     * 2. first onboarding and NOT email already taken => in this case,
+     *    the CIT does not need his email to be compared with another one,
+     *    so the areSameEmails will always be false.
      * 3. Not first onboarding => if the CIT write the same email as the one
      *    he already send, he is blocked.
      */

--- a/ts/screens/profile/CduEmailInsertScreen.tsx
+++ b/ts/screens/profile/CduEmailInsertScreen.tsx
@@ -178,7 +178,7 @@ const CduEmailInsertScreen = (props: Props) => {
       ),
     [areSameEmails, email]
   );
-  const isButtonDisabled = !isValidEmail() && !isLoading;
+  const isContinueButtonDisabled = !isValidEmail() && !isLoading;
 
   const continueOnPress = () => {
     Keyboard.dismiss();
@@ -192,7 +192,7 @@ const CduEmailInsertScreen = (props: Props) => {
 
   const renderFooterButtons = () => {
     const continueButtonProps = {
-      disabled: isButtonDisabled,
+      disabled: isContinueButtonDisabled,
       onPress: continueOnPress,
       label: I18n.t("global.buttons.continue"),
       accessibilityLabel: I18n.t("global.buttons.continue"),
@@ -390,7 +390,7 @@ const CduEmailInsertScreen = (props: Props) => {
                       returnKeyType: "done",
                       // continueOnPress is called by pressing the
                       // button on the keyboard only if the mail is valid
-                      onSubmitEditing: isButtonDisabled
+                      onSubmitEditing: isContinueButtonDisabled
                         ? undefined
                         : continueOnPress,
                       autoCapitalize: "none",

--- a/ts/screens/profile/CduEmailInsertScreen.tsx
+++ b/ts/screens/profile/CduEmailInsertScreen.tsx
@@ -212,6 +212,15 @@ const CduEmailInsertScreen = (props: Props) => {
   };
 
   const handleOnChangeEmailText = (value: string) => {
+    /**
+     * SCENARIOS:
+     * 1. first onboarding and email already taken => if the CIT write
+     *    the same email as the one he has to modify, he is blocked
+     * 2. first onboarding and NOT email already taken => the email
+     *    with which he/she is logged in is valid and the CIT is not blocked
+     * 3. Not first onboarding => if the CIT write the same email as the one
+     *    he already send, he is blocked.
+     */
     if (isFirstOnBoarding) {
       setAreSameEmails(
         isProfileEmailAlreadyTaken
@@ -378,6 +387,8 @@ const CduEmailInsertScreen = (props: Props) => {
                     }
                     inputProps={{
                       returnKeyType: "done",
+                      // continueOnPress is called by pressing the
+                      // button on the keyboard only if the mail is valid
                       onSubmitEditing: isButtonDisabled
                         ? undefined
                         : continueOnPress,


### PR DESCRIPTION
## Short description
During tests, we realised that in the firs onboarding scenario, the CIT who logs in using SPID and has a valid email, does not see his pre-filled email and if he tries to enter it, an error is displayed that does not allow him to continue. 
So, in this PR we are going to fix this bug. 

<p>

| ❌ | ✅ |
| - | - |
 | <video src="https://github.com/pagopa/io-app/assets/83651704/9eb94d8a-a9c8-49d2-add8-4c516c49cc37" /> | <video src="https://github.com/pagopa/io-app/assets/83651704/827f6cf8-ed63-45c1-bce8-8a4b77cf8478" /> |

</p>

## How to test
Run the application as first onboarding and test all cases