### PR TITLE
fix: `LandingScreen`'s `Carousel` translations

### DIFF
--- a/ts/screens/authentication/LandingScreen.tsx
+++ b/ts/screens/authentication/LandingScreen.tsx
@@ -54,52 +54,6 @@ import {
 } from "./analytics";
 import { Carousel } from "./carousel/Carousel";
 
-const carouselCards: ReadonlyArray<
-  ComponentProps<typeof LandingCardComponent>
-> = [
-  {
-    id: 0,
-    pictogramName: "hello",
-    title: I18n.t("authentication.landing.card5-title"),
-    content: I18n.t("authentication.landing.card5-content"),
-    accessibilityLabel: `${I18n.t(
-      "authentication.landing.accessibility.carousel.label"
-    )}. ${I18n.t("authentication.landing.card5-title")}. ${I18n.t(
-      "authentication.landing.card5-content-accessibility"
-    )}`,
-    accessibilityHint: I18n.t(
-      "authentication.landing.accessibility.carousel.hint"
-    )
-  },
-  {
-    id: 1,
-    pictogramName: "star",
-    title: I18n.t("authentication.landing.card1-title"),
-    content: I18n.t("authentication.landing.card1-content"),
-    accessibilityLabel: `${I18n.t(
-      "authentication.landing.card1-title"
-    )}. ${I18n.t("authentication.landing.card1-content")}`
-  },
-  {
-    id: 2,
-    pictogramName: "cardFavourite",
-    title: I18n.t("authentication.landing.card2-title"),
-    content: I18n.t("authentication.landing.card2-content"),
-    accessibilityLabel: `${I18n.t(
-      "authentication.landing.card2-title"
-    )}. ${I18n.t("authentication.landing.card2-content")}`
-  },
-  {
-    id: 3,
-    pictogramName: "doc",
-    title: I18n.t("authentication.landing.card3-title"),
-    content: I18n.t("authentication.landing.card3-content"),
-    accessibilityLabel: `${I18n.t(
-      "authentication.landing.card3-title"
-    )}. ${I18n.t("authentication.landing.card3-content")}`
-  }
-];
-
 const contextualHelpMarkdown: ContextualHelpPropsMarkdown = {
   title: "authentication.landing.contextualHelpTitle",
   body: "authentication.landing.contextualHelpContent"
@@ -256,6 +210,55 @@ export const LandingScreen = () => {
       {
         days: isFastLoginEnabled ? "365" : "30"
       }
+    );
+
+    const carouselCards: ReadonlyArray<
+      ComponentProps<typeof LandingCardComponent>
+    > = React.useMemo(
+      () => [
+        {
+          id: 0,
+          pictogramName: "hello",
+          title: I18n.t("authentication.landing.card5-title"),
+          content: I18n.t("authentication.landing.card5-content"),
+          accessibilityLabel: `${I18n.t(
+            "authentication.landing.accessibility.carousel.label"
+          )}. ${I18n.t("authentication.landing.card5-title")}. ${I18n.t(
+            "authentication.landing.card5-content-accessibility"
+          )}`,
+          accessibilityHint: I18n.t(
+            "authentication.landing.accessibility.carousel.hint"
+          )
+        },
+        {
+          id: 1,
+          pictogramName: "star",
+          title: I18n.t("authentication.landing.card1-title"),
+          content: I18n.t("authentication.landing.card1-content"),
+          accessibilityLabel: `${I18n.t(
+            "authentication.landing.card1-title"
+          )}. ${I18n.t("authentication.landing.card1-content")}`
+        },
+        {
+          id: 2,
+          pictogramName: "cardFavourite",
+          title: I18n.t("authentication.landing.card2-title"),
+          content: I18n.t("authentication.landing.card2-content"),
+          accessibilityLabel: `${I18n.t(
+            "authentication.landing.card2-title"
+          )}. ${I18n.t("authentication.landing.card2-content")}`
+        },
+        {
+          id: 3,
+          pictogramName: "doc",
+          title: I18n.t("authentication.landing.card3-title"),
+          content: I18n.t("authentication.landing.card3-content"),
+          accessibilityLabel: `${I18n.t(
+            "authentication.landing.card3-title"
+          )}. ${I18n.t("authentication.landing.card3-content")}`
+        }
+      ],
+      []
     );
 
     return (


### PR DESCRIPTION
## Short description
This PR fixes the `Carousel`'s translations in `LandingScreen` that didn't follow the citizen's locale.

<details open><summary>Details</summary>
<p>

| ❌ wrong | ✅ 🤖 | ✅ 🍏 | 
| - | - | - | 
| <video src="https://github.com/pagopa/io-app/assets/16268789/5a2ab9ed-cb55-409e-9844-70c303959b74" /> | <video src="https://github.com/pagopa/io-app/assets/16268789/eec186fc-2f3c-47b7-9199-25187eb1fe26" /> | <video src="https://github.com/pagopa/io-app/assets/16268789/cc8d800f-789a-46e3-94c2-6b83191a8931" />

</p>
</details> 

## How to test
Login with the dev-server with a citizen that has chosen an `EN` locale, then logout and check that the carousel is translated in english as the all page.
