### PR TITLE
fix(IT Wallet): [SIW-1403] Check CIE support independently of user authentication

### DIFF
--- a/ts/features/itwallet/common/saga/index.ts
+++ b/ts/features/itwallet/common/saga/index.ts
@@ -12,6 +12,7 @@ export function* watchItwSaga(): SagaIterator {
   yield* fork(handleWalletCredentialsRehydration);
   yield* fork(watchItwIdentificationSaga);
 
+  // TODO: [SIW-1404] remove this CIE check and move the logic to xstate
   yield* put(itwCieIsSupported.request());
   // IT Wallet trial status refresh
   yield* put(trialSystemActivationStatus.request(itwTrialId));

--- a/ts/features/itwallet/common/saga/index.ts
+++ b/ts/features/itwallet/common/saga/index.ts
@@ -5,12 +5,14 @@ import { watchItwIdentificationSaga } from "../../identification/saga";
 import { checkWalletInstanceStateSaga } from "../../lifecycle/saga/checkWalletInstanceStateSaga";
 import { handleWalletCredentialsRehydration } from "../../credentials/saga/handleWalletCredentialsRehydration";
 import { itwTrialId } from "../../../../config";
+import { itwCieIsSupported } from "../../identification/store/actions";
 
 export function* watchItwSaga(): SagaIterator {
   yield* fork(checkWalletInstanceStateSaga);
   yield* fork(handleWalletCredentialsRehydration);
   yield* fork(watchItwIdentificationSaga);
 
+  yield* put(itwCieIsSupported.request());
   // IT Wallet trial status refresh
   yield* put(trialSystemActivationStatus.request(itwTrialId));
 }

--- a/ts/features/itwallet/identification/saga/handleCieSupportedSaga.ts
+++ b/ts/features/itwallet/identification/saga/handleCieSupportedSaga.ts
@@ -1,0 +1,13 @@
+import cieManager from "@pagopa/react-native-cie";
+import { call, put } from "typed-redux-saga/macro";
+import { convertUnknownToError } from "../../../../utils/errors";
+import { itwCieIsSupported } from "../store/actions";
+
+export function* handleCieSupportedSaga() {
+  try {
+    const response = yield* call(cieManager.isCIEAuthenticationSupported);
+    yield* put(itwCieIsSupported.success(response));
+  } catch (e) {
+    yield* put(itwCieIsSupported.failure(convertUnknownToError(e)));
+  }
+}

--- a/ts/features/itwallet/identification/saga/index.ts
+++ b/ts/features/itwallet/identification/saga/index.ts
@@ -1,8 +1,10 @@
 import { SagaIterator } from "redux-saga";
 import { takeLatest } from "typed-redux-saga/macro";
-import { itwNfcIsEnabled } from "../store/actions";
+import { itwCieIsSupported, itwNfcIsEnabled } from "../store/actions";
 import { handleNfcEnabledSaga } from "./handleNfcEnabledSaga";
+import { handleCieSupportedSaga } from "./handleCieSupportedSaga";
 
 export function* watchItwIdentificationSaga(): SagaIterator {
   yield* takeLatest(itwNfcIsEnabled.request, handleNfcEnabledSaga);
+  yield* takeLatest(itwCieIsSupported.request, handleCieSupportedSaga);
 }

--- a/ts/features/itwallet/identification/saga/index.ts
+++ b/ts/features/itwallet/identification/saga/index.ts
@@ -4,6 +4,7 @@ import { itwCieIsSupported, itwNfcIsEnabled } from "../store/actions";
 import { handleNfcEnabledSaga } from "./handleNfcEnabledSaga";
 import { handleCieSupportedSaga } from "./handleCieSupportedSaga";
 
+// TODO: [SIW-1404] remove this saga and move the logic to xstate
 export function* watchItwIdentificationSaga(): SagaIterator {
   yield* takeLatest(itwNfcIsEnabled.request, handleNfcEnabledSaga);
   yield* takeLatest(itwCieIsSupported.request, handleCieSupportedSaga);

--- a/ts/features/itwallet/identification/screens/ItwIdentificationModeSelectionScreen.tsx
+++ b/ts/features/itwallet/identification/screens/ItwIdentificationModeSelectionScreen.tsx
@@ -10,15 +10,15 @@ import React from "react";
 import { IOScrollViewWithLargeHeader } from "../../../../components/ui/IOScrollViewWithLargeHeader";
 import I18n from "../../../../i18n";
 import { useIOSelector } from "../../../../store/hooks";
-import { isCieSupportedSelector } from "../../../../store/reducers/cie";
 import { cieFlowForDevServerEnabled } from "../../../cieLogin/utils";
 import { ItwEidIssuanceMachineContext } from "../../machine/provider";
 import ItwMarkdown from "../../common/components/ItwMarkdown";
+import { itwIsCieSupportedSelector } from "../store/selectors";
 
 export const ItwIdentificationModeSelectionScreen = () => {
   const machineRef = ItwEidIssuanceMachineContext.useActorRef();
 
-  const isCieSupportedPot = useIOSelector(isCieSupportedSelector);
+  const isCieSupportedPot = useIOSelector(itwIsCieSupportedSelector);
 
   const isCieSupported = React.useMemo(
     () => cieFlowForDevServerEnabled || pot.getOrElse(isCieSupportedPot, false),

--- a/ts/features/itwallet/identification/store/actions/index.ts
+++ b/ts/features/itwallet/identification/store/actions/index.ts
@@ -6,4 +6,12 @@ export const itwNfcIsEnabled = createAsyncAction(
   "ITW_NFC_IS_ENABLED_FAILURE"
 )<void, boolean, Error>();
 
-export type ItwIdentificationActions = ActionType<typeof itwNfcIsEnabled>;
+export const itwCieIsSupported = createAsyncAction(
+  "ITW_CIE_IS_SUPPORTED_REQUEST",
+  "ITW_CIE_IS_SUPPORTED_SUCCESS",
+  "ITW_CIE_IS_SUPPORTED_FAILURE"
+)<void, boolean, Error>();
+
+export type ItwIdentificationActions =
+  | ActionType<typeof itwNfcIsEnabled>
+  | ActionType<typeof itwCieIsSupported>;

--- a/ts/features/itwallet/identification/store/actions/index.ts
+++ b/ts/features/itwallet/identification/store/actions/index.ts
@@ -1,5 +1,6 @@
 import { ActionType, createAsyncAction } from "typesafe-actions";
 
+// TODO: [SIW-1404] remove these actions and move the logic to xstate
 export const itwNfcIsEnabled = createAsyncAction(
   "ITW_NFC_IS_ENABLED_REQUEST",
   "ITW_NFC_IS_ENABLED_SUCCESS",

--- a/ts/features/itwallet/identification/store/reducers/index.ts
+++ b/ts/features/itwallet/identification/store/reducers/index.ts
@@ -1,14 +1,16 @@
 import * as pot from "@pagopa/ts-commons/lib/pot";
 import { getType } from "typesafe-actions";
 import { Action } from "../../../../../store/actions/types";
-import { itwNfcIsEnabled } from "../actions";
+import { itwCieIsSupported, itwNfcIsEnabled } from "../actions";
 
 export type ItwIdentificationState = {
   isNfcEnabled: pot.Pot<boolean, Error>;
+  isCieSupported: pot.Pot<boolean, Error>;
 };
 
 const INITIAL_STATE: ItwIdentificationState = {
-  isNfcEnabled: pot.none
+  isNfcEnabled: pot.none,
+  isCieSupported: pot.none
 };
 
 const reducer = (
@@ -30,6 +32,21 @@ const reducer = (
       return {
         ...state,
         isNfcEnabled: pot.toError(state.isNfcEnabled, action.payload)
+      };
+    case getType(itwCieIsSupported.request):
+      return {
+        ...state,
+        isCieSupported: pot.toLoading(state.isCieSupported)
+      };
+    case getType(itwCieIsSupported.success):
+      return {
+        ...state,
+        isCieSupported: pot.some(action.payload)
+      };
+    case getType(itwCieIsSupported.failure):
+      return {
+        ...state,
+        isCieSupported: pot.toError(state.isCieSupported, action.payload)
       };
   }
   return state;

--- a/ts/features/itwallet/identification/store/reducers/index.ts
+++ b/ts/features/itwallet/identification/store/reducers/index.ts
@@ -3,6 +3,7 @@ import { getType } from "typesafe-actions";
 import { Action } from "../../../../../store/actions/types";
 import { itwCieIsSupported, itwNfcIsEnabled } from "../actions";
 
+// TODO: [SIW-1404] remove this reducer and move the logic to xstate
 export type ItwIdentificationState = {
   isNfcEnabled: pot.Pot<boolean, Error>;
   isCieSupported: pot.Pot<boolean, Error>;

--- a/ts/features/itwallet/identification/store/selectors/index.ts
+++ b/ts/features/itwallet/identification/store/selectors/index.ts
@@ -2,3 +2,6 @@ import { GlobalState } from "../../../../../store/reducers/types";
 
 export const itwIsNfcEnabledSelector = (state: GlobalState) =>
   state.features.itWallet.identification.isNfcEnabled;
+
+export const itwIsCieSupportedSelector = (state: GlobalState) =>
+  state.features.itWallet.identification.isCieSupported;

--- a/ts/features/itwallet/identification/store/selectors/index.ts
+++ b/ts/features/itwallet/identification/store/selectors/index.ts
@@ -1,5 +1,6 @@
 import { GlobalState } from "../../../../../store/reducers/types";
 
+// TODO: [SIW-1404] remove these selectors and move the logic to xstate
 export const itwIsNfcEnabledSelector = (state: GlobalState) =>
   state.features.itWallet.identification.isNfcEnabled;
 


### PR DESCRIPTION
## Short description
This PR fixes a bug that occurs when the user is already authenticated (has a session token): in that scenario the app does not check whether CIE is supported, so in IT Wallet identification mode selection screen the button CIE+pin does not appear.

## List of changes proposed in this pull request
- Store the CIE supported status in the `identification` reducer
- Call the CIE SDK manager independently of user authentication

## How to test
Launch the app with an active session, and activate the wallet: the button CIE+pin should be visible.
