### PR TITLE
chore: [IOPAE-1213] Update Services Search EmptyState copy and font size

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2153,7 +2153,7 @@ services:
       cancel: "Cancel"
       clear: "Clear"
     emptyState:
-      title: "Enter at least three characters to search for the name of a national or local institution"
+      title: "Enter the name of an organization, national or local"
   details:
     failure:
       title: "There is a temporary problem. Please try again"

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2156,7 +2156,7 @@ services:
       cancel: "Cancel"
       clear: "Clear"
     emptyState:
-      title: "Enter the name of an institution, national or local"
+      title: "Enter the name of an institution,\nnational or local"
   details:
     failure:
       title: "There is a temporary problem. Please try again"

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2154,7 +2154,7 @@ services:
       cancel: "Cancel"
       clear: "Clear"
     emptyState:
-      title: "Enter the name of an organization, national or local"
+      title: "Enter the name of an institution, national or local"
   details:
     failure:
       title: "There is a temporary problem. Please try again"
@@ -2174,7 +2174,7 @@ services:
       phone: "Contact the institution"
       email: "Send email"
       pec: "Send PEC"
-      fiscalCode: "Organization's fiscal code"
+      fiscalCode: "Institution's fiscal code"
       address: "Address"
       serviceId: "Service ID"
     tosAndPrivacy:
@@ -2182,9 +2182,9 @@ services:
       tosLink: "Terms and conditions"
       privacyLink: "Privacy information"
 serviceDetail:
-  fiscalCode: "Organization's fiscal code"
-  fiscalCodeAccessibility: "Organization's fiscal code"
-  fiscalCodeAccessibilityCopy: "Copy organization's fiscal code"
+  fiscalCode: "Institution's fiscal code"
+  fiscalCodeAccessibility: "Institution's fiscal code"
+  fiscalCodeAccessibilityCopy: "Copy Institution's fiscal code"
   contacts:
     title: "This service can:"
   headerTitle: "Service details"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2156,7 +2156,7 @@ services:
       cancel: "Annulla"
       clear: "Cancella"
     emptyState:
-      title: "Inserisci il nome di un ente, nazionale o locale"
+      title: "Inserisci il nome di un ente,\nnazionale o locale"
   details:
     failure:
       title: "C'è un problema temporaneo, riprova"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2153,7 +2153,7 @@ services:
       cancel: "Annulla"
       clear: "Cancella"
     emptyState:
-      title: "Inserisci almeno tre caratteri per cercare il nome di un ente, nazionale o locale"
+      title: "Inserisci il nome di un ente, nazionale o locale"
   details:
     failure:
       title: "C'è un problema temporaneo, riprova"

--- a/ts/components/services/ServiceMetadata/__tests__/__snapshots__/InformationRow.test.tsx.snap
+++ b/ts/components/services/ServiceMetadata/__tests__/__snapshots__/InformationRow.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`the InformationRow component should match the snapshot 1`] = `
       weight="Regular"
       weightColorFactory={[Function]}
     >
-      Organization's Fiscal Code
+      Institution's Fiscal Code
     </Text>
     <View
       style={

--- a/ts/features/services/common/components/EmptyState.tsx
+++ b/ts/features/services/common/components/EmptyState.tsx
@@ -1,7 +1,5 @@
-import React from "react";
-import { StyleSheet, View } from "react-native";
 import {
-  H3,
+  H6,
   IOPictograms,
   IOStyles,
   IOVisualCostants,
@@ -9,6 +7,8 @@ import {
   VSpacer,
   WithTestID
 } from "@pagopa/io-app-design-system";
+import React from "react";
+import { StyleSheet, View } from "react-native";
 
 const styles = StyleSheet.create({
   container: {
@@ -30,6 +30,6 @@ export const EmptyState = ({ pictogram, title, testID }: EmptyStateProps) => (
       <Pictogram name={pictogram} size={120} />
       <VSpacer size={24} />
     </View>
-    <H3 style={styles.text}>{title}</H3>
+    <H6 style={styles.text}>{title}</H6>
   </View>
 );


### PR DESCRIPTION
## Short description
Update Services Search `EmptyState` component copy and font size.

<img src="https://github.com/pagopa/io-app/assets/118166285/b0de57f1-3e19-4e4e-b444-fabc82ea2783" width="360" />

## List of changes proposed in this pull request
- Update copy
- Update font from H3 to H6

## How to test
Navigate to services search screen to better appreciate changes.
