### PR TITLE
chore(Cross): [IOAPPX-282] Move Mixpanel URL into env file

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -30,6 +30,8 @@ CONTENT_REPO_URL='http://127.0.0.1:3000/static_contents'
 PRIVACY_URL='https://io.italia.it/app-content/tos_privacy.html'
 # Privacy url for Zendesk usage
 ZENDESK_PRIVACY_URL='https://www.pagopa.it/it/privacy-policy-assistenza/'
+# Mixpanel 
+MIXPANEL_URL='https://api-eu.mixpanel.com'
 MIXPANEL_TOKEN='0cb505dace6f4b3ceb9e17c7fcd7c66f'
 # Test overlay caption, if the string is nonempty will be displayed in the TestOverlay
 # TEST_OVERLAY_CAPTION='Functionality name here!'

--- a/.env.production
+++ b/.env.production
@@ -30,6 +30,8 @@ CONTENT_REPO_URL='https://assets.cdn.io.pagopa.it'
 PRIVACY_URL='https://io.italia.it/app-content/tos_privacy.html'
 # Privacy url for Zendesk usage
 ZENDESK_PRIVACY_URL='https://www.pagopa.it/it/privacy-policy-assistenza/'
+# Mixpanel 
+MIXPANEL_URL='https://api-eu.mixpanel.com'
 MIXPANEL_TOKEN='0cb505dace6f4b3ceb9e17c7fcd7c66f'
 # Test overlay caption, if the string is nonempty will be displayed in the TestOverlay
 # TEST_OVERLAY_CAPTION='Functionality name here!'

--- a/ts/config.ts
+++ b/ts/config.ts
@@ -43,10 +43,18 @@ const DEFAULT_TOT_SERVICE_FETCH_WORKERS = 5;
 // https://pagopa.atlassian.net/browse/IA-474
 const DEFAULT_PAGE_SIZE = 12;
 
+// Default mixpanel EU url
+const DEFAULT_MIXPANEL_URL = "https://api-eu.mixpanel.com";
+
 export const environment: string = Config.ENVIRONMENT;
 export const apiUrlPrefix: string = Config.API_URL_PREFIX;
 export const pagoPaApiUrlPrefix: string = Config.PAGOPA_API_URL_PREFIX;
 export const pagoPaApiUrlPrefixTest: string = Config.PAGOPA_API_URL_PREFIX_TEST;
+export const mixpanelUrl = pipe(
+  Config.MIXPANEL_URL,
+  NonEmptyString.decode,
+  E.getOrElse(() => DEFAULT_MIXPANEL_URL)
+);
 export const mixpanelToken: string = Config.MIXPANEL_TOKEN;
 export const isDebugBiometricIdentificationEnabled =
   Config.DEBUG_BIOMETRIC_IDENTIFICATION === "YES";

--- a/ts/mixpanel.ts
+++ b/ts/mixpanel.ts
@@ -1,5 +1,5 @@
 import { Mixpanel } from "mixpanel-react-native";
-import { mixpanelToken } from "./config";
+import { mixpanelToken, mixpanelUrl } from "./config";
 import { getDeviceId } from "./utils/device";
 import { GlobalState } from "./store/reducers/types";
 import { updateMixpanelSuperProperties } from "./mixpanelConfig/superProperties";
@@ -17,11 +17,7 @@ export const initializeMixPanel = async (state: GlobalState) => {
   }
   const trackAutomaticEvents = true;
   const privateInstance = new Mixpanel(mixpanelToken, trackAutomaticEvents);
-  await privateInstance.init(
-    undefined,
-    undefined,
-    "https://api-eu.mixpanel.com"
-  );
+  await privateInstance.init(undefined, undefined, mixpanelUrl);
   mixpanel = privateInstance;
   // On app first open
   // On profile page, when user opt-in


### PR DESCRIPTION
## Short description
This PR moves the Mixpanel URL into our env file.

## List of changes proposed in this pull request
- Adds the URL in `.env.local` and `.env.production`;
- Adds the constant in `config.ts`; 
- Remove the hardcoded URL from `mixpanel.ts`.

## How to test
Test if Mixpanel events are tracked properly.
