### PR TITLE
fix: [IOCOM-1612] BUGFIX: FIMS decode error in iOS

### DIFF
--- a/ts/features/fims/singleSignOn/saga/handleFimsAbortOrCancel.ts
+++ b/ts/features/fims/singleSignOn/saga/handleFimsAbortOrCancel.ts
@@ -6,7 +6,11 @@ import {
 import { call, select } from "typed-redux-saga/macro";
 import { fimsDomainSelector } from "../../../../store/reducers/backendStatus";
 import { fimsPartialAbortUrl } from "../store/reducers";
-import { buildAbsoluteUrl, logToMixPanel } from "./sagaUtils";
+import {
+  buildAbsoluteUrl,
+  formatHttpClientResponseForMixPanel,
+  logToMixPanel
+} from "./sagaUtils";
 import { handleFimsResourcesDeallocation } from "./handleFimsResourcesDeallocation";
 
 const abortTimeoutMillisecondsGenerator = () => 8000;
@@ -31,7 +35,9 @@ export function* handleFimsAbortOrCancel() {
       if (isFailureResponse(abortResponse)) {
         yield* call(
           logToMixPanel,
-          `Abort call failed: ${JSON.stringify(abortResponse)}`
+          `Abort call failed: ${formatHttpClientResponseForMixPanel(
+            abortResponse
+          )}`
         );
       }
     } else {

--- a/ts/features/fims/singleSignOn/saga/handleFimsGetConsentsList.ts
+++ b/ts/features/fims/singleSignOn/saga/handleFimsGetConsentsList.ts
@@ -11,7 +11,10 @@ import { ConsentData } from "../types";
 import { fimsGetConsentsListAction } from "../store/actions";
 import { fimsTokenSelector } from "../../../../store/reducers/authentication";
 import { fimsDomainSelector } from "../../../../store/reducers/backendStatus";
-import { logToMixPanel } from "./sagaUtils";
+import {
+  formatHttpClientResponseForMixPanel,
+  logToMixPanel
+} from "./sagaUtils";
 
 export function* handleFimsGetConsentsList(
   action: ActionType<typeof fimsGetConsentsListAction.request>
@@ -48,7 +51,9 @@ export function* handleFimsGetConsentsList(
       return;
     }
     logToMixPanel(
-      `consent data fetch error: ${JSON.stringify(getConsentsResult)}`
+      `consent data fetch error: ${formatHttpClientResponseForMixPanel(
+        getConsentsResult
+      )}`
     );
     yield* put(fimsGetConsentsListAction.failure("consent data fetch error"));
     return;

--- a/ts/features/fims/singleSignOn/saga/handleFimsGetRedirectUrlAndOpenIAB.ts
+++ b/ts/features/fims/singleSignOn/saga/handleFimsGetRedirectUrlAndOpenIAB.ts
@@ -25,7 +25,11 @@ import {
 } from "../../../lollipop/store/reducers/lollipop";
 import { generateKeyInfo } from "../../../lollipop/saga";
 import { lollipopRequestInit } from "../../../lollipop/utils/fetch";
-import { buildAbsoluteUrl, logToMixPanel } from "./sagaUtils";
+import {
+  buildAbsoluteUrl,
+  formatHttpClientResponseForMixPanel,
+  logToMixPanel
+} from "./sagaUtils";
 import { handleFimsResourcesDeallocation } from "./handleFimsResourcesDeallocation";
 
 // note: IAB => InAppBrowser
@@ -68,7 +72,7 @@ export function* handleFimsGetRedirectUrlAndOpenIAB(
       return;
     }
     logToMixPanel(
-      `could not get RelyingParty redirect URL, ${JSON.stringify(
+      `could not get RelyingParty redirect URL, ${formatHttpClientResponseForMixPanel(
         rpRedirectResponse
       )}`
     );

--- a/ts/features/fims/singleSignOn/saga/handleFimsResourcesDeallocation.ts
+++ b/ts/features/fims/singleSignOn/saga/handleFimsResourcesDeallocation.ts
@@ -6,11 +6,16 @@ import {
 import { StackActions } from "@react-navigation/native";
 import { fimsDomainSelector } from "../../../../store/reducers/backendStatus";
 import NavigationService from "../../../../navigation/NavigationService";
+import { fimsRelyingPartyDomainSelector } from "../store/reducers";
 
 export function* handleFimsResourcesDeallocation() {
   const oidcProviderUrl = yield* select(fimsDomainSelector);
+  const rpDomain = yield* select(fimsRelyingPartyDomainSelector);
   if (oidcProviderUrl) {
     yield* call(removeAllCookiesForDomain, oidcProviderUrl);
+  }
+  if (rpDomain) {
+    yield* call(removeAllCookiesForDomain, rpDomain);
   }
   yield* call(deallocate);
   yield* call(NavigationService.dispatchNavigationAction, StackActions.pop());

--- a/ts/features/fims/singleSignOn/saga/sagaUtils.ts
+++ b/ts/features/fims/singleSignOn/saga/sagaUtils.ts
@@ -1,3 +1,9 @@
+import {
+  HttpClientFailureResponse,
+  HttpClientResponse,
+  HttpClientSuccessResponse
+} from "@pagopa/io-react-native-http-client";
+import { pipe } from "fp-ts/lib/function";
 import { URL as PolyfillURL } from "react-native-url-polyfill";
 import { mixpanelTrack } from "../../../../mixpanel";
 import { buildEventProperties } from "../../../../utils/analytics";
@@ -34,6 +40,33 @@ export const getDomainFromUrl = (url: string) => {
     return undefined;
   }
 };
+
+export const foldNativeHttpClientResponse =
+  <T>(
+    foldSuccess: (res: HttpClientSuccessResponse) => T,
+    foldFailure: (res: HttpClientFailureResponse) => T
+  ) =>
+  (res: HttpClientResponse) => {
+    switch (res.type) {
+      case "success":
+        return foldSuccess(res);
+      default:
+        return foldFailure(res);
+    }
+  };
+
+export const formatHttpClientResponseForMixPanel = (
+  resData: HttpClientResponse
+) =>
+  pipe(
+    resData,
+    foldNativeHttpClientResponse(
+      success =>
+        `${success.type}, ${success.status}, ${success.body}, ${success.headers}`,
+      failure =>
+        `${failure.type}, ${failure.code}, ${failure.message}, ${failure.headers}`
+    )
+  );
 
 export const logToMixPanel = (toLog: string) => {
   void mixpanelTrack(

--- a/ts/features/fims/singleSignOn/saga/sagaUtils.ts
+++ b/ts/features/fims/singleSignOn/saga/sagaUtils.ts
@@ -27,6 +27,14 @@ export const buildAbsoluteUrl = (
   }
 };
 
+export const getDomainFromUrl = (url: string) => {
+  try {
+    return new PolyfillURL(url).origin;
+  } catch {
+    return undefined;
+  }
+};
+
 export const logToMixPanel = (toLog: string) => {
   void mixpanelTrack(
     "FIMS_TECH_TEMP_ERROR",

--- a/ts/features/fims/singleSignOn/store/reducers/index.ts
+++ b/ts/features/fims/singleSignOn/store/reducers/index.ts
@@ -1,27 +1,30 @@
 import * as pot from "@pagopa/ts-commons/lib/pot";
-import { identity, pipe } from "fp-ts/lib/function";
 import * as B from "fp-ts/lib/boolean";
+import { identity, pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
 import { getType } from "typesafe-actions";
 import { Action } from "../../../../../store/actions/types";
 import { GlobalState } from "../../../../../store/reducers/types";
+import { isStrictNone } from "../../../../../utils/pot";
+import { getDomainFromUrl } from "../../saga/sagaUtils";
+import { ConsentData } from "../../types";
 import {
   fimsCancelOrAbortAction,
   fimsGetConsentsListAction,
   fimsGetRedirectUrlAndOpenIABAction
 } from "../actions";
-import { ConsentData } from "../../types";
-import { isStrictNone } from "../../../../../utils/pot";
 
 type FimsFlowStateTags = "consents" | "in-app-browser" | "abort";
 
 export type FimsSSOState = {
   currentFlowState: FimsFlowStateTags;
   consentsData: pot.Pot<ConsentData, string>; // string -> errMessage
+  relyingPartyDomain?: string;
 };
 
 const INITIAL_STATE: FimsSSOState = {
   currentFlowState: "consents",
+  relyingPartyDomain: undefined,
   consentsData: pot.none
 };
 
@@ -33,7 +36,8 @@ const reducer = (
     case getType(fimsGetConsentsListAction.request):
       return {
         currentFlowState: "consents",
-        consentsData: pot.noneLoading
+        consentsData: pot.noneLoading,
+        relyingPartyDomain: getDomainFromUrl(action.payload.ctaUrl)
       };
     case getType(fimsGetConsentsListAction.success):
       return {
@@ -42,6 +46,7 @@ const reducer = (
       };
     case getType(fimsGetRedirectUrlAndOpenIABAction.request):
       return {
+        ...state,
         currentFlowState: "in-app-browser",
         consentsData: pot.noneLoading
       };
@@ -71,6 +76,9 @@ const reducer = (
 
 export const fimsConsentsDataSelector = (state: GlobalState) =>
   state.features.fims.sso.consentsData;
+
+export const fimsRelyingPartyDomainSelector = (state: GlobalState) =>
+  state.features.fims.sso.relyingPartyDomain;
 
 export const fimsPartialAbortUrl = (state: GlobalState) =>
   pipe(state, fimsConsentsDataSelector, abortUrlFromConsentsPot, O.toUndefined);


### PR DESCRIPTION
## Short description
Fixed a cookie related problem that caused a decode error when running the FIMS flow for the second time in the same session, when on an iOS device
 
## List of changes proposed in this pull request
- added cookie clearing for the RP domain at the end of a FIMS auth flow (any exit/end case)

## How to test
using an iOS device, with the PROD env, run a fims flow, and then re-run it without exiting the app.
do so a couple of times in succession, and make sure that no decode error ever appears.
