### PR TITLE
[IOAPPX-257] Upload iOS dSYM files as artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,12 @@ jobs:
           APP_STORE_API_KEY_ISSUER_ID: ${{secrets.APP_STORE_API_KEY_ISSUER_ID}}
           ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD: ${{secrets.ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD}}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+      - id: upload-dsym-files
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.0.3
+        with:
+          name: ItaliaApp.app.dSYM.zip
+          path: ios/ItaliaApp.app.dSYM.zip
+          retention-days: 60        
   notify-new-version:
     environment: dev
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Short description
This PR adds the upload `dSYM` zip file as an artifact to the `release-ios` job in `release.yml` workflow.
We can then use dSYM file to symbolicate crash reports download from Xcode or taken from appstoreconnect.



## How to test
Make a new release and check whether the `dSYM` zip file is put as artifacts. 
