### PR TITLE
chore: [IOCOM-1578] Updated types for FIMS consents, latest Http Client version

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -142,7 +142,7 @@ PODS:
   - OpenSSL-Universal (1.1.1100)
   - pagopa-io-react-native-crypto (0.3.0):
     - React-Core
-  - pagopa-io-react-native-http-client (1.0.2):
+  - pagopa-io-react-native-http-client (1.0.5):
     - Alamofire (~> 5.9.1)
     - React-Core
   - pagopa-io-react-native-jwt (1.2.0):
@@ -952,7 +952,7 @@ SPEC CHECKSUMS:
   nanopb: d4d75c12cd1316f4a64e3c6963f879ecd4b5e0d5
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   pagopa-io-react-native-crypto: 6aa9f33e4bf64ef420ad97c720c1ad0f876cd470
-  pagopa-io-react-native-http-client: 0799ed85dfe45c56765a394ab1f39aa2fb56f09d
+  pagopa-io-react-native-http-client: 8ed571ea31ec9e6216688f63056e5c92bcbe484d
   pagopa-io-react-native-jwt: f89a378bbc5ebfd93c24ec5993e97545a4815157
   pagopa-io-react-native-login-utils: 9fb43fd59dcc864a24343209e74bd7429659456a
   pagopa-react-native-zendesk: e4a63ee0745a567b641110f7ff78e457086ab7a3

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@pagopa/io-app-design-system": "1.39.4",
     "@pagopa/io-pagopa-commons": "^3.1.0",
     "@pagopa/io-react-native-crypto": "^0.3.0",
-    "@pagopa/io-react-native-http-client": "1.0.2",
+    "@pagopa/io-react-native-http-client": "1.0.5",
     "@pagopa/io-react-native-jwt": "^1.2.0",
     "@pagopa/io-react-native-login-utils": "^1.0.1",
     "@pagopa/io-react-native-wallet": "^0.11.1",

--- a/ts/features/fims/singleSignOn/components/FimsSuccessBody.tsx
+++ b/ts/features/fims/singleSignOn/components/FimsSuccessBody.tsx
@@ -157,7 +157,7 @@ export const FimsFlowSuccessBody = ({
                   dispatch(
                     fimsGetRedirectUrlAndOpenIABAction.request(
                       // eslint-disable-next-line no-underscore-dangle
-                      { acceptUrl: consents._links.confirm.href }
+                      { acceptUrl: consents._links.consent.href }
                     )
                   )
               }

--- a/ts/features/fims/singleSignOn/types/index.ts
+++ b/ts/features/fims/singleSignOn/types/index.ts
@@ -1,12 +1,12 @@
 import * as t from "io-ts";
 
-const confirmType = t.type({
+const singleLinkType = t.type({
   href: t.string
 });
 
 const linksType = t.type({
-  abort: confirmType,
-  confirm: confirmType
+  abort: singleLinkType,
+  consent: singleLinkType
 });
 
 const claimType = t.partial({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3271,6 +3271,7 @@
   integrity sha512-PugtgEw8u++zAyBpDpSkR8K1OsT2l8QWp3ECL6bZHFoq9PfHDoKeGFWSuX2Z+Ghy93k1fkKf8tsmqNBv+8dEfQ==
   dependencies:
     "@types/node" ">= 8"
+
 "@pagopa/io-app-design-system@1.39.4":
   version "1.39.4"
   resolved "https://registry.yarnpkg.com/@pagopa/io-app-design-system/-/io-app-design-system-1.39.4.tgz#494b00b69f0d1330ae14ca99270bceb9b97a7298"
@@ -3305,10 +3306,10 @@
   resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-crypto/-/io-react-native-crypto-0.3.0.tgz#4181a53e36d4cd142b93ef133d3d227d9d360f96"
   integrity sha512-3H5CqJwpEYX14QNUhqbSizJBFBeIQRFv8Bw/46+YILTZpvCloVDjfSrPDsKNLZdC1d05wfUSTGGRncMQOB2kMg==
 
-"@pagopa/io-react-native-http-client@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-http-client/-/io-react-native-http-client-1.0.2.tgz#8d92a7ea920f1fe01f5632ccb939bb7961392bd6"
-  integrity sha512-UVd0S8gV8RUf6ZlHhQDb2jvEyMlc+XQ76j44ewRiP4xGNDX9QmYGfr+QNUmg0PwJ55OoeH6j5lbWiW2Mh1QCtQ==
+"@pagopa/io-react-native-http-client@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-http-client/-/io-react-native-http-client-1.0.5.tgz#5dbc4812732e7842ade594f3a29b8ff32b621628"
+  integrity sha512-JGQX9UxZY22LqZd+hAb+O+7jB4z6EAbUqkIBSAm6wqb71k282RtyJgWGDYdYsig2DPKeWbs66nF240csqDAOtw==
   dependencies:
     auto-changelog "^2.4.0"
 


### PR DESCRIPTION
## Short description
This PR updates the FIMS consents types and the native HTTP client version

## List of changes proposed in this pull request
- Updated FIMS consents type
- HTTP Client version to 1.0.5 (support for empty body serialisation on iOS and support for serialisation error on both platforms)

## How to test
Using the io-dev-api-server, check that the FIMS flow succeeds.
