### PR TITLE
chore(Cross): [IOAPPX-246] Update `Podfile.lock` for `io-react-native-login-utils`

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -137,7 +137,7 @@ PODS:
   - OpenSSL-Universal (1.1.1100)
   - pagopa-io-react-native-crypto (0.2.1):
     - React-Core
-  - pagopa-io-react-native-login-utils (0.2.2):
+  - pagopa-io-react-native-login-utils (1.0.0):
     - React-Core
   - PromisesObjC (2.0.0)
   - Protobuf (3.19.1)
@@ -945,7 +945,7 @@ SPEC CHECKSUMS:
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   pagopa-io-react-native-crypto: 644fece16966f2e1ea1f872344ee5a3c6c8761a1
-  pagopa-io-react-native-login-utils: 51a58dc0e5fe3cba461759b9e98e795fc22e17c8
+  pagopa-io-react-native-login-utils: 442a5e2ab8db2c476fed2cff6d7ad16388ff1f21
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   Protobuf: 3724efa50cb2846d7ccebc8691c574e85fd74471
   RCT-Folly: b9d9fe1fc70114b751c076104e52f3b1b5e5a95a


### PR DESCRIPTION
## Short description
This PR updates the `Podfile.lock` after the `io-react-native-login-utils` update of [this](https://github.com/pagopa/io-app/pull/5474) PR.

## How to test
Run `yarn` and `cd ios && bundler exec pod install && cd ..`. Finally, run `git status` and ensure that there are no changes.
