### PR TITLE
chore: [IOBP-640] map `isAllCCP` field into authentication transaction

### DIFF
--- a/ts/features/payments/checkout/saga/networking/handleWalletPaymentAuthorization.ts
+++ b/ts/features/payments/checkout/saga/networking/handleWalletPaymentAuthorization.ts
@@ -48,7 +48,7 @@ export function* handleWalletPaymentAuthorization(
     const requestBody: RequestAuthorizationRequest = {
       amount: action.payload.paymentAmount,
       fee: action.payload.paymentFees,
-      isAllCCP: true,
+      isAllCCP: action.payload.isAllCCP,
       language: LanguageEnum.IT,
       pspId: action.payload.pspId,
       details

--- a/ts/features/payments/checkout/screens/WalletPaymentConfirmScreen.tsx
+++ b/ts/features/payments/checkout/screens/WalletPaymentConfirmScreen.tsx
@@ -70,11 +70,18 @@ const WalletPaymentConfirmScreen = () => {
       O.map(({ paymentDetail, paymentMethodId, selectedPsp, transaction }) => {
         // In case of guest payment walletId could be undefined
         const walletId = O.toUndefined(selectedWalletIdOption);
-
+        const isAllCCP = pipe(
+          transaction.payments[0],
+          O.fromNullable,
+          O.map(payment => payment.isAllCCP),
+          O.chain(isAllCCP => pipe(isAllCCP, O.fromNullable)),
+          O.getOrElse(() => false)
+        );
         startPaymentAuthorizaton({
           paymentAmount: paymentDetail.amount as AmountEuroCents,
           paymentFees: (selectedPsp.taxPayerFee ?? 0) as AmountEuroCents,
           pspId: selectedPsp.idPsp ?? "",
+          isAllCCP,
           transactionId: transaction.transactionId,
           walletId,
           paymentMethodId

--- a/ts/features/payments/checkout/store/actions/networking.ts
+++ b/ts/features/payments/checkout/store/actions/networking.ts
@@ -75,6 +75,7 @@ export type WalletPaymentAuthorizePayload = {
   walletId?: string;
   paymentMethodId: string;
   pspId: string;
+  isAllCCP: boolean;
   paymentAmount: AmountEuroCents;
   paymentFees: AmountEuroCents;
 };


### PR DESCRIPTION
## Short description
This PR aims to map the `isAllCCP` field during the payment authorization request. Currently, it was always sent to `true`

## List of changes proposed in this pull request
- Added the additional property `isAllCCP` from the `WalletPaymentAuthorizePayload`
- Mapped the field `isAllCCP` from the principal payment method from the first element of the array.

## How to test
In the UAT environment, start the new payment flow and when you reach the final payment button that starts the review, you should be able to do it without getting any errors.
