### PR TITLE
fix: [IOPAE-1315] Fix organizationFiscalCode copy to clipboard value in service details screen

### DIFF
--- a/ts/features/services/details/components/ServiceDetailsMetadata.tsx
+++ b/ts/features/services/details/components/ServiceDetailsMetadata.tsx
@@ -133,7 +133,7 @@ export const ServiceDetailsMetadata = ({
       kind: "ListItemInfoCopy",
       label: I18n.t("services.details.metadata.fiscalCode"),
       icon: "entityCode",
-      onPress: handleItemOnPress(serviceId, "COPY"),
+      onPress: handleItemOnPress(organizationFiscalCode, "COPY"),
       value: organizationFiscalCode,
       testID: "service-details-metadata-org-fiscal-code"
     },


### PR DESCRIPTION
## Short description
This PR fix the _"copy to clipboard"_ value of `organizationFiscalCode` list item in **ServiceDetailsScreen**.
Before the fix, the `serviceId` value was mistakenly copied instead of `organizationFiscalCode`.

## How to test
In any service detail, scroll through the service details and tap on the _OrganizationFiscalCode_ item.
Paste the copied value outside the app _(for example on a notepad)_ and you'll be able to verify that it is exactly the `OrganizationFiscalCode` shown in the tapped info list item.
