### PR TITLE
chore: [IOCOM-1541] Show push notification token in the profile section (dev mode on)

### DIFF
--- a/ts/screens/profile/DeveloperModeSection.tsx
+++ b/ts/screens/profile/DeveloperModeSection.tsx
@@ -188,10 +188,7 @@ const DeveloperDataSection = () => {
   const isFastLoginEnabled = useIOSelector(isFastLoginEnabledSelector);
   const sessionToken = useIOSelector(sessionTokenSelector);
   const walletToken = useIOSelector(walletTokenSelector);
-  const { id: notificationId } = useIOSelector(
-    notificationsInstallationSelector
-  );
-  const { token: notificationToken } = useIOSelector(
+  const { id: notificationId, token: notificationToken } = useIOSelector(
     notificationsInstallationSelector
   );
   const publicKey = useIOSelector(lollipopPublicKeySelector);
@@ -224,7 +221,7 @@ const DeveloperDataSection = () => {
       onPress: () => clipboardSetStringWithFeedback(`${notificationId}`)
     },
     {
-      condition: isDevEnv && !!notificationToken,
+      condition: !!notificationToken,
       label: "Notification token",
       value: `${notificationToken}`,
       onPress: () => clipboardSetStringWithFeedback(`${notificationToken}`)


### PR DESCRIPTION
## Short description
This PR makes the Push Notification token available in the profile section when the developer mode is enabled.

## List of changes proposed in this pull request
- Removed the guard that prevented the token to be shown when in production

## How to test
Run the application and check that the token is visibile when the dev mode is enabled.
