### PR TITLE
chore(Cross): [IOAPPX-327] Remove NDEF as NFC format for iOS

### DIFF
--- a/ios/ItaliaApp/Info.plist
+++ b/ios/ItaliaApp/Info.plist
@@ -47,7 +47,7 @@
     <key>LSSupportsOpeningDocumentsInPlace</key>
     <true/>
     <key>NFCReaderUsageDescription</key>
-    <string>NFC tag to read CIE cards</string>
+    <string>NFC tag to read EIC cards</string>
     <key>NSAppTransportSecurity</key>
     <dict>
       <key>NSExceptionDomains</key>

--- a/ios/ItaliaApp/Info.plist
+++ b/ios/ItaliaApp/Info.plist
@@ -47,7 +47,7 @@
     <key>LSSupportsOpeningDocumentsInPlace</key>
     <true/>
     <key>NFCReaderUsageDescription</key>
-    <string>NFC tag to read NDEF messages into the application</string>
+    <string>NFC tag to read CIE cards</string>
     <key>NSAppTransportSecurity</key>
     <dict>
       <key>NSExceptionDomains</key>

--- a/ios/ItaliaApp/ItaliaApp.entitlements
+++ b/ios/ItaliaApp/ItaliaApp.entitlements
@@ -11,7 +11,6 @@
 	<key>com.apple.developer.nfc.readersession.formats</key>
 	<array>
 		<string>TAG</string>
-		<string>NDEF</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Short description
This PR removes `NDEF` as `NFC` format for iOS. We discovered an issue after setting the deployment version to `14.0` while sending the app for approval: 

`18:02:19]: ERROR: [ContentDelivery.Uploader] Asset validation failed (90778) Invalid entitlement for core nfc framework. The sdk version '17.2' and min OS version '14.0' are not compatible for the entitlement 'com.apple.developer.nfc.readersession.formats' because 'NDEF is disallowed'. (ID: 8d8d0695-b5a8-4108-8b07-74211c7ae133)`

The removal of `NDEF` should be safe as our CIE SDK uses [NFCTagReaderSession](https://github.com/pagopa/io-cie-ios-sdk/blob/b7c63653d85eb28ff81841b89f99dceb9c64026d/ciesdk/iociesdkios/CIEIDSdk.swift#L133) with [iso14443](https://developer.apple.com/documentation/corenfc/nfctagreadersession/pollingoption/3043850-iso14443) option which is the one used by the CIE, according to the [official documentation](https://www.cartaidentita.interno.gov.it/downloads/2021/03/cie_3.0_-_specifiche_chip.pdf). 

It remains unclear whether or not `NDEF` should be removed from the SDK as well.

## List of changes proposed in this pull request
- Remove `NDEF` from the `.entitlements` file;
- Update the usage string in `Info.plist`.

## How to test
Build the app on an iOS physical device by ruinning `yarn cie-ios:prod` and test the CIE login.