### PR TITLE
feat: [IOCOM-1059] Remove 'Open' CTA on Android attachment preview (new DS)

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1924,9 +1924,13 @@ messageDetails:
 messagePDFPreview:
   title: "PDF Preview"
   singleBtn: "Save or share"
+  singleBtnAccessibility: "Save or share document"
   open: "Open"
   save: "Save"
+  saveAccessibility: "Save document"
   savedAtLocation: "Document {{name}} was successfully saved in your Download folder."
+  share: "Share"
+  shareAccessibility: "Share document"
   pdfAccessibility: "Preview of the PDF document"
   errors:
     previewing:

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1924,9 +1924,13 @@ messageDetails:
 messagePDFPreview:
   title: "Anteprima PDF"
   singleBtn: "Salva o condividi"
+  singleBtnAccessibility: "Salva o condividi documento"
   open: "Apri"
   save: "Salva"
+  saveAccessibility: "Salva documento"
   savedAtLocation: "Il documento {{name}} è stato salvato nella cartella Download."
+  share: "Condividi"
+  shareAccessibility: "Condividi documento"
   pdfAccessibility: "Anteprima documento PDF"
   errors:
     previewing:

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   "dependencies": {
     "@babel/plugin-transform-regenerator": "^7.18.6",
     "@gorhom/bottom-sheet": "^4.1.5",
-    "@pagopa/io-app-design-system": "1.23.2",
+    "@pagopa/io-app-design-system": "1.23.3",
     "@pagopa/io-pagopa-commons": "^3.1.0",
     "@pagopa/io-react-native-crypto": "^0.2.1",
     "@pagopa/io-react-native-login-utils": "^1.0.0",

--- a/ts/components/__tests__/__snapshots__/LoadingSpinnerOverlay.test.tsx.snap
+++ b/ts/components/__tests__/__snapshots__/LoadingSpinnerOverlay.test.tsx.snap
@@ -305,6 +305,7 @@ exports[`LoadingSpinnerOverlay Should match all-properties and loading snapshot 
             <Text
               allowFontScaling={false}
               ellipsizeMode="tail"
+              importantForAccessibility="no-hide-descendants"
               maxFontSizeMultiplier={1.3}
               numberOfLines={1}
               style={

--- a/ts/components/screens/__tests__/__snapshots__/OperationResultScreenContent.test.tsx.snap
+++ b/ts/components/screens/__tests__/__snapshots__/OperationResultScreenContent.test.tsx.snap
@@ -527,6 +527,7 @@ exports[`OperationResultScreenContent should match the snapshot with default pro
                                             "fontSize": 16,
                                           }
                                         }
+                                        importantForAccessibility="no-hide-descendants"
                                         maxFontSizeMultiplier={1.3}
                                         numberOfLines={1}
                                         style={

--- a/ts/features/messages/screens/MessageAttachment.tsx
+++ b/ts/features/messages/screens/MessageAttachment.tsx
@@ -21,7 +21,6 @@ import {
 } from "../analytics";
 import { ServiceId } from "../../../../definitions/backend/ServiceId";
 import {
-  trackPNAttachmentOpen,
   trackPNAttachmentOpeningSuccess,
   trackPNAttachmentSave,
   trackPNAttachmentSaveShare,
@@ -40,20 +39,30 @@ export type MessageAttachmentNavigationParams = Readonly<{
   serviceId?: ServiceId;
 }>;
 
-const renderFooter = (
-  name: string,
-  mimeType: string,
-  downloadPath: string,
-  isPN: boolean,
-  attachmentCategory?: string
-) =>
+type MessageAttachmentFooterProps = {
+  attachmentCategory?: string;
+  downloadPath: string;
+  isPN: boolean;
+  mimeType: string;
+  name: string;
+};
+
+const MessageAttachmentFooter = ({
+  attachmentCategory,
+  downloadPath,
+  isPN,
+  mimeType,
+  name
+}: MessageAttachmentFooterProps) =>
   isIos ? (
     <FooterWithButtons
       type={"SingleButton"}
       primary={{
         type: "Solid",
         buttonProps: {
-          accessibilityLabel: I18n.t("messagePDFPreview.singleBtn"),
+          accessibilityLabel: I18n.t(
+            "messagePDFPreview.singleBtnAccessibility"
+          ),
           onPress: () => {
             onShare(isPN, attachmentCategory);
             ReactNativeBlobUtil.ios.presentOptionsMenu(downloadPath);
@@ -64,24 +73,24 @@ const renderFooter = (
     />
   ) : (
     <FooterWithButtons
-      type={"ThreeButtonsInLine"}
-      primary={{
-        type: "Outline",
+      type={"TwoButtonsInlineHalf"}
+      secondary={{
+        type: "Solid",
         buttonProps: {
-          accessibilityLabel: I18n.t("global.buttons.share"),
+          accessibilityLabel: I18n.t("messagePDFPreview.saveAccessibility"),
           onPress: () => {
             onShare(isPN, attachmentCategory);
             share(`file://${downloadPath}`, undefined, false)().catch(_ => {
               IOToast.show(I18n.t("messagePDFPreview.errors.sharing"));
             });
           },
-          label: I18n.t("global.buttons.share")
+          label: I18n.t("messagePDFPreview.share")
         }
       }}
-      third={{
-        type: "Outline",
+      primary={{
+        type: "Solid",
         buttonProps: {
-          accessibilityLabel: I18n.t("messagePDFPreview.save"),
+          accessibilityLabel: I18n.t("messagePDFPreview.saveAccessibility"),
           onPress: () => {
             onDownload(isPN, attachmentCategory);
             ReactNativeBlobUtil.MediaCollection.copyToMediaStore(
@@ -105,21 +114,6 @@ const renderFooter = (
               });
           },
           label: I18n.t("messagePDFPreview.save")
-        }
-      }}
-      secondary={{
-        type: "Solid",
-        buttonProps: {
-          accessibilityLabel: I18n.t("messagePDFPreview.open"),
-          onPress: () => {
-            onOpen(isPN, attachmentCategory);
-            ReactNativeBlobUtil.android
-              .actionViewIntent(downloadPath, mimeType)
-              .catch(_ => {
-                IOToast.error(I18n.t("messagePDFPreview.errors.opening"));
-              });
-          },
-          label: I18n.t("messagePDFPreview.open")
         }
       }}
     />
@@ -164,15 +158,6 @@ const onShare = (isPN: boolean, attachmentCategory?: string) =>
             () => trackPNAttachmentSaveShare(attachmentCategory)
           )
         )
-    )
-  );
-
-const onOpen = (isPN: boolean, attachmentCategory?: string) =>
-  pipe(
-    isPN,
-    B.fold(
-      () => trackThirdPartyMessageAttachmentUserAction("open"),
-      () => trackPNAttachmentOpen(attachmentCategory)
     )
   );
 
@@ -237,7 +222,13 @@ export const MessageAttachment = (
           onLoadComplete={() => onLoadComplete(isPN, attachmentCategory)}
         />
       )}
-      {renderFooter(name, mimeType, downloadPathOpt, isPN, attachmentCategory)}
+      <MessageAttachmentFooter
+        attachmentCategory={attachmentCategory}
+        downloadPath={downloadPathOpt}
+        isPN={isPN}
+        mimeType={mimeType}
+        name={name}
+      />
     </>
   );
 };

--- a/ts/features/messages/screens/MessageAttachment.tsx
+++ b/ts/features/messages/screens/MessageAttachment.tsx
@@ -77,7 +77,7 @@ const MessageAttachmentFooter = ({
       secondary={{
         type: "Solid",
         buttonProps: {
-          accessibilityLabel: I18n.t("messagePDFPreview.saveAccessibility"),
+          accessibilityLabel: I18n.t("messagePDFPreview.shareAccessibility"),
           onPress: () => {
             onShare(isPN, attachmentCategory);
             share(`file://${downloadPath}`, undefined, false)().catch(_ => {

--- a/ts/features/messages/screens/__tests__/__snapshots__/MessageAttachment.test.tsx.snap
+++ b/ts/features/messages/screens/__tests__/__snapshots__/MessageAttachment.test.tsx.snap
@@ -486,7 +486,7 @@ exports[`MessageAttachment Should match the snapshot when everything went fine 1
                               }
                             >
                               <View
-                                accessibilityLabel="Save or share"
+                                accessibilityLabel="Save or share document"
                                 accessibilityRole="button"
                                 accessibilityState={
                                   Object {
@@ -566,6 +566,7 @@ exports[`MessageAttachment Should match the snapshot when everything went fine 1
                                           "fontSize": 16,
                                         }
                                       }
+                                      importantForAccessibility="no-hide-descendants"
                                       maxFontSizeMultiplier={1.3}
                                       numberOfLines={1}
                                       style={

--- a/yarn.lock
+++ b/yarn.lock
@@ -3277,10 +3277,10 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@pagopa/io-app-design-system@1.23.2":
-  version "1.23.2"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-app-design-system/-/io-app-design-system-1.23.2.tgz#739da99711af7c208b547d7c0b5cc82c77e1bad3"
-  integrity sha512-MqQnd5bHxGwXd+KdAb95e0Onw2C2Ic+GpJnIUSWN15sggb4oF/bl14tViMhV2yCJCpq7dYaiS8GmdWQjl2fQIQ==
+"@pagopa/io-app-design-system@1.23.3":
+  version "1.23.3"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-app-design-system/-/io-app-design-system-1.23.3.tgz#6b9b31c616f13148874ba144191ba544b45811b0"
+  integrity sha512-67YKokZnTtM+mXkYYvNV69Ml0c/2KU00BTam9l/BDYmeUUc/D7kleoi8T5lKlBNd9ZNMscPyVbvPcDkiHPjB3A==
   dependencies:
     "@pagopa/ts-commons" "^12.0.0"
     "@testing-library/jest-native" "^5.4.2"


### PR DESCRIPTION
## Short description
This PR removes the OPEN CTA on an attachment's preview, on Android devices.
![Screenshot 2024-02-19 at 14 54 20](https://github.com/pagopa/io-app/assets/5150343/24ec3694-a24f-463d-8b6d-a15fc11ed12a)

## List of changes proposed in this pull request
- Open CTA removed
- Proper accessibility labels for remaining CTAs
- New DS version that improves accessibility readings on CTA buttons for Android
- Updated snapshots

## How to test
Using the io-dev-api-server, check that on an Android devices the two remaining CTA still work as expected (accessibility included)
