### PR TITLE
fix: [IOCOM-1154] Fix for `undefined` value on `isDesignSystemEnabled` (and double navigation bar)

### DIFF
--- a/ts/features/messages/navigation/MessagesNavigator.tsx
+++ b/ts/features/messages/navigation/MessagesNavigator.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { createStackNavigator } from "@react-navigation/stack";
-import { useIOExperimentalDesign } from "@pagopa/io-app-design-system";
 import { EUCovidCertStackNavigator } from "../../euCovidCert/navigation/navigator";
 import EUCOVIDCERT_ROUTES from "../../euCovidCert/navigation/routes";
 import LegacyMessageDetailScreen from "../screens/LegacyMessageDetailScreen";
@@ -15,25 +14,14 @@ import { isPnEnabledSelector } from "../../../store/reducers/backendStatus";
 import { LegacyMessageDetailAttachment } from "../screens/LegacyMessageAttachment";
 import { isDesignSystemEnabledSelector } from "../../../store/reducers/persistedPreferences";
 import { MessageAttachmentScreen } from "../screens/MessageAttachmentScreen";
-import { mixpanelTrack } from "../../../mixpanel";
 import { MessagesParamsList } from "./params";
 import { MESSAGES_ROUTES } from "./routes";
 
 const Stack = createStackNavigator<MessagesParamsList>();
 
 export const MessagesStackNavigator = () => {
-  const isDesignSystemEnabledUnsafe = useIOSelector(
-    isDesignSystemEnabledSelector
-  );
-  const isDesignSystemEnabled = !!isDesignSystemEnabledUnsafe;
+  const isDesignSystemEnabled = useIOSelector(isDesignSystemEnabledSelector);
   const isPnEnabled = useIOSelector(isPnEnabledSelector);
-
-  const { isExperimental } = useIOExperimentalDesign();
-
-  void mixpanelTrack("DESIGN_SYSTEM_STATUS", {
-    isDesignSystemEnabled: isDesignSystemEnabledUnsafe,
-    isExperimentalContextEnabled: isExperimental
-  });
 
   return (
     <Stack.Navigator

--- a/ts/store/reducers/persistedPreferences.ts
+++ b/ts/store/reducers/persistedPreferences.ts
@@ -38,6 +38,11 @@ export type PersistedPreferencesState = Readonly<{
   isMixpanelEnabled: boolean | null;
   isPnTestEnabled: boolean;
   isIdPayTestEnabled?: boolean;
+  // 'isDesignSystemEnabled' has been introduced without a migration
+  // (PR https://github.com/pagopa/io-app/pull/4427) so there are cases
+  // where its value is `undefined` (when the user updates the app without
+  // changing the variable value later). Typescript cannot detect this so
+  // be sure to handle such case when reading and using this value
   isDesignSystemEnabled: boolean;
 }>;
 
@@ -182,8 +187,13 @@ export const isPnTestEnabledSelector = (state: GlobalState) =>
 export const isIdPayTestEnabledSelector = (state: GlobalState) =>
   !!state.persistedPreferences?.isIdPayTestEnabled;
 
+// 'isDesignSystemEnabled' has been introduced without a migration
+// (PR https://github.com/pagopa/io-app/pull/4427) so there are cases
+// where its value is `undefined` (when the user updates the app without
+// changing the variable value later). Typescript cannot detect this so
+// we must make sure that the signature's return type is respected
 export const isDesignSystemEnabledSelector = (state: GlobalState) =>
-  state.persistedPreferences.isDesignSystemEnabled;
+  state.persistedPreferences.isDesignSystemEnabled ?? false;
 
 // returns the preferred language as an Option from the persisted store
 export const preferredLanguageSelector = createSelector<


### PR DESCRIPTION
## Short description
This PR fixes the double navigation bar by addressing an `undefined` value in the redux store.

## List of changes proposed in this pull request
- `isDesignSystemEnabled` may have the `undefined` value in some cases. Comments have been added to explain the anomaly and the related selector has been changed to make sure that no `undefined` value is returned

## How to test
Check that no double navigation bar is displayed on a message details.
