### PR TITLE
chore(IT Wallet): [SIW-1406] Remove gesture navigation in IT Wallet credential issuance screens

### DIFF
--- a/ts/features/itwallet/common/hooks/useItwDisbleGestureNavigation.ts
+++ b/ts/features/itwallet/common/hooks/useItwDisbleGestureNavigation.ts
@@ -1,0 +1,18 @@
+import React from "react";
+import { useIONavigation } from "../../../../navigation/params/AppParamsList";
+
+/**
+ * This hook disables gesture navigation and reenables it when the screen is unmounted
+ */
+export const useItwDisbleGestureNavigation = () => {
+  const navigation = useIONavigation();
+  React.useEffect(() => {
+    // Disable swipe
+    navigation.setOptions({ gestureEnabled: false });
+    navigation.getParent()?.setOptions({ gestureEnabled: false });
+    // Re-enable swipe after going back
+    return () => {
+      navigation.getParent()?.setOptions({ gestureEnabled: true });
+    };
+  }, [navigation]);
+};

--- a/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialPreviewScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialPreviewScreen.tsx
@@ -19,7 +19,9 @@ import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { identificationRequest } from "../../../../store/actions/identification";
 import { useIODispatch } from "../../../../store/hooks";
 import { ItwCredentialClaimsList } from "../../common/components/ItwCredentialClaimList";
+import { useItwDisbleGestureNavigation } from "../../common/hooks/useItwDisbleGestureNavigation";
 import { useItwDismissalDialog } from "../../common/hooks/useItwDismissalDialog";
+import { getCredentialNameFromType } from "../../common/utils/itwCredentialUtils";
 import { CredentialType } from "../../common/utils/itwMocksUtils";
 import { StoredCredential } from "../../common/utils/itwTypesUtils";
 import {
@@ -28,7 +30,7 @@ import {
   selectIsLoading
 } from "../../machine/credential/selectors";
 import { ItwCredentialIssuanceMachineContext } from "../../machine/provider";
-import { getCredentialNameFromType } from "../../common/utils/itwCredentialUtils";
+import { useAvoidHardwareBackButton } from "../../../../utils/useAvoidHardwareBackButton";
 
 export const ItwIssuanceCredentialPreviewScreen = () => {
   const credentialTypeOption = ItwCredentialIssuanceMachineContext.useSelector(
@@ -85,6 +87,9 @@ const ContentView = ({ credentialType, credential }: ContentViewProps) => {
       )
     );
   };
+
+  useItwDisbleGestureNavigation();
+  useAvoidHardwareBackButton();
 
   useHeaderSecondLevel({
     title: "",

--- a/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialTrustIssuerScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialTrustIssuerScreen.tsx
@@ -19,6 +19,7 @@ import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
 import I18n from "../../../../i18n";
 import { useIOSelector } from "../../../../store/hooks";
 import ItwMarkdown from "../../common/components/ItwMarkdown";
+import { useItwDisbleGestureNavigation } from "../../common/hooks/useItwDisbleGestureNavigation";
 import { useItwDismissalDialog } from "../../common/hooks/useItwDismissalDialog";
 import { parseClaims } from "../../common/utils/itwClaimsUtils";
 import { getCredentialNameFromType } from "../../common/utils/itwCredentialUtils";
@@ -39,6 +40,7 @@ import {
   ItwRequestedClaimsList,
   RequiredClaim
 } from "../components/ItwRequiredClaimsList";
+import { useAvoidHardwareBackButton } from "../../../../utils/useAvoidHardwareBackButton";
 
 const ItwIssuanceCredentialTrustIssuerScreen = () => {
   const eidOption = useIOSelector(itwCredentialsEidSelector);
@@ -84,6 +86,9 @@ const ContentView = ({ credentialType, eid }: ContentViewProps) => {
   const dismissDialog = useItwDismissalDialog(() =>
     machineRef.send({ type: "close" })
   );
+
+  useItwDisbleGestureNavigation();
+  useAvoidHardwareBackButton();
 
   useHeaderSecondLevel({ title: "", goBack: dismissDialog.show });
 


### PR DESCRIPTION
## Short description
This PR removes gesture navigation in IT Wallet credential issuance screens, which was causing desync between xstate machine and navigation state

## List of changes proposed in this pull request
- Added `useItwDisbleGestureNavigation`
- Disabled gesture navigation in `ItwIssuanceCredentialPreviewScreen` and `ItwIssuanceCredentialTrustIssuerScreen` components

## How to test
Start the mDL issuance, check that you can't navigate back by using gestures
