### PR TITLE
fix(Cross): [IOAPPX-335] E2e tests hanging forever

### DIFF
--- a/ts/components/ui/LoadingIndicator.e2e.ts
+++ b/ts/components/ui/LoadingIndicator.e2e.ts
@@ -1,0 +1,3 @@
+import { RefreshIndicator } from "./RefreshIndicator";
+
+export const LoadingIndicator = RefreshIndicator;

--- a/ts/components/ui/RefreshIndicator.tsx
+++ b/ts/components/ui/RefreshIndicator.tsx
@@ -18,12 +18,12 @@ const styles = StyleSheet.create({
 
 const isAndroid = Platform.OS === "android";
 
-export const RefreshIndicator: React.FunctionComponent = () => {
+export const RefreshIndicator = (props: { testID?: string }) => {
   const activityIndicator = (
     <ActivityIndicator
       size={isAndroid ? 24 : "large"}
       color={isAndroid ? variables.brandPrimary : undefined}
-      testID={"refreshIndicator"}
+      testID={props.testID ?? "refreshIndicator"}
     />
   );
   return isAndroid ? (


### PR DESCRIPTION
## Short description
This PR fixes the issue where E2E tests hang after displaying a `LoadingIndicator`.

> [!tip]
> [![Run e2e tests](https://github.com/pagopa/io-app/actions/workflows/test-e2e.yml/badge.svg?branch=cross-fix-e2e-tests)](https://github.com/pagopa/io-app/actions/workflows/test-e2e.yml)

## List of changes proposed in this pull request
- Replaced `LoadingIndicator` with `RefreshIndicator` for E2E tests.

## How to test
Run E2E tests locally.
