### PR TITLE
[IOCOM-1154] Fix for double navigation bar on message details

### DIFF
--- a/ts/features/messages/navigation/MessagesNavigator.tsx
+++ b/ts/features/messages/navigation/MessagesNavigator.tsx
@@ -26,7 +26,11 @@ export const MessagesStackNavigator = () => {
   return (
     <Stack.Navigator
       initialRouteName={MESSAGES_ROUTES.MESSAGE_ROUTER}
-      screenOptions={{ gestureEnabled: isGestureEnabled, headerMode: "screen" }}
+      screenOptions={{
+        gestureEnabled: isGestureEnabled,
+        headerMode: "screen",
+        headerShown: isDesignSystemEnabled
+      }}
     >
       <Stack.Group>
         <Stack.Screen
@@ -44,9 +48,6 @@ export const MessagesStackNavigator = () => {
               ? MessageDetailsScreen
               : LegacyMessageDetailScreen
           }
-          options={{
-            headerShown: isDesignSystemEnabled
-          }}
         />
 
         <Stack.Screen
@@ -56,9 +57,6 @@ export const MessagesStackNavigator = () => {
               ? MessageAttachmentScreen
               : LegacyMessageDetailAttachment
           }
-          options={{
-            headerShown: isDesignSystemEnabled
-          }}
         />
 
         <Stack.Screen

--- a/ts/features/pn/navigation/navigator.tsx
+++ b/ts/features/pn/navigation/navigator.tsx
@@ -19,7 +19,11 @@ export const PnStackNavigator = () => {
   return (
     <Stack.Navigator
       initialRouteName={PN_ROUTES.MESSAGE_DETAILS}
-      screenOptions={{ gestureEnabled: isGestureEnabled, headerMode: "screen" }}
+      screenOptions={{
+        gestureEnabled: isGestureEnabled,
+        headerMode: "screen",
+        headerShown: isDesignSystemEnabled
+      }}
     >
       <Stack.Screen
         name={PN_ROUTES.MESSAGE_DETAILS}
@@ -28,9 +32,6 @@ export const PnStackNavigator = () => {
             ? MessageDetailsScreen
             : LegacyMessageDetailsScreen
         }
-        options={{
-          headerShown: isDesignSystemEnabled
-        }}
       />
       <Stack.Screen
         name={PN_ROUTES.MESSAGE_ATTACHMENT}
@@ -39,9 +40,6 @@ export const PnStackNavigator = () => {
             ? MessageAttachmentScreen
             : LegacyAttachmentPreviewScreen
         }
-        options={{
-          headerShown: isDesignSystemEnabled
-        }}
       />
       <Stack.Screen
         name={PN_ROUTES.CANCELLED_MESSAGE_PAID_PAYMENT}


### PR DESCRIPTION
## Short description
This PR fixes the double header shown on the message details screen.

## List of changes proposed in this pull request
- `headerShown` set at `Stack.Navigator` level instead of `Stack.Screen`

## How to test
Check that the message details screen does not have a double navigation header.
