### PR TITLE
chore: [IOCOM-1549] Double avatar standard message detail

### DIFF
--- a/ts/features/messages/components/MessageDetail/MessageDetailsHeader.tsx
+++ b/ts/features/messages/components/MessageDetail/MessageDetailsHeader.tsx
@@ -11,6 +11,7 @@ import { logosForService } from "../../../services/common/utils";
 import { useIOSelector } from "../../../../store/hooks";
 import { serviceByIdPotSelector } from "../../../services/details/store/reducers";
 import { gapBetweenItemsInAGrid } from "../../utils";
+import { UIMessageId } from "../../types";
 import { OrganizationHeader } from "./OrganizationHeader";
 
 const styles = StyleSheet.create({
@@ -25,6 +26,7 @@ const styles = StyleSheet.create({
 
 export type MessageDetailsHeaderProps = PropsWithChildren<{
   createdAt: Date;
+  messageId: UIMessageId;
   serviceId: ServiceId;
   subject: string;
 }>;
@@ -47,6 +49,7 @@ const MessageDetailsHeaderContent = ({
 
 export const MessageDetailsHeader = ({
   children,
+  messageId,
   serviceId,
   ...rest
 }: MessageDetailsHeaderProps) => {
@@ -66,6 +69,7 @@ export const MessageDetailsHeader = ({
       {service && (
         <>
           <OrganizationHeader
+            messageId={messageId}
             logoUri={logosForService(service)}
             organizationName={service.organization_name}
             serviceId={serviceId}

--- a/ts/features/messages/components/MessageDetail/OrganizationHeader.tsx
+++ b/ts/features/messages/components/MessageDetail/OrganizationHeader.tsx
@@ -10,8 +10,13 @@ import {
 import { ServiceId } from "../../../../../definitions/backend/ServiceId";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { SERVICES_ROUTES } from "../../../services/common/navigation/routes";
+import { useIOSelector } from "../../../../store/hooks";
+import { messagePaymentDataSelector } from "../../store/reducers/detailsById";
+import { UIMessageId } from "../../types";
+import { DoubleAvatar } from "../Home/DS/DoubleAvatar";
 
 export type OrganizationHeaderProps = {
+  messageId: UIMessageId;
   organizationName: string;
   serviceId: ServiceId;
   serviceName: string;
@@ -34,12 +39,16 @@ const styles = StyleSheet.create({
 });
 
 export const OrganizationHeader = ({
+  messageId,
   logoUri,
   serviceId,
   organizationName,
   serviceName
 }: OrganizationHeaderProps) => {
   const navigation = useIONavigation();
+  const paymentData = useIOSelector(state =>
+    messagePaymentDataSelector(state, messageId)
+  );
   const navigateToServiceDetails = useCallback(
     () =>
       navigation.navigate(SERVICES_ROUTES.SERVICES_NAVIGATOR, {
@@ -59,7 +68,11 @@ export const OrganizationHeader = ({
         </LabelSmall>
       </View>
       <View style={styles.itemAvatar}>
-        <Avatar logoUri={logoUri} size="small" />
+        {paymentData ? (
+          <DoubleAvatar backgroundLogoUri={logoUri} />
+        ) : (
+          <Avatar logoUri={logoUri} size="small" />
+        )}
       </View>
     </View>
   );

--- a/ts/features/messages/components/MessageDetail/__tests__/MessageDetailsHeader.test.tsx
+++ b/ts/features/messages/components/MessageDetail/__tests__/MessageDetailsHeader.test.tsx
@@ -11,9 +11,11 @@ import { loadServiceDetail } from "../../../../services/details/store/actions/de
 import { service_1 } from "../../../__mocks__/messages";
 import { reproduceSequence } from "../../../../../utils/tests";
 import { MESSAGES_ROUTES } from "../../../navigation/routes";
+import { UIMessageId } from "../../../types";
 
 const defaultProps: ComponentProps<typeof MessageDetailsHeader> = {
   createdAt: new Date("2021-10-18T16:00:30.541Z"),
+  messageId: "01J3DE93YA7QYAD9WZQZCP98M6" as UIMessageId,
   serviceId: service_1.service_id,
   subject: "#### Subject ####"
 };

--- a/ts/features/messages/components/MessageDetail/__tests__/OrganizationHeader.test.tsx
+++ b/ts/features/messages/components/MessageDetail/__tests__/OrganizationHeader.test.tsx
@@ -8,6 +8,7 @@ import { MESSAGES_ROUTES } from "../../../navigation/routes";
 import { appReducer } from "../../../../../store/reducers";
 import { preferencesDesignSystemSetEnabled } from "../../../../../store/actions/persistedPreferences";
 import { applicationChangeState } from "../../../../../store/actions/application";
+import { UIMessageId } from "../../../types";
 
 describe("OrganizationHeader component", () => {
   it("should match the snapshot", () => {
@@ -17,6 +18,7 @@ describe("OrganizationHeader component", () => {
 });
 
 const renderComponent = () => {
+  const messageId = "01J3DE93YA7QYAD9WZQZCP98M6" as UIMessageId;
   const serviceId = "01HXEPR9JD8838JZDN3YD0EF0Z" as ServiceId;
   const initialState = appReducer(undefined, applicationChangeState("active"));
   const designSystemState = appReducer(
@@ -29,6 +31,7 @@ const renderComponent = () => {
     () => (
       <OrganizationHeader
         logoUri={require("../../../../../../img/test/logo.png")}
+        messageId={messageId}
         organizationName={"#### organization_name ####"}
         serviceName={"#### service name ####"}
         serviceId={serviceId}

--- a/ts/features/messages/screens/MessageDetailsScreen.tsx
+++ b/ts/features/messages/screens/MessageDetailsScreen.tsx
@@ -178,6 +178,7 @@ export const MessageDetailsScreen = (props: MessageDetailsScreenProps) => {
         <View style={styles.container}>
           <ContentWrapper>
             <MessageDetailsHeader
+              messageId={messageId}
               serviceId={serviceId}
               subject={subject}
               createdAt={message.createdAt}

--- a/ts/features/pn/components/MessageDetails.tsx
+++ b/ts/features/pn/components/MessageDetails.tsx
@@ -73,6 +73,7 @@ export const MessageDetails = ({
       >
         <ContentWrapper>
           <MessageDetailsHeader
+            messageId={messageId}
             serviceId={serviceId}
             subject={message.subject}
             createdAt={message.created_at}


### PR DESCRIPTION
## Short description
This PR adds the double avatar on standard message details, when the message contains a payment.

![Simulator Screenshot - iPhone 15 - 2024-07-22 at 16 50 28](https://github.com/user-attachments/assets/c903fdaf-ce92-467d-94f9-65441d2c27d4)


## List of changes proposed in this pull request
- Double avatar instead of Avatar if the message has payment data

## How to test
Using the io-dev-api-server, check that a message with payment shows the double avatar. Also check that standard messages and SEND ones do not.
