### PR TITLE
fix: Translations on Services Preference Screens and Identification Modal

### DIFF
--- a/ts/screens/profile/components/services/ServicesContactComponent.tsx
+++ b/ts/screens/profile/components/services/ServicesContactComponent.tsx
@@ -11,27 +11,28 @@ type Props = {
   showBadge?: boolean;
 };
 
-const options = [
-  {
-    value: I18n.t("services.optIn.preferences.quickConfig.title"),
-    id: ServicesPreferencesModeEnum.AUTO,
-    description: (
-      <LabelSmall color="grey-700" weight="Regular">
-        {I18n.t("services.optIn.preferences.quickConfig.body.text1")}{" "}
-        <Text style={{ color: IOColors["grey-700"], fontWeight: "600" }}>
-          {I18n.t("services.optIn.preferences.quickConfig.body.text2")}
-        </Text>
-      </LabelSmall>
-    )
-  },
-  {
-    value: I18n.t("services.optIn.preferences.manualConfig.title"),
-    id: ServicesPreferencesModeEnum.MANUAL,
-    description: I18n.t("services.optIn.preferences.manualConfig.body.text1")
-  }
-];
-
 const ServicesContactComponent = (props: Props): ReactElement => {
+  // We put the option inside the component to handle translations
+  const options = [
+    {
+      value: I18n.t("services.optIn.preferences.quickConfig.title"),
+      id: ServicesPreferencesModeEnum.AUTO,
+      description: (
+        <LabelSmall color="grey-700" weight="Regular">
+          {I18n.t("services.optIn.preferences.quickConfig.body.text1")}{" "}
+          <Text style={{ color: IOColors["grey-700"], fontWeight: "600" }}>
+            {I18n.t("services.optIn.preferences.quickConfig.body.text2")}
+          </Text>
+        </LabelSmall>
+      )
+    },
+    {
+      value: I18n.t("services.optIn.preferences.manualConfig.title"),
+      id: ServicesPreferencesModeEnum.MANUAL,
+      description: I18n.t("services.optIn.preferences.manualConfig.body.text1")
+    }
+  ];
+
   const { mode, onSelectMode } = props;
   const [selectedItem, setSelectedItem] = useState(mode);
   const prevMode = usePrevious(mode);

--- a/ts/utils/identification/index.tsx
+++ b/ts/utils/identification/index.tsx
@@ -21,26 +21,42 @@ export const getBiometryIconName = (
   }
 };
 
-const unlockCode = I18n.t("identification.instructions.unlockCode");
-const unlockCodePrefix = I18n.t(
-  "identification.instructions.unlockCodepPrefix"
-);
-const fingerprint = I18n.t("identification.instructions.fingerprint");
-const fingerprintPrefix = I18n.t(
-  "identification.instructions.fingerprintPrefix"
-);
-const faceId = I18n.t("identification.instructions.faceId");
-const faceIdPrefix = I18n.t("identification.instructions.faceIdPrefix");
-const congiunction = I18n.t("identification.instructions.congiunction");
-
-const unlockCodeInstruction = `${unlockCodePrefix} ${unlockCode}`;
-const fingerprintInstruction = `${fingerprintPrefix} ${fingerprint}`;
-const faceIdInstruction = `${faceIdPrefix} ${faceId}`;
+const getTranlations = () => {
+  const unlockCode = I18n.t("identification.instructions.unlockCode");
+  const unlockCodePrefix = I18n.t(
+    "identification.instructions.unlockCodepPrefix"
+  );
+  const fingerprint = I18n.t("identification.instructions.fingerprint");
+  const fingerprintPrefix = I18n.t(
+    "identification.instructions.fingerprintPrefix"
+  );
+  const faceId = I18n.t("identification.instructions.faceId");
+  const faceIdPrefix = I18n.t("identification.instructions.faceIdPrefix");
+  return {
+    unlockCode,
+    unlockCodePrefix,
+    fingerprint,
+    fingerprintPrefix,
+    faceId,
+    faceIdPrefix,
+    congiunction: I18n.t("identification.instructions.congiunction"),
+    unlockCodeInstruction: `${unlockCodePrefix} ${unlockCode}`,
+    fingerprintInstruction: `${fingerprintPrefix} ${fingerprint}`,
+    faceIdInstruction: `${faceIdPrefix} ${faceId}`
+  };
+};
 
 export const getAccessibiliyIdentificationInstructions = (
   biometricType: BiometricsValidType | undefined,
   isBimoetricIdentificatoinFailed: boolean = false
 ) => {
+  const {
+    unlockCodeInstruction,
+    fingerprintInstruction,
+    faceIdInstruction,
+    congiunction
+  } = getTranlations();
+
   if (isBimoetricIdentificatoinFailed) {
     return unlockCodeInstruction;
   }
@@ -65,6 +81,15 @@ export const IdentificationInstructionsComponent = (props: {
     biometricType,
     isBimoetricIdentificatoinFailed
   );
+  const {
+    unlockCode,
+    unlockCodePrefix,
+    fingerprint,
+    fingerprintPrefix,
+    faceId,
+    faceIdPrefix,
+    congiunction
+  } = getTranlations();
   const instructionComponent = (
     <View style={IOStyles.row}>
       <LabelSmall color="white" weight="Regular">


### PR DESCRIPTION
## Short description
This PR fixes translation on Services Preference Screens and Identification Modal

## How to test
Run the app in a device with a different language from the actually logged in user (ex. Device: EN, User: IT) and check that all the strings in the above mentioned screens are translated correctly.
