### PR TITLE
chore: [IOBP-552,IOBP-556] Additional onboarding outcome screen for BPay

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1231,6 +1231,10 @@ wallet:
         title: Hai già aggiunto questo metodo
         subtitle: ""
         primaryAction: Chiudi
+      BPAY_NOT_FOUND:
+        title: Non abbiamo trovato alcun BANCOMAT Pay attivo
+        subtitle: "Contatta la tua Banca per attivare il servizio."
+        primaryAction: Chiudi
   alert:
     supportedCardPageLinkError: An error occurred while opening the supported cards page.
     msgErrorUpdateApp: "An error occurred while opening the app store"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1203,7 +1203,7 @@ wallet:
             description: "Cercheremo tutte le carte intestate a te presso le banche aderenti al servizio"
     generalError: "C'è stato un errore generico durante l'aggiunta del metodo di pagamento"
     success:
-      title: "La carta è stata aggiunta!"
+      title: "Il metodo è stato aggiunto"
       continueButton: "Vedi dettagli"
     failure:
       GENERIC_ERROR:

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1231,6 +1231,10 @@ wallet:
         title: Hai già aggiunto questo metodo
         subtitle: ""
         primaryAction: Chiudi
+      BPAY_NOT_FOUND:
+        title: Non abbiamo trovato alcun BANCOMAT Pay attivo
+        subtitle: "Contatta la tua Banca per attivare il servizio."
+        primaryAction: Chiudi
   alert:
     supportedCardPageLinkError: Si è verificato un errore durante l'apertura della pagina di riferimento per le carte supportate.
     msgErrorUpdateApp: "Si è verificato un errore durante l'apertura dello store delle app"

--- a/ts/features/walletV3/onboarding/types/index.ts
+++ b/ts/features/walletV3/onboarding/types/index.ts
@@ -8,7 +8,8 @@ export enum OnboardingOutcomeEnum {
   TIMEOUT = "4",
   CANCELED_BY_USER = "8",
   INVALID_SESSION = "14",
-  ALREADY_ONBOARDED = "15"
+  ALREADY_ONBOARDED = "15",
+  BPAY_NOT_FOUND = "16"
 }
 
 export type OnboardingOutcome = `${OnboardingOutcomeEnum}`;

--- a/ts/features/walletV3/onboarding/utils/index.ts
+++ b/ts/features/walletV3/onboarding/utils/index.ts
@@ -31,7 +31,8 @@ export const ONBOARDING_OUTCOME_ERROR_PICTOGRAM: Record<
   [OnboardingOutcomeEnum.TIMEOUT]: "time",
   [OnboardingOutcomeEnum.CANCELED_BY_USER]: "trash",
   [OnboardingOutcomeEnum.INVALID_SESSION]: "umbrellaNew",
-  [OnboardingOutcomeEnum.ALREADY_ONBOARDED]: "success"
+  [OnboardingOutcomeEnum.ALREADY_ONBOARDED]: "success",
+  [OnboardingOutcomeEnum.BPAY_NOT_FOUND]: "attention"
 };
 
 /**


### PR DESCRIPTION
## Short description
This PR adds the outcome screen to show when there is an outcome `16` from the onboarding webview. In addition, the text from the success onboarding screen feedback has been changed.

## List of changes proposed in this pull request
- Addedd additional outcome 16 as `BPAY_NOT_FOUND`
- Added locales and pictogram for the `BPAY_NOT_FOUND` outcome.

## How to test
- Checkout this PR from the io-dev-app-server: https://github.com/pagopa/io-dev-api-server/pull/350
- Then, start an onboarding process from the playground and choose `16 - BPAY_NOT_FOUND` from the dropdown list shown in the webview

## Preview

https://github.com/pagopa/io-app/assets/34343582/63622a3f-1332-4478-80ff-43e47d3dc1e5


