### PR TITLE
fix: [IOBP-554] Removed A11y override into transaction operation details

### DIFF
--- a/ts/features/payments/transaction/screens/PaymentsTransactionOperationDetails.tsx
+++ b/ts/features/payments/transaction/screens/PaymentsTransactionOperationDetails.tsx
@@ -64,7 +64,6 @@ const WalletTransactionOperationDetailsScreen = () => {
       <ScrollView style={styles.scrollViewContainer}>
         {operationDetails.importo && (
           <ListItemInfo
-            accessibilityLabel={I18n.t("transaction.details.operation.amount")}
             label={I18n.t("transaction.details.operation.amount")}
             value={formatNumberCentsToAmount(
               operationDetails.importo,
@@ -78,9 +77,6 @@ const WalletTransactionOperationDetailsScreen = () => {
           <>
             <ListItemInfo
               label={I18n.t("transaction.details.operation.creditor")}
-              accessibilityLabel={I18n.t(
-                "transaction.details.operation.creditor"
-              )}
               value={operationDetails.enteBeneficiario}
             />
             <Divider />
@@ -90,9 +86,6 @@ const WalletTransactionOperationDetailsScreen = () => {
           <>
             <ListItemInfo
               label={I18n.t("transaction.details.operation.debtor")}
-              accessibilityLabel={I18n.t(
-                "transaction.details.operation.debtor"
-              )}
               value={getDebtorText()}
             />
             <Divider />
@@ -102,7 +95,6 @@ const WalletTransactionOperationDetailsScreen = () => {
           <>
             <ListItemInfo
               label={I18n.t("transaction.details.operation.iuv")}
-              accessibilityLabel={I18n.t("transaction.details.operation.iuv")}
               value={operationDetails.IUV}
             />
             <Divider />
@@ -112,7 +104,6 @@ const WalletTransactionOperationDetailsScreen = () => {
           <ListItemInfo
             numberOfLines={4}
             label={I18n.t("transaction.details.operation.subject")}
-            accessibilityLabel={I18n.t("transaction.details.operation.subject")}
             value={operationSubject}
           />
         )}


### PR DESCRIPTION
## Short description
This PR fixes the a11y values into the new transaction operation details screen in order to spell correctly the value of each list item

## List of changes proposed in this pull request
- Removed the `accessibilityLabel` override for the list items

## How to test
Enable the DS feature flag and navigate to the transactions list, then inside of it you should be able to use the voice-over to listen to the values in the correct way

## Preview

https://github.com/pagopa/io-app/assets/34343582/b914a74a-33f8-4c54-8e3b-b608079cc314


