### PR TITLE
feat: [IOCOM-858] Generic payment update for messages

### DIFF
--- a/ts/boot/__tests__/__snapshots__/persistedStore.test.ts.snap
+++ b/ts/boot/__tests__/__snapshots__/persistedStore.test.ts.snap
@@ -79,6 +79,7 @@ Object {
       },
     },
     "paginatedById": Object {},
+    "payments": Object {},
     "thirdPartyById": Object {},
   },
   "messagesStatus": Object {},

--- a/ts/features/messages/saga/handlePaymentUpdateRequests.ts
+++ b/ts/features/messages/saga/handlePaymentUpdateRequests.ts
@@ -13,7 +13,7 @@ import {
 
 const generatePaymentUpdateWorkerCount = () => 5;
 
-export function* watchPaymentUpdateRequests(
+export function* handlePaymentUpdateRequests(
   getVerificaRpt: ReturnType<typeof BackendClient>["getVerificaRpt"]
 ) {
   // create a channel to queue incoming requests
@@ -28,7 +28,7 @@ export function* watchPaymentUpdateRequests(
   // eslint-disable-next-line functional/no-let
   for (let i = 0; i < paymentUpdateWorkerCount; i++) {
     yield* fork(
-      handlePaymentUpdateRequests,
+      paymentUpdateRequestWorker,
       paymentUpdateChannel,
       getVerificaRpt
     );
@@ -56,7 +56,7 @@ export function* watchPaymentUpdateRequests(
   }
 }
 
-function* handlePaymentUpdateRequests(
+function* paymentUpdateRequestWorker(
   paymentStatusChannel: Channel<
     ActionType<typeof updatePaymentForMessage.request>
   >,

--- a/ts/features/messages/saga/index.ts
+++ b/ts/features/messages/saga/index.ts
@@ -40,6 +40,7 @@ import { handleUpsertMessageStatusAttribues } from "./handleUpsertMessageStatusA
 import { handleMigrateToPagination } from "./handleMigrateToPagination";
 import { handleMessagePrecondition } from "./handleMessagePrecondition";
 import { handleThirdPartyMessage } from "./handleThirdPartyMessage";
+import { watchPaymentUpdateRequests } from "./watchPaymentUpdateRequests";
 
 /**
  * Handle messages requests
@@ -112,6 +113,9 @@ export function* watchMessagesSaga(
     handleDownloadAttachment,
     bearerToken
   );
+
+  // handle the request for updating a message's payment
+  yield* fork(watchPaymentUpdateRequests, backendClient.getVerificaRpt);
 
   // handle the request for removing a downloaded attachment
   yield* takeEvery(removeCachedAttachment, handleClearAttachment);

--- a/ts/features/messages/saga/index.ts
+++ b/ts/features/messages/saga/index.ts
@@ -40,7 +40,7 @@ import { handleUpsertMessageStatusAttribues } from "./handleUpsertMessageStatusA
 import { handleMigrateToPagination } from "./handleMigrateToPagination";
 import { handleMessagePrecondition } from "./handleMessagePrecondition";
 import { handleThirdPartyMessage } from "./handleThirdPartyMessage";
-import { watchPaymentUpdateRequests } from "./watchPaymentUpdateRequests";
+import { handlePaymentUpdateRequests } from "./handlePaymentUpdateRequests";
 
 /**
  * Handle messages requests
@@ -115,7 +115,7 @@ export function* watchMessagesSaga(
   );
 
   // handle the request for updating a message's payment
-  yield* fork(watchPaymentUpdateRequests, backendClient.getVerificaRpt);
+  yield* fork(handlePaymentUpdateRequests, backendClient.getVerificaRpt);
 
   // handle the request for removing a downloaded attachment
   yield* takeEvery(removeCachedAttachment, handleClearAttachment);

--- a/ts/features/messages/saga/watchPaymentUpdateRequests.ts
+++ b/ts/features/messages/saga/watchPaymentUpdateRequests.ts
@@ -3,13 +3,13 @@ import { Channel, buffers, channel } from "redux-saga";
 import { call, flush, fork, put, take } from "typed-redux-saga/macro";
 import { ActionType, isActionOf } from "typesafe-actions";
 import { RptIdFromString } from "@pagopa/io-pagopa-commons/lib/pagopa";
-import { BackendClient } from "../../../../api/backend";
+import { BackendClient } from "../../../api/backend";
+import { commonPaymentVerificationProcedure } from "../../../sagas/wallet/pagopaApis";
+import { Detail_v2Enum } from "../../../../definitions/backend/PaymentProblemJson";
 import {
-  updatePaymentForMessage,
-  cancelQueuedPaymentUpdates
-} from "../actions";
-import { commonPaymentVerificationProcedure } from "../../../../sagas/wallet/pagopaApis";
-import { Detail_v2Enum } from "../../../../../definitions/backend/PaymentProblemJson";
+  cancelQueuedPaymentUpdates,
+  updatePaymentForMessage
+} from "../store/actions";
 
 const generatePaymentUpdateWorkerCount = () => 5;
 

--- a/ts/features/messages/store/actions/index.ts
+++ b/ts/features/messages/store/actions/index.ts
@@ -17,6 +17,8 @@ import { MessageCategory } from "../../../../../definitions/backend/MessageCateg
 import { ThirdPartyMessagePrecondition } from "../../../../../definitions/backend/ThirdPartyMessagePrecondition";
 import { MessagesStatus } from "../reducers/messagesStatus";
 import { ThirdPartyAttachment } from "../../../../../definitions/backend/ThirdPartyAttachment";
+import { PaymentRequestsGetResponse } from "../../../../../definitions/backend/PaymentRequestsGetResponse";
+import { Detail_v2Enum } from "../../../../../definitions/backend/PaymentProblemJson";
 
 export type ThirdPartyMessageActions = ActionType<typeof loadThirdPartyMessage>;
 
@@ -270,6 +272,51 @@ export const removeCachedAttachment = createStandardAction(
   "REMOVE_CACHED_ATTACHMENT"
 )<DownloadAttachmentSuccess>();
 
+export type UpdatePaymentForMessageRequest = {
+  messageId: UIMessageId;
+  paymentId: string;
+};
+
+export type UpdatePaymentForMessageSuccess = {
+  messageId: UIMessageId;
+  paymentId: string;
+  paymentData: PaymentRequestsGetResponse;
+};
+
+export type UpdatePaymentForMessageFailure = {
+  messageId: UIMessageId;
+  paymentId: string;
+  details: Detail_v2Enum;
+};
+
+export type UpdatePaymentForMessageCancel =
+  ReadonlyArray<UpdatePaymentForMessageRequest>;
+
+export const updatePaymentForMessage = createAsyncAction(
+  "UPDATE_PAYMENT_FOR_MESSAGE_REQUEST",
+  "UPDATE_PAYMENT_FOR_MESSAGE_SUCCESS",
+  "UPDATE_PAYMENT_FOR_MESSAGE_FAILURE",
+  "UPDATE_PAYMENT_FOR_MESSAGE_CANCEL"
+)<
+  UpdatePaymentForMessageRequest,
+  UpdatePaymentForMessageSuccess,
+  UpdatePaymentForMessageFailure,
+  UpdatePaymentForMessageCancel
+>();
+
+export const cancelQueuedPaymentUpdates = createAction(
+  "CANCEL_QUEUED_PAYMENT_UPDATES"
+);
+
+export const setMessagesSelectedPayment = createAction(
+  "MESSAGES_SET_SELECTED_PAYMENT",
+  resolve => (paymentId: string) => resolve({ paymentId })
+);
+
+export const clearMessagesSelectedPayment = createAction(
+  "MESSAGES_CLEAR_SELECTED_PAYMENT"
+);
+
 export type MessagesActions = ActionType<
   | typeof reloadAllMessages
   | typeof loadNextPageMessages
@@ -290,4 +337,8 @@ export type MessagesActions = ActionType<
   | typeof getMessageDataAction
   | typeof cancelGetMessageDataAction
   | typeof resetGetMessageDataAction
+  | typeof updatePaymentForMessage
+  | typeof cancelQueuedPaymentUpdates
+  | typeof setMessagesSelectedPayment
+  | typeof clearMessagesSelectedPayment
 >;

--- a/ts/features/messages/store/reducers/__tests__/payments.test.ts
+++ b/ts/features/messages/store/reducers/__tests__/payments.test.ts
@@ -14,8 +14,8 @@ import {
   remoteUndefined
 } from "../../../../../common/model/RemoteValue";
 import {
-  clearSelectedPayment,
-  setSelectedPayment,
+  clearMessagesSelectedPayment,
+  setMessagesSelectedPayment,
   updatePaymentForMessage
 } from "../../actions";
 import {
@@ -25,7 +25,7 @@ import {
   paymentsReducer,
   selectedPaymentIdSelector,
   shouldUpdatePaymentSelector
-} from "../payments";
+} from "../../../../messages/store/reducers/payments";
 
 describe("PN Payments reducer's tests", () => {
   it("Should match initial state upon initialization", () => {
@@ -323,14 +323,14 @@ describe("PN Payments reducer's tests", () => {
   });
   it("Should have the paymentId for a setSelectedPayment action", () => {
     const paymentId = "p1";
-    const setSelectedPaymentAction = setSelectedPayment(paymentId);
+    const setSelectedPaymentAction = setMessagesSelectedPayment(paymentId);
     const paymentsState = paymentsReducer(undefined, setSelectedPaymentAction);
     const selectedPaymentId = paymentsState.selectedPayment;
     expect(selectedPaymentId).toBe(paymentId);
   });
   it("Should clear the paymentId for a clearSelectedPayment action", () => {
     const paymentId = "p1";
-    const setSelectedPaymentAction = setSelectedPayment(paymentId);
+    const setSelectedPaymentAction = setMessagesSelectedPayment(paymentId);
     const startingPaymentsState = paymentsReducer(
       undefined,
       setSelectedPaymentAction
@@ -339,14 +339,14 @@ describe("PN Payments reducer's tests", () => {
     expect(startingSelectedPaymentId).toBe(paymentId);
     const endingPaymentsState = paymentsReducer(
       startingPaymentsState,
-      clearSelectedPayment()
+      clearMessagesSelectedPayment()
     );
     const endingSelectedPaymentId = endingPaymentsState.selectedPayment;
     expect(endingSelectedPaymentId).toBeUndefined();
   });
   it("Should clear the paymentId for a reloadAllMessages action", () => {
     const paymentId = "p1";
-    const setSelectedPaymentAction = setSelectedPayment(paymentId);
+    const setSelectedPaymentAction = setMessagesSelectedPayment(paymentId);
     const startingPaymentsState = paymentsReducer(
       undefined,
       setSelectedPaymentAction
@@ -441,7 +441,7 @@ describe("PN Payments selectors' tests", () => {
     });
     const state = appReducer(startingState, updatePaymentForMessageAction);
     const paymentStatusOnStore =
-      state.features.pn.payments["m1" as UIMessageId]?.p1;
+      state.entities.messages.payments["m1" as UIMessageId]?.p1;
     expect(paymentStatusOnStore).toBe(remoteLoading);
     const paymentStatus = paymentStatusForUISelector(
       state,
@@ -691,7 +691,7 @@ describe("PN Payments selectors' tests", () => {
     expect(selectedPaymentId).toBeUndefined();
   });
   it("selectedPaymentIdSelector should return the selected payment", () => {
-    const appState = appReducer(undefined, setSelectedPayment("p1"));
+    const appState = appReducer(undefined, setMessagesSelectedPayment("p1"));
     const selectedPaymentId = selectedPaymentIdSelector(appState);
     expect(selectedPaymentId).toBe("p1");
   });

--- a/ts/features/messages/store/reducers/index.ts
+++ b/ts/features/messages/store/reducers/index.ts
@@ -16,6 +16,7 @@ import {
   messagePreconditionReducer
 } from "./messagePrecondition";
 import { MessageGetStatus, messageGetStatusReducer } from "./messageGetStatus";
+import { MultiplePaymentState, paymentsReducer } from "./payments";
 
 export type MessagesState = Readonly<{
   allPaginated: AllPaginated;
@@ -25,6 +26,7 @@ export type MessagesState = Readonly<{
   downloads: Downloads;
   messagePrecondition: MessagePrecondition;
   messageGetStatus: MessageGetStatus;
+  payments: MultiplePaymentState;
 }>;
 
 const reducer = combineReducers<MessagesState, Action>({
@@ -34,7 +36,8 @@ const reducer = combineReducers<MessagesState, Action>({
   thirdPartyById: thirdPartyByIdReducer,
   downloads: downloadsReducer,
   messagePrecondition: messagePreconditionReducer,
-  messageGetStatus: messageGetStatusReducer
+  messageGetStatus: messageGetStatusReducer,
+  payments: paymentsReducer
 });
 
 export default reducer;

--- a/ts/features/messages/store/reducers/payments.ts
+++ b/ts/features/messages/store/reducers/payments.ts
@@ -4,7 +4,7 @@ import * as RA from "fp-ts/lib/ReadonlyArray";
 import * as O from "fp-ts/lib/Option";
 import { getType } from "typesafe-actions";
 import { Action } from "../../../../store/actions/types";
-import { UIMessageId } from "../../../messages/types";
+import { UIMessageId } from "../../types";
 import { GlobalState } from "../../../../store/reducers/types";
 import {
   isError,
@@ -18,15 +18,15 @@ import {
   RemoteValue
 } from "../../../../common/model/RemoteValue";
 import {
-  clearSelectedPayment,
-  setSelectedPayment,
+  clearMessagesSelectedPayment,
+  reloadAllMessages,
+  setMessagesSelectedPayment,
   updatePaymentForMessage
 } from "../actions";
 import { Detail_v2Enum } from "../../../../../definitions/backend/PaymentProblemJson";
 import { PaymentRequestsGetResponse } from "../../../../../definitions/backend/PaymentRequestsGetResponse";
 import { NotificationPaymentInfo } from "../../../../../definitions/pn/NotificationPaymentInfo";
-import { getRptIdStringFromPayment } from "../../utils/rptId";
-import { reloadAllMessages } from "../../../messages/store/actions";
+import { getRptIdStringFromPayment } from "../../../pn/utils/rptId";
 
 export type MultiplePaymentState = {
   [key: UIMessageId]: SinglePaymentState | undefined;
@@ -81,12 +81,12 @@ export const paymentsReducer = (
         }),
         state
       );
-    case getType(setSelectedPayment):
+    case getType(setMessagesSelectedPayment):
       return {
         ...state,
         selectedPayment: action.payload.paymentId
       };
-    case getType(clearSelectedPayment):
+    case getType(clearMessagesSelectedPayment):
       return {
         ...state,
         selectedPayment: undefined
@@ -103,7 +103,7 @@ export const shouldUpdatePaymentSelector = (
   paymentId: string
 ) =>
   pipe(
-    state.features.pn.payments[messageId],
+    state.entities.messages.payments[messageId],
     O.fromNullable,
     O.chainNullableK(multiplePaymentState => multiplePaymentState[paymentId]),
     O.getOrElse<RemoteValue<PaymentRequestsGetResponse, Detail_v2Enum>>(
@@ -118,7 +118,7 @@ export const paymentStatusForUISelector = (
   paymentId: string
 ): RemoteValue<PaymentRequestsGetResponse, Detail_v2Enum> =>
   pipe(
-    state.features.pn.payments[messageId],
+    state.entities.messages.payments[messageId],
     O.fromNullable,
     O.chainNullableK(multiplePaymentState => multiplePaymentState[paymentId]),
     O.getOrElse<RemoteValue<PaymentRequestsGetResponse, Detail_v2Enum>>(
@@ -134,7 +134,7 @@ export const paymentsButtonStateSelector = (
   maxVisiblePaymentCount: number
 ) =>
   pipe(
-    state.features.pn.payments[messageId],
+    state.entities.messages.payments[messageId],
     O.fromNullable,
     computeUpdatedPaymentCount(payments, maxVisiblePaymentCount),
     buttonStateFromUpdatedPaymentCount(payments, maxVisiblePaymentCount)
@@ -238,4 +238,4 @@ const buttonStateFromUpdatedPaymentCount =
     );
 
 export const selectedPaymentIdSelector = (state: GlobalState) =>
-  state.features.pn.payments.selectedPayment;
+  state.entities.messages.payments.selectedPayment;

--- a/ts/features/pn/components/MessageFooter.tsx
+++ b/ts/features/pn/components/MessageFooter.tsx
@@ -6,7 +6,7 @@ import { useDispatch } from "react-redux";
 import { NotificationPaymentInfo } from "../../../../definitions/pn/NotificationPaymentInfo";
 import { useIOSelector } from "../../../store/hooks";
 import { UIMessageId } from "../../messages/types";
-import { paymentsButtonStateSelector } from "../store/reducers/payments";
+import { paymentsButtonStateSelector } from "../../messages/store/reducers/payments";
 import variables from "../../../theme/variables";
 import { initializeAndNavigateToWalletForPayment } from "../utils";
 import { getRptIdStringFromPayment } from "../utils/rptId";

--- a/ts/features/pn/components/MessagePaymentBottomSheet.tsx
+++ b/ts/features/pn/components/MessagePaymentBottomSheet.tsx
@@ -5,7 +5,7 @@ import { useDispatch } from "react-redux";
 import { NotificationPaymentInfo } from "../../../../definitions/pn/NotificationPaymentInfo";
 import { UIMessageId } from "../../messages/types";
 import { useIOBottomSheetModal } from "../../../utils/hooks/bottomSheet";
-import { cancelQueuedPaymentUpdates } from "../store/actions";
+import { cancelQueuedPaymentUpdates } from "../../messages/store/actions";
 import { MessagePaymentItem } from "./MessagePaymentItem";
 
 export type MessagePaymentBottomSheetProps = {

--- a/ts/features/pn/components/MessagePaymentItem.tsx
+++ b/ts/features/pn/components/MessagePaymentItem.tsx
@@ -16,9 +16,9 @@ import { GlobalState } from "../../../store/reducers/types";
 import {
   paymentStatusForUISelector,
   shouldUpdatePaymentSelector
-} from "../store/reducers/payments";
+} from "../../messages/store/reducers/payments";
 import { useIOSelector } from "../../../store/hooks";
-import { updatePaymentForMessage } from "../store/actions";
+import { updatePaymentForMessage } from "../../messages/store/actions";
 import { RemoteValue, fold } from "../../../common/model/RemoteValue";
 import { PaymentRequestsGetResponse } from "../../../../definitions/backend/PaymentRequestsGetResponse";
 import { Detail_v2Enum } from "../../../../definitions/backend/PaymentProblemJson";

--- a/ts/features/pn/components/MessagePayments.tsx
+++ b/ts/features/pn/components/MessagePayments.tsx
@@ -17,7 +17,7 @@ import { InfoBox } from "../../../components/box/InfoBox";
 import { H5 } from "../../../components/core/typography/H5";
 import { UIMessageId } from "../../messages/types";
 import { useIOSelector } from "../../../store/hooks";
-import { paymentsButtonStateSelector } from "../store/reducers/payments";
+import { paymentsButtonStateSelector } from "../../messages/store/reducers/payments";
 import { trackPNShowAllPayments } from "../analytics";
 import PN_ROUTES from "../navigation/routes";
 import { MESSAGES_ROUTES } from "../../messages/navigation/routes";

--- a/ts/features/pn/components/__test__/MessagePaymentItem.test.tsx
+++ b/ts/features/pn/components/__test__/MessagePaymentItem.test.tsx
@@ -6,9 +6,9 @@ import { renderScreenWithNavigationStoreContext } from "../../../../utils/testWr
 import { MessagePaymentItem } from "../MessagePaymentItem";
 import { UIMessageId } from "../../../messages/types";
 import { NotificationPaymentInfo } from "../../../../../definitions/pn/NotificationPaymentInfo";
-import { updatePaymentForMessage } from "../../store/actions";
-import { PaymentRequestsGetResponse } from "../../../../../definitions/backend/PaymentRequestsGetResponse";
 import { Detail_v2Enum } from "../../../../../definitions/backend/PaymentProblemJson";
+import { updatePaymentForMessage } from "../../../messages/store/actions";
+import { PaymentRequestsGetResponse } from "../../../../../definitions/backend/PaymentRequestsGetResponse";
 
 describe("MessagePaymentItem component", () => {
   it("Should match the snapshot for a loading item", () => {

--- a/ts/features/pn/components/__test__/MessagePayments.test.tsx
+++ b/ts/features/pn/components/__test__/MessagePayments.test.tsx
@@ -5,10 +5,10 @@ import { appReducer } from "../../../../store/reducers";
 import { renderScreenWithNavigationStoreContext } from "../../../../utils/testWrapper";
 import { UIMessageId } from "../../../messages/types";
 import { NotificationPaymentInfo } from "../../../../../definitions/pn/NotificationPaymentInfo";
-import { updatePaymentForMessage } from "../../store/actions";
 import { PaymentRequestsGetResponse } from "../../../../../definitions/backend/PaymentRequestsGetResponse";
 import { Detail_v2Enum } from "../../../../../definitions/backend/PaymentProblemJson";
 import { MessagePayments } from "../MessagePayments";
+import { updatePaymentForMessage } from "../../../messages/store/actions";
 
 describe("MessagePayments component", () => {
   it("Should match the snapshot for a single loading payment", () => {

--- a/ts/features/pn/screens/LegacyMessageDetailsScreen.tsx
+++ b/ts/features/pn/screens/LegacyMessageDetailsScreen.tsx
@@ -15,7 +15,12 @@ import { useOnFirstRender } from "../../../utils/hooks/useOnFirstRender";
 import { LegacyMessageDetails } from "../components/LegacyMessageDetails";
 import { PnParamsList } from "../navigation/params";
 import { pnMessageFromIdSelector } from "../store/reducers";
-import { cancelPreviousAttachmentDownload } from "../../messages/store/actions";
+import {
+  cancelPreviousAttachmentDownload,
+  cancelQueuedPaymentUpdates,
+  clearMessagesSelectedPayment,
+  updatePaymentForMessage
+} from "../../messages/store/actions";
 import { profileFiscalCodeSelector } from "../../../store/reducers/profile";
 import {
   containsF24FromPNMessagePot,
@@ -26,12 +31,9 @@ import { trackPNUxSuccess } from "../analytics";
 import { isStrictSome } from "../../../utils/pot";
 import {
   cancelPaymentStatusTracking,
-  cancelQueuedPaymentUpdates,
-  clearSelectedPayment,
-  startPaymentStatusTracking,
-  updatePaymentForMessage
+  startPaymentStatusTracking
 } from "../store/actions";
-import { selectedPaymentIdSelector } from "../store/reducers/payments";
+import { selectedPaymentIdSelector } from "../../messages/store/reducers/payments";
 import { InfoScreenComponent } from "../../../components/infoScreen/InfoScreenComponent";
 import { renderInfoRasterImage } from "../../../components/infoScreen/imageRendering";
 import genericErrorIcon from "../../../../img/wallet/errors/generic-error-icon.png";
@@ -84,7 +86,7 @@ export const LegacyMessageDetailsScreen = (
       const globalState = store.getState();
       const selectedPaymentId = selectedPaymentIdSelector(globalState);
       if (selectedPaymentId) {
-        dispatch(clearSelectedPayment());
+        dispatch(clearMessagesSelectedPayment());
         dispatch(
           updatePaymentForMessage.request({
             messageId,

--- a/ts/features/pn/screens/MessageDetailsScreen.tsx
+++ b/ts/features/pn/screens/MessageDetailsScreen.tsx
@@ -17,7 +17,12 @@ import { useOnFirstRender } from "../../../utils/hooks/useOnFirstRender";
 import { MessageDetails } from "../components/MessageDetails";
 import { PnParamsList } from "../navigation/params";
 import { pnMessageFromIdSelector } from "../store/reducers";
-import { cancelPreviousAttachmentDownload } from "../../messages/store/actions";
+import {
+  cancelPreviousAttachmentDownload,
+  cancelQueuedPaymentUpdates,
+  clearMessagesSelectedPayment,
+  updatePaymentForMessage
+} from "../../messages/store/actions";
 import { profileFiscalCodeSelector } from "../../../store/reducers/profile";
 import {
   containsF24FromPNMessagePot,
@@ -28,13 +33,10 @@ import { trackPNUxSuccess } from "../analytics";
 import { isStrictSome } from "../../../utils/pot";
 import {
   cancelPaymentStatusTracking,
-  cancelQueuedPaymentUpdates,
-  clearSelectedPayment,
-  startPaymentStatusTracking,
-  updatePaymentForMessage
+  startPaymentStatusTracking
 } from "../store/actions";
 import { GlobalState } from "../../../store/reducers/types";
-import { selectedPaymentIdSelector } from "../store/reducers/payments";
+import { selectedPaymentIdSelector } from "../../messages/store/reducers/payments";
 import { useHeaderSecondLevel } from "../../../hooks/useHeaderSecondLevel";
 import { OperationResultScreenContent } from "../../../components/screens/OperationResultScreenContent";
 
@@ -98,7 +100,7 @@ export const MessageDetailsScreen = () => {
       const globalState = store.getState() as GlobalState;
       const selectedPaymentId = selectedPaymentIdSelector(globalState);
       if (selectedPaymentId) {
-        dispatch(clearSelectedPayment());
+        dispatch(clearMessagesSelectedPayment());
         dispatch(
           updatePaymentForMessage.request({
             messageId,

--- a/ts/features/pn/store/actions/index.ts
+++ b/ts/features/pn/store/actions/index.ts
@@ -1,27 +1,5 @@
 import { ActionType, createAction, createAsyncAction } from "typesafe-actions";
 import { UIMessageId } from "../../../messages/types";
-import { PaymentRequestsGetResponse } from "../../../../../definitions/backend/PaymentRequestsGetResponse";
-import { Detail_v2Enum } from "../../../../../definitions/backend/PaymentProblemJson";
-
-export type UpdatePaymentForMessageRequest = {
-  messageId: UIMessageId;
-  paymentId: string;
-};
-
-export type UpdatePaymentForMessageSuccess = {
-  messageId: UIMessageId;
-  paymentId: string;
-  paymentData: PaymentRequestsGetResponse;
-};
-
-export type UpdatePaymentForMessageFailure = {
-  messageId: UIMessageId;
-  paymentId: string;
-  details: Detail_v2Enum;
-};
-
-export type UpdatePaymentForMessageCancel =
-  ReadonlyArray<UpdatePaymentForMessageRequest>;
 
 export const pnActivationUpsert = createAsyncAction(
   "PN_ACTIVATION_UPSERT_REQUEST",
@@ -29,42 +7,15 @@ export const pnActivationUpsert = createAsyncAction(
   "PN_ACTIVATION_UPSERT_FAILURE"
 )<boolean, boolean, Error>();
 
-export const updatePaymentForMessage = createAsyncAction(
-  "UPDATE_PAYMENT_FOR_MESSAGE_REQUEST",
-  "UPDATE_PAYMENT_FOR_MESSAGE_SUCCESS",
-  "UPDATE_PAYMENT_FOR_MESSAGE_FAILURE",
-  "UPDATE_PAYMENT_FOR_MESSAGE_CANCEL"
-)<
-  UpdatePaymentForMessageRequest,
-  UpdatePaymentForMessageSuccess,
-  UpdatePaymentForMessageFailure,
-  UpdatePaymentForMessageCancel
->();
-
-export const cancelQueuedPaymentUpdates = createAction(
-  "CANCEL_QUEUED_PAYMENT_UPDATES"
-);
-
-export const setSelectedPayment = createAction(
-  "PN_SET_SELECTED_PAYMENT",
-  resolve => (paymentId: string) => resolve({ paymentId })
-);
-
-export const clearSelectedPayment = createAction("PN_CLEAR_SELECTED_PAYMENT");
-
 export const startPaymentStatusTracking = createAction(
-  "PN_START_TRACKING_PAYMENT_STATUS",
+  "MESSAGES_START_TRACKING_PAYMENT_STATUS",
   resolve => (messageId: UIMessageId) => resolve({ messageId })
 );
 export const cancelPaymentStatusTracking = createAction(
-  "PN_CANCEL_PAYMENT_STATUS_TRACKING"
+  "MESSAGES_CANCEL_PAYMENT_STATUS_TRACKING"
 );
 
 export type PnActions =
   | ActionType<typeof pnActivationUpsert>
-  | ActionType<typeof updatePaymentForMessage>
-  | ActionType<typeof cancelQueuedPaymentUpdates>
-  | ActionType<typeof setSelectedPayment>
-  | ActionType<typeof clearSelectedPayment>
   | ActionType<typeof startPaymentStatusTracking>
   | ActionType<typeof cancelPaymentStatusTracking>;

--- a/ts/features/pn/store/reducers/index.ts
+++ b/ts/features/pn/store/reducers/index.ts
@@ -9,16 +9,13 @@ import { toPNMessage } from "../types/transformers";
 import { UIMessageId } from "../../../messages/types";
 import { GlobalState } from "../../../../store/reducers/types";
 import { pnActivationReducer, PnActivationState } from "./activation";
-import { MultiplePaymentState, paymentsReducer } from "./payments";
 
 export type PnState = {
   activation: PnActivationState;
-  payments: MultiplePaymentState;
 };
 
 export const pnReducer = combineReducers<PnState, Action>({
-  activation: pnActivationReducer,
-  payments: paymentsReducer
+  activation: pnActivationReducer
 });
 
 export const pnMessageFromIdSelector = createSelector(

--- a/ts/features/pn/store/sagas/watchPaymentStatusSaga.ts
+++ b/ts/features/pn/store/sagas/watchPaymentStatusSaga.ts
@@ -2,10 +2,10 @@ import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
 import { call, race, select, take } from "typed-redux-saga/macro";
 import { ActionType, isActionOf } from "typesafe-actions";
+import { updatePaymentForMessage } from "../../../messages/store/actions";
 import {
   cancelPaymentStatusTracking,
-  startPaymentStatusTracking,
-  updatePaymentForMessage
+  startPaymentStatusTracking
 } from "../actions";
 import {
   maxVisiblePaymentCountGenerator,

--- a/ts/features/pn/store/sagas/watchPnSaga.ts
+++ b/ts/features/pn/store/sagas/watchPnSaga.ts
@@ -4,7 +4,7 @@ import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
 import * as E from "fp-ts/lib/Either";
 import { SagaIterator } from "redux-saga";
-import { call, fork, put, select, takeLatest } from "typed-redux-saga/macro";
+import { call, put, select, takeLatest } from "typed-redux-saga/macro";
 import { ActionType } from "typesafe-actions";
 import { apiUrlPrefix } from "../../../../config";
 import { isPnTestEnabledSelector } from "../../../../store/reducers/persistedPreferences";
@@ -18,8 +18,6 @@ import {
 } from "../../analytics";
 import { servicePreferenceSelector } from "../../../../store/reducers/entities/services/servicePreference";
 import { isServicePreferenceResponseSuccess } from "../../../../types/services/ServicePreferenceResponse";
-import { BackendClient } from "../../../../api/backend";
-import { watchPaymentUpdateRequests } from "./watchPaymentUpdateRequests";
 import { watchPaymentStatusForMixpanelTracking } from "./watchPaymentStatusSaga";
 
 function* handlePnActivation(
@@ -75,10 +73,7 @@ function* reportPNServiceStatusOnFailure(predictedValue: boolean) {
   trackPNServiceStatusChangeError(isServiceActive);
 }
 
-export function* watchPnSaga(
-  bearerToken: SessionToken,
-  getVerificaRpt: BackendClient["getVerificaRpt"]
-): SagaIterator {
+export function* watchPnSaga(bearerToken: SessionToken): SagaIterator {
   const pnClient = createPnClient(apiUrlPrefix, bearerToken);
 
   yield* takeLatest(
@@ -86,8 +81,6 @@ export function* watchPnSaga(
     handlePnActivation,
     pnClient.upsertPNActivation
   );
-
-  yield* fork(watchPaymentUpdateRequests, getVerificaRpt);
 
   yield* takeLatest(
     startPaymentStatusTracking,

--- a/ts/features/pn/utils/index.ts
+++ b/ts/features/pn/utils/index.ts
@@ -20,10 +20,10 @@ import { NotificationPaymentInfo } from "../../../../definitions/pn/Notification
 import { paymentInitializeState } from "../../../store/actions/wallet/payment";
 import NavigationService from "../../../navigation/NavigationService";
 import ROUTES from "../../../navigation/routes";
-import { setSelectedPayment } from "../store/actions";
 import { trackPNPaymentStart } from "../analytics";
 import { ATTACHMENT_CATEGORY } from "../../messages/types/attachmentCategory";
 import { ThirdPartyAttachment } from "../../../../definitions/backend/ThirdPartyAttachment";
+import { setMessagesSelectedPayment } from "../../messages/store/actions";
 
 export const maxVisiblePaymentCountGenerator = () => 5;
 
@@ -148,7 +148,7 @@ export const initializeAndNavigateToWalletForPayment = (
 
   trackPNPaymentStart();
 
-  dispatch(setSelectedPayment(paymentId));
+  dispatch(setMessagesSelectedPayment(paymentId));
   dispatch(paymentInitializeState());
 
   NavigationService.navigate(ROUTES.WALLET_NAVIGATOR, {

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -523,7 +523,7 @@ export function* initializeApplicationSaga(
 
   if (pnEnabled) {
     // Start watching for PN actions
-    yield* fork(watchPnSaga, sessionToken, backendClient.getVerificaRpt);
+    yield* fork(watchPnSaga, sessionToken);
   }
 
   const idPayTestEnabled: ReturnType<typeof isIdPayTestEnabledSelector> =


### PR DESCRIPTION
## Short description
This PR moves actions, reducer and saga to handle a message payment update from PN to general messages.

## List of changes proposed in this pull request
- Related files have been moved and renamed
- Redux `payments` entity has been moved from `pn` to `messages` (since it is not persisted, it does not need a migration)

## How to test
Using the io-dev-api-server, check that, on a PN message, payments are still updated properly.
