### PR TITLE
[IOCOM-1611] Proper selection feedback for single row message items

### DIFF
--- a/ts/features/messages/components/Home/DS/CustomPressableListItemBase.tsx
+++ b/ts/features/messages/components/Home/DS/CustomPressableListItemBase.tsx
@@ -46,14 +46,15 @@ export const CustomPressableListItemBase = ({
         {
           backgroundColor: selected ? IOColors["blueIO-50"] : undefined
         },
-        minHeight ? { minHeight, justifyContent: "center" } : {}
+        minHeight ? { minHeight } : {}
       ]}
       {...props}
     >
       <Animated.View
         style={[
           IOListItemStyles.listItem,
-          !selected ? animatedBackgroundStyle : undefined
+          !selected ? animatedBackgroundStyle : undefined,
+          { flexGrow: 1, justifyContent: "center" }
         ]}
       >
         <Animated.View

--- a/ts/features/messages/components/Home/__tests__/__snapshots__/WrappedMessageListItem.test.tsx.snap
+++ b/ts/features/messages/components/Home/__tests__/__snapshots__/WrappedMessageListItem.test.tsx.snap
@@ -372,7 +372,6 @@ exports[`WrappedMessageListItem should match snapshot, from SEND, read message 1
                               "backgroundColor": undefined,
                             },
                             {
-                              "justifyContent": "center",
                               "minHeight": 133,
                             },
                           ]
@@ -389,6 +388,10 @@ exports[`WrappedMessageListItem should match snapshot, from SEND, read message 1
                               },
                               {
                                 "backgroundColor": undefined,
+                              },
+                              {
+                                "flexGrow": 1,
+                                "justifyContent": "center",
                               },
                             ]
                           }
@@ -1408,7 +1411,6 @@ exports[`WrappedMessageListItem should match snapshot, from SEND, unread message
                               "backgroundColor": undefined,
                             },
                             {
-                              "justifyContent": "center",
                               "minHeight": 133,
                             },
                           ]
@@ -1425,6 +1427,10 @@ exports[`WrappedMessageListItem should match snapshot, from SEND, unread message
                               },
                               {
                                 "backgroundColor": undefined,
+                              },
+                              {
+                                "flexGrow": 1,
+                                "justifyContent": "center",
                               },
                             ]
                           }
@@ -2499,7 +2505,6 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, contains p
                               "backgroundColor": undefined,
                             },
                             {
-                              "justifyContent": "center",
                               "minHeight": 133,
                             },
                           ]
@@ -2516,6 +2521,10 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, contains p
                               },
                               {
                                 "backgroundColor": undefined,
+                              },
+                              {
+                                "flexGrow": 1,
+                                "justifyContent": "center",
                               },
                             ]
                           }
@@ -3566,7 +3575,6 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, contains p
                               "backgroundColor": undefined,
                             },
                             {
-                              "justifyContent": "center",
                               "minHeight": 133,
                             },
                           ]
@@ -3583,6 +3591,10 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, contains p
                               },
                               {
                                 "backgroundColor": undefined,
+                              },
+                              {
+                                "flexGrow": 1,
+                                "justifyContent": "center",
                               },
                             ]
                           }
@@ -4688,7 +4700,6 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, contains u
                               "backgroundColor": undefined,
                             },
                             {
-                              "justifyContent": "center",
                               "minHeight": 95,
                             },
                           ]
@@ -4705,6 +4716,10 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, contains u
                               },
                               {
                                 "backgroundColor": undefined,
+                              },
+                              {
+                                "flexGrow": 1,
+                                "justifyContent": "center",
                               },
                             ]
                           }
@@ -5630,7 +5645,6 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, contains u
                               "backgroundColor": undefined,
                             },
                             {
-                              "justifyContent": "center",
                               "minHeight": 95,
                             },
                           ]
@@ -5647,6 +5661,10 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, contains u
                               },
                               {
                                 "backgroundColor": undefined,
+                              },
+                              {
+                                "flexGrow": 1,
+                                "justifyContent": "center",
                               },
                             ]
                           }
@@ -6627,7 +6645,6 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, not a paym
                               "backgroundColor": undefined,
                             },
                             {
-                              "justifyContent": "center",
                               "minHeight": 95,
                             },
                           ]
@@ -6644,6 +6661,10 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, not a paym
                               },
                               {
                                 "backgroundColor": undefined,
+                              },
+                              {
+                                "flexGrow": 1,
+                                "justifyContent": "center",
                               },
                             ]
                           }
@@ -7448,7 +7469,6 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, not a paym
                               "backgroundColor": undefined,
                             },
                             {
-                              "justifyContent": "center",
                               "minHeight": 95,
                             },
                           ]
@@ -7465,6 +7485,10 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, not a paym
                               },
                               {
                                 "backgroundColor": undefined,
+                              },
+                              {
+                                "flexGrow": 1,
+                                "justifyContent": "center",
                               },
                             ]
                           }


### PR DESCRIPTION
## Short description
This PR fixes the single row items on the message list, so that the background selection fills the whole cell.

## List of changes proposed in this pull request
- Internal view of pressable set to expand and justify its content

## How to test
Using the io-dev-api-server, check that the selection feedback fill the entire cell.
