### PR TITLE
chore: [IOBP-783] Add explaination PayPal banner into payment method details screen

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3121,6 +3121,10 @@ features:
         error: Impossibile scaricare la ricevuta, riprova più tardi.
         download: Scarica ricevuta
     details:
+      payPal:
+        banner:
+          title: Vuoi pagare in 3 rate?
+          content: Non usare questo metodo. Durante il pagamento, seleziona "PayPal (anche in 3 rate)".
       pspAlert:
         description: "Per questo metodo è attivo il pagamento veloce con il gestore {{pspBusinessName}}."
         action: "Cosa significa?"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3121,6 +3121,10 @@ features:
         error: Impossibile scaricare la ricevuta, riprova più tardi.
         download: Scarica ricevuta
     details:
+      payPal:
+        banner:
+          title: Vuoi pagare in 3 rate?
+          content: Non usare questo metodo. Durante il pagamento, seleziona "PayPal (anche in 3 rate)".
       pspAlert:
         description: "Per questo metodo è attivo il pagamento veloce con il gestore {{pspBusinessName}}."
         action: "Cosa significa?"

--- a/ts/features/payments/details/components/PaymentsMethodPspDetailsAlert.tsx
+++ b/ts/features/payments/details/components/PaymentsMethodPspDetailsAlert.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
 import { Alert, VSpacer } from "@pagopa/io-app-design-system";
+import Animated, { LinearTransition } from "react-native-reanimated";
 import I18n from "../../../../i18n";
 import { usePaymentsMethodPspDetailsBottomSheet } from "./PaymentsMethodPspDetailsBottomSheet";
+import { PaymentsMethodPspPayPalBanner } from "./PaymentsMethodPspPayPalBanner";
 
 type PaymentsMethodPspDetailsAlertProps = {
   pspBusinessName: string;
@@ -21,16 +23,19 @@ export const PaymentsMethodPspDetailsAlert = ({
 
   return (
     <>
-      <Alert
-        content={I18n.t("features.payments.details.pspAlert.description", {
-          pspBusinessName
-        })}
-        variant="info"
-        action={I18n.t("features.payments.details.pspAlert.action")}
-        onPress={presentPspDetailsBottomSheet}
-      />
-      <VSpacer size={24} />
-      {pspDetailsBottomSheet}
+      <PaymentsMethodPspPayPalBanner />
+      <Animated.View layout={LinearTransition.duration(200)}>
+        <Alert
+          content={I18n.t("features.payments.details.pspAlert.description", {
+            pspBusinessName
+          })}
+          variant="info"
+          action={I18n.t("features.payments.details.pspAlert.action")}
+          onPress={presentPspDetailsBottomSheet}
+        />
+        <VSpacer size={24} />
+        {pspDetailsBottomSheet}
+      </Animated.View>
     </>
   );
 };

--- a/ts/features/payments/details/components/PaymentsMethodPspPayPalBanner.tsx
+++ b/ts/features/payments/details/components/PaymentsMethodPspPayPalBanner.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { VSpacer, Banner } from "@pagopa/io-app-design-system";
+
+import Animated, { FadeOut } from "react-native-reanimated";
+import I18n from "../../../../i18n";
+import { useIODispatch, useIOSelector } from "../../../../store/hooks";
+import { paymentsTogglePayPalBannerAction } from "../store/actions";
+import { showPayPalBannerSelector } from "../store/selectors";
+
+const PaymentsMethodPspPayPalBanner = () => {
+  const bannerViewRef = React.useRef(null);
+  const dispatch = useIODispatch();
+  const showBanner = useIOSelector(showPayPalBannerSelector);
+
+  const handleOnCloseBanner = () => {
+    dispatch(paymentsTogglePayPalBannerAction());
+  };
+
+  if (showBanner) {
+    return (
+      // The zIndex is set to 9999 due to a known bug of react-native-reanimated (https://github.com/software-mansion/react-native-reanimated/issues/4534)
+      <Animated.View exiting={FadeOut.duration(200)} style={{ zIndex: 9999 }}>
+        <Banner
+          color="neutral"
+          pictogramName="help"
+          title={I18n.t("features.payments.details.payPal.banner.title")}
+          size="big"
+          content={I18n.t("features.payments.details.payPal.banner.content")}
+          onClose={handleOnCloseBanner}
+          labelClose={I18n.t(
+            "idpay.initiative.discountDetails.IDPayCode.banner.close"
+          )}
+          viewRef={bannerViewRef}
+        />
+        <VSpacer size={24} />
+      </Animated.View>
+    );
+  }
+
+  return undefined;
+};
+
+export { PaymentsMethodPspPayPalBanner };

--- a/ts/features/payments/details/store/actions/index.ts
+++ b/ts/features/payments/details/store/actions/index.ts
@@ -1,4 +1,8 @@
-import { ActionType, createAsyncAction } from "typesafe-actions";
+import {
+  ActionType,
+  createAsyncAction,
+  createStandardAction
+} from "typesafe-actions";
 import { NetworkError } from "../../../../../utils/errors";
 import { WalletInfo } from "../../../../../../definitions/pagopa/walletv3/WalletInfo";
 
@@ -35,7 +39,13 @@ export const paymentsTogglePagoPaCapabilityAction = createAsyncAction(
   "PAYMENTS_TOGGLE_PAGOPA_CAPABILITY_CANCEL"
 )<TogglePagoPaCapabilityPayload, void, NetworkError, void>();
 
+/** This action is used to close the PayPal banner into a payment method details of type paypal */
+export const paymentsTogglePayPalBannerAction = createStandardAction(
+  "PAYMENTS_TOGGLE_PAYPAL_BANNER"
+)<void>();
+
 export type PaymentsMethodDetailsActions =
   | ActionType<typeof paymentsGetMethodDetailsAction>
   | ActionType<typeof paymentsDeleteMethodAction>
-  | ActionType<typeof paymentsTogglePagoPaCapabilityAction>;
+  | ActionType<typeof paymentsTogglePagoPaCapabilityAction>
+  | ActionType<typeof paymentsTogglePayPalBannerAction>;

--- a/ts/features/payments/details/store/reducers/index.ts
+++ b/ts/features/payments/details/store/reducers/index.ts
@@ -1,3 +1,5 @@
+import { PersistConfig, persistReducer } from "redux-persist";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as pot from "@pagopa/ts-commons/lib/pot";
 import { getType } from "typesafe-actions";
 import { Action } from "../../../../../store/actions/types";
@@ -7,15 +9,18 @@ import { WalletApplicationStatusEnum } from "../../../../../../definitions/pagop
 import { WalletInfo } from "../../../../../../definitions/pagopa/walletv3/WalletInfo";
 import {
   paymentsGetMethodDetailsAction,
-  paymentsTogglePagoPaCapabilityAction
+  paymentsTogglePagoPaCapabilityAction,
+  paymentsTogglePayPalBannerAction
 } from "../actions";
 
 export type PaymentsMethodDetailsState = {
   walletDetails: pot.Pot<WalletInfo, NetworkError>;
+  isWalletPayPalBannerClosed: boolean;
 };
 
 const INITIAL_STATE: PaymentsMethodDetailsState = {
-  walletDetails: pot.noneLoading
+  walletDetails: pot.noneLoading,
+  isWalletPayPalBannerClosed: false
 };
 
 const reducer = (
@@ -44,7 +49,11 @@ const reducer = (
         ...state,
         walletDetails: pot.none
       };
-
+    case getType(paymentsTogglePayPalBannerAction):
+      return {
+        ...state,
+        isWalletPayPalBannerClosed: !state.isWalletPayPalBannerClosed
+      };
     // TOGGLE PAGOPA CAPABILITY
     case getType(paymentsTogglePagoPaCapabilityAction.success):
       const walletDetails = pot.getOrElse(
@@ -76,4 +85,18 @@ const reducer = (
   return state;
 };
 
-export default reducer;
+const CURRENT_REDUX_FEATURES_STORE_VERSION = -1;
+
+const persistConfig: PersistConfig = {
+  key: "paymentsWallet",
+  storage: AsyncStorage,
+  version: CURRENT_REDUX_FEATURES_STORE_VERSION,
+  whitelist: ["isWalletPayPalBannerClosed"]
+};
+
+export const persistedReducer = persistReducer<
+  PaymentsMethodDetailsState,
+  Action
+>(persistConfig, reducer);
+
+export default persistedReducer;

--- a/ts/features/payments/details/store/selectors/index.ts
+++ b/ts/features/payments/details/store/selectors/index.ts
@@ -2,3 +2,6 @@ import { GlobalState } from "../../../../../store/reducers/types";
 
 export const selectPaymentMethodDetails = (state: GlobalState) =>
   state.features.payments.details.walletDetails;
+
+export const showPayPalBannerSelector = (state: GlobalState) =>
+  !state.features.payments.details.isWalletPayPalBannerClosed;


### PR DESCRIPTION
## Short description
This PR adds the explaination PayPal banner into payment method details screen, it explains how doest it works the PayPal "paga in 3 rate" feature.

## List of changes proposed in this pull request
- Added an animated Banner into the Paypal payment method details screen;
- Added the `isWalletPayPalBannerClosed` flag in the reducer to be persisted in case the user closes the banner
- Added locales
- Added `paymentsTogglePayPalBannerAction` to toggle the banner.

## How to test
Onboard a Paypal payment method and the first time you enter in it's details, you should be able to see the banner.

## Preview

https://github.com/user-attachments/assets/cbd521e2-ece3-4c32-ba67-2b31a38bba5a


