### PR TITLE
fix: [IOCOM-1620] FIMS validity checks on flow starting CTA

### DIFF
--- a/ts/features/fims/singleSignOn/saga/sagaUtils.ts
+++ b/ts/features/fims/singleSignOn/saga/sagaUtils.ts
@@ -74,3 +74,16 @@ export const logToMixPanel = (toLog: string) => {
     buildEventProperties("TECH", undefined, { message: toLog })
   );
 };
+
+export const isRedirect = (statusCode: number) =>
+  statusCode >= 300 && statusCode < 400;
+
+export const isValidRedirectResponse = (
+  res: HttpClientResponse
+): res is HttpClientSuccessResponse & {
+  headers: { location: string };
+} =>
+  res.type === "success" &&
+  isRedirect(res.status) &&
+  !!res.headers.location &&
+  res.headers.location.trim().length > 0;


### PR DESCRIPTION
## Short description
addition of validity checks for the FIMS flow starting CTA

## List of changes proposed in this pull request
- moved some utility functions to a shared file
- added valid redirect check for the cta response
- added baseUrl check for the CTA response

## How to test
using the dev-server, while checked out in the FIMS branch, run the fims flow and make sure nothing breaks.
Furthermore, you can update the relyingPartyRouter in the dev-server to return a wrong url, so that the wrong redirect error will be triggered.
