### PR TITLE
[IOPID-1579] Adopt the new DS on `RefreshTokenLoadingScreen`

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3534,6 +3534,8 @@ unsupportedDevice:
   cta:
     faq: "Learn more"
 fastLogin:
+  loadingScreen:
+    title: "Ti stiamo autenticando"
   userInteraction:
     sessionExpired:
       noPin:

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3534,6 +3534,8 @@ unsupportedDevice:
   cta:
     faq: "Come mai?"
 fastLogin:
+  loadingScreen:
+    title: "Ti stiamo autenticando"
   userInteraction:
     sessionExpired:
       noPin:

--- a/ts/components/screens/LoadingScreenContent.tsx
+++ b/ts/components/screens/LoadingScreenContent.tsx
@@ -1,0 +1,72 @@
+/**
+ * An ingress screen to choose the real first screen the user must navigate to.
+ */
+import * as React from "react";
+import { View, StyleSheet, Platform, AccessibilityInfo } from "react-native";
+import {
+  ContentWrapper,
+  H3,
+  IOStyles,
+  VSpacer
+} from "@pagopa/io-app-design-system";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { LoadingIndicator } from "../../components/ui/LoadingIndicator";
+import { useOnFirstRender } from "../../utils/hooks/useOnFirstRender";
+
+const styles = StyleSheet.create({
+  container: {
+    ...IOStyles.bgWhite,
+    ...IOStyles.centerJustified,
+    ...IOStyles.flex
+  },
+  contentTitle: {
+    textAlign: "center"
+  },
+  content: {
+    alignItems: "center"
+  }
+});
+
+const SPACE_BETWEEN_SPINNER_AND_TEXT = 24;
+
+type LoadingScreenContentProps = {
+  contentTitle: string;
+};
+
+export const LoadingScreenContent = (props: LoadingScreenContentProps) => {
+  const { contentTitle } = props;
+
+  useOnFirstRender(() => {
+    // Since the screen is shown for a very short time,
+    // we prefer to announce the content to the screen reader,
+    // instead of focusing the first element.
+    if (Platform.OS === "android") {
+      // We use it only on Android, because on iOS the screen reader
+      // stops reading the content when the ingress screen is unmounted
+      // and the focus is moved to another element.
+      AccessibilityInfo.announceForAccessibility(contentTitle);
+    }
+  });
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ContentWrapper>
+        <View style={styles.content}>
+          <View
+            accessible={false}
+            accessibilityElementsHidden={true}
+            importantForAccessibility={"no-hide-descendants"}
+          >
+            <LoadingIndicator />
+          </View>
+          <VSpacer size={SPACE_BETWEEN_SPINNER_AND_TEXT} />
+          <H3 style={styles.contentTitle} accessibilityLabel={contentTitle}>
+            {contentTitle}
+          </H3>
+        </View>
+      </ContentWrapper>
+    </SafeAreaView>
+  );
+};
+
+export default LoadingScreenContent;

--- a/ts/features/fastLogin/screens/RefreshTokenLoadingScreen.tsx
+++ b/ts/features/fastLogin/screens/RefreshTokenLoadingScreen.tsx
@@ -1,31 +1,8 @@
 import * as React from "react";
-import { Modal, View, StyleSheet } from "react-native";
-import {
-  ContentWrapper,
-  H3,
-  IOStyles,
-  VSpacer
-} from "@pagopa/io-app-design-system";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { Modal } from "react-native";
 import I18n from "../../../i18n";
 import { useAvoidHardwareBackButton } from "../../../utils/useAvoidHardwareBackButton";
-import { LoadingIndicator } from "../../../components/ui/LoadingIndicator";
-
-const styles = StyleSheet.create({
-  container: {
-    ...IOStyles.bgWhite,
-    ...IOStyles.centerJustified,
-    ...IOStyles.flex
-  },
-  contentTitle: {
-    textAlign: "center"
-  },
-  content: {
-    alignItems: "center"
-  }
-});
-
-const SPACE_BETWEEN_SPINNER_AND_TEXT = 24;
+import LoadingScreenContent from "../../../components/screens/LoadingScreenContent";
 
 const RefreshTokenLoadingScreen = () => {
   useAvoidHardwareBackButton();
@@ -34,23 +11,7 @@ const RefreshTokenLoadingScreen = () => {
 
   return (
     <Modal>
-      <SafeAreaView style={styles.container}>
-        <ContentWrapper>
-          <View style={styles.content}>
-            <View
-              accessible={false}
-              accessibilityElementsHidden={true}
-              importantForAccessibility={"no-hide-descendants"}
-            >
-              <LoadingIndicator />
-            </View>
-            <VSpacer size={SPACE_BETWEEN_SPINNER_AND_TEXT} />
-            <H3 style={styles.contentTitle} accessibilityLabel={contentTitle}>
-              {contentTitle}
-            </H3>
-          </View>
-        </ContentWrapper>
-      </SafeAreaView>
+      <LoadingScreenContent contentTitle={contentTitle} />
     </Modal>
   );
 };

--- a/ts/features/fastLogin/screens/RefreshTokenLoadingScreen.tsx
+++ b/ts/features/fastLogin/screens/RefreshTokenLoadingScreen.tsx
@@ -1,17 +1,56 @@
 import * as React from "react";
-import { Modal } from "react-native";
+import { Modal, View, StyleSheet } from "react-native";
+import {
+  ContentWrapper,
+  H3,
+  IOStyles,
+  VSpacer
+} from "@pagopa/io-app-design-system";
+import { SafeAreaView } from "react-native-safe-area-context";
+import I18n from "../../../i18n";
 import { useAvoidHardwareBackButton } from "../../../utils/useAvoidHardwareBackButton";
-import LoadingSpinnerOverlay from "../../../components/LoadingSpinnerOverlay";
-import { isDevEnv } from "../../../utils/environment";
-import { Body } from "../../../components/core/typography/Body";
+import { LoadingIndicator } from "../../../components/ui/LoadingIndicator";
+
+const styles = StyleSheet.create({
+  container: {
+    ...IOStyles.bgWhite,
+    ...IOStyles.centerJustified,
+    ...IOStyles.flex
+  },
+  contentTitle: {
+    textAlign: "center"
+  },
+  content: {
+    alignItems: "center"
+  }
+});
+
+const SPACE_BETWEEN_SPINNER_AND_TEXT = 24;
 
 const RefreshTokenLoadingScreen = () => {
   useAvoidHardwareBackButton();
 
+  const contentTitle = I18n.t("fastLogin.loadingScreen.title");
+
   return (
     <Modal>
-      <LoadingSpinnerOverlay isLoading={true} loadingOpacity={1} />
-      {isDevEnv && <Body>This is the RefreshTokenLoadingScreen</Body>}
+      <SafeAreaView style={styles.container}>
+        <ContentWrapper>
+          <View style={styles.content}>
+            <View
+              accessible={false}
+              accessibilityElementsHidden={true}
+              importantForAccessibility={"no-hide-descendants"}
+            >
+              <LoadingIndicator />
+            </View>
+            <VSpacer size={SPACE_BETWEEN_SPINNER_AND_TEXT} />
+            <H3 style={styles.contentTitle} accessibilityLabel={contentTitle}>
+              {contentTitle}
+            </H3>
+          </View>
+        </ContentWrapper>
+      </SafeAreaView>
     </Modal>
   );
 };

--- a/ts/screens/ingress/IngressScreen.tsx
+++ b/ts/screens/ingress/IngressScreen.tsx
@@ -2,67 +2,16 @@
  * An ingress screen to choose the real first screen the user must navigate to.
  */
 import * as React from "react";
-import { View, StyleSheet, AccessibilityInfo, Platform } from "react-native";
-import {
-  ContentWrapper,
-  H3,
-  IOStyles,
-  VSpacer
-} from "@pagopa/io-app-design-system";
-import { SafeAreaView } from "react-native-safe-area-context";
 import I18n from "../../i18n";
 import { useOnFirstRender } from "../../utils/hooks/useOnFirstRender";
 import { trackIngressScreen } from "../profile/analytics";
-import { LoadingIndicator } from "../../components/ui/LoadingIndicator";
-
-const styles = StyleSheet.create({
-  container: {
-    ...IOStyles.bgWhite,
-    ...IOStyles.centerJustified,
-    ...IOStyles.flex
-  },
-  contentTitle: {
-    textAlign: "center"
-  },
-  content: {
-    alignItems: "center"
-  }
-});
-
-const SPACE_BETWEEN_SPINNER_AND_TEXT = 24;
+import LoadingScreenContent from "../../components/screens/LoadingScreenContent";
 
 export const IngressScreen = () => {
   const contentTitle = I18n.t("startup.title");
   useOnFirstRender(() => {
     trackIngressScreen();
-    // Since the screen is shown for a very short time,
-    // we prefer to announce the content to the screen reader,
-    // instead of focusing the first element.
-    if (Platform.OS === "android") {
-      // We use it only on Android, because on iOS the screen reader
-      // stops reading the content when the ingress screen is unmounted
-      // and the focus is moved to another element.
-      AccessibilityInfo.announceForAccessibility(contentTitle);
-    }
   });
 
-  return (
-    <SafeAreaView style={styles.container}>
-      <ContentWrapper>
-        <View style={styles.content}>
-          <View
-            accessible={false}
-            accessibilityElementsHidden={true}
-            importantForAccessibility={"no-hide-descendants"}
-          >
-            <LoadingIndicator />
-          </View>
-          <VSpacer size={SPACE_BETWEEN_SPINNER_AND_TEXT} />
-          <H3 style={styles.contentTitle} accessibilityLabel={contentTitle}>
-            {contentTitle}
-          </H3>
-        </View>
-      </ContentWrapper>
-    </SafeAreaView>
-  );
+  return <LoadingScreenContent contentTitle={contentTitle} />;
 };


### PR DESCRIPTION
## Short description
This PR addresses the redesign of `RefreshTokenLoadingScreen` by adopting the new DS. 

> [!TIP]
> Review Privacy ✅
> Translations ⏳
>
> Test e2e: TODO

## List of changes proposed in this pull request
- Group the common code in `LoadingScreenContent`.
- Adopt of the new DS to `RefreshTokenLoadingScreen` through `LoadingScreenContent`.
- Refactor `IngressScreen` with `LoadingScreenContent`.

<details><summary>🎦 Demo 🎦</summary>
<p>

| Demo |
| - | 
| <video src="https://github.com/pagopa/io-app/assets/16268789/e0f50f7f-8423-4070-88d1-0d7e48deae88" /> |  

</details> 

## How to test
- Test FL session refresh and check that the new loading screen `RefreshTokenLoadingScreen` is shown during the token refreshing.
- Test that there are no regression on `IngressScreen`.