### PR TITLE
fix: [IOBP-582] Behavior of the new payment go back with only one PSP

### DIFF
--- a/ts/features/payments/payment/components/WalletPaymentConfirmContent.tsx
+++ b/ts/features/payments/payment/components/WalletPaymentConfirmContent.tsx
@@ -19,6 +19,7 @@ import {
   WALLET_PAYMENT_TERMS_AND_CONDITIONS_URL,
   getPaymentLogo
 } from "../../common/utils";
+import { WalletPaymentStepEnum } from "../types";
 import { UIWalletInfoDetails } from "../../details/types/UIWalletInfoDetails";
 import { walletPaymentSetCurrentStep } from "../store/actions/orchestration";
 import { walletPaymentPspListSelector } from "../store/selectors";
@@ -77,7 +78,13 @@ export const WalletPaymentConfirmContent = ({
         paymentLogo={getPaymentLogo(paymentMethodDetails)}
         title={getPaymentTitle(paymentMethodDetails)}
         subtitle={getPaymentSubtitle(paymentMethodDetails)}
-        onPress={() => dispatch(walletPaymentSetCurrentStep(1))}
+        onPress={() =>
+          dispatch(
+            walletPaymentSetCurrentStep(
+              WalletPaymentStepEnum.PICK_PAYMENT_METHOD
+            )
+          )
+        }
       />
       <VSpacer size={24} />
       <ListItemHeader
@@ -93,7 +100,9 @@ export const WalletPaymentConfirmContent = ({
         subtitle={`${I18n.t("payment.confirm.feeAppliedBy")} ${
           selectedPsp.bundleName
         }`}
-        onPress={() => dispatch(walletPaymentSetCurrentStep(2))}
+        onPress={() =>
+          dispatch(walletPaymentSetCurrentStep(WalletPaymentStepEnum.PICK_PSP))
+        }
       />
       <VSpacer size={24} />
       <WalletPaymentTotalAmount totalAmount={totalAmount} />

--- a/ts/features/payments/payment/components/WalletPaymentHeader.tsx
+++ b/ts/features/payments/payment/components/WalletPaymentHeader.tsx
@@ -18,6 +18,7 @@ import { useHardwareBackButton } from "../../../../hooks/useHardwareBackButton";
 import { WALLET_PAYMENT_STEP_MAX } from "../store/reducers";
 import { walletPaymentPspListSelector } from "../store/selectors";
 import { walletPaymentResetPspList } from "../store/actions/networking";
+import { WalletPaymentStepEnum } from "../types";
 
 type WalletPaymentHeaderProps = {
   currentStep: number;
@@ -37,19 +38,27 @@ const WalletPaymentHeader = ({ currentStep }: WalletPaymentHeaderProps) => {
   });
 
   const handleGoBack = React.useCallback(() => {
-    if (currentStep === 1 && goBackHandler) {
+    if (
+      currentStep === WalletPaymentStepEnum.PICK_PAYMENT_METHOD &&
+      goBackHandler
+    ) {
       return goBackHandler();
     }
 
-    if (currentStep === 1) {
+    if (currentStep === WalletPaymentStepEnum.PICK_PAYMENT_METHOD) {
       return navigation.goBack();
     }
 
-    if (currentStep === 3 && pspList.length === 1) {
-      dispatch(walletPaymentSetCurrentStep(currentStep - 2));
+    if (
+      currentStep === WalletPaymentStepEnum.CONFIRM_TRANSACTION &&
+      pspList.length === 1
+    ) {
+      dispatch(
+        walletPaymentSetCurrentStep(WalletPaymentStepEnum.PICK_PAYMENT_METHOD)
+      );
       dispatch(walletPaymentResetPspList());
     } else {
-      dispatch(walletPaymentSetCurrentStep(currentStep - 1));
+      dispatch(walletPaymentSetCurrentStep(WalletPaymentStepEnum.PICK_PSP));
     }
   }, [navigation, dispatch, goBackHandler, currentStep, pspList]);
 

--- a/ts/features/payments/payment/screens/WalletPaymentPickMethodScreen.tsx
+++ b/ts/features/payments/payment/screens/WalletPaymentPickMethodScreen.tsx
@@ -51,6 +51,7 @@ import {
   walletPaymentUserWalletsSelector
 } from "../store/selectors";
 import { WalletPaymentOutcomeEnum } from "../types/PaymentOutcomeEnum";
+import { WalletPaymentStepEnum } from "../types";
 
 type SavedMethodState = {
   kind: "saved";
@@ -125,9 +126,13 @@ const WalletPaymentPickMethodScreen = () => {
       pot.toOption,
       O.map(pspList => {
         if (pspList.length > 1) {
-          dispatch(walletPaymentSetCurrentStep(2));
+          dispatch(walletPaymentSetCurrentStep(WalletPaymentStepEnum.PICK_PSP));
         } else if (pspList.length >= 1) {
-          dispatch(walletPaymentSetCurrentStep(3));
+          dispatch(
+            walletPaymentSetCurrentStep(
+              WalletPaymentStepEnum.CONFIRM_TRANSACTION
+            )
+          );
         }
       })
     );

--- a/ts/features/payments/payment/screens/WalletPaymentPickPspScreen.tsx
+++ b/ts/features/payments/payment/screens/WalletPaymentPickPspScreen.tsx
@@ -29,7 +29,7 @@ import {
   walletPaymentPickedPspSelector,
   walletPaymentPspListSelector
 } from "../store/selectors";
-import { WalletPaymentPspSortType } from "../types";
+import { WalletPaymentPspSortType, WalletPaymentStepEnum } from "../types";
 import { WalletPaymentOutcomeEnum } from "../types/PaymentOutcomeEnum";
 
 const WalletPaymentPickPspScreen = () => {
@@ -103,7 +103,9 @@ const WalletPaymentPickPspScreen = () => {
   );
 
   const handleContinue = () => {
-    dispatch(walletPaymentSetCurrentStep(3));
+    dispatch(
+      walletPaymentSetCurrentStep(WalletPaymentStepEnum.CONFIRM_TRANSACTION)
+    );
   };
 
   const sortButtonProps: ListItemHeader["endElement"] = React.useMemo(

--- a/ts/features/payments/payment/store/__tests__/store.test.ts
+++ b/ts/features/payments/payment/store/__tests__/store.test.ts
@@ -4,7 +4,7 @@ import { createStore } from "redux";
 import { applicationChangeState } from "../../../../../store/actions/application";
 import { appReducer } from "../../../../../store/reducers";
 import { walletPaymentSetCurrentStep } from "../actions/orchestration";
-import { WALLET_PAYMENT_STEP_MAX, WalletPaymentState } from "../reducers";
+import { WalletPaymentState } from "../reducers";
 
 const INITIAL_STATE: WalletPaymentState = {
   currentStep: 1,
@@ -33,11 +33,6 @@ describe("Test Wallet reducer", () => {
 
     store.dispatch(walletPaymentSetCurrentStep(2));
     expect(store.getState().features.payments.payment.currentStep).toBe(2);
-
-    store.dispatch(walletPaymentSetCurrentStep(20));
-    expect(store.getState().features.payments.payment.currentStep).toBe(
-      WALLET_PAYMENT_STEP_MAX
-    );
 
     store.dispatch(walletPaymentSetCurrentStep(0));
     expect(store.getState().features.payments.payment.currentStep).toBe(1);

--- a/ts/features/payments/payment/store/actions/orchestration.ts
+++ b/ts/features/payments/payment/store/actions/orchestration.ts
@@ -1,11 +1,15 @@
 import { ActionType, createStandardAction } from "typesafe-actions";
 import { Bundle } from "../../../../../../definitions/pagopa/ecommerce/Bundle";
 import { WalletInfo } from "../../../../../../definitions/pagopa/ecommerce/WalletInfo";
-import { PaymentStartOrigin, PaymentStartRoute } from "../../types";
+import {
+  PaymentStartOrigin,
+  PaymentStartRoute,
+  WalletPaymentStepEnum
+} from "../../types";
 
 export const walletPaymentSetCurrentStep = createStandardAction(
   "WALLET_PAYMENT_SET_CURRENT_STEP"
-)<number>();
+)<WalletPaymentStepEnum>();
 
 export type PaymentInitStateParams = {
   startOrigin?: PaymentStartOrigin;

--- a/ts/features/payments/payment/store/reducers/index.ts
+++ b/ts/features/payments/payment/store/reducers/index.ts
@@ -9,7 +9,7 @@ import { RptId } from "../../../../../../definitions/pagopa/ecommerce/RptId";
 import { TransactionInfo } from "../../../../../../definitions/pagopa/ecommerce/TransactionInfo";
 import { Action } from "../../../../../store/actions/types";
 import { NetworkError } from "../../../../../utils/errors";
-import { PaymentStartRoute } from "../../types";
+import { PaymentStartRoute, WalletPaymentStepEnum } from "../../types";
 import {
   walletPaymentAuthorization,
   walletPaymentCalculateFees,
@@ -36,7 +36,7 @@ import { WalletInfo } from "../../../../../../definitions/pagopa/ecommerce/Walle
 export const WALLET_PAYMENT_STEP_MAX = 4;
 
 export type WalletPaymentState = {
-  currentStep: number;
+  currentStep: WalletPaymentStepEnum;
   rptId?: RptId;
   sessionToken: pot.Pot<string, NetworkError>;
   paymentDetails: pot.Pot<
@@ -55,7 +55,7 @@ export type WalletPaymentState = {
 };
 
 const INITIAL_STATE: WalletPaymentState = {
-  currentStep: 1,
+  currentStep: WalletPaymentStepEnum.PICK_PAYMENT_METHOD,
   sessionToken: pot.none,
   paymentDetails: pot.none,
   userWallets: pot.none,

--- a/ts/features/payments/payment/types/index.ts
+++ b/ts/features/payments/payment/types/index.ts
@@ -14,3 +14,10 @@ export type PaymentStartRoute = {
   routeName: keyof AppParamsList;
   routeKey: NavigatorScreenParams<AppParamsList>["screen"];
 };
+
+export enum WalletPaymentStepEnum {
+  NONE = 0,
+  PICK_PAYMENT_METHOD = 1,
+  PICK_PSP = 2,
+  CONFIRM_TRANSACTION = 3
+}


### PR DESCRIPTION
## Short description
This PR fixes the behavior when the user goes back from the confirmation screen with a payment method that has only one PSP. 

## List of changes proposed in this pull request
- Added a check inside the wallet payment header go back handler, if the user is at the third step and the current method has only one PSP, it must be redirected to the first step (selecting the payment method), otherwise go back selecting the PSP from the PSP list screen

## How to test
- Start a payment inside the new payment playground and choose a payment method with only one PSP
- When you reach the confirmation page, try to go back: You should be redirected to the pick payment method screen

## Preview

|Before|After|
|-|-|
|<video src="https://github.com/pagopa/io-app/assets/34343582/2f0b81be-25d8-4420-a86a-9c6e63e736ff" />|<video src="https://github.com/pagopa/io-app/assets/34343582/e5785dbb-4595-48bd-899b-19024f1b4798" />
