### PR TITLE
fix: [IOCOM-1154] Fix for double navigation bar on message details

### DIFF
--- a/ts/features/messages/navigation/MessagesNavigator.tsx
+++ b/ts/features/messages/navigation/MessagesNavigator.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { createStackNavigator } from "@react-navigation/stack";
+import { useIOExperimentalDesign } from "@pagopa/io-app-design-system";
 import { EUCovidCertStackNavigator } from "../../euCovidCert/navigation/navigator";
 import EUCOVIDCERT_ROUTES from "../../euCovidCert/navigation/routes";
 import LegacyMessageDetailScreen from "../screens/LegacyMessageDetailScreen";
@@ -14,15 +15,25 @@ import { isPnEnabledSelector } from "../../../store/reducers/backendStatus";
 import { LegacyMessageDetailAttachment } from "../screens/LegacyMessageAttachment";
 import { isDesignSystemEnabledSelector } from "../../../store/reducers/persistedPreferences";
 import { MessageAttachmentScreen } from "../screens/MessageAttachmentScreen";
+import { mixpanelTrack } from "../../../mixpanel";
 import { MessagesParamsList } from "./params";
 import { MESSAGES_ROUTES } from "./routes";
 
 const Stack = createStackNavigator<MessagesParamsList>();
 
 export const MessagesStackNavigator = () => {
-  const isDesignSystemEnabled =
-    useIOSelector(isDesignSystemEnabledSelector) ?? false;
+  const isDesignSystemEnabledUnsafe = useIOSelector(
+    isDesignSystemEnabledSelector
+  );
+  const isDesignSystemEnabled = !!isDesignSystemEnabledUnsafe;
   const isPnEnabled = useIOSelector(isPnEnabledSelector);
+
+  const { isExperimental } = useIOExperimentalDesign();
+
+  void mixpanelTrack("DESIGN_SYSTEM_STATUS", {
+    isDesignSystemEnabled: isDesignSystemEnabledUnsafe,
+    isExperimentalContextEnabled: isExperimental
+  });
 
   return (
     <Stack.Navigator

--- a/ts/features/messages/navigation/MessagesNavigator.tsx
+++ b/ts/features/messages/navigation/MessagesNavigator.tsx
@@ -20,7 +20,8 @@ import { MESSAGES_ROUTES } from "./routes";
 const Stack = createStackNavigator<MessagesParamsList>();
 
 export const MessagesStackNavigator = () => {
-  const isDesignSystemEnabled = useIOSelector(isDesignSystemEnabledSelector);
+  const isDesignSystemEnabled =
+    useIOSelector(isDesignSystemEnabledSelector) ?? false;
   const isPnEnabled = useIOSelector(isPnEnabledSelector);
 
   return (


### PR DESCRIPTION
## Short description
This PR fixes the double header shown on the message details screen.

## List of changes proposed in this pull request
- output of isDesignSystemEnabledSelector is checked against undefined values

## How to test
Check that the message details screen does not have a double navigation header.
