### PR TITLE
chore: [IOBP-635] Removed FF from the new transaction details screen

### DIFF
--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -75,10 +75,7 @@ import {
   isIdPayEnabledSelector
 } from "../../store/reducers/backendStatus";
 import { paymentsHistorySelector } from "../../store/reducers/payments/history";
-import {
-  isDesignSystemEnabledSelector,
-  isPagoPATestEnabledSelector
-} from "../../store/reducers/persistedPreferences";
+import { isPagoPATestEnabledSelector } from "../../store/reducers/persistedPreferences";
 import { GlobalState } from "../../store/reducers/types";
 import { creditCardAttemptsSelector } from "../../store/reducers/wallet/creditCard";
 import {
@@ -392,19 +389,15 @@ class WalletHomeScreen extends React.PureComponent<Props, State> {
   private navigateToWalletTransactionDetailsScreen = (
     transaction: Transaction
   ) => {
-    if (this.props.isDesignSystemEnabled) {
-      this.props.navigation.navigate(
-        PaymentsTransactionRoutes.PAYMENT_TRANSACTION_NAVIGATOR,
-        {
-          screen: PaymentsTransactionRoutes.PAYMENT_TRANSACTION_DETAILS,
-          params: {
-            transactionId: transaction.id
-          }
+    this.props.navigation.navigate(
+      PaymentsTransactionRoutes.PAYMENT_TRANSACTION_NAVIGATOR,
+      {
+        screen: PaymentsTransactionRoutes.PAYMENT_TRANSACTION_DETAILS,
+        params: {
+          transactionId: transaction.id
         }
-      );
-    } else {
-      this.props.navigateToTransactionDetailsScreen(transaction);
-    }
+      }
+    );
   };
 
   private transactionList(
@@ -517,7 +510,6 @@ const mapStateToProps = (state: GlobalState) => ({
   isCgnEnabled: isCGNEnabledSelector(state),
   bancomatListVisibleInWallet: bancomatListVisibleInWalletSelector(state),
   coBadgeListVisibleInWallet: cobadgeListVisibleInWalletSelector(state),
-  isDesignSystemEnabled: isDesignSystemEnabledSelector(state),
   isIdPayEnabled: isIdPayEnabledSelector(state)
 });
 


### PR DESCRIPTION
## Short description
This PR removes the feature flag on the new transaction details screen with the current interface

## List of changes proposed in this pull request
- Removed check on the design system feature flag to navigate to the new transaction details screen

## How to test
Disable the new design system feature flag and navigate to a transaction details with the old transaction list

## Preview

https://github.com/pagopa/io-app/assets/34343582/ec4e4228-960e-472e-8f55-dd7e014e596e


