### PR TITLE
chore(Cross): [IOAPPX-259] Upgrade `io-app-design-system` to `v.1.25.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   "dependencies": {
     "@babel/plugin-transform-regenerator": "^7.18.6",
     "@gorhom/bottom-sheet": "^4.1.5",
-    "@pagopa/io-app-design-system": "1.25.0",
+    "@pagopa/io-app-design-system": "1.25.1",
     "@pagopa/io-pagopa-commons": "^3.1.0",
     "@pagopa/io-react-native-crypto": "^0.2.1",
     "@pagopa/io-react-native-http-client": "^0.1.3",

--- a/ts/features/fci/components/SignatureFieldItem.tsx
+++ b/ts/features/fci/components/SignatureFieldItem.tsx
@@ -46,11 +46,7 @@ const SignatureFieldItem = (props: Props) => {
         onValueChange={() => {
           onChange(!checked);
         }}
-        accessibilityLabel={
-          checked
-            ? I18n.t("features.fci.signatureFields.accessibility.selected")
-            : I18n.t("features.fci.signatureFields.accessibility.unselected")
-        }
+        accessibilityLabel={props.title}
       />
       <View style={[IOStyles.row, styles.details]}>
         <LabelLink

--- a/ts/features/fci/components/__tests__/__snapshots__/SignatureFieldItem.test.tsx.snap
+++ b/ts/features/fci/components/__tests__/__snapshots__/SignatureFieldItem.test.tsx.snap
@@ -13,6 +13,14 @@ exports[`Test SignatureFieldItem component should render a SignatureFieldItem co
   }
 >
   <View
+    accessibilityLabel="Clause title 1"
+    accessibilityRole="checkbox"
+    accessibilityState={
+      Object {
+        "checked": false,
+        "disabled": false,
+      }
+    }
     accessible={true}
     collapsable={false}
     focusable={true}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3277,10 +3277,10 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@pagopa/io-app-design-system@1.25.0":
-  version "1.25.0"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-app-design-system/-/io-app-design-system-1.25.0.tgz#b8d61c629d135aa802b3bc2505a770fa97f3ad77"
-  integrity sha512-yha3rmSQ4DZMYzd3S25o2hohOGqzOm/c4la1iAgRXGDfUr51gNC3kawUq0bcHdXY+nlfi2Es+6AvRVRTpI9KqA==
+"@pagopa/io-app-design-system@1.25.1":
+  version "1.25.1"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-app-design-system/-/io-app-design-system-1.25.1.tgz#01211e065c8b32ee4bb6b22b9e86c52d68a9d74c"
+  integrity sha512-fxxYCJWL2KR8l2klrsMqQInGWH//Qq15QJOdCAPYofe3kFFY1DA+MWvCZTFZimB3KwcJzPC7hAINZ6mFilbP0Q==
   dependencies:
     "@pagopa/ts-commons" "^12.0.0"
     "@testing-library/jest-native" "^5.4.2"


### PR DESCRIPTION
## Short description
This PR upgrade `io-app-design-system` to `v.1.25.1` that solves some accessibility issues

## How to test
- Start the app and try to use the `ListItemCheckbox` component.
- Using the Accessibility inspector check whether the accessibility label and checkbox state are read correctly.