### PR TITLE
[IOCOM-1411] Navigation to message routing, from new DS messages' home

### DIFF
--- a/ts/features/messages/components/Home/MessageList.tsx
+++ b/ts/features/messages/components/Home/MessageList.tsx
@@ -53,7 +53,7 @@ export const MessageList = ({ category }: MessageListProps) => {
         </View>
       )}
       ItemSeparatorComponent={messageList ? () => <Divider /> : undefined}
-      renderItem={({ item }) => {
+      renderItem={({ index, item }) => {
         if (typeof item === "number") {
           return (
             <MessageListItemSkeleton
@@ -61,7 +61,7 @@ export const MessageList = ({ category }: MessageListProps) => {
             />
           );
         } else {
-          return <WrappedMessageListItem message={item} />;
+          return <WrappedMessageListItem index={index} message={item} />;
         }
       }}
     />

--- a/ts/features/messages/components/Home/WrappedMessageListItem.tsx
+++ b/ts/features/messages/components/Home/WrappedMessageListItem.tsx
@@ -10,13 +10,13 @@ import { logosForService } from "../../../../utils/services";
 import I18n from "../../../../i18n";
 import { TagEnum } from "../../../../../definitions/backend/MessageCategoryPN";
 import { convertDateToWordDistance } from "../../utils/convertDateToWordDistance";
+import { useIONavigation } from "../../../../navigation/params/AppParamsList";
+import { MESSAGES_ROUTES } from "../../navigation/routes";
 import {
   accessibilityLabelForMessageItem,
   getLoadServiceDetailsActionIfNeeded
 } from "./homeUtils";
 import { MessageListItem } from "./DS/MessageListItem";
-import { useIONavigation } from "../../../../navigation/params/AppParamsList";
-import { MESSAGES_ROUTES } from "../../navigation/routes";
 
 type WrappedMessageListItemProps = {
   index: number;

--- a/ts/features/messages/components/Home/WrappedMessageListItem.tsx
+++ b/ts/features/messages/components/Home/WrappedMessageListItem.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import {
   useIODispatch,
   useIOSelector,
@@ -15,14 +15,19 @@ import {
   getLoadServiceDetailsActionIfNeeded
 } from "./homeUtils";
 import { MessageListItem } from "./DS/MessageListItem";
+import { useIONavigation } from "../../../../navigation/params/AppParamsList";
+import { MESSAGES_ROUTES } from "../../navigation/routes";
 
 type WrappedMessageListItemProps = {
+  index: number;
   message: UIMessage;
 };
 
 export const WrappedMessageListItem = ({
+  index,
   message
 }: WrappedMessageListItemProps) => {
+  const navigation = useIONavigation();
   const dispatch = useIODispatch();
   const store = useIOStore();
   const serviceId = message.serviceId;
@@ -64,18 +69,30 @@ export const WrappedMessageListItem = ({
     [message]
   );
 
+  const onPressCallback = useCallback(() => {
+    // TODO preconditions IOCOM-840
+    navigation.navigate(MESSAGES_ROUTES.MESSAGES_NAVIGATOR, {
+      screen: MESSAGES_ROUTES.MESSAGE_ROUTER,
+      params: {
+        messageId: message.id,
+        fromNotification: false
+      }
+    });
+  }, [message, navigation]);
+
   return (
     <MessageListItem
       accessibilityLabel={accessibilityLabel}
       serviceName={serviceName}
       messageTitle={messageTitle}
       onLongPress={() => undefined}
-      onPress={() => undefined}
+      onPress={onPressCallback}
       serviceLogos={serviceLogoUriSources}
       badgeText={badgeText}
       isRead={isRead}
       organizationName={organizationName}
       formattedDate={messageDate}
+      testID={`wrapped_message_list_item_${index}`}
     />
   );
 };

--- a/ts/features/messages/components/Home/__tests__/__snapshots__/WrappedMessageListItem.test.tsx.snap
+++ b/ts/features/messages/components/Home/__tests__/__snapshots__/WrappedMessageListItem.test.tsx.snap
@@ -342,6 +342,7 @@ exports[`WrappedMessageListItem should match snapshot,     from SEND,   read mes
                             "backgroundColor": undefined,
                           }
                         }
+                        testID="wrapped_message_list_item_0"
                       >
                         <View
                           style={
@@ -1372,6 +1373,7 @@ exports[`WrappedMessageListItem should match snapshot,     from SEND, unread mes
                             "backgroundColor": undefined,
                           }
                         }
+                        testID="wrapped_message_list_item_0"
                       >
                         <View
                           style={
@@ -2457,6 +2459,7 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND,   read mes
                             "backgroundColor": undefined,
                           }
                         }
+                        testID="wrapped_message_list_item_0"
                       >
                         <View
                           style={
@@ -3272,6 +3275,7 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, unread mes
                             "backgroundColor": undefined,
                           }
                         }
+                        testID="wrapped_message_list_item_0"
                       >
                         <View
                           style={


### PR DESCRIPTION
## Short description
This PR adds the navigation to the message routing on a message tap, on the new DS messages' home.

Precondition handling will come in a later PR (same goes for archiving/unarchiving)

## List of changes proposed in this pull request
- Added callback to navigate to the message router upon MessageListItem tap selection

## How to test
Using the io-dev-api-server, enable the new DS and the new messages' home. Select a message.
