### PR TITLE
chore: [IOBP-568] Adapted `OperationResultScreen` to change payment outcome 17 description

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1753,7 +1753,7 @@ wallet:
         title: Il metodo di pagamento non è supportato
       WAITING_CONFIRMATION_EMAIL:
         title: Attendi la conferma via email
-        subtitle: Non è stato possibile verificare l'esito del pagamento. Se è andato a buon fine, riceverai a breve un'email. Se non arriva, contatta l'assistenza.
+        subtitle: Riceverai l'esito del pagamento all'indirizzo
       METHOD_NOT_ENABLED:
         title: Abilita il metodo per effettuare pagamenti in app
         subtitle: Prima di riprovare con il pagamento, seleziona il metodo nel tuo Portafoglio e abilita la funzionalità “Pagamenti in app”.

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1753,7 +1753,7 @@ wallet:
         title: Il metodo di pagamento non è supportato
       WAITING_CONFIRMATION_EMAIL:
         title: Attendi la conferma via email
-        subtitle: Non è stato possibile verificare l'esito del pagamento. Se è andato a buon fine, riceverai a breve un'email. Se non arriva, contatta l'assistenza.
+        subtitle: Riceverai l'esito del pagamento all'indirizzo
       METHOD_NOT_ENABLED:
         title: Abilita il metodo per effettuare pagamenti in app
         subtitle: Prima di riprovare con il pagamento, seleziona il metodo nel tuo Portafoglio e abilita la funzionalità “Pagamenti in app”.

--- a/ts/components/screens/OperationResultScreenContent.tsx
+++ b/ts/components/screens/OperationResultScreenContent.tsx
@@ -19,7 +19,7 @@ import { LabelSmall } from "../core/typography/LabelSmall";
 type OperationResultScreenContentProps = WithTestID<{
   pictogram?: IOPictograms;
   title: string;
-  subtitle?: string;
+  subtitle?: string | React.ReactNode;
   action?: Pick<
     ButtonSolidProps,
     "label" | "accessibilityLabel" | "onPress" | "testID"
@@ -58,9 +58,13 @@ const OperationResultScreenContent = ({
       {subtitle && (
         <>
           <VSpacer size={8} />
-          <LabelSmall style={styles.text} color="grey-650" weight="Regular">
-            {subtitle}
-          </LabelSmall>
+          {typeof subtitle === "string" ? (
+            <LabelSmall style={styles.text} color="grey-650" weight="Regular">
+              {subtitle}
+            </LabelSmall>
+          ) : (
+            subtitle
+          )}
         </>
       )}
       {action && (

--- a/ts/features/walletV3/payment/screens/WalletPaymentOutcomeScreen.tsx
+++ b/ts/features/walletV3/payment/screens/WalletPaymentOutcomeScreen.tsx
@@ -1,5 +1,7 @@
 import * as pot from "@pagopa/ts-commons/lib/pot";
+import { StyleSheet } from "react-native";
 import { RouteProp, useRoute } from "@react-navigation/native";
+import { LabelSmall } from "@pagopa/io-app-design-system";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
 import React from "react";
@@ -23,6 +25,7 @@ import {
   WalletPaymentOutcome,
   WalletPaymentOutcomeEnum
 } from "../types/PaymentOutcomeEnum";
+import { profileEmailSelector } from "../../../../store/reducers/profile";
 
 type WalletPaymentOutcomeScreenNavigationParams = {
   outcome: WalletPaymentOutcome;
@@ -42,6 +45,9 @@ const WalletPaymentOutcomeScreen = () => {
   const navigation = useIONavigation();
   const paymentDetailsPot = useIOSelector(walletPaymentDetailsSelector);
   const paymentStartRoute = useIOSelector(walletPaymentStartRouteSelector);
+
+  const profileEmailOption = useIOSelector(profileEmailSelector);
+  const profileEmail = O.toUndefined(profileEmailOption);
 
   const supportModal = usePaymentFailureSupportModal({
     outcome
@@ -187,9 +193,7 @@ const WalletPaymentOutcomeScreen = () => {
           title: I18n.t(
             "wallet.payment.outcome.WAITING_CONFIRMATION_EMAIL.title"
           ),
-          subtitle: I18n.t(
-            "wallet.payment.outcome.WAITING_CONFIRMATION_EMAIL.subtitle"
-          ),
+          subtitle: <WaitingConfirmationEmailSubtitle />,
           action: closeFailureAction
         };
       case WalletPaymentOutcomeEnum.METHOD_NOT_ENABLED:
@@ -204,6 +208,18 @@ const WalletPaymentOutcomeScreen = () => {
     }
   };
 
+  const WaitingConfirmationEmailSubtitle = () => (
+    <>
+      <LabelSmall style={styles.text} color="grey-650" weight="Regular">
+        {I18n.t("wallet.payment.outcome.WAITING_CONFIRMATION_EMAIL.subtitle")}{" "}
+        <LabelSmall style={styles.text} color="grey-650" weight="SemiBold">
+          {profileEmail}
+        </LabelSmall>
+        .
+      </LabelSmall>
+    </>
+  );
+
   const requiresFeedback = outcome === WalletPaymentOutcomeEnum.SUCCESS;
 
   return (
@@ -215,6 +231,12 @@ const WalletPaymentOutcomeScreen = () => {
     </>
   );
 };
+
+const styles = StyleSheet.create({
+  text: {
+    textAlign: "center"
+  }
+});
 
 export { WalletPaymentOutcomeScreen };
 export type { WalletPaymentOutcomeScreenNavigationParams };


### PR DESCRIPTION
## Short description
This PR adapts the `OperationResultScreen` to accept also a ReactNode as a description since there is a new requirement to have custom text as the following showed in this figma URL: https://www.figma.com/file/KY9BpP4LaSSd18fuYMwxYK/Paga-un-avviso-pagoPA?type=design&node-id=2346-6079&mode=design&t=2XwD7iFjaIal2SwH-4

## List of changes proposed in this pull request
- Adapted the `OperationResultScreen` description
- Edited the description text from the locales according to the figma above;

## How to test
- Start a new payment flow from the playground
- Reach the webview and select from the dropdown outcome list the outcome number `17`

## Preview
<img src="https://github.com/pagopa/io-app/assets/34343582/9b76752f-ed46-45c9-ad6c-b97e2e62652f" width="300" />
