### PR TITLE
fix: restore `backendStatus` previous selector

### DIFF
--- a/ts/screens/modal/SystemOffModal.tsx
+++ b/ts/screens/modal/SystemOffModal.tsx
@@ -9,13 +9,14 @@ import * as React from "react";
 import { Modal } from "react-native";
 import { useSelector } from "react-redux";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import _ from "lodash";
 import I18n from "../../i18n";
 import { backendStatusSelector } from "../../store/reducers/backendStatus";
 import { OperationResultScreenContent } from "../../components/screens/OperationResultScreenContent";
 import { getFullLocale } from "../../utils/locale";
 
 const SystemOffModal = () => {
-  const backendStatus = useSelector(backendStatusSelector);
+  const backendStatus = useSelector(backendStatusSelector, _.isEqual);
   const locale = getFullLocale();
 
   const subtitle = React.useMemo(() => {

--- a/ts/store/reducers/backendStatus.ts
+++ b/ts/store/reducers/backendStatus.ts
@@ -54,10 +54,9 @@ export const backendServicesStatusSelector = (
   state: GlobalState
 ): BackendStatusState => state.backendStatus;
 
-export const backendStatusSelector = createSelector(
-  backendServicesStatusSelector,
-  backendStatus => backendStatus.status
-);
+export const backendStatusSelector = (
+  state: GlobalState
+): O.Option<BackendStatus> => state.backendStatus.status;
 
 // return the section status for the given key. if it is not present, returns undefined
 export const sectionStatusSelector = (sectionStatusKey: SectionStatusKey) =>


### PR DESCRIPTION
## Short description
This PR removes the use of `reselect` introduced in `backendStatus` selector, because it's redundant.
It uses `lodash` to do a deep equality comparison in the `SystemOffModal`, to avoid unnecessary re-rendering.

## Acknowledgments
@Vangaorth 
