### PR TITLE
chore: [IOPAE-1240] Restore scroll to top in the `ServicesHomeScreen`

### DIFF
--- a/ts/features/services/home/screens/ServicesHomeScreen.tsx
+++ b/ts/features/services/home/screens/ServicesHomeScreen.tsx
@@ -8,9 +8,10 @@ import {
   SearchInput,
   VSpacer
 } from "@pagopa/io-app-design-system";
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { FlatList, ListRenderItemInfo, StyleSheet, View } from "react-native";
 import { Institution } from "../../../../../definitions/services/Institution";
+import { useTabItemPressWhenScreenActive } from "../../../../hooks/useTabItemPressWhenScreenActive";
 import I18n from "../../../../i18n";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { useIODispatch } from "../../../../store/hooks";
@@ -35,6 +36,8 @@ export const ServicesHomeScreen = () => {
   const navigation = useIONavigation();
   const isFirstRender = useFirstRender();
 
+  const flatListRef = useRef<FlatList<Institution>>(null);
+
   const {
     currentPage,
     data,
@@ -46,6 +49,11 @@ export const ServicesHomeScreen = () => {
     isRefreshing,
     refreshInstitutions
   } = useInstitutionsFetcher();
+
+  useTabItemPressWhenScreenActive(
+    () => flatListRef.current?.scrollToOffset({ offset: 0, animated: true }),
+    false
+  );
 
   useOnFirstRender(() => fetchInstitutions(0));
 
@@ -170,6 +178,7 @@ export const ServicesHomeScreen = () => {
       onEndReached={handleEndReached}
       onEndReachedThreshold={0.001}
       onRefresh={handleRefresh}
+      ref={flatListRef}
       refreshing={isRefreshing}
       renderItem={renderInstitutionItem}
     />


### PR DESCRIPTION
## Short description
This PR restores the scroll to top action in the `ServicesHomeScreen`.

<details open><summary>Details</summary>

<p>

| services |
| - | 
| <video src="https://github.com/pagopa/io-app/assets/29163287/baffc4b4-82da-4cf6-965b-7275118f63bd" width="300"/> |
</p>
</details> 

## List of changes proposed in this pull request
see commit list

## How to test
Navigate to the services tab, scroll down and then tap on the services tab. Check that the screen scrolls to top when tapping on the active tab