### PR TITLE
chore(IT Wallet): [SIW-1405] Add WI reset button in IT Wallet playgrounds

### DIFF
--- a/ts/features/itwallet/common/components/ItwCredentialClaim.tsx
+++ b/ts/features/itwallet/common/components/ItwCredentialClaim.tsx
@@ -196,8 +196,8 @@ const ImageClaimItem = ({ label, claim }: { label: string; claim: string }) => (
       <Image
         source={{ uri: claim }}
         style={{
-          width: 250,
-          height: 250
+          width: 200,
+          aspectRatio: 3 / 4
         }}
         resizeMode="contain"
         accessibilityIgnoresInvertColors
@@ -337,12 +337,16 @@ export const ItwCredentialClaim = ({
           return <ImageClaimItem label={claim.label} claim={fixedImage} />;
         } else if (DrivingPrivilegesClaim.is(decoded)) {
           return decoded.map((elem, index) => (
-            <DrivingPrivilegesClaimItem
-              label={claim.label}
-              claim={elem}
-              key={`${index}_{elem.label}`}
-              detailsButtonVisible={!isPreview}
-            />
+            <React.Fragment
+              key={`${index}_${claim.label}_${elem.driving_privilege}`}
+            >
+              {index !== 0 && <Divider />}
+              <DrivingPrivilegesClaimItem
+                label={claim.label}
+                claim={elem}
+                detailsButtonVisible={!isPreview}
+              />
+            </React.Fragment>
           ));
         } else if (FiscalCodeClaim.is(decoded)) {
           const fiscalCode = pipe(

--- a/ts/features/itwallet/playgrounds/screens/ItwPlayground.tsx
+++ b/ts/features/itwallet/playgrounds/screens/ItwPlayground.tsx
@@ -86,12 +86,12 @@ const ItwPlayground = () => {
           onPress={() => undefined}
         />
         <VSpacer size={16} />
+        <ItwLifecycleSection />
+        <VSpacer size={16} />
         {
           /* F&F Experimentation */
           __DEV__ ? (
             <>
-              <ItwLifecycleSection />
-              <VSpacer size={16} />
               <ItwTrialSystemSection />
               <VSpacer size={16} />
             </>


### PR DESCRIPTION
## Short description
This PR adds the WI reset button in IT Wallet playgrounds

## List of changes proposed in this pull request
- Removed __DEV__ flag from WI reset button
- Fixed visualization problems in credential detail screen

## How to test
Static check should pass.
Go to **Profile > Playgrounds > IT Wallet**, make sure the reset button is visible.
