### PR TITLE
[IOCOm-1553] Proper logic for `getImageState` on `DoubleAvatar`

### DIFF
--- a/ts/features/messages/components/Home/DS/DoubleAvatar.tsx
+++ b/ts/features/messages/components/Home/DS/DoubleAvatar.tsx
@@ -62,11 +62,12 @@ const getImageState = (
 ) => {
   switch (typeof backgroundLogoUri) {
     case "number":
-      return addCacheTimestampToUri(backgroundLogoUri as ImageURISource);
+      return backgroundLogoUri;
     case "object":
       if (Array.isArray(backgroundLogoUri)) {
         return addCacheTimestampToUri(backgroundLogoUri[0]);
-      } // eslint-disable-next-line no-fallthrough
+      }
+      return addCacheTimestampToUri(backgroundLogoUri as ImageURISource);
     default:
       return undefined;
   }


### PR DESCRIPTION
## Short description
This PR fixes a regression in `getImageState` on `DoubleAvatar`.

## List of changes proposed in this pull request
- Proper handling of input when it is of type `number` or `ImageURISource`

## How to test
Check the code against the one in `Avatar` (DS) and verify that, given an input, the output is the same.
