### PR TITLE
chore(IT Wallet): [SIW-1382] Remove TINIT prefix from fiscal code claim visualisation

### DIFF
--- a/ts/features/itwallet/common/components/ItwCredentialClaim.tsx
+++ b/ts/features/itwallet/common/components/ItwCredentialClaim.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import { Divider, ListItemInfo } from "@pagopa/io-app-design-system";
 import * as E from "fp-ts/Either";
+import * as O from "fp-ts/Option";
 import { pipe } from "fp-ts/lib/function";
 import { Image } from "react-native";
 import { DateFromString } from "@pagopa/ts-commons/lib/dates";
@@ -11,12 +12,14 @@ import {
   DrivingPrivilegeClaimType,
   DrivingPrivilegesClaim,
   EvidenceClaim,
+  FiscalCodeClaim,
   ImageClaim,
   ImageClaimNoUrl,
   PlaceOfBirthClaim,
   PlaceOfBirthClaimType,
   PlainTextClaim,
   dateClaimsConfig,
+  extractFiscalCode,
   previewDateClaimsConfig
 } from "../utils/itwClaimsUtils";
 import I18n from "../../../../i18n";
@@ -341,6 +344,13 @@ export const ItwCredentialClaim = ({
               detailsButtonVisible={!isPreview}
             />
           ));
+        } else if (FiscalCodeClaim.is(decoded)) {
+          const fiscalCode = pipe(
+            decoded,
+            extractFiscalCode,
+            O.getOrElseW(() => decoded)
+          );
+          return <PlainTextClaimItem label={claim.label} claim={fiscalCode} />;
         } else if (PlainTextClaim.is(decoded)) {
           return <PlainTextClaimItem label={claim.label} claim={decoded} />; // must be the last one to be checked due to overlap with IPatternStringTag
         } else {

--- a/ts/features/itwallet/common/utils/itwClaimsUtils.ts
+++ b/ts/features/itwallet/common/utils/itwClaimsUtils.ts
@@ -166,6 +166,9 @@ const PICTURE_URL_REGEX = "^data:image\\/png;base64,";
 const PICTURE_WITHOUT_URL_REGEX =
   "(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)";
 
+const FISCAL_CODE_WITH_PREFIX =
+  "(TINIT-[A-Z]{6}[0-9LMNPQRSTUV]{2}[ABCDEHLMPRST][0-9LMNPQRSTUV]{2}[A-Z][0-9LMNPQRSTUV]{3}[A-Z])";
+
 /**
  * io-ts decoder for the date claim field of the credential.
  * The date format is checked against the regex dateFormatRegex, which is currenlty mocked.
@@ -221,6 +224,11 @@ export type DrivingPrivilegesClaimType = t.TypeOf<
 >;
 
 /**
+ * Decoder for the fiscal code. This is needed since we have to remove the INIT prefix when rendering it.
+ */
+export const FiscalCodeClaim = PatternString(FISCAL_CODE_WITH_PREFIX);
+
+/**
  * Alias for the string fallback of the claim field of the credential.
  */
 export const PlainTextClaim = t.string;
@@ -249,6 +257,8 @@ export const ClaimValue = t.union([
   ImageClaim,
   // Otherwise parse an image without URL
   ImageClaimNoUrl,
+  // Otherwise parse a fiscal code
+  FiscalCodeClaim,
   // Otherwise fallback to string
   PlainTextClaim
 ]);

--- a/ts/features/itwallet/issuance/components/ItwRequiredClaimsList.tsx
+++ b/ts/features/itwallet/issuance/components/ItwRequiredClaimsList.tsx
@@ -10,6 +10,7 @@ import * as RA from "fp-ts/lib/ReadonlyArray";
 import { pipe } from "fp-ts/lib/function";
 import React from "react";
 import { StyleSheet, View } from "react-native";
+import * as O from "fp-ts/Option";
 import I18n from "../../../../i18n";
 import { localeDateFormat } from "../../../../utils/locale";
 import {
@@ -18,6 +19,8 @@ import {
   DateClaim,
   DrivingPrivilegesClaim,
   EvidenceClaim,
+  extractFiscalCode,
+  FiscalCodeClaim,
   ImageClaim,
   ImageClaimNoUrl,
   PlaceOfBirthClaim,
@@ -97,6 +100,12 @@ export const getClaimDisplayValue = (
           return decoded;
         } else if (DrivingPrivilegesClaim.is(decoded)) {
           return decoded.map(e => e.driving_privilege);
+        } else if (FiscalCodeClaim.is(decoded)) {
+          return pipe(
+            decoded,
+            extractFiscalCode,
+            O.getOrElseW(() => decoded)
+          );
         } else if (PlainTextClaim.is(decoded)) {
           return decoded; // must be the last one to be checked due to overlap with IPatternStringTag
         }


### PR DESCRIPTION
## Short description
This PR removes the `TINIT` prefix from the fiscal code claim during the visualisation.

## List of changes proposed in this pull request
- Adds a `FiscalCodeClaim` decoder which uses a regex to parse a fiscal code with the `TINIT` prefix; 
- Adds the aforementioned decoder in both `ItwRequiredClaimsList` and `ItwCredentialClaim` which render the claim during the preview, details and presentation screen. If the decoded claim is of type `FiscalCodeClaim` then it extracts the fiscal code without the prefix.

## How to test
Test a eID issuance flow and check the preview screen. Then check the details screen and try to obtain a MDL to check the presentation screen. The fiscal code shouldn't have the `TINIT` prefix;
