### PR TITLE
fix: [IOPAE-1253] Set `keepCancelVisible` prop to true on SearchInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   "dependencies": {
     "@babel/plugin-transform-regenerator": "^7.18.6",
     "@gorhom/bottom-sheet": "^4.1.5",
-    "@pagopa/io-app-design-system": "1.39.0",
+    "@pagopa/io-app-design-system": "1.39.1",
     "@pagopa/io-pagopa-commons": "^3.1.0",
     "@pagopa/io-react-native-crypto": "^0.3.0",
     "@pagopa/io-react-native-http-client": "1.0.2",

--- a/ts/features/services/search/screens/SearchScreen.tsx
+++ b/ts/features/services/search/screens/SearchScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { View } from "react-native";
+import { Platform, View } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FlashList, ListRenderItemInfo } from "@shopify/flash-list";
@@ -35,7 +35,7 @@ export const SearchScreen = () => {
   const dispatch = useIODispatch();
   const navigation = useIONavigation();
 
-  const ref = useRef<SearchInputRef>(null);
+  const searchInputRef = useRef<SearchInputRef>(null);
   const [query, setQuery] = useState<string>("");
 
   const {
@@ -52,7 +52,7 @@ export const SearchScreen = () => {
 
   useFocusEffect(
     useCallback(() => {
-      ref.current?.focus();
+      searchInputRef.current?.focus();
     }, [])
   );
 
@@ -164,13 +164,15 @@ export const SearchScreen = () => {
         ]}
       >
         <SearchInput
-          ref={ref}
           accessibilityLabel={I18n.t("services.search.input.placeholderShort")}
+          autoFocus={true}
           cancelButtonLabel={I18n.t("services.search.input.cancel")}
           clearAccessibilityLabel={I18n.t("services.search.input.clear")}
+          keepCancelVisible={true}
           onCancel={handleCancel}
           onChangeText={handleChangeText}
           placeholder={I18n.t("services.search.input.placeholderShort")}
+          ref={searchInputRef}
           value={query}
         />
       </View>
@@ -185,6 +187,10 @@ export const SearchScreen = () => {
         onEndReachedThreshold={0.1}
         ListEmptyComponent={renderListEmptyComponent}
         ListFooterComponent={renderListFooterComponent}
+        keyboardDismissMode={Platform.select({
+          ios: "interactive",
+          default: "on-drag"
+        })}
         keyboardShouldPersistTaps="handled"
       />
     </>

--- a/ts/navigation/AuthenticatedStackNavigator.tsx
+++ b/ts/navigation/AuthenticatedStackNavigator.tsx
@@ -3,6 +3,7 @@ import {
   TransitionPresets
 } from "@react-navigation/stack";
 import React from "react";
+import { Platform } from "react-native";
 import WorkunitGenericFailure from "../components/error/WorkunitGenericFailure";
 import { fimsEnabled } from "../config";
 import { BarcodeScanScreen } from "../features/barcode/screens/BarcodeScanScreen";
@@ -168,8 +169,13 @@ const AuthenticatedStackNavigator = () => {
         component={SearchScreen}
         options={{
           ...hideHeaderOptions,
-          animationEnabled: false,
-          gestureEnabled: false
+          gestureEnabled: false,
+          ...Platform.select({
+            ios: {
+              animationEnabled: false
+            },
+            default: undefined
+          })
         }}
       />
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3272,10 +3272,10 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@pagopa/io-app-design-system@1.39.0":
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-app-design-system/-/io-app-design-system-1.39.0.tgz#072ad36f4e163a63ce545f0c020c5828e25621d2"
-  integrity sha512-saFzbeJsvyaPHMt75NW2L1Z+Zz3M98FgilqIL7GVK56Fga+aY2CwxNAnANN4lA4PprdqGpyb7OrkTRT9/3aPZA== 
+"@pagopa/io-app-design-system@1.39.1":
+  version "1.39.1"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-app-design-system/-/io-app-design-system-1.39.1.tgz#a1c5d4b3d6ad5f1ced3230155ae213e354f63856"
+  integrity sha512-h1bgUOOP6yc9OXWm+MYNTtm9XIMH1ZY0Ti+lVjxXGLzxEjgHbZGlF/DJ/O1sprYU9J12LnszJx9dM1i85/c9oQ==
   dependencies:
     "@pagopa/ts-commons" "^12.0.0"
     "@testing-library/jest-native" "^5.4.2"


### PR DESCRIPTION
This PR depends on https://github.com/pagopa/io-app-design-system/pull/289

## Short description
This PR sets `keepCancelVisible` prop to true on SearchInput component.

<details open><summary>Details</summary>

<p>

| SearchInput |
| - | 
| <video src="https://github.com/pagopa/io-app/assets/29163287/20838c71-f3b2-485a-b50f-205bfb7dd58d" width="300"/> |
</p>
</details> 

## List of changes proposed in this pull request
- bump `@pagopa/io-app-design-system` to 1.39.1
- set `keepCancelVisible` prop to true on SearchInput
- set `keyboardDismissMode` prop to `interactive` for ios and `on-drag` as default

## How to test
using `io-dev-api-server`, navigate to services search screen and check that the cancel button is always visible when input loses focus
