### PR TITLE
chore: [IOPAE-1235] Search screen enhancements

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2154,6 +2154,7 @@ services:
   search:
     input:
       placeholder: "Search for a national or local institution"
+      placeholderShort: "Search for an institution"
       cancel: "Cancel"
       clear: "Clear"
     emptyState:

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2154,6 +2154,7 @@ services:
   search:
     input:
       placeholder: "Cerca un ente nazionale o locale"
+      placeholderShort: "Cerca un ente"
       cancel: "Annulla"
       clear: "Cancella"
     emptyState:

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   "dependencies": {
     "@babel/plugin-transform-regenerator": "^7.18.6",
     "@gorhom/bottom-sheet": "^4.1.5",
-    "@pagopa/io-app-design-system": "1.38.3",
+    "@pagopa/io-app-design-system": "1.38.5",
     "@pagopa/io-pagopa-commons": "^3.1.0",
     "@pagopa/io-react-native-crypto": "^0.3.0",
     "@pagopa/io-react-native-http-client": "1.0.2",

--- a/ts/features/services/common/navigation/navigator.tsx
+++ b/ts/features/services/common/navigation/navigator.tsx
@@ -3,7 +3,6 @@ import { createStackNavigator } from "@react-navigation/stack";
 import { isGestureEnabled } from "../../../../utils/navigation";
 import { ServiceDetailsScreen } from "../../details/screens/ServiceDetailsScreen";
 import { InstitutionServicesScreen } from "../../institution/screens/InstitutionServicesScreen";
-import { SearchScreen } from "../../search/screens/SearchScreen";
 import { ServicesParamsList } from "./params";
 import { SERVICES_ROUTES } from "./routes";
 
@@ -22,7 +21,6 @@ const ServicesNavigator = () => (
       name={SERVICES_ROUTES.INSTITUTION_SERVICES}
       component={InstitutionServicesScreen}
     />
-    <Stack.Screen name={SERVICES_ROUTES.SEARCH} component={SearchScreen} />
     <Stack.Screen
       name={SERVICES_ROUTES.SERVICE_DETAIL}
       component={ServiceDetailsScreen}

--- a/ts/features/services/common/navigation/params.ts
+++ b/ts/features/services/common/navigation/params.ts
@@ -5,5 +5,4 @@ import { SERVICES_ROUTES } from "./routes";
 export type ServicesParamsList = {
   [SERVICES_ROUTES.SERVICE_DETAIL]: ServiceDetailsScreenRouteParams;
   [SERVICES_ROUTES.INSTITUTION_SERVICES]: InstitutionServicesScreenRouteParams;
-  [SERVICES_ROUTES.SEARCH]: undefined;
 };

--- a/ts/features/services/home/components/FeaturedInstitutionList.tsx
+++ b/ts/features/services/home/components/FeaturedInstitutionList.tsx
@@ -76,7 +76,7 @@ export const FeaturedInstitutionList = () => {
           institutions={mappedFeaturedInstitutions}
         />
       )}
-      <VSpacer size={24} />
+      <VSpacer size={16} />
     </>
   );
 };

--- a/ts/features/services/home/components/FeaturedServiceList.tsx
+++ b/ts/features/services/home/components/FeaturedServiceList.tsx
@@ -74,7 +74,7 @@ export const FeaturedServiceList = () => {
       ) : (
         <FeaturedServicesCarousel services={mappedFeaturedServices} />
       )}
-      <VSpacer size={24} />
+      <VSpacer size={16} />
     </>
   );
 };

--- a/ts/features/services/home/screens/ServicesHomeScreen.tsx
+++ b/ts/features/services/home/screens/ServicesHomeScreen.tsx
@@ -81,10 +81,7 @@ export const ServicesHomeScreen = () => {
   }, [isFirstRender, isLoading]);
 
   const navigateToSearch = useCallback(
-    () =>
-      navigation.navigate(SERVICES_ROUTES.SERVICES_NAVIGATOR, {
-        screen: SERVICES_ROUTES.SEARCH
-      }),
+    () => navigation.navigate(SERVICES_ROUTES.SEARCH),
     [navigation]
   );
 
@@ -103,6 +100,7 @@ export const ServicesHomeScreen = () => {
             }
           }}
         />
+        <VSpacer size={16} />
         <FeaturedServiceList />
         <FeaturedInstitutionList />
         <ListItemHeader label={I18n.t("services.home.institutions.title")} />

--- a/ts/features/services/search/hooks/useInstitutionsFetcher.tsx
+++ b/ts/features/services/search/hooks/useInstitutionsFetcher.tsx
@@ -10,7 +10,7 @@ import {
   paginatedInstitutionsSelector
 } from "../store/reducers";
 
-const LIMIT: number = 10;
+const LIMIT: number = 15;
 
 export const useInstitutionsFetcher = () => {
   const dispatch = useIODispatch();

--- a/ts/features/services/search/screens/SearchScreen.tsx
+++ b/ts/features/services/search/screens/SearchScreen.tsx
@@ -1,15 +1,18 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { View } from "react-native";
+import { useFocusEffect } from "@react-navigation/native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FlashList, ListRenderItemInfo } from "@shopify/flash-list";
 import {
-  ContentWrapper,
   Divider,
+  IOSpacingScale,
   IOStyles,
   IOToast,
   SearchInput,
+  SearchInputRef,
   VSpacer
 } from "@pagopa/io-app-design-system";
 import I18n from "../../../../i18n";
-import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
 import { useInstitutionsFetcher } from "../hooks/useInstitutionsFetcher";
 import { Institution } from "../../../../../definitions/services/Institution";
 import { searchPaginatedInstitutionsGet } from "../store/actions";
@@ -23,13 +26,16 @@ import { ListItemSearchInstitution } from "../../common/components/ListItemSearc
 import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
 import * as analytics from "../../common/analytics";
 
-const MIN_QUERY_LENGTH: number = 3;
+const INPUT_PADDING: IOSpacingScale = 16;
 const LIST_ITEM_HEIGHT: number = 70;
+const MIN_QUERY_LENGTH: number = 3;
 
 export const SearchScreen = () => {
+  const insets = useSafeAreaInsets();
   const dispatch = useIODispatch();
   const navigation = useIONavigation();
 
+  const ref = useRef<SearchInputRef>(null);
   const [query, setQuery] = useState<string>("");
 
   const {
@@ -43,6 +49,12 @@ export const SearchScreen = () => {
   } = useInstitutionsFetcher();
 
   useOnFirstRender(() => analytics.trackSearchPage());
+
+  useFocusEffect(
+    useCallback(() => {
+      ref.current?.focus();
+    }, [])
+  );
 
   useEffect(() => {
     if (isError) {
@@ -58,10 +70,7 @@ export const SearchScreen = () => {
     [dispatch, navigation]
   );
 
-  useHeaderSecondLevel({
-    title: "",
-    supportRequest: true
-  });
+  const handleCancel = useCallback(() => navigation.goBack(), [navigation]);
 
   const handleChangeText = (text: string) => {
     setQuery(text);
@@ -145,18 +154,26 @@ export const SearchScreen = () => {
 
   return (
     <>
-      <ContentWrapper>
+      <View
+        style={[
+          {
+            marginTop: insets.top,
+            paddingVertical: INPUT_PADDING
+          },
+          IOStyles.horizontalContentPadding
+        ]}
+      >
         <SearchInput
-          autoFocus
-          accessibilityLabel={I18n.t("services.search.input.placeholder")}
+          ref={ref}
+          accessibilityLabel={I18n.t("services.search.input.placeholderShort")}
           cancelButtonLabel={I18n.t("services.search.input.cancel")}
           clearAccessibilityLabel={I18n.t("services.search.input.clear")}
+          onCancel={handleCancel}
           onChangeText={handleChangeText}
-          placeholder={I18n.t("services.search.input.placeholder")}
+          placeholder={I18n.t("services.search.input.placeholderShort")}
           value={query}
         />
-        <VSpacer />
-      </ContentWrapper>
+      </View>
       <FlashList
         ItemSeparatorComponent={() => <Divider />}
         contentContainerStyle={IOStyles.horizontalContentPadding}

--- a/ts/navigation/AuthenticatedStackNavigator.tsx
+++ b/ts/navigation/AuthenticatedStackNavigator.tsx
@@ -81,6 +81,7 @@ import { ItwStackNavigator } from "../features/itwallet/navigation/ItwStackNavig
 import { ITW_ROUTES } from "../features/itwallet/navigation/routes";
 import { FIMS_ROUTES, FimsNavigator } from "../features/fims/navigation";
 import FIMS_LEGACY_ROUTES from "../features/fimsLegacy/navigation/routes";
+import { SearchScreen } from "../features/services/search/screens/SearchScreen";
 import CheckEmailNavigator from "./CheckEmailNavigator";
 import OnboardingNavigator from "./OnboardingNavigator";
 import { AppParamsList } from "./params/AppParamsList";
@@ -158,9 +159,20 @@ const AuthenticatedStackNavigator = () => {
       )}
       <Stack.Screen
         name={SERVICES_ROUTES.SERVICES_NAVIGATOR}
-        options={hideHeaderOptions}
+        options={{ ...hideHeaderOptions, gestureEnabled: isGestureEnabled }}
         component={ServicesNavigator}
       />
+      {/* This screen is outside the ServicesNavigator to change gesture and transion behaviour. */}
+      <Stack.Screen
+        name={SERVICES_ROUTES.SEARCH}
+        component={SearchScreen}
+        options={{
+          ...hideHeaderOptions,
+          animationEnabled: false,
+          gestureEnabled: false
+        }}
+      />
+
       <Stack.Screen
         name={ROUTES.PROFILE_NAVIGATOR}
         options={hideHeaderOptions}

--- a/ts/navigation/components/HeaderFirstLevelHandler.tsx
+++ b/ts/navigation/components/HeaderFirstLevelHandler.tsx
@@ -123,9 +123,7 @@ export const HeaderFirstLevelHandler = ({ currentRouteName }: Props) => {
             accessibilityLabel: I18n.t("global.accessibility.search"),
             onPress: () => {
               analytics.trackSearchStart({ source: "header_icon" });
-              navigation.navigate(SERVICES_ROUTES.SERVICES_NAVIGATOR, {
-                screen: SERVICES_ROUTES.SEARCH
-              });
+              navigation.navigate(SERVICES_ROUTES.SEARCH);
             }
           }
         };

--- a/ts/navigation/params/AppParamsList.ts
+++ b/ts/navigation/params/AppParamsList.ts
@@ -87,6 +87,7 @@ export type AppParamsList = {
   [MESSAGES_ROUTES.MESSAGES_NAVIGATOR]: NavigatorScreenParams<MessagesParamsList>;
   [ROUTES.WALLET_NAVIGATOR]: NavigatorScreenParams<WalletParamsList>;
   [SERVICES_ROUTES.SERVICES_NAVIGATOR]: NavigatorScreenParams<ServicesParamsList>;
+  [SERVICES_ROUTES.SEARCH]: undefined;
   [ROUTES.PROFILE_NAVIGATOR]: NavigatorScreenParams<ProfileParamsList>;
 
   [ROUTES.BARCODE_SCAN]: undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3272,10 +3272,10 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@pagopa/io-app-design-system@1.38.3":
-  version "1.38.3"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-app-design-system/-/io-app-design-system-1.38.3.tgz#5a43c114f81a419d86c02d628cd8bfb09f542017"
-  integrity sha512-F8FYv6oHBB+xFg3nMz7TVTC4J5hqVjpLifHqQ2QLB8Us6KGWpCB6mNgRtWnMqsY3zY4hEcd4iofS4f5W9i5GHQ==
+"@pagopa/io-app-design-system@1.38.5":
+  version "1.38.5"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-app-design-system/-/io-app-design-system-1.38.5.tgz#b767ab37cdb612ddcb3c57670104fafe5d6400a7"
+  integrity sha512-0u3bFVHLeo+8Q0Yf5nEnxQ6JPL0KsprbN0EutlqZUMMXee+IsiK/ZVfSjsNlF1/cNqVs8FwwDDLducm8nF4CKQ==
   dependencies:
     "@pagopa/ts-commons" "^12.0.0"
     "@testing-library/jest-native" "^5.4.2"


### PR DESCRIPTION
## Short description
The main purpose of this PR is to improve the usability and overall experience of the services search section.

<details open><summary>Details</summary>
<p>

| services |
| - | 
| <video src="https://github.com/pagopa/io-app/assets/29163287/e7c6b067-255e-472c-8831-7826d71447e1" /> |

</p>
</details> 

## List of changes proposed in this pull request
- enabled gesture on all services sub-routes (except on SearchScreen)
- removed transition on `SearchScreen` component
- removed `useHeaderSecondLevel` on `SearchScreen` component
- added `handleCancel` callback to navigate back
- update locales
- bump `@pagopa/io-app-design-system` to `1.38.5`
- minor layout fixes

## How to test
Using `io-dev-api-server`, navigate to the services tab. Check that the search works as expected.
