### PR TITLE
chore: [IOBP-572] Move currency symbol to the right of the amount

### DIFF
--- a/ts/features/walletV3/payment/screens/WalletPaymentDetailScreen.tsx
+++ b/ts/features/walletV3/payment/screens/WalletPaymentDetailScreen.tsx
@@ -157,7 +157,7 @@ const WalletPaymentDetailContent = ({
   );
 
   const amount = pipe(payment.amount, centsToAmount, amount =>
-    formatNumberAmount(amount, true)
+    formatNumberAmount(amount, true, "right")
   );
 
   const dueDate = pipe(

--- a/ts/screens/wallet/payment/components/TransactionSummary.tsx
+++ b/ts/screens/wallet/payment/components/TransactionSummary.tsx
@@ -118,7 +118,11 @@ export const TransactionSummary = (props: Props): React.ReactElement => {
 
   const amount = pot.toUndefined(
     pot.map(props.paymentVerification, _ =>
-      formatNumberAmount(centsToAmount(_.importoSingoloVersamento), true)
+      formatNumberAmount(
+        centsToAmount(_.importoSingoloVersamento),
+        true,
+        "right"
+      )
     )
   );
 


### PR DESCRIPTION
## Short description
This PR moves the currency symbol to the right of the amount text

## List of changes proposed in this pull request
- Added the "right" value to the utility function for both TransactionSummary (the old one) and TransactionSummaryScreen (the new one)

## How to test
- Start a payment process, inside the page you should be able to see the "Amount" label with the currency symbol at the end

## Preview
<img src="https://github.com/pagopa/io-app/assets/34343582/e6499111-297f-4449-b51f-f8d317e9ab6f)" width="300" />