### PR TITLE
[IOPAE-1067] Add skeleton in `ServiceDetailsScreen`

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2093,6 +2093,21 @@ services:
       inbox: "Contact you in app"
       pushNotifications: "Send you push notifications"
       messageReadStatus: "Receive read receipts"
+    metadata:
+      title: "Contacts and info"
+      website: "Browse Website"
+      downloadApp: "Download app"
+      support: "Get support"
+      phone: "Contact the institution"
+      email: "Send email"
+      pec: "Send PEC"
+      fiscalCode: "Organization's fiscal code"
+      address: "Address"
+      serviceId: "Service ID"
+    tosAndPrivacy: 
+      title: "Terms of use and Privacy"
+      tosLink: "Terms and conditions"
+      privacyLink: "Privacy information"
 serviceDetail:
   fiscalCode: "Organization's fiscal code"
   fiscalCodeAccessibility: "Organization's fiscal code"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2093,6 +2093,21 @@ services:
       inbox: "Contattarti in app"
       pushNotifications: "Inviarti notifiche push"
       messageReadStatus: "Ricevere conferme di lettura"
+    metadata:
+      title: "Contatti ed informazioni"
+      website: "Visita il sito"
+      downloadApp: "Scarica l'app"
+      support: "Richiedi assistenza"
+      phone: "Contatta l'ente"
+      email: "Invia un'email"
+      pec: "Invia una PEC"
+      fiscalCode: "Codice fiscale ente"
+      address: "Indirizzo"
+      serviceId: "ID servizio"
+    tosAndPrivacy: 
+      title: "Termini e Privacy"
+      tosLink: "Termini e condizioni d'uso"
+      privacyLink: "Informativa sulla privacy"
 serviceDetail:
   fiscalCode: "C.F. Ente"
   fiscalCodeAccessibility: "Codice fiscale Ente"

--- a/ts/components/services/SpecialServices/LegacySpecialServicesCTA.tsx
+++ b/ts/components/services/SpecialServices/LegacySpecialServicesCTA.tsx
@@ -5,8 +5,8 @@ import * as O from "fp-ts/lib/Option";
 import { ServiceId } from "../../../../definitions/backend/ServiceId";
 import { cdcEnabled } from "../../../config";
 import CdcServiceCTA from "../../../features/bonus/cdc/components/CdcServiceCTA";
-import CgnServiceCTA from "../../../features/bonus/cgn/components/CgnServiceCTA";
-import PnServiceCTA from "../../../features/pn/components/ServiceCTA";
+import LegacyCgnServiceCTA from "../../../features/bonus/cgn/components/LegacyCgnServiceCTA";
+import LegacyPnServiceCTA from "../../../features/pn/components/LegacyServiceCTA";
 import I18n from "../../../i18n";
 import { useIOSelector } from "../../../store/hooks";
 import {
@@ -59,7 +59,7 @@ const renderCta = (
     )
   );
 
-const SpecialServicesCTA = (props: Props) => {
+const LegacySpecialServicesCTA = (props: Props) => {
   const { customSpecialFlowOpt } = props;
 
   const isCGNEnabled = useIOSelector(isCGNEnabledSelector);
@@ -91,7 +91,7 @@ const SpecialServicesCTA = (props: Props) => {
                 return renderCta(
                   isEnabled,
                   isSupported,
-                  <CgnServiceCTA serviceId={props.serviceId} />
+                  <LegacyCgnServiceCTA serviceId={props.serviceId} />
                 );
               case "cdc":
                 return renderCta(isEnabled, isSupported, <CdcServiceCTA />);
@@ -99,7 +99,7 @@ const SpecialServicesCTA = (props: Props) => {
                 return renderCta(
                   isEnabled,
                   isSupported,
-                  <PnServiceCTA
+                  <LegacyPnServiceCTA
                     serviceId={props.serviceId}
                     activate={props.activate}
                   />
@@ -114,4 +114,4 @@ const SpecialServicesCTA = (props: Props) => {
   );
 };
 
-export default SpecialServicesCTA;
+export default LegacySpecialServicesCTA;

--- a/ts/components/ui/Markdown/LoadingSkeleton.tsx
+++ b/ts/components/ui/Markdown/LoadingSkeleton.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { View } from "react-native";
 import Placeholder from "rn-placeholder";
-import { VSpacer } from "@pagopa/io-app-design-system";
+import { IOColors, VSpacer } from "@pagopa/io-app-design-system";
 import I18n from "../../../i18n";
 
 type LoadingSkeletonProps = {
@@ -19,23 +19,77 @@ export const LoadingSkeleton = ({ testID }: LoadingSkeletonProps) => (
       importantForAccessibility="no-hide-descendants"
       accessibilityElementsHidden={true}
     >
-      <Placeholder.Box width={"98%"} animate={"fade"} height={21} radius={4} />
+      <Placeholder.Box
+        width={"98%"}
+        animate={"fade"}
+        color={IOColors["grey-100"]}
+        height={21}
+        radius={4}
+      />
       <VSpacer size={8} />
-      <Placeholder.Box width={"86%"} animate={"fade"} height={21} radius={4} />
+      <Placeholder.Box
+        width={"86%"}
+        animate={"fade"}
+        color={IOColors["grey-100"]}
+        height={21}
+        radius={4}
+      />
       <VSpacer size={8} />
-      <Placeholder.Box width={"92%"} animate={"fade"} height={21} radius={4} />
+      <Placeholder.Box
+        width={"92%"}
+        animate={"fade"}
+        color={IOColors["grey-100"]}
+        height={21}
+        radius={4}
+      />
       <VSpacer size={8} />
-      <Placeholder.Box width={"80%"} animate={"fade"} height={21} radius={4} />
+      <Placeholder.Box
+        width={"80%"}
+        animate={"fade"}
+        color={IOColors["grey-100"]}
+        height={21}
+        radius={4}
+      />
       <VSpacer size={8} />
-      <Placeholder.Box width={"90%"} animate={"fade"} height={21} radius={4} />
+      <Placeholder.Box
+        width={"90%"}
+        animate={"fade"}
+        color={IOColors["grey-100"]}
+        height={21}
+        radius={4}
+      />
       <VSpacer size={8} />
-      <Placeholder.Box width={"96%"} animate={"fade"} height={21} radius={4} />
+      <Placeholder.Box
+        width={"96%"}
+        animate={"fade"}
+        color={IOColors["grey-100"]}
+        height={21}
+        radius={4}
+      />
       <VSpacer size={8} />
-      <Placeholder.Box width={"84%"} animate={"fade"} height={21} radius={4} />
+      <Placeholder.Box
+        width={"84%"}
+        animate={"fade"}
+        color={IOColors["grey-100"]}
+        height={21}
+        radius={4}
+      />
       <VSpacer size={8} />
-      <Placeholder.Box width={"88%"} animate={"fade"} height={21} radius={4} />
+      <Placeholder.Box
+        width={"88%"}
+        animate={"fade"}
+        color={IOColors["grey-100"]}
+        height={21}
+        radius={4}
+      />
       <VSpacer size={8} />
-      <Placeholder.Box width={"94%"} animate={"fade"} height={21} radius={4} />
+      <Placeholder.Box
+        width={"94%"}
+        animate={"fade"}
+        color={IOColors["grey-100"]}
+        height={21}
+        radius={4}
+      />
     </View>
   </View>
 );

--- a/ts/features/bonus/cgn/__e2e__/utils.ts
+++ b/ts/features/bonus/cgn/__e2e__/utils.ts
@@ -30,7 +30,9 @@ export const activateCGNBonusSuccess = async () => {
   // make sure to scroll to bottom, otherwise in small devices the element will not be visible nor tappable
   await scrollView.scrollTo("bottom");
 
-  const unsubscribeCgnCta = element(by.id("cgnDeactivateBonusTestId"));
+  const unsubscribeCgnCta = element(
+    by.id("service-cgn-deactivate-bonus-button")
+  );
   await waitFor(unsubscribeCgnCta)
     .toBeVisible()
     .withTimeout(e2eWaitRenderTimeout);

--- a/ts/features/bonus/cgn/components/CgnServiceCTA.tsx
+++ b/ts/features/bonus/cgn/components/CgnServiceCTA.tsx
@@ -1,34 +1,44 @@
-import * as React from "react";
-import { useEffect, useRef } from "react";
-import * as pot from "@pagopa/ts-commons/lib/pot";
+import React, { useCallback, useEffect, useRef } from "react";
 import { Alert } from "react-native";
+import { ButtonSolid, IOToast } from "@pagopa/io-app-design-system";
 import { constNull } from "fp-ts/lib/function";
-import { Label } from "../../../../components/core/typography/Label";
-import ButtonDefaultOpacity from "../../../../components/ButtonDefaultOpacity";
+import * as pot from "@pagopa/ts-commons/lib/pot";
 import I18n from "../../../../i18n";
 import { useIODispatch, useIOSelector } from "../../../../store/hooks";
-import { servicePreferenceSelector } from "../../../services/store/reducers/servicePreference";
-import { isServicePreferenceResponseSuccess } from "../../../services/types/ServicePreferenceResponse";
+import {
+  servicePreferenceResponseSuccessSelector,
+  servicePreferenceSelector
+} from "../../../services/store/reducers/servicePreference";
 import { ServiceId } from "../../../../../definitions/backend/ServiceId";
 import { cgnActivationStart } from "../store/actions/activation";
 import { cgnUnsubscribe } from "../store/actions/unsubscribe";
 import { fold, isLoading } from "../../../../common/model/RemoteValue";
-import { showToast } from "../../../../utils/showToast";
 import { cgnUnsubscribeSelector } from "../store/reducers/unsubscribe";
 import { loadServicePreference } from "../../../services/store/actions";
-import ActivityIndicator from "../../../../components/ui/ActivityIndicator";
 import { loadAvailableBonuses } from "../../common/store/actions/availableBonusesTypes";
 
-type Props = {
+type CgnServiceCtaProps = {
   serviceId: ServiceId;
 };
-const CgnServiceCTA = (props: Props) => {
+
+export const CgnServiceCta = ({ serviceId }: CgnServiceCtaProps) => {
   const isFirstRender = useRef<boolean>(true);
+
   const dispatch = useIODispatch();
-  const servicePreference = useIOSelector(servicePreferenceSelector);
+
+  const servicePreferenceResponseSuccess = useIOSelector(
+    servicePreferenceResponseSuccessSelector
+  );
+
+  const servicePreferencePot = useIOSelector(servicePreferenceSelector);
+
   const unsubscriptionStatus = useIOSelector(cgnUnsubscribeSelector);
 
-  const servicePreferenceValue = pot.getOrElse(servicePreference, undefined);
+  const isLoadingStatus =
+    pot.isLoading(servicePreferencePot) || isLoading(unsubscriptionStatus);
+
+  const isServiceActive =
+    servicePreferenceResponseSuccess?.value.inbox ?? false;
 
   useEffect(() => {
     if (!isFirstRender.current) {
@@ -37,75 +47,67 @@ const CgnServiceCTA = (props: Props) => {
         constNull,
         constNull,
         () => {
-          showToast(I18n.t("bonus.cgn.activation.deactivate.toast"), "success");
-          dispatch(loadServicePreference.request(props.serviceId));
+          IOToast.success(I18n.t("bonus.cgn.activation.deactivate.toast"));
+          dispatch(loadServicePreference.request(serviceId));
         },
-        () => {
-          showToast(I18n.t("global.genericError"), "danger");
-        }
+        () => IOToast.error(I18n.t("global.genericError"))
       );
     }
     // eslint-disable-next-line functional/immutable-data
     isFirstRender.current = false;
-  }, [unsubscriptionStatus, dispatch, props.serviceId]);
+  }, [unsubscriptionStatus, dispatch, serviceId]);
+
+  const handleUnsubscriptionStatus = useCallback(
+    () =>
+      Alert.alert(
+        I18n.t("bonus.cgn.activation.deactivate.alert.title"),
+        I18n.t("bonus.cgn.activation.deactivate.alert.message"),
+        [
+          {
+            text: I18n.t("global.buttons.cancel"),
+            style: "cancel"
+          },
+          {
+            text: I18n.t("global.buttons.deactivate"),
+            onPress: () => dispatch(cgnUnsubscribe.request())
+          }
+        ]
+      ),
+    [dispatch]
+  );
 
   if (
-    !servicePreferenceValue ||
-    servicePreferenceValue.id !== props.serviceId
+    !servicePreferenceResponseSuccess ||
+    servicePreferenceResponseSuccess.id !== serviceId
   ) {
     return null;
   }
-  const isServiceActive =
-    servicePreferenceValue &&
-    isServicePreferenceResponseSuccess(servicePreferenceValue) &&
-    servicePreferenceValue.value.inbox;
-
-  const requestUnsubscription = () => {
-    Alert.alert(
-      I18n.t("bonus.cgn.activation.deactivate.alert.title"),
-      I18n.t("bonus.cgn.activation.deactivate.alert.message"),
-      [
-        {
-          text: I18n.t("global.buttons.cancel"),
-          style: "cancel"
-        },
-        {
-          text: I18n.t("global.buttons.deactivate"),
-          onPress: () => dispatch(cgnUnsubscribe.request())
-        }
-      ]
-    );
-  };
 
   if (isServiceActive) {
-    if (isLoading(unsubscriptionStatus)) {
-      return <ActivityIndicator />;
-    }
     return (
-      <ButtonDefaultOpacity
-        block
-        bordered
-        danger
-        onPress={requestUnsubscription}
-      >
-        <Label testID="cgnDeactivateBonusTestId" color={"red"}>
-          {I18n.t("bonus.cgn.cta.deactivateBonus")}
-        </Label>
-      </ButtonDefaultOpacity>
+      <ButtonSolid
+        fullWidth
+        color="danger"
+        accessibilityLabel={I18n.t("bonus.cgn.cta.deactivateBonus")}
+        label={I18n.t("bonus.cgn.cta.deactivateBonus")}
+        loading={isLoadingStatus}
+        testID="service-cgn-deactivate-bonus-button"
+        onPress={handleUnsubscriptionStatus}
+      />
     );
   }
+
   return (
-    <ButtonDefaultOpacity
-      block
-      primary
+    <ButtonSolid
+      fullWidth
+      accessibilityLabel={I18n.t("bonus.cgn.cta.activeBonus")}
+      label={I18n.t("bonus.cgn.cta.activeBonus")}
+      loading={isLoadingStatus}
+      testID="service-activate-bonus-button"
       onPress={() => {
         dispatch(loadAvailableBonuses.request());
         dispatch(cgnActivationStart());
       }}
-      testID="service-activate-bonus-button"
-    >
-      <Label color={"white"}>{I18n.t("bonus.cgn.cta.activeBonus")}</Label>
-    </ButtonDefaultOpacity>
+    />
   );
 };
-export default CgnServiceCTA;

--- a/ts/features/bonus/cgn/components/LegacyCgnServiceCTA.tsx
+++ b/ts/features/bonus/cgn/components/LegacyCgnServiceCTA.tsx
@@ -1,0 +1,111 @@
+import * as React from "react";
+import { useEffect, useRef } from "react";
+import * as pot from "@pagopa/ts-commons/lib/pot";
+import { Alert } from "react-native";
+import { constNull } from "fp-ts/lib/function";
+import { Label } from "../../../../components/core/typography/Label";
+import ButtonDefaultOpacity from "../../../../components/ButtonDefaultOpacity";
+import I18n from "../../../../i18n";
+import { useIODispatch, useIOSelector } from "../../../../store/hooks";
+import { servicePreferenceSelector } from "../../../services/store/reducers/servicePreference";
+import { isServicePreferenceResponseSuccess } from "../../../services/types/ServicePreferenceResponse";
+import { ServiceId } from "../../../../../definitions/backend/ServiceId";
+import { cgnActivationStart } from "../store/actions/activation";
+import { cgnUnsubscribe } from "../store/actions/unsubscribe";
+import { fold, isLoading } from "../../../../common/model/RemoteValue";
+import { showToast } from "../../../../utils/showToast";
+import { cgnUnsubscribeSelector } from "../store/reducers/unsubscribe";
+import { loadServicePreference } from "../../../services/store/actions";
+import ActivityIndicator from "../../../../components/ui/ActivityIndicator";
+import { loadAvailableBonuses } from "../../common/store/actions/availableBonusesTypes";
+
+type Props = {
+  serviceId: ServiceId;
+};
+const LegacyCgnServiceCTA = (props: Props) => {
+  const isFirstRender = useRef<boolean>(true);
+  const dispatch = useIODispatch();
+  const servicePreference = useIOSelector(servicePreferenceSelector);
+  const unsubscriptionStatus = useIOSelector(cgnUnsubscribeSelector);
+
+  const servicePreferenceValue = pot.getOrElse(servicePreference, undefined);
+
+  useEffect(() => {
+    if (!isFirstRender.current) {
+      fold(
+        unsubscriptionStatus,
+        constNull,
+        constNull,
+        () => {
+          showToast(I18n.t("bonus.cgn.activation.deactivate.toast"), "success");
+          dispatch(loadServicePreference.request(props.serviceId));
+        },
+        () => {
+          showToast(I18n.t("global.genericError"), "danger");
+        }
+      );
+    }
+    // eslint-disable-next-line functional/immutable-data
+    isFirstRender.current = false;
+  }, [unsubscriptionStatus, dispatch, props.serviceId]);
+
+  if (
+    !servicePreferenceValue ||
+    servicePreferenceValue.id !== props.serviceId
+  ) {
+    return null;
+  }
+  const isServiceActive =
+    servicePreferenceValue &&
+    isServicePreferenceResponseSuccess(servicePreferenceValue) &&
+    servicePreferenceValue.value.inbox;
+
+  const requestUnsubscription = () => {
+    Alert.alert(
+      I18n.t("bonus.cgn.activation.deactivate.alert.title"),
+      I18n.t("bonus.cgn.activation.deactivate.alert.message"),
+      [
+        {
+          text: I18n.t("global.buttons.cancel"),
+          style: "cancel"
+        },
+        {
+          text: I18n.t("global.buttons.deactivate"),
+          onPress: () => dispatch(cgnUnsubscribe.request())
+        }
+      ]
+    );
+  };
+
+  if (isServiceActive) {
+    if (isLoading(unsubscriptionStatus)) {
+      return <ActivityIndicator />;
+    }
+    return (
+      <ButtonDefaultOpacity
+        block
+        bordered
+        danger
+        onPress={requestUnsubscription}
+      >
+        <Label testID="service-cgn-deactivate-bonus-button" color={"red"}>
+          {I18n.t("bonus.cgn.cta.deactivateBonus")}
+        </Label>
+      </ButtonDefaultOpacity>
+    );
+  }
+  return (
+    <ButtonDefaultOpacity
+      block
+      primary
+      onPress={() => {
+        dispatch(loadAvailableBonuses.request());
+        dispatch(cgnActivationStart());
+      }}
+      testID="service-activate-bonus-button"
+    >
+      <Label color={"white"}>{I18n.t("bonus.cgn.cta.activeBonus")}</Label>
+    </ButtonDefaultOpacity>
+  );
+};
+export default LegacyCgnServiceCTA;

--- a/ts/features/bonus/cgn/components/detail/CgnUnsubscribe.tsx
+++ b/ts/features/bonus/cgn/components/detail/CgnUnsubscribe.tsx
@@ -55,7 +55,7 @@ const CgnUnsubscribe = () => {
         accessibilityRole={"button"}
         accessibilityLabel={I18n.t("bonus.cgn.cta.deactivateBonus")}
         onPress={requestUnsubscription}
-        testID="cgnDeactivateBonusTestId"
+        testID="service-cgn-deactivate-bonus-button"
       >
         {I18n.t("bonus.cgn.cta.deactivateBonus")}
       </LabelLink>

--- a/ts/features/pn/components/LegacyServiceCTA.tsx
+++ b/ts/features/pn/components/LegacyServiceCTA.tsx
@@ -1,0 +1,161 @@
+import React, { useEffect, useState } from "react";
+import * as pot from "@pagopa/ts-commons/lib/pot";
+import { identity, pipe } from "fp-ts/lib/function";
+import * as O from "fp-ts/lib/Option";
+import { ActivityIndicator } from "react-native";
+import { IOColors } from "@pagopa/io-app-design-system";
+import { ServiceId } from "../../../../definitions/backend/ServiceId";
+import ButtonDefaultOpacity from "../../../components/ButtonDefaultOpacity";
+import { Label } from "../../../components/core/typography/Label";
+import I18n from "../../../i18n";
+import { useIODispatch, useIOSelector } from "../../../store/hooks";
+import { servicePreferenceSelector } from "../../services/store/reducers/servicePreference";
+import { isServicePreferenceResponseSuccess } from "../../services/types/ServicePreferenceResponse";
+import { AppDispatch } from "../../../App";
+import { pnActivationUpsert } from "../store/actions";
+import { pnActivationSelector } from "../store/reducers/activation";
+import { showToast } from "../../../utils/showToast";
+import { Link } from "../../../components/core/typography/Link";
+import { useOnFirstRender } from "../../../utils/hooks/useOnFirstRender";
+import { loadServicePreference } from "../../services/store/actions";
+import {
+  trackPNServiceActivated,
+  trackPNServiceDeactivated,
+  trackPNServiceStartActivation,
+  trackPNServiceStartDeactivation
+} from "../analytics";
+
+type Props = {
+  serviceId: ServiceId;
+  activate?: boolean;
+};
+
+const LoadingIndicator = () => (
+  <ActivityIndicator
+    animating={true}
+    size={"small"}
+    color={IOColors.bluegreyDark}
+    accessible={true}
+    accessibilityHint={I18n.t("global.accessibility.activityIndicator.hint")}
+    accessibilityLabel={I18n.t("global.accessibility.activityIndicator.label")}
+    importantForAccessibility={"no-hide-descendants"}
+  />
+);
+
+const LoadingButton = (props: { isServiceActive: boolean }) => (
+  <ButtonDefaultOpacity
+    block
+    primary
+    style={{
+      backgroundColor: props.isServiceActive
+        ? IOColors.white
+        : IOColors.greyLight,
+      width: "100%"
+    }}
+  >
+    <LoadingIndicator />
+  </ButtonDefaultOpacity>
+);
+
+const ActivateButton = (props: { dispatch: AppDispatch }) => (
+  <ButtonDefaultOpacity
+    block
+    primary
+    onPress={() => {
+      trackPNServiceStartActivation();
+      props.dispatch(pnActivationUpsert.request({ value: true }));
+    }}
+  >
+    <Label color={"white"}>{I18n.t("features.pn.service.activate")}</Label>
+  </ButtonDefaultOpacity>
+);
+
+const DeactivateButton = (props: { dispatch: AppDispatch }) => (
+  <ButtonDefaultOpacity
+    block
+    primary
+    onPress={() => {
+      trackPNServiceStartDeactivation();
+      props.dispatch(pnActivationUpsert.request({ value: false }));
+    }}
+    style={{
+      backgroundColor: IOColors.white
+    }}
+  >
+    <Link weight={"SemiBold"} color={"red"}>
+      {I18n.t("features.pn.service.deactivate")}
+    </Link>
+  </ButtonDefaultOpacity>
+);
+
+// eslint-disable-next-line sonarjs/cognitive-complexity
+const LegacyPnServiceCTA = ({ serviceId, activate }: Props) => {
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const dispatch = useIODispatch();
+  const serviceActivation = useIOSelector(pnActivationSelector);
+  const servicePreference = useIOSelector(servicePreferenceSelector);
+  const servicePreferenceValue = pot.getOrElse(servicePreference, undefined);
+
+  const isLoading =
+    pot.isLoading(servicePreference) ||
+    pot.isLoading(serviceActivation) ||
+    pot.isUpdating(serviceActivation);
+
+  const isServiceActive =
+    servicePreferenceValue &&
+    isServicePreferenceResponseSuccess(servicePreferenceValue) &&
+    servicePreferenceValue.value.inbox;
+
+  useEffect(() => {
+    const wasUpdating = isUpdating;
+    const isStillUpdating = pot.isUpdating(serviceActivation);
+    const isError = pot.isError(serviceActivation);
+    if (wasUpdating && !isStillUpdating) {
+      if (isError) {
+        showToast(I18n.t("features.pn.service.toast.error"), "danger");
+      } else {
+        dispatch(loadServicePreference.request(serviceId));
+        if (pot.toUndefined(serviceActivation)) {
+          showToast(I18n.t("features.pn.service.toast.activated"), "success");
+        }
+      }
+    }
+    setIsUpdating(isStillUpdating);
+  }, [isUpdating, dispatch, serviceId, serviceActivation, isServiceActive]);
+
+  useOnFirstRender(() => {
+    pipe(
+      isServiceActive,
+      O.fromNullable,
+      O.filter(identity),
+      O.fold(
+        () => trackPNServiceDeactivated(),
+        () => trackPNServiceActivated()
+      )
+    );
+    pipe(
+      activate,
+      O.fromNullable,
+      O.filter(identity),
+      O.fold(
+        () => undefined,
+        () => void dispatch(pnActivationUpsert.request({ value: true }))
+      )
+    );
+  });
+
+  if (!servicePreferenceValue || servicePreferenceValue.id !== serviceId) {
+    return null;
+  }
+
+  return isLoading ? (
+    <LoadingButton isServiceActive={isServiceActive ?? false} />
+  ) : isServiceActive ? (
+    <DeactivateButton dispatch={dispatch} />
+  ) : (
+    <ActivateButton dispatch={dispatch} />
+  );
+};
+
+export default LegacyPnServiceCTA;

--- a/ts/features/pn/store/actions/index.ts
+++ b/ts/features/pn/store/actions/index.ts
@@ -1,11 +1,17 @@
 import { ActionType, createAction, createAsyncAction } from "typesafe-actions";
 import { UIMessageId } from "../../../messages/types";
 
+type TogglePnActivationPayload = {
+  value: boolean;
+  onSuccess?: () => void;
+  onFailure?: () => void;
+};
+
 export const pnActivationUpsert = createAsyncAction(
   "PN_ACTIVATION_UPSERT_REQUEST",
   "PN_ACTIVATION_UPSERT_SUCCESS",
   "PN_ACTIVATION_UPSERT_FAILURE"
-)<boolean, boolean, Error>();
+)<TogglePnActivationPayload, boolean, Error>();
 
 export const startPaymentStatusTracking = createAction(
   "MESSAGES_START_TRACKING_PAYMENT_STATUS",

--- a/ts/features/pn/store/reducers/activation.ts
+++ b/ts/features/pn/store/reducers/activation.ts
@@ -1,6 +1,6 @@
 import * as pot from "@pagopa/ts-commons/lib/pot";
-import { createSelector } from "reselect";
 import { getType } from "typesafe-actions";
+import { pipe } from "fp-ts/lib/function";
 import { loadServicePreference } from "../../../services/store/actions";
 import { Action } from "../../../../store/actions/types";
 import { GlobalState } from "../../../../store/reducers/types";
@@ -21,7 +21,7 @@ export const pnActivationReducer = (
 ): PnActivationState => {
   switch (action.type) {
     case getType(pnActivationUpsert.request):
-      return pot.toUpdating(state, action.payload);
+      return pot.toUpdating(state, action.payload.value);
     case getType(pnActivationUpsert.success):
       return pot.some(action.payload);
     case getType(pnActivationUpsert.failure):
@@ -32,7 +32,13 @@ export const pnActivationReducer = (
   return state;
 };
 
-export const pnActivationSelector = createSelector(
-  [(state: GlobalState) => state.features.pn.activation],
-  (_): PnActivationState => _
-);
+export const pnActivationSelector = (state: GlobalState): PnActivationState =>
+  state.features.pn.activation;
+
+export const isLoadingPnActivationSelector = (state: GlobalState) =>
+  pipe(
+    state,
+    pnActivationSelector,
+    pnActivationPot =>
+      pot.isLoading(pnActivationPot) || pot.isUpdating(pnActivationPot)
+  );

--- a/ts/features/pn/store/sagas/watchPnSaga.ts
+++ b/ts/features/pn/store/sagas/watchPnSaga.ts
@@ -24,7 +24,7 @@ function* handlePnActivation(
   upsertPnActivation: PnClient["upsertPNActivation"],
   action: ActionType<typeof pnActivationUpsert.request>
 ) {
-  const activation_status = action.payload;
+  const activation_status = action.payload.value;
   try {
     const isTest: ReturnType<typeof isPnTestEnabledSelector> = yield* select(
       isPnTestEnabledSelector
@@ -41,9 +41,11 @@ function* handlePnActivation(
       yield* put(
         pnActivationUpsert.failure(new Error(readableReport(result.left)))
       );
+      action.payload.onFailure?.();
     } else if (result.right.status === 204) {
       trackPNServiceStatusChangeSuccess(activation_status);
       yield* put(pnActivationUpsert.success(activation_status));
+      action.payload.onSuccess?.();
     } else {
       yield* call(reportPNServiceStatusOnFailure, !activation_status);
       yield* put(
@@ -51,6 +53,7 @@ function* handlePnActivation(
           new Error(`response status ${result.right.status}`)
         )
       );
+      action.payload.onFailure?.();
     }
   } catch (e) {
     yield* call(reportPNServiceStatusOnFailure, !activation_status);

--- a/ts/features/services/components/CardWithMarkdownContent.tsx
+++ b/ts/features/services/components/CardWithMarkdownContent.tsx
@@ -2,6 +2,7 @@ import React, { memo } from "react";
 import { StyleSheet, View } from "react-native";
 import { IOColors } from "@pagopa/io-app-design-system";
 import { Markdown } from "../../../components/ui/Markdown/Markdown";
+import { LoadingSkeleton } from "../../../components/ui/Markdown/LoadingSkeleton";
 
 const styles = StyleSheet.create({
   card: {
@@ -31,4 +32,10 @@ const CardWithMarkdownContent = memo(
   )
 );
 
-export { CardWithMarkdownContent };
+const CardWithMarkdownContentSkeleton = () => (
+  <View style={styles.card}>
+    <LoadingSkeleton />
+  </View>
+);
+
+export { CardWithMarkdownContent, CardWithMarkdownContentSkeleton };

--- a/ts/features/services/components/ServiceDetailsFooterActions.tsx
+++ b/ts/features/services/components/ServiceDetailsFooterActions.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { Easing, StyleProp, StyleSheet, View, ViewStyle } from "react-native";
+import { easeGradient } from "react-native-easing-gradient";
+import LinearGradient from "react-native-linear-gradient";
+import Animated from "react-native-reanimated";
+import {
+  IOColors,
+  IOVisualCostants,
+  WithTestID,
+  hexToRgba
+} from "@pagopa/io-app-design-system";
+import { ServiceStandardActions } from "./ServiceStandardActions";
+import { ServiceSpecialAction } from "./ServiceSpecialAction";
+
+const HEADER_BG_COLOR: IOColors = "white";
+
+const styles = StyleSheet.create({
+  buttonContainer: {
+    paddingHorizontal: IOVisualCostants.appMarginDefault,
+    width: "100%",
+    flex: 1,
+    flexShrink: 0,
+    justifyContent: "flex-end"
+  },
+  gradientContainer: {
+    ...StyleSheet.absoluteFillObject
+  }
+});
+
+type BottomActionsDimensions = {
+  bottomMargin: number;
+  safeBottomAreaHeight: number;
+};
+
+type ServiceDetailsFooterActionsProps = WithTestID<{
+  dimensions: BottomActionsDimensions;
+  transitionAnimStyle: Animated.AnimateStyle<StyleProp<ViewStyle>>;
+  children?: React.ReactNode;
+  debugMode?: boolean;
+  specialActionProps?: React.ComponentProps<typeof ServiceSpecialAction>;
+  standardActionsProps?: React.ComponentProps<typeof ServiceStandardActions>;
+}>;
+
+const { colors, locations } = easeGradient({
+  colorStops: {
+    0: { color: hexToRgba(IOColors[HEADER_BG_COLOR], 0) },
+    1: { color: IOColors[HEADER_BG_COLOR] }
+  },
+  easing: Easing.ease,
+  extraColorStopsPerTransition: 20
+});
+
+export const ServiceDetailsFooterActions = ({
+  dimensions,
+  transitionAnimStyle,
+  debugMode = false,
+  specialActionProps,
+  standardActionsProps,
+  testID
+}: ServiceDetailsFooterActionsProps) => {
+  const { bottomMargin, safeBottomAreaHeight } = dimensions;
+
+  return (
+    <View
+      style={{
+        width: "100%",
+        position: "absolute",
+        bottom: 0,
+        height: bottomMargin + safeBottomAreaHeight,
+        paddingBottom: bottomMargin
+      }}
+      testID={testID}
+      pointerEvents="box-none"
+    >
+      <Animated.View
+        style={[
+          styles.gradientContainer,
+          debugMode && {
+            borderTopColor: IOColors["error-500"],
+            borderTopWidth: 1,
+            backgroundColor: hexToRgba(IOColors["error-500"], 0.5)
+          },
+          transitionAnimStyle
+        ]}
+        pointerEvents="none"
+      >
+        <LinearGradient
+          style={{
+            height: (bottomMargin + safeBottomAreaHeight) * 0.45
+          }}
+          locations={locations}
+          colors={colors}
+        />
+        <View
+          style={{
+            bottom: 0,
+            height: (bottomMargin + safeBottomAreaHeight) * 0.55,
+            backgroundColor: IOColors[HEADER_BG_COLOR]
+          }}
+        />
+      </Animated.View>
+
+      <View style={styles.buttonContainer} pointerEvents="box-none">
+        {specialActionProps && <ServiceSpecialAction {...specialActionProps} />}
+        {standardActionsProps && (
+          <ServiceStandardActions {...standardActionsProps} />
+        )}
+      </View>
+    </View>
+  );
+};

--- a/ts/features/services/components/ServiceDetailsHeader.tsx
+++ b/ts/features/services/components/ServiceDetailsHeader.tsx
@@ -3,10 +3,14 @@ import { ImageURISource, StyleSheet, View } from "react-native";
 import {
   Avatar,
   H3,
+  IOColors,
   IOSpacingScale,
   IOStyles,
-  LabelSmall
+  IOVisualCostants,
+  LabelSmall,
+  VSpacer
 } from "@pagopa/io-app-design-system";
+import Placeholder from "rn-placeholder";
 
 const ITEM_PADDING_VERTICAL: IOSpacingScale = 6;
 const AVATAR_MARGIN_RIGHT: IOSpacingScale = 16;
@@ -43,6 +47,45 @@ export const ServiceDetailsHeader = ({
       <LabelSmall fontSize="regular" color="grey-700">
         {organizationName}
       </LabelSmall>
+    </View>
+  </View>
+);
+
+export const ServiceDetailsHeaderSkeleton = () => (
+  <View style={styles.container} accessible={true}>
+    <View style={styles.itemAvatar}>
+      <Placeholder.Box
+        width={IOVisualCostants.avatarSizeMedium}
+        height={IOVisualCostants.avatarSizeMedium}
+        animate="fade"
+        radius={IOVisualCostants.avatarRadiusSizeMedium}
+        color={IOColors["grey-200"]}
+      />
+    </View>
+    <View style={IOStyles.flex}>
+      <Placeholder.Box
+        animate="fade"
+        color={IOColors["grey-200"]}
+        height={16}
+        width={"100%"}
+        radius={8}
+      />
+      <VSpacer size={8} />
+      <Placeholder.Box
+        animate="fade"
+        color={IOColors["grey-200"]}
+        height={16}
+        width={"80%"}
+        radius={8}
+      />
+      <VSpacer size={8} />
+      <Placeholder.Box
+        animate="fade"
+        color={IOColors["grey-200"]}
+        height={8}
+        width={"60%"}
+        radius={8}
+      />
     </View>
   </View>
 );

--- a/ts/features/services/components/ServiceDetailsMetadata.tsx
+++ b/ts/features/services/components/ServiceDetailsMetadata.tsx
@@ -1,0 +1,189 @@
+import React, { useCallback } from "react";
+import { FlatList, Linking, ListRenderItemInfo, Platform } from "react-native";
+import {
+  Divider,
+  ListItemAction,
+  ListItemHeader,
+  ListItemInfo,
+  ListItemInfoCopy
+} from "@pagopa/io-app-design-system";
+import { ServiceId } from "../../../../definitions/backend/ServiceId";
+import I18n from "../../../i18n";
+import { useIOSelector } from "../../../store/hooks";
+import { serviceMetadataByIdSelector } from "../store/reducers/servicesById";
+import { clipboardSetStringWithFeedback } from "../../../utils/clipboard";
+import { openWebUrl } from "../../../utils/url";
+
+type MetadataActionListItem = {
+  kind: "ListItemAction";
+  condition?: boolean;
+} & Omit<ListItemAction, "accessibilityLabel" | "variant">;
+
+type MetadataInfoListItem = {
+  kind: "ListItemInfo";
+  condition?: boolean;
+} & Omit<ListItemInfo, "accessibilityLabel">;
+
+type MetadataInfoCopyListItem = {
+  kind: "ListItemInfoCopy";
+  condition?: boolean;
+} & Omit<ListItemInfoCopy, "accessibilityLabel">;
+
+type MetadataListItem =
+  | MetadataActionListItem
+  | MetadataInfoListItem
+  | MetadataInfoCopyListItem;
+
+export type ServiceDetailsMetadataProps = {
+  organizationFiscalCode: string;
+  serviceId: ServiceId;
+};
+
+export const ServiceDetailsMetadata = ({
+  organizationFiscalCode,
+  serviceId
+}: ServiceDetailsMetadataProps) => {
+  const serviceMetadataById = useIOSelector(state =>
+    serviceMetadataByIdSelector(state, serviceId)
+  );
+
+  const {
+    app_android,
+    app_ios,
+    address,
+    email,
+    pec,
+    phone,
+    support_url,
+    web_url
+  } = serviceMetadataById || {};
+
+  const metadataListItems: ReadonlyArray<MetadataListItem> = [
+    {
+      kind: "ListItemAction",
+      condition: !!web_url,
+      icon: "website",
+      label: I18n.t("services.details.metadata.website"),
+      onPress: () => openWebUrl(`${web_url}`),
+      testID: "service-details-metadata-web-url"
+    },
+    {
+      kind: "ListItemAction",
+      condition: Platform.OS === "android" && !!app_android,
+      icon: "device",
+      label: I18n.t("services.details.metadata.downloadApp"),
+      onPress: () => openWebUrl(`${app_android}`),
+      testID: "service-details-metadata-app-android"
+    },
+    {
+      kind: "ListItemAction",
+      condition: Platform.OS === "ios" && !!app_ios,
+      icon: "device",
+      label: I18n.t("services.details.metadata.downloadApp"),
+      onPress: () => openWebUrl(`${app_ios}`),
+      testID: "service-details-metadata-app-ios"
+    },
+    {
+      kind: "ListItemAction",
+      condition: !!support_url,
+      icon: "chat",
+      label: I18n.t("services.details.metadata.support"),
+      onPress: () => openWebUrl(`${support_url}`),
+      testID: "service-details-metadata-support-url"
+    },
+    {
+      kind: "ListItemAction",
+      icon: "phone",
+      condition: !!phone,
+      label: I18n.t("services.details.metadata.phone"),
+      onPress: () => Linking.openURL(`tel:${phone}`),
+      testID: "service-details-metadata-phone"
+    },
+    {
+      kind: "ListItemAction",
+      condition: !!email,
+      icon: "email",
+      label: I18n.t("services.details.metadata.email"),
+      onPress: () => Linking.openURL(`mailto:${email}`),
+      testID: "service-details-metadata-email"
+    },
+    {
+      kind: "ListItemAction",
+      condition: !!pec,
+      icon: "pec",
+      label: I18n.t("services.details.metadata.pec"),
+      onPress: () => Linking.openURL(`mailto:${pec}`),
+      testID: "service-details-metadata-pec"
+    },
+    {
+      kind: "ListItemInfoCopy",
+      label: I18n.t("services.details.metadata.fiscalCode"),
+      icon: "entityCode",
+      onPress: () => clipboardSetStringWithFeedback(organizationFiscalCode),
+      value: organizationFiscalCode,
+      testID: "service-details-metadata-org-fiscal-code"
+    },
+    {
+      kind: "ListItemInfo",
+      condition: !!address,
+      icon: "mapPin",
+      label: I18n.t("services.details.metadata.address"),
+      testID: "service-details-metadata-address",
+      value: address
+    },
+
+    {
+      kind: "ListItemInfo",
+      icon: "pinOff",
+      label: I18n.t("services.details.metadata.serviceId"),
+      testID: "service-details-metadata-service-id",
+      value: serviceId
+    }
+  ];
+
+  const filteredMetadataListItems = metadataListItems.filter(
+    item => item.condition !== false
+  );
+
+  const renderItem = useCallback(
+    ({
+      item: { condition, ...rest }
+    }: ListRenderItemInfo<MetadataListItem>) => {
+      switch (rest.kind) {
+        case "ListItemAction":
+          return (
+            <ListItemAction
+              variant="primary"
+              {...rest}
+              accessibilityLabel={rest.label}
+            />
+          );
+        case "ListItemInfo":
+          return <ListItemInfo {...rest} accessibilityLabel={rest.label} />;
+        case "ListItemInfoCopy":
+          return <ListItemInfoCopy {...rest} accessibilityLabel={rest.label} />;
+        default:
+          return null;
+      }
+    },
+    []
+  );
+
+  const ListHeaderComponent = (
+    <ListItemHeader
+      label={I18n.t("services.details.metadata.title")}
+      testID="service-details-metadata-header"
+    />
+  );
+
+  return (
+    <FlatList
+      ListHeaderComponent={ListHeaderComponent}
+      ItemSeparatorComponent={() => <Divider />}
+      data={filteredMetadataListItems}
+      keyExtractor={item => item.label}
+      renderItem={renderItem}
+      scrollEnabled={false}
+    />
+  );
+};

--- a/ts/features/services/components/ServiceDetailsPreferences.tsx
+++ b/ts/features/services/components/ServiceDetailsPreferences.tsx
@@ -71,12 +71,8 @@ export const ServiceDetailsPreferences = ({
     serviceMetadataInfoSelector(state, serviceId)
   );
 
-  const isInboxPreferenceEnabled = pipe(
-    servicePreferenceResponseSuccess,
-    O.fromNullable,
-    O.map(servicePreference => servicePreference.value.inbox),
-    O.getOrElse(() => false)
-  );
+  const isInboxPreferenceEnabled =
+    servicePreferenceResponseSuccess?.value.inbox ?? false;
 
   useEffect(() => {
     if (!isFirstRender && isErrorServicePreference) {

--- a/ts/features/services/components/ServiceDetailsScreenComponent.tsx
+++ b/ts/features/services/components/ServiceDetailsScreenComponent.tsx
@@ -1,0 +1,285 @@
+import React, { useCallback, useMemo, useRef } from "react";
+import { StyleSheet } from "react-native";
+import Animated, {
+  Easing,
+  useAnimatedScrollHandler,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming
+} from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import {
+  IOSpacingScale,
+  IOVisualCostants,
+  buttonSolidHeight
+} from "@pagopa/io-app-design-system";
+import { useLinkTo } from "@react-navigation/native";
+import { pipe } from "fp-ts/lib/function";
+import * as O from "fp-ts/lib/Option";
+import { ServiceId } from "../../../../definitions/backend/ServiceId";
+import { useHeaderSecondLevel } from "../../../hooks/useHeaderSecondLevel";
+import { useIOSelector } from "../../../store/hooks";
+import { CTA, CTAS } from "../../messages/types/MessageCTA";
+import { getServiceCTA, handleCtaAction } from "../../messages/utils/messages";
+import {
+  serviceMetadataByIdSelector,
+  serviceMetadataInfoSelector
+} from "../store/reducers/servicesById";
+import { ServiceDetailsFooterActions } from "./ServiceDetailsFooterActions";
+import { ServiceStandardActions } from "./ServiceStandardActions";
+import { ServiceSpecialAction } from "./ServiceSpecialAction";
+
+const scrollTriggerOffsetValue: number = 88;
+const gradientSafeArea: IOSpacingScale = 16;
+
+const styles = StyleSheet.create({
+  scrollContentContainer: {
+    flexGrow: 1
+  }
+});
+
+type StandardActionsProps = {
+  props: React.ComponentProps<typeof ServiceStandardActions> | undefined;
+  offset: number;
+};
+
+type SpecialActionProps = {
+  props: React.ComponentProps<typeof ServiceSpecialAction> | undefined;
+  offset: number;
+};
+
+type ServiceDetailsScreenComponentProps = {
+  children: React.ReactNode;
+  serviceId: ServiceId;
+  activate?: boolean;
+  isLoading?: boolean;
+  title?: string;
+};
+
+export const ServiceDetailsScreenComponent = ({
+  children,
+  serviceId,
+  activate,
+  isLoading = false,
+  title = ""
+}: ServiceDetailsScreenComponentProps) => {
+  const linkTo = useLinkTo();
+
+  const safeBottomAreaHeight = useRef(0);
+  const safeAreaInsets = useSafeAreaInsets();
+
+  const gradientOpacity = useSharedValue(1);
+  const scrollTranslationY = useSharedValue(0);
+
+  const bottomMargin: number = useMemo(
+    () =>
+      safeAreaInsets.bottom === 0
+        ? IOVisualCostants.appMarginDefault
+        : safeAreaInsets.bottom,
+    [safeAreaInsets]
+  );
+
+  useHeaderSecondLevel({
+    title,
+    supportRequest: true,
+    transparent: true,
+    scrollValues: {
+      triggerOffset: scrollTriggerOffsetValue,
+      contentOffsetY: scrollTranslationY
+    }
+  });
+
+  const footerGradientOpacityTransition = useAnimatedStyle(() => ({
+    opacity: withTiming(gradientOpacity.value, {
+      duration: 200,
+      easing: Easing.ease
+    })
+  }));
+
+  const scrollHandler = useAnimatedScrollHandler(
+    ({ contentOffset, layoutMeasurement, contentSize }) => {
+      // eslint-disable-next-line functional/immutable-data
+      scrollTranslationY.value = contentOffset.y;
+
+      const isEndReached =
+        Math.floor(layoutMeasurement.height + contentOffset.y) >=
+        Math.floor(contentSize.height);
+
+      // eslint-disable-next-line functional/immutable-data
+      gradientOpacity.value = isEndReached ? 0 : 1;
+    }
+  );
+
+  const serviceMetadata = useIOSelector(state =>
+    serviceMetadataByIdSelector(state, serviceId)
+  );
+
+  const serviceMetadataInfo = useIOSelector(state =>
+    serviceMetadataInfoSelector(state, serviceId)
+  );
+
+  const maybeServiceCtas = useMemo(
+    () => getServiceCTA(serviceMetadata),
+    [serviceMetadata]
+  );
+
+  const handlePressCta = useCallback(
+    (cta: CTA) => handleCtaAction(cta, linkTo, serviceId),
+    [linkTo, serviceId]
+  );
+
+  const getPropsForStandardActions = useCallback(
+    (
+      ctas: CTAS,
+      isCustomCtaVisible: boolean = false
+    ): StandardActionsProps | undefined => {
+      if (isCustomCtaVisible && ctas.cta_1 && ctas.cta_2) {
+        const { cta_1, cta_2 } = ctas;
+
+        return {
+          offset: buttonSolidHeight * 2,
+          props: {
+            type: "TwoCtasWithCustomFlow",
+            primaryActionProps: {
+              label: cta_1.text,
+              accessibilityLabel: cta_1.text,
+              onPress: () => handlePressCta(cta_1)
+            },
+            secondaryActionProps: {
+              label: cta_2.text,
+              accessibilityLabel: cta_2.text,
+              onPress: () => handlePressCta(cta_2)
+            }
+          }
+        };
+      }
+
+      if (isCustomCtaVisible && ctas.cta_1) {
+        const { cta_1 } = ctas;
+
+        return {
+          offset: buttonSolidHeight,
+          props: {
+            type: "SingleCtaWithCustomFlow",
+            primaryActionProps: {
+              label: cta_1.text,
+              accessibilityLabel: cta_1.text,
+              onPress: () => handlePressCta(cta_1)
+            }
+          }
+        };
+      }
+
+      if (ctas.cta_1 && ctas.cta_2) {
+        const { cta_1, cta_2 } = ctas;
+
+        return {
+          offset: buttonSolidHeight * 2,
+          props: {
+            type: "TwoCtas",
+            primaryActionProps: {
+              label: cta_1.text,
+              accessibilityLabel: cta_1.text,
+              onPress: () => handlePressCta(cta_1)
+            },
+            secondaryActionProps: {
+              label: cta_2.text,
+              accessibilityLabel: cta_2.text,
+              onPress: () => handlePressCta(cta_2)
+            }
+          }
+        };
+      }
+
+      if (ctas.cta_1) {
+        return {
+          offset: buttonSolidHeight,
+          props: {
+            type: "SingleCta",
+            primaryActionProps: {
+              label: ctas.cta_1.text,
+              accessibilityLabel: ctas.cta_1.text,
+              onPress: () => handlePressCta(ctas.cta_1)
+            }
+          }
+        };
+      }
+
+      return undefined;
+    },
+    [handlePressCta]
+  );
+
+  const footerComponent = () => {
+    const standardActions = pipe(
+      maybeServiceCtas,
+      O.chain(ctas =>
+        pipe(
+          getPropsForStandardActions(
+            ctas,
+            serviceMetadataInfo?.isSpecialService
+          ),
+          O.fromNullable
+        )
+      ),
+      O.getOrElse<StandardActionsProps>(() => ({
+        offset: 0,
+        props: undefined
+      }))
+    );
+
+    const specialAction = pipe(
+      serviceMetadataInfo?.isSpecialService,
+      O.fromNullable,
+      O.map(() => ({
+        offset: buttonSolidHeight,
+        props: {
+          serviceId,
+          customSpecialFlowOpt: serviceMetadataInfo?.customSpecialFlow,
+          activate
+        }
+      })),
+      O.getOrElse<SpecialActionProps>(() => ({
+        offset: 0,
+        props: undefined
+      }))
+    );
+
+    // eslint-disable-next-line functional/immutable-data
+    safeBottomAreaHeight.current =
+      standardActions.offset + specialAction.offset + gradientSafeArea;
+
+    return (
+      <ServiceDetailsFooterActions
+        dimensions={{
+          bottomMargin,
+          safeBottomAreaHeight: safeBottomAreaHeight.current
+        }}
+        specialActionProps={specialAction.props}
+        standardActionsProps={standardActions.props}
+        transitionAnimStyle={footerGradientOpacityTransition}
+      />
+    );
+  };
+
+  return (
+    <>
+      <Animated.ScrollView
+        contentContainerStyle={[
+          styles.scrollContentContainer,
+          {
+            paddingBottom: bottomMargin + safeBottomAreaHeight.current
+          }
+        ]}
+        onScroll={scrollHandler}
+        scrollEventThrottle={16}
+        snapToOffsets={[0, scrollTriggerOffsetValue]}
+        snapToEnd={false}
+        decelerationRate="normal"
+      >
+        {children}
+      </Animated.ScrollView>
+      {!isLoading && footerComponent()}
+    </>
+  );
+};

--- a/ts/features/services/components/ServiceDetailsTosAndPrivacy.tsx
+++ b/ts/features/services/components/ServiceDetailsTosAndPrivacy.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback } from "react";
+import { FlatList, ListRenderItemInfo } from "react-native";
+import {
+  Divider,
+  ListItemAction,
+  ListItemHeader,
+  VSpacer
+} from "@pagopa/io-app-design-system";
+import I18n from "../../../i18n";
+import { openWebUrl } from "../../../utils/url";
+import { useIOSelector } from "../../../store/hooks";
+import { serviceMetadataByIdSelector } from "../store/reducers/servicesById";
+import { ServiceId } from "../../../../definitions/backend/ServiceId";
+
+type TosAndPrivacyListItem = {
+  condition?: boolean;
+} & Omit<ListItemAction, "variant" | "accessibilityLabel">;
+
+export type ServiceDetailsTosAndPrivacyProps = {
+  serviceId: ServiceId;
+};
+
+export const ServiceDetailsTosAndPrivacy = ({
+  serviceId
+}: ServiceDetailsTosAndPrivacyProps) => {
+  const serviceMetadataById = useIOSelector(state =>
+    serviceMetadataByIdSelector(state, serviceId)
+  );
+
+  const { privacy_url, tos_url } = serviceMetadataById || {};
+
+  const tosAndPrivacyListItems: ReadonlyArray<TosAndPrivacyListItem> = [
+    {
+      condition: !!tos_url,
+      icon: "terms",
+      label: I18n.t("services.details.tosAndPrivacy.tosLink"),
+      onPress: () => openWebUrl(`${tos_url}`)
+    },
+    {
+      condition: !!privacy_url,
+      icon: "security",
+      label: I18n.t("services.details.tosAndPrivacy.privacyLink"),
+      onPress: () => openWebUrl(`${privacy_url}`)
+    }
+  ];
+
+  const filteredTosAndPrivacyListItems = tosAndPrivacyListItems.filter(
+    item => item.condition !== false
+  );
+
+  const renderItem = useCallback(
+    ({
+      item: { condition, ...rest }
+    }: ListRenderItemInfo<TosAndPrivacyListItem>) => (
+      <ListItemAction
+        {...rest}
+        accessibilityLabel={rest.label}
+        variant="primary"
+      />
+    ),
+    []
+  );
+
+  if (filteredTosAndPrivacyListItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <VSpacer size={40} />
+      <FlatList
+        ListHeaderComponent={
+          <ListItemHeader
+            label={I18n.t("services.details.tosAndPrivacy.title")}
+          />
+        }
+        ItemSeparatorComponent={() => <Divider />}
+        data={filteredTosAndPrivacyListItems}
+        keyExtractor={item => item.label}
+        renderItem={renderItem}
+        scrollEnabled={false}
+      />
+    </>
+  );
+};

--- a/ts/features/services/components/ServiceSpecialAction.tsx
+++ b/ts/features/services/components/ServiceSpecialAction.tsx
@@ -1,0 +1,115 @@
+import React, { useCallback } from "react";
+import { ButtonSolid } from "@pagopa/io-app-design-system";
+import * as O from "fp-ts/lib/Option";
+import * as B from "fp-ts/lib/boolean";
+import { constNull, pipe } from "fp-ts/lib/function";
+import { ServiceId } from "../../../../definitions/backend/ServiceId";
+import { cdcEnabled } from "../../../config";
+import I18n from "../../../i18n";
+import { useIOSelector } from "../../../store/hooks";
+import {
+  isCGNEnabledSelector,
+  isCdcEnabledSelector,
+  isPnEnabledSelector,
+  isPnSupportedSelector
+} from "../../../store/reducers/backendStatus";
+import { openAppStoreUrl } from "../../../utils/url";
+import { CgnServiceCta } from "../../bonus/cgn/components/CgnServiceCTA";
+import { PnServiceCta } from "../../pn/components/ServiceCTA";
+
+type SpecialServiceConfig = {
+  isEnabled: boolean;
+  isSupported: boolean;
+};
+
+type ServiceSpecialActionProps = {
+  customSpecialFlowOpt?: string;
+  serviceId: ServiceId;
+  activate?: boolean;
+};
+
+const UpdateAppCta = () => {
+  const handleOnPress = useCallback(() => openAppStoreUrl(), []);
+
+  return (
+    <ButtonSolid
+      fullWidth
+      accessibilityLabel={I18n.t("btnUpdateApp")}
+      label={I18n.t("btnUpdateApp")}
+      onPress={handleOnPress}
+    />
+  );
+};
+
+const renderCta = (
+  isEnabled: boolean,
+  isSupported: boolean,
+  cta: JSX.Element
+) =>
+  pipe(
+    isEnabled,
+    B.fold(constNull, () =>
+      pipe(
+        isSupported,
+        B.fold(
+          () => <UpdateAppCta />,
+          () => cta
+        )
+      )
+    )
+  );
+
+export const ServiceSpecialAction = ({
+  serviceId,
+  activate,
+  customSpecialFlowOpt
+}: ServiceSpecialActionProps) => {
+  const isCGNEnabled = useIOSelector(isCGNEnabledSelector);
+  const cdcEnabledSelector = useIOSelector(isCdcEnabledSelector);
+
+  const isCdcEnabled = cdcEnabledSelector && cdcEnabled;
+
+  const isPnEnabled = useIOSelector(isPnEnabledSelector);
+  const isPnSupported = useIOSelector(isPnSupportedSelector);
+
+  const mapSpecialServiceConfig = new Map<string, SpecialServiceConfig>([
+    ["cgn", { isEnabled: isCGNEnabled, isSupported: true }],
+    ["cdc", { isEnabled: isCdcEnabled, isSupported: true }],
+    ["pn", { isEnabled: isPnEnabled, isSupported: isPnSupported }]
+  ]);
+
+  return pipe(
+    customSpecialFlowOpt,
+    O.fromNullable,
+    O.fold(constNull, csf =>
+      pipe(
+        mapSpecialServiceConfig.get(csf),
+        O.fromNullable,
+        O.fold(
+          () => <UpdateAppCta />,
+          ({ isEnabled, isSupported }) => {
+            switch (csf) {
+              case "cgn":
+                return renderCta(
+                  isEnabled,
+                  isSupported,
+                  <CgnServiceCta serviceId={serviceId} />
+                );
+              case "cdc":
+                // CdC is disabled: the flow needs to be reviewed
+                return null;
+              case "pn":
+                return renderCta(
+                  isEnabled,
+                  isSupported,
+                  <PnServiceCta serviceId={serviceId} activate={activate} />
+                );
+              default:
+                return <UpdateAppCta />;
+            }
+          }
+        )
+      )
+    )
+  );
+};

--- a/ts/features/services/components/ServiceStandardActions.tsx
+++ b/ts/features/services/components/ServiceStandardActions.tsx
@@ -1,0 +1,82 @@
+import React, { ComponentProps } from "react";
+import { StyleSheet, View } from "react-native";
+import {
+  ButtonLink,
+  ButtonOutline,
+  ButtonSolid,
+  IOStyles,
+  VSpacer
+} from "@pagopa/io-app-design-system";
+
+const styles = StyleSheet.create({
+  actionsContainer: {
+    flex: 1,
+    justifyContent: "flex-end"
+  }
+});
+
+export type ServiceStandardActionsProps =
+  | {
+      type: "SingleCta";
+      primaryActionProps: Omit<ComponentProps<typeof ButtonSolid>, "fullWidth">;
+      secondaryActionProps?: never;
+    }
+  | {
+      type: "SingleCtaWithCustomFlow";
+      primaryActionProps: ComponentProps<typeof ButtonLink>;
+      secondaryActionProps?: never;
+    }
+  | {
+      type: "TwoCtas";
+      primaryActionProps: Omit<ComponentProps<typeof ButtonSolid>, "fullWidth">;
+      secondaryActionProps: ComponentProps<typeof ButtonLink>;
+    }
+  | {
+      type: "TwoCtasWithCustomFlow";
+      primaryActionProps: Omit<
+        ComponentProps<typeof ButtonOutline>,
+        "fullWidth"
+      >;
+      secondaryActionProps: ComponentProps<typeof ButtonLink>;
+    };
+
+export const ServiceStandardActions = (props: ServiceStandardActionsProps) => {
+  const BlockCtas = () => {
+    switch (props.type) {
+      case "SingleCta":
+        return <ButtonSolid fullWidth {...props.primaryActionProps} />;
+      case "SingleCtaWithCustomFlow":
+        return (
+          <View style={IOStyles.selfCenter}>
+            <ButtonLink {...props.primaryActionProps} />
+          </View>
+        );
+      case "TwoCtas":
+        return (
+          <>
+            <ButtonSolid fullWidth {...props.primaryActionProps} />
+            <VSpacer size={24} />
+            <View style={IOStyles.selfCenter}>
+              <ButtonLink {...props.secondaryActionProps} />
+            </View>
+          </>
+        );
+      case "TwoCtasWithCustomFlow":
+        return (
+          <>
+            <ButtonOutline fullWidth {...props.primaryActionProps} />
+            <VSpacer size={24} />
+            <View style={IOStyles.selfCenter}>
+              <ButtonLink {...props.secondaryActionProps} />
+            </View>
+          </>
+        );
+    }
+  };
+
+  return (
+    <View style={styles.actionsContainer}>
+      <BlockCtas />
+    </View>
+  );
+};

--- a/ts/features/services/screens/ServiceDetailsScreen.tsx
+++ b/ts/features/services/screens/ServiceDetailsScreen.tsx
@@ -12,9 +12,15 @@ import { IOStackNavigationRouteProps } from "../../../navigation/params/AppParam
 import { loadServiceDetail } from "../../../store/actions/services";
 import { useIODispatch, useIOSelector } from "../../../store/hooks";
 import { logosForService } from "../../../utils/services";
-import { CardWithMarkdownContent } from "../components/CardWithMarkdownContent";
+import {
+  CardWithMarkdownContent,
+  CardWithMarkdownContentSkeleton
+} from "../components/CardWithMarkdownContent";
 import { ServiceDetailsFailure } from "../components/ServiceDetailsFailure";
-import { ServiceDetailsHeader } from "../components/ServiceDetailsHeader";
+import {
+  ServiceDetailsHeader,
+  ServiceDetailsHeaderSkeleton
+} from "../components/ServiceDetailsHeader";
 import { ServiceDetailsMetadata } from "../components/ServiceDetailsMetadata";
 import { ServiceDetailsPreferences } from "../components/ServiceDetailsPreferences";
 import { ServiceDetailsScreenComponent } from "../components/ServiceDetailsScreenComponent";
@@ -91,7 +97,33 @@ export const ServiceDetailsScreen = ({ route }: ServiceDetailsScreenProps) => {
   }
 
   if (isLoadingService) {
-    // TODO: add a loading screen
+    return (
+      <ServiceDetailsScreenComponent
+        activate={activate}
+        isLoading={true}
+        serviceId={serviceId}
+      >
+        <View
+          style={[
+            styles.headerContainer,
+            {
+              paddingTop: windowHeight + headerHeight,
+              marginTop: -windowHeight
+            }
+          ]}
+        >
+          <ContentWrapper>
+            <ServiceDetailsHeaderSkeleton />
+            <VSpacer size={16} />
+          </ContentWrapper>
+        </View>
+        <ContentWrapper>
+          <View style={styles.cardContainer}>
+            <CardWithMarkdownContentSkeleton />
+          </View>
+        </ContentWrapper>
+      </ServiceDetailsScreenComponent>
+    );
   }
 
   const {

--- a/ts/screens/services/LegacyServiceDetailsScreen.tsx
+++ b/ts/screens/services/LegacyServiceDetailsScreen.tsx
@@ -19,7 +19,7 @@ import BaseScreenComponent, {
 import { EdgeBorderComponent } from "../../components/screens/EdgeBorderComponent";
 import ContactPreferencesToggles from "../../components/services/ContactPreferencesToggles";
 import ServiceMetadataComponent from "../../components/services/ServiceMetadata";
-import SpecialServicesCTA from "../../components/services/SpecialServices/SpecialServicesCTA";
+import LegacySpecialServicesCTA from "../../components/services/SpecialServices/LegacySpecialServicesCTA";
 import TosAndPrivacyBox from "../../components/services/TosAndPrivacyBox";
 import LegacyMarkdown from "../../components/ui/Markdown/LegacyMarkdown";
 import { FooterTopShadow } from "../../components/FooterTopShadow";
@@ -188,7 +188,7 @@ const LegacyServiceDetailsScreen = (props: Props) => {
             {!!specialServiceInfoOpt && (
               <>
                 <VSpacer size={8} />
-                <SpecialServicesCTA
+                <LegacySpecialServicesCTA
                   serviceId={serviceId}
                   customSpecialFlowOpt={
                     specialServiceInfoOpt.customSpecialFlowOpt


### PR DESCRIPTION
This pr depends on https://github.com/pagopa/io-app/pull/5677

## Short description
This PR adds the skeleton for the loading state in `ServiceDetailsScreen`.

<details open><summary>Details</summary>
<p>

| service details  |
| - |
| <video src="https://github.com/pagopa/io-app/assets/29163287/befbec7c-57cb-42c7-9067-de424e8d49e7" width="300"/> |

</p>
</details> 

## List of changes proposed in this pull request
- updated ServiceDetailsScreen in order to display the skeleton

## How to test
Using `io-dev-api-server`, navigate to the services tab and tap a service. Check that the screen is displayed correctly.
