### PR TITLE
chore: [IOBP-557] Handled 404 response status with empty list from user wallet list

### DIFF
--- a/ts/features/walletV3/payment/saga/networking/handleWalletPaymentGetUserWallets.ts
+++ b/ts/features/walletV3/payment/saga/networking/handleWalletPaymentGetUserWallets.ts
@@ -48,6 +48,9 @@ export function* handleWalletPaymentGetUserWallets(
             if (res.status === 200) {
               return walletPaymentGetUserWallets.success(res.value);
             }
+            if (res.status === 404) {
+              return walletPaymentGetUserWallets.success({ wallets: [] });
+            }
             return walletPaymentGetUserWallets.failure({
               ...getGenericError(new Error(`Error: ${res.status}`))
             });


### PR DESCRIPTION
## Short description
This PR handles the 404 response from the user wallet list as an empty list instead of showing a generic error screen.

## List of changes proposed in this pull request
- Added a result status check to verify if the status is 404, it will be treated as an empty wallet list

## How to test
- Edit the response of the e-commerce wallet list from the `io-dev-app-server` to return a 404 status response
- Start a payment flow from the playground section
- As soon as you get the user wallet list, you should be able to see a screen that invites the user to onboard a new payment method instead of showing a generic error screen

## Preview

|Before|After|
|-|-|
|<video src="https://github.com/pagopa/io-app/assets/34343582/82148601-6bf1-48b5-a418-859f7cae6660" /> | <video src="https://github.com/pagopa/io-app/assets/34343582/dcda0224-54a2-47a1-8b85-f14f4e88fb97" />


