### PR TITLE
fix: [IOBP-458,IOBP-459] Added accessibility label to the RNavScreenWithLargeHeader component

### DIFF
--- a/ts/components/ui/RNavScreenWithLargeHeader.tsx
+++ b/ts/components/ui/RNavScreenWithLargeHeader.tsx
@@ -22,11 +22,16 @@ import {
 import { SupportRequestParams } from "../../hooks/useStartSupportRequest";
 import I18n from "../../i18n";
 
+export type LargeHeaderTitleProps = {
+  label: string;
+  accessibilityLabel: string;
+  testID?: string;
+};
+
 type Props = {
   children: React.ReactNode;
   fixedBottomSlot?: React.ReactNode;
-  title: string;
-  titleTestID?: string;
+  title: LargeHeaderTitleProps;
   description?: string;
   goBack?: BackProps["goBack"];
   headerActionsProp?: HeaderActionProps;
@@ -49,7 +54,6 @@ export const RNavScreenWithLargeHeader = ({
   children,
   fixedBottomSlot,
   title,
-  titleTestID,
   goBack,
   description,
   contextualHelp,
@@ -75,7 +79,7 @@ export const RNavScreenWithLargeHeader = ({
   const headerProps: ComponentProps<typeof HeaderSecondLevel> = useHeaderProps({
     backAccessibilityLabel: I18n.t("global.buttons.back"),
     goBack: goBack ?? navigation.goBack,
-    title,
+    title: title.label,
     scrollValues: {
       contentOffsetY: translationY,
       triggerOffset: titleHeight
@@ -109,7 +113,12 @@ export const RNavScreenWithLargeHeader = ({
           style={IOStyles.horizontalContentPadding}
           onLayout={getTitleHeight}
         >
-          <H2 testID={titleTestID}>{title}</H2>
+          <H2
+            testID={title.testID}
+            accessibilityLabel={title.accessibilityLabel}
+          >
+            {title.label}
+          </H2>
         </View>
 
         {description && (

--- a/ts/features/design-system/core/DSHeaderSecondLevel.tsx
+++ b/ts/features/design-system/core/DSHeaderSecondLevel.tsx
@@ -3,7 +3,13 @@ import { Body, VSpacer } from "@pagopa/io-app-design-system";
 import { RNavScreenWithLargeHeader } from "../../../components/ui/RNavScreenWithLargeHeader";
 
 export const DSHeaderSecondLevel = () => (
-  <RNavScreenWithLargeHeader title="Questo è un titolo lungo, ma lungo lungo davvero, eh!">
+  <RNavScreenWithLargeHeader
+    title={{
+      label: "Questo è un titolo lungo, ma lungo lungo davvero, eh!",
+      accessibilityLabel:
+        "Questo è un titolo lungo, ma lungo lungo davvero, eh!"
+    }}
+  >
     <VSpacer />
     {[...Array(50)].map((_el, i) => (
       <Body key={`body-${i}`}>Repeated text</Body>

--- a/ts/features/idpay/details/screens/IdPayOperationsListScreen.tsx
+++ b/ts/features/idpay/details/screens/IdPayOperationsListScreen.tsx
@@ -130,9 +130,14 @@ export const IdPayOperationsListScreen = () => {
 
   return (
     <RNavScreenWithLargeHeader
-      title={I18n.t(
-        "idpay.initiative.details.initiativeDetailsScreen.configured.operationsList.title"
-      )}
+      title={{
+        label: I18n.t(
+          "idpay.initiative.details.initiativeDetailsScreen.configured.operationsList.title"
+        ),
+        accessibilityLabel: I18n.t(
+          "idpay.initiative.details.initiativeDetailsScreen.configured.operationsList.title"
+        )
+      }}
     >
       <ContentWrapper>
         <VSpacer size={8} />

--- a/ts/features/walletV3/transaction/screens/WalletTransactionDetailsScreen.tsx
+++ b/ts/features/walletV3/transaction/screens/WalletTransactionDetailsScreen.tsx
@@ -76,7 +76,12 @@ const WalletTransactionDetailsScreen = () => {
 
   return (
     <RNavScreenWithLargeHeader
-      title={I18n.t("transaction.details.title")}
+      title={{
+        label: I18n.t("transaction.details.title"),
+        accessibilityLabel: `${I18n.t("global.accessibility.inputLabel", {
+          header: I18n.t("transaction.details.title")
+        })}`
+      }}
       contextualHelp={emptyContextualHelp}
       faqCategories={["wallet_transaction"]}
       headerActionsProp={{ showHelp: true }}

--- a/ts/features/walletV3/transaction/screens/WalletTransactionOperationDetails.tsx
+++ b/ts/features/walletV3/transaction/screens/WalletTransactionOperationDetails.tsx
@@ -58,7 +58,12 @@ const WalletTransactionOperationDetailsScreen = () => {
 
   return (
     <RNavScreenWithLargeHeader
-      title={cleanTransactionDescription(operationName)}
+      title={{
+        label: cleanTransactionDescription(operationName),
+        accessibilityLabel: `${I18n.t("global.accessibility.inputLabel", {
+          header: cleanTransactionDescription(operationName)
+        })}`
+      }}
     >
       <ScrollView style={styles.scrollViewContainer}>
         {operationDetails.importo && (

--- a/ts/screens/onboarding/OnboardingServicesPreferenceScreen.tsx
+++ b/ts/screens/onboarding/OnboardingServicesPreferenceScreen.tsx
@@ -115,7 +115,10 @@ const OnboardingServicesPreferenceScreen = (
   const showBadge = !isFirstOnboarding;
   return (
     <RNavScreenWithLargeHeader
-      title={I18n.t("services.optIn.preferences.title")}
+      title={{
+        label: I18n.t("services.optIn.preferences.title"),
+        accessibilityLabel: I18n.t("services.optIn.preferences.title")
+      }}
       description={I18n.t("services.optIn.preferences.body")}
       headerActionsProp={{ showHelp: true }}
       contextualHelp={emptyContextualHelp}

--- a/ts/screens/onboarding/OnboardingShareDataScreen.tsx
+++ b/ts/screens/onboarding/OnboardingShareDataScreen.tsx
@@ -71,8 +71,13 @@ const OnboardingShareDataScreen = (props: Props): React.ReactElement => {
   return (
     <RNavScreenWithLargeHeader
       goBack={handleGoBack}
-      title={I18n.t("profile.main.privacy.shareData.screen.title")}
-      titleTestID={"share-data-component-title"}
+      title={{
+        label: I18n.t("profile.main.privacy.shareData.screen.title"),
+        accessibilityLabel: I18n.t(
+          "profile.main.privacy.shareData.screen.title"
+        ),
+        testID: "share-data-component-title"
+      }}
       description={I18n.t("profile.main.privacy.shareData.screen.description")}
       fixedBottomSlot={
         <SafeAreaView>

--- a/ts/screens/profile/CalendarsPreferencesScreen.tsx
+++ b/ts/screens/profile/CalendarsPreferencesScreen.tsx
@@ -51,7 +51,12 @@ class CalendarsPreferencesScreen extends React.PureComponent<Props, State> {
     const { isLoading } = this.state;
     return (
       <RNavScreenWithLargeHeader
-        title={I18n.t("profile.preferences.list.preferred_calendar.title")}
+        title={{
+          label: I18n.t("profile.preferences.list.preferred_calendar.title"),
+          accessibilityLabel: I18n.t(
+            "profile.preferences.list.preferred_calendar.title"
+          )
+        }}
         description={I18n.t("messages.cta.reminderCalendarSelect")}
         contextualHelpMarkdown={contextualHelpMarkdown}
         headerActionsProp={{ showHelp: true }}

--- a/ts/screens/profile/LanguagesPreferencesScreen.tsx
+++ b/ts/screens/profile/LanguagesPreferencesScreen.tsx
@@ -122,7 +122,12 @@ class LanguagesPreferencesScreen extends React.PureComponent<Props, State> {
   public render() {
     const ContainerComponent = withLoadingSpinner(() => (
       <RNavScreenWithLargeHeader
-        title={I18n.t("profile.preferences.list.preferred_language.title")}
+        title={{
+          label: I18n.t("profile.preferences.list.preferred_language.title"),
+          accessibilityLabel: I18n.t(
+            "profile.preferences.list.preferred_language.title"
+          )
+        }}
         description={I18n.t(
           "profile.preferences.list.preferred_language.subtitle"
         )}

--- a/ts/screens/profile/NotificationsPreferencesScreen.tsx
+++ b/ts/screens/profile/NotificationsPreferencesScreen.tsx
@@ -60,7 +60,10 @@ export const NotificationsPreferencesScreen = () => {
 
   return (
     <RNavScreenWithLargeHeader
-      title={I18n.t("profile.preferences.notifications.header")}
+      title={{
+        label: I18n.t("profile.preferences.notifications.header"),
+        accessibilityLabel: I18n.t("profile.preferences.notifications.header")
+      }}
       description={I18n.t("profile.preferences.notifications.subtitle")}
       contextualHelpMarkdown={contextualHelpMarkdown}
       headerActionsProp={{ showHelp: true }}

--- a/ts/screens/profile/PreferencesScreen.tsx
+++ b/ts/screens/profile/PreferencesScreen.tsx
@@ -243,7 +243,10 @@ class PreferencesScreen extends React.Component<Props> {
 
     return (
       <RNavScreenWithLargeHeader
-        title={I18n.t("profile.preferences.title")}
+        title={{
+          label: I18n.t("profile.preferences.title"),
+          accessibilityLabel: I18n.t("profile.preferences.title")
+        }}
         description={I18n.t("profile.preferences.subtitle")}
         contextualHelpMarkdown={contextualHelpMarkdown}
         headerActionsProp={{ showHelp: true }}

--- a/ts/screens/profile/PrivacyMainScreen.tsx
+++ b/ts/screens/profile/PrivacyMainScreen.tsx
@@ -262,7 +262,10 @@ const PrivacyMainScreen = ({ navigation }: Props) => {
 
   return (
     <RNavScreenWithLargeHeader
-      title={I18n.t("profile.main.privacy.title")}
+      title={{
+        label: I18n.t("profile.main.privacy.title"),
+        accessibilityLabel: I18n.t("profile.main.privacy.title")
+      }}
       description={I18n.t("profile.main.privacy.subtitle")}
       headerActionsProp={{ showHelp: true }}
     >

--- a/ts/screens/profile/ProfileAboutApp.tsx
+++ b/ts/screens/profile/ProfileAboutApp.tsx
@@ -6,7 +6,10 @@ import I18n from "../../i18n";
 
 const ProfileAboutApp = () => (
   <RNavScreenWithLargeHeader
-    title={I18n.t("profile.main.appInfo.title")}
+    title={{
+      label: I18n.t("profile.main.appInfo.title"),
+      accessibilityLabel: I18n.t("profile.main.appInfo.title")
+    }}
     headerActionsProp={{ showHelp: false }}
   >
     <ContentWrapper>

--- a/ts/screens/profile/ProfileDataScreen.tsx
+++ b/ts/screens/profile/ProfileDataScreen.tsx
@@ -51,7 +51,10 @@ const ProfileDataScreen: React.FC<Props> = ({
   };
   return (
     <RNavScreenWithLargeHeader
-      title={I18n.t("profile.data.title")}
+      title={{
+        label: I18n.t("profile.data.title"),
+        accessibilityLabel: I18n.t("profile.data.title")
+      }}
       description={I18n.t("profile.data.subtitle")}
       headerActionsProp={{ showHelp: true }}
       contextualHelpMarkdown={contextualHelpMarkdown}

--- a/ts/screens/profile/RemoveAccountInfoScreen.tsx
+++ b/ts/screens/profile/RemoveAccountInfoScreen.tsx
@@ -36,7 +36,10 @@ const RemoveAccountInfo: React.FunctionComponent<Props> = props => {
   );
   return (
     <RNavScreenWithLargeHeader
-      title={I18n.t("profile.main.privacy.removeAccount.title")}
+      title={{
+        label: I18n.t("profile.main.privacy.removeAccount.title"),
+        accessibilityLabel: I18n.t("profile.main.privacy.removeAccount.title")
+      }}
       fixedBottomSlot={footerComponent}
     >
       <ContentWrapper>

--- a/ts/screens/profile/SecurityScreen.tsx
+++ b/ts/screens/profile/SecurityScreen.tsx
@@ -122,7 +122,10 @@ const SecurityScreen = (): React.ReactElement => {
 
   return (
     <RNavScreenWithLargeHeader
-      title={I18n.t("profile.security.title")}
+      title={{
+        label: I18n.t("profile.security.title"),
+        accessibilityLabel: I18n.t("profile.security.title")
+      }}
       description={I18n.t("profile.security.subtitle")}
       headerActionsProp={{ showHelp: true }}
       contextualHelpMarkdown={contextualHelpMarkdown}

--- a/ts/screens/profile/ServicesPreferenceScreen.tsx
+++ b/ts/screens/profile/ServicesPreferenceScreen.tsx
@@ -70,7 +70,10 @@ const ServicesPreferenceScreen = (props: Props): React.ReactElement => {
 
   return (
     <RNavScreenWithLargeHeader
-      title={I18n.t("services.optIn.preferences.title")}
+      title={{
+        label: I18n.t("services.optIn.preferences.title"),
+        accessibilityLabel: I18n.t("services.optIn.preferences.title")
+      }}
       description={I18n.t("services.optIn.preferences.body")}
       headerActionsProp={{ showHelp: true }}
     >

--- a/ts/screens/profile/ShareDataScreen.tsx
+++ b/ts/screens/profile/ShareDataScreen.tsx
@@ -65,8 +65,13 @@ const ShareDataScreen = (props: Props): React.ReactElement => {
 
   return (
     <RNavScreenWithLargeHeader
-      title={I18n.t("profile.main.privacy.shareData.screen.title")}
-      titleTestID={"share-data-component-title"}
+      title={{
+        label: I18n.t("profile.main.privacy.shareData.screen.title"),
+        accessibilityLabel: I18n.t(
+          "profile.main.privacy.shareData.screen.title"
+        ),
+        testID: "share-data-component-title"
+      }}
       description={I18n.t("profile.main.privacy.shareData.screen.description")}
       fixedBottomSlot={
         <SafeAreaView>


### PR DESCRIPTION
## Short description
This PR adds the `accessibilityLabel` to the RNavScreenWithLargeHeader title and inside the new Transaction details screen has been added the role of the accessibility label

## List of changes proposed in this pull request
- Added `accessibilityLabel` into `title` RNavScreenWithLargeHeader prop
- Adapted the already used RNavScreenWithLargeHeader with the new title object prop

## How to test
- Enable the DS flag
- With the voiceover enabled, navigate to the new Transaction Screen details
- You should be able to hear the "heading" role by the voiceover tapping on the header title

## Acknowledgment
@dmnplb @thisisjp 
