### PR TITLE
chore(IT Wallet): [SIW-1408] Add more info about failure in credential issuance failure screen

### DIFF
--- a/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialFailureScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialFailureScreen.tsx
@@ -1,6 +1,7 @@
 import { Alert } from "@pagopa/io-app-design-system";
 import { constNull, pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
+import * as E from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import React from "react";
 import {
@@ -76,13 +77,11 @@ const ErrorAlertDebugOnly = ({ failure }: ContentViewProps) => {
     return null;
   }
 
-  const renderErrorText = () =>
-    pipe(
-      failure.reason instanceof Error ? failure.reason.message : failure.reason,
-      t.string.decode,
-      O.fromEither,
-      O.getOrElse(() => "Unknown error")
-    );
+  const errorText = pipe(
+    failure.reason instanceof Error ? failure.reason.message : failure.reason,
+    t.string.decode,
+    E.getOrElse(() => "Unknown error")
+  );
 
-  return <Alert variant="error" content={renderErrorText()} />;
+  return <Alert variant="error" content={errorText} />;
 };

--- a/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialFailureScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialFailureScreen.tsx
@@ -1,17 +1,23 @@
-import * as O from "fp-ts/lib/Option";
+import { Alert } from "@pagopa/io-app-design-system";
 import { constNull, pipe } from "fp-ts/lib/function";
+import * as O from "fp-ts/lib/Option";
+import * as t from "io-ts";
 import React from "react";
 import {
   OperationResultScreenContent,
   OperationResultScreenContentProps
 } from "../../../../components/screens/OperationResultScreenContent";
 import I18n from "../../../../i18n";
+import { useIOSelector } from "../../../../store/hooks";
+import { isDebugModeEnabledSelector } from "../../../../store/reducers/debug";
 import {
+  CredentialIssuanceFailure,
   CredentialIssuanceFailureType,
   CredentialIssuanceFailureTypeEnum
 } from "../../machine/credential/failure";
 import { selectFailureOption } from "../../machine/credential/selectors";
 import { ItwCredentialIssuanceMachineContext } from "../../machine/provider";
+import { DebugPrettyPrint } from "../../../../components/DebugPrettyPrint";
 
 export const ItwIssuanceCredentialFailureScreen = () => {
   const failureOption =
@@ -19,13 +25,12 @@ export const ItwIssuanceCredentialFailureScreen = () => {
 
   return pipe(
     failureOption,
-    O.map(failure => failure.type),
-    O.alt(() => O.some(CredentialIssuanceFailureTypeEnum.GENERIC)),
+    O.alt(() => O.some({ type: CredentialIssuanceFailureTypeEnum.GENERIC })),
     O.fold(constNull, type => <ContentView failure={type} />)
   );
 };
 
-type ContentViewProps = { failure: CredentialIssuanceFailureType };
+type ContentViewProps = { failure: CredentialIssuanceFailure };
 
 /**
  * Renders the content of the screen
@@ -57,6 +62,34 @@ const ContentView = ({ failure }: ContentViewProps) => {
     }
   };
 
-  const resultScreenProps = resultScreensMap[failure];
-  return <OperationResultScreenContent {...resultScreenProps} />;
+  const resultScreenProps = resultScreensMap[failure.type];
+  return (
+    <OperationResultScreenContent {...resultScreenProps}>
+      <ErrorAlertDebugOnly failure={failure} />
+    </OperationResultScreenContent>
+  );
+};
+
+const ErrorAlertDebugOnly = ({
+  failure
+}: {
+  failure: CredentialIssuanceFailure;
+}) => {
+  const isDebug = useIOSelector(isDebugModeEnabledSelector);
+
+  if (!isDebug) {
+    return null;
+  }
+
+  const renderErrorText = () =>
+    pipe(
+      failure.reason instanceof Error ? failure.reason.message : failure.reason,
+      t.string.decode,
+      O.fromEither,
+      O.getOrElse(() => "Unknown error")
+    );
+
+  return <DebugPrettyPrint />;
+
+  return <Alert variant="error" content={renderErrorText()} />;
 };

--- a/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialFailureScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialFailureScreen.tsx
@@ -17,7 +17,6 @@ import {
 } from "../../machine/credential/failure";
 import { selectFailureOption } from "../../machine/credential/selectors";
 import { ItwCredentialIssuanceMachineContext } from "../../machine/provider";
-import { DebugPrettyPrint } from "../../../../components/DebugPrettyPrint";
 
 export const ItwIssuanceCredentialFailureScreen = () => {
   const failureOption =
@@ -70,11 +69,7 @@ const ContentView = ({ failure }: ContentViewProps) => {
   );
 };
 
-const ErrorAlertDebugOnly = ({
-  failure
-}: {
-  failure: CredentialIssuanceFailure;
-}) => {
+const ErrorAlertDebugOnly = ({ failure }: ContentViewProps) => {
   const isDebug = useIOSelector(isDebugModeEnabledSelector);
 
   if (!isDebug) {
@@ -88,8 +83,6 @@ const ErrorAlertDebugOnly = ({
       O.fromEither,
       O.getOrElse(() => "Unknown error")
     );
-
-  return <DebugPrettyPrint />;
 
   return <Alert variant="error" content={renderErrorText()} />;
 };


### PR DESCRIPTION
## Short description
This PR adds more info about failure in credential issuance failure screen when debug mode is enabled

## List of changes proposed in this pull request
- Added `Alert` with failure reason in `ItwIssuanceCredentialFailureScreen`

## How to test
Start the **mDL** issuance flow with debug mode active, if a failure happens you should be able to see an Alert with the reason of the failure.
