### PR TITLE
fix(Cross): I18n imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -120,7 +120,23 @@ module.exports = {
       "off" /* Error when you launch the lint command */,
     "react-native/no-single-element-style-arrays": "warn",
     /* Too much verbose. It also requires a lot of effort in the main repo */
-    "react-native-a11y/has-accessibility-hint": "off"
+    "react-native-a11y/has-accessibility-hint": "off",
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            name: "i18n-js",
+            message: 'Importing I18n from "i18n-js" is not allowed. Import it from "ts/i18n.ts" instead.',
+          }, 
+          {
+            name: "@pagopa/ts-commons",
+            importNames: ["pot"],
+            message: 'Importing { pot } from "@pagopa/ts-commons" is not allowed. Use \'import * as pot from "@pagopa/ts-commons/lib/pot"\' instead.',
+          }
+        ],           
+      }
+    ]
   },
   env: {
     "react-native/react-native": true

--- a/ts/components/AppVersion.tsx
+++ b/ts/components/AppVersion.tsx
@@ -1,4 +1,3 @@
-import I18n from "i18n-js";
 import * as React from "react";
 import {
   GestureResponderEvent,
@@ -6,6 +5,7 @@ import {
   StyleSheet,
   View
 } from "react-native";
+import I18n from "../i18n";
 import { WithTestID } from "../types/WithTestID";
 import { getAppVersion } from "../utils/appVersion";
 import { LabelSmall } from "./core/typography/LabelSmall";

--- a/ts/components/ContextualInfo.tsx
+++ b/ts/components/ContextualInfo.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { BackHandler, NativeEventSubscription, View } from "react-native";
-import I18n from "i18n-js";
 import {
   ContentWrapper,
   HeaderSecondLevel,
   IOColors,
   IOStyles
 } from "@pagopa/io-app-design-system";
+import I18n from "../i18n";
 import { H1 } from "./core/typography/H1";
 
 type Props = Readonly<{

--- a/ts/components/__tests__/TosWebviewComponent.test.tsx
+++ b/ts/components/__tests__/TosWebviewComponent.test.tsx
@@ -8,7 +8,7 @@ import renderer from "react-test-renderer";
 //   WebViewMessageEvent,
 //   WebViewNavigationEvent
 // } from "react-native-webview/lib/WebViewTypes";
-// import I18n from "i18n-js";
+// import I18n from "../../i18n";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import TosWebviewComponent from "../TosWebviewComponent";
 import { FlowType } from "../../utils/analytics";

--- a/ts/components/screens/IdpCustomContextualHelpContent.tsx
+++ b/ts/components/screens/IdpCustomContextualHelpContent.tsx
@@ -1,10 +1,10 @@
-import I18n from "i18n-js";
 import * as React from "react";
 import {
   ButtonOutline,
   ButtonSolid,
   VSpacer
 } from "@pagopa/io-app-design-system";
+import I18n from "../../i18n";
 import { Idp } from "../../../definitions/content/Idp";
 import { handleItemOnPress } from "../../utils/url";
 import LegacyMarkdown from "../ui/Markdown/LegacyMarkdown";

--- a/ts/components/ui/LoadingIndicator.tsx
+++ b/ts/components/ui/LoadingIndicator.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { LoadingSpinner } from "@pagopa/io-app-design-system";
-import I18n from "i18n-js";
+import I18n from "../../i18n";
 import { WithTestID } from "../../types/WithTestID";
 import { useInteractiveElementDefaultColor } from "../../utils/hooks/theme";
 

--- a/ts/features/bonus/cgn/screens/merchants/CgnMerchantLandingWebview.tsx
+++ b/ts/features/bonus/cgn/screens/merchants/CgnMerchantLandingWebview.tsx
@@ -1,7 +1,7 @@
 import { Route, useRoute } from "@react-navigation/core";
 import * as React from "react";
 import { SafeAreaView } from "react-native";
-import I18n from "i18n-js";
+import I18n from "../../../../../i18n";
 import { IOStyles } from "../../../../../components/core/variables/IOStyles";
 import BaseScreenComponent from "../../../../../components/screens/BaseScreenComponent";
 import WebviewComponent from "../../../../../components/WebviewComponent";

--- a/ts/features/fastLogin/screens/FastLoginModals.tsx
+++ b/ts/features/fastLogin/screens/FastLoginModals.tsx
@@ -1,5 +1,5 @@
-import I18n from "i18n-js";
 import React from "react";
+import I18n from "../../../i18n";
 import { TokenRefreshState } from "../store/reducers/tokenRefreshReducer";
 import { logoutRequest } from "../../../store/actions/authentication";
 import {

--- a/ts/features/fci/components/__tests__/__snapshots__/LoadingComponent.test.tsx.snap
+++ b/ts/features/fci/components/__tests__/__snapshots__/LoadingComponent.test.tsx.snap
@@ -11,8 +11,8 @@ exports[`Test LoadingComponent component should render a LoadingComponent compon
   }
 >
   <View
-    accessibilityHint="[missing "en.global.accessibility.activityIndicator.hint" translation]"
-    accessibilityLabel="[missing "en.global.accessibility.activityIndicator.label" translation]"
+    accessibilityHint="Wait for the content load"
+    accessibilityLabel="Loading"
     accessibilityRole="progressbar"
     accessible={true}
     importantForAccessibility="no-hide-descendants"

--- a/ts/features/lollipop/screens/UnsupportedDeviceScreen.tsx
+++ b/ts/features/lollipop/screens/UnsupportedDeviceScreen.tsx
@@ -1,6 +1,6 @@
-import I18n from "i18n-js";
 import * as React from "react";
 import { Modal } from "react-native";
+import I18n from "../../../i18n";
 import { unsupportedDeviceLearnMoreUrl } from "../../../config";
 import { openWebUrl } from "../../../utils/url";
 import { useAvoidHardwareBackButton } from "../../../utils/useAvoidHardwareBackButton";

--- a/ts/features/payments/common/utils/index.ts
+++ b/ts/features/payments/common/utils/index.ts
@@ -5,8 +5,8 @@ import {
 } from "@pagopa/io-app-design-system";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
-import I18n from "i18n-js";
 import _ from "lodash";
+import I18n from "../../../../i18n";
 import { Bundle } from "../../../../../definitions/pagopa/ecommerce/Bundle";
 import { WalletApplicationStatusEnum } from "../../../../../definitions/pagopa/walletv3/WalletApplicationStatus";
 import { WalletInfo } from "../../../../../definitions/pagopa/walletv3/WalletInfo";

--- a/ts/features/pn/components/LegacyMessagePayments.tsx
+++ b/ts/features/pn/components/LegacyMessagePayments.tsx
@@ -3,7 +3,6 @@ import * as RA from "fp-ts/lib/ReadonlyArray";
 import * as O from "fp-ts/lib/Option";
 import React, { MutableRefObject } from "react";
 import { StyleSheet, View } from "react-native";
-import I18n from "i18n-js";
 import {
   ButtonLink,
   ModulePaymentNotice,
@@ -11,6 +10,7 @@ import {
 } from "@pagopa/io-app-design-system";
 import { CommonActions, useNavigation } from "@react-navigation/native";
 import Placeholder from "rn-placeholder";
+import I18n from "../../../i18n";
 import { getBadgeTextByPaymentNoticeStatus } from "../../messages/utils/strings";
 import { NotificationPaymentInfo } from "../../../../definitions/pn/NotificationPaymentInfo";
 import { InfoBox } from "../../../components/box/InfoBox";

--- a/ts/features/pn/components/MessagePayments.tsx
+++ b/ts/features/pn/components/MessagePayments.tsx
@@ -3,7 +3,6 @@ import * as RA from "fp-ts/lib/ReadonlyArray";
 import * as O from "fp-ts/lib/Option";
 import React, { MutableRefObject } from "react";
 import { StyleSheet, View } from "react-native";
-import I18n from "i18n-js";
 import {
   ButtonLink,
   ListItemHeader,
@@ -12,6 +11,7 @@ import {
 } from "@pagopa/io-app-design-system";
 import { CommonActions, useNavigation } from "@react-navigation/native";
 import Placeholder from "rn-placeholder";
+import I18n from "../../../i18n";
 import { getBadgeTextByPaymentNoticeStatus } from "../../messages/utils/strings";
 import { NotificationPaymentInfo } from "../../../../definitions/pn/NotificationPaymentInfo";
 import { UIMessageId } from "../../messages/types";

--- a/ts/screens/onboarding/__tests__/OnboardingTosScreen.test.tsx
+++ b/ts/screens/onboarding/__tests__/OnboardingTosScreen.test.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as pot from "@pagopa/ts-commons/lib/pot";
 import * as O from "fp-ts/lib/Option";
 import configureMockStore from "redux-mock-store";
-import I18n from "i18n-js";
+import I18n from "../../../i18n";
 // import WebView from "react-native-webview";
 // import {
 //   WebViewErrorEvent,

--- a/ts/screens/profile/playgrounds/MarkdownPlayground.tsx
+++ b/ts/screens/profile/playgrounds/MarkdownPlayground.tsx
@@ -10,9 +10,9 @@ import {
 } from "@pagopa/io-app-design-system";
 import { useLinkTo } from "@react-navigation/native";
 import * as O from "fp-ts/lib/Option";
-import I18n from "i18n-js";
 import React, { useCallback } from "react";
 import { ScrollView, StyleSheet, TextInput, View } from "react-native";
+import I18n from "../../../i18n";
 import { MessageBodyMarkdown } from "../../../../definitions/backend/MessageBodyMarkdown";
 import { ExtractedCtaButton } from "../../../components/cta/ExtractedCtaButton";
 import LegacyMarkdown from "../../../components/ui/Markdown/LegacyMarkdown";


### PR DESCRIPTION
## Short description
This PR fixes all the wrong `I18n` imports (`import I18n from "i18n-js"`), replacing them with the right ones (`ts/i18n.ts`) and adds a **lint** rule for it (`import I18n from "i18n-js"`)

It also takes the chance to add a **lint** rule for this wrong import too: `import { pot } from "@pagopa/ts-commons";`.

![Screenshot 2024-07-12 at 14 36 16](https://github.com/user-attachments/assets/1eb01162-e8e7-412c-8fbc-1f9b0a4e4589)


