### PR TITLE
feat: [IOCOM-881] Update message attachment preview

### DIFF
--- a/ts/features/messages/components/MessageDetail/index.tsx
+++ b/ts/features/messages/components/MessageDetail/index.tsx
@@ -162,8 +162,7 @@ const MessageDetailsComponent = ({
         params: {
           messageId,
           serviceId: serviceIdOpt,
-          attachmentId: attachment.id,
-          isPN: false
+          attachmentId: attachment.id
         }
       });
     },

--- a/ts/features/messages/hooks/useAttachmentDownload.tsx
+++ b/ts/features/messages/hooks/useAttachmentDownload.tsx
@@ -49,8 +49,7 @@ export const useAttachmentDownload = (
       params: {
         messageId,
         serviceId,
-        attachmentId,
-        isPN: false
+        attachmentId
       }
     });
   }, [attachmentId, dispatch, messageId, navigation, serviceId]);

--- a/ts/features/messages/navigation/MessagesNavigator.tsx
+++ b/ts/features/messages/navigation/MessagesNavigator.tsx
@@ -13,7 +13,7 @@ import { isGestureEnabled } from "../../../utils/navigation";
 import { isPnEnabledSelector } from "../../../store/reducers/backendStatus";
 import { LegacyMessageDetailAttachment } from "../screens/LegacyMessageAttachment";
 import { isDesignSystemEnabledSelector } from "../../../store/reducers/persistedPreferences";
-import { MessageAttachment } from "../screens/MessageAttachment";
+import { MessageAttachmentScreen } from "../screens/MessageAttachmentScreen";
 import { MessagesParamsList } from "./params";
 import { MESSAGES_ROUTES } from "./routes";
 
@@ -53,7 +53,7 @@ export const MessagesStackNavigator = () => {
           name={MESSAGES_ROUTES.MESSAGE_DETAIL_ATTACHMENT}
           component={
             isDesignSystemEnabled
-              ? MessageAttachment
+              ? MessageAttachmentScreen
               : LegacyMessageDetailAttachment
           }
           options={{

--- a/ts/features/messages/navigation/params.ts
+++ b/ts/features/messages/navigation/params.ts
@@ -1,19 +1,19 @@
 import { NavigatorScreenParams } from "@react-navigation/native";
 import EUCOVIDCERT_ROUTES from "../../euCovidCert/navigation/routes";
 import PN_ROUTES from "../../pn/navigation/routes";
-import { MessageRouterScreenNavigationParams } from "../screens/MessageRouterScreen";
-import { MessageDetailsScreenNavigationParams } from "../screens/MessageDetailsScreen";
+import { MessageRouterScreenRouteParams } from "../screens/MessageRouterScreen";
+import { MessageDetailsScreenRouteParams } from "../screens/MessageDetailsScreen";
 import { EUCovidCertParamsList } from "../../euCovidCert/navigation/params";
 import { PnParamsList } from "../../pn/navigation/params";
-import { MessageAttachmentNavigationParams } from "../screens/MessageAttachment";
-import { MessageCalendarRouteParams } from "../screens/MessageCalendarScreen";
+import { MessageAttachmentScreenRouteParams } from "../screens/MessageAttachmentScreen";
+import { MessageCalendarScreenRouteParams } from "../screens/MessageCalendarScreen";
 import { MESSAGES_ROUTES } from "./routes";
 
 export type MessagesParamsList = {
-  [MESSAGES_ROUTES.MESSAGE_ROUTER]: MessageRouterScreenNavigationParams;
-  [MESSAGES_ROUTES.MESSAGE_DETAIL]: MessageDetailsScreenNavigationParams;
-  [MESSAGES_ROUTES.MESSAGE_DETAIL_ATTACHMENT]: MessageAttachmentNavigationParams;
-  [MESSAGES_ROUTES.MESSAGE_DETAIL_CALENDAR]: MessageCalendarRouteParams;
+  [MESSAGES_ROUTES.MESSAGE_ROUTER]: MessageRouterScreenRouteParams;
+  [MESSAGES_ROUTES.MESSAGE_DETAIL]: MessageDetailsScreenRouteParams;
+  [MESSAGES_ROUTES.MESSAGE_DETAIL_ATTACHMENT]: MessageAttachmentScreenRouteParams;
+  [MESSAGES_ROUTES.MESSAGE_DETAIL_CALENDAR]: MessageCalendarScreenRouteParams;
   [EUCOVIDCERT_ROUTES.MAIN]: NavigatorScreenParams<EUCovidCertParamsList>;
   [PN_ROUTES.MAIN]: NavigatorScreenParams<PnParamsList>;
 };

--- a/ts/features/messages/screens/MessageAttachmentScreen.tsx
+++ b/ts/features/messages/screens/MessageAttachmentScreen.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { UIMessageId } from "../types";
+import { IOStackNavigationRouteProps } from "../../../navigation/params/AppParamsList";
+import { MessagesParamsList } from "../navigation/params";
+import { ServiceId } from "../../../../definitions/backend/ServiceId";
+import { MessageAttachment } from "../components/MessageAttachment/MessageAttachment";
+import { useHeaderSecondLevel } from "../../../hooks/useHeaderSecondLevel";
+
+export type MessageAttachmentScreenRouteParams = {
+  messageId: UIMessageId;
+  attachmentId: string;
+  serviceId?: ServiceId;
+};
+
+type MessageAttachmentScreenProps = IOStackNavigationRouteProps<
+  MessagesParamsList,
+  "MESSAGE_DETAIL_ATTACHMENT"
+>;
+
+export const MessageAttachmentScreen = (
+  props: MessageAttachmentScreenProps
+) => {
+  const { attachmentId, messageId, serviceId } = props.route.params;
+
+  useHeaderSecondLevel({
+    title: "",
+    supportRequest: true
+  });
+
+  return (
+    <MessageAttachment
+      attachmentId={attachmentId}
+      isPN={false}
+      messageId={messageId}
+      serviceId={serviceId}
+    />
+  );
+};

--- a/ts/features/messages/screens/MessageCalendarScreen.tsx
+++ b/ts/features/messages/screens/MessageCalendarScreen.tsx
@@ -24,7 +24,7 @@ import { findDeviceCalendarsTask } from "../../../utils/calendar";
 import { messageDetailsByIdSelector } from "../store/reducers/detailsById";
 import { useMessageCalendar } from "../hooks/useMessageCalendar";
 
-export type MessageCalendarRouteParams = {
+export type MessageCalendarScreenRouteParams = {
   messageId: UIMessageId;
 };
 

--- a/ts/features/messages/screens/MessageDetailsScreen.tsx
+++ b/ts/features/messages/screens/MessageDetailsScreen.tsx
@@ -35,7 +35,7 @@ import { localeDateFormat } from "../../../utils/locale";
 import { MessageDetailsTagBox } from "../components/MessageDetail/MessageDetailsTagBox";
 import { MessageDetailsReminder } from "../components/MessageDetail/MessageDetailsReminder";
 
-export type MessageDetailsScreenNavigationParams = {
+export type MessageDetailsScreenRouteParams = {
   messageId: UIMessageId;
   serviceId: ServiceId;
 };

--- a/ts/features/messages/screens/MessageRouterScreen.tsx
+++ b/ts/features/messages/screens/MessageRouterScreen.tsx
@@ -28,7 +28,7 @@ import EUCOVIDCERT_ROUTES from "../../euCovidCert/navigation/routes";
 import PN_ROUTES from "../../pn/navigation/routes";
 import { MESSAGES_ROUTES } from "../navigation/routes";
 
-export type MessageRouterScreenNavigationParams = {
+export type MessageRouterScreenRouteParams = {
   messageId: UIMessageId;
   fromNotification: boolean;
 };

--- a/ts/features/messages/screens/__tests__/MessageAttachment.test.tsx
+++ b/ts/features/messages/screens/__tests__/MessageAttachment.test.tsx
@@ -4,7 +4,7 @@ import { renderScreenWithNavigationStoreContext } from "../../../../utils/testWr
 import { MESSAGES_ROUTES } from "../../navigation/routes";
 import { appReducer } from "../../../../store/reducers";
 import { applicationChangeState } from "../../../../store/actions/application";
-import { MessageAttachment } from "../MessageAttachment";
+import { MessageAttachmentScreen } from "../MessageAttachmentScreen";
 import { ServiceId } from "../../../../../definitions/backend/ServiceId";
 import { downloadAttachment } from "../../store/actions";
 import { preferencesDesignSystemSetEnabled } from "../../../../store/actions/persistedPreferences";
@@ -52,7 +52,7 @@ const renderScreen = (
   );
 
   return renderScreenWithNavigationStoreContext(
-    MessageAttachment,
+    MessageAttachmentScreen,
     MESSAGES_ROUTES.MESSAGE_DETAIL_ATTACHMENT,
     { messageId, attachmentId, isPN: false, serviceId },
     store

--- a/ts/features/messages/store/actions/navigation.ts
+++ b/ts/features/messages/store/actions/navigation.ts
@@ -1,13 +1,13 @@
 import { CommonActions } from "@react-navigation/native";
 import { MESSAGES_ROUTES } from "../../navigation/routes";
-import { MessageRouterScreenNavigationParams } from "../../screens/MessageRouterScreen";
-import { MessageDetailsScreenNavigationParams } from "../../screens/MessageDetailsScreen";
+import { MessageRouterScreenRouteParams } from "../../screens/MessageRouterScreen";
+import { MessageDetailsScreenRouteParams } from "../../screens/MessageDetailsScreen";
 
 /**
  * Open the Message Detail screen supporting the new UIMessage type.
  */
 export const navigateToMessageDetailScreenAction = (
-  params: MessageDetailsScreenNavigationParams
+  params: MessageDetailsScreenRouteParams
 ) =>
   CommonActions.navigate(MESSAGES_ROUTES.MESSAGES_NAVIGATOR, {
     screen: MESSAGES_ROUTES.MESSAGE_DETAIL,
@@ -18,7 +18,7 @@ export const navigateToMessageDetailScreenAction = (
  * Open the Message Detail Router supporting the new UIMessage type.
  */
 export const navigateToMessageRouterAction = (
-  params: MessageRouterScreenNavigationParams
+  params: MessageRouterScreenRouteParams
 ) =>
   CommonActions.navigate(MESSAGES_ROUTES.MESSAGES_NAVIGATOR, {
     screen: MESSAGES_ROUTES.MESSAGE_ROUTER,

--- a/ts/features/pn/components/LegacyMessageDetails.tsx
+++ b/ts/features/pn/components/LegacyMessageDetails.tsx
@@ -86,9 +86,8 @@ export const LegacyMessageDetails = ({
         params: {
           screen: PN_ROUTES.MESSAGE_ATTACHMENT,
           params: {
-            messageId,
             attachmentId: attachment.id,
-            category: attachment.category
+            messageId
           }
         }
       });

--- a/ts/features/pn/navigation/navigator.tsx
+++ b/ts/features/pn/navigation/navigator.tsx
@@ -1,9 +1,10 @@
-import * as React from "react";
+import React from "react";
 import { createStackNavigator } from "@react-navigation/stack";
 import { isGestureEnabled } from "../../../utils/navigation";
-import { MessageDetailsScreen } from "../screens/MessageDetailsScreen";
 import { LegacyMessageDetailsScreen } from "../screens/LegacyMessageDetailsScreen";
-import { AttachmentPreviewScreen } from "../screens/AttachmentPreviewScreen";
+import { LegacyAttachmentPreviewScreen } from "../screens/LegacyAttachmentPreviewScreen";
+import { MessageDetailsScreen } from "../screens/MessageDetailsScreen";
+import { MessageAttachmentScreen } from "../screens/MessageAttachmentScreen";
 import { PaidPaymentScreen } from "../screens/PaidPaymentScreen";
 import { useIOSelector } from "../../../store/hooks";
 import { isDesignSystemEnabledSelector } from "../../../store/reducers/persistedPreferences";
@@ -33,9 +34,13 @@ export const PnStackNavigator = () => {
       />
       <Stack.Screen
         name={PN_ROUTES.MESSAGE_ATTACHMENT}
-        component={AttachmentPreviewScreen}
+        component={
+          isDesignSystemEnabled
+            ? MessageAttachmentScreen
+            : LegacyAttachmentPreviewScreen
+        }
         options={{
-          headerShown: false
+          headerShown: isDesignSystemEnabled
         }}
       />
       <Stack.Screen

--- a/ts/features/pn/navigation/params.ts
+++ b/ts/features/pn/navigation/params.ts
@@ -1,10 +1,10 @@
-import { AttachmentPreviewScreenNavigationParams } from "../screens/AttachmentPreviewScreen";
-import { MessageDetailsScreenNavigationParams } from "../screens/MessageDetailsScreen";
-import { PaidPaymentScreenNavigationParams } from "../screens/PaidPaymentScreen";
+import { MessageAttachmentScreenRouteParams } from "../screens/MessageAttachmentScreen";
+import { MessageDetailsScreenRouteParams } from "../screens/MessageDetailsScreen";
+import { PaidPaymentScreenRouteParams } from "../screens/PaidPaymentScreen";
 import PN_ROUTES from "./routes";
 
 export type PnParamsList = {
-  [PN_ROUTES.MESSAGE_DETAILS]: MessageDetailsScreenNavigationParams;
-  [PN_ROUTES.MESSAGE_ATTACHMENT]: AttachmentPreviewScreenNavigationParams;
-  [PN_ROUTES.CANCELLED_MESSAGE_PAID_PAYMENT]: PaidPaymentScreenNavigationParams;
+  [PN_ROUTES.MESSAGE_DETAILS]: MessageDetailsScreenRouteParams;
+  [PN_ROUTES.MESSAGE_ATTACHMENT]: MessageAttachmentScreenRouteParams;
+  [PN_ROUTES.CANCELLED_MESSAGE_PAID_PAYMENT]: PaidPaymentScreenRouteParams;
 };

--- a/ts/features/pn/screens/LegacyAttachmentPreviewScreen.tsx
+++ b/ts/features/pn/screens/LegacyAttachmentPreviewScreen.tsx
@@ -3,7 +3,6 @@ import { pipe } from "fp-ts/lib/function";
 import * as B from "fp-ts/lib/boolean";
 import * as O from "fp-ts/lib/Option";
 import { PnParamsList } from "../navigation/params";
-import { UIMessageId } from "../../messages/types";
 import { IOStackNavigationRouteProps } from "../../../navigation/params/AppParamsList";
 import { useIOSelector } from "../../../store/hooks";
 import { pnMessageAttachmentSelector } from "../store/reducers";
@@ -17,22 +16,16 @@ import {
 import { isIos } from "../../../utils/platform";
 import { LegacyMessageAttachmentPreview } from "../../messages/components/MessageAttachment/LegacyMessageAttachmentPreview";
 
-export type AttachmentPreviewScreenNavigationParams = Readonly<{
-  messageId: UIMessageId;
-  attachmentId: string;
-  category?: string;
-}>;
-
-type AttachmentPreviewScreenProps = IOStackNavigationRouteProps<
+type LegacyAttachmentPreviewScreenProps = IOStackNavigationRouteProps<
   PnParamsList,
   "PN_ROUTES_MESSAGE_ATTACHMENT"
 >;
 
-export const AttachmentPreviewScreen = ({
+export const LegacyAttachmentPreviewScreen = ({
   navigation,
   route
-}: AttachmentPreviewScreenProps) => {
-  const { messageId, attachmentId, category } = route.params;
+}: LegacyAttachmentPreviewScreenProps) => {
+  const { messageId, attachmentId } = route.params;
   // This ref is needed otherwise the auto back on the useEffect will fire multiple
   // times, since its dependencies change during the back navigation
   const autoBackOnErrorHandled = useRef(false);
@@ -55,21 +48,37 @@ export const AttachmentPreviewScreen = ({
       messageId={messageId}
       enableDownloadAttachment={false}
       attachment={maybePnMessageAttachment.value}
-      onOpen={() => trackPNAttachmentOpen(category)}
+      onOpen={() =>
+        trackPNAttachmentOpen(maybePnMessageAttachment.value.category)
+      }
       onShare={() =>
         pipe(
           isIos,
           B.fold(
-            () => trackPNAttachmentShare(category),
-            () => trackPNAttachmentSaveShare(category)
+            () =>
+              trackPNAttachmentShare(maybePnMessageAttachment.value.category),
+            () =>
+              trackPNAttachmentSaveShare(
+                maybePnMessageAttachment.value.category
+              )
           )
         )
       }
-      onDownload={() => trackPNAttachmentSave(category)}
-      onLoadComplete={() =>
-        trackPNAttachmentOpeningSuccess("displayer", category)
+      onDownload={() =>
+        trackPNAttachmentSave(maybePnMessageAttachment.value.category)
       }
-      onPDFError={() => trackPNAttachmentOpeningSuccess("error", category)}
+      onLoadComplete={() =>
+        trackPNAttachmentOpeningSuccess(
+          "displayer",
+          maybePnMessageAttachment.value.category
+        )
+      }
+      onPDFError={() =>
+        trackPNAttachmentOpeningSuccess(
+          "error",
+          maybePnMessageAttachment.value.category
+        )
+      }
     />
   ) : (
     <></>

--- a/ts/features/pn/screens/MessageAttachmentScreen.tsx
+++ b/ts/features/pn/screens/MessageAttachmentScreen.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { UIMessageId } from "../../messages/types";
+import { IOStackNavigationRouteProps } from "../../../navigation/params/AppParamsList";
+import { PnParamsList } from "../navigation/params";
+import { MessageAttachment } from "../../messages/components/MessageAttachment/MessageAttachment";
+import { useHeaderSecondLevel } from "../../../hooks/useHeaderSecondLevel";
+
+export type MessageAttachmentScreenRouteParams = Readonly<{
+  messageId: UIMessageId;
+  attachmentId: string;
+}>;
+
+type MessageAttachmentScreenProps = IOStackNavigationRouteProps<
+  PnParamsList,
+  "PN_ROUTES_MESSAGE_ATTACHMENT"
+>;
+
+export const MessageAttachmentScreen = (
+  props: MessageAttachmentScreenProps
+) => {
+  const { attachmentId, messageId } = props.route.params;
+
+  useHeaderSecondLevel({
+    title: "",
+    supportRequest: true
+  });
+
+  return (
+    <MessageAttachment
+      attachmentId={attachmentId}
+      isPN={true}
+      messageId={messageId}
+    />
+  );
+};

--- a/ts/features/pn/screens/MessageDetailsScreen.tsx
+++ b/ts/features/pn/screens/MessageDetailsScreen.tsx
@@ -38,7 +38,7 @@ import { selectedPaymentIdSelector } from "../store/reducers/payments";
 import { useHeaderSecondLevel } from "../../../hooks/useHeaderSecondLevel";
 import { OperationResultScreenContent } from "../../../components/screens/OperationResultScreenContent";
 
-export type MessageDetailsScreenNavigationParams = {
+export type MessageDetailsScreenRouteParams = {
   messageId: UIMessageId;
   serviceId: ServiceId;
   firstTimeOpening: boolean;

--- a/ts/features/pn/screens/PaidPaymentScreen.tsx
+++ b/ts/features/pn/screens/PaidPaymentScreen.tsx
@@ -1,40 +1,33 @@
 import React from "react";
-import * as O from "fp-ts/lib/Option";
-import I18n from "i18n-js";
-import { SafeAreaView, ScrollView, StyleSheet } from "react-native";
+import { SafeAreaView, ScrollView } from "react-native";
 import { ListItemInfoCopy } from "@pagopa/io-app-design-system";
-import { Route, useRoute } from "@react-navigation/native";
+import * as O from "fp-ts/lib/Option";
+import I18n from "../../../i18n";
 import { IOStyles } from "../../../components/core/variables/IOStyles";
 import BaseScreenComponent from "../../../components/screens/BaseScreenComponent";
 import { TransactionSummaryStatus } from "../../../screens/wallet/payment/components/TransactionSummaryStatus";
 import { clipboardSetStringWithFeedback } from "../../../utils/clipboard";
-import customVariables from "../../../theme/variables";
 import { emptyContextualHelp } from "../../../utils/emptyContextualHelp";
 import { TransactionSummaryError } from "../../../screens/wallet/payment/TransactionSummaryScreen";
+import { IOStackNavigationRouteProps } from "../../../navigation/params/AppParamsList";
+import { PnParamsList } from "../navigation/params";
 
-const styles = StyleSheet.create({
-  container: {
-    paddingHorizontal: customVariables.contentPadding
-  }
-});
-
-export type PaidPaymentScreenNavigationParams = Readonly<{
+export type PaidPaymentScreenRouteParams = Readonly<{
   noticeCode: string;
   creditorTaxId?: string;
 }>;
+
+type PaidPaymentScreenProps = IOStackNavigationRouteProps<
+  PnParamsList,
+  "PN_CANCELLED_MESSAGE_PAID_PAYMENT"
+>;
 
 const paidPaymentError = O.some(
   "PPT_PAGAMENTO_DUPLICATO"
 ) as TransactionSummaryError;
 
-export const PaidPaymentScreen = (): React.ReactElement => {
-  const { noticeCode, creditorTaxId: maybeCreditorTaxId } =
-    useRoute<
-      Route<
-        "PN_CANCELLED_MESSAGE_PAID_PAYMENT",
-        PaidPaymentScreenNavigationParams
-      >
-    >().params;
+export const PaidPaymentScreen = ({ route }: PaidPaymentScreenProps) => {
+  const { noticeCode, creditorTaxId } = route.params;
   const formattedPaymentNoticeNumber = noticeCode
     .replace(/(\d{4})/g, "$1  ")
     .trim();
@@ -47,21 +40,21 @@ export const PaidPaymentScreen = (): React.ReactElement => {
     >
       <SafeAreaView style={IOStyles.flex}>
         <TransactionSummaryStatus error={paidPaymentError} />
-        <ScrollView style={styles.container}>
+        <ScrollView style={IOStyles.horizontalContentPadding}>
           <ListItemInfoCopy
             label={I18n.t("payment.noticeCode")}
             accessibilityLabel={I18n.t("payment.noticeCode")}
             value={formattedPaymentNoticeNumber}
             onPress={() => clipboardSetStringWithFeedback(noticeCode)}
           />
-          {maybeCreditorTaxId && (
+          {creditorTaxId && (
             <ListItemInfoCopy
               label={I18n.t("wallet.firstTransactionSummary.entityCode")}
               accessibilityLabel={I18n.t(
                 "wallet.firstTransactionSummary.entityCode"
               )}
-              value={maybeCreditorTaxId}
-              onPress={() => clipboardSetStringWithFeedback(maybeCreditorTaxId)}
+              value={creditorTaxId}
+              onPress={() => clipboardSetStringWithFeedback(creditorTaxId)}
             />
           )}
         </ScrollView>

--- a/ts/features/pn/screens/__test__/PaidPaymentScreen.test.tsx
+++ b/ts/features/pn/screens/__test__/PaidPaymentScreen.test.tsx
@@ -1,30 +1,25 @@
-import * as React from "react";
-import { createStackNavigator } from "@react-navigation/stack";
-import renderer from "react-test-renderer";
 import { cleanup } from "@testing-library/react-native";
-import { NavigationContainer } from "@react-navigation/native";
 import configureMockStore from "redux-mock-store";
-import { Provider } from "react-redux";
 import { PaidPaymentScreen } from "../PaidPaymentScreen";
 import PN_ROUTES from "../../navigation/routes";
 import { GlobalState } from "../../../../store/reducers/types";
 import { applicationChangeState } from "../../../../store/actions/application";
 import { appReducer } from "../../../../store/reducers";
+import { renderScreenWithNavigationStoreContext } from "../../../../utils/testWrapper";
 
 describe("PaidPaymentScreen", () => {
   // Needed to avoid `ReferenceError: You are trying to `import` a file after the Jest environment has been torn down.`
   afterEach(cleanup);
   it("should render with back button, title, help button, paid banner, notice code and creditor tax id", () => {
-    const tree = renderer
-      .create(generateComponent(generateNoticeCode(), generateCreditorTaxId()))
-      .toJSON();
-    expect(tree).toMatchSnapshot();
+    const component = generateComponent(
+      generateNoticeCode(),
+      generateCreditorTaxId()
+    );
+    expect(component.toJSON()).toMatchSnapshot();
   });
   it("should render with back button, title, help button, paid banner and notice code but no creditor tax id", () => {
-    const tree = renderer
-      .create(generateComponent(generateNoticeCode()))
-      .toJSON();
-    expect(tree).toMatchSnapshot();
+    const component = generateComponent(generateNoticeCode());
+    expect(component.toJSON()).toMatchSnapshot();
   });
 });
 
@@ -34,21 +29,11 @@ const generateCreditorTaxId = () => "00000000009";
 const generateComponent = (noticeCode: string, creditorTaxId?: string) => {
   const globalState = appReducer(undefined, applicationChangeState("active"));
   const store = configureMockStore<GlobalState>()(globalState);
-  const Stack = createStackNavigator();
-  return (
-    <Provider store={store}>
-      <NavigationContainer>
-        <Stack.Navigator>
-          <Stack.Screen
-            name={PN_ROUTES.CANCELLED_MESSAGE_PAID_PAYMENT}
-            component={PaidPaymentScreen}
-            initialParams={{
-              noticeCode,
-              creditorTaxId
-            }}
-          />
-        </Stack.Navigator>
-      </NavigationContainer>
-    </Provider>
+
+  return renderScreenWithNavigationStoreContext<GlobalState>(
+    PaidPaymentScreen,
+    PN_ROUTES.CANCELLED_MESSAGE_PAID_PAYMENT,
+    { noticeCode, creditorTaxId },
+    store
   );
 };

--- a/ts/features/pn/screens/__test__/__snapshots__/PaidPaymentScreen.test.tsx.snap
+++ b/ts/features/pn/screens/__test__/__snapshots__/PaidPaymentScreen.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`PaidPaymentScreen should render with back button, title, help button, p
       style={
         Array [
           Object {
-            "backgroundColor": "rgb(242, 242, 242)",
+            "backgroundColor": "#FFFFFF",
             "flex": 1,
           },
           undefined,
@@ -65,7 +65,7 @@ exports[`PaidPaymentScreen should render with back button, title, help button, p
               collapsable={false}
               style={
                 Object {
-                  "backgroundColor": "rgb(255, 255, 255)",
+                  "backgroundColor": "#FFFFFF",
                   "borderBottomColor": "rgb(216, 216, 216)",
                   "flex": 1,
                   "shadowColor": "rgb(216, 216, 216)",
@@ -297,7 +297,7 @@ exports[`PaidPaymentScreen should render with back button, title, help button, p
                       },
                       Array [
                         Object {
-                          "backgroundColor": "rgb(242, 242, 242)",
+                          "backgroundColor": "#FFFFFF",
                         },
                         undefined,
                       ],
@@ -1030,7 +1030,7 @@ exports[`PaidPaymentScreen should render with back button, title, help button, p
       style={
         Array [
           Object {
-            "backgroundColor": "rgb(242, 242, 242)",
+            "backgroundColor": "#FFFFFF",
             "flex": 1,
           },
           undefined,
@@ -1072,7 +1072,7 @@ exports[`PaidPaymentScreen should render with back button, title, help button, p
               collapsable={false}
               style={
                 Object {
-                  "backgroundColor": "rgb(255, 255, 255)",
+                  "backgroundColor": "#FFFFFF",
                   "borderBottomColor": "rgb(216, 216, 216)",
                   "flex": 1,
                   "shadowColor": "rgb(216, 216, 216)",
@@ -1304,7 +1304,7 @@ exports[`PaidPaymentScreen should render with back button, title, help button, p
                       },
                       Array [
                         Object {
-                          "backgroundColor": "rgb(242, 242, 242)",
+                          "backgroundColor": "#FFFFFF",
                         },
                         undefined,
                       ],


### PR DESCRIPTION
## Short description
This PR updates message attachment preview. The preview has been updated by sharing the `MessageAttachment` component between standard messages and SEND messages.

## List of changes proposed in this pull request
- converted the `MessageAttachment` screen into a component
- created the screen `messages/screens/MessageAttachmentScreen.tsx`
- created the screen `pn/screens/MessageAttachmentScreen.tsx`
- updated the params naming convention

## How to test
Using `io-dev-api-server`, generate messages with attachments. Navigate to the message attachment preview and check that everything is displayed correctly.