### PR TITLE
chore: [IOPAE-1249] Fix the endless loop of FlatList's `onEndReached`

### DIFF
--- a/ts/features/services/home/hooks/useInstitutionsFetcher.tsx
+++ b/ts/features/services/home/hooks/useInstitutionsFetcher.tsx
@@ -46,7 +46,7 @@ export const useInstitutionsFetcher = () => {
     [dispatch, isLoading, isUpdating]
   );
 
-  const fetchInstitutions = useCallback(
+  const fetchNextPage = useCallback(
     (page: number) => {
       if (isLastPage) {
         return;
@@ -57,7 +57,7 @@ export const useInstitutionsFetcher = () => {
     [isLastPage, fetchPage]
   );
 
-  const refreshInstitutions = useCallback(() => {
+  const refresh = useCallback(() => {
     setIsRefreshing(true);
     fetchPage(0);
   }, [fetchPage]);
@@ -65,12 +65,13 @@ export const useInstitutionsFetcher = () => {
   return {
     currentPage,
     data: paginatedInstitutions,
+    fetchPage,
+    fetchNextPage,
     isError,
     isLastPage,
     isLoading,
     isUpdating,
     isRefreshing,
-    fetchInstitutions,
-    refreshInstitutions
+    refresh
   };
 };

--- a/ts/features/services/home/screens/ServicesHomeScreen.tsx
+++ b/ts/features/services/home/screens/ServicesHomeScreen.tsx
@@ -145,10 +145,10 @@ export const ServicesHomeScreen = () => {
 
   const handleEndReached = useCallback(
     ({ distanceFromEnd }: { distanceFromEnd: number }) => {
-      // Managed behaviour:
+      // Managed behavior:
       // at the end of data load, in case of response error,
       // the footer is removed from total list length and
-      // "onEndReached" is triggered continuously causing an endless loop.
+      // `onEndReached` is triggered continuously causing an endless loop.
       // Implemented solution:
       // this guard is needed to avoid endless loop
       if (distanceFromEnd === 0) {

--- a/ts/features/services/institution/screens/InstitutionServicesScreen.tsx
+++ b/ts/features/services/institution/screens/InstitutionServicesScreen.tsx
@@ -135,7 +135,14 @@ export const InstitutionServicesScreen = ({
   );
 
   const handleEndReached = useCallback(
-    () => fetchNextPage(currentPage + 1),
+    ({ distanceFromEnd }: { distanceFromEnd: number }) => {
+      // guard needed to avoid endless loop
+      if (distanceFromEnd === 0) {
+        return;
+      }
+
+      fetchNextPage(currentPage + 1);
+    },
     [currentPage, fetchNextPage]
   );
 
@@ -233,7 +240,7 @@ export const InstitutionServicesScreen = ({
       data={data?.services || []}
       keyExtractor={(item, index) => `service-${item.id}-${index}`}
       onEndReached={handleEndReached}
-      onEndReachedThreshold={0.001}
+      onEndReachedThreshold={0.1}
       renderItem={renderItem}
       refreshControl={refreshControl}
       testID="intitution-services-list"


### PR DESCRIPTION
## Short description
This PR solves an infinite loop of the `onEndReached` function. This bug occurs when list height is incremented during data load and reduced when data load fails (a common practice to display a loading skeleton).

<details open><summary>Details</summary>

<p>

| endless loop |
| - | 
| <video src="https://github.com/pagopa/io-app/assets/29163287/bf706906-3a31-4183-8060-45a41b4dbf99" /> |
</p>

| fix endless loop |
| - | 
| <video src="https://github.com/pagopa/io-app/assets/29163287/8afc3639-547c-4b3f-bac0-bd101fdff3a5"/> |
</p>
</details> 

## List of changes proposed in this pull request
- Added a guard to prevent endless loop

## How to test
Try to reproduce the same actions shown in the video.
