### PR TITLE
[IOPOID-1834] Fix IdP selection scrolling on older Android devices.

### DIFF
--- a/ts/navigation/AuthenticationNavigator.tsx
+++ b/ts/navigation/AuthenticationNavigator.tsx
@@ -30,7 +30,11 @@ const Stack = createStackNavigator<AuthenticationParamsList>();
 const AuthenticationStackNavigator = () => (
   <Stack.Navigator
     initialRouteName={ROUTES.AUTHENTICATION_LANDING}
-    screenOptions={{ gestureEnabled: true, headerShown: false }}
+    screenOptions={{
+      gestureEnabled: true,
+      gestureDirection: "horizontal",
+      headerShown: false
+    }}
   >
     <Stack.Screen
       name={ROUTES.AUTHENTICATION_LANDING}


### PR DESCRIPTION
## Short description
This PR forces scroll direction as "horizontal" on the `AuthenticationNavigator`.

## List of changes proposed in this pull request
- Force the scroll direction as "horizontal" on the `AuthenticationNavigator`.

## How to test
- Make an auth flow on both Android and iOS devices and check that all works fine.
- Test on Android emulator running Android OS < 8 and check that the IdP list scroll as expected.
