### PR TITLE
[SIW-1391] Move IT Wallet trial id to .env variables

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -88,6 +88,7 @@ WALLET_API_BASEURL='http://127.0.0.1:3000'
 # Wallet V3 test/env RESTful API
 WALLET_API_UAT_BASEURL='https://api.uat.platform.pagopa.it'
 # IT Wallet
+ITW_TRIAL_ID="01J2GN4TA8FB6DPTAX3T3YD6M1" # Use "01J2E5JA8QGYCFZRZGYQ33PXKN" for tests
 ITW_WALLET_PROVIDER_BASE_URL="https://io-d-itn-wallet-func.azurewebsites.net/"
 ITW_PID_PROVIDER_BASE_URL="https://pre.eid.wallet.ipzs.it"
 ITW_EAA_PROVIDER_BASE_URL="https://pre.eaa.wallet.ipzs.it"

--- a/.env.production
+++ b/.env.production
@@ -88,6 +88,7 @@ WALLET_API_BASEURL='https://api.platform.pagopa.it'
 # Wallet test/env RESTful API
 WALLET_API_UAT_BASEURL='https://api.uat.platform.pagopa.it'
 # IT Wallet
+ITW_TRIAL_ID="01J2GN4TA8FB6DPTAX3T3YD6M1"
 ITW_WALLET_PROVIDER_BASE_URL="https://walletprovider.example.org"
 ITW_PID_PROVIDER_BASE_URL="https://pidissuer.example.org"
 ITW_EAA_PROVIDER_BASE_URL="https://eaaissuer.example.org"

--- a/ts/config.ts
+++ b/ts/config.ts
@@ -8,6 +8,7 @@ import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
 import * as t from "io-ts";
 import Config from "react-native-config";
+import { TrialId } from "../definitions/trial_system/TrialId";
 
 // default repository for fetching app content (e.g. services metadata)
 const DEFAULT_CONTENT_REPO_URL =
@@ -241,6 +242,7 @@ export const walletApiUatBaseUrl = Config.WALLET_API_UAT_BASEURL;
 export const defaultPin = "162534";
 
 // IT Wallet
+export const itwTrialId = Config.ITW_TRIAL_ID as TrialId;
 export const itwWalletProviderBaseUrl = Config.ITW_WALLET_PROVIDER_BASE_URL;
 export const itwGoogleCloudProjectNumber =
   Config.ITW_GOOGLE_CLOUD_PROJECT_NUMBER;

--- a/ts/features/itwallet/common/components/ItwDiscoveryBanner.tsx
+++ b/ts/features/itwallet/common/components/ItwDiscoveryBanner.tsx
@@ -4,9 +4,8 @@ import { StyleSheet, View } from "react-native";
 import I18n from "../../../../i18n";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { useIOSelector } from "../../../../store/hooks";
-import { isTrialActiveSelector } from "../../../trialSystem/store/reducers";
+import { isItwTrialActiveSelector } from "../../../trialSystem/store/reducers";
 import { ITW_ROUTES } from "../../navigation/routes";
-import { ITW_TRIAL_ID } from "../utils/itwTrialUtils";
 import { itwLifecycleIsValidSelector } from "../../lifecycle/store/selectors";
 import { isItwEnabledSelector } from "../../../../store/reducers/backendStatus";
 
@@ -22,7 +21,7 @@ export const ItwDiscoveryBanner = ({
   const bannerRef = React.createRef<View>();
   const navigation = useIONavigation();
   const [isVisible, setVisible] = React.useState(true);
-  const isItwTrialActive = useIOSelector(isTrialActiveSelector(ITW_TRIAL_ID));
+  const isItwTrialActive = useIOSelector(isItwTrialActiveSelector);
   const isItwValid = useIOSelector(itwLifecycleIsValidSelector);
   const isItwEnabled = useIOSelector(isItwEnabledSelector);
 

--- a/ts/features/itwallet/common/components/__tests__/ItwDiscoveryBanner.test.tsx
+++ b/ts/features/itwallet/common/components/__tests__/ItwDiscoveryBanner.test.tsx
@@ -13,8 +13,8 @@ import { BackendStatusState } from "../../../../../store/reducers/backendStatus"
 import { GlobalState } from "../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
 import { ItwLifecycleState } from "../../../lifecycle/store/reducers";
-import { ITW_TRIAL_ID } from "../../utils/itwTrialUtils";
 import { ItwDiscoveryBanner } from "../ItwDiscoveryBanner";
+import { itwTrialId } from "../../../../../config";
 
 type RenderOptions = {
   isItwTrial?: boolean;
@@ -61,7 +61,7 @@ const renderComponent = ({
     _.merge(undefined, globalState, {
       trialSystem: isItwTrial
         ? {
-            [ITW_TRIAL_ID]: pot.some(SubscriptionStateEnum.ACTIVE)
+            [itwTrialId]: pot.some(SubscriptionStateEnum.ACTIVE)
           }
         : {},
       features: {

--- a/ts/features/itwallet/common/saga/index.ts
+++ b/ts/features/itwallet/common/saga/index.ts
@@ -5,7 +5,7 @@ import { trialSystemActivationStatus } from "../../../trialSystem/store/actions"
 import { watchItwIdentificationSaga } from "../../identification/saga";
 import { checkWalletInstanceStateSaga } from "../../lifecycle/saga/checkWalletInstanceStateSaga";
 import { handleWalletCredentialsRehydration } from "../../credentials/saga/handleWalletCredentialsRehydration";
-import { ITW_TRIAL_ID } from "../utils/itwTrialUtils";
+import { itwTrialId } from "../../../../config";
 
 export function* watchItwSaga(): SagaIterator {
   const isItWalletTestEnabled: ReturnType<
@@ -22,5 +22,5 @@ export function* watchItwSaga(): SagaIterator {
   yield* fork(watchItwIdentificationSaga);
 
   // IT Wallet trial status refresh
-  yield* put(trialSystemActivationStatus.request(ITW_TRIAL_ID));
+  yield* put(trialSystemActivationStatus.request(itwTrialId));
 }

--- a/ts/features/itwallet/common/utils/itwTrialUtils.ts
+++ b/ts/features/itwallet/common/utils/itwTrialUtils.ts
@@ -1,3 +1,0 @@
-import { TrialId } from "../../../../../definitions/trial_system/TrialId";
-
-export const ITW_TRIAL_ID = "01J2GN4TA8FB6DPTAX3T3YD6M1" as TrialId;

--- a/ts/features/itwallet/onboarding/screens/WalletCardOnboardingScreen.tsx
+++ b/ts/features/itwallet/onboarding/screens/WalletCardOnboardingScreen.tsx
@@ -23,10 +23,9 @@ import { cgnActivationStart } from "../../../bonus/cgn/store/actions/activation"
 import { isCgnInformationAvailableSelector } from "../../../bonus/cgn/store/reducers/details";
 import { loadAvailableBonuses } from "../../../bonus/common/store/actions/availableBonusesTypes";
 import { PaymentsOnboardingRoutes } from "../../../payments/onboarding/navigation/routes";
-import { isTrialActiveSelector } from "../../../trialSystem/store/reducers";
+import { isItwTrialActiveSelector } from "../../../trialSystem/store/reducers";
 import { getCredentialNameFromType } from "../../common/utils/itwCredentialUtils";
 import { CredentialType } from "../../common/utils/itwMocksUtils";
-import { ITW_TRIAL_ID } from "../../common/utils/itwTrialUtils";
 import { itwCredentialsTypesSelector } from "../../credentials/store/selectors";
 import { itwLifecycleIsValidSelector } from "../../lifecycle/store/selectors";
 import {
@@ -49,7 +48,7 @@ const WalletCardOnboardingScreen = () => {
   const isCgnAlreadyActive = useIOSelector(isCgnInformationAvailableSelector);
 
   const isItWalletEnabled = useIOSelector(isItWalletTestEnabledSelector);
-  const isItwTrialEnabled = useIOSelector(isTrialActiveSelector(ITW_TRIAL_ID));
+  const isItwTrialEnabled = useIOSelector(isItwTrialActiveSelector);
   const isItwValid = useIOSelector(itwLifecycleIsValidSelector);
   const isItwEnabled = useIOSelector(isItwEnabledSelector);
   const itwCredentialsTypes = useIOSelector(itwCredentialsTypesSelector);

--- a/ts/features/itwallet/onboarding/screens/__tests__/WalletCardOnboardingScreen.test.tsx
+++ b/ts/features/itwallet/onboarding/screens/__tests__/WalletCardOnboardingScreen.test.tsx
@@ -15,12 +15,12 @@ import { appReducer } from "../../../../../store/reducers";
 import { BackendStatusState } from "../../../../../store/reducers/backendStatus";
 import { GlobalState } from "../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
-import { ITW_TRIAL_ID } from "../../../common/utils/itwTrialUtils";
 import { ItwCredentialIssuanceMachineContext } from "../../../machine/provider";
 import { ITW_ROUTES } from "../../../navigation/routes";
 import { WalletCardOnboardingScreen } from "../WalletCardOnboardingScreen";
 import { ToolEnum } from "../../../../../../definitions/content/AssistanceToolConfig";
 import { ItwLifecycleState } from "../../../lifecycle/store/reducers";
+import { itwTrialId } from "../../../../../config";
 
 type RenderOptions = {
   isIdPayEnabled?: boolean;
@@ -96,7 +96,7 @@ const renderComponent = ({
         }
       },
       trialSystem: {
-        [ITW_TRIAL_ID as TrialId]: itwTrialStatus
+        [itwTrialId as TrialId]: itwTrialStatus
           ? pot.some(itwTrialStatus)
           : pot.none
       },

--- a/ts/features/itwallet/playgrounds/components/ItwTrialSystemSection.tsx
+++ b/ts/features/itwallet/playgrounds/components/ItwTrialSystemSection.tsx
@@ -19,24 +19,24 @@ import {
   isUpdatingTrialStatusSelector,
   trialStatusSelector
 } from "../../../trialSystem/store/reducers";
-import { ITW_TRIAL_ID } from "../../common/utils/itwTrialUtils";
+import { itwTrialId } from "../../../../config";
 
 export const ItwTrialSystemSection = () => {
   const dispatch = useIODispatch();
-  const status = useIOSelector(trialStatusSelector(ITW_TRIAL_ID));
-  const isLoading = useIOSelector(isLoadingTrialStatusSelector(ITW_TRIAL_ID));
-  const isUpdating = useIOSelector(isUpdatingTrialStatusSelector(ITW_TRIAL_ID));
+  const status = useIOSelector(trialStatusSelector(itwTrialId));
+  const isLoading = useIOSelector(isLoadingTrialStatusSelector(itwTrialId));
+  const isUpdating = useIOSelector(isUpdatingTrialStatusSelector(itwTrialId));
 
   const subscribe = () => {
-    dispatch(trialSystemActivationStatusUpsert.request(ITW_TRIAL_ID));
+    dispatch(trialSystemActivationStatusUpsert.request(itwTrialId));
   };
 
   const refresh = () => {
-    dispatch(trialSystemActivationStatus.request(ITW_TRIAL_ID));
+    dispatch(trialSystemActivationStatus.request(itwTrialId));
   };
 
   const reset = () => {
-    dispatch(trialSystemActivationStatusReset(ITW_TRIAL_ID));
+    dispatch(trialSystemActivationStatusReset(itwTrialId));
   };
 
   return (

--- a/ts/features/newWallet/components/WalletCardsContainer.tsx
+++ b/ts/features/newWallet/components/WalletCardsContainer.tsx
@@ -6,9 +6,8 @@ import I18n from "../../../i18n";
 import { useIOSelector } from "../../../store/hooks";
 import { isItwEnabledSelector } from "../../../store/reducers/backendStatus";
 import { ItwDiscoveryBanner } from "../../itwallet/common/components/ItwDiscoveryBanner";
-import { ITW_TRIAL_ID } from "../../itwallet/common/utils/itwTrialUtils";
 import { itwLifecycleIsValidSelector } from "../../itwallet/lifecycle/store/selectors";
-import { isTrialActiveSelector } from "../../trialSystem/store/reducers";
+import { isItwTrialActiveSelector } from "../../trialSystem/store/reducers";
 import {
   selectIsWalletCardsLoading,
   selectSortedWalletCards,
@@ -60,7 +59,7 @@ const ItwCardsContainer = ({
   isStacked
 }: Pick<WalletCardsCategoryContainerProps, "isStacked">) => {
   const cards = useIOSelector(selectWalletItwCards);
-  const isItwTrialEnabled = useIOSelector(isTrialActiveSelector(ITW_TRIAL_ID));
+  const isItwTrialEnabled = useIOSelector(isItwTrialActiveSelector);
   const isItwValid = useIOSelector(itwLifecycleIsValidSelector);
   const isItwEnabled = useIOSelector(isItwEnabledSelector);
 
@@ -105,7 +104,7 @@ const OtherCardsContainer = ({
   isStacked
 }: Pick<WalletCardsCategoryContainerProps, "isStacked">) => {
   const cards = useIOSelector(selectWalletOtherCards);
-  const isItwTrialEnabled = useIOSelector(isTrialActiveSelector(ITW_TRIAL_ID));
+  const isItwTrialEnabled = useIOSelector(isItwTrialActiveSelector);
 
   if (cards.length === 0) {
     return null;

--- a/ts/features/newWallet/components/__tests__/WalletCardsContainer.test.tsx
+++ b/ts/features/newWallet/components/__tests__/WalletCardsContainer.test.tsx
@@ -14,12 +14,12 @@ import { BackendStatusState } from "../../../../store/reducers/backendStatus";
 import { GlobalState } from "../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../utils/testWrapper";
 import { CredentialType } from "../../../itwallet/common/utils/itwMocksUtils";
-import { ITW_TRIAL_ID } from "../../../itwallet/common/utils/itwTrialUtils";
 import { ItwLifecycleState } from "../../../itwallet/lifecycle/store/reducers";
 import { WalletCardsState } from "../../store/reducers/cards";
 import { WalletPlaceholdersState } from "../../store/reducers/placeholders";
 import { WalletCard } from "../../types";
 import { WalletCardsContainer } from "../WalletCardsContainer";
+import { itwTrialId } from "../../../../config";
 
 type RenderOptions = {
   cards?: WalletCardsState;
@@ -179,7 +179,7 @@ const renderComponent = ({
     _.merge(undefined, globalState, {
       trialSystem: isItwTrial
         ? {
-            [ITW_TRIAL_ID]: pot.some(SubscriptionStateEnum.ACTIVE)
+            [itwTrialId]: pot.some(SubscriptionStateEnum.ACTIVE)
           }
         : {},
       features: {

--- a/ts/features/trialSystem/store/reducers/index.ts
+++ b/ts/features/trialSystem/store/reducers/index.ts
@@ -14,6 +14,7 @@ import {
   trialSystemActivationStatusUpsert
 } from "../actions";
 import { GlobalState } from "../../../../store/reducers/types";
+import { itwTrialId } from "../../../../config";
 
 export type TrialSystemState = Record<
   TrialId,
@@ -116,3 +117,8 @@ export const isTrialActiveSelector = (id: TrialId) =>
     trialStatusSelector(id),
     status => status === SubscriptionStateEnum.ACTIVE
   );
+
+/**
+ * Allows to know if the user has the acces to the IT Wallet features
+ */
+export const isItwTrialActiveSelector = isTrialActiveSelector(itwTrialId);


### PR DESCRIPTION
## Short description
This PR moves the IT Wallet trial ID to the .env variables 

## List of changes proposed in this pull request
- Added `ITW_TRIAL_ID` env variable
- Added `isItwTrialActiveSelector` selector to easily get ITW trial status

## How to test
Go to **Profile > Playgrounds > IT Wallet > Trial**, check that the correct trial id is displayed.