### PR TITLE
chore: [IOBP-686] Removed temporary the latest used payment method section

### DIFF
--- a/ts/features/payments/checkout/components/CheckoutPaymentMethodsList.tsx
+++ b/ts/features/payments/checkout/components/CheckoutPaymentMethodsList.tsx
@@ -23,7 +23,6 @@ import {
   walletPaymentAllMethodsSelector,
   walletPaymentSelectedPaymentMethodIdOptionSelector,
   walletPaymentSelectedWalletIdOptionSelector,
-  walletPaymentUserWalletLastUpdatedSelector,
   walletPaymentUserWalletsSelector
 } from "../store/selectors/paymentMethods";
 import { getPaymentLogoFromWalletDetails } from "../../common/utils";
@@ -38,9 +37,6 @@ const CheckoutPaymentMethodsList = () => {
   const paymentAmountPot = useIOSelector(walletPaymentAmountSelector);
   const allPaymentMethods = useIOSelector(walletPaymentAllMethodsSelector);
   const userWallets = useIOSelector(walletPaymentUserWalletsSelector);
-  const latestPaymentMethodUsed = useIOSelector(
-    walletPaymentUserWalletLastUpdatedSelector
-  );
 
   const selectedUserWalletIdOption = useIOSelector(
     walletPaymentSelectedWalletIdOptionSelector
@@ -55,17 +51,6 @@ const CheckoutPaymentMethodsList = () => {
     O.getOrElse(() => 0)
   );
 
-  const latestPaymentMethodListItem = useMemo(
-    () =>
-      pipe(
-        latestPaymentMethodUsed,
-        O.chainNullableK(mapUserWalletToRadioItem),
-        O.map(A.of),
-        O.getOrElse(() => [] as Array<RadioItem<string>>)
-      ),
-    [latestPaymentMethodUsed]
-  );
-
   const userPaymentMethodListItems = useMemo(
     () =>
       pipe(
@@ -74,15 +59,9 @@ const CheckoutPaymentMethodsList = () => {
         O.map(methods => methods.map(mapUserWalletToRadioItem)),
         O.map(A.map(O.fromNullable)),
         O.map(A.compact),
-        O.map(
-          A.filter(
-            method =>
-              !latestPaymentMethodListItem.some(item => item.id === method.id)
-          )
-        ),
         O.getOrElse(() => [] as Array<RadioItem<string>>)
       ),
-    [userWallets, latestPaymentMethodListItem]
+    [userWallets]
   );
 
   const allPaymentMethodListItems = useMemo(
@@ -100,17 +79,11 @@ const CheckoutPaymentMethodsList = () => {
 
   useEffect(() => {
     const hasDisabledMethods =
-      [
-        ...userPaymentMethodListItems,
-        ...allPaymentMethodListItems,
-        ...latestPaymentMethodListItem
-      ].find(item => item.disabled) !== undefined;
+      [...userPaymentMethodListItems, ...allPaymentMethodListItems].find(
+        item => item.disabled
+      ) !== undefined;
     setShouldShowWarningBanner(hasDisabledMethods);
-  }, [
-    userPaymentMethodListItems,
-    allPaymentMethodListItems,
-    latestPaymentMethodListItem
-  ]);
+  }, [userPaymentMethodListItems, allPaymentMethodListItems]);
 
   const handleSelectUserWallet = (walletId: string) =>
     pipe(
@@ -158,17 +131,6 @@ const CheckoutPaymentMethodsList = () => {
           action={I18n.t("wallet.payment.methodSelection.alert.cta")}
         />
       )}
-      {!_.isEmpty(latestPaymentMethodListItem) && (
-        <ListItemHeader
-          label={I18n.t("wallet.payment.methodSelection.latestMethod")}
-        />
-      )}
-      <RadioGroup<string>
-        type="radioListItem"
-        selectedItem={selectedWalletId}
-        items={latestPaymentMethodListItem}
-        onPress={handleSelectUserWallet}
-      />
       {!_.isEmpty(userPaymentMethodListItems) && (
         <ListItemHeader
           label={I18n.t("wallet.payment.methodSelection.yourMethods")}


### PR DESCRIPTION
## Short description
This PR temporarily removes the “last method used” functionality. It will later be integrated following a legal review to require user consent to save the recently used payment method.

## List of changes proposed in this pull request
- Removed the latestPaymentMethodUsed from the `CheckoutPaymentMethodsList`

## How to test
When you start a payment flow with the new payment section, you shouldn't be able to see the "recently used payment method"

## Preview
<img src="https://github.com/pagopa/io-app/assets/34343582/f16c4138-48e1-47d9-8394-97550e8f53e7" width="350px" />

