### PR TITLE
chore: [IOPAE-1212] Added button to navigate the search screen

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2139,6 +2139,7 @@ services:
         title: Featured Institutions
     institutions:
       title: National
+    searchLink: Search all available local services
   institution:
     failure:
       title: "There is a temporary problem. Please try again"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2139,6 +2139,7 @@ services:
         title: Enti in evidenza
     institutions:
       title: Nazionali
+    searchLink: Cerca tra tutti i servizi locali disponibili
   institution:
     failure:
       title: "C'è un problema temporaneo, riprova"

--- a/ts/features/services/home/hooks/useInstitutionsFetcher.tsx
+++ b/ts/features/services/home/hooks/useInstitutionsFetcher.tsx
@@ -66,6 +66,7 @@ export const useInstitutionsFetcher = () => {
     currentPage,
     data: paginatedInstitutions,
     isError,
+    isLastPage,
     isLoading,
     isUpdating,
     isRefreshing,

--- a/ts/features/services/home/screens/ServicesHomeScreen.tsx
+++ b/ts/features/services/home/screens/ServicesHomeScreen.tsx
@@ -1,5 +1,3 @@
-import React, { useCallback, useEffect } from "react";
-import { FlatList, ListRenderItemInfo, StyleSheet, View } from "react-native";
 import {
   ButtonLink,
   Divider,
@@ -10,8 +8,10 @@ import {
   SearchInput,
   VSpacer
 } from "@pagopa/io-app-design-system";
-import I18n from "../../../../i18n";
+import React, { useCallback, useEffect } from "react";
+import { FlatList, ListRenderItemInfo, StyleSheet, View } from "react-native";
 import { Institution } from "../../../../../definitions/services/Institution";
+import I18n from "../../../../i18n";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { useIODispatch } from "../../../../store/hooks";
 import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
@@ -19,10 +19,10 @@ import { InstitutionListSkeleton } from "../../common/components/InstitutionList
 import { useFirstRender } from "../../common/hooks/useFirstRender";
 import { SERVICES_ROUTES } from "../../common/navigation/routes";
 import { getLogoForInstitution } from "../../common/utils";
-import { useInstitutionsFetcher } from "../hooks/useInstitutionsFetcher";
-import { featuredInstitutionsGet, featuredServicesGet } from "../store/actions";
 import { FeaturedInstitutionList } from "../components/FeaturedInstitutionList";
 import { FeaturedServiceList } from "../components/FeaturedServiceList";
+import { useInstitutionsFetcher } from "../hooks/useInstitutionsFetcher";
+import { featuredInstitutionsGet, featuredServicesGet } from "../store/actions";
 
 const styles = StyleSheet.create({
   scrollContentContainer: {
@@ -93,14 +93,6 @@ export const ServicesHomeScreen = () => {
       </>
     ),
     [navigateToSearch]
-  );
-
-  const navigateToSearch = useCallback(
-    () =>
-      navigation.navigate(SERVICES_ROUTES.SERVICES_NAVIGATOR, {
-        screen: SERVICES_ROUTES.SEARCH
-      }),
-    [navigation]
   );
 
   const renderListFooterComponent = useCallback(() => {

--- a/ts/features/services/home/screens/ServicesHomeScreen.tsx
+++ b/ts/features/services/home/screens/ServicesHomeScreen.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect } from "react";
-import { FlatList, ListRenderItemInfo, StyleSheet } from "react-native";
+import { FlatList, ListRenderItemInfo, StyleSheet, View } from "react-native";
 import {
+  ButtonLink,
   Divider,
   IOStyles,
   IOToast,
@@ -38,6 +39,7 @@ export const ServicesHomeScreen = () => {
     data,
     fetchInstitutions,
     isError,
+    isLastPage,
     isLoading,
     isUpdating,
     isRefreshing,
@@ -75,12 +77,36 @@ export const ServicesHomeScreen = () => {
     []
   );
 
+  const navigateToSearch = useCallback(
+    () =>
+      navigation.navigate(SERVICES_ROUTES.SERVICES_NAVIGATOR, {
+        screen: SERVICES_ROUTES.SEARCH
+      }),
+    [navigation]
+  );
+
   const renderListFooterComponent = useCallback(() => {
     if (isUpdating && !isRefreshing) {
       return <InstitutionListSkeleton />;
     }
+
+    if (isLastPage) {
+      return (
+        <>
+          <VSpacer size={16} />
+          <View style={[IOStyles.alignCenter, IOStyles.selfCenter]}>
+            <ButtonLink
+              label={I18n.t("services.home.searchLink")}
+              onPress={navigateToSearch}
+            />
+          </View>
+          <VSpacer size={24} />
+        </>
+      );
+    }
+
     return <VSpacer size={16} />;
-  }, [isUpdating, isRefreshing]);
+  }, [isLastPage, isUpdating, isRefreshing, navigateToSearch]);
 
   const handleRefresh = useCallback(() => {
     dispatch(featuredServicesGet.request());


### PR DESCRIPTION
## Short description
This PR adds button in services tab to navigate the search screen

<details open><summary>Details</summary>

<p>

| services |
| - | 
| <video src="https://github.com/pagopa/io-app/assets/29163287/7edd0401-009e-4a8c-b459-ce690ddec96e" width="300"/> |
</p>
</details> 

## List of changes proposed in this pull request
- added button in services tab
- updated locales

## How to test
Using `io-dev-api-server`, navigate to the services tab. Check that the button is present at the end of the institution list.
