### PR TITLE
fix(Cross): [IOAPPX-326] Fix bug on Android when using `SemiBold` font weight

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   "dependencies": {
     "@babel/plugin-transform-regenerator": "^7.18.6",
     "@gorhom/bottom-sheet": "^4.1.5",
-    "@pagopa/io-app-design-system": "1.39.2",
+    "@pagopa/io-app-design-system": "1.39.4",
     "@pagopa/io-pagopa-commons": "^3.1.0",
     "@pagopa/io-react-native-crypto": "^0.3.0",
     "@pagopa/io-react-native-http-client": "1.0.2",

--- a/ts/components/AppVersion.tsx
+++ b/ts/components/AppVersion.tsx
@@ -33,7 +33,7 @@ const AppVersion = ({ onPress, testID }: AppVersion) => {
       accessibilityLabel={appVersionText}
     >
       <View style={[styles.versionButton, IOStyles.row, IOStyles.alignCenter]}>
-        <LabelSmall numberOfLines={1} weight="SemiBold" color="grey-650">
+        <LabelSmall numberOfLines={1} weight="Semibold" color="grey-650">
           {appVersionText}
         </LabelSmall>
       </View>

--- a/ts/components/DebugInfoOverlay.tsx
+++ b/ts/components/DebugInfoOverlay.tsx
@@ -1,5 +1,12 @@
 import * as React from "react";
-import { StyleSheet, Pressable, SafeAreaView, View, Text } from "react-native";
+import {
+  StyleSheet,
+  Pressable,
+  SafeAreaView,
+  View,
+  Text,
+  Platform
+} from "react-native";
 import { connect } from "react-redux";
 import { useState } from "react";
 import { widthPercentageToDP } from "react-native-responsive-screen";
@@ -27,7 +34,7 @@ const debugItemBorderColor = hexToRgba(IOColors.black, 0.1);
 const styles = StyleSheet.create({
   versionContainer: {
     ...StyleSheet.absoluteFillObject,
-    top: -8,
+    top: Platform.OS === "android" ? 0 : -8,
     justifyContent: "flex-start",
     alignItems: "center",
     zIndex: 1000
@@ -35,7 +42,7 @@ const styles = StyleSheet.create({
   versionText: {
     fontSize: 12,
     color: IOColors["grey-850"],
-    ...makeFontStyleObject("SemiBold")
+    ...makeFontStyleObject("Semibold")
   },
   screenDebugText: {
     fontSize: 12,

--- a/ts/components/PagoPATestIndicator.tsx
+++ b/ts/components/PagoPATestIndicator.tsx
@@ -28,7 +28,7 @@ const styles = StyleSheet.create({
     fontSize: 9,
     textTransform: "uppercase",
     color: IOColors["grey-850"],
-    ...makeFontStyleObject("SemiBold")
+    ...makeFontStyleObject("Semibold")
   }
 });
 

--- a/ts/components/__tests__/__snapshots__/OrganizationHeader.test.tsx.snap
+++ b/ts/components/__tests__/__snapshots__/OrganizationHeader.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`OrganizationHeader should match the snapshot 1`] = `
       allowFontScaling={false}
       color="bluegreyDark"
       defaultColor="bluegreyDark"
-      defaultWeight="SemiBold"
+      defaultWeight="Semibold"
       font="TitilliumSansPro"
       fontStyle={
         Object {
@@ -43,7 +43,7 @@ exports[`OrganizationHeader should match the snapshot 1`] = `
           },
         ]
       }
-      weight="SemiBold"
+      weight="Semibold"
     >
       Universala Esperanto-Asocio
     </Text>

--- a/ts/components/core/IOBadge.tsx
+++ b/ts/components/core/IOBadge.tsx
@@ -92,7 +92,7 @@ const styles = StyleSheet.create({
   },
   label: {
     alignSelf: "center",
-    ...makeFontStyleObject("SemiBold")
+    ...makeFontStyleObject("Semibold")
   },
   labelSizeDefault: {
     fontSize: 14,

--- a/ts/components/core/README.md
+++ b/ts/components/core/README.md
@@ -5,11 +5,11 @@
  
 ## Fonts
 
-The application uses the font _Titillium Sans Pro_. Fonts are handled differently than Android and iOS. To use the font, `TitilliumSansPro-SemiBoldItalic` example, you must apply the following properties for Android:
+The application uses the font _Titillium Sans Pro_. Fonts are handled differently than Android and iOS. To use the font, `TitilliumSansPro-SemiboldItalic` example, you must apply the following properties for Android:
 
 ```css
 {
-  fontFamily: 'TitilliumSansPro-SemiBoldItalic'
+  fontFamily: 'TitilliumSansPro-SemiboldItalic'
 }
 ```
 

--- a/ts/components/core/__mock__/fontMocks.ts
+++ b/ts/components/core/__mock__/fontMocks.ts
@@ -2,7 +2,7 @@ import { IOFontWeight } from "../fonts";
 
 export const fontWeightsMocks: ReadonlyArray<IOFontWeight> = [
   "Bold",
-  "SemiBold",
+  "Semibold",
   "Regular",
   "Light"
 ];

--- a/ts/components/core/fonts.ts
+++ b/ts/components/core/fonts.ts
@@ -8,7 +8,7 @@ import { Platform } from "react-native";
 
 export type IOFontFamily = keyof typeof fonts;
 
-const weights = ["Light", "Regular", "SemiBold", "Bold"] as const;
+const weights = ["Light", "Regular", "Semibold", "Bold"] as const;
 export type IOFontWeight = (typeof weights)[number];
 
 const weightValues = ["300", "400", "600", "700"] as const;
@@ -49,7 +49,7 @@ const fonts = {
 export const fontWeights: Record<IOFontWeight, FontWeightValue> = {
   Light: "300",
   Regular: "400",
-  SemiBold: "600",
+  Semibold: "600",
   Bold: "700"
 };
 

--- a/ts/components/core/typography/Body.tsx
+++ b/ts/components/core/typography/Body.tsx
@@ -9,7 +9,7 @@ type PartialAllowedColors = Extract<
   "bluegreyDark" | "white" | "blue" | "bluegrey" | "bluegreyLight"
 >;
 type AllowedColors = PartialAllowedColors | IOTheme["textBody-default"];
-type AllowedWeight = Extract<IOFontWeight, "Regular" | "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Regular" | "Semibold">;
 
 type OwnProps = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>

--- a/ts/components/core/typography/ComposedBodyFromArray.tsx
+++ b/ts/components/core/typography/ComposedBodyFromArray.tsx
@@ -13,7 +13,7 @@ type PartialAllowedColors = Extract<
   "bluegreyDark" | "white" | "blue" | "bluegrey" | "bluegreyLight"
 >;
 type AllowedColors = PartialAllowedColors | IOTheme["textBody-default"];
-type AllowedWeight = IOFontWeight | "Regular" | "SemiBold";
+type AllowedWeight = IOFontWeight | "Regular" | "Semibold";
 
 export type BodyProps = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors> & {

--- a/ts/components/core/typography/H2.tsx
+++ b/ts/components/core/typography/H2.tsx
@@ -16,7 +16,7 @@ type AllowedColors =
   | PartialAllowedColors
   | IOColorsStatusForeground
   | IOTheme["textHeading-default"];
-type AllowedWeight = Extract<IOFontWeight, "Bold" | "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Bold" | "Semibold">;
 
 type OwnProps = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>

--- a/ts/components/core/typography/H3.tsx
+++ b/ts/components/core/typography/H3.tsx
@@ -4,7 +4,7 @@ import { IOFontFamily, IOFontWeight } from "../fonts";
 import { useTypographyFactory } from "./Factory";
 import { ExternalTypographyProps, RequiredTypographyProps } from "./common";
 
-// these colors are allowed only when the weight is SemiBold
+// these colors are allowed only when the weight is Semibold
 type AllowedSemiBoldColors = Extract<
   IOColors,
   | "bluegreyDark"
@@ -35,11 +35,11 @@ type AllowedColors =
   | IOTheme["textHeading-default"];
 
 // all the possible weight
-type AllowedWeight = Extract<IOFontWeight, "Bold" | "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Bold" | "Semibold">;
 
-// these are the properties allowed only if weight is undefined or SemiBold
+// these are the properties allowed only if weight is undefined or Semibold
 type SemiBoldProps = {
-  weight?: Extract<IOFontWeight, "SemiBold">;
+  weight?: Extract<IOFontWeight, "Semibold">;
   color?: AllowedSemiBoldColors | IOTheme["textHeading-default"];
 };
 
@@ -68,11 +68,11 @@ export const calculateH3WeightColor = (
   weight?: AllowedWeight,
   color?: AllowedColors
 ): RequiredTypographyProps<AllowedWeight, AllowedColors> => {
-  const newWeight = weight ?? "SemiBold";
+  const newWeight = weight ?? "Semibold";
   const newColor =
     color !== undefined
       ? color
-      : newWeight === "SemiBold"
+      : newWeight === "Semibold"
       ? "bluegreyDark"
       : "white";
   return {
@@ -83,7 +83,7 @@ export const calculateH3WeightColor = (
 
 /**
  * Typography component to render `H3` text with font size {@link fontSize} and fontFamily {@link fontName}.
- * default values(if not defined) are weight: `SemiBold`, color: `bluegreyDark`
+ * default values(if not defined) are weight: `Semibold`, color: `bluegreyDark`
  * @param props
  * @constructor
  */

--- a/ts/components/core/typography/H3.tsx
+++ b/ts/components/core/typography/H3.tsx
@@ -5,7 +5,7 @@ import { useTypographyFactory } from "./Factory";
 import { ExternalTypographyProps, RequiredTypographyProps } from "./common";
 
 // these colors are allowed only when the weight is Semibold
-type AllowedSemiBoldColors = Extract<
+type AllowedSemiboldColors = Extract<
   IOColors,
   | "bluegreyDark"
   | "bluegreyLight"
@@ -31,16 +31,16 @@ type AllowedBoldColors = Extract<
 // all the possible colors
 type AllowedColors =
   | AllowedBoldColors
-  | AllowedSemiBoldColors
+  | AllowedSemiboldColors
   | IOTheme["textHeading-default"];
 
 // all the possible weight
 type AllowedWeight = Extract<IOFontWeight, "Bold" | "Semibold">;
 
 // these are the properties allowed only if weight is undefined or Semibold
-type SemiBoldProps = {
+type SemiboldProps = {
   weight?: Extract<IOFontWeight, "Semibold">;
-  color?: AllowedSemiBoldColors | IOTheme["textHeading-default"];
+  color?: AllowedSemiboldColors | IOTheme["textHeading-default"];
 };
 
 // these are the properties allowed only if weight is Bold
@@ -49,7 +49,7 @@ type BoldProps = {
   color?: AllowedBoldColors | IOTheme["textHeading-default"];
 };
 
-type BoldKindProps = SemiBoldProps | BoldProps;
+type BoldKindProps = SemiboldProps | BoldProps;
 
 type OwnProps = ExternalTypographyProps<BoldKindProps>;
 

--- a/ts/components/core/typography/H4.tsx
+++ b/ts/components/core/typography/H4.tsx
@@ -10,7 +10,7 @@ type AllowedBoldColors = Extract<
   "bluegreyDark" | "blue" | "white" | "greenLight"
 >;
 
-// these colors are allowed only when the weight is SemiBold
+// these colors are allowed only when the weight is Semibold
 type AllowedSemiBoldColors = Extract<
   IOColors,
   "white" | "bluegreyDark" | "blue" | "bluegreyLight"
@@ -29,7 +29,7 @@ type AllowedColors =
   | AllowedRegularColors;
 
 // all the possible weight
-type AllowedWeight = Extract<IOFontWeight, "Bold" | "SemiBold" | "Regular">;
+type AllowedWeight = Extract<IOFontWeight, "Bold" | "Semibold" | "Regular">;
 
 // these are the properties allowed only if weight is Bold or undefined
 type BoldProps = {
@@ -37,13 +37,13 @@ type BoldProps = {
   color?: AllowedBoldColors;
 };
 
-// these are the properties allowed only if weight is undefined or SemiBold
+// these are the properties allowed only if weight is undefined or Semibold
 type SemiBoldProps = {
-  weight: Extract<IOFontWeight, "SemiBold">;
+  weight: Extract<IOFontWeight, "Semibold">;
   color?: AllowedSemiBoldColors;
 };
 
-// these are the properties allowed only if weight is undefined or SemiBold
+// these are the properties allowed only if weight is undefined or Semibold
 type RegularProps = {
   weight: Extract<IOFontWeight, "Regular">;
   color?: AllowedRegularColors;
@@ -74,7 +74,7 @@ export const calculateH4WeightColor = (
       ? color
       : newWeight === "Bold"
       ? "bluegreyDark"
-      : newWeight === "SemiBold"
+      : newWeight === "Semibold"
       ? "white"
       : "bluegreyDark";
   return {

--- a/ts/components/core/typography/H4.tsx
+++ b/ts/components/core/typography/H4.tsx
@@ -11,7 +11,7 @@ type AllowedBoldColors = Extract<
 >;
 
 // these colors are allowed only when the weight is Semibold
-type AllowedSemiBoldColors = Extract<
+type AllowedSemiboldColors = Extract<
   IOColors,
   "white" | "bluegreyDark" | "blue" | "bluegreyLight"
 >;
@@ -25,7 +25,7 @@ type AllowedRegularColors = Extract<
 // all the possible colors
 type AllowedColors =
   | AllowedBoldColors
-  | AllowedSemiBoldColors
+  | AllowedSemiboldColors
   | AllowedRegularColors;
 
 // all the possible weight
@@ -38,9 +38,9 @@ type BoldProps = {
 };
 
 // these are the properties allowed only if weight is undefined or Semibold
-type SemiBoldProps = {
+type SemiboldProps = {
   weight: Extract<IOFontWeight, "Semibold">;
-  color?: AllowedSemiBoldColors;
+  color?: AllowedSemiboldColors;
 };
 
 // these are the properties allowed only if weight is undefined or Semibold
@@ -49,7 +49,7 @@ type RegularProps = {
   color?: AllowedRegularColors;
 };
 
-type BoldKindProps = SemiBoldProps | BoldProps | RegularProps;
+type BoldKindProps = SemiboldProps | BoldProps | RegularProps;
 
 export type OwnProps = ExternalTypographyProps<BoldKindProps>;
 

--- a/ts/components/core/typography/H5.tsx
+++ b/ts/components/core/typography/H5.tsx
@@ -4,7 +4,7 @@ import { IOFontFamily, IOFontWeight } from "../fonts";
 import { ExternalTypographyProps } from "./common";
 import { useTypographyFactory } from "./Factory";
 
-// these colors are allowed only when the weight is SemiBold
+// these colors are allowed only when the weight is Semibold
 type AllowedSemiBoldColors = Extract<
   IOColors,
   "bluegreyDark" | "bluegrey" | "bluegreyLight" | "blue" | "white" | "red"
@@ -26,11 +26,11 @@ type AllowedRegularColors = Extract<
 type AllowedColors = AllowedSemiBoldColors | AllowedRegularColors;
 
 // all the possible weight
-type AllowedWeight = Extract<IOFontWeight, "SemiBold" | "Regular">;
+type AllowedWeight = Extract<IOFontWeight, "Semibold" | "Regular">;
 
-// these are the properties allowed only if weight is undefined or SemiBold
+// these are the properties allowed only if weight is undefined or Semibold
 type SemiBoldProps = {
-  weight?: Extract<IOFontWeight, "SemiBold">;
+  weight?: Extract<IOFontWeight, "Semibold">;
   color?: AllowedSemiBoldColors;
 };
 
@@ -47,11 +47,11 @@ type OwnProps = ExternalTypographyProps<BoldKindProps>;
 const fontName: IOFontFamily = "TitilliumSansPro";
 export const h5FontSize = 14;
 export const h5DefaultColor: AllowedColors = "bluegreyDark";
-export const h5DefaultWeight: AllowedWeight = "SemiBold";
+export const h5DefaultWeight: AllowedWeight = "Semibold";
 
 /**
  * Typography component to render `H5` text with font size {@link fontSize} and fontFamily {@link fontName}.
- * default values(if not defined) are weight: `SemiBold`, color: `bluegreyDark`
+ * default values(if not defined) are weight: `Semibold`, color: `bluegreyDark`
  * @param props
  * @constructor
  */

--- a/ts/components/core/typography/H5.tsx
+++ b/ts/components/core/typography/H5.tsx
@@ -5,7 +5,7 @@ import { ExternalTypographyProps } from "./common";
 import { useTypographyFactory } from "./Factory";
 
 // these colors are allowed only when the weight is Semibold
-type AllowedSemiBoldColors = Extract<
+type AllowedSemiboldColors = Extract<
   IOColors,
   "bluegreyDark" | "bluegrey" | "bluegreyLight" | "blue" | "white" | "red"
 >;
@@ -23,15 +23,15 @@ type AllowedRegularColors = Extract<
 >;
 
 // all the possible colors
-type AllowedColors = AllowedSemiBoldColors | AllowedRegularColors;
+type AllowedColors = AllowedSemiboldColors | AllowedRegularColors;
 
 // all the possible weight
 type AllowedWeight = Extract<IOFontWeight, "Semibold" | "Regular">;
 
 // these are the properties allowed only if weight is undefined or Semibold
-type SemiBoldProps = {
+type SemiboldProps = {
   weight?: Extract<IOFontWeight, "Semibold">;
-  color?: AllowedSemiBoldColors;
+  color?: AllowedSemiboldColors;
 };
 
 // these are the properties allowed only if weight is Bold
@@ -40,7 +40,7 @@ type RegularProps = {
   color?: AllowedRegularColors;
 };
 
-type BoldKindProps = SemiBoldProps | RegularProps;
+type BoldKindProps = SemiboldProps | RegularProps;
 
 type OwnProps = ExternalTypographyProps<BoldKindProps>;
 

--- a/ts/components/core/typography/Label.tsx
+++ b/ts/components/core/typography/Label.tsx
@@ -13,7 +13,7 @@ type PartialAllowedColors = Extract<
   "blue" | "bluegrey" | "bluegreyDark" | "white" | "red"
 >;
 type AllowedColors = PartialAllowedColors | IOColorsStatusForeground;
-type AllowedWeight = Extract<IOFontWeight, "Bold" | "Regular" | "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Bold" | "Regular" | "Semibold">;
 type LabelProps = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>
 > & { fontSize?: FontSize };

--- a/ts/components/core/typography/LabelSmall.tsx
+++ b/ts/components/core/typography/LabelSmall.tsx
@@ -15,7 +15,7 @@ type PartialAllowedColors = Extract<
   | "grey-200"
 >;
 type AllowedColors = PartialAllowedColors | IOTheme["textBody-tertiary"];
-type AllowedWeight = Extract<IOFontWeight, "Bold" | "Regular" | "SemiBold">;
+type AllowedWeight = Extract<IOFontWeight, "Bold" | "Regular" | "Semibold">;
 type FontSize = "regular" | "small";
 type AllowedFontSize = { fontSize?: FontSize };
 type OwnProps = ExternalTypographyProps<

--- a/ts/components/core/typography/Link.tsx
+++ b/ts/components/core/typography/Link.tsx
@@ -5,7 +5,7 @@ import { useTypographyFactory } from "./Factory";
 import { ExternalTypographyProps, TypographyProps } from "./common";
 
 type AllowedColors = IOColors;
-type AllowedWeight = Extract<IOFontWeight, "SemiBold" | "Bold">;
+type AllowedWeight = Extract<IOFontWeight, "Semibold" | "Bold">;
 
 type OwnProps = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>
@@ -14,11 +14,11 @@ type OwnProps = ExternalTypographyProps<
 const fontName: IOFontFamily = "TitilliumSansPro";
 const fontSize = 16;
 export const linkDefaultColor: AllowedColors = "blue";
-export const linkDefaultWeight: AllowedWeight = "SemiBold";
+export const linkDefaultWeight: AllowedWeight = "Semibold";
 
 /**
  * Typography component to render `Link` text with font size {@link fontSize} and fontFamily {@link fontName}.
- * default values(if not defined) are weight: `SemiBold`, color: `blue`
+ * default values(if not defined) are weight: `Semibold`, color: `blue`
  * @param props`
  * @constructor
  */

--- a/ts/components/core/typography/Monospace.tsx
+++ b/ts/components/core/typography/Monospace.tsx
@@ -5,7 +5,7 @@ import { ExternalTypographyProps, TypographyProps } from "./common";
 import { useTypographyFactory } from "./Factory";
 
 type AllowedColors = Extract<IOColors, "bluegreyDark" | "bluegrey">;
-type AllowedWeight = Extract<IOFontWeight, "Regular" | "SemiBold" | "Bold">;
+type AllowedWeight = Extract<IOFontWeight, "Regular" | "Semibold" | "Bold">;
 
 type OwnProps = ExternalTypographyProps<
   TypographyProps<AllowedWeight, AllowedColors>

--- a/ts/components/core/typography/__test__/ComposedBodyFromArray.test.tsx
+++ b/ts/components/core/typography/__test__/ComposedBodyFromArray.test.tsx
@@ -93,7 +93,7 @@ describe("ComposedBodyFromArray", () => {
     },
     {
       text: " weights",
-      weight: "SemiBold"
+      weight: "Semibold"
     }
   ] as Array<BodyProps>;
 });

--- a/ts/components/core/typography/__test__/__snapshots__/ComposedBodyFromArray.test.tsx.snap
+++ b/ts/components/core/typography/__test__/__snapshots__/ComposedBodyFromArray.test.tsx.snap
@@ -382,7 +382,7 @@ exports[`ComposedBodyFromArray should match snapshot, multiple items body, auto 
         },
       ]
     }
-    weight="SemiBold"
+    weight="Semibold"
   >
      weights
   </Text>
@@ -567,7 +567,7 @@ exports[`ComposedBodyFromArray should match snapshot, multiple items body, cente
         },
       ]
     }
-    weight="SemiBold"
+    weight="Semibold"
   >
      weights
   </Text>
@@ -752,7 +752,7 @@ exports[`ComposedBodyFromArray should match snapshot, multiple items body, defau
         },
       ]
     }
-    weight="SemiBold"
+    weight="Semibold"
   >
      weights
   </Text>
@@ -937,7 +937,7 @@ exports[`ComposedBodyFromArray should match snapshot, multiple items body, justi
         },
       ]
     }
-    weight="SemiBold"
+    weight="Semibold"
   >
      weights
   </Text>
@@ -1122,7 +1122,7 @@ exports[`ComposedBodyFromArray should match snapshot, multiple items body, left 
         },
       ]
     }
-    weight="SemiBold"
+    weight="Semibold"
   >
      weights
   </Text>
@@ -1307,7 +1307,7 @@ exports[`ComposedBodyFromArray should match snapshot, multiple items body, right
         },
       ]
     }
-    weight="SemiBold"
+    weight="Semibold"
   >
      weights
   </Text>

--- a/ts/components/core/typography/__test__/__snapshots__/typography.test.tsx.snap
+++ b/ts/components/core/typography/__test__/__snapshots__/typography.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`Test Typography Components H3 Snapshot 1`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
   weightColorFactory={[Function]}
 >
   Text
@@ -183,7 +183,7 @@ exports[`Test Typography Components H3 Snapshot 2`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
   weightColorFactory={[Function]}
 >
   Text
@@ -214,7 +214,7 @@ exports[`Test Typography Components H3 Snapshot 3`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
   weightColorFactory={[Function]}
 >
   Text
@@ -400,7 +400,7 @@ exports[`Test Typography Components H4 Snapshot 4`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
   weightColorFactory={[Function]}
 >
   Text
@@ -431,7 +431,7 @@ exports[`Test Typography Components H4 Snapshot 5`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
   weightColorFactory={[Function]}
 >
   Text
@@ -566,7 +566,7 @@ exports[`Test Typography Components H5 Snapshot 1`] = `
 <Text
   color="bluegreyDark"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     Object {
@@ -586,7 +586,7 @@ exports[`Test Typography Components H5 Snapshot 1`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -596,7 +596,7 @@ exports[`Test Typography Components H5 Snapshot 2`] = `
 <Text
   color="bluegrey"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     Object {
@@ -616,7 +616,7 @@ exports[`Test Typography Components H5 Snapshot 2`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -626,7 +626,7 @@ exports[`Test Typography Components H5 Snapshot 3`] = `
 <Text
   color="blue"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     Object {
@@ -646,7 +646,7 @@ exports[`Test Typography Components H5 Snapshot 3`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -656,7 +656,7 @@ exports[`Test Typography Components H5 Snapshot 4`] = `
 <Text
   color="white"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     Object {
@@ -676,7 +676,7 @@ exports[`Test Typography Components H5 Snapshot 4`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>
@@ -686,7 +686,7 @@ exports[`Test Typography Components H5 Snapshot 5`] = `
 <Text
   color="bluegreyDark"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     Object {
@@ -716,7 +716,7 @@ exports[`Test Typography Components H5 Snapshot 6`] = `
 <Text
   color="bluegrey"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     Object {
@@ -746,7 +746,7 @@ exports[`Test Typography Components H5 Snapshot 7`] = `
 <Text
   color="blue"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     Object {
@@ -1056,7 +1056,7 @@ exports[`Test Typography Components Link Snapshot 1`] = `
 <Text
   color="blue"
   defaultColor="blue"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     Object {
@@ -1078,7 +1078,7 @@ exports[`Test Typography Components Link Snapshot 1`] = `
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   Text
 </Text>

--- a/ts/components/core/typography/__test__/typography.test.tsx
+++ b/ts/components/core/typography/__test__/typography.test.tsx
@@ -57,18 +57,18 @@ describe("Test Typography Components", () => {
     const h4white = TestRenderer.create(<H4 color={"white"}>Text</H4>).toJSON();
     expect(h4white).toMatchSnapshot();
     // Semibold weight
-    const h4SemiBoldwhite = TestRenderer.create(
+    const h4Semiboldwhite = TestRenderer.create(
       <H4 weight={"Semibold"} color={"white"}>
         Text
       </H4>
     ).toJSON();
-    expect(h4SemiBoldwhite).toMatchSnapshot();
+    expect(h4Semiboldwhite).toMatchSnapshot();
 
     // Semibold default color
-    const h4SemiBoldDefault = TestRenderer.create(
+    const h4SemiboldDefault = TestRenderer.create(
       <H4 weight={"Semibold"}>Text</H4>
     ).toJSON();
-    expect(h4SemiBoldDefault).toMatchSnapshot();
+    expect(h4SemiboldDefault).toMatchSnapshot();
 
     // Regular weight
     // with regular weight, default color is bluegreydark

--- a/ts/components/core/typography/__test__/typography.test.tsx
+++ b/ts/components/core/typography/__test__/typography.test.tsx
@@ -26,7 +26,7 @@ describe("Test Typography Components", () => {
     expect(h2Default).toMatchSnapshot();
   });
   it("H3 Snapshot", () => {
-    // SemiBold weight, default weight
+    // Semibold weight, default weight
     const h3Default = TestRenderer.create(<H3>Text</H3>).toJSON();
     expect(h3Default).toMatchSnapshot();
     const h3bluegreyLight = TestRenderer.create(
@@ -56,9 +56,9 @@ describe("Test Typography Components", () => {
     expect(h4Dblue).toMatchSnapshot();
     const h4white = TestRenderer.create(<H4 color={"white"}>Text</H4>).toJSON();
     expect(h4white).toMatchSnapshot();
-    // SemiBold weight
+    // Semibold weight
     const h4SemiBoldwhite = TestRenderer.create(
-      <H4 weight={"SemiBold"} color={"white"}>
+      <H4 weight={"Semibold"} color={"white"}>
         Text
       </H4>
     ).toJSON();
@@ -66,7 +66,7 @@ describe("Test Typography Components", () => {
 
     // Semibold default color
     const h4SemiBoldDefault = TestRenderer.create(
-      <H4 weight={"SemiBold"}>Text</H4>
+      <H4 weight={"Semibold"}>Text</H4>
     ).toJSON();
     expect(h4SemiBoldDefault).toMatchSnapshot();
 
@@ -99,7 +99,7 @@ describe("Test Typography Components", () => {
     expect(h4Regularwhite).toMatchSnapshot();
   });
   it("H5 Snapshot", () => {
-    // SemiBold weight, default
+    // Semibold weight, default
     const h5Default = TestRenderer.create(<H5>Text</H5>).toJSON();
     expect(h5Default).toMatchSnapshot();
     const h5Defaultbluegrey = TestRenderer.create(

--- a/ts/components/screens/ListItemComponent.tsx
+++ b/ts/components/screens/ListItemComponent.tsx
@@ -68,7 +68,7 @@ const styles = StyleSheet.create({
   listItemText: {
     fontSize: 18,
     lineHeight: 24,
-    ...makeFontStyleObject("SemiBold", undefined, "TitilliumSansPro")
+    ...makeFontStyleObject("Semibold", undefined, "TitilliumSansPro")
   },
   spacingBase: {
     paddingTop: 6,

--- a/ts/components/screens/__tests__/ScreenWithListItems.test.tsx
+++ b/ts/components/screens/__tests__/ScreenWithListItems.test.tsx
@@ -66,7 +66,7 @@ describe("ScreenWithListItems", () => {
             style: {
               textAlign: "center"
             },
-            weight: "SemiBold"
+            weight: "Semibold"
           }
         ]
       };

--- a/ts/components/screens/__tests__/__snapshots__/LoadingScreenContent.test.tsx.snap
+++ b/ts/components/screens/__tests__/__snapshots__/LoadingScreenContent.test.tsx.snap
@@ -539,7 +539,7 @@ exports[`LoadingScreenContent should match the snapshot with title, a child, hea
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -564,7 +564,7 @@ exports[`LoadingScreenContent should match the snapshot with title, a child, hea
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Test Content Title
                             </Text>
@@ -1131,7 +1131,7 @@ exports[`LoadingScreenContent should match the snapshot with title, a child, hea
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -1156,7 +1156,7 @@ exports[`LoadingScreenContent should match the snapshot with title, a child, hea
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Test Content Title
                             </Text>
@@ -1718,7 +1718,7 @@ exports[`LoadingScreenContent should match the snapshot with title, no children,
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -1743,7 +1743,7 @@ exports[`LoadingScreenContent should match the snapshot with title, no children,
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Test Content Title
                             </Text>
@@ -2307,7 +2307,7 @@ exports[`LoadingScreenContent should match the snapshot with title, no children,
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -2332,7 +2332,7 @@ exports[`LoadingScreenContent should match the snapshot with title, no children,
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Test Content Title
                             </Text>

--- a/ts/components/screens/__tests__/__snapshots__/OperationResultScreenContent.test.tsx.snap
+++ b/ts/components/screens/__tests__/__snapshots__/OperationResultScreenContent.test.tsx.snap
@@ -358,7 +358,7 @@ exports[`OperationResultScreenContent should match the snapshot with default pro
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -383,7 +383,7 @@ exports[`OperationResultScreenContent should match the snapshot with default pro
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               title
                             </Text>

--- a/ts/components/screens/__tests__/__snapshots__/ScreenWithListItems.test.tsx.snap
+++ b/ts/components/screens/__tests__/__snapshots__/ScreenWithListItems.test.tsx.snap
@@ -336,7 +336,7 @@ exports[`ScreenWithListItems Rendering renders correctly with default props 1`] 
                             allowFontScaling={false}
                             color="black"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -358,7 +358,7 @@ exports[`ScreenWithListItems Rendering renders correctly with default props 1`] 
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             Test Title
                           </Text>
@@ -443,7 +443,7 @@ exports[`ScreenWithListItems Rendering renders correctly with default props 1`] 
                                     allowFontScaling={false}
                                     color="grey-700"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -466,7 +466,7 @@ exports[`ScreenWithListItems Rendering renders correctly with default props 1`] 
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     List Header
                                   </Text>
@@ -595,7 +595,7 @@ exports[`ScreenWithListItems Rendering renders correctly with default props 1`] 
                                           allowFontScaling={false}
                                           color="black"
                                           defaultColor="black"
-                                          defaultWeight="SemiBold"
+                                          defaultWeight="Semibold"
                                           font="TitilliumSansPro"
                                           fontStyle={
                                             Object {
@@ -618,7 +618,7 @@ exports[`ScreenWithListItems Rendering renders correctly with default props 1`] 
                                               },
                                             ]
                                           }
-                                          weight="SemiBold"
+                                          weight="Semibold"
                                         >
                                           Value 1
                                         </Text>
@@ -706,7 +706,7 @@ exports[`ScreenWithListItems Rendering renders correctly with default props 1`] 
                                           allowFontScaling={false}
                                           color="black"
                                           defaultColor="black"
-                                          defaultWeight="SemiBold"
+                                          defaultWeight="Semibold"
                                           font="TitilliumSansPro"
                                           fontStyle={
                                             Object {
@@ -729,7 +729,7 @@ exports[`ScreenWithListItems Rendering renders correctly with default props 1`] 
                                               },
                                             ]
                                           }
-                                          weight="SemiBold"
+                                          weight="Semibold"
                                         >
                                           Value 2
                                         </Text>
@@ -1341,7 +1341,7 @@ exports[`ScreenWithListItems Rendering renders correctly without optional props 
                             allowFontScaling={false}
                             color="black"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -1363,7 +1363,7 @@ exports[`ScreenWithListItems Rendering renders correctly without optional props 
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           />
                           <RCTScrollView
                             ItemSeparatorComponent={[Function]}
@@ -2004,7 +2004,7 @@ exports[`ScreenWithListItems Rendering renders subtitle as array correctly 1`] =
                             allowFontScaling={false}
                             color="black"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -2026,7 +2026,7 @@ exports[`ScreenWithListItems Rendering renders subtitle as array correctly 1`] =
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             Test Title
                           </Text>
@@ -2130,7 +2130,7 @@ exports[`ScreenWithListItems Rendering renders subtitle as array correctly 1`] =
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Subtitle Part 2 Bold
                             </Text>
@@ -2179,7 +2179,7 @@ exports[`ScreenWithListItems Rendering renders subtitle as array correctly 1`] =
                                     allowFontScaling={false}
                                     color="grey-700"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -2202,7 +2202,7 @@ exports[`ScreenWithListItems Rendering renders subtitle as array correctly 1`] =
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     List Header
                                   </Text>
@@ -2331,7 +2331,7 @@ exports[`ScreenWithListItems Rendering renders subtitle as array correctly 1`] =
                                           allowFontScaling={false}
                                           color="black"
                                           defaultColor="black"
-                                          defaultWeight="SemiBold"
+                                          defaultWeight="Semibold"
                                           font="TitilliumSansPro"
                                           fontStyle={
                                             Object {
@@ -2354,7 +2354,7 @@ exports[`ScreenWithListItems Rendering renders subtitle as array correctly 1`] =
                                               },
                                             ]
                                           }
-                                          weight="SemiBold"
+                                          weight="Semibold"
                                         >
                                           Value 1
                                         </Text>
@@ -2442,7 +2442,7 @@ exports[`ScreenWithListItems Rendering renders subtitle as array correctly 1`] =
                                           allowFontScaling={false}
                                           color="black"
                                           defaultColor="black"
-                                          defaultWeight="SemiBold"
+                                          defaultWeight="Semibold"
                                           font="TitilliumSansPro"
                                           fontStyle={
                                             Object {
@@ -2465,7 +2465,7 @@ exports[`ScreenWithListItems Rendering renders subtitle as array correctly 1`] =
                                               },
                                             ]
                                           }
-                                          weight="SemiBold"
+                                          weight="Semibold"
                                         >
                                           Value 2
                                         </Text>

--- a/ts/components/services/SectionHeader.tsx
+++ b/ts/components/services/SectionHeader.tsx
@@ -27,7 +27,7 @@ const sectionHeader: React.FC<Props> = ({ iconName, title }) => (
   <View style={styles.header}>
     <Icon name={iconName} color="bluegrey" size={20} />
     <HSpacer size={8} />
-    <H3 weight={"SemiBold"} color={"bluegrey"} accessibilityRole={"header"}>
+    <H3 weight={"Semibold"} color={"bluegrey"} accessibilityRole={"header"}>
       {I18n.t(title)}
     </H3>
   </View>

--- a/ts/components/services/ServiceMetadata/InformationRow.tsx
+++ b/ts/components/services/ServiceMetadata/InformationRow.tsx
@@ -51,7 +51,7 @@ const InformationRow = ({
         numberOfLines={1}
         ellipsizeMode="tail"
         color={"blue"}
-        weight={"SemiBold"}
+        weight={"Semibold"}
       >
         {value}
       </H4>

--- a/ts/components/services/ServiceMetadata/__tests__/__snapshots__/InformationRow.test.tsx.snap
+++ b/ts/components/services/ServiceMetadata/__tests__/__snapshots__/InformationRow.test.tsx.snap
@@ -89,7 +89,7 @@ exports[`the InformationRow component should match the snapshot 1`] = `
           },
         ]
       }
-      weight="SemiBold"
+      weight="Semibold"
       weightColorFactory={[Function]}
     >
       via Roma

--- a/ts/components/services/__tests__/__snapshots__/LinkRow.test.tsx.snap
+++ b/ts/components/services/__tests__/__snapshots__/LinkRow.test.tsx.snap
@@ -6,7 +6,7 @@ Array [
     accessibilityRole="link"
     color="blue"
     defaultColor="blue"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     ellipsizeMode="tail"
     font="TitilliumSansPro"
     fontStyle={
@@ -34,7 +34,7 @@ Array [
         },
       ]
     }
-    weight="SemiBold"
+    weight="Semibold"
   >
     Email
   </Text>,

--- a/ts/components/services/__tests__/__snapshots__/SectionHeader.test.tsx.snap
+++ b/ts/components/services/__tests__/__snapshots__/SectionHeader.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`SectionHeader component should match the snapshot 1`] = `
         },
       ]
     }
-    weight="SemiBold"
+    weight="Semibold"
     weightColorFactory={[Function]}
   >
     ID

--- a/ts/components/ui/Accordion.tsx
+++ b/ts/components/ui/Accordion.tsx
@@ -53,7 +53,7 @@ const Accordion: React.FunctionComponent<Props> = (props: Props) => {
     >
       <View style={styles.header}>
         <View style={IOStyles.flex}>
-          <Body weight="SemiBold">{title}</Body>
+          <Body weight="Semibold">{title}</Body>
         </View>
         <View
           style={{

--- a/ts/components/wallet/PaymentHistoryItem.tsx
+++ b/ts/components/wallet/PaymentHistoryItem.tsx
@@ -58,7 +58,7 @@ export default class PaymentHistoryItem extends React.PureComponent<Props> {
         <VSpacer size={4} />
         <View style={styles.text3Line}>
           <View style={[styles.text3Container, IOStyles.flex, IOStyles.row]}>
-            <Body color="bluegreyDark" weight="SemiBold" numberOfLines={2}>
+            <Body color="bluegreyDark" weight="Semibold" numberOfLines={2}>
               {`${I18n.t("payment.IUV")} ${this.props.text3}`}
             </Body>
           </View>

--- a/ts/components/wallet/PaymentMethodsList.tsx
+++ b/ts/components/wallet/PaymentMethodsList.tsx
@@ -153,7 +153,7 @@ const renderListItem = (
               <View style={IOStyles.rowSpaceBetween}>
                 <View>
                   {badgeStatus?.badge}
-                  <H3 color={"bluegreyDark"} weight={"SemiBold"}>
+                  <H3 color={"bluegreyDark"} weight={"Semibold"}>
                     {itemInfo.item.name}
                   </H3>
                 </View>
@@ -189,7 +189,7 @@ const renderListItem = (
                   variant="solid"
                   color="blue"
                 />
-                <H3 color={"bluegrey"} weight={"SemiBold"}>
+                <H3 color={"bluegrey"} weight={"Semibold"}>
                   {itemInfo.item.name}
                 </H3>
               </View>

--- a/ts/components/wallet/PaymentSummaryComponent.tsx
+++ b/ts/components/wallet/PaymentSummaryComponent.tsx
@@ -52,7 +52,7 @@ export const PaymentSummaryComponent = (props: Props) => {
           {label}
         </Body>
         <Body
-          weight="SemiBold"
+          weight="Semibold"
           color={props.dark ? "white" : "bluegreyDark"}
           selectable={true}
         >

--- a/ts/components/wallet/SelectionBox.tsx
+++ b/ts/components/wallet/SelectionBox.tsx
@@ -70,7 +70,7 @@ export const SelectionBox = (props: Props) => (
 
       {props.ctaText && (
         <View style={styles.selectionBoxTrail}>
-          <H4 color="blue" weight="SemiBold">
+          <H4 color="blue" weight="Semibold">
             {props.ctaText}
           </H4>
         </View>

--- a/ts/components/wallet/TransactionsList.tsx
+++ b/ts/components/wallet/TransactionsList.tsx
@@ -145,7 +145,7 @@ export const TransactionsList = (props: Props) => {
     <ScrollView scrollEnabled={false} style={styles.scrollView}>
       <View>
         <View style={styles.subHeaderContent}>
-          <H3 weight={"SemiBold"} color={"bluegreyDark"}>
+          <H3 weight={"Semibold"} color={"bluegreyDark"}>
             {I18n.t("wallet.latestTransactions")}
           </H3>
         </View>

--- a/ts/components/wallet/payment/PickPaymentMethodBaseListItem.tsx
+++ b/ts/components/wallet/payment/PickPaymentMethodBaseListItem.tsx
@@ -69,7 +69,7 @@ const PickPaymentMethodBaseListItem: React.FC<Props> = ({
         />
         <VSpacer size={16} />
         <View style={styles.paymentMethodInfo}>
-          <H4 weight={"SemiBold"} color={"bluegreyDark"} numberOfLines={1}>
+          <H4 weight={"Semibold"} color={"bluegreyDark"} numberOfLines={1}>
             {title}
           </H4>
           <H5 weight={"Regular"} color={"bluegreyDark"} numberOfLines={2}>

--- a/ts/features/bonus/cdc/screens/CdcBonusRequestSelectResidence.tsx
+++ b/ts/features/bonus/cdc/screens/CdcBonusRequestSelectResidence.tsx
@@ -80,7 +80,7 @@ const CdcBonusRequestSelectResidence = () => {
               >
                 <Icon name="bonus" size={20} />
                 <HSpacer size={16} />
-                <H3 weight={"SemiBold"} color={"bluegrey"}>
+                <H3 weight={"Semibold"} color={"bluegrey"}>
                   {b.year}
                 </H3>
               </View>

--- a/ts/features/bonus/cgn/components/__test__/__snapshots__/CgnCard.test.tsx.snap
+++ b/ts/features/bonus/cgn/components/__test__/__snapshots__/CgnCard.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`CgnCard should match the snapshot 1`] = `
         allowFontScaling={false}
         color="black"
         defaultColor="black"
-        defaultWeight="SemiBold"
+        defaultWeight="Semibold"
         font="TitilliumSansPro"
         fontStyle={
           Object {
@@ -72,7 +72,7 @@ exports[`CgnCard should match the snapshot 1`] = `
             },
           ]
         }
-        weight="SemiBold"
+        weight="Semibold"
       >
         Carta Giovani Nazionale
       </Text>
@@ -81,7 +81,7 @@ exports[`CgnCard should match the snapshot 1`] = `
       allowFontScaling={false}
       color="black"
       defaultColor="black"
-      defaultWeight="SemiBold"
+      defaultWeight="Semibold"
       font="TitilliumSansPro"
       fontStyle={
         Object {
@@ -106,7 +106,7 @@ exports[`CgnCard should match the snapshot 1`] = `
           },
         ]
       }
-      weight="SemiBold"
+      weight="Semibold"
     >
       Dipartimento per le politiche giovanili e il servizio civile universale
     </Text>
@@ -114,7 +114,7 @@ exports[`CgnCard should match the snapshot 1`] = `
       allowFontScaling={false}
       color="blueItalia-850"
       defaultColor="black"
-      defaultWeight="SemiBold"
+      defaultWeight="Semibold"
       font="TitilliumSansPro"
       fontStyle={
         Object {
@@ -136,7 +136,7 @@ exports[`CgnCard should match the snapshot 1`] = `
           },
         ]
       }
-      weight="SemiBold"
+      weight="Semibold"
     >
       Valida fino al 12/23
     </Text>

--- a/ts/features/bonus/cgn/components/merchants/CgnDiscountDetail.tsx
+++ b/ts/features/bonus/cgn/components/merchants/CgnDiscountDetail.tsx
@@ -100,7 +100,7 @@ export const CgnDiscountDetail: React.FunctionComponent<Props> = ({
                   />
                   <HSpacer size={8} />
                   <H5
-                    weight={"SemiBold"}
+                    weight={"Semibold"}
                     color={"bluegrey"}
                     testID={"category-name"}
                   >

--- a/ts/features/bonus/cgn/components/merchants/CgnDiscountValueBox.tsx
+++ b/ts/features/bonus/cgn/components/merchants/CgnDiscountValueBox.tsx
@@ -46,7 +46,7 @@ const CgnDiscountValueBox = ({ value, small }: ValueBoxProps) => {
     E.getOrElse(() => "-")
   );
   const percentage = (
-    <H5 weight={"SemiBold"} color={"white"}>
+    <H5 weight={"Semibold"} color={"white"}>
       {PERCENTAGE_SYMBOL}
     </H5>
   );

--- a/ts/features/bonus/cgn/components/merchants/CgnMerchantListItem.tsx
+++ b/ts/features/bonus/cgn/components/merchants/CgnMerchantListItem.tsx
@@ -45,7 +45,7 @@ export const renderCategoryElement = (category: ProductCategory) =>
         <View style={styles.row}>
           <Icon name={c.icon} size={20} color="bluegrey" />
           <HSpacer size={8} />
-          <H5 weight={"SemiBold"} color={"bluegrey"}>
+          <H5 weight={"Semibold"} color={"bluegrey"}>
             {I18n.t(c.nameKey).toLocaleUpperCase()}
           </H5>
         </View>
@@ -76,7 +76,7 @@ const CategoriesRow = ({ categories }: Pick<Props, "categories">) => (
                   }}
                 />
                 <HSpacer size={8} />
-                <H5 color={"bluegrey"} weight={"SemiBold"}>
+                <H5 color={"bluegrey"} weight={"Semibold"}>
                   {I18n.t("bonus.cgn.merchantDetail.categories.counting", {
                     count: categories.length - 1
                   }).toLocaleUpperCase()}

--- a/ts/features/bonus/cgn/components/merchants/__test__/__snapshots__/CgnDiscountDetail.test.tsx.snap
+++ b/ts/features/bonus/cgn/components/merchants/__test__/__snapshots__/CgnDiscountDetail.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`when rendering on match snapshot for OTP discount 1`] = `
           },
         ]
       }
-      weight="SemiBold"
+      weight="Semibold"
       weightColorFactory={[Function]}
     >
       Discount code
@@ -215,7 +215,7 @@ exports[`when rendering on match snapshot for OTP discount 1`] = `
         },
       ]
     }
-    weight="SemiBold"
+    weight="Semibold"
     weightColorFactory={[Function]}
   >
     Validity
@@ -326,7 +326,7 @@ exports[`when rendering on match snapshot for bucket discount 1`] = `
         },
       ]
     }
-    weight="SemiBold"
+    weight="Semibold"
     weightColorFactory={[Function]}
   >
     Validity
@@ -437,7 +437,7 @@ exports[`when rendering on match snapshot for landing page discount 1`] = `
         },
       ]
     }
-    weight="SemiBold"
+    weight="Semibold"
     weightColorFactory={[Function]}
   >
     Validity
@@ -555,7 +555,7 @@ exports[`when rendering on match snapshot for static code 1`] = `
         },
       ]
     }
-    weight="SemiBold"
+    weight="Semibold"
     weightColorFactory={[Function]}
   >
     Discount code
@@ -699,7 +699,7 @@ exports[`when rendering on match snapshot for static code 1`] = `
         },
       ]
     }
-    weight="SemiBold"
+    weight="Semibold"
     weightColorFactory={[Function]}
   >
     Validity

--- a/ts/features/bonus/cgn/components/merchants/discount/__test__/__snapshots__/CgnDiscountCodeComponent.test.tsx.snap
+++ b/ts/features/bonus/cgn/components/merchants/discount/__test__/__snapshots__/CgnDiscountCodeComponent.test.tsx.snap
@@ -34,7 +34,7 @@ Array [
         },
       ]
     }
-    weight="SemiBold"
+    weight="Semibold"
     weightColorFactory={[Function]}
   >
     Discount code

--- a/ts/features/bonus/cgn/components/merchants/search/OrderOption.tsx
+++ b/ts/features/bonus/cgn/components/merchants/search/OrderOption.tsx
@@ -20,7 +20,7 @@ const OrderOption = ({ text, value, onPress, checked }: Props) => (
     }}
     onPress={() => onPress(value)}
   >
-    <H4 weight={checked ? "SemiBold" : "Regular"} color={"bluegreyDark"}>
+    <H4 weight={checked ? "Semibold" : "Regular"} color={"bluegreyDark"}>
       {text}
     </H4>
     <Icon

--- a/ts/features/bonus/cgn/screens/merchants/CgnMerchantsTabsScreen.tsx
+++ b/ts/features/bonus/cgn/screens/merchants/CgnMerchantsTabsScreen.tsx
@@ -36,7 +36,7 @@ type Props = ReturnType<typeof mapStateToProps> &
 //     backgroundColor: customVariables.contentPrimaryBackground
 //   },
 //   activeTextStyle: {
-//     ...makeFontStyleObject("SemiBold"),
+//     ...makeFontStyleObject("Semibold"),
 //     fontSize: Platform.OS === "android" ? 16 : undefined,
 //     fontWeight: Platform.OS === "android" ? "normal" : "bold",
 //     color: customVariables.brandPrimary

--- a/ts/features/bonus/common/components/BonusInformationComponent.tsx
+++ b/ts/features/bonus/common/components/BonusInformationComponent.tsx
@@ -87,7 +87,7 @@ const getTosFooter = (
                   {I18n.t("bonus.bonusVacanze.advice")}
                 </Body>
                 <LabelLink
-                  weight={"SemiBold"}
+                  weight={"Semibold"}
                   numberOfLines={1}
                   onPress={() => handleModalPress(bT)}
                 >

--- a/ts/features/design-system/core/DSAccordion.tsx
+++ b/ts/features/design-system/core/DSAccordion.tsx
@@ -16,23 +16,19 @@ import { DesignSystemScreen } from "../components/DesignSystemScreen";
 
 const assistanceData: Array<AccordionItem> = [
   {
-    id: 1,
     title: "Come posso pagare su IO?",
     body: "Puoi pagare con carte di debito, credito e prepagate, con PayPal o BANCOMAT Pay."
   },
   {
-    id: 2,
     title: "Come posso eliminare un metodo di pagamento?",
     body: "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi 'Elimina questo metodo!"
   },
   {
-    id: 3,
     title:
       "Nel 2021 ho maturato degli importi che non mi sono ancora stati rimborsati. Cosa posso fare?",
     body: "Probabilmente non hai indicato l'IBAN del conto su cui desideri ricevere l'accredito, oppure quello che hai indicato non è valido.Per inserire l'IBAN o verificarne la correttezza, apri l'app, vai al Portafoglio e premi sulla card del Cashback. Poi, inseriscilo o modificalo e seleziona 'Continua'. Entro 90 giorni riceverai tramite l'app 10 un messaggio sullo stato del rimborso. Le attività tra PagoPA S.p.A. e Consap S.p.A. per i pagamenti dei rimborsi sono in corso di dismissione, quindi, se non inserisci o non correggi l'IBAN entro il 31/07/2022, potrebbe non essere più possibile effettuare il bonifico per il rimborso."
   },
   {
-    id: 4,
     title: "Come posso eliminare un metodo di pagamento?",
     body: (
       <Body>
@@ -43,7 +39,6 @@ const assistanceData: Array<AccordionItem> = [
     )
   },
   {
-    id: 5,
     title:
       "Nel 2021 ho maturato degli importi che non mi sono ancora stati rimborsati. Cosa posso fare?",
     body: "Probabilmente non hai indicato l'IBAN del conto su cui desideri ricevere l'accredito, oppure quello che hai indicato non è valido.Per inserire l'IBAN o verificarne la correttezza, apri l'app, vai al Portafoglio e premi sulla card del Cashback. Poi, inseriscilo o modificalo e seleziona 'Continua'. Entro 90 giorni riceverai tramite l'app 10 un messaggio sullo stato del rimborso. Le attività tra PagoPA S.p.A. e Consap S.p.A. per i pagamenti dei rimborsi sono in corso di dismissione, quindi, se non inserisci o non correggi l'IBAN entro il 31/07/2022, potrebbe non essere più possibile effettuare il bonifico per il rimborso."
@@ -60,7 +55,7 @@ export const DSAccordion = () => {
   const theme = useIOTheme();
 
   const renderItem = ({ item }: ListRenderItemInfo<AccordionItem>) => (
-    <AccordionItem id={item.id} title={item.title} body={item.body} />
+    <AccordionItem title={item.title} body={item.body} />
   );
 
   return (
@@ -73,7 +68,7 @@ export const DSAccordion = () => {
         }}
         ListHeaderComponent={renderAccordionHeader}
         ItemSeparatorComponent={() => <VSpacer size={8} />}
-        keyExtractor={(item, index) => `${item.id}-${index}`}
+        keyExtractor={(item, index) => `${item.title}-${index}`}
         renderItem={renderItem}
       />
 

--- a/ts/features/design-system/core/DSAdvice.tsx
+++ b/ts/features/design-system/core/DSAdvice.tsx
@@ -51,7 +51,7 @@ export const DSAdvice = () => (
     {renderBanner()}
 
     <VSpacer size={40} />
-    <H2 color={"bluegrey"} weight={"SemiBold"} style={{ marginBottom: 16 }}>
+    <H2 color={"bluegrey"} weight={"Semibold"} style={{ marginBottom: 16 }}>
       Legacy components
     </H2>
     <AdviceComponent
@@ -110,7 +110,7 @@ export const DSAdvice = () => (
 
 const renderFeatureInfo = () => (
   <>
-    <H2 color={"bluegrey"} weight={"SemiBold"} style={{ marginBottom: 16 }}>
+    <H2 color={"bluegrey"} weight={"Semibold"} style={{ marginBottom: 16 }}>
       FeatureInfo
     </H2>
     <DSComponentViewerBox name="FeatureInfo · with Icon">
@@ -167,7 +167,7 @@ const renderBanner = () => {
 
   return (
     <>
-      <H2 color={"bluegrey"} weight={"SemiBold"} style={{ marginBottom: 16 }}>
+      <H2 color={"bluegrey"} weight={"Semibold"} style={{ marginBottom: 16 }}>
         Banner
       </H2>
       {bannerBackgroundColours.map(color => (

--- a/ts/features/design-system/core/DSAlert.tsx
+++ b/ts/features/design-system/core/DSAlert.tsx
@@ -20,7 +20,7 @@ export const DSAlert = () => {
   return (
     <DesignSystemScreen title={"Alert"}>
       {/* Content only */}
-      <H2 color={"bluegrey"} weight={"SemiBold"} style={{ marginBottom: 16 }}>
+      <H2 color={"bluegrey"} weight={"Semibold"} style={{ marginBottom: 16 }}>
         Content only
       </H2>
       <Alert
@@ -55,7 +55,7 @@ export const DSAlert = () => {
 
       <VSpacer size={40} />
 
-      <H2 color={"bluegrey"} weight={"SemiBold"} style={{ marginBottom: 16 }}>
+      <H2 color={"bluegrey"} weight={"Semibold"} style={{ marginBottom: 16 }}>
         Title + Content
       </H2>
 
@@ -104,7 +104,7 @@ export const DSAlert = () => {
 
       <VSpacer size={40} />
 
-      <H2 color={"bluegrey"} weight={"SemiBold"} style={{ marginBottom: 16 }}>
+      <H2 color={"bluegrey"} weight={"Semibold"} style={{ marginBottom: 16 }}>
         Content + Action
       </H2>
 
@@ -157,7 +157,7 @@ export const DSAlert = () => {
       <VSpacer size={40} />
 
       {/* Full width */}
-      <H2 color={"bluegrey"} weight={"SemiBold"} style={{ marginBottom: 16 }}>
+      <H2 color={"bluegrey"} weight={"Semibold"} style={{ marginBottom: 16 }}>
         Full width
       </H2>
       <DSFullWidthComponent>
@@ -221,7 +221,7 @@ export const DSAlert = () => {
 
       <VSpacer size={40} />
 
-      <H2 color={"bluegrey"} weight={"SemiBold"} style={{ marginBottom: 16 }}>
+      <H2 color={"bluegrey"} weight={"Semibold"} style={{ marginBottom: 16 }}>
         Legacy components
       </H2>
       <DSFullWidthComponent>

--- a/ts/features/design-system/core/DSBadges.tsx
+++ b/ts/features/design-system/core/DSBadges.tsx
@@ -48,7 +48,7 @@ export const DSBadges = () => (
 
     <VSpacer size={24} />
 
-    <H4 weight="SemiBold" color="bluegreyDark">
+    <H4 weight="Semibold" color="bluegreyDark">
       DiscountValueBox (CGN)
     </H4>
     <VSpacer size={16} />
@@ -62,7 +62,7 @@ export const DSBadges = () => (
 
     <H3>Notifications</H3>
     <VSpacer size={16} />
-    <H4 weight="SemiBold" color="bluegreyDark">
+    <H4 weight="Semibold" color="bluegreyDark">
       CustomBadge
     </H4>
     <VSpacer size={16} />

--- a/ts/features/design-system/core/DSBottomSheet.tsx
+++ b/ts/features/design-system/core/DSBottomSheet.tsx
@@ -192,7 +192,7 @@ export const DSBottomSheet = () => {
     >
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         Available bottom sheets
@@ -235,7 +235,7 @@ export const DSBottomSheet = () => {
       />
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         Legacy

--- a/ts/features/design-system/core/DSButtons.tsx
+++ b/ts/features/design-system/core/DSButtons.tsx
@@ -51,7 +51,7 @@ export const DSButtons = () => {
     <DesignSystemScreen title={"Buttons"}>
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         ButtonSolid
@@ -62,7 +62,7 @@ export const DSButtons = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         ButtonOutline
@@ -73,7 +73,7 @@ export const DSButtons = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         ButtonLink
@@ -84,7 +84,7 @@ export const DSButtons = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         IconButton
@@ -95,7 +95,7 @@ export const DSButtons = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         IconButtonSolid
@@ -106,7 +106,7 @@ export const DSButtons = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         IconButtonContained (Icebox)
@@ -117,7 +117,7 @@ export const DSButtons = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         Block Buttons (not NativeBase)
@@ -128,7 +128,7 @@ export const DSButtons = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         Specific buttons

--- a/ts/features/design-system/core/DSColors.tsx
+++ b/ts/features/design-system/core/DSColors.tsx
@@ -150,7 +150,7 @@ const ColorThemeGroup = ({
       {name && (
         <H3
           color={theme["textHeading-default"]}
-          weight={"SemiBold"}
+          weight={"Semibold"}
           style={{ marginBottom: sectionTitleMargin }}
         >
           {name}
@@ -241,7 +241,7 @@ const ColorGroup = ({ name, colorObject }: ColorGroupProps) => {
       {name && (
         <H3
           color={theme["textHeading-default"]}
-          weight={"SemiBold"}
+          weight={"Semibold"}
           style={{ marginBottom: sectionTitleMargin }}
         >
           {name}
@@ -299,7 +299,7 @@ export const DSColors = () => {
       {/* Gradients */}
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: sectionTitleMargin }}
       >
         Gradients
@@ -314,7 +314,7 @@ export const DSColors = () => {
 
       {/* Legacy */}
       <View style={{ marginBottom: sectionTitleMargin }}>
-        <H2 color={theme["textHeading-default"]} weight={"SemiBold"}>
+        <H2 color={theme["textHeading-default"]} weight={"Semibold"}>
           Legacy palette (†2023)
         </H2>
         <LabelSmall weight={"Regular"} color={theme["textBody-tertiary"]}>

--- a/ts/features/design-system/core/DSIcons.tsx
+++ b/ts/features/design-system/core/DSIcons.tsx
@@ -98,7 +98,7 @@ export const DSIcons = () => {
       </View>
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12 }}
       >
         Navigation
@@ -121,7 +121,7 @@ export const DSIcons = () => {
       </View>
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12 }}
       >
         Biometric
@@ -144,7 +144,7 @@ export const DSIcons = () => {
       </View>
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12 }}
       >
         Categories
@@ -167,7 +167,7 @@ export const DSIcons = () => {
       </View>
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12 }}
       >
         Product
@@ -190,7 +190,7 @@ export const DSIcons = () => {
       </View>
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12 }}
       >
         System
@@ -214,7 +214,7 @@ export const DSIcons = () => {
 
       <H3
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12 }}
       >
         IconContained
@@ -229,7 +229,7 @@ export const DSIcons = () => {
 
       <H3
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12 }}
       >
         Sizes
@@ -253,7 +253,7 @@ export const DSIcons = () => {
       </View>
       <H3
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12 }}
       >
         Colors

--- a/ts/features/design-system/core/DSLayout.tsx
+++ b/ts/features/design-system/core/DSLayout.tsx
@@ -32,7 +32,7 @@ export const DSLayout = () => {
         </H1>
         <H3
           color={theme["textHeading-default"]}
-          weight={"SemiBold"}
+          weight={"Semibold"}
           style={{ marginBottom: 16 }}
         >
           ContentWrapper
@@ -81,7 +81,7 @@ export const DSLayout = () => {
 
         <H3
           color={theme["textHeading-default"]}
-          weight={"SemiBold"}
+          weight={"Semibold"}
           style={{ marginBottom: 16 }}
         >
           VSpacer
@@ -102,7 +102,7 @@ export const DSLayout = () => {
 
         <H3
           color={theme["textHeading-default"]}
-          weight={"SemiBold"}
+          weight={"Semibold"}
           style={{ marginBottom: 16 }}
         >
           HSpacer
@@ -132,7 +132,7 @@ export const DSLayout = () => {
 
         <H3
           color={theme["textHeading-default"]}
-          weight={"SemiBold"}
+          weight={"Semibold"}
           style={{ marginBottom: 16 }}
         >
           Default (Horizontal)

--- a/ts/features/design-system/core/DSLegacyPictograms.tsx
+++ b/ts/features/design-system/core/DSLegacyPictograms.tsx
@@ -128,7 +128,7 @@ export const DSLegacyPictograms = () => {
       </View>
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         EU Covid Certificate

--- a/ts/features/design-system/core/DSListItems.tsx
+++ b/ts/features/design-system/core/DSListItems.tsx
@@ -47,7 +47,7 @@ export const DSListItems = () => {
     <DesignSystemScreen title="List Items">
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ListItemNav
@@ -56,7 +56,7 @@ export const DSListItems = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ListItemInfoCopy
@@ -65,7 +65,7 @@ export const DSListItems = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ListItemInfo
@@ -74,7 +74,7 @@ export const DSListItems = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ListItemHeader
@@ -83,7 +83,7 @@ export const DSListItems = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ListItemAction
@@ -92,7 +92,7 @@ export const DSListItems = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ListItemTransaction
@@ -103,7 +103,7 @@ export const DSListItems = () => {
 
       <H2
         color={"bluegrey"}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         NativeBase lookalikes (not NativeBase)
@@ -123,7 +123,7 @@ export const DSListItems = () => {
 
       <H2
         color={"bluegrey"}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ListItemComponent (NativeBase)
@@ -216,7 +216,7 @@ export const DSListItems = () => {
 
       <H2
         color={"bluegrey"}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         Derivated from ListItem (NativeBase)
@@ -246,7 +246,7 @@ export const DSListItems = () => {
       </DSComponentViewerBox>
       <H2
         color={"bluegrey"}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         Misc
@@ -267,7 +267,7 @@ export const DSListItems = () => {
 
       <H2
         color={"bluegrey"}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         Native (Not NativeBase)

--- a/ts/features/design-system/core/DSLoaders.tsx
+++ b/ts/features/design-system/core/DSLoaders.tsx
@@ -90,7 +90,7 @@ export const DSLoaders = () => {
       {/* Present in the main Messages screen */}
       <H3
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={styles.sectionTitle}
       >
         Activity Indicator
@@ -116,7 +116,7 @@ export const DSLoaders = () => {
 
       <H3
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={styles.sectionTitle}
       >
         Loading Indicator
@@ -127,7 +127,7 @@ export const DSLoaders = () => {
 
       <H3
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={styles.sectionTitle}
       >
         Loading Spinner

--- a/ts/features/design-system/core/DSLogos.tsx
+++ b/ts/features/design-system/core/DSLogos.tsx
@@ -50,7 +50,7 @@ export const DSLogos = () => {
     <DesignSystemScreen title={"Logos"}>
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         Avatar
@@ -61,7 +61,7 @@ export const DSLogos = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         Payment Networks (Small)
@@ -72,7 +72,7 @@ export const DSLogos = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         Payment Networks (Big)
@@ -83,7 +83,7 @@ export const DSLogos = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         Banks (Extended)
@@ -94,7 +94,7 @@ export const DSLogos = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         Payment Networks (Card)

--- a/ts/features/design-system/core/DSModules.tsx
+++ b/ts/features/design-system/core/DSModules.tsx
@@ -45,7 +45,7 @@ export const DSModules = () => {
     <DesignSystemScreen title="Modules">
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         ModuleAttachment
@@ -56,7 +56,7 @@ export const DSModules = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         ModulePaymentNotice
@@ -67,7 +67,7 @@ export const DSModules = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         ModuleCheckout
@@ -78,7 +78,7 @@ export const DSModules = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ModuleCredential
@@ -89,7 +89,7 @@ export const DSModules = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16, marginTop: 16 }}
       >
         ModuleNavigation
@@ -100,7 +100,7 @@ export const DSModules = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         ButtonExtendedOutline
@@ -111,7 +111,7 @@ export const DSModules = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 16 }}
       >
         ModuleIDP

--- a/ts/features/design-system/core/DSPictograms.tsx
+++ b/ts/features/design-system/core/DSPictograms.tsx
@@ -99,7 +99,7 @@ export const DSPictograms = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{
           marginBottom: 16
         }}
@@ -125,7 +125,7 @@ export const DSPictograms = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{
           marginBottom: 16
         }}
@@ -151,7 +151,7 @@ export const DSPictograms = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{
           marginBottom: 16
         }}
@@ -188,7 +188,7 @@ export const DSPictograms = () => {
 
       <H2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{
           marginBottom: 16
         }}

--- a/ts/features/design-system/core/DSScreenOperationResult.tsx
+++ b/ts/features/design-system/core/DSScreenOperationResult.tsx
@@ -19,7 +19,7 @@ const DSScreenOperationResult = () => {
       style: {
         textAlign: "center"
       },
-      weight: "SemiBold"
+      weight: "Semibold"
     },
     {
       text: I18n.t("email.cduScreens.emailAlreadyTaken.subtitleEnd"),

--- a/ts/features/design-system/core/DSSelection.tsx
+++ b/ts/features/design-system/core/DSSelection.tsx
@@ -67,7 +67,7 @@ export const DSSelection = () => (
     {/* SwitchLabel */}
     {renderAnimatedSwitch()}
     {/* Legacy components */}
-    <H2 weight={"SemiBold"} style={{ marginBottom: 16, marginTop: 16 }}>
+    <H2 weight={"Semibold"} style={{ marginBottom: 16, marginTop: 16 }}>
       Legacy components
     </H2>
     <H4>{"<CheckBox />"}</H4>

--- a/ts/features/design-system/core/DSStepper.tsx
+++ b/ts/features/design-system/core/DSStepper.tsx
@@ -15,7 +15,7 @@ export const DSStepper = () => {
   return (
     <DesignSystemScreen title={"Stepper"} noMargin>
       <View style={{ paddingHorizontal: IOVisualCostants.appMarginDefault }}>
-        <H3 color={theme["textHeading-default"]} weight={"SemiBold"}>
+        <H3 color={theme["textHeading-default"]} weight={"Semibold"}>
           Stepper
         </H3>
       </View>

--- a/ts/features/design-system/core/DSTextFields.tsx
+++ b/ts/features/design-system/core/DSTextFields.tsx
@@ -339,7 +339,7 @@ const LegacyTextFields = () => {
 
       <H2
         color={"bluegrey"}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12, marginTop: 48 }}
       >
         Authentication
@@ -368,7 +368,7 @@ const LegacyTextFields = () => {
 
       <H2
         color={"bluegrey"}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: 12, marginTop: 48 }}
       >
         Payments

--- a/ts/features/design-system/core/DSToastNotifications.tsx
+++ b/ts/features/design-system/core/DSToastNotifications.tsx
@@ -10,7 +10,7 @@ import { DesignSystemScreen } from "../components/DesignSystemScreen";
 
 export const DSToastNotifications = () => (
   <DesignSystemScreen title={"Toast Notifications (NativeBase)"}>
-    <H3 color={"bluegrey"} weight={"SemiBold"} style={{ marginBottom: 16 }}>
+    <H3 color={"bluegrey"} weight={"Semibold"} style={{ marginBottom: 16 }}>
       Events
     </H3>
 
@@ -68,7 +68,7 @@ export const DSToastNotifications = () => (
 
     <H3
       color={"bluegrey"}
-      weight={"SemiBold"}
+      weight={"Semibold"}
       style={{ marginTop: 32, marginBottom: 16 }}
     >
       Component

--- a/ts/features/design-system/core/DSTypography.tsx
+++ b/ts/features/design-system/core/DSTypography.tsx
@@ -53,7 +53,7 @@ export const DSTypography = () => {
     <DesignSystemScreen title={"Typography"}>
       <LegacyH2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: sectionTitleMargin }}
       >
         New typographic scale
@@ -95,7 +95,7 @@ export const DSTypography = () => {
 
       <LegacyH2
         color={theme["textHeading-default"]}
-        weight={"SemiBold"}
+        weight={"Semibold"}
         style={{ marginBottom: sectionTitleMargin }}
       >
         Legacy typographic scale
@@ -143,7 +143,7 @@ export const LegacyH2Row = () => (
     <View>
       <LegacyH2>{getTitle("H2")}</LegacyH2>
       <LegacyH2 style={styles.distancedTitle}>{getLongerTitle("H2")}</LegacyH2>
-      <LegacyH2 style={styles.distancedTitle} weight={"SemiBold"}>
+      <LegacyH2 style={styles.distancedTitle} weight={"Semibold"}>
         {getTitle("H2 Semibold")}
       </LegacyH2>
     </View>
@@ -188,10 +188,10 @@ export const LegacyH4Row = () => (
     </View>
     <VSpacer size={16} />
     <View style={styles.row}>
-      {/* SemiBold */}
+      {/* Semibold */}
       <View style={{ backgroundColor: IOColors.bluegrey }}>
-        <LegacyH4 color={"white"} weight={"SemiBold"}>
-          Header H4 SemiBold
+        <LegacyH4 color={"white"} weight={"Semibold"}>
+          Header H4 Semibold
         </LegacyH4>
       </View>
     </View>

--- a/ts/features/euCovidCert/components/__test__/__snapshots__/EuCovidCertHeader.test.tsx.snap
+++ b/ts/features/euCovidCert/components/__test__/__snapshots__/EuCovidCertHeader.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`EuCovidCertHeader it should match the snapshot 1`] = `
       allowFontScaling={false}
       color="bluegreyDark"
       defaultColor="bluegreyDark"
-      defaultWeight="SemiBold"
+      defaultWeight="Semibold"
       font="TitilliumSansPro"
       fontStyle={
         Object {
@@ -44,7 +44,7 @@ exports[`EuCovidCertHeader it should match the snapshot 1`] = `
         ]
       }
       testID="EuCovidCertHeaderTitle"
-      weight="SemiBold"
+      weight="Semibold"
     >
       title
     </Text>
@@ -52,7 +52,7 @@ exports[`EuCovidCertHeader it should match the snapshot 1`] = `
       allowFontScaling={false}
       color="bluegreyDark"
       defaultColor="bluegreyDark"
-      defaultWeight="SemiBold"
+      defaultWeight="Semibold"
       font="TitilliumSansPro"
       fontStyle={
         Object {
@@ -75,7 +75,7 @@ exports[`EuCovidCertHeader it should match the snapshot 1`] = `
         ]
       }
       testID="EuCovidCertHeaderSubTitle"
-      weight="SemiBold"
+      weight="Semibold"
     >
       subtitle
     </Text>

--- a/ts/features/euCovidCert/screens/valid/EuCovidCertValidScreen.tsx
+++ b/ts/features/euCovidCert/screens/valid/EuCovidCertValidScreen.tsx
@@ -146,7 +146,7 @@ const addBottomSheetItem = (config: {
     <View style={styles.flexColumn}>
       <View style={styles.row}>
         <View style={IOStyles.flex}>
-          <H3 color={"bluegreyDark"} weight={"SemiBold"}>
+          <H3 color={"bluegreyDark"} weight={"Semibold"}>
             {config.title}
           </H3>
           <H5 color={"bluegrey"} weight={"Regular"}>
@@ -182,7 +182,7 @@ const Footer = (props: FooterProps): React.ReactElement => {
       })}
     </View>,
     <View style={IOStyles.flex}>
-      <H3 color={"bluegreyDark"} weight={"SemiBold"}>
+      <H3 color={"bluegreyDark"} weight={"Semibold"}>
         {I18n.t("features.euCovidCertificate.save.bottomSheet.title")}
       </H3>
       <H5 color={"bluegrey"} weight={"Regular"}>

--- a/ts/features/fci/components/DocumentWithSignature.tsx
+++ b/ts/features/fci/components/DocumentWithSignature.tsx
@@ -190,7 +190,7 @@ const DocumentWithSignature = (props: Props) => {
     >
       <View style={[IOStyles.horizontalContentPadding, styles.header]}>
         <HSpacer />
-        <H5 weight={"SemiBold"} color={"bluegrey"} style={styles.headerTitle}>
+        <H5 weight={"Semibold"} color={"bluegrey"} style={styles.headerTitle}>
           {I18n.t("messagePDFPreview.title")}
         </H5>
         <IconButton

--- a/ts/features/fci/components/__tests__/__snapshots__/DocumentsNavigationBar.test.tsx.snap
+++ b/ts/features/fci/components/__tests__/__snapshots__/DocumentsNavigationBar.test.tsx.snap
@@ -145,7 +145,7 @@ exports[`Test DocumentsNavigationBar component should render a DocumentsNavigati
     allowFontScaling={false}
     color="black"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -167,7 +167,7 @@ exports[`Test DocumentsNavigationBar component should render a DocumentsNavigati
         },
       ]
     }
-    weight="SemiBold"
+    weight="Semibold"
   >
     Documento 1 di 2
   </Text>
@@ -295,7 +295,7 @@ exports[`Test DocumentsNavigationBar component should render a DocumentsNavigati
     allowFontScaling={false}
     color="black"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -320,7 +320,7 @@ exports[`Test DocumentsNavigationBar component should render a DocumentsNavigati
         },
       ]
     }
-    weight="SemiBold"
+    weight="Semibold"
   >
     Pagina 1 di 2
   </Text>

--- a/ts/features/fci/components/__tests__/__snapshots__/LinkedText.test.tsx.snap
+++ b/ts/features/fci/components/__tests__/__snapshots__/LinkedText.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Test LinkedText component should render a LinkedText component with pro
   allowFontScaling={false}
   color="bluegreyDark"
   defaultColor="bluegreyDark"
-  defaultWeight="SemiBold"
+  defaultWeight="Semibold"
   font="TitilliumSansPro"
   fontStyle={
     Object {
@@ -27,13 +27,13 @@ exports[`Test LinkedText component should render a LinkedText component with pro
       },
     ]
   }
-  weight="SemiBold"
+  weight="Semibold"
 >
   <Text
     allowFontScaling={false}
     color="bluegreyDark"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -61,7 +61,7 @@ exports[`Test LinkedText component should render a LinkedText component with pro
     allowFontScaling={false}
     color="bluegreyDark"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -91,7 +91,7 @@ exports[`Test LinkedText component should render a LinkedText component with pro
     allowFontScaling={false}
     color="bluegreyDark"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -121,7 +121,7 @@ exports[`Test LinkedText component should render a LinkedText component with pro
     allowFontScaling={false}
     color="bluegreyDark"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -151,7 +151,7 @@ exports[`Test LinkedText component should render a LinkedText component with pro
     allowFontScaling={false}
     color="bluegreyDark"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -181,7 +181,7 @@ exports[`Test LinkedText component should render a LinkedText component with pro
     allowFontScaling={false}
     color="bluegreyDark"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -211,7 +211,7 @@ exports[`Test LinkedText component should render a LinkedText component with pro
     allowFontScaling={false}
     color="bluegreyDark"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -241,7 +241,7 @@ exports[`Test LinkedText component should render a LinkedText component with pro
     allowFontScaling={false}
     color="bluegreyDark"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -271,7 +271,7 @@ exports[`Test LinkedText component should render a LinkedText component with pro
     allowFontScaling={false}
     color="bluegreyDark"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -301,7 +301,7 @@ exports[`Test LinkedText component should render a LinkedText component with pro
     allowFontScaling={false}
     color="bluegreyDark"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -331,7 +331,7 @@ exports[`Test LinkedText component should render a LinkedText component with pro
     allowFontScaling={false}
     color="bluegreyDark"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -361,7 +361,7 @@ exports[`Test LinkedText component should render a LinkedText component with pro
     allowFontScaling={false}
     color="bluegreyDark"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -391,7 +391,7 @@ exports[`Test LinkedText component should render a LinkedText component with pro
     allowFontScaling={false}
     color="bluegreyDark"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -421,7 +421,7 @@ exports[`Test LinkedText component should render a LinkedText component with pro
     allowFontScaling={false}
     color="bluegreyDark"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -451,7 +451,7 @@ exports[`Test LinkedText component should render a LinkedText component with pro
     allowFontScaling={false}
     color="bluegreyDark"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -481,7 +481,7 @@ exports[`Test LinkedText component should render a LinkedText component with pro
     allowFontScaling={false}
     color="bluegreyDark"
     defaultColor="black"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {

--- a/ts/features/fci/components/__tests__/__snapshots__/LoadingComponent.test.tsx.snap
+++ b/ts/features/fci/components/__tests__/__snapshots__/LoadingComponent.test.tsx.snap
@@ -200,7 +200,7 @@ exports[`Test LoadingComponent component should render a LoadingComponent compon
     allowFontScaling={false}
     color="bluegreyDark"
     defaultColor="bluegreyDark"
-    defaultWeight="SemiBold"
+    defaultWeight="Semibold"
     font="TitilliumSansPro"
     fontStyle={
       Object {
@@ -226,7 +226,7 @@ exports[`Test LoadingComponent component should render a LoadingComponent compon
       ]
     }
     testID="LoadingSpinnerCaptionTitleID"
-    weight="SemiBold"
+    weight="Semibold"
   >
     Loading
   </Text>

--- a/ts/features/fci/components/__tests__/__snapshots__/QtspClauseListItem.test.tsx.snap
+++ b/ts/features/fci/components/__tests__/__snapshots__/QtspClauseListItem.test.tsx.snap
@@ -341,7 +341,7 @@ exports[`Test QtspClauseListItem component should render a QtspClauseListItem co
                             allowFontScaling={false}
                             color="bluegreyDark"
                             defaultColor="bluegreyDark"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -363,13 +363,13 @@ exports[`Test QtspClauseListItem component should render a QtspClauseListItem co
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             <Text
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -400,7 +400,7 @@ exports[`Test QtspClauseListItem component should render a QtspClauseListItem co
                               allowFontScaling={false}
                               color="blue"
                               defaultColor="blue"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -425,7 +425,7 @@ exports[`Test QtspClauseListItem component should render a QtspClauseListItem co
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               QUADRO E - AUTOCERTIFICAZIONE E SOTTOSCRIZIONE DA PARTE DEL TITOLARE.
                             </Text>
@@ -433,7 +433,7 @@ exports[`Test QtspClauseListItem component should render a QtspClauseListItem co
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -595,7 +595,7 @@ exports[`Test QtspClauseListItem component should render a QtspClauseListItem co
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -620,7 +620,7 @@ exports[`Test QtspClauseListItem component should render a QtspClauseListItem co
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             />
                           </View>
                         </View>

--- a/ts/features/fci/components/__tests__/__snapshots__/SignatureFieldItem.test.tsx.snap
+++ b/ts/features/fci/components/__tests__/__snapshots__/SignatureFieldItem.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`Test SignatureFieldItem component should render a SignatureFieldItem co
               allowFontScaling={false}
               color="black"
               defaultColor="black"
-              defaultWeight="SemiBold"
+              defaultWeight="Semibold"
               font="TitilliumSansPro"
               fontStyle={
                 Object {
@@ -115,7 +115,7 @@ exports[`Test SignatureFieldItem component should render a SignatureFieldItem co
                   },
                 ]
               }
-              weight="SemiBold"
+              weight="Semibold"
             >
               Clause title 1
             </Text>
@@ -222,7 +222,7 @@ exports[`Test SignatureFieldItem component should render a SignatureFieldItem co
       allowFontScaling={false}
       color="blue"
       defaultColor="blue"
-      defaultWeight="SemiBold"
+      defaultWeight="Semibold"
       font="TitilliumSansPro"
       fontStyle={
         Object {
@@ -248,7 +248,7 @@ exports[`Test SignatureFieldItem component should render a SignatureFieldItem co
         ]
       }
       testID="SignatureFieldItemDetailTestID"
-      weight="SemiBold"
+      weight="Semibold"
     >
       See on document
     </Text>

--- a/ts/features/idpay/barcode/components/BarcodeExpirationProgressBar.tsx
+++ b/ts/features/idpay/barcode/components/BarcodeExpirationProgressBar.tsx
@@ -45,7 +45,7 @@ export const IdPayBarcodeExpireProgressBar = ({
         <LabelSmall weight="Regular" color="black">
           {I18n.t("idpay.barCode.resultScreen.success.expiresIn")}
         </LabelSmall>
-        <LabelSmall weight="SemiBold" color="black">
+        <LabelSmall weight="Semibold" color="black">
           {formattedSecondsToExpiration}
         </LabelSmall>
       </View>

--- a/ts/features/idpay/barcode/screens/IdPayBarcodeResultScreen.tsx
+++ b/ts/features/idpay/barcode/screens/IdPayBarcodeResultScreen.tsx
@@ -149,7 +149,7 @@ const SuccessContent = ({ goBack, barcode }: SuccessContentProps) => {
             <LabelSmall weight="Regular" color="black">
               {I18n.t("idpay.barCode.resultScreen.success.validUpTo")}
             </LabelSmall>
-            <LabelSmall weight="SemiBold" color="black">
+            <LabelSmall weight="Semibold" color="black">
               {formatNumberCurrencyCents(barcode.residualBudgetCents)}
             </LabelSmall>
           </View>

--- a/ts/features/idpay/common/components/Table.tsx
+++ b/ts/features/idpay/common/components/Table.tsx
@@ -22,7 +22,7 @@ const renderTable = (data: ReadonlyArray<TableRow>): React.ReactNode =>
       <Fragment key={`${item.label}_${index}`}>
         <View style={styles.infoRow} testID={item.testID}>
           <Body>{item.label}</Body>
-          <Body weight="SemiBold">{item.value}</Body>
+          <Body weight="Semibold">{item.value}</Body>
         </View>
         {!isLast && <Divider />}
       </Fragment>

--- a/ts/features/idpay/configuration/screens/IbanConfigurationLandingScreen.tsx
+++ b/ts/features/idpay/configuration/screens/IbanConfigurationLandingScreen.tsx
@@ -83,7 +83,7 @@ const IbanConfigurationLanding = () => {
           <Body style={styles.textCenter}>
             {I18n.t("idpay.configuration.iban.landing.body")}
           </Body>
-          <Body color="blue" weight="SemiBold" onPress={present}>
+          <Body color="blue" weight="Semibold" onPress={present}>
             {I18n.t("idpay.configuration.iban.landing.bodyLink")}
           </Body>
         </View>

--- a/ts/features/idpay/configuration/screens/InitiativeConfigurationIntroScreen.tsx
+++ b/ts/features/idpay/configuration/screens/InitiativeConfigurationIntroScreen.tsx
@@ -44,7 +44,7 @@ const RequiredDataItem = (props: RequiredDataItemProps) => (
   <View style={[IOStyles.row, styles.listItem]}>
     {!!props.icon && <View style={styles.icon}>{props.icon}</View>}
     <View>
-      <H4 weight="SemiBold" color="bluegreyDark">
+      <H4 weight="Semibold" color="bluegreyDark">
         {props.title}
       </H4>
       <LabelSmall weight="Regular" color="bluegrey">

--- a/ts/features/idpay/configuration/screens/InstrumentsEnrollmentScreen.tsx
+++ b/ts/features/idpay/configuration/screens/InstrumentsEnrollmentScreen.tsx
@@ -123,7 +123,7 @@ const InstrumentsEnrollmentScreen = () => {
       component: (
         <Body>
           {I18n.t("idpay.configuration.instruments.enrollmentSheet.bodyFirst")}
-          <Body weight="SemiBold">
+          <Body weight="Semibold">
             {I18n.t(
               "idpay.configuration.instruments.enrollmentSheet.bodyBold"
             ) + "\n"}

--- a/ts/features/idpay/details/components/InitiativeTimelineComponent.tsx
+++ b/ts/features/idpay/details/components/InitiativeTimelineComponent.tsx
@@ -85,7 +85,7 @@ const TimelineHeaderComponent = (props: { onShowMorePress?: () => void }) => (
         "idpay.initiative.details.initiativeDetailsScreen.configured.yourOperations"
       )}
     </H3>
-    <Body weight="SemiBold" color="blue" onPress={props.onShowMorePress}>
+    <Body weight="Semibold" color="blue" onPress={props.onShowMorePress}>
       {I18n.t(
         "idpay.initiative.details.initiativeDetailsScreen.configured.settings.showMore"
       )}

--- a/ts/features/idpay/details/screens/IdPayOperationsListScreen.tsx
+++ b/ts/features/idpay/details/screens/IdPayOperationsListScreen.tsx
@@ -95,7 +95,7 @@ export const IdPayOperationsListScreen = () => {
       () => (
         <Placeholder.Box animate="fade" height={18} width={70} radius={4} />
       ),
-      dateString => <Body weight="SemiBold">{dateString}</Body>
+      dateString => <Body weight="Semibold">{dateString}</Body>
     )
   );
 

--- a/ts/features/idpay/onboarding/screens/MultiValuePrerequisitesScreen.tsx
+++ b/ts/features/idpay/onboarding/screens/MultiValuePrerequisitesScreen.tsx
@@ -35,7 +35,7 @@ const CustomListItem = ({ text, onPress, checked }: ListItemProps) => (
       <View
         style={[IOStyles.flex, IOStyles.rowSpaceBetween, styles.innerListItem]}
       >
-        <H4 weight={checked ? "SemiBold" : "Regular"} color={"bluegreyDark"}>
+        <H4 weight={checked ? "Semibold" : "Regular"} color={"bluegreyDark"}>
           {text}
         </H4>
         <Icon

--- a/ts/features/idpay/timeline/components/TimelineDiscountTransactionDetailsComponent.tsx
+++ b/ts/features/idpay/timeline/components/TimelineDiscountTransactionDetailsComponent.tsx
@@ -73,7 +73,7 @@ const TimelineDiscountTransactionDetailsComponent = (props: Props) => {
             "idpay.initiative.operationDetails.discount.details.labels.totalAmount"
           )}
         </Body>
-        <Body weight="SemiBold">{formattedAmount}</Body>
+        <Body weight="Semibold">{formattedAmount}</Body>
       </View>
       <View style={styles.detailRow}>
         <Body>
@@ -81,7 +81,7 @@ const TimelineDiscountTransactionDetailsComponent = (props: Props) => {
             "idpay.initiative.operationDetails.discount.details.labels.idpayAmount"
           )}
         </Body>
-        <Body weight="SemiBold">
+        <Body weight="Semibold">
           {formatNumberAmount(transaction.accrued, true)}
         </Body>
       </View>
@@ -99,7 +99,7 @@ const TimelineDiscountTransactionDetailsComponent = (props: Props) => {
         </Body>
         <HSpacer size={16} />
         <Body
-          weight="SemiBold"
+          weight="Semibold"
           numberOfLines={2}
           style={{ flex: 1, textAlign: "right" }}
         >
@@ -112,7 +112,7 @@ const TimelineDiscountTransactionDetailsComponent = (props: Props) => {
             "idpay.initiative.operationDetails.discount.details.labels.status"
           )}
         </Body>
-        <Body weight="SemiBold">
+        <Body weight="Semibold">
           {I18n.t(
             `idpay.initiative.operationDetails.discount.labels.${transaction.status}`
           )}
@@ -122,7 +122,7 @@ const TimelineDiscountTransactionDetailsComponent = (props: Props) => {
         <Body>
           {I18n.t("idpay.initiative.operationDetails.transaction.date")}
         </Body>
-        <Body weight="SemiBold">
+        <Body weight="Semibold">
           {format(transaction.operationDate, "DD MMM YYYY, HH:mm")}
         </Body>
       </View>
@@ -135,7 +135,7 @@ const TimelineDiscountTransactionDetailsComponent = (props: Props) => {
         <HSpacer size={16} />
         <View style={[IOStyles.flex, IOStyles.row]}>
           <Body
-            weight="SemiBold"
+            weight="Semibold"
             numberOfLines={1}
             ellipsizeMode="tail"
             style={IOStyles.flex}

--- a/ts/features/idpay/timeline/components/TimelineRefundDetailsComponent.tsx
+++ b/ts/features/idpay/timeline/components/TimelineRefundDetailsComponent.tsx
@@ -87,11 +87,11 @@ const TimelineRefundDetailsComponent = (props: Props) => {
       {rejectedAlertComponent}
       <View style={styles.detailRow}>
         <Body>{I18n.t("idpay.initiative.operationDetails.refund.iban")}</Body>
-        <Body weight="SemiBold">{refund.iban}</Body>
+        <Body weight="Semibold">{refund.iban}</Body>
       </View>
       <View style={styles.detailRow}>
         <Body>{I18n.t("idpay.initiative.operationDetails.refund.amount")}</Body>
-        <Body weight="SemiBold">{formattedAmount}</Body>
+        <Body weight="Semibold">{formattedAmount}</Body>
       </View>
       <View style={styles.detailRow}>
         <Body>
@@ -119,11 +119,11 @@ const TimelineRefundDetailsComponent = (props: Props) => {
       </View>
       <View style={styles.detailRow}>
         <Body>{I18n.t("idpay.initiative.operationDetails.refund.period")}</Body>
-        <Body weight="SemiBold">{getRefundPeriodDateString(refund)}</Body>
+        <Body weight="Semibold">{getRefundPeriodDateString(refund)}</Body>
       </View>
       <View style={styles.detailRow}>
         <Body>Data rimborso</Body>
-        <Body weight="SemiBold">
+        <Body weight="Semibold">
           {format(refund.operationDate, "DD MMM YYYY, HH:mm")}
         </Body>
       </View>
@@ -132,7 +132,7 @@ const TimelineRefundDetailsComponent = (props: Props) => {
         <HSpacer size={16} />
         <View style={[IOStyles.flex, IOStyles.row]}>
           <Body
-            weight="SemiBold"
+            weight="Semibold"
             numberOfLines={1}
             ellipsizeMode="tail"
             style={IOStyles.flex}

--- a/ts/features/idpay/timeline/components/TimelineTransactionDetailsComponent.tsx
+++ b/ts/features/idpay/timeline/components/TimelineTransactionDetailsComponent.tsx
@@ -71,7 +71,7 @@ const TimelineTransactionDetailsComponent = (props: Props) => {
             isExtended={false}
           />
           <HSpacer size={8} />
-          <Body weight="SemiBold">
+          <Body weight="Semibold">
             {I18n.t("idpay.initiative.operationDetails.transaction.maskedPan", {
               lastDigits: transaction.maskedPan
             })}
@@ -82,7 +82,7 @@ const TimelineTransactionDetailsComponent = (props: Props) => {
         <Body>
           {I18n.t("idpay.initiative.operationDetails.transaction.amountLabel")}
         </Body>
-        <Body weight="SemiBold">{formattedAmount}</Body>
+        <Body weight="Semibold">{formattedAmount}</Body>
       </View>
       <View style={styles.detailRow}>
         <Body>
@@ -90,7 +90,7 @@ const TimelineTransactionDetailsComponent = (props: Props) => {
             "idpay.initiative.operationDetails.transaction.accruedAmountLabel"
           )}
         </Body>
-        <Body weight="SemiBold">{formattedAccrued}</Body>
+        <Body weight="Semibold">{formattedAccrued}</Body>
       </View>
       <ItemSeparatorComponent noPadded={true} />
       <VSpacer size={24} />
@@ -102,7 +102,7 @@ const TimelineTransactionDetailsComponent = (props: Props) => {
         <Body>
           {I18n.t("idpay.initiative.operationDetails.transaction.date")}
         </Body>
-        <Body weight="SemiBold">
+        <Body weight="Semibold">
           {format(transaction.operationDate, "DD MMM YYYY, HH:mm")}
         </Body>
       </View>
@@ -110,7 +110,7 @@ const TimelineTransactionDetailsComponent = (props: Props) => {
         <Body>
           {I18n.t("idpay.initiative.operationDetails.transaction.circuit")}
         </Body>
-        <Body weight="SemiBold">
+        <Body weight="Semibold">
           {getLabelForCircuitType(transaction.circuitType)}
         </Body>
       </View>
@@ -121,7 +121,7 @@ const TimelineTransactionDetailsComponent = (props: Props) => {
         <HSpacer size={16} />
         <View style={[IOStyles.flex, IOStyles.row]}>
           <Body
-            weight="SemiBold"
+            weight="Semibold"
             numberOfLines={1}
             ellipsizeMode="tail"
             style={IOStyles.flex}
@@ -139,7 +139,7 @@ const TimelineTransactionDetailsComponent = (props: Props) => {
         <HSpacer size={16} />
         <View style={[IOStyles.flex, IOStyles.row]}>
           <Body
-            weight="SemiBold"
+            weight="Semibold"
             numberOfLines={1}
             ellipsizeMode="tail"
             style={IOStyles.flex}

--- a/ts/features/idpay/wallet/components/IDPayCardPreviewComponent.tsx
+++ b/ts/features/idpay/wallet/components/IDPayCardPreviewComponent.tsx
@@ -84,7 +84,7 @@ const IDPayCardPreviewComponent = (props: Props) => {
             </H4>
             <HSpacer size={8} />
             <LabelSmall
-              weight="SemiBold"
+              weight="Semibold"
               fontSize="regular"
               color="black"
               ellipsizeMode={"tail"}

--- a/ts/features/idpay/wallet/components/__tests__/__snapshots__/IdPayCard.test.tsx.snap
+++ b/ts/features/idpay/wallet/components/__tests__/__snapshots__/IdPayCard.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`IdPayCard should match the snapshot 1`] = `
           allowFontScaling={false}
           color="blueItalia-850"
           defaultColor="black"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           ellipsizeMode="tail"
           font="TitilliumSansPro"
           fontStyle={
@@ -74,7 +74,7 @@ exports[`IdPayCard should match the snapshot 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           18 app
         </Text>
@@ -142,7 +142,7 @@ exports[`IdPayCard should match the snapshot 1`] = `
         allowFontScaling={false}
         color="black"
         defaultColor="black"
-        defaultWeight="SemiBold"
+        defaultWeight="Semibold"
         font="TitilliumSansPro"
         fontStyle={
           Object {
@@ -164,7 +164,7 @@ exports[`IdPayCard should match the snapshot 1`] = `
             },
           ]
         }
-        weight="SemiBold"
+        weight="Semibold"
       >
         Disponibile
       </Text>
@@ -172,7 +172,7 @@ exports[`IdPayCard should match the snapshot 1`] = `
         allowFontScaling={false}
         color="blueItalia-500"
         defaultColor="bluegreyDark"
-        defaultWeight="SemiBold"
+        defaultWeight="Semibold"
         font="TitilliumSansPro"
         fontStyle={
           Object {
@@ -194,7 +194,7 @@ exports[`IdPayCard should match the snapshot 1`] = `
             },
           ]
         }
-        weight="SemiBold"
+        weight="Semibold"
       >
         9,999.00 €
       </Text>
@@ -203,7 +203,7 @@ exports[`IdPayCard should match the snapshot 1`] = `
       allowFontScaling={false}
       color="blueItalia-850"
       defaultColor="black"
-      defaultWeight="SemiBold"
+      defaultWeight="Semibold"
       font="TitilliumSansPro"
       fontStyle={
         Object {
@@ -225,7 +225,7 @@ exports[`IdPayCard should match the snapshot 1`] = `
           },
         ]
       }
-      weight="SemiBold"
+      weight="Semibold"
     >
       Valida fino al 12/23
     </Text>

--- a/ts/features/itwallet/common/components/ItwCredentialCard.tsx
+++ b/ts/features/itwallet/common/components/ItwCredentialCard.tsx
@@ -57,7 +57,7 @@ export const ItwCredentialCard = ({
           <View style={styles.header}>
             <Body
               color={labelColor}
-              weight="SemiBold"
+              weight="Semibold"
               numberOfLines={2}
               style={{ flex: 1 }}
             >
@@ -86,7 +86,7 @@ const CredentialData = ({ data }: DataProps) => (
     {data.map(value => (
       <Body
         color="bluegreyDark"
-        weight="SemiBold"
+        weight="Semibold"
         key={`credential_data_${value}`}
       >
         {value}

--- a/ts/features/itwallet/common/components/__tests__/__snapshots__/ItwCredentialCard.test.tsx.snap
+++ b/ts/features/itwallet/common/components/__tests__/__snapshots__/ItwCredentialCard.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`ItwCredentialCard should match snapshot when status is "expired" 1`] = 
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           IDENTITÀ DIGITALE
         </Text>
@@ -379,7 +379,7 @@ exports[`ItwCredentialCard should match snapshot when status is "expiring" 1`] =
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           IDENTITÀ DIGITALE
         </Text>
@@ -672,7 +672,7 @@ exports[`ItwCredentialCard should match snapshot when status is "pending" 1`] = 
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           IDENTITÀ DIGITALE
         </Text>
@@ -965,7 +965,7 @@ exports[`ItwCredentialCard should match snapshot when status is "valid" 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           IDENTITÀ DIGITALE
         </Text>
@@ -1005,7 +1005,7 @@ exports[`ItwCredentialCard should match snapshot when status is "valid" 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           ABCDEFG ABCDEFG
         </Text>
@@ -1035,7 +1035,7 @@ exports[`ItwCredentialCard should match snapshot when status is "valid" 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           AAAAAA99A99A999A
         </Text>
@@ -1158,7 +1158,7 @@ exports[`ItwCredentialCard should render the preview 1`] = `
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           IDENTITÀ DIGITALE
         </Text>

--- a/ts/features/itwallet/common/components/__tests__/__snapshots__/ItwCredentialClaimsSection.test.tsx.snap
+++ b/ts/features/itwallet/common/components/__tests__/__snapshots__/ItwCredentialClaimsSection.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`ItwCredentialClaimsSection should match the snapshot when claims are hi
       allowFontScaling={false}
       color="grey-700"
       defaultColor="black"
-      defaultWeight="SemiBold"
+      defaultWeight="Semibold"
       font="TitilliumSansPro"
       fontStyle={
         Object {
@@ -36,7 +36,7 @@ exports[`ItwCredentialClaimsSection should match the snapshot when claims are hi
           },
         ]
       }
-      weight="SemiBold"
+      weight="Semibold"
     >
       Personal data
     </Text>
@@ -221,7 +221,7 @@ exports[`ItwCredentialClaimsSection should match the snapshot when claims are hi
               allowFontScaling={false}
               color="black"
               defaultColor="black"
-              defaultWeight="SemiBold"
+              defaultWeight="Semibold"
               font="TitilliumSansPro"
               fontStyle={
                 Object {
@@ -244,7 +244,7 @@ exports[`ItwCredentialClaimsSection should match the snapshot when claims are hi
                   },
                 ]
               }
-              weight="SemiBold"
+              weight="Semibold"
             >
               ******
             </Text>
@@ -326,7 +326,7 @@ exports[`ItwCredentialClaimsSection should match the snapshot when claims are hi
               allowFontScaling={false}
               color="black"
               defaultColor="black"
-              defaultWeight="SemiBold"
+              defaultWeight="Semibold"
               font="TitilliumSansPro"
               fontStyle={
                 Object {
@@ -349,7 +349,7 @@ exports[`ItwCredentialClaimsSection should match the snapshot when claims are hi
                   },
                 ]
               }
-              weight="SemiBold"
+              weight="Semibold"
             >
               ******
             </Text>
@@ -431,7 +431,7 @@ exports[`ItwCredentialClaimsSection should match the snapshot when claims are hi
               allowFontScaling={false}
               color="black"
               defaultColor="black"
-              defaultWeight="SemiBold"
+              defaultWeight="Semibold"
               font="TitilliumSansPro"
               fontStyle={
                 Object {
@@ -454,7 +454,7 @@ exports[`ItwCredentialClaimsSection should match the snapshot when claims are hi
                   },
                 ]
               }
-              weight="SemiBold"
+              weight="Semibold"
             >
               Attributo non riconosciuto
             </Text>
@@ -488,7 +488,7 @@ exports[`ItwCredentialClaimsSection should match the snapshot when claims are vi
       allowFontScaling={false}
       color="grey-700"
       defaultColor="black"
-      defaultWeight="SemiBold"
+      defaultWeight="Semibold"
       font="TitilliumSansPro"
       fontStyle={
         Object {
@@ -510,7 +510,7 @@ exports[`ItwCredentialClaimsSection should match the snapshot when claims are vi
           },
         ]
       }
-      weight="SemiBold"
+      weight="Semibold"
     >
       Personal data
     </Text>
@@ -695,7 +695,7 @@ exports[`ItwCredentialClaimsSection should match the snapshot when claims are vi
               allowFontScaling={false}
               color="black"
               defaultColor="black"
-              defaultWeight="SemiBold"
+              defaultWeight="Semibold"
               font="TitilliumSansPro"
               fontStyle={
                 Object {
@@ -718,7 +718,7 @@ exports[`ItwCredentialClaimsSection should match the snapshot when claims are vi
                   },
                 ]
               }
-              weight="SemiBold"
+              weight="Semibold"
             >
               Luigi
             </Text>
@@ -800,7 +800,7 @@ exports[`ItwCredentialClaimsSection should match the snapshot when claims are vi
               allowFontScaling={false}
               color="black"
               defaultColor="black"
-              defaultWeight="SemiBold"
+              defaultWeight="Semibold"
               font="TitilliumSansPro"
               fontStyle={
                 Object {
@@ -823,7 +823,7 @@ exports[`ItwCredentialClaimsSection should match the snapshot when claims are vi
                   },
                 ]
               }
-              weight="SemiBold"
+              weight="Semibold"
             >
               Rossi
             </Text>
@@ -905,7 +905,7 @@ exports[`ItwCredentialClaimsSection should match the snapshot when claims are vi
               allowFontScaling={false}
               color="black"
               defaultColor="black"
-              defaultWeight="SemiBold"
+              defaultWeight="Semibold"
               font="TitilliumSansPro"
               fontStyle={
                 Object {
@@ -928,7 +928,7 @@ exports[`ItwCredentialClaimsSection should match the snapshot when claims are vi
                   },
                 ]
               }
-              weight="SemiBold"
+              weight="Semibold"
             >
               Attributo non riconosciuto
             </Text>

--- a/ts/features/messages/components/Home/DS/MessageListItem.tsx
+++ b/ts/features/messages/components/Home/DS/MessageListItem.tsx
@@ -121,7 +121,7 @@ export const MessageListItem = ({
         </View>
         <View style={styles.serviceNameAndMessageTitleContainer}>
           <Body numberOfLines={2} style={IOStyles.flex}>
-            <LabelSmall fontSize="regular" color="grey-700" weight="SemiBold">
+            <LabelSmall fontSize="regular" color="grey-700" weight="Semibold">
               {serviceName}
             </LabelSmall>
             <Caption weight="Regular" color="grey-700">

--- a/ts/features/messages/components/Home/__tests__/__snapshots__/EmptyList.test.tsx.snap
+++ b/ts/features/messages/components/Home/__tests__/__snapshots__/EmptyList.test.tsx.snap
@@ -500,7 +500,7 @@ exports[`EmptyList should match snapshot, ARCHIVE category, pot.none 1`] = `
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -525,7 +525,7 @@ exports[`EmptyList should match snapshot, ARCHIVE category, pot.none 1`] = `
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Your archive is empty.
                             </Text>
@@ -1085,7 +1085,7 @@ exports[`EmptyList should match snapshot, ARCHIVE category, pot.noneError 1`] = 
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -1110,7 +1110,7 @@ exports[`EmptyList should match snapshot, ARCHIVE category, pot.noneError 1`] = 
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Loading messages has failed
                             </Text>
@@ -2422,7 +2422,7 @@ exports[`EmptyList should match snapshot, ARCHIVE category, pot.some, empty data
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -2447,7 +2447,7 @@ exports[`EmptyList should match snapshot, ARCHIVE category, pot.some, empty data
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Your archive is empty.
                             </Text>
@@ -3338,7 +3338,7 @@ exports[`EmptyList should match snapshot, ARCHIVE category, pot.someError, empty
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -3363,7 +3363,7 @@ exports[`EmptyList should match snapshot, ARCHIVE category, pot.someError, empty
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Your archive is empty.
                             </Text>
@@ -4254,7 +4254,7 @@ exports[`EmptyList should match snapshot, ARCHIVE category, pot.someLoading, emp
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -4279,7 +4279,7 @@ exports[`EmptyList should match snapshot, ARCHIVE category, pot.someLoading, emp
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Your archive is empty.
                             </Text>
@@ -5170,7 +5170,7 @@ exports[`EmptyList should match snapshot, ARCHIVE category, pot.someUpdating, em
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -5195,7 +5195,7 @@ exports[`EmptyList should match snapshot, ARCHIVE category, pot.someUpdating, em
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Your archive is empty.
                             </Text>
@@ -6086,7 +6086,7 @@ exports[`EmptyList should match snapshot, INBOX   category, pot.none 1`] = `
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -6111,7 +6111,7 @@ exports[`EmptyList should match snapshot, INBOX   category, pot.none 1`] = `
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Your message list is empty.
                             </Text>
@@ -6671,7 +6671,7 @@ exports[`EmptyList should match snapshot, INBOX   category, pot.noneError 1`] = 
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -6696,7 +6696,7 @@ exports[`EmptyList should match snapshot, INBOX   category, pot.noneError 1`] = 
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Loading messages has failed
                             </Text>
@@ -8008,7 +8008,7 @@ exports[`EmptyList should match snapshot, INBOX   category, pot.some, empty data
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -8033,7 +8033,7 @@ exports[`EmptyList should match snapshot, INBOX   category, pot.some, empty data
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Your message list is empty.
                             </Text>
@@ -8924,7 +8924,7 @@ exports[`EmptyList should match snapshot, INBOX   category, pot.someError, empty
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -8949,7 +8949,7 @@ exports[`EmptyList should match snapshot, INBOX   category, pot.someError, empty
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Your message list is empty.
                             </Text>
@@ -9840,7 +9840,7 @@ exports[`EmptyList should match snapshot, INBOX   category, pot.someLoading, emp
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -9865,7 +9865,7 @@ exports[`EmptyList should match snapshot, INBOX   category, pot.someLoading, emp
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Your message list is empty.
                             </Text>
@@ -10756,7 +10756,7 @@ exports[`EmptyList should match snapshot, INBOX   category, pot.someUpdating, em
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -10781,7 +10781,7 @@ exports[`EmptyList should match snapshot, INBOX   category, pot.someUpdating, em
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Your message list is empty.
                             </Text>

--- a/ts/features/messages/components/Home/__tests__/__snapshots__/Item.test.tsx.snap
+++ b/ts/features/messages/components/Home/__tests__/__snapshots__/Item.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`MessageList Item component when \`isRead\` is true should match the sna
       <Text
         color="bluegreyDark"
         defaultColor="bluegreyDark"
-        defaultWeight="SemiBold"
+        defaultWeight="Semibold"
         font="TitilliumSansPro"
         fontStyle={
           Object {
@@ -66,7 +66,7 @@ exports[`MessageList Item component when \`isRead\` is true should match the sna
             },
           ]
         }
-        weight="SemiBold"
+        weight="Semibold"
       >
         Ċentru tas-Saħħa
       </Text>
@@ -230,7 +230,7 @@ exports[`MessageList Item component when \`isRead\` is true should match the sna
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
           weightColorFactory={[Function]}
         >
           Għandek flus?
@@ -286,7 +286,7 @@ exports[`MessageList Item component when \`isSelectionModeEnabled\` is true and 
       <Text
         color="bluegreyDark"
         defaultColor="bluegreyDark"
-        defaultWeight="SemiBold"
+        defaultWeight="Semibold"
         font="TitilliumSansPro"
         fontStyle={
           Object {
@@ -307,7 +307,7 @@ exports[`MessageList Item component when \`isSelectionModeEnabled\` is true and 
             },
           ]
         }
-        weight="SemiBold"
+        weight="Semibold"
       >
         Ċentru tas-Saħħa
       </Text>
@@ -531,7 +531,7 @@ exports[`MessageList Item component when \`isSelectionModeEnabled\` is true and 
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
           weightColorFactory={[Function]}
         >
           Għandek flus?
@@ -660,7 +660,7 @@ exports[`MessageList Item component when \`isSelectionModeEnabled\` is true and 
       <Text
         color="bluegreyDark"
         defaultColor="bluegreyDark"
-        defaultWeight="SemiBold"
+        defaultWeight="Semibold"
         font="TitilliumSansPro"
         fontStyle={
           Object {
@@ -681,7 +681,7 @@ exports[`MessageList Item component when \`isSelectionModeEnabled\` is true and 
             },
           ]
         }
-        weight="SemiBold"
+        weight="Semibold"
       >
         Ċentru tas-Saħħa
       </Text>
@@ -905,7 +905,7 @@ exports[`MessageList Item component when \`isSelectionModeEnabled\` is true and 
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
           weightColorFactory={[Function]}
         >
           Għandek flus?
@@ -1076,7 +1076,7 @@ exports[`MessageList Item component when category is LEGAL_MESSAGE should match 
       <Text
         color="bluegreyDark"
         defaultColor="bluegreyDark"
-        defaultWeight="SemiBold"
+        defaultWeight="Semibold"
         font="TitilliumSansPro"
         fontStyle={
           Object {
@@ -1097,7 +1097,7 @@ exports[`MessageList Item component when category is LEGAL_MESSAGE should match 
             },
           ]
         }
-        weight="SemiBold"
+        weight="Semibold"
       >
         Ċentru tas-Saħħa
       </Text>
@@ -1321,7 +1321,7 @@ exports[`MessageList Item component when category is LEGAL_MESSAGE should match 
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
           weightColorFactory={[Function]}
         >
           Għandek flus?
@@ -1377,7 +1377,7 @@ exports[`MessageList Item component when category is PN should match the snapsho
       <Text
         color="bluegreyDark"
         defaultColor="bluegreyDark"
-        defaultWeight="SemiBold"
+        defaultWeight="Semibold"
         font="TitilliumSansPro"
         fontStyle={
           Object {
@@ -1398,7 +1398,7 @@ exports[`MessageList Item component when category is PN should match the snapsho
             },
           ]
         }
-        weight="SemiBold"
+        weight="Semibold"
       >
         Ċentru tas-Saħħa
       </Text>
@@ -1622,7 +1622,7 @@ exports[`MessageList Item component when category is PN should match the snapsho
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
           weightColorFactory={[Function]}
         >
           Għandek flus?
@@ -1678,7 +1678,7 @@ exports[`MessageList Item component when category=EU_COVID_CERT and rptId matche
       <Text
         color="bluegreyDark"
         defaultColor="bluegreyDark"
-        defaultWeight="SemiBold"
+        defaultWeight="Semibold"
         font="TitilliumSansPro"
         fontStyle={
           Object {
@@ -1699,7 +1699,7 @@ exports[`MessageList Item component when category=EU_COVID_CERT and rptId matche
             },
           ]
         }
-        weight="SemiBold"
+        weight="Semibold"
       >
         Ċentru tas-Saħħa
       </Text>
@@ -1927,7 +1927,7 @@ exports[`MessageList Item component when category=EU_COVID_CERT and rptId matche
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
           weightColorFactory={[Function]}
         >
           Għandek flus?
@@ -2060,7 +2060,7 @@ exports[`MessageList Item component when category=GENERIC and rptId matches=fals
       <Text
         color="bluegreyDark"
         defaultColor="bluegreyDark"
-        defaultWeight="SemiBold"
+        defaultWeight="Semibold"
         font="TitilliumSansPro"
         fontStyle={
           Object {
@@ -2081,7 +2081,7 @@ exports[`MessageList Item component when category=GENERIC and rptId matches=fals
             },
           ]
         }
-        weight="SemiBold"
+        weight="Semibold"
       >
         Ċentru tas-Saħħa
       </Text>
@@ -2305,7 +2305,7 @@ exports[`MessageList Item component when category=GENERIC and rptId matches=fals
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
           weightColorFactory={[Function]}
         >
           Għandek flus?
@@ -2361,7 +2361,7 @@ exports[`MessageList Item component when category=PAYMENT and rptId matches=fals
       <Text
         color="bluegreyDark"
         defaultColor="bluegreyDark"
-        defaultWeight="SemiBold"
+        defaultWeight="Semibold"
         font="TitilliumSansPro"
         fontStyle={
           Object {
@@ -2382,7 +2382,7 @@ exports[`MessageList Item component when category=PAYMENT and rptId matches=fals
             },
           ]
         }
-        weight="SemiBold"
+        weight="Semibold"
       >
         Ċentru tas-Saħħa
       </Text>
@@ -2606,7 +2606,7 @@ exports[`MessageList Item component when category=PAYMENT and rptId matches=fals
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
           weightColorFactory={[Function]}
         >
           Għandek flus?
@@ -2662,7 +2662,7 @@ exports[`MessageList Item component when category=PAYMENT and rptId matches=true
       <Text
         color="bluegreyDark"
         defaultColor="bluegreyDark"
-        defaultWeight="SemiBold"
+        defaultWeight="Semibold"
         font="TitilliumSansPro"
         fontStyle={
           Object {
@@ -2683,7 +2683,7 @@ exports[`MessageList Item component when category=PAYMENT and rptId matches=true
             },
           ]
         }
-        weight="SemiBold"
+        weight="Semibold"
       >
         Ċentru tas-Saħħa
       </Text>
@@ -2907,7 +2907,7 @@ exports[`MessageList Item component when category=PAYMENT and rptId matches=true
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
           weightColorFactory={[Function]}
         >
           Għandek flus?
@@ -3011,7 +3011,7 @@ exports[`MessageList Item component with all the flags set to false should match
       <Text
         color="bluegreyDark"
         defaultColor="bluegreyDark"
-        defaultWeight="SemiBold"
+        defaultWeight="Semibold"
         font="TitilliumSansPro"
         fontStyle={
           Object {
@@ -3032,7 +3032,7 @@ exports[`MessageList Item component with all the flags set to false should match
             },
           ]
         }
-        weight="SemiBold"
+        weight="Semibold"
       >
         Ċentru tas-Saħħa
       </Text>
@@ -3256,7 +3256,7 @@ exports[`MessageList Item component with all the flags set to false should match
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
           weightColorFactory={[Function]}
         >
           Għandek flus?

--- a/ts/features/messages/components/Home/__tests__/__snapshots__/TabNavigationContainer.test.tsx.snap
+++ b/ts/features/messages/components/Home/__tests__/__snapshots__/TabNavigationContainer.test.tsx.snap
@@ -506,7 +506,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -528,7 +528,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Inbox
                                   </Text>
@@ -673,7 +673,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                     allowFontScaling={false}
                                     color="blue"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -695,7 +695,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Archived
                                   </Text>
@@ -1237,7 +1237,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                     allowFontScaling={false}
                                     color="blue"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -1259,7 +1259,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Inbox
                                   </Text>
@@ -1404,7 +1404,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -1426,7 +1426,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Archived
                                   </Text>

--- a/ts/features/messages/components/Home/__tests__/__snapshots__/WrappedMessageListItem.test.tsx.snap
+++ b/ts/features/messages/components/Home/__tests__/__snapshots__/WrappedMessageListItem.test.tsx.snap
@@ -600,7 +600,7 @@ exports[`WrappedMessageListItem should match snapshot,     from SEND,   read mes
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -626,7 +626,7 @@ exports[`WrappedMessageListItem should match snapshot,     from SEND,   read mes
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Organization name
                                   </Text>
@@ -731,7 +731,7 @@ exports[`WrappedMessageListItem should match snapshot,     from SEND,   read mes
                                           },
                                         ]
                                       }
-                                      weight="SemiBold"
+                                      weight="Semibold"
                                     >
                                       Service name
                                     </Text>
@@ -1631,7 +1631,7 @@ exports[`WrappedMessageListItem should match snapshot,     from SEND, unread mes
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -1657,7 +1657,7 @@ exports[`WrappedMessageListItem should match snapshot,     from SEND, unread mes
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Organization name
                                   </Text>
@@ -1762,7 +1762,7 @@ exports[`WrappedMessageListItem should match snapshot,     from SEND, unread mes
                                           },
                                         ]
                                       }
-                                      weight="SemiBold"
+                                      weight="Semibold"
                                     >
                                       Service name
                                     </Text>
@@ -2717,7 +2717,7 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND,   read mes
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -2743,7 +2743,7 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND,   read mes
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Organization name
                                   </Text>
@@ -2848,7 +2848,7 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND,   read mes
                                           },
                                         ]
                                       }
-                                      weight="SemiBold"
+                                      weight="Semibold"
                                     >
                                       Service name
                                     </Text>
@@ -3533,7 +3533,7 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, unread mes
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -3559,7 +3559,7 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, unread mes
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Organization name
                                   </Text>
@@ -3664,7 +3664,7 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, unread mes
                                           },
                                         ]
                                       }
-                                      weight="SemiBold"
+                                      weight="Semibold"
                                     >
                                       Service name
                                     </Text>

--- a/ts/features/messages/components/Home/legacy/EmptyListComponent.tsx
+++ b/ts/features/messages/components/Home/legacy/EmptyListComponent.tsx
@@ -22,7 +22,7 @@ export const EmptyListComponent = (props: Props) => (
     <VSpacer size={16} />
     <Pictogram name={props.pictogram} />
     <VSpacer size={24} />
-    <Body weight="SemiBold">{props.title}</Body>
+    <Body weight="Semibold">{props.title}</Body>
     {props.subtitle && (
       <>
         <VSpacer size={24} />

--- a/ts/features/messages/components/MessageDetail/DueDateBar.tsx
+++ b/ts/features/messages/components/MessageDetail/DueDateBar.tsx
@@ -65,9 +65,9 @@ const TextContent: React.FunctionComponent<{
       return (
         <>
           {I18n.t("messages.cta.payment.expiredAlert.block1")}
-          <Body weight="SemiBold" color="white">{` ${date} `}</Body>
+          <Body weight="Semibold" color="white">{` ${date} `}</Body>
           {I18n.t("messages.cta.payment.expiredAlert.block2")}
-          <Body weight="SemiBold" color="white">{` ${time}`}</Body>
+          <Body weight="Semibold" color="white">{` ${time}`}</Body>
         </>
       );
     case "valid":
@@ -75,9 +75,9 @@ const TextContent: React.FunctionComponent<{
       return (
         <>
           {I18n.t("messages.cta.payment.expiringOrValidAlert.block1")}
-          <Body weight="SemiBold">{` ${date} `}</Body>
+          <Body weight="Semibold">{` ${date} `}</Body>
           {I18n.t("messages.cta.payment.expiringOrValidAlert.block2")}
-          <Body weight="SemiBold">{` ${time}`}</Body>
+          <Body weight="Semibold">{` ${time}`}</Body>
         </>
       );
   }

--- a/ts/features/messages/components/MessageDetail/LegacyMessageAttachments.tsx
+++ b/ts/features/messages/components/MessageDetail/LegacyMessageAttachments.tsx
@@ -110,7 +110,7 @@ const LegacyAttachmentItem = (props: LegacyMessageAttachmentProps) => {
         <View style={styles.middleSection}>
           <H5
             color={"bluegrey"}
-            weight={"SemiBold"}
+            weight={"Semibold"}
             ellipsizeMode={"middle"}
             numberOfLines={2}
           >

--- a/ts/features/messages/components/MessageDetail/LegacyModuleAttachment.tsx
+++ b/ts/features/messages/components/MessageDetail/LegacyModuleAttachment.tsx
@@ -120,7 +120,7 @@ const LegacyModuleAttachmentContent = ({
         <Icon name={formatMap[format]} size={ICON_SIZE} color="blue" />
       </View>
       <View style={IOStyles.flex}>
-        <LabelSmall numberOfLines={1} weight="SemiBold" color="bluegrey">
+        <LabelSmall numberOfLines={1} weight="Semibold" color="bluegrey">
           {title}
         </LabelSmall>
         {subtitle && (

--- a/ts/features/messages/components/MessageDetail/RemoteContentBanner.tsx
+++ b/ts/features/messages/components/MessageDetail/RemoteContentBanner.tsx
@@ -20,7 +20,7 @@ export const RemoteContentBanner = () => {
         {
           key: "RCB_T1",
           text: I18n.t("messageDetails.bottomSheet.bodyPt2"),
-          weight: "SemiBold"
+          weight: "Semibold"
         },
         {
           key: "RCB_T2",
@@ -30,7 +30,7 @@ export const RemoteContentBanner = () => {
         {
           key: "RCB_T3",
           text: I18n.t("messageDetails.bottomSheet.bodyPt4"),
-          weight: "SemiBold"
+          weight: "Semibold"
         },
         {
           key: "RCB_T4",

--- a/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/Content.test.tsx.snap
+++ b/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/Content.test.tsx.snap
@@ -200,7 +200,7 @@ exports[`MessageDetailData component when service's contact detail are not defin
       accessibilityRole="link"
       color="blue"
       defaultColor="blue"
-      defaultWeight="SemiBold"
+      defaultWeight="Semibold"
       font="TitilliumSansPro"
       fontStyle={
         Object {

--- a/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/DueDate.test.tsx.snap
+++ b/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/DueDate.test.tsx.snap
@@ -253,7 +253,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            31/01/2022 
         </Text>
@@ -283,7 +283,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            22:59
         </Text>
@@ -553,7 +553,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            28/02/2022 
         </Text>
@@ -583,7 +583,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            22:59
         </Text>
@@ -853,7 +853,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            28/02/2023 
         </Text>
@@ -883,7 +883,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            22:59
         </Text>
@@ -1153,7 +1153,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            29/02/2024 
         </Text>
@@ -1183,7 +1183,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            22:59
         </Text>
@@ -1453,7 +1453,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            31/03/2022 
         </Text>
@@ -1483,7 +1483,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            22:59
         </Text>
@@ -1753,7 +1753,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            30/04/2022 
         </Text>
@@ -1783,7 +1783,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            22:59
         </Text>
@@ -2053,7 +2053,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            31/05/2022 
         </Text>
@@ -2083,7 +2083,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            22:59
         </Text>
@@ -2353,7 +2353,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            30/06/2022 
         </Text>
@@ -2383,7 +2383,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            22:59
         </Text>
@@ -2653,7 +2653,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            31/07/2022 
         </Text>
@@ -2683,7 +2683,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            22:59
         </Text>
@@ -2953,7 +2953,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            31/08/2022 
         </Text>
@@ -2983,7 +2983,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            22:59
         </Text>
@@ -3253,7 +3253,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            30/09/2022 
         </Text>
@@ -3283,7 +3283,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            22:59
         </Text>
@@ -3553,7 +3553,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            31/10/2022 
         </Text>
@@ -3583,7 +3583,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            22:59
         </Text>
@@ -3853,7 +3853,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            01/12/2022 
         </Text>
@@ -3883,7 +3883,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            22:59
         </Text>
@@ -4153,7 +4153,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            31/12/2022 
         </Text>
@@ -4183,7 +4183,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            22:59
         </Text>
@@ -4453,7 +4453,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            31/01/2022 
         </Text>
@@ -4483,7 +4483,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            23:59
         </Text>
@@ -4753,7 +4753,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            28/02/2022 
         </Text>
@@ -4783,7 +4783,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            23:59
         </Text>
@@ -5053,7 +5053,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            28/02/2023 
         </Text>
@@ -5083,7 +5083,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            23:59
         </Text>
@@ -5353,7 +5353,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            29/02/2024 
         </Text>
@@ -5383,7 +5383,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            23:59
         </Text>
@@ -5653,7 +5653,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            31/03/2022 
         </Text>
@@ -5683,7 +5683,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            23:59
         </Text>
@@ -5953,7 +5953,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            30/04/2022 
         </Text>
@@ -5983,7 +5983,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            23:59
         </Text>
@@ -6253,7 +6253,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            31/05/2022 
         </Text>
@@ -6283,7 +6283,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            23:59
         </Text>
@@ -6553,7 +6553,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            30/06/2022 
         </Text>
@@ -6583,7 +6583,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            23:59
         </Text>
@@ -6853,7 +6853,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            31/07/2022 
         </Text>
@@ -6883,7 +6883,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            23:59
         </Text>
@@ -7153,7 +7153,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            31/08/2022 
         </Text>
@@ -7183,7 +7183,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            23:59
         </Text>
@@ -7453,7 +7453,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            30/09/2022 
         </Text>
@@ -7483,7 +7483,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            23:59
         </Text>
@@ -7753,7 +7753,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            31/10/2022 
         </Text>
@@ -7783,7 +7783,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            23:59
         </Text>
@@ -8053,7 +8053,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            01/12/2022 
         </Text>
@@ -8083,7 +8083,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            23:59
         </Text>
@@ -8353,7 +8353,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            31/12/2022 
         </Text>
@@ -8383,7 +8383,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            23:59
         </Text>
@@ -8653,7 +8653,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            01/12/2021 
         </Text>
@@ -8683,7 +8683,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            13:29
         </Text>
@@ -8953,7 +8953,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            01/12/2021 
         </Text>
@@ -8983,7 +8983,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            13:29
         </Text>
@@ -9253,7 +9253,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            01/12/2021 
         </Text>
@@ -9283,7 +9283,7 @@ Array [
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
            13:29
         </Text>

--- a/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/MessageDetailsAttachmentItem.test.tsx.snap
+++ b/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/MessageDetailsAttachmentItem.test.tsx.snap
@@ -382,7 +382,7 @@ exports[`MessageDetailsAttachmentItem Should match snapshot when is fetching the
                               allowFontScaling={false}
                               color="blueIO-500"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -405,7 +405,7 @@ exports[`MessageDetailsAttachmentItem Should match snapshot when is fetching the
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               1
                             </Text>
@@ -1052,7 +1052,7 @@ exports[`MessageDetailsAttachmentItem Should match snapshot when the attachment 
                               allowFontScaling={false}
                               color="blueIO-500"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -1075,7 +1075,7 @@ exports[`MessageDetailsAttachmentItem Should match snapshot when the attachment 
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               1
                             </Text>
@@ -1605,7 +1605,7 @@ exports[`MessageDetailsAttachmentItem Should match snapshot with all parameters 
                               allowFontScaling={false}
                               color="blueIO-500"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -1628,7 +1628,7 @@ exports[`MessageDetailsAttachmentItem Should match snapshot with all parameters 
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               A PDF File
                             </Text>
@@ -2165,7 +2165,7 @@ exports[`MessageDetailsAttachmentItem Should match snapshot with required parame
                               allowFontScaling={false}
                               color="blueIO-500"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -2188,7 +2188,7 @@ exports[`MessageDetailsAttachmentItem Should match snapshot with required parame
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               A PDF File
                             </Text>

--- a/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/MessageDetailsAttachments.test.tsx.snap
+++ b/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/MessageDetailsAttachments.test.tsx.snap
@@ -421,7 +421,7 @@ exports[`MessageDetailsAttachments Should match snapshot with 1 attachment 1`] =
                                 allowFontScaling={false}
                                 color="grey-700"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -444,7 +444,7 @@ exports[`MessageDetailsAttachments Should match snapshot with 1 attachment 1`] =
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 Attachments
                               </Text>
@@ -886,7 +886,7 @@ exports[`MessageDetailsAttachments Should match snapshot with 1 attachment that 
                                 allowFontScaling={false}
                                 color="grey-700"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -909,7 +909,7 @@ exports[`MessageDetailsAttachments Should match snapshot with 1 attachment that 
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 Attachments
                               </Text>
@@ -2013,7 +2013,7 @@ exports[`MessageDetailsAttachments Should match snapshot with 10 attachments 1`]
                                 allowFontScaling={false}
                                 color="grey-700"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -2036,7 +2036,7 @@ exports[`MessageDetailsAttachments Should match snapshot with 10 attachments 1`]
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 Attachments
                               </Text>
@@ -2478,7 +2478,7 @@ exports[`MessageDetailsAttachments Should match snapshot with 10 attachments tha
                                 allowFontScaling={false}
                                 color="grey-700"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -2501,7 +2501,7 @@ exports[`MessageDetailsAttachments Should match snapshot with 10 attachments tha
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 Attachments
                               </Text>

--- a/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/MessageDetailsHeader.test.tsx.snap
+++ b/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/MessageDetailsHeader.test.tsx.snap
@@ -341,7 +341,7 @@ exports[`MessageDetailsHeader component should match the snapshot with default p
                         allowFontScaling={false}
                         color="bluegreyDark"
                         defaultColor="bluegreyDark"
-                        defaultWeight="SemiBold"
+                        defaultWeight="Semibold"
                         font="TitilliumSansPro"
                         fontStyle={
                           Object {
@@ -364,7 +364,7 @@ exports[`MessageDetailsHeader component should match the snapshot with default p
                           ]
                         }
                         testID="message-header-subject"
-                        weight="SemiBold"
+                        weight="Semibold"
                       >
                         #### Subject ####
                       </Text>
@@ -441,7 +441,7 @@ exports[`MessageDetailsHeader component should match the snapshot with default p
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -463,7 +463,7 @@ exports[`MessageDetailsHeader component should match the snapshot with default p
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             Ċentru tas-Saħħa
                           </Text>

--- a/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/MessageDetailsPayment.test.tsx.snap
+++ b/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/MessageDetailsPayment.test.tsx.snap
@@ -772,7 +772,7 @@ exports[`MessageDetailsPayment Should match snapshot when there are payment data
                                 allowFontScaling={false}
                                 color="grey-700"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -795,7 +795,7 @@ exports[`MessageDetailsPayment Should match snapshot when there are payment data
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 pagoPA notices
                               </Text>

--- a/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/MessagePaymentItem.test.tsx.snap
+++ b/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/MessagePaymentItem.test.tsx.snap
@@ -884,7 +884,7 @@ exports[`MessagePaymentItem component Should match the snapshot for a payable it
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 Causale
                               </Text>
@@ -904,7 +904,7 @@ exports[`MessagePaymentItem component Should match the snapshot for a payable it
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -927,7 +927,7 @@ exports[`MessagePaymentItem component Should match the snapshot for a payable it
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 0.99 €
                               </Text>
@@ -1444,7 +1444,7 @@ exports[`MessagePaymentItem component Should match the snapshot for a processed 
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 n1
                               </Text>

--- a/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/OrganizationHeader.test.tsx.snap
+++ b/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/OrganizationHeader.test.tsx.snap
@@ -340,7 +340,7 @@ exports[`OrganizationHeader component should match the snapshot 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -362,7 +362,7 @@ exports[`OrganizationHeader component should match the snapshot 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             #### organization_name ####
                           </Text>

--- a/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/RemoteContentBanner.test.tsx.snap
+++ b/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/RemoteContentBanner.test.tsx.snap
@@ -835,7 +835,7 @@ exports[`RemoteContentBanner Should match snapshot 1`] = `
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   after you've received it
                                 </Text>
@@ -897,7 +897,7 @@ The sender can edit the information in a dynamic message only
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   specific cases
                                 </Text>

--- a/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/ShowMoreListItem.test.tsx.snap
+++ b/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/ShowMoreListItem.test.tsx.snap
@@ -1069,7 +1069,7 @@ exports[`ShowMoreListItem should match snapshot, one section, no items 1`] = `
                                         allowFontScaling={false}
                                         color="grey-700"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -1092,7 +1092,7 @@ exports[`ShowMoreListItem should match snapshot, one section, no items 1`] = `
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         Section 1 title
                                       </Text>
@@ -1662,7 +1662,7 @@ exports[`ShowMoreListItem should match snapshot, one section, one item, no icon 
                                         allowFontScaling={false}
                                         color="grey-700"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -1685,7 +1685,7 @@ exports[`ShowMoreListItem should match snapshot, one section, one item, no icon 
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         Section 1 title
                                       </Text>
@@ -1783,7 +1783,7 @@ exports[`ShowMoreListItem should match snapshot, one section, one item, no icon 
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -1806,7 +1806,7 @@ exports[`ShowMoreListItem should match snapshot, one section, one item, no icon 
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         value 1
                                       </Text>
@@ -2444,7 +2444,7 @@ exports[`ShowMoreListItem should match snapshot, one section, one item, with ico
                                         allowFontScaling={false}
                                         color="grey-700"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -2467,7 +2467,7 @@ exports[`ShowMoreListItem should match snapshot, one section, one item, with ico
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         Section 1 title
                                       </Text>
@@ -2633,7 +2633,7 @@ exports[`ShowMoreListItem should match snapshot, one section, one item, with ico
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -2656,7 +2656,7 @@ exports[`ShowMoreListItem should match snapshot, one section, one item, with ico
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         value 1
                                       </Text>
@@ -3294,7 +3294,7 @@ exports[`ShowMoreListItem should match snapshot, one section, two items, no icon
                                         allowFontScaling={false}
                                         color="grey-700"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -3317,7 +3317,7 @@ exports[`ShowMoreListItem should match snapshot, one section, two items, no icon
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         Section 1 title
                                       </Text>
@@ -3415,7 +3415,7 @@ exports[`ShowMoreListItem should match snapshot, one section, two items, no icon
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -3438,7 +3438,7 @@ exports[`ShowMoreListItem should match snapshot, one section, two items, no icon
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         value 1
                                       </Text>
@@ -3612,7 +3612,7 @@ exports[`ShowMoreListItem should match snapshot, one section, two items, no icon
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -3635,7 +3635,7 @@ exports[`ShowMoreListItem should match snapshot, one section, two items, no icon
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         value 2
                                       </Text>
@@ -4273,7 +4273,7 @@ exports[`ShowMoreListItem should match snapshot, one section, two items, with ic
                                         allowFontScaling={false}
                                         color="grey-700"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -4296,7 +4296,7 @@ exports[`ShowMoreListItem should match snapshot, one section, two items, with ic
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         Section 1 title
                                       </Text>
@@ -4462,7 +4462,7 @@ exports[`ShowMoreListItem should match snapshot, one section, two items, with ic
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -4485,7 +4485,7 @@ exports[`ShowMoreListItem should match snapshot, one section, two items, with ic
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         value 1
                                       </Text>
@@ -4727,7 +4727,7 @@ exports[`ShowMoreListItem should match snapshot, one section, two items, with ic
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -4750,7 +4750,7 @@ exports[`ShowMoreListItem should match snapshot, one section, two items, with ic
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         value 2
                                       </Text>
@@ -5388,7 +5388,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                         allowFontScaling={false}
                                         color="grey-700"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -5411,7 +5411,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         Section 1 title
                                       </Text>
@@ -5509,7 +5509,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -5532,7 +5532,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         value 1
                                       </Text>
@@ -5645,7 +5645,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                         allowFontScaling={false}
                                         color="grey-700"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -5668,7 +5668,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         Section 2 title
                                       </Text>
@@ -5766,7 +5766,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -5789,7 +5789,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         value 2
                                       </Text>
@@ -6031,7 +6031,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -6054,7 +6054,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         value 3
                                       </Text>
@@ -6167,7 +6167,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                         allowFontScaling={false}
                                         color="grey-700"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -6190,7 +6190,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         Section 3 title
                                       </Text>
@@ -6288,7 +6288,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -6311,7 +6311,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         value 4
                                       </Text>
@@ -6553,7 +6553,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -6576,7 +6576,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         value 5
                                       </Text>
@@ -6750,7 +6750,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -6773,7 +6773,7 @@ exports[`ShowMoreListItem should match snapshot, three sections, different item 
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         value 6
                                       </Text>
@@ -7411,7 +7411,7 @@ exports[`ShowMoreListItem should match snapshot, two sections, different item co
                                         allowFontScaling={false}
                                         color="grey-700"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -7434,7 +7434,7 @@ exports[`ShowMoreListItem should match snapshot, two sections, different item co
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         Section 1 title
                                       </Text>
@@ -7532,7 +7532,7 @@ exports[`ShowMoreListItem should match snapshot, two sections, different item co
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -7555,7 +7555,7 @@ exports[`ShowMoreListItem should match snapshot, two sections, different item co
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         value 1
                                       </Text>
@@ -7668,7 +7668,7 @@ exports[`ShowMoreListItem should match snapshot, two sections, different item co
                                         allowFontScaling={false}
                                         color="grey-700"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -7691,7 +7691,7 @@ exports[`ShowMoreListItem should match snapshot, two sections, different item co
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         Section 2 title
                                       </Text>
@@ -7789,7 +7789,7 @@ exports[`ShowMoreListItem should match snapshot, two sections, different item co
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -7812,7 +7812,7 @@ exports[`ShowMoreListItem should match snapshot, two sections, different item co
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         value 2
                                       </Text>
@@ -8054,7 +8054,7 @@ exports[`ShowMoreListItem should match snapshot, two sections, different item co
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -8077,7 +8077,7 @@ exports[`ShowMoreListItem should match snapshot, two sections, different item co
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         value 3
                                       </Text>

--- a/ts/features/messages/components/__test__/__snapshots__/EmptyListComponent.test.tsx.snap
+++ b/ts/features/messages/components/__test__/__snapshots__/EmptyListComponent.test.tsx.snap
@@ -130,7 +130,7 @@ exports[`EmptyListComponent matches the snapshot 1`] = `
         },
       ]
     }
-    weight="SemiBold"
+    weight="Semibold"
   >
     Your message list is empty.
   </Text>

--- a/ts/features/messages/navigation/MessagesHomeTabNavigator.tsx
+++ b/ts/features/messages/navigation/MessagesHomeTabNavigator.tsx
@@ -35,7 +35,7 @@ const MessagesHomeTabNavigator = () => (
         height: 40
       },
       tabBarLabelStyle: {
-        ...makeFontStyleObject("SemiBold"),
+        ...makeFontStyleObject("Semibold"),
         fontSize: Platform.OS === "android" ? 16 : undefined,
         fontWeight: Platform.OS === "android" ? "normal" : "bold",
         textTransform: "capitalize",

--- a/ts/features/messages/screens/__tests__/__snapshots__/MessageAttachment.test.tsx.snap
+++ b/ts/features/messages/screens/__tests__/__snapshots__/MessageAttachment.test.tsx.snap
@@ -651,6 +651,10 @@ exports[`MessageAttachment Should match the snapshot when everything went fine 1
                               Object {
                                 "backgroundColor": "#FFFFFF",
                               },
+                              Object {
+                                "backgroundColor": "#FFFFFF",
+                                "borderColor": "transparent",
+                              },
                             ]
                           }
                         >
@@ -1375,7 +1379,7 @@ exports[`MessageAttachment Should match the snapshot when there is an error 1`] 
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -1400,7 +1404,7 @@ exports[`MessageAttachment Should match the snapshot when there is an error 1`] 
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               There is a temporary problem, please try again.
                             </Text>
@@ -1471,6 +1475,10 @@ exports[`MessageAttachment Should match the snapshot when there is an error 1`] 
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": "#FFFFFF",
+                                "borderColor": "transparent",
                               },
                             ]
                           }

--- a/ts/features/messages/screens/__tests__/__snapshots__/MessageRouterScreen.test.tsx.snap
+++ b/ts/features/messages/screens/__tests__/__snapshots__/MessageRouterScreen.test.tsx.snap
@@ -403,7 +403,7 @@ exports[`MessageRouterScreen should match snapshot before starting to retrieve m
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -428,7 +428,7 @@ exports[`MessageRouterScreen should match snapshot before starting to retrieve m
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Loading message details
                             </Text>
@@ -504,6 +504,10 @@ exports[`MessageRouterScreen should match snapshot before starting to retrieve m
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": "#FFFFFF",
+                                "borderColor": "transparent",
                               },
                             ]
                           }
@@ -1230,7 +1234,7 @@ exports[`MessageRouterScreen should match snapshot if message data retrieval was
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -1255,7 +1259,7 @@ exports[`MessageRouterScreen should match snapshot if message data retrieval was
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Loading message details
                             </Text>
@@ -1331,6 +1335,10 @@ exports[`MessageRouterScreen should match snapshot if message data retrieval was
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": "#FFFFFF",
+                                "borderColor": "transparent",
                               },
                             ]
                           }
@@ -2056,7 +2064,7 @@ exports[`MessageRouterScreen should match snapshot on message data retrieval fai
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -2081,7 +2089,7 @@ exports[`MessageRouterScreen should match snapshot on message data retrieval fai
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               There is a temporary problem, please try again.
                             </Text>
@@ -2344,6 +2352,10 @@ exports[`MessageRouterScreen should match snapshot on message data retrieval fai
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": "#FFFFFF",
+                                "borderColor": "transparent",
                               },
                             ]
                           }
@@ -3070,7 +3082,7 @@ exports[`MessageRouterScreen should match snapshot on message data retrieval suc
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -3095,7 +3107,7 @@ exports[`MessageRouterScreen should match snapshot on message data retrieval suc
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Loading message details
                             </Text>
@@ -3171,6 +3183,10 @@ exports[`MessageRouterScreen should match snapshot on message data retrieval suc
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": "#FFFFFF",
+                                "borderColor": "transparent",
                               },
                             ]
                           }
@@ -3897,7 +3913,7 @@ exports[`MessageRouterScreen should match snapshot while retrieving message data
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -3922,7 +3938,7 @@ exports[`MessageRouterScreen should match snapshot while retrieving message data
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Loading message details
                             </Text>
@@ -3998,6 +4014,10 @@ exports[`MessageRouterScreen should match snapshot while retrieving message data
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": "#FFFFFF",
+                                "borderColor": "transparent",
                               },
                             ]
                           }

--- a/ts/features/payments/checkout/screens/WalletPaymentPickPspScreen.tsx
+++ b/ts/features/payments/checkout/screens/WalletPaymentPickPspScreen.tsx
@@ -120,7 +120,7 @@ const WalletPaymentPickPspScreen = () => {
         <Body>{I18n.t("wallet.payment.psp.description")}</Body>
         <Body>
           {I18n.t("wallet.payment.psp.taxDescription")}{" "}
-          <Body weight="SemiBold">
+          <Body weight="Semibold">
             {I18n.t("wallet.payment.psp.taxDescriptionBold")}
           </Body>
         </Body>

--- a/ts/features/payments/common/components/__tests__/__snapshots__/PaymentCardBig.test.tsx.snap
+++ b/ts/features/payments/common/components/__tests__/__snapshots__/PaymentCardBig.test.tsx.snap
@@ -825,7 +825,7 @@ exports[`PaymentCardBig component matches snapshot for paypal 1`] = `
                           allowFontScaling={false}
                           color="black"
                           defaultColor="black"
-                          defaultWeight="SemiBold"
+                          defaultWeight="Semibold"
                           ellipsizeMode="tail"
                           font="TitilliumSansPro"
                           fontStyle={
@@ -852,7 +852,7 @@ exports[`PaymentCardBig component matches snapshot for paypal 1`] = `
                               },
                             ]
                           }
-                          weight="SemiBold"
+                          weight="Semibold"
                         >
                           someEmail@test.com
                         </Text>

--- a/ts/features/payments/details/components/WalletDetailsPaymentMethodInitiatives.tsx
+++ b/ts/features/payments/details/components/WalletDetailsPaymentMethodInitiatives.tsx
@@ -59,7 +59,7 @@ const WalletDetailsPaymentMethodInitiatives = (
       <View style={[IOStyles.rowSpaceBetween, IOStyles.alignCenter]}>
         <H6 color={"grey-700"}>{I18n.t("wallet.capability.title")}</H6>
         <Body
-          weight="SemiBold"
+          weight="Semibold"
           color="blue"
           onPress={navigateToPairableInitiativesList}
         >

--- a/ts/features/payments/transaction/components/PaymentsLegacyAttachmentBottomSheet.tsx
+++ b/ts/features/payments/transaction/components/PaymentsLegacyAttachmentBottomSheet.tsx
@@ -45,7 +45,7 @@ type ParagraphWithTitleProps = {
 
 const ParagraphWithTitle = ({ title, body }: ParagraphWithTitleProps) => (
   <View>
-    <Body weight="SemiBold" color="black">
+    <Body weight="Semibold" color="black">
       {title}
     </Body>
     <VSpacer size={8} />

--- a/ts/features/pn/components/MessageTimeline.tsx
+++ b/ts/features/pn/components/MessageTimeline.tsx
@@ -92,10 +92,10 @@ const PnMessageTimelineItem = (props: ItemProps) => (
       />
     </View>
     <View style={styles.details}>
-      <LabelSmall fontSize="regular" color="bluegrey" weight="SemiBold">
+      <LabelSmall fontSize="regular" color="bluegrey" weight="Semibold">
         {props.time}
       </LabelSmall>
-      <Body color="bluegreyDark" weight="SemiBold">
+      <Body color="bluegreyDark" weight="Semibold">
         {props.text}
       </Body>
     </View>

--- a/ts/features/pn/components/__test__/__snapshots__/F24ListBottomSheetLink.test.tsx.snap
+++ b/ts/features/pn/components/__test__/__snapshots__/F24ListBottomSheetLink.test.tsx.snap
@@ -518,7 +518,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                         allowFontScaling={false}
                                         color="blueIO-500"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -541,7 +541,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         0
                                       </Text>
@@ -746,7 +746,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                         allowFontScaling={false}
                                         color="blueIO-500"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -769,7 +769,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         1
                                       </Text>
@@ -974,7 +974,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                         allowFontScaling={false}
                                         color="blueIO-500"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -997,7 +997,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         2
                                       </Text>
@@ -1202,7 +1202,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                         allowFontScaling={false}
                                         color="blueIO-500"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -1225,7 +1225,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         3
                                       </Text>
@@ -1430,7 +1430,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                         allowFontScaling={false}
                                         color="blueIO-500"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -1453,7 +1453,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         4
                                       </Text>
@@ -1658,7 +1658,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                         allowFontScaling={false}
                                         color="blueIO-500"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -1681,7 +1681,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         5
                                       </Text>
@@ -1886,7 +1886,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                         allowFontScaling={false}
                                         color="blueIO-500"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -1909,7 +1909,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         6
                                       </Text>
@@ -2114,7 +2114,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                         allowFontScaling={false}
                                         color="blueIO-500"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -2137,7 +2137,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         7
                                       </Text>
@@ -2342,7 +2342,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                         allowFontScaling={false}
                                         color="blueIO-500"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -2365,7 +2365,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         8
                                       </Text>
@@ -2570,7 +2570,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                         allowFontScaling={false}
                                         color="blueIO-500"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -2593,7 +2593,7 @@ exports[`F24ListBottomSheetLink should be snapshot for a 10 items F24 list 1`] =
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         9
                                       </Text>
@@ -3736,7 +3736,7 @@ exports[`F24ListBottomSheetLink should be snapshot for an 1 item F24 list 1`] = 
                                         allowFontScaling={false}
                                         color="blueIO-500"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -3759,7 +3759,7 @@ exports[`F24ListBottomSheetLink should be snapshot for an 1 item F24 list 1`] = 
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         0
                                       </Text>

--- a/ts/features/pn/components/__test__/__snapshots__/F24Section.test.tsx.snap
+++ b/ts/features/pn/components/__test__/__snapshots__/F24Section.test.tsx.snap
@@ -424,7 +424,7 @@ exports[`F24Section should match snapshot when there are more than one F24 1`] =
                                 allowFontScaling={false}
                                 color="grey-700"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -447,7 +447,7 @@ exports[`F24Section should match snapshot when there are more than one F24 1`] =
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 Modelli F24
                               </Text>
@@ -691,7 +691,7 @@ exports[`F24Section should match snapshot when there are more than one F24 1`] =
                                         allowFontScaling={false}
                                         color="blueIO-500"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -714,7 +714,7 @@ exports[`F24Section should match snapshot when there are more than one F24 1`] =
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         2
                                       </Text>
@@ -919,7 +919,7 @@ exports[`F24Section should match snapshot when there are more than one F24 1`] =
                                         allowFontScaling={false}
                                         color="blueIO-500"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -942,7 +942,7 @@ exports[`F24Section should match snapshot when there are more than one F24 1`] =
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         4
                                       </Text>
@@ -2519,7 +2519,7 @@ exports[`F24Section should match snapshot when there is a single F24 1`] = `
                                 allowFontScaling={false}
                                 color="grey-700"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -2542,7 +2542,7 @@ exports[`F24Section should match snapshot when there is a single F24 1`] = `
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 Modelli F24
                               </Text>
@@ -2650,7 +2650,7 @@ exports[`F24Section should match snapshot when there is a single F24 1`] = `
                               allowFontScaling={false}
                               color="blueIO-500"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -2673,7 +2673,7 @@ exports[`F24Section should match snapshot when there is a single F24 1`] = `
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               2
                             </Text>

--- a/ts/features/pn/components/__test__/__snapshots__/LegacyMessageF24.test.tsx.snap
+++ b/ts/features/pn/components/__test__/__snapshots__/LegacyMessageF24.test.tsx.snap
@@ -1090,7 +1090,7 @@ exports[`MessageF24 component when there is only one F24 should match the snapsh
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     invoice.pdf
                                   </Text>

--- a/ts/features/pn/components/__test__/__snapshots__/LegacyMessagePayments.test.tsx.snap
+++ b/ts/features/pn/components/__test__/__snapshots__/LegacyMessagePayments.test.tsx.snap
@@ -806,7 +806,7 @@ exports[`LegacyMessagePayments component Should match the snapshot for a cancell
                               <Text
                                 color="bluegreyDark"
                                 defaultColor="bluegreyDark"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -950,7 +950,7 @@ exports[`LegacyMessagePayments component Should match the snapshot for a cancell
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     n1
                                   </Text>
@@ -1191,7 +1191,7 @@ exports[`LegacyMessagePayments component Should match the snapshot for a cancell
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     n2
                                   </Text>
@@ -1432,7 +1432,7 @@ exports[`LegacyMessagePayments component Should match the snapshot for a cancell
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     n3
                                   </Text>

--- a/ts/features/pn/components/__test__/__snapshots__/MessageDetails.test.tsx.snap
+++ b/ts/features/pn/components/__test__/__snapshots__/MessageDetails.test.tsx.snap
@@ -558,7 +558,7 @@ exports[`MessageDetails component should match the snapshot with default props 1
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -581,7 +581,7 @@ exports[`MessageDetails component should match the snapshot with default props 1
                                 ]
                               }
                               testID="message-header-subject"
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               ######## subject ########
                             </Text>
@@ -1127,7 +1127,7 @@ exports[`MessageDetails component should match the snapshot with default props 1
                                               allowFontScaling={false}
                                               color="grey-700"
                                               defaultColor="black"
-                                              defaultWeight="SemiBold"
+                                              defaultWeight="Semibold"
                                               font="TitilliumSansPro"
                                               fontStyle={
                                                 Object {
@@ -1150,7 +1150,7 @@ exports[`MessageDetails component should match the snapshot with default props 1
                                                   },
                                                 ]
                                               }
-                                              weight="SemiBold"
+                                              weight="Semibold"
                                             >
                                               Notifica
                                             </Text>
@@ -1316,7 +1316,7 @@ exports[`MessageDetails component should match the snapshot with default props 1
                                               allowFontScaling={false}
                                               color="blue"
                                               defaultColor="black"
-                                              defaultWeight="SemiBold"
+                                              defaultWeight="Semibold"
                                               font="TitilliumSansPro"
                                               fontStyle={
                                                 Object {
@@ -1339,7 +1339,7 @@ exports[`MessageDetails component should match the snapshot with default props 1
                                                   },
                                                 ]
                                               }
-                                              weight="SemiBold"
+                                              weight="Semibold"
                                             >
                                               731143-7-0317-8200-0
                                             </Text>
@@ -1452,7 +1452,7 @@ exports[`MessageDetails component should match the snapshot with default props 1
                                               allowFontScaling={false}
                                               color="grey-700"
                                               defaultColor="black"
-                                              defaultWeight="SemiBold"
+                                              defaultWeight="Semibold"
                                               font="TitilliumSansPro"
                                               fontStyle={
                                                 Object {
@@ -1475,7 +1475,7 @@ exports[`MessageDetails component should match the snapshot with default props 1
                                                   },
                                                 ]
                                               }
-                                              weight="SemiBold"
+                                              weight="Semibold"
                                             >
                                               Message
                                             </Text>
@@ -1641,7 +1641,7 @@ exports[`MessageDetails component should match the snapshot with default props 1
                                               allowFontScaling={false}
                                               color="blue"
                                               defaultColor="black"
-                                              defaultWeight="SemiBold"
+                                              defaultWeight="Semibold"
                                               font="TitilliumSansPro"
                                               fontStyle={
                                                 Object {
@@ -1664,7 +1664,7 @@ exports[`MessageDetails component should match the snapshot with default props 1
                                                   },
                                                 ]
                                               }
-                                              weight="SemiBold"
+                                              weight="Semibold"
                                             >
                                               01HRYR6C761DGH3S84HBBXMMKT
                                             </Text>

--- a/ts/features/pn/components/__test__/__snapshots__/MessagePaymentBottomSheet.test.tsx.snap
+++ b/ts/features/pn/components/__test__/__snapshots__/MessagePaymentBottomSheet.test.tsx.snap
@@ -841,7 +841,7 @@ exports[`MessagePaymentBottomSheet should match snapshot, six payments 1`] = `
                                           },
                                         ]
                                       }
-                                      weight="SemiBold"
+                                      weight="Semibold"
                                     >
                                       Uno due tre
                                     </Text>
@@ -861,7 +861,7 @@ exports[`MessagePaymentBottomSheet should match snapshot, six payments 1`] = `
                                       allowFontScaling={false}
                                       color="blue"
                                       defaultColor="black"
-                                      defaultWeight="SemiBold"
+                                      defaultWeight="Semibold"
                                       font="TitilliumSansPro"
                                       fontStyle={
                                         Object {
@@ -884,7 +884,7 @@ exports[`MessagePaymentBottomSheet should match snapshot, six payments 1`] = `
                                           },
                                         ]
                                       }
-                                      weight="SemiBold"
+                                      weight="Semibold"
                                     >
                                       1.99 €
                                     </Text>
@@ -1069,7 +1069,7 @@ exports[`MessagePaymentBottomSheet should match snapshot, six payments 1`] = `
                                           },
                                         ]
                                       }
-                                      weight="SemiBold"
+                                      weight="Semibold"
                                     >
                                       0123  4567  8912  3456  20
                                     </Text>
@@ -1309,7 +1309,7 @@ exports[`MessagePaymentBottomSheet should match snapshot, six payments 1`] = `
                                           },
                                         ]
                                       }
-                                      weight="SemiBold"
+                                      weight="Semibold"
                                     >
                                       0123  4567  8912  3456  30
                                     </Text>
@@ -1549,7 +1549,7 @@ exports[`MessagePaymentBottomSheet should match snapshot, six payments 1`] = `
                                           },
                                         ]
                                       }
-                                      weight="SemiBold"
+                                      weight="Semibold"
                                     >
                                       0123  4567  8912  3456  40
                                     </Text>
@@ -1789,7 +1789,7 @@ exports[`MessagePaymentBottomSheet should match snapshot, six payments 1`] = `
                                           },
                                         ]
                                       }
-                                      weight="SemiBold"
+                                      weight="Semibold"
                                     >
                                       0123  4567  8912  3456  50
                                     </Text>
@@ -2029,7 +2029,7 @@ exports[`MessagePaymentBottomSheet should match snapshot, six payments 1`] = `
                                           },
                                         ]
                                       }
-                                      weight="SemiBold"
+                                      weight="Semibold"
                                     >
                                       0123  4567  8912  3456  60
                                     </Text>
@@ -2269,7 +2269,7 @@ exports[`MessagePaymentBottomSheet should match snapshot, six payments 1`] = `
                                           },
                                         ]
                                       }
-                                      weight="SemiBold"
+                                      weight="Semibold"
                                     >
                                       0123  4567  8912  3456  70
                                     </Text>

--- a/ts/features/pn/components/__test__/__snapshots__/MessagePayments.test.tsx.snap
+++ b/ts/features/pn/components/__test__/__snapshots__/MessagePayments.test.tsx.snap
@@ -765,7 +765,7 @@ exports[`MessagePayments should match snapshot when cancelled, with payments, wi
                                 allowFontScaling={false}
                                 color="grey-700"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -788,7 +788,7 @@ exports[`MessagePayments should match snapshot when cancelled, with payments, wi
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 Avvisi pagoPA
                               </Text>
@@ -914,7 +914,7 @@ exports[`MessagePayments should match snapshot when cancelled, with payments, wi
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 01234567890012345678912345610
                               </Text>
@@ -1155,7 +1155,7 @@ exports[`MessagePayments should match snapshot when cancelled, with payments, wi
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 01234567890012345678912345620
                               </Text>
@@ -1396,7 +1396,7 @@ exports[`MessagePayments should match snapshot when cancelled, with payments, wi
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 01234567890012345678912345630
                               </Text>
@@ -1637,7 +1637,7 @@ exports[`MessagePayments should match snapshot when cancelled, with payments, wi
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 01234567890012345678912345640
                               </Text>
@@ -1878,7 +1878,7 @@ exports[`MessagePayments should match snapshot when cancelled, with payments, wi
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 01234567890012345678912345650
                               </Text>
@@ -2119,7 +2119,7 @@ exports[`MessagePayments should match snapshot when cancelled, with payments, wi
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 01234567890012345678912345660
                               </Text>
@@ -2360,7 +2360,7 @@ exports[`MessagePayments should match snapshot when cancelled, with payments, wi
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 01234567890012345678912345670
                               </Text>
@@ -2930,7 +2930,7 @@ exports[`MessagePayments should match snapshot when cancelled, without payments,
                                 allowFontScaling={false}
                                 color="grey-700"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -2953,7 +2953,7 @@ exports[`MessagePayments should match snapshot when cancelled, without payments,
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 Avvisi pagoPA
                               </Text>
@@ -3079,7 +3079,7 @@ exports[`MessagePayments should match snapshot when cancelled, without payments,
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 01234567890012345678912345610
                               </Text>
@@ -3320,7 +3320,7 @@ exports[`MessagePayments should match snapshot when cancelled, without payments,
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 01234567890012345678912345620
                               </Text>
@@ -3561,7 +3561,7 @@ exports[`MessagePayments should match snapshot when cancelled, without payments,
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 01234567890012345678912345630
                               </Text>
@@ -3802,7 +3802,7 @@ exports[`MessagePayments should match snapshot when cancelled, without payments,
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 01234567890012345678912345640
                               </Text>
@@ -4043,7 +4043,7 @@ exports[`MessagePayments should match snapshot when cancelled, without payments,
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 01234567890012345678912345650
                               </Text>
@@ -4284,7 +4284,7 @@ exports[`MessagePayments should match snapshot when cancelled, without payments,
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 01234567890012345678912345660
                               </Text>
@@ -4525,7 +4525,7 @@ exports[`MessagePayments should match snapshot when cancelled, without payments,
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 01234567890012345678912345670
                               </Text>
@@ -5426,7 +5426,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                 allowFontScaling={false}
                                 color="grey-700"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -5449,7 +5449,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 Avvisi pagoPA
                               </Text>
@@ -5567,7 +5567,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 hendrerit orci id dolor consectetur
                               </Text>
@@ -5587,7 +5587,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -5610,7 +5610,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 1.99 €
                               </Text>
@@ -5795,7 +5795,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 0123  4567  8912  3456  20
                               </Text>
@@ -6035,7 +6035,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 0123  4567  8912  3456  30
                               </Text>
@@ -6275,7 +6275,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 0123  4567  8912  3456  40
                               </Text>
@@ -6515,7 +6515,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 0123  4567  8912  3456  50
                               </Text>
@@ -7085,7 +7085,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                 allowFontScaling={false}
                                 color="grey-700"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -7108,7 +7108,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 Avvisi pagoPA
                               </Text>
@@ -7226,7 +7226,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 hendrerit orci id dolor consectetur
                               </Text>
@@ -7246,7 +7246,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -7269,7 +7269,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 1.99 €
                               </Text>
@@ -7454,7 +7454,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 0123  4567  8912  3456  20
                               </Text>
@@ -7694,7 +7694,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 0123  4567  8912  3456  30
                               </Text>
@@ -7934,7 +7934,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 0123  4567  8912  3456  40
                               </Text>
@@ -8174,7 +8174,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with five (ma
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 0123  4567  8912  3456  50
                               </Text>
@@ -8744,7 +8744,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                 allowFontScaling={false}
                                 color="grey-700"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -8767,7 +8767,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 Avvisi pagoPA
                               </Text>
@@ -8885,7 +8885,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 hendrerit orci id dolor consectetur
                               </Text>
@@ -8905,7 +8905,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -8928,7 +8928,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 1.99 €
                               </Text>
@@ -9113,7 +9113,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 0123  4567  8912  3456  20
                               </Text>
@@ -9353,7 +9353,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 0123  4567  8912  3456  30
                               </Text>
@@ -9593,7 +9593,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 0123  4567  8912  3456  40
                               </Text>
@@ -9833,7 +9833,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 0123  4567  8912  3456  50
                               </Text>
@@ -10511,7 +10511,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                 allowFontScaling={false}
                                 color="grey-700"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -10534,7 +10534,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 Avvisi pagoPA
                               </Text>
@@ -10652,7 +10652,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 hendrerit orci id dolor consectetur
                               </Text>
@@ -10672,7 +10672,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -10695,7 +10695,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 1.99 €
                               </Text>
@@ -10880,7 +10880,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 0123  4567  8912  3456  20
                               </Text>
@@ -11120,7 +11120,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 0123  4567  8912  3456  30
                               </Text>
@@ -11360,7 +11360,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 0123  4567  8912  3456  40
                               </Text>
@@ -11600,7 +11600,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with more-tha
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 0123  4567  8912  3456  50
                               </Text>
@@ -12278,7 +12278,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with one paya
                                 allowFontScaling={false}
                                 color="grey-700"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -12301,7 +12301,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with one paya
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 Avvisi pagoPA
                               </Text>
@@ -12419,7 +12419,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with one paya
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 hendrerit orci id dolor consectetur
                               </Text>
@@ -12439,7 +12439,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with one paya
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -12462,7 +12462,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with one paya
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 1.99 €
                               </Text>
@@ -12977,7 +12977,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with one paya
                                 allowFontScaling={false}
                                 color="grey-700"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -13000,7 +13000,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with one paya
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 Avvisi pagoPA
                               </Text>
@@ -13118,7 +13118,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with one paya
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 hendrerit orci id dolor consectetur
                               </Text>
@@ -13138,7 +13138,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with one paya
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -13161,7 +13161,7 @@ exports[`MessagePayments should match snapshot when not cancelled, with one paya
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 1.99 €
                               </Text>

--- a/ts/features/pn/components/__test__/__snapshots__/Timeline.test.tsx.snap
+++ b/ts/features/pn/components/__test__/__snapshots__/Timeline.test.tsx.snap
@@ -344,7 +344,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -366,7 +366,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             1
                           </Text>
@@ -465,7 +465,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -487,7 +487,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             Depositata
                           </Text>
@@ -555,7 +555,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -577,7 +577,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             3
                           </Text>
@@ -674,7 +674,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -696,7 +696,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             Annullata
                           </Text>
@@ -764,7 +764,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -786,7 +786,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             6
                           </Text>
@@ -883,7 +883,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -905,7 +905,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             Consegnata
                           </Text>
@@ -973,7 +973,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -995,7 +995,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             9
                           </Text>
@@ -1092,7 +1092,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -1114,7 +1114,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             Invio in corso
                           </Text>
@@ -1182,7 +1182,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -1204,7 +1204,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             11
                           </Text>
@@ -1301,7 +1301,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -1323,7 +1323,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             Perfezionata per decorrenza termini
                           </Text>
@@ -1391,7 +1391,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -1413,7 +1413,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             14
                           </Text>
@@ -1510,7 +1510,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -1532,7 +1532,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             Destinatario irreperibile
                           </Text>
@@ -1600,7 +1600,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -1622,7 +1622,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             15
                           </Text>
@@ -1719,7 +1719,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -1741,7 +1741,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             Avvenuto accesso
                           </Text>
@@ -1809,7 +1809,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -1831,7 +1831,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             18
                           </Text>
@@ -1928,7 +1928,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -1950,7 +1950,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             Pagata
                           </Text>
@@ -2018,7 +2018,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -2040,7 +2040,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             21
                           </Text>
@@ -2137,7 +2137,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -2159,7 +2159,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             REFUSED
                           </Text>
@@ -2227,7 +2227,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -2249,7 +2249,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             24
                           </Text>
@@ -2346,7 +2346,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -2368,7 +2368,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             IN VALIDATION
                           </Text>
@@ -2436,7 +2436,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -2458,7 +2458,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             27
                           </Text>
@@ -2555,7 +2555,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -2577,7 +2577,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             Depositata
                           </Text>
@@ -2645,7 +2645,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -2667,7 +2667,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             30
                           </Text>
@@ -2766,7 +2766,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                             allowFontScaling={false}
                             color="grey-700"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -2788,7 +2788,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             Annullata
                           </Text>

--- a/ts/features/pn/components/__test__/__snapshots__/TimelineListItem.test.tsx.snap
+++ b/ts/features/pn/components/__test__/__snapshots__/TimelineListItem.test.tsx.snap
@@ -529,7 +529,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -551,7 +551,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   28
                                 </Text>
@@ -650,7 +650,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -672,7 +672,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Pagata
                                 </Text>
@@ -740,7 +740,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -762,7 +762,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   25
                                 </Text>
@@ -859,7 +859,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -881,7 +881,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Consegnata
                                 </Text>
@@ -949,7 +949,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -971,7 +971,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   23
                                 </Text>
@@ -1068,7 +1068,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -1090,7 +1090,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Invio in corso
                                 </Text>
@@ -1158,7 +1158,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -1180,7 +1180,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   20
                                 </Text>
@@ -1277,7 +1277,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -1299,7 +1299,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   REFUSED
                                 </Text>
@@ -1367,7 +1367,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -1389,7 +1389,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   18
                                 </Text>
@@ -1486,7 +1486,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -1508,7 +1508,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Depositata
                                 </Text>
@@ -1576,7 +1576,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -1598,7 +1598,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   13
                                 </Text>
@@ -1695,7 +1695,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -1717,7 +1717,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   IN VALIDATION
                                 </Text>
@@ -1785,7 +1785,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -1807,7 +1807,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   10
                                 </Text>
@@ -1904,7 +1904,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -1926,7 +1926,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Annullata
                                 </Text>
@@ -1994,7 +1994,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -2016,7 +2016,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   07
                                 </Text>
@@ -2113,7 +2113,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -2135,7 +2135,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Destinatario irreperibile
                                 </Text>
@@ -2203,7 +2203,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -2225,7 +2225,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   03
                                 </Text>
@@ -2322,7 +2322,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -2344,7 +2344,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Perfezionata per decorrenza termini
                                 </Text>
@@ -2412,7 +2412,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -2434,7 +2434,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   01
                                 </Text>
@@ -2533,7 +2533,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -2555,7 +2555,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Avvenuto accesso
                                 </Text>
@@ -3143,7 +3143,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -3165,7 +3165,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   28
                                 </Text>
@@ -3264,7 +3264,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -3286,7 +3286,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Pagata
                                 </Text>
@@ -3354,7 +3354,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -3376,7 +3376,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   25
                                 </Text>
@@ -3473,7 +3473,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -3495,7 +3495,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Consegnata
                                 </Text>
@@ -3563,7 +3563,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -3585,7 +3585,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   23
                                 </Text>
@@ -3682,7 +3682,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -3704,7 +3704,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Invio in corso
                                 </Text>
@@ -3772,7 +3772,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -3794,7 +3794,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   20
                                 </Text>
@@ -3891,7 +3891,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -3913,7 +3913,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   REFUSED
                                 </Text>
@@ -3981,7 +3981,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -4003,7 +4003,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   18
                                 </Text>
@@ -4100,7 +4100,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -4122,7 +4122,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Depositata
                                 </Text>
@@ -4190,7 +4190,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -4212,7 +4212,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   13
                                 </Text>
@@ -4309,7 +4309,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -4331,7 +4331,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   IN VALIDATION
                                 </Text>
@@ -4399,7 +4399,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -4421,7 +4421,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   10
                                 </Text>
@@ -4518,7 +4518,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -4540,7 +4540,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Annullata
                                 </Text>
@@ -4608,7 +4608,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -4630,7 +4630,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   07
                                 </Text>
@@ -4727,7 +4727,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -4749,7 +4749,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Destinatario irreperibile
                                 </Text>
@@ -4817,7 +4817,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -4839,7 +4839,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   03
                                 </Text>
@@ -4936,7 +4936,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -4958,7 +4958,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Perfezionata per decorrenza termini
                                 </Text>
@@ -5026,7 +5026,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -5048,7 +5048,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   01
                                 </Text>
@@ -5147,7 +5147,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -5169,7 +5169,7 @@ exports[`TimelineListItem Should match snapshot, all handled-status items histor
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Avvenuto accesso
                                 </Text>

--- a/ts/features/pn/screens/__test__/__snapshots__/LegacyPaidPaymentScreen.test.tsx.snap
+++ b/ts/features/pn/screens/__test__/__snapshots__/LegacyPaidPaymentScreen.test.tsx.snap
@@ -832,7 +832,7 @@ exports[`LegacyPaidPaymentScreen should render with back button, title, help but
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -855,7 +855,7 @@ exports[`LegacyPaidPaymentScreen should render with back button, title, help but
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         0180  1198  8086  4794  97
                                       </Text>
@@ -1780,7 +1780,7 @@ exports[`LegacyPaidPaymentScreen should render with back button, title, help but
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -1803,7 +1803,7 @@ exports[`LegacyPaidPaymentScreen should render with back button, title, help but
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         0180  1198  8086  4794  97
                                       </Text>
@@ -1969,7 +1969,7 @@ exports[`LegacyPaidPaymentScreen should render with back button, title, help but
                                         allowFontScaling={false}
                                         color="blue"
                                         defaultColor="black"
-                                        defaultWeight="SemiBold"
+                                        defaultWeight="Semibold"
                                         font="TitilliumSansPro"
                                         fontStyle={
                                           Object {
@@ -1992,7 +1992,7 @@ exports[`LegacyPaidPaymentScreen should render with back button, title, help but
                                             },
                                           ]
                                         }
-                                        weight="SemiBold"
+                                        weight="Semibold"
                                       >
                                         00000000009
                                       </Text>

--- a/ts/features/pn/screens/__test__/__snapshots__/MessageDetailsScreen.test.tsx.snap
+++ b/ts/features/pn/screens/__test__/__snapshots__/MessageDetailsScreen.test.tsx.snap
@@ -417,7 +417,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -440,7 +440,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                                 ]
                               }
                               testID="message-header-subject"
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               ######## subject ########
                             </Text>
@@ -517,7 +517,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                                   allowFontScaling={false}
                                   color="grey-700"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -539,7 +539,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Ċentru tas-Saħħa
                                 </Text>
@@ -790,7 +790,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                                       allowFontScaling={false}
                                       color="grey-700"
                                       defaultColor="black"
-                                      defaultWeight="SemiBold"
+                                      defaultWeight="Semibold"
                                       font="TitilliumSansPro"
                                       fontStyle={
                                         Object {
@@ -813,7 +813,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                                           },
                                         ]
                                       }
-                                      weight="SemiBold"
+                                      weight="Semibold"
                                     >
                                       Attachments
                                     </Text>
@@ -884,7 +884,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                                     allowFontScaling={false}
                                     color="blueIO-500"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -907,7 +907,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     A First Attachment
                                   </Text>
@@ -1112,7 +1112,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                                     allowFontScaling={false}
                                     color="blueIO-500"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -1135,7 +1135,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     A Second Attachment
                                   </Text>
@@ -1716,7 +1716,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                                               allowFontScaling={false}
                                               color="grey-700"
                                               defaultColor="black"
-                                              defaultWeight="SemiBold"
+                                              defaultWeight="Semibold"
                                               font="TitilliumSansPro"
                                               fontStyle={
                                                 Object {
@@ -1739,7 +1739,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                                                   },
                                                 ]
                                               }
-                                              weight="SemiBold"
+                                              weight="Semibold"
                                             >
                                               Notifica
                                             </Text>
@@ -1905,7 +1905,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                                               allowFontScaling={false}
                                               color="blue"
                                               defaultColor="black"
-                                              defaultWeight="SemiBold"
+                                              defaultWeight="Semibold"
                                               font="TitilliumSansPro"
                                               fontStyle={
                                                 Object {
@@ -1928,7 +1928,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                                                   },
                                                 ]
                                               }
-                                              weight="SemiBold"
+                                              weight="Semibold"
                                             >
                                               731143-7-0317-8200-0
                                             </Text>
@@ -2041,7 +2041,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                                               allowFontScaling={false}
                                               color="grey-700"
                                               defaultColor="black"
-                                              defaultWeight="SemiBold"
+                                              defaultWeight="Semibold"
                                               font="TitilliumSansPro"
                                               fontStyle={
                                                 Object {
@@ -2064,7 +2064,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                                                   },
                                                 ]
                                               }
-                                              weight="SemiBold"
+                                              weight="Semibold"
                                             >
                                               Message
                                             </Text>
@@ -2230,7 +2230,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                                               allowFontScaling={false}
                                               color="blue"
                                               defaultColor="black"
-                                              defaultWeight="SemiBold"
+                                              defaultWeight="Semibold"
                                               font="TitilliumSansPro"
                                               fontStyle={
                                                 Object {
@@ -2253,7 +2253,7 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                                                   },
                                                 ]
                                               }
-                                              weight="SemiBold"
+                                              weight="Semibold"
                                             >
                                               FAT00001
                                             </Text>
@@ -2360,6 +2360,10 @@ exports[`MessageDetailsScreen should match the snapshot when everything went fin
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": "#FFFFFF",
+                                "borderColor": "transparent",
                               },
                             ]
                           }
@@ -3085,7 +3089,7 @@ exports[`MessageDetailsScreen should match the snapshot when there is an error 1
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -3110,7 +3114,7 @@ exports[`MessageDetailsScreen should match the snapshot when there is an error 1
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Qualcosa è andato storto
                             </Text>
@@ -3181,6 +3185,10 @@ exports[`MessageDetailsScreen should match the snapshot when there is an error 1
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": "#FFFFFF",
+                                "borderColor": "transparent",
                               },
                             ]
                           }

--- a/ts/features/pn/screens/__test__/__snapshots__/PaidPaymentScreen.test.tsx.snap
+++ b/ts/features/pn/screens/__test__/__snapshots__/PaidPaymentScreen.test.tsx.snap
@@ -410,7 +410,7 @@ exports[`PaidPaymentScreen should match snapshot 1`] = `
                               allowFontScaling={false}
                               color="bluegreyDark"
                               defaultColor="bluegreyDark"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -435,7 +435,7 @@ exports[`PaidPaymentScreen should match snapshot 1`] = `
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Questo avviso è stato già pagato!
                             </Text>
@@ -595,6 +595,10 @@ exports[`PaidPaymentScreen should match snapshot 1`] = `
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": "#FFFFFF",
+                                "borderColor": "transparent",
                               },
                             ]
                           }

--- a/ts/features/pushNotifications/components/NotificationPreviewSample.tsx
+++ b/ts/features/pushNotifications/components/NotificationPreviewSample.tsx
@@ -77,7 +77,7 @@ export const NotificationPreviewSample = ({
       <Icon color="blueIO-450" name="productIOApp" />
       <HSpacer />
       <View style={IOStyles.flex}>
-        <H6 weight="SemiBold">{I18n.t(titleKey)}</H6>
+        <H6 weight="Semibold">{I18n.t(titleKey)}</H6>
         <Label fontSize="small" weight="Regular">
           {I18n.t(messageKey)}
         </Label>

--- a/ts/features/pushNotifications/components/__tests__/__snapshots__/NotificationPreviewSample.test.tsx.snap
+++ b/ts/features/pushNotifications/components/__tests__/__snapshots__/NotificationPreviewSample.test.tsx.snap
@@ -468,7 +468,7 @@ exports[`NotificationPreviewSample should match snapshot, preview off, reminder 
                             allowFontScaling={false}
                             color="black"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -490,7 +490,7 @@ exports[`NotificationPreviewSample should match snapshot, preview off, reminder 
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             You have a new message
                           </Text>
@@ -1007,7 +1007,7 @@ exports[`NotificationPreviewSample should match snapshot, preview off, reminder 
                             allowFontScaling={false}
                             color="black"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -1029,7 +1029,7 @@ exports[`NotificationPreviewSample should match snapshot, preview off, reminder 
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             You have a notice due tomorrow
                           </Text>
@@ -1546,7 +1546,7 @@ exports[`NotificationPreviewSample should match snapshot, preview on, reminder o
                             allowFontScaling={false}
                             color="black"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -1568,7 +1568,7 @@ exports[`NotificationPreviewSample should match snapshot, preview on, reminder o
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             Comune di Ipazia
                           </Text>
@@ -2085,7 +2085,7 @@ exports[`NotificationPreviewSample should match snapshot, preview on, reminder o
                             allowFontScaling={false}
                             color="black"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -2107,7 +2107,7 @@ exports[`NotificationPreviewSample should match snapshot, preview on, reminder o
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             You have a notice due soon
                           </Text>

--- a/ts/features/pushNotifications/components/__tests__/__snapshots__/NotificationsPreferencesPreview.test.tsx.snap
+++ b/ts/features/pushNotifications/components/__tests__/__snapshots__/NotificationsPreferencesPreview.test.tsx.snap
@@ -501,7 +501,7 @@ exports[`NotificationsPreferencesPreview should match snapshot, preview off, rem
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -523,7 +523,7 @@ exports[`NotificationsPreferencesPreview should match snapshot, preview off, rem
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               You have a new message
                             </Text>
@@ -1074,7 +1074,7 @@ exports[`NotificationsPreferencesPreview should match snapshot, preview off, rem
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -1096,7 +1096,7 @@ exports[`NotificationsPreferencesPreview should match snapshot, preview off, rem
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               You have a notice due tomorrow
                             </Text>
@@ -1647,7 +1647,7 @@ exports[`NotificationsPreferencesPreview should match snapshot, preview on, remi
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -1669,7 +1669,7 @@ exports[`NotificationsPreferencesPreview should match snapshot, preview on, remi
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Comune di Ipazia
                             </Text>
@@ -2220,7 +2220,7 @@ exports[`NotificationsPreferencesPreview should match snapshot, preview on, remi
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -2242,7 +2242,7 @@ exports[`NotificationsPreferencesPreview should match snapshot, preview on, remi
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               You have a notice due soon
                             </Text>

--- a/ts/features/pushNotifications/screens/__tests__/__snapshots__/OnboardingNotificationsInfoScreenConsent.test.tsx.snap
+++ b/ts/features/pushNotifications/screens/__tests__/__snapshots__/OnboardingNotificationsInfoScreenConsent.test.tsx.snap
@@ -519,7 +519,7 @@ exports[`OnboardingNotificationsInfoScreenConsent should match snapshot 1`] = `
                                 allowFontScaling={false}
                                 color="black"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -541,7 +541,7 @@ exports[`OnboardingNotificationsInfoScreenConsent should match snapshot 1`] = `
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 Enable push notifications not to miss important messages!
                               </Text>
@@ -593,7 +593,7 @@ exports[`OnboardingNotificationsInfoScreenConsent should match snapshot 1`] = `
                                 allowFontScaling={false}
                                 color="grey-700"
                                 defaultColor="black"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -615,7 +615,7 @@ exports[`OnboardingNotificationsInfoScreenConsent should match snapshot 1`] = `
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 Here's how:
                               </Text>
@@ -870,7 +870,7 @@ exports[`OnboardingNotificationsInfoScreenConsent should match snapshot 1`] = `
                                       allowFontScaling={false}
                                       color="black"
                                       defaultColor="black"
-                                      defaultWeight="SemiBold"
+                                      defaultWeight="Semibold"
                                       font="TitilliumSansPro"
                                       fontStyle={
                                         Object {
@@ -893,7 +893,7 @@ exports[`OnboardingNotificationsInfoScreenConsent should match snapshot 1`] = `
                                           },
                                         ]
                                       }
-                                      weight="SemiBold"
+                                      weight="Semibold"
                                     >
                                       Go to "Settings"
                                     </Text>
@@ -1094,7 +1094,7 @@ exports[`OnboardingNotificationsInfoScreenConsent should match snapshot 1`] = `
                                       allowFontScaling={false}
                                       color="black"
                                       defaultColor="black"
-                                      defaultWeight="SemiBold"
+                                      defaultWeight="Semibold"
                                       font="TitilliumSansPro"
                                       fontStyle={
                                         Object {
@@ -1117,7 +1117,7 @@ exports[`OnboardingNotificationsInfoScreenConsent should match snapshot 1`] = `
                                           },
                                         ]
                                       }
-                                      weight="SemiBold"
+                                      weight="Semibold"
                                     >
                                       Select "Notifications"
                                     </Text>
@@ -1270,7 +1270,7 @@ exports[`OnboardingNotificationsInfoScreenConsent should match snapshot 1`] = `
                                       allowFontScaling={false}
                                       color="black"
                                       defaultColor="black"
-                                      defaultWeight="SemiBold"
+                                      defaultWeight="Semibold"
                                       font="TitilliumSansPro"
                                       fontStyle={
                                         Object {
@@ -1293,7 +1293,7 @@ exports[`OnboardingNotificationsInfoScreenConsent should match snapshot 1`] = `
                                           },
                                         ]
                                       }
-                                      weight="SemiBold"
+                                      weight="Semibold"
                                     >
                                       Enable "Allow Notifications"
                                     </Text>

--- a/ts/features/pushNotifications/screens/__tests__/__snapshots__/OnboardingNotificationsPreferencesScreen.test.tsx.snap
+++ b/ts/features/pushNotifications/screens/__tests__/__snapshots__/OnboardingNotificationsPreferencesScreen.test.tsx.snap
@@ -197,7 +197,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -219,7 +219,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -449,7 +449,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -471,7 +471,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a notice due soon
                                   </Text>
@@ -568,7 +568,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -594,7 +594,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -696,7 +696,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -722,7 +722,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -788,7 +788,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -814,7 +814,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -1391,6 +1391,10 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": "#FFFFFF",
+                                "borderColor": "transparent",
                               },
                             ]
                           }
@@ -1806,7 +1810,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -1828,7 +1832,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -2058,7 +2062,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -2080,7 +2084,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a new message
                                   </Text>
@@ -2177,7 +2181,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -2203,7 +2207,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -2305,7 +2309,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -2331,7 +2335,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -2397,7 +2401,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -2423,7 +2427,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -3001,6 +3005,10 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": "#FFFFFF",
+                                "borderColor": "transparent",
                               },
                             ]
                           }
@@ -3416,7 +3424,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -3438,7 +3446,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -3668,7 +3676,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -3690,7 +3698,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a notice due tomorrow
                                   </Text>
@@ -3787,7 +3795,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -3813,7 +3821,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -3915,7 +3923,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -3941,7 +3949,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -4007,7 +4015,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -4033,7 +4041,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -4611,6 +4619,10 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": "#FFFFFF",
+                                "borderColor": "transparent",
                               },
                             ]
                           }
@@ -5026,7 +5038,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -5048,7 +5060,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -5278,7 +5290,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -5300,7 +5312,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Comune di Ipazia
                                   </Text>
@@ -5397,7 +5409,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -5423,7 +5435,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -5525,7 +5537,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -5551,7 +5563,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -5617,7 +5629,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -5643,7 +5655,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -6222,6 +6234,10 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when not
                               Object {
                                 "backgroundColor": "#FFFFFF",
                               },
+                              Object {
+                                "backgroundColor": "#FFFFFF",
+                                "borderColor": "transparent",
+                              },
                             ]
                           }
                         >
@@ -6636,7 +6652,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when upd
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -6658,7 +6674,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when upd
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -6888,7 +6904,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when upd
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -6910,7 +6926,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when upd
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a notice due soon
                                   </Text>
@@ -7007,7 +7023,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when upd
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -7033,7 +7049,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when upd
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -7282,7 +7298,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when upd
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -7308,7 +7324,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when upd
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -7374,7 +7390,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when upd
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -7400,7 +7416,7 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when upd
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -8262,6 +8278,10 @@ exports[`OnboardingNotificationsPreferencesScreen should match snapshot when upd
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": "#FFFFFF",
+                                "borderColor": "transparent",
                               },
                             ]
                           }

--- a/ts/features/services/common/components/__tests__/__snapshots__/ServicesHeader.test.tsx.snap
+++ b/ts/features/services/common/components/__tests__/__snapshots__/ServicesHeader.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`ServicesHeader component should match the snapshot 1`] = `
       allowFontScaling={false}
       color="bluegreyDark"
       defaultColor="bluegreyDark"
-      defaultWeight="SemiBold"
+      defaultWeight="Semibold"
       font="TitilliumSansPro"
       fontStyle={
         Object {
@@ -105,7 +105,7 @@ exports[`ServicesHeader component should match the snapshot 1`] = `
           },
         ]
       }
-      weight="SemiBold"
+      weight="Semibold"
     >
       #### title ####
     </Text>

--- a/ts/features/services/common/components/__tests__/__snapshots__/ServicesHeaderSection.test.tsx.snap
+++ b/ts/features/services/common/components/__tests__/__snapshots__/ServicesHeaderSection.test.tsx.snap
@@ -272,7 +272,7 @@ exports[`ServicesHeaderSection component should match the snapshot for service h
           allowFontScaling={false}
           color="bluegreyDark"
           defaultColor="bluegreyDark"
-          defaultWeight="SemiBold"
+          defaultWeight="Semibold"
           font="TitilliumSansPro"
           fontStyle={
             Object {
@@ -294,7 +294,7 @@ exports[`ServicesHeaderSection component should match the snapshot for service h
               },
             ]
           }
-          weight="SemiBold"
+          weight="Semibold"
         >
           #### title ####
         </Text>

--- a/ts/features/services/home/components/__tests__/__snapshots__/FeaturedInstitutionCard.test.tsx.snap
+++ b/ts/features/services/home/components/__tests__/__snapshots__/FeaturedInstitutionCard.test.tsx.snap
@@ -447,7 +447,7 @@ exports[`FeaturedInstitutionCard should match the snapshot 1`] = `
                                   allowFontScaling={false}
                                   color="hanPurple-850"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -471,7 +471,7 @@ exports[`FeaturedInstitutionCard should match the snapshot 1`] = `
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   ### Institution ###
                                 </Text>
@@ -943,7 +943,7 @@ exports[`FeaturedInstitutionCard should match the snapshot when isNew is true 1`
                                   allowFontScaling={false}
                                   color="hanPurple-850"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -967,7 +967,7 @@ exports[`FeaturedInstitutionCard should match the snapshot when isNew is true 1`
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   ### Institution ###
                                 </Text>

--- a/ts/features/services/home/components/__tests__/__snapshots__/FeaturedServiceCard.test.tsx.snap
+++ b/ts/features/services/home/components/__tests__/__snapshots__/FeaturedServiceCard.test.tsx.snap
@@ -443,7 +443,7 @@ exports[`FeaturedServiceCard should match the snapshot 1`] = `
                                 allowFontScaling={false}
                                 color="blueIO-850"
                                 defaultColor="bluegreyDark"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -467,7 +467,7 @@ exports[`FeaturedServiceCard should match the snapshot 1`] = `
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 ### Service ###
                               </Text>
@@ -978,7 +978,7 @@ exports[`FeaturedServiceCard should match the snapshot when isNew is true 1`] = 
                                 allowFontScaling={false}
                                 color="hanPurple-850"
                                 defaultColor="bluegreyDark"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontStyle={
                                   Object {
@@ -1002,7 +1002,7 @@ exports[`FeaturedServiceCard should match the snapshot when isNew is true 1`] = 
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 ### Service ###
                               </Text>

--- a/ts/features/wallet/cobadge/component/BaseCoBadgeCard.tsx
+++ b/ts/features/wallet/cobadge/component/BaseCoBadgeCard.tsx
@@ -135,7 +135,7 @@ const BaseCoBadgeCard: React.FunctionComponent<Props> = (props: Props) => {
             <>
               <VSpacer size={16} />
               <H5
-                weight={props.isExpired ? "SemiBold" : "Regular"}
+                weight={props.isExpired ? "Semibold" : "Regular"}
                 color={props.isExpired ? "red" : "bluegreyDark"}
                 testID={"expirationDate"}
               >

--- a/ts/features/wallet/component/card/FeaturedCard.tsx
+++ b/ts/features/wallet/component/card/FeaturedCard.tsx
@@ -86,7 +86,7 @@ const FeaturedCard: React.FunctionComponent<Props> = (props: Props) => (
       )}
     </View>
     <VSpacer size={8} />
-    <H3 weight={"SemiBold"} color={"blue"}>
+    <H3 weight={"Semibold"} color={"blue"}>
       {props.title}
     </H3>
   </TouchableDefaultOpacity>

--- a/ts/features/wallet/component/card/FeaturedCardCarousel.tsx
+++ b/ts/features/wallet/component/card/FeaturedCardCarousel.tsx
@@ -120,7 +120,7 @@ const FeaturedCardCarousel: React.FunctionComponent<Props> = (props: Props) => {
   return props.availableBonusesList.length > 0 && anyBonusNotActive ? (
     <View style={styles.container} testID={"FeaturedCardCarousel"}>
       <View style={IOStyles.horizontalContentPadding}>
-        <H3 weight={"SemiBold"} color={"bluegreyDark"}>
+        <H3 weight={"Semibold"} color={"bluegreyDark"}>
           {I18n.t("wallet.featured")}
         </H3>
       </View>

--- a/ts/features/wallet/component/features/PaymentMethodInitiatives.tsx
+++ b/ts/features/wallet/component/features/PaymentMethodInitiatives.tsx
@@ -63,7 +63,7 @@ const PaymentMethodInitiatives = (props: Props): React.ReactElement | null => {
       <View style={[IOStyles.rowSpaceBetween, IOStyles.alignCenter]}>
         <H6 color={"grey-700"}>{I18n.t("wallet.capability.title")}</H6>
         <Body
-          weight="SemiBold"
+          weight="Semibold"
           color="blue"
           onPress={navigateToPairableInitiativesList}
         >

--- a/ts/features/wallet/onboarding/cobadge/screens/CoBadgeChooseType.tsx
+++ b/ts/features/wallet/onboarding/cobadge/screens/CoBadgeChooseType.tsx
@@ -71,7 +71,7 @@ const renderListItem = (cardPathItem: ListRenderItemInfo<IAddCardPath>) => (
     <View style={styles.flexColumn}>
       <View style={styles.row}>
         <View>
-          <H3 color={"bluegreyDark"} weight={"SemiBold"}>
+          <H3 color={"bluegreyDark"} weight={"Semibold"}>
             {cardPathItem.item.title}
           </H3>
         </View>

--- a/ts/features/wallet/onboarding/paypal/components/PspInfoBottomSheet.tsx
+++ b/ts/features/wallet/onboarding/paypal/components/PspInfoBottomSheet.tsx
@@ -65,7 +65,7 @@ const getItem = (props: Props) => [
           accessibilityRole="button"
           onPress={() => props.pspPrivacyUrl && openWebUrl(props.pspPrivacyUrl)}
         >
-          <Link weight={"SemiBold"}>
+          <Link weight={"Semibold"}>
             {I18n.t(
               "wallet.onboarding.paypal.selectPsp.infoBottomSheet.row3Description1",
               { psp: props.pspName }

--- a/ts/features/wallet/onboarding/paypal/components/PspRadioItem.tsx
+++ b/ts/features/wallet/onboarding/paypal/components/PspRadioItem.tsx
@@ -102,7 +102,7 @@ export const PspRadioItem = (
         O.fold(
           () => (
             <H4
-              weight={"SemiBold"}
+              weight={"Semibold"}
               color={"bluegreyDark"}
               testID={"pspNameTestID"}
             >

--- a/ts/features/wallet/onboarding/paypal/screen/__tests__/__snapshots__/PspRadioItem.test.tsx.snap
+++ b/ts/features/wallet/onboarding/paypal/screen/__tests__/__snapshots__/PspRadioItem.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`PspRadioItem match snapshot 1`] = `
       ]
     }
     testID="pspNameTestID"
-    weight="SemiBold"
+    weight="Semibold"
     weightColorFactory={[Function]}
   >
     PayTipper
@@ -520,7 +520,7 @@ exports[`PspRadioItem match snapshot 1`] = `
                     accessible={true}
                     color="blue"
                     defaultColor="blue"
-                    defaultWeight="SemiBold"
+                    defaultWeight="Semibold"
                     focusable={true}
                     font="TitilliumSansPro"
                     fontStyle={
@@ -550,7 +550,7 @@ exports[`PspRadioItem match snapshot 1`] = `
                         },
                       ]
                     }
-                    weight="SemiBold"
+                    weight="Semibold"
                   >
                     PayTipper’s Terms and Conditions and Privacy Policy apply
                   </Text>

--- a/ts/features/wallet/paypal/screen/PayPalPspUpdateScreen.tsx
+++ b/ts/features/wallet/paypal/screen/PayPalPspUpdateScreen.tsx
@@ -113,7 +113,7 @@ const PspItem = (props: { psp: IOPayPalPsp; onPress: () => void }) => {
           O.fold(
             () => (
               <H4
-                weight={"SemiBold"}
+                weight={"Semibold"}
                 color={"bluegreyDark"}
                 testID={"pspNameTestID"}
               >

--- a/ts/navigation/ServicesHomeTabNavigator.tsx
+++ b/ts/navigation/ServicesHomeTabNavigator.tsx
@@ -23,7 +23,7 @@ const ServicesHomeTabNavigator = () => (
         height: 40
       },
       tabBarLabelStyle: {
-        ...makeFontStyleObject("SemiBold"),
+        ...makeFontStyleObject("Semibold"),
         fontSize: Platform.OS === "android" ? 16 : undefined,
         fontWeight: Platform.OS === "android" ? "normal" : "bold",
         textTransform: "capitalize",

--- a/ts/screens/authentication/TestAuthenticationScreen.tsx
+++ b/ts/screens/authentication/TestAuthenticationScreen.tsx
@@ -42,7 +42,7 @@ const checkUsernameValid = (username: string): boolean =>
 const VersionView = () => (
   <View style={styles.appVersion} testID="appVersionView">
     <Body>{I18n.t("profile.main.appVersion")}</Body>
-    <Body numberOfLines={1} weight="SemiBold" testID="appVersion">
+    <Body numberOfLines={1} weight="Semibold" testID="appVersion">
       {getAppVersion()}
     </Body>
   </View>

--- a/ts/screens/authentication/UnlockAccessComponent.tsx
+++ b/ts/screens/authentication/UnlockAccessComponent.tsx
@@ -36,7 +36,7 @@ const UnlockAccessComponent = (props: UnlockAccessProps) => {
         {I18n.t("authentication.unlockmodal.description1_4")}{" "}
       </Body>
       <VSpacer size={24} />
-      <H6 weight="SemiBold">{I18n.t("authentication.unlockmodal.title2")}</H6>
+      <H6 weight="Semibold">{I18n.t("authentication.unlockmodal.title2")}</H6>
       <VSpacer size={24} />
       <FeatureInfo
         iconName="security"

--- a/ts/screens/authentication/cie/__test__/__snapshots__/ActivateNfcScreen.test.tsx.snap
+++ b/ts/screens/authentication/cie/__test__/__snapshots__/ActivateNfcScreen.test.tsx.snap
@@ -336,7 +336,7 @@ exports[`ActivateNfcScreen UI Rendering renders the screen with header, title, s
                             allowFontScaling={false}
                             color="black"
                             defaultColor="black"
-                            defaultWeight="SemiBold"
+                            defaultWeight="Semibold"
                             font="TitilliumSansPro"
                             fontStyle={
                               Object {
@@ -358,7 +358,7 @@ exports[`ActivateNfcScreen UI Rendering renders the screen with header, title, s
                                 },
                               ]
                             }
-                            weight="SemiBold"
+                            weight="Semibold"
                           >
                             Enable NFC to continue
                           </Text>
@@ -443,7 +443,7 @@ exports[`ActivateNfcScreen UI Rendering renders the screen with header, title, s
                                     allowFontScaling={false}
                                     color="grey-700"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -466,7 +466,7 @@ exports[`ActivateNfcScreen UI Rendering renders the screen with header, title, s
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     How to do it::
                                   </Text>
@@ -683,7 +683,7 @@ exports[`ActivateNfcScreen UI Rendering renders the screen with header, title, s
                                           allowFontScaling={false}
                                           color="black"
                                           defaultColor="black"
-                                          defaultWeight="SemiBold"
+                                          defaultWeight="Semibold"
                                           font="TitilliumSansPro"
                                           fontStyle={
                                             Object {
@@ -706,7 +706,7 @@ exports[`ActivateNfcScreen UI Rendering renders the screen with header, title, s
                                               },
                                             ]
                                           }
-                                          weight="SemiBold"
+                                          weight="Semibold"
                                         >
                                           Open 'Settings'
                                         </Text>
@@ -921,7 +921,7 @@ exports[`ActivateNfcScreen UI Rendering renders the screen with header, title, s
                                           allowFontScaling={false}
                                           color="black"
                                           defaultColor="black"
-                                          defaultWeight="SemiBold"
+                                          defaultWeight="Semibold"
                                           font="TitilliumSansPro"
                                           fontStyle={
                                             Object {
@@ -944,7 +944,7 @@ exports[`ActivateNfcScreen UI Rendering renders the screen with header, title, s
                                               },
                                             ]
                                           }
-                                          weight="SemiBold"
+                                          weight="Semibold"
                                         >
                                           Search for ‘NFC’ functionality
                                         </Text>
@@ -1097,7 +1097,7 @@ exports[`ActivateNfcScreen UI Rendering renders the screen with header, title, s
                                           allowFontScaling={false}
                                           color="black"
                                           defaultColor="black"
-                                          defaultWeight="SemiBold"
+                                          defaultWeight="Semibold"
                                           font="TitilliumSansPro"
                                           fontStyle={
                                             Object {
@@ -1120,7 +1120,7 @@ exports[`ActivateNfcScreen UI Rendering renders the screen with header, title, s
                                               },
                                             ]
                                           }
-                                          weight="SemiBold"
+                                          weight="Semibold"
                                         >
                                           Turn it on
                                         </Text>

--- a/ts/screens/onboarding/biometric&securityChecks/FingerprintScreen.tsx
+++ b/ts/screens/onboarding/biometric&securityChecks/FingerprintScreen.tsx
@@ -89,7 +89,7 @@ const FingerprintScreen = () => {
         >
           <Body>
             {I18n.t("onboarding.biometric.available.body.infoStart") + " "}
-            <Body weight="SemiBold">
+            <Body weight="Semibold">
               {I18n.t("onboarding.biometric.available.body.biometricType") +
                 " "}
             </Body>

--- a/ts/screens/onboarding/biometric&securityChecks/MissingDeviceBiometricScreen.tsx
+++ b/ts/screens/onboarding/biometric&securityChecks/MissingDeviceBiometricScreen.tsx
@@ -79,7 +79,7 @@ const MissingDeviceBiometricScreen = () => {
         >
           <Body>
             {I18n.t("onboarding.biometric.available.body.infoStart") + " "}
-            <Body weight="SemiBold">
+            <Body weight="Semibold">
               {I18n.t("onboarding.biometric.available.body.biometricType") +
                 " "}
             </Body>

--- a/ts/screens/onboarding/biometric&securityChecks/MissingDevicePinScreen.tsx
+++ b/ts/screens/onboarding/biometric&securityChecks/MissingDevicePinScreen.tsx
@@ -78,7 +78,7 @@ const MissingDevicePinScreen = () => {
           <Body>
             {I18n.t("onboarding.biometric.unavailable.body.firstInfoStart") +
               " "}
-            <Body weight="SemiBold">
+            <Body weight="Semibold">
               {I18n.t("onboarding.biometric.unavailable.body.firstInfoEnd")}
             </Body>
           </Body>
@@ -86,7 +86,7 @@ const MissingDevicePinScreen = () => {
           <Body>
             {I18n.t("onboarding.biometric.unavailable.body.secondInfoStart") +
               " "}
-            <Body weight="SemiBold">
+            <Body weight="Semibold">
               {I18n.t("onboarding.biometric.unavailable.body.secondInfoEnd")}
             </Body>
           </Body>

--- a/ts/screens/profile/EmailForwardingScreen.tsx
+++ b/ts/screens/profile/EmailForwardingScreen.tsx
@@ -125,7 +125,7 @@ class EmailForwardingScreenClass extends React.Component<Props, State> {
             <View style={IOStyles.horizontalContentPadding}>
               <Body>
                 <Body>{I18n.t("send_email_messages.subtitle")}</Body>
-                <Body weight="SemiBold">{` ${this.props.userEmail}`}</Body>
+                <Body weight="Semibold">{` ${this.props.userEmail}`}</Body>
                 <Body>{I18n.t("global.symbols.question")}</Body>
               </Body>
             </View>

--- a/ts/screens/profile/EmailInsertScreen.tsx
+++ b/ts/screens/profile/EmailInsertScreen.tsx
@@ -428,7 +428,7 @@ const EmailInsertScreen = () => {
               ) : (
                 <>
                   {I18n.t("email.edit.subtitle")}
-                  <Body weight="SemiBold">
+                  <Body weight="Semibold">
                     {` ${pipe(
                       optionEmail,
                       O.getOrElse(() => "")

--- a/ts/screens/profile/EmailValidationSendEmailScreen.tsx
+++ b/ts/screens/profile/EmailValidationSendEmailScreen.tsx
@@ -278,7 +278,7 @@ const EmailValidationSendEmailScreen = () => {
                   ? "email.newvalidemail.subtitle"
                   : "email.newvalidate.subtitle"
               )}{" "}
-              <Body weight="SemiBold">{email}</Body>
+              <Body weight="Semibold">{email}</Body>
             </Body>
           </View>
           <VSpacer size={24} />

--- a/ts/screens/profile/FiscalCodeScreen.tsx
+++ b/ts/screens/profile/FiscalCodeScreen.tsx
@@ -69,7 +69,7 @@ const FiscalCodeScreen = () => {
             style={styles.box}
             testID="barcode-box"
           >
-            <LabelSmall weight="SemiBold" color="black">
+            <LabelSmall weight="Semibold" color="black">
               {nameSurname}
             </LabelSmall>
             <Barcode

--- a/ts/screens/profile/__test__/__snapshots__/LanguagesPreferencesScreen.test.tsx.snap
+++ b/ts/screens/profile/__test__/__snapshots__/LanguagesPreferencesScreen.test.tsx.snap
@@ -234,7 +234,7 @@ exports[`LanguagesPreferencesScreen UI Rendering renders the screen with, title,
                                   allowFontScaling={false}
                                   color="black"
                                   defaultColor="black"
-                                  defaultWeight="SemiBold"
+                                  defaultWeight="Semibold"
                                   font="TitilliumSansPro"
                                   fontStyle={
                                     Object {
@@ -256,7 +256,7 @@ exports[`LanguagesPreferencesScreen UI Rendering renders the screen with, title,
                                       },
                                     ]
                                   }
-                                  weight="SemiBold"
+                                  weight="Semibold"
                                 >
                                   Favourite language
                                 </Text>
@@ -404,7 +404,7 @@ exports[`LanguagesPreferencesScreen UI Rendering renders the screen with, title,
                                             allowFontScaling={false}
                                             color="black"
                                             defaultColor="black"
-                                            defaultWeight="SemiBold"
+                                            defaultWeight="Semibold"
                                             font="TitilliumSansPro"
                                             fontStyle={
                                               Object {
@@ -429,7 +429,7 @@ exports[`LanguagesPreferencesScreen UI Rendering renders the screen with, title,
                                                 },
                                               ]
                                             }
-                                            weight="SemiBold"
+                                            weight="Semibold"
                                           >
                                             Italian
                                           </Text>
@@ -600,7 +600,7 @@ exports[`LanguagesPreferencesScreen UI Rendering renders the screen with, title,
                                             allowFontScaling={false}
                                             color="black"
                                             defaultColor="black"
-                                            defaultWeight="SemiBold"
+                                            defaultWeight="Semibold"
                                             font="TitilliumSansPro"
                                             fontStyle={
                                               Object {
@@ -625,7 +625,7 @@ exports[`LanguagesPreferencesScreen UI Rendering renders the screen with, title,
                                                 },
                                               ]
                                             }
-                                            weight="SemiBold"
+                                            weight="Semibold"
                                           >
                                             English
                                           </Text>
@@ -796,7 +796,7 @@ exports[`LanguagesPreferencesScreen UI Rendering renders the screen with, title,
                                             allowFontScaling={false}
                                             color="black"
                                             defaultColor="black"
-                                            defaultWeight="SemiBold"
+                                            defaultWeight="Semibold"
                                             font="TitilliumSansPro"
                                             fontStyle={
                                               Object {
@@ -821,7 +821,7 @@ exports[`LanguagesPreferencesScreen UI Rendering renders the screen with, title,
                                                 },
                                               ]
                                             }
-                                            weight="SemiBold"
+                                            weight="Semibold"
                                           >
                                             German
                                           </Text>
@@ -943,6 +943,10 @@ exports[`LanguagesPreferencesScreen UI Rendering renders the screen with, title,
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }

--- a/ts/screens/profile/__test__/__snapshots__/NotificationsPreferencesScreen.test.tsx.snap
+++ b/ts/screens/profile/__test__/__snapshots__/NotificationsPreferencesScreen.test.tsx.snap
@@ -213,7 +213,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -235,7 +235,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -488,7 +488,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -510,7 +510,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a new message
                                   </Text>
@@ -607,7 +607,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -633,7 +633,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -735,7 +735,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -761,7 +761,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -827,7 +827,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -853,7 +853,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -1049,6 +1049,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }
@@ -1587,7 +1591,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -1609,7 +1613,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -1862,7 +1866,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -1884,7 +1888,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a new message
                                   </Text>
@@ -1981,7 +1985,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -2007,7 +2011,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -2109,7 +2113,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -2135,7 +2139,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -2201,7 +2205,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -2227,7 +2231,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -2423,6 +2427,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }
@@ -2961,7 +2969,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -2983,7 +2991,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -3236,7 +3244,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -3258,7 +3266,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a new message
                                   </Text>
@@ -3355,7 +3363,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -3381,7 +3389,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -3483,7 +3491,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -3509,7 +3517,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -3575,7 +3583,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -3601,7 +3609,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -3797,6 +3805,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }
@@ -4335,7 +4347,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -4357,7 +4369,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -4610,7 +4622,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -4632,7 +4644,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a notice due tomorrow
                                   </Text>
@@ -4729,7 +4741,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -4755,7 +4767,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -4857,7 +4869,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -4883,7 +4895,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -4949,7 +4961,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -4975,7 +4987,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -5171,6 +5183,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }
@@ -5709,7 +5725,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -5731,7 +5747,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -5984,7 +6000,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -6006,7 +6022,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a new message
                                   </Text>
@@ -6103,7 +6119,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -6129,7 +6145,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -6231,7 +6247,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -6257,7 +6273,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -6323,7 +6339,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -6349,7 +6365,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -6545,6 +6561,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }
@@ -7083,7 +7103,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -7105,7 +7125,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -7358,7 +7378,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -7380,7 +7400,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a new message
                                   </Text>
@@ -7477,7 +7497,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -7503,7 +7523,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -7605,7 +7625,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -7631,7 +7651,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -7697,7 +7717,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -7723,7 +7743,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -7919,6 +7939,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, disabled  preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }
@@ -8457,7 +8481,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -8479,7 +8503,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -8732,7 +8756,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -8754,7 +8778,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a new message
                                   </Text>
@@ -8851,7 +8875,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -8877,7 +8901,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -8979,7 +9003,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -9005,7 +9029,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -9071,7 +9095,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -9097,7 +9121,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -9293,6 +9317,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }
@@ -9831,7 +9859,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -9853,7 +9881,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -10106,7 +10134,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -10128,7 +10156,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Comune di Ipazia
                                   </Text>
@@ -10225,7 +10253,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -10251,7 +10279,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -10353,7 +10381,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -10379,7 +10407,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -10445,7 +10473,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -10471,7 +10499,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -10667,6 +10695,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }
@@ -11205,7 +11237,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -11227,7 +11259,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -11480,7 +11512,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -11502,7 +11534,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a new message
                                   </Text>
@@ -11599,7 +11631,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -11625,7 +11657,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -11727,7 +11759,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -11753,7 +11785,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -11819,7 +11851,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -11845,7 +11877,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -12041,6 +12073,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }
@@ -12579,7 +12615,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -12601,7 +12637,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -12854,7 +12890,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -12876,7 +12912,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a notice due soon
                                   </Text>
@@ -12973,7 +13009,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -12999,7 +13035,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -13101,7 +13137,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -13127,7 +13163,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -13193,7 +13229,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -13219,7 +13255,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -13415,6 +13451,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }
@@ -13953,7 +13993,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -13975,7 +14015,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -14228,7 +14268,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -14250,7 +14290,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a new message
                                   </Text>
@@ -14347,7 +14387,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -14373,7 +14413,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -14475,7 +14515,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -14501,7 +14541,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -14567,7 +14607,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -14593,7 +14633,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -14789,6 +14829,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }
@@ -15327,7 +15371,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -15349,7 +15393,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -15602,7 +15646,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -15624,7 +15668,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Comune di Ipazia
                                   </Text>
@@ -15721,7 +15765,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -15747,7 +15791,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -15849,7 +15893,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -15875,7 +15919,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -15941,7 +15985,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -15967,7 +16011,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -16163,6 +16207,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, enabled   preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }
@@ -16701,7 +16749,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -16723,7 +16771,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -16976,7 +17024,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -16998,7 +17046,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a new message
                                   </Text>
@@ -17095,7 +17143,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -17121,7 +17169,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -17223,7 +17271,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -17249,7 +17297,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -17315,7 +17363,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -17341,7 +17389,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -17537,6 +17585,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }
@@ -18075,7 +18127,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -18097,7 +18149,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -18350,7 +18402,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -18372,7 +18424,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a new message
                                   </Text>
@@ -18469,7 +18521,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -18495,7 +18547,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -18597,7 +18649,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -18623,7 +18675,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -18689,7 +18741,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -18715,7 +18767,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -18911,6 +18963,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }
@@ -19449,7 +19505,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -19471,7 +19527,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -19724,7 +19780,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -19746,7 +19802,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a new message
                                   </Text>
@@ -19843,7 +19899,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -19869,7 +19925,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -19971,7 +20027,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -19997,7 +20053,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -20063,7 +20119,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -20089,7 +20145,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -20285,6 +20341,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }
@@ -20823,7 +20883,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -20845,7 +20905,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -21098,7 +21158,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -21120,7 +21180,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a notice due tomorrow
                                   </Text>
@@ -21217,7 +21277,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -21243,7 +21303,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -21345,7 +21405,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -21371,7 +21431,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -21437,7 +21497,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -21463,7 +21523,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -21659,6 +21719,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }
@@ -22197,7 +22261,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -22219,7 +22283,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -22472,7 +22536,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -22494,7 +22558,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a new message
                                   </Text>
@@ -22591,7 +22655,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -22617,7 +22681,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -22719,7 +22783,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -22745,7 +22809,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -22811,7 +22875,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -22837,7 +22901,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -23033,6 +23097,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }
@@ -23571,7 +23639,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                               allowFontScaling={false}
                               color="black"
                               defaultColor="black"
-                              defaultWeight="SemiBold"
+                              defaultWeight="Semibold"
                               font="TitilliumSansPro"
                               fontStyle={
                                 Object {
@@ -23593,7 +23661,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                   },
                                 ]
                               }
-                              weight="SemiBold"
+                              weight="Semibold"
                             >
                               Customize push notifications
                             </Text>
@@ -23846,7 +23914,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -23868,7 +23936,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     You have a new message
                                   </Text>
@@ -23965,7 +24033,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -23991,7 +24059,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Show a preview
                                   </Text>
@@ -24093,7 +24161,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                 allowFontScaling={false}
                                 color="blue"
                                 defaultColor="blue"
-                                defaultWeight="SemiBold"
+                                defaultWeight="Semibold"
                                 font="TitilliumSansPro"
                                 fontSize="small"
                                 fontStyle={
@@ -24119,7 +24187,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     },
                                   ]
                                 }
-                                weight="SemiBold"
+                                weight="Semibold"
                               >
                                 More info
                               </Text>
@@ -24185,7 +24253,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                     allowFontScaling={false}
                                     color="black"
                                     defaultColor="black"
-                                    defaultWeight="SemiBold"
+                                    defaultWeight="Semibold"
                                     font="TitilliumSansPro"
                                     fontStyle={
                                       Object {
@@ -24211,7 +24279,7 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                                         },
                                       ]
                                     }
-                                    weight="SemiBold"
+                                    weight="Semibold"
                                   >
                                     Allow reminders
                                   </Text>
@@ -24407,6 +24475,10 @@ exports[`NotificationsPreferencesScreen should match snapshot, undefined preview
                               Object {},
                               Object {
                                 "backgroundColor": "#FFFFFF",
+                              },
+                              Object {
+                                "backgroundColor": undefined,
+                                "borderColor": undefined,
                               },
                             ]
                           }

--- a/ts/screens/profile/components/CountdownComponent.tsx
+++ b/ts/screens/profile/components/CountdownComponent.tsx
@@ -36,7 +36,7 @@ const Countdown = (props: CountdownProps) => {
         <VSpacer size={8} />
         <Body weight="Regular" style={{ textAlign: "center" }} color="black">
           {I18n.t("email.newvalidate.countdowntext")}{" "}
-          <Body weight="SemiBold" color="black">
+          <Body weight="Semibold" color="black">
             {timerCount}s
           </Body>
         </Body>

--- a/ts/screens/profile/mailCheck/EmailAlreadyTakenScreen.tsx
+++ b/ts/screens/profile/mailCheck/EmailAlreadyTakenScreen.tsx
@@ -74,7 +74,7 @@ const EmailAlreadyTakenScreen = () => {
         style: {
           textAlign: "center"
         },
-        weight: "SemiBold"
+        weight: "Semibold"
       },
       {
         text: I18n.t("email.cduScreens.emailAlreadyTaken.subtitleEnd"),

--- a/ts/screens/profile/mailCheck/ValidateEmailScreen.tsx
+++ b/ts/screens/profile/mailCheck/ValidateEmailScreen.tsx
@@ -75,7 +75,7 @@ const ValidateEmailScreen = () => {
         style: {
           textAlign: "center"
         },
-        weight: "SemiBold"
+        weight: "Semibold"
       }
     ],
     [email]

--- a/ts/screens/services/ServicesHomeScreen.tsx
+++ b/ts/screens/services/ServicesHomeScreen.tsx
@@ -214,7 +214,7 @@ class ServicesHomeScreen extends React.Component<Props, State> {
           source={require("../../../img/services/icon-loading-services.png")}
         />
         <VSpacer size={40} />
-        <Body weight="SemiBold">{I18n.t("services.loading.title")}</Body>
+        <Body weight="Semibold">{I18n.t("services.loading.title")}</Body>
         <Body>{I18n.t("services.loading.subtitle")}</Body>
       </View>
     );

--- a/ts/screens/wallet/ConfirmCardDetailsScreen.tsx
+++ b/ts/screens/wallet/ConfirmCardDetailsScreen.tsx
@@ -272,7 +272,7 @@ class ConfirmCardDetailsScreen extends React.Component<Props, State> {
               <VSpacer size={24} />
               <View style={styles.preferredMethodContainer}>
                 <View style={IOStyles.flex}>
-                  <H4 weight={"SemiBold"} color={"bluegreyDark"}>
+                  <H4 weight={"Semibold"} color={"bluegreyDark"}>
                     {I18n.t("wallet.saveCard.infoTitle")}
                   </H4>
                   <H5 weight={"Regular"} color={"bluegrey"}>

--- a/ts/screens/wallet/PaymentHistoryDetailsScreen.tsx
+++ b/ts/screens/wallet/PaymentHistoryDetailsScreen.tsx
@@ -323,7 +323,7 @@ class PaymentHistoryDetailsScreen extends React.Component<Props> {
               {O.isSome(data.errorDetail) && (
                 <View key={"error"}>
                   <Body>{I18n.t("payment.errorDetails")}</Body>
-                  <Body weight="SemiBold" color="bluegreyDark">
+                  <Body weight="Semibold" color="bluegreyDark">
                     {data.errorDetail.value}
                   </Body>
                 </View>
@@ -381,7 +381,7 @@ class PaymentHistoryDetailsScreen extends React.Component<Props> {
                   <View
                     style={[IOStyles.rowSpaceBetween, IOStyles.alignCenter]}
                   >
-                    <Body weight="SemiBold" color="bluegreyDark">
+                    <Body weight="Semibold" color="bluegreyDark">
                       {data.idTransaction}
                     </Body>
                     <CopyButtonComponent

--- a/ts/screens/wallet/TransactionDetailsScreen.tsx
+++ b/ts/screens/wallet/TransactionDetailsScreen.tsx
@@ -200,7 +200,7 @@ class TransactionDetailsScreen extends React.Component<
         <View style={[IOStyles.flex, IOStyles.selfCenter]}>
           <Body>{label}</Body>
         </View>
-        <Body color="bluegreyDark" weight="SemiBold" selectable={true}>
+        <Body color="bluegreyDark" weight="Semibold" selectable={true}>
           {value}
         </Body>
       </View>
@@ -311,7 +311,7 @@ class TransactionDetailsScreen extends React.Component<
             </View>
           ) : (
             data.paymentMethodBrand && (
-              <Body weight="SemiBold">{data.paymentMethodBrand}</Body>
+              <Body weight="Semibold">{data.paymentMethodBrand}</Body>
             )
           )}
 
@@ -325,7 +325,7 @@ class TransactionDetailsScreen extends React.Component<
               {I18n.t("wallet.firstTransactionSummary.idTransaction")}
             </Body>
             <View style={IOStyles.rowSpaceBetween}>
-              <Body weight="SemiBold">{data.idTransaction}</Body>
+              <Body weight="Semibold">{data.idTransaction}</Body>
               <CopyButtonComponent textToCopy={data.idTransaction.toString()} />
             </View>
           </View>

--- a/ts/screens/wallet/WalletHomeScreen.tsx
+++ b/ts/screens/wallet/WalletHomeScreen.tsx
@@ -347,7 +347,7 @@ class WalletHomeScreen extends React.PureComponent<Props, State> {
   private transactionError() {
     return (
       <View style={[styles.noBottomPadding, styles.whiteBg, IOStyles.flex]}>
-        <H3 weight="SemiBold" color="bluegreyDark">
+        <H3 weight="Semibold" color="bluegreyDark">
           {I18n.t("wallet.latestTransactions")}
         </H3>
         <VSpacer size={16} />

--- a/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
+++ b/ts/screens/wallet/payment/ConfirmPaymentMethodScreen.tsx
@@ -446,7 +446,7 @@ const ConfirmPaymentMethodScreen: React.FC<ConfirmPaymentMethodScreenProps> = (
                 accessibilityLabel={`${paymentReason}, ${formattedSingleAmount}`}
                 accessible
               >
-                <H4 weight="SemiBold" color="bluegreyDark" numberOfLines={1}>
+                <H4 weight="Semibold" color="bluegreyDark" numberOfLines={1}>
                   {paymentReason}
                 </H4>
 
@@ -526,7 +526,7 @@ const ConfirmPaymentMethodScreen: React.FC<ConfirmPaymentMethodScreenProps> = (
                       )} `}
                     </LabelSmall>
 
-                    <LabelSmall weight="SemiBold">
+                    <LabelSmall weight="Semibold">
                       {I18n.t(
                         "wallet.onboarding.paypal.paymentCheckout.privacyTerms"
                       )}

--- a/ts/theme/fonts.ts
+++ b/ts/theme/fonts.ts
@@ -22,7 +22,7 @@ const fonts = {
 const fontWeights = {
   "300": "Light",
   "400": "Regular",
-  "600": "SemiBold",
+  "600": "Semibold",
   "700": "Bold"
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3272,10 +3272,10 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@pagopa/io-app-design-system@1.39.2":
-  version "1.39.2"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-app-design-system/-/io-app-design-system-1.39.2.tgz#8478a991cfc64bf9f51e11788470e182a09ab383"
-  integrity sha512-7qpbGq/Bcr6TktZHudA9ZM4aeYslV/YKxCbI0dRx6OSZvNcLn304VX0F8ur1MvGUnIEjHas2WQ75vBPn/NYNAQ==
+"@pagopa/io-app-design-system@1.39.4":
+  version "1.39.4"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-app-design-system/-/io-app-design-system-1.39.4.tgz#494b00b69f0d1330ae14ca99270bceb9b97a7298"
+  integrity sha512-yxTkgfIQSpUOXCC/FPmGyyaPOWU1H+BSTZAma2ClNkvl0t3biMiRMJZO3qicWd6pzqyzEqLqP0VNPrs/K7GFWQ==
   dependencies:
     "@pagopa/ts-commons" "^12.0.0"
     "@testing-library/jest-native" "^5.4.2"


### PR DESCRIPTION
> [!warning]
> This PR depends on:
> * https://github.com/pagopa/io-app-design-system/pull/293

## Short description
This PR fixes a **critical** UI bug on Android when using the `SemiBold` font weight. The new _**Titillium Sans Pro**_ uses `Semibold` as a font attribute, while the previous _**Titillium Web**_ fonts used `SemiBold`. Android didn't handle this edge case and rendered everything with the fallback system font.
  
## List of changes proposed in this pull request
- Replace `SemiBold` font weight attribute with `Semibold` in all the typographic styles

## How to test
1. Launch the app with an Android physical or virtual device
2. Check **Typography** screen or everything else in the app
