### PR TITLE
fix: cie error component navigation object not found

### DIFF
--- a/ts/components/cie/CieRequestAuthenticationOverlay.tsx
+++ b/ts/components/cie/CieRequestAuthenticationOverlay.tsx
@@ -22,7 +22,6 @@ import { getIdpLoginUri } from "../../utils/login";
 import { closeInjectedScript } from "../../utils/webview";
 import { IOStyles } from "../core/variables/IOStyles";
 import { withLoadingSpinner } from "../helpers/withLoadingSpinner";
-import GenericErrorComponent from "../screens/GenericErrorComponent";
 import { lollipopKeyTagSelector } from "../../features/lollipop/store/reducers/lollipop";
 import { useIODispatch, useIOSelector } from "../../store/hooks";
 import { isMixpanelEnabled } from "../../store/reducers/persistedPreferences";
@@ -32,6 +31,7 @@ import { isFastLoginEnabledSelector } from "../../features/fastLogin/store/selec
 import { isCieLoginUatEnabledSelector } from "../../features/cieLogin/store/selectors";
 import { cieFlowForDevServerEnabled } from "../../features/cieLogin/utils";
 import { selectedIdentityProviderSelector } from "../../store/reducers/authentication";
+import { OperationResultScreenContent } from "../screens/OperationResultScreenContent";
 
 const styles = StyleSheet.create({
   errorContainer: {
@@ -308,12 +308,19 @@ const ErrorComponent = (
   props: { onRetry: () => void } & Pick<Props, "onClose">
 ) => (
   <SafeAreaView style={[IOStyles.flex, styles.errorContainer]}>
-    <GenericErrorComponent
-      avoidNavigationEvents={true}
-      onRetry={props.onRetry}
-      onCancel={props.onClose}
-      image={require("../../../img/broken-link.png")} // TODO: use custom or generic image?
-      text={I18n.t("authentication.errors.network.title")} // TODO: use custom or generic text?
+    <OperationResultScreenContent
+      pictogram="umbrellaNew"
+      title={I18n.t("authentication.errors.network.title")}
+      action={{
+        label: I18n.t("global.buttons.retry"),
+        accessibilityLabel: I18n.t("global.buttons.retry"),
+        onPress: props.onRetry
+      }}
+      secondaryAction={{
+        label: I18n.t("global.buttons.cancel"),
+        accessibilityLabel: I18n.t("global.buttons.cancel"),
+        onPress: props.onClose
+      }}
     />
   </SafeAreaView>
 );


### PR DESCRIPTION
## Short description
This PR fixes and error that occurs during the rendering of the `GenericErrorComponent` in the EIC login flow.

| ❌ | as-is | new ✅ | 
| -  | - | - |
| <img width=250 src="https://github.com/pagopa/io-app/assets/16268789/ee5582c7-ea5f-49fe-9e96-2204907361e9" /> | <img width=250 src="https://github.com/pagopa/io-app/assets/16268789/4057c4b9-545b-462d-b4a8-fc60395cdb70" /> | <img width=250 src="https://github.com/pagopa/io-app/assets/16268789/3164f113-662e-4b95-bd7b-8605f6405194" /> | 

## List of changes proposed in this pull request
- Simply replace the `GenericErrorComponent` with `OperationResultScreenContent`

## How to test
On Android device try a login with EIC with the dev server stopped. You can see the new error component.
