### PR TITLE
fix: import URL on postMessage script to send slack message on release completed

### DIFF
--- a/scripts/ts/common/slack/postMessage.ts
+++ b/scripts/ts/common/slack/postMessage.ts
@@ -1,3 +1,4 @@
+import { URL } from "url";
 import fetch from "node-fetch";
 
 const endpoint = "https://slack.com/api/chat.postMessage";


### PR DESCRIPTION
## Short description
Minor fix to restore message on release completed to slack channel

## How to test
[Latest message](https://pagopaspa.slack.com/archives/CQVJ1JES2/p1720616295842229) was sent from local env
