### PR TITLE
chore: [IOBP-568] Add email to payment outcome 17 description

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1754,7 +1754,8 @@ wallet:
         title: Il metodo di pagamento non è supportato
       WAITING_CONFIRMATION_EMAIL:
         title: Attendi la conferma via email
-        subtitle: Non è stato possibile verificare l'esito del pagamento. Se è andato a buon fine, riceverai a breve un'email. Se non arriva, contatta l'assistenza.
+        subtitle: Riceverai l'esito del pagamento all'indirizzo {{email}}
+        defaultSubtitle: Riceverai l'esito del pagamento all'indirizzo email associato.
       METHOD_NOT_ENABLED:
         title: Abilita il metodo per effettuare pagamenti in app
         subtitle: Prima di riprovare con il pagamento, seleziona il metodo nel tuo Portafoglio e abilita la funzionalità “Pagamenti in app”.

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1754,7 +1754,8 @@ wallet:
         title: Il metodo di pagamento non è supportato
       WAITING_CONFIRMATION_EMAIL:
         title: Attendi la conferma via email
-        subtitle: Non è stato possibile verificare l'esito del pagamento. Se è andato a buon fine, riceverai a breve un'email. Se non arriva, contatta l'assistenza.
+        subtitle: Riceverai l'esito del pagamento all'indirizzo {{email}}
+        defaultSubtitle: Riceverai l'esito del pagamento all'indirizzo email associato.
       METHOD_NOT_ENABLED:
         title: Abilita il metodo per effettuare pagamenti in app
         subtitle: Prima di riprovare con il pagamento, seleziona il metodo nel tuo Portafoglio e abilita la funzionalità “Pagamenti in app”.

--- a/ts/features/payments/payment/screens/WalletPaymentOutcomeScreen.tsx
+++ b/ts/features/payments/payment/screens/WalletPaymentOutcomeScreen.tsx
@@ -23,6 +23,7 @@ import {
   WalletPaymentOutcome,
   WalletPaymentOutcomeEnum
 } from "../types/PaymentOutcomeEnum";
+import { profileEmailSelector } from "../../../../store/reducers/profile";
 
 type WalletPaymentOutcomeScreenNavigationParams = {
   outcome: WalletPaymentOutcome;
@@ -42,6 +43,7 @@ const WalletPaymentOutcomeScreen = () => {
   const navigation = useIONavigation();
   const paymentDetailsPot = useIOSelector(walletPaymentDetailsSelector);
   const paymentStartRoute = useIOSelector(walletPaymentStartRouteSelector);
+  const profileEmailOption = useIOSelector(profileEmailSelector);
 
   const supportModal = usePaymentFailureSupportModal({
     outcome
@@ -187,8 +189,19 @@ const WalletPaymentOutcomeScreen = () => {
           title: I18n.t(
             "wallet.payment.outcome.WAITING_CONFIRMATION_EMAIL.title"
           ),
-          subtitle: I18n.t(
-            "wallet.payment.outcome.WAITING_CONFIRMATION_EMAIL.subtitle"
+          subtitle: pipe(
+            profileEmailOption,
+            O.map(email =>
+              I18n.t(
+                "wallet.payment.outcome.WAITING_CONFIRMATION_EMAIL.subtitle",
+                { email }
+              )
+            ),
+            O.getOrElse(() =>
+              I18n.t(
+                "wallet.payment.outcome.WAITING_CONFIRMATION_EMAIL.defaultSubtitle"
+              )
+            )
           ),
           action: closeFailureAction
         };


### PR DESCRIPTION
## Short description
This PR adds the user email to the payment outcome 17 description if available, otherwise shows a generic description.

## List of changes proposed in this pull request
- Edited the description text from the locales;
- Added the email selector to get the user email from the `WalletPaymentOutcomeScreen`

## How to test
- Start a new payment flow from the playground
- Reach the webview and select from the dropdown outcome list the outcome number `17`

## Preview
<img src="https://github.com/pagopa/io-app/assets/34343582/7ab99980-6331-41a2-bbc5-edd8f0a3548f" width="300" />
