### PR TITLE
chore: [IOBP-517] Removes unnecessary gallery permission on iOS 

### DIFF
--- a/ts/utils/permission.ts
+++ b/ts/utils/permission.ts
@@ -11,18 +11,12 @@ export const requestIOPermission = async (
   permission: RNPermissions.Permission,
   rationale?: RNPermissions.Rationale
 ): Promise<boolean> => {
-  // Be aware that some permissions may return "unavailable" event if the library
-  // documents them as supported. One notorious case is the iOS PHOTO_LIBRARY_ADD_ONLY
-  // permission. If such permission is automatically handled by the system upon request
-  // (such as PHOTO_LIBRARY_ADD_ONLY is), then you should not use this function to
-  // check nor to request such permission
-  const checkResult = await RNPermissions.check(permission);
-  if (checkResult === "granted") {
+  if (await checkIOPermission(permission)) {
     return true;
   }
 
   const requestStatus = await RNPermissions.request(permission, rationale);
-  return requestStatus === "granted";
+  return requestStatus === "granted" || requestStatus === "limited";
 };
 
 /**
@@ -33,8 +27,13 @@ export const requestIOPermission = async (
 export const checkIOPermission = async (
   permission: RNPermissions.Permission
 ): Promise<boolean> => {
+  // Be aware that some permissions may return "unavailable" event if the library
+  // documents them as supported. One notorious case is the iOS PHOTO_LIBRARY_ADD_ONLY
+  // permission. If such permission is automatically handled by the system upon request
+  // (such as PHOTO_LIBRARY_ADD_ONLY is), then you should not use this function to
+  // check nor to request such permission
   const checkResult = await RNPermissions.check(permission);
-  return checkResult === "granted";
+  return checkResult === "granted" || checkResult === "limited";
 };
 
 /**

--- a/ts/utils/permission.ts
+++ b/ts/utils/permission.ts
@@ -16,7 +16,7 @@ export const requestIOPermission = async (
   }
 
   const requestStatus = await RNPermissions.request(permission, rationale);
-  return requestStatus === "granted" || requestStatus === "limited";
+  return requestStatus === "granted";
 };
 
 /**
@@ -33,7 +33,7 @@ export const checkIOPermission = async (
   // (such as PHOTO_LIBRARY_ADD_ONLY is), then you should not use this function to
   // check nor to request such permission
   const checkResult = await RNPermissions.check(permission);
-  return checkResult === "granted" || checkResult === "limited";
+  return checkResult === "granted";
 };
 
 /**
@@ -68,11 +68,6 @@ export const requestMediaPermission = async () => {
           ? RNPermissions.PERMISSIONS.ANDROID.READ_MEDIA_IMAGES
           : RNPermissions.PERMISSIONS.ANDROID.READ_EXTERNAL_STORAGE
       );
-    case "ios":
-      if (parseInt(Platform.Version, 10) >= 17) {
-        return true;
-      }
-      return requestIOPermission(RNPermissions.PERMISSIONS.IOS.PHOTO_LIBRARY);
     default:
       return false;
   }

--- a/ts/utils/permission.ts
+++ b/ts/utils/permission.ts
@@ -11,7 +11,8 @@ export const requestIOPermission = async (
   permission: RNPermissions.Permission,
   rationale?: RNPermissions.Rationale
 ): Promise<boolean> => {
-  if (await checkIOPermission(permission)) {
+  const checkResult = await checkIOPermission(permission);
+  if (checkResult) {
     return true;
   }
 

--- a/ts/utils/permission.ts
+++ b/ts/utils/permission.ts
@@ -70,6 +70,9 @@ export const requestMediaPermission = async () => {
           : RNPermissions.PERMISSIONS.ANDROID.READ_EXTERNAL_STORAGE
       );
     case "ios":
+      if (parseInt(Platform.Version, 10) >= 17) {
+        return true;
+      }
       return requestIOPermission(RNPermissions.PERMISSIONS.IOS.PHOTO_LIBRARY);
     default:
       return false;


### PR DESCRIPTION
## Short description
This PR removes an unnecessary gallery permission request on iOS.

## List of changes proposed in this pull request
- Removed iOS case in `requestMediaPermission` function

## How to test
From the QR Code scan screen, choose the upload photo option and check that on iOS no prompt is displayed.

## Previews

<video src="https://github.com/pagopa/io-app/assets/6160324/d6bfab14-2a8b-41dd-b77b-2f6d343ed974" />
