### PR TITLE
[IOAPPX-325] Fix wrong behavior of `FooterActions`' sticky example on Android devices

### DIFF
--- a/ts/features/design-system/core/DSFooterActionsSticky.tsx
+++ b/ts/features/design-system/core/DSFooterActionsSticky.tsx
@@ -31,12 +31,12 @@ export const DSFooterActionsSticky = () => {
 
   const scrollY = useSharedValue<number>(0);
 
-  /* We can't just use `screenHeight` from `Dimensions` because
+  /* We can't just use `windowHeight` from `Dimensions` because
   it doesn't count the fixed block used by `react-navigation`
   for the header */
-  const { height: screenHeight } = Dimensions.get("screen");
+  const { height: windowHeight } = Dimensions.get("window");
   const headerHeight = useHeaderHeight();
-  const activeScreenHeight = screenHeight - headerHeight;
+  const activeScreenHeight = windowHeight - headerHeight;
 
   /* Disambiguation:
   actionBlock:            Block element fixed at the bottom of the screen


### PR DESCRIPTION
## Short description
This PR fixes the wrong behavior of `FooterActions`' sticky example on Android devices. The action block stopped earlier than intended, resulting in buggy behavior.

## List of changes proposed in this pull request
- Use the correct `Dimensions` value for the calculations

## How to test
Test the screen **FooterActions (sticky)** (Debug)