### PR TITLE
feat: [IOBP-689,IOBP-699] Add new payment method management type handling

### DIFF
--- a/ts/features/payments/checkout/saga/networking/handleWalletPaymentAuthorization.ts
+++ b/ts/features/payments/checkout/saga/networking/handleWalletPaymentAuthorization.ts
@@ -8,6 +8,8 @@ import {
   RequestAuthorizationRequest
 } from "../../../../../../definitions/pagopa/ecommerce/RequestAuthorizationRequest";
 import { WalletDetailTypeEnum } from "../../../../../../definitions/pagopa/ecommerce/WalletDetailType";
+import { RedirectDetailTypeEnum } from "../../../../../../definitions/pagopa/ecommerce/RedirectDetailType";
+import { PaymentMethodManagementTypeEnum } from "../../../../../../definitions/pagopa/ecommerce/PaymentMethodManagementType";
 import { SagaCallReturnType } from "../../../../../types/utils";
 import { getGenericError, getNetworkError } from "../../../../../utils/errors";
 import { readablePrivacyReport } from "../../../../../utils/reporters";
@@ -41,7 +43,11 @@ export function* handleWalletPaymentAuthorization(
             walletId: action.payload.walletId
           }
         : {
-            detailType: ApmDetailTypeEnum.apm,
+            detailType:
+              action.payload.paymentMethodManagement ===
+              PaymentMethodManagementTypeEnum.REDIRECT
+                ? RedirectDetailTypeEnum.redirect
+                : ApmDetailTypeEnum.apm,
             paymentMethodId: action.payload.paymentMethodId
           };
 

--- a/ts/features/payments/checkout/screens/WalletPaymentConfirmScreen.tsx
+++ b/ts/features/payments/checkout/screens/WalletPaymentConfirmScreen.tsx
@@ -30,6 +30,7 @@ import { walletPaymentSetCurrentStep } from "../store/actions/orchestration";
 import { walletPaymentDetailsSelector } from "../store/selectors";
 import {
   walletPaymentSelectedPaymentMethodIdOptionSelector,
+  walletPaymentSelectedPaymentMethodManagementOptionSelector,
   walletPaymentSelectedPaymentMethodOptionSelector,
   walletPaymentSelectedWalletIdOptionSelector,
   walletPaymentSelectedWalletOptionSelector
@@ -56,6 +57,9 @@ const WalletPaymentConfirmScreen = () => {
   const selectedPaymentMethodIdOption = useIOSelector(
     walletPaymentSelectedPaymentMethodIdOptionSelector
   );
+  const selectedPaymentMethodManagement = useIOSelector(
+    walletPaymentSelectedPaymentMethodManagementOptionSelector
+  );
 
   const selectedPspOption = useIOSelector(walletPaymentSelectedPspSelector);
 
@@ -65,27 +69,37 @@ const WalletPaymentConfirmScreen = () => {
         paymentDetail: pot.toOption(paymentDetailsPot),
         paymentMethodId: selectedPaymentMethodIdOption,
         selectedPsp: selectedPspOption,
-        transaction: pot.toOption(transactionPot)
+        transaction: pot.toOption(transactionPot),
+        paymentMethodManagement: selectedPaymentMethodManagement
       }),
-      O.map(({ paymentDetail, paymentMethodId, selectedPsp, transaction }) => {
-        // In case of guest payment walletId could be undefined
-        const walletId = O.toUndefined(selectedWalletIdOption);
-        const isAllCCP = pipe(
-          transaction.payments[0],
-          O.fromNullable,
-          O.chainNullableK(payment => payment.isAllCCP),
-          O.getOrElse(() => false)
-        );
-        startPaymentAuthorizaton({
-          paymentAmount: paymentDetail.amount as AmountEuroCents,
-          paymentFees: (selectedPsp.taxPayerFee ?? 0) as AmountEuroCents,
-          pspId: selectedPsp.idPsp ?? "",
-          isAllCCP,
-          transactionId: transaction.transactionId,
-          walletId,
-          paymentMethodId
-        });
-      })
+      O.map(
+        ({
+          paymentDetail,
+          paymentMethodId,
+          selectedPsp,
+          transaction,
+          paymentMethodManagement
+        }) => {
+          // In case of guest payment walletId could be undefined
+          const walletId = O.toUndefined(selectedWalletIdOption);
+          const isAllCCP = pipe(
+            transaction.payments[0],
+            O.fromNullable,
+            O.chainNullableK(payment => payment.isAllCCP),
+            O.getOrElse(() => false)
+          );
+          startPaymentAuthorizaton({
+            paymentAmount: paymentDetail.amount as AmountEuroCents,
+            paymentFees: (selectedPsp.taxPayerFee ?? 0) as AmountEuroCents,
+            pspId: selectedPsp.idPsp ?? "",
+            isAllCCP,
+            transactionId: transaction.transactionId,
+            walletId,
+            paymentMethodId,
+            paymentMethodManagement
+          });
+        }
+      )
     );
 
   const handleAuthorizationOutcome = React.useCallback(

--- a/ts/features/payments/checkout/store/actions/networking.ts
+++ b/ts/features/payments/checkout/store/actions/networking.ts
@@ -8,6 +8,7 @@ import { NewTransactionResponse } from "../../../../../../definitions/pagopa/eco
 import { PaymentMethodsResponse } from "../../../../../../definitions/pagopa/ecommerce/PaymentMethodsResponse";
 import { PaymentRequestsGetResponse } from "../../../../../../definitions/pagopa/ecommerce/PaymentRequestsGetResponse";
 import { RequestAuthorizationResponse } from "../../../../../../definitions/pagopa/ecommerce/RequestAuthorizationResponse";
+import { PaymentMethodManagementTypeEnum } from "../../../../../../definitions/pagopa/ecommerce/PaymentMethodManagementType";
 import { RptId } from "../../../../../../definitions/pagopa/ecommerce/RptId";
 import { TransactionInfo } from "../../../../../../definitions/pagopa/ecommerce/TransactionInfo";
 import { Wallets } from "../../../../../../definitions/pagopa/ecommerce/Wallets";
@@ -83,6 +84,7 @@ export type WalletPaymentAuthorizePayload = {
   isAllCCP: boolean;
   paymentAmount: AmountEuroCents;
   paymentFees: AmountEuroCents;
+  paymentMethodManagement: PaymentMethodManagementTypeEnum;
 };
 
 export const paymentsStartPaymentAuthorizationAction = createAsyncAction(

--- a/ts/features/payments/checkout/store/selectors/paymentMethods.ts
+++ b/ts/features/payments/checkout/store/selectors/paymentMethods.ts
@@ -85,6 +85,16 @@ export const walletPaymentSelectedWalletIdOptionSelector = createSelector(
     )
 );
 
+export const walletPaymentSelectedPaymentMethodManagementOptionSelector =
+  createSelector(
+    walletPaymentSelectedPaymentMethodOptionSelector,
+    selectedPaymentMethodOption =>
+      pipe(
+        selectedPaymentMethodOption,
+        O.map(({ methodManagement }) => methodManagement)
+      )
+  );
+
 export const notHasValidPaymentMethodsSelector = createSelector(
   walletPaymentAllMethodsSelector,
   walletPaymentUserWalletsSelector,

--- a/ts/features/payments/checkout/utils/index.ts
+++ b/ts/features/payments/checkout/utils/index.ts
@@ -10,10 +10,12 @@ export const WALLET_PAYMENT_FEEDBACK_URL =
   "https://io.italia.it/diccilatua/ces-pagamento";
 
 export const isValidPaymentMethod = (method: PaymentMethodResponse) =>
-  method.methodManagement === PaymentMethodManagementTypeEnum.ONBOARDABLE ||
-  method.methodManagement === PaymentMethodManagementTypeEnum.NOT_ONBOARDABLE ||
-  method.methodManagement ===
-    PaymentMethodManagementTypeEnum.ONBOARDABLE_WITH_PAYMENT;
+  [
+    PaymentMethodManagementTypeEnum.ONBOARDABLE,
+    PaymentMethodManagementTypeEnum.NOT_ONBOARDABLE,
+    PaymentMethodManagementTypeEnum.ONBOARDABLE_WITH_PAYMENT,
+    PaymentMethodManagementTypeEnum.REDIRECT
+  ].includes(method.methodManagement);
 
 export const getLatestUsedWallet = (
   wallets: ReadonlyArray<WalletInfo>


### PR DESCRIPTION
## Short description
This PR adds management of REDIRECT-type payment methods. If a payment method is of type REDIRECT, during the generation of the authorization request it must be passed as `detailType` to `redirect`.

## List of changes proposed in this pull request
- Added `REDIRECT` as a valid payment method
- Add the handling of the payment method management type in the `handleWalletPaymentAuthorization` saga. If the method management is REDIRECT, it means that we have to provide `RedirectDetailTypeEnum.redirect` as `detailType` attribute 

## How to test
- Checkout the dev-server from this PR: https://github.com/pagopa/io-dev-api-server/pull/390
- You should be able to see a new payment method (i.e. PostePay)
- Selecting that payment method, when you reach the authentication request (when you're in the confirmation screen), you should check in the request that `detailType` is `redirect`

## Preview

https://github.com/pagopa/io-app/assets/34343582/b4594d9b-5321-48d9-ad06-c1026e7162ce



