### PR TITLE
chore: [IOBP-513] Added loading state in onboarding list wallet

### DIFF
--- a/ts/features/walletV3/onboarding/hooks/useWalletOnboardingWebView.tsx
+++ b/ts/features/walletV3/onboarding/hooks/useWalletOnboardingWebView.tsx
@@ -49,6 +49,7 @@ export const useWalletOnboardingWebView = (
   props: WalletOnboardingWebViewProps
 ) => {
   const { onSuccess, onError, onFailure, onDismiss } = props;
+  const [isLoading, setIsLoading] = React.useState(false);
   const onboardingStartupResult = useIOSelector(
     walletOnboardingStartupSelector
   );
@@ -84,6 +85,8 @@ export const useWalletOnboardingWebView = (
       handleResultOnboarding(resultUrl);
     } catch (err) {
       onDismiss?.();
+    } finally {
+      setIsLoading(false);
     }
   }, [onboardingStartupResult, handleResultOnboarding, onDismiss]);
 
@@ -108,11 +111,13 @@ export const useWalletOnboardingWebView = (
 
   const startOnboarding = (paymentMethodId: string) => {
     if (!pot.isLoading(onboardingStartupResult)) {
+      setIsLoading(true);
       dispatch(walletStartOnboarding.request({ paymentMethodId }));
     }
   };
 
   return {
-    startOnboarding
+    startOnboarding,
+    isLoading
   };
 };

--- a/ts/features/walletV3/onboarding/screens/WalletOnboardingSelectPaymentMethodScreen.tsx
+++ b/ts/features/walletV3/onboarding/screens/WalletOnboardingSelectPaymentMethodScreen.tsx
@@ -26,6 +26,7 @@ import { OperationResultScreenContent } from "../../../../components/screens/Ope
 import { PaymentMethodStatusEnum } from "../../../../../definitions/pagopa/walletv3/PaymentMethodStatus";
 import { useWalletOnboardingWebView } from "../hooks/useWalletOnboardingWebView";
 import { OnboardingOutcomeEnum, OnboardingResult } from "../types";
+import LoadingSpinnerOverlay from "../../../../components/LoadingSpinnerOverlay";
 
 const WalletOnboardingSelectPaymentMethodScreen = () => {
   const navigation = useNavigation<WalletOnboardingStackNavigation>();
@@ -46,7 +47,7 @@ const WalletOnboardingSelectPaymentMethodScreen = () => {
     O.getOrElseW(() => [])
   );
 
-  const { startOnboarding } = useWalletOnboardingWebView({
+  const { startOnboarding, isLoading } = useWalletOnboardingWebView({
     onSuccess: (outcome, walletId) =>
       navigateToFeedbackPage({ status: "SUCCESS", outcome, walletId }),
     onFailure: outcome =>
@@ -78,29 +79,31 @@ const WalletOnboardingSelectPaymentMethodScreen = () => {
   };
 
   return (
-    <TopScreenComponent goBack>
-      {pot.isError(paymentMethodsPot) ? (
-        <OperationResultScreenContent
-          pictogram="umbrellaNew"
-          title={I18n.t("genericError")}
-          subtitle={I18n.t("global.genericError")}
-          action={{
-            label: I18n.t("global.genericRetry"),
-            accessibilityLabel: I18n.t("global.genericRetry"),
-            onPress: () => dispatch(walletGetPaymentMethods.request())
-          }}
-        />
-      ) : (
-        <SafeAreaView style={IOStyles.flex}>
-          <WalletOnboardingPaymentMethodsList
-            header={<PaymentMethodsHeading />}
-            isLoading={isLoadingPaymentMethods}
-            onSelectPaymentMethod={handleSelectedPaymentMethod}
-            paymentMethods={availablePaymentMethods}
+    <LoadingSpinnerOverlay isLoading={isLoading}>
+      <TopScreenComponent goBack>
+        {pot.isError(paymentMethodsPot) ? (
+          <OperationResultScreenContent
+            pictogram="umbrellaNew"
+            title={I18n.t("genericError")}
+            subtitle={I18n.t("global.genericError")}
+            action={{
+              label: I18n.t("global.genericRetry"),
+              accessibilityLabel: I18n.t("global.genericRetry"),
+              onPress: () => dispatch(walletGetPaymentMethods.request())
+            }}
           />
-        </SafeAreaView>
-      )}
-    </TopScreenComponent>
+        ) : (
+          <SafeAreaView style={IOStyles.flex}>
+            <WalletOnboardingPaymentMethodsList
+              header={<PaymentMethodsHeading />}
+              isLoading={isLoadingPaymentMethods}
+              onSelectPaymentMethod={handleSelectedPaymentMethod}
+              paymentMethods={availablePaymentMethods}
+            />
+          </SafeAreaView>
+        )}
+      </TopScreenComponent>
+    </LoadingSpinnerOverlay>
   );
 };
 


### PR DESCRIPTION
## Short description
This PR handles the loading state meanwhile the webview of the selected payment method to onboard is shown.

## List of changes proposed in this pull request
- Added prop `isLoading` inside the `useWalletOnboardingWebView` custom hook
- Wrapped the entire screen with the `LoadingSpinnerOverlay` component;

## How to test
Open the new start onboarding process and select one of the shown payment methods, you should be able to see a loading spinner.

## Preview
<video src="https://github.com/pagopa/io-app/assets/34343582/4275be6f-2385-4823-92bb-b3e2203b0d59" />

