### PR TITLE
chore: [IOPID-1999] - Change IdentificationModal behavior displayed on PIN change operation 

### DIFF
--- a/ts/screens/profile/SecurityScreen.tsx
+++ b/ts/screens/profile/SecurityScreen.tsx
@@ -89,7 +89,7 @@ const SecurityScreen = (): React.ReactElement => {
     dispatch(
       identificationRequest(
         true,
-        false,
+        true,
         undefined,
         undefined,
         {


### PR DESCRIPTION
## Short description
When the pin change flow is triggered, the `IdentificationModal` used for validating certain in-app operations will be shown instead of the one used for app login. This variant is closable, unlike the previously implemented one.
## List of changes proposed in this pull request
- Changed `IdentificationModal` variant.

## How to test
Navigate to `Profile -> Security -> Change the unlock code` to trigger the pin change flow.