### PR TITLE
[IOBP-506] i18n fix in transaction details

### DIFF
--- a/locales/de/index.yml
+++ b/locales/de/index.yml
@@ -2459,7 +2459,7 @@ transaction:
     title: "Details zur Transaktion"
     totalAmount: "Insgesamt"
     totalFee: "Der Gesamtbetrag umfasst "
-    totalFeePsp: "Provision, berechnet von {{pspName}}"
+    totalFeePsp: "Provision, berechnet von {{pspName}}."
     totalFeeNoPsp: "Provision, die vom Transaktionsdienstleister (PSP) erhoben wird."
     info:
       title: "Informationen zur Transaktion"

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3859,7 +3859,7 @@ transaction:
     title: Dettaglio operazione
     totalAmount: Totale
     totalFee: Il totale comprende
-    totalFeePsp: di commissione, applicata da {{pspName}}
+    totalFeePsp: "di commissione, applicata da {{pspName}}."
     totalFeeNoPsp: "di commissione, applicata dal gestore della transazione (PSP)."
     info:
       title: Informazioni sulla transazione

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3859,7 +3859,7 @@ transaction:
     title: Dettaglio operazione
     totalAmount: Totale
     totalFee: Il totale comprende
-    totalFeePsp: di commissione, applicata da {{pspName}}
+    totalFeePsp: "di commissione, applicata da {{pspName}}."
     totalFeeNoPsp: "di commissione, applicata dal gestore della transazione (PSP)."
     info:
       title: Informazioni sulla transazione

--- a/ts/features/walletV3/transaction/components/WalletTransactionHeadingSection.tsx
+++ b/ts/features/walletV3/transaction/components/WalletTransactionHeadingSection.tsx
@@ -68,7 +68,6 @@ export const WalletTransactionHeadingSection = ({
                 pspName: psp.businessName
               })
             : I18n.t("transaction.details.totalFeeNoPsp")}
-          .
         </Body>
       );
     }


### PR DESCRIPTION
## Short description
fixed I18n bug in `WALLET_TRANSACTION_DETAILS`

## List of changes proposed in this pull request
- added missing dot to I18n
- removed dot from component, in order to organize all text in a locale

## How to test
in the app, open a transaction's details and check that both with a correctly loaded PSP and with an error loading a PSP the copy is correct and displays a single dot at the end of the sentence.