### PR TITLE
chore: [IOBP-763] Added subtitle to payment success outcome screen

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1847,6 +1847,7 @@ wallet:
     outcome:
       SUCCESS:
         title: Hai pagato {{amount}}
+        subtitle: La ricevuta è nella sezione Pagamenti.
         button: Ok, chiudi
         banner:
           title: Puoi dirci com’è andata?

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1847,6 +1847,7 @@ wallet:
     outcome:
       SUCCESS:
         title: Hai pagato {{amount}}
+        subtitle: La ricevuta è nella sezione Pagamenti.
         button: Ok, chiudi
         banner:
           title: Puoi dirci com’è andata?

--- a/ts/features/payments/checkout/screens/WalletPaymentOutcomeScreen.tsx
+++ b/ts/features/payments/checkout/screens/WalletPaymentOutcomeScreen.tsx
@@ -222,6 +222,7 @@ const WalletPaymentOutcomeScreen = () => {
           title: I18n.t("wallet.payment.outcome.SUCCESS.title", {
             amount: paymentAmount
           }),
+          subtitle: I18n.t("wallet.payment.outcome.SUCCESS.subtitle"),
           action: closeSuccessAction
         };
       case WalletPaymentOutcomeEnum.GENERIC_ERROR:


### PR DESCRIPTION
## Short description
This PR adds a subtitle to the payment success outcome screen

## List of changes proposed in this pull request
- Added locales
- Added subtitle props from payment outcome screen

## How to test
Complete any payment and reach the success screen

## Preview
<img src="https://github.com/user-attachments/assets/6ebd4671-d3fa-411a-97de-f8343ac48dcf" width="300" />
