### PR TITLE
chore: fix CGN e2e test scroll

### DIFF
--- a/ts/features/bonus/cgn/__e2e__/cgn.e2e.ts
+++ b/ts/features/bonus/cgn/__e2e__/cgn.e2e.ts
@@ -24,15 +24,14 @@ const activateBonusSuccess = async () => {
   await element(by.id("cgnConfirmButtonTestId")).tap();
 
   // wait for unsubscribe cta
-  // make sure to scroll to bottom, otherwise in small devices the element will not be visible nor tappable
   const scrollView = element(by.id("CGNCardDetailsScrollView"));
-  try {
-    await scrollView.scroll(100, "down", NaN, 0.3);
-  } catch (e) {
-    // Unfortunately, sometimes the scroll fails with the testing reporting
-    // 'this view is not scrollable'. In such cases, the 'deactive button'
-    // is visible so we catch and ignore the scroll error
-  }
+
+  // The section has a loading spinner on top of
+  // everything so we must wait for it to disappear
+  await waitFor(scrollView).toBeVisible().withTimeout(e2eWaitRenderTimeout);
+
+  // make sure to scroll to bottom, otherwise in small devices the element will not be visible nor tappable
+  await scrollView.scrollTo("bottom");
 
   const unsubscribeCgnCta = element(by.id("cgnDeactivateBonusTestId"));
   await waitFor(unsubscribeCgnCta)

--- a/ts/features/bonus/cgn/__e2e__/cgn.e2e.ts
+++ b/ts/features/bonus/cgn/__e2e__/cgn.e2e.ts
@@ -26,7 +26,13 @@ const activateBonusSuccess = async () => {
   // wait for unsubscribe cta
   // make sure to scroll to bottom, otherwise in small devices the element will not be visible nor tappable
   const scrollView = element(by.id("CGNCardDetailsScrollView"));
-  await scrollView.scrollTo("bottom");
+  try {
+    await scrollView.scroll(100, "down", NaN, 0.3);
+  } catch (e) {
+    // Unfortunately, sometimes the scroll fails with the testing reporting
+    // 'this view is not scrollable'. In such cases, the 'deactive button'
+    // is visible so we catch and ignore the scroll error
+  }
 
   const unsubscribeCgnCta = element(by.id("cgnDeactivateBonusTestId"));
   await waitFor(unsubscribeCgnCta)


### PR DESCRIPTION
## Short description
This PR fixes a problem on the E2E CGN test, where the card view is reported as not scrollable.

## List of changes proposed in this pull request
- the scroll method has been try-catched, since the error appears when the view has already reached its bottom

## How to test
Run the E2E tests.
