### PR TITLE
chore(IT Wallet): [SIW-1378] Remove image claim decoding without URL schema

### DIFF
--- a/ts/features/itwallet/common/components/ItwCredentialClaim.tsx
+++ b/ts/features/itwallet/common/components/ItwCredentialClaim.tsx
@@ -14,7 +14,6 @@ import {
   EvidenceClaim,
   FiscalCodeClaim,
   ImageClaim,
-  ImageClaimNoUrl,
   PlaceOfBirthClaim,
   PlaceOfBirthClaimType,
   PlainTextClaim,
@@ -29,8 +28,6 @@ import { useIOBottomSheetAutoresizableModal } from "../../../../utils/hooks/bott
 import { getExpireStatus } from "../../../../utils/dates";
 
 const HIDDEN_CLAIM = "******";
-
-const base64Url = "data:image/png;base64,";
 
 /**
  * Component which renders a place of birth type claim.
@@ -331,10 +328,6 @@ export const ItwCredentialClaim = ({
           );
         } else if (ImageClaim.is(decoded)) {
           return <ImageClaimItem label={claim.label} claim={decoded} />;
-        } else if (ImageClaimNoUrl.is(decoded)) {
-          // TODO [SIW-1378] remove this branch when the image claim is always with url
-          const fixedImage = base64Url.concat(decoded);
-          return <ImageClaimItem label={claim.label} claim={fixedImage} />;
         } else if (DrivingPrivilegesClaim.is(decoded)) {
           return decoded.map((elem, index) => (
             <DrivingPrivilegesClaimItem

--- a/ts/features/itwallet/common/utils/__tests__/itwClaimsUtils.test.ts
+++ b/ts/features/itwallet/common/utils/__tests__/itwClaimsUtils.test.ts
@@ -165,16 +165,8 @@ describe("ImageClaim", () => {
     const decoded = ImageClaim.decode("data:image/bmp;base64,${base64}");
     expect(E.isRight(decoded)).toBe(true);
   });
-  it("should decode a valid gif image", () => {
+  it("should decode an unsupported image", () => {
     const decoded = ImageClaim.decode("data:image/gif;base64,${base64}");
-    expect(E.isRight(decoded)).toBe(true);
-  });
-  it("should decode a valid webp image", () => {
-    const decoded = ImageClaim.decode("data:image/webp;base64,${base64}");
-    expect(E.isRight(decoded)).toBe(true);
-  });
-  it("should not decode an unsupported image", () => {
-    const decoded = ImageClaim.decode("data:image/psd;base64,${base64}");
     expect(E.isLeft(decoded)).toBe(true);
   });
 });

--- a/ts/features/itwallet/common/utils/__tests__/itwClaimsUtils.test.ts
+++ b/ts/features/itwallet/common/utils/__tests__/itwClaimsUtils.test.ts
@@ -1,11 +1,13 @@
 import MockDate from "mockdate";
 import { format } from "date-fns";
 import * as O from "fp-ts/lib/Option";
+import * as E from "fp-ts/lib/Either";
 import {
   extractFiscalCode,
   getCredentialExpireDate,
   getCredentialExpireDays,
-  getCredentialExpireStatus
+  getCredentialExpireStatus,
+  ImageClaim
 } from "../itwClaimsUtils";
 
 describe("getCredentialExpireDate", () => {
@@ -141,5 +143,38 @@ describe("extractFiscalCode", () => {
 
   it("returns none when the string does not contain any fiscal code", () => {
     expect(extractFiscalCode("RANDOM_STRING_MRARS001H1B")).toEqual(O.none);
+  });
+});
+
+describe("ImageClaim", () => {
+  const base64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAEElEQVR4nGKKrzEGBAAA//8CVAERMRFlewAAAABJRU5ErkJggg==";
+  it("should decode a valid png image", () => {
+    const decoded = ImageClaim.decode(`data:image/png;base64,${base64}`);
+    expect(E.isRight(decoded)).toBe(true);
+  });
+  it("should decode a valid jpg image", () => {
+    const decoded = ImageClaim.decode("data:image/jpg;base64,${base64}");
+    expect(E.isRight(decoded)).toBe(true);
+  });
+  it("should decode a valid jpeg image", () => {
+    const decoded = ImageClaim.decode("data:image/jpeg;base64,${base64}");
+    expect(E.isRight(decoded)).toBe(true);
+  });
+  it("should decode a valid bmp image", () => {
+    const decoded = ImageClaim.decode("data:image/bmp;base64,${base64}");
+    expect(E.isRight(decoded)).toBe(true);
+  });
+  it("should decode a valid gif image", () => {
+    const decoded = ImageClaim.decode("data:image/gif;base64,${base64}");
+    expect(E.isRight(decoded)).toBe(true);
+  });
+  it("should decode a valid webp image", () => {
+    const decoded = ImageClaim.decode("data:image/webp;base64,${base64}");
+    expect(E.isRight(decoded)).toBe(true);
+  });
+  it("should not decode an unsupported image", () => {
+    const decoded = ImageClaim.decode("data:image/psd;base64,${base64}");
+    expect(E.isLeft(decoded)).toBe(true);
   });
 });

--- a/ts/features/itwallet/common/utils/__tests__/itwClaimsUtils.test.ts
+++ b/ts/features/itwallet/common/utils/__tests__/itwClaimsUtils.test.ts
@@ -154,19 +154,19 @@ describe("ImageClaim", () => {
     expect(E.isRight(decoded)).toBe(true);
   });
   it("should decode a valid jpg image", () => {
-    const decoded = ImageClaim.decode("data:image/jpg;base64,${base64}");
+    const decoded = ImageClaim.decode(`data:image/jpg;base64,${base64}`);
     expect(E.isRight(decoded)).toBe(true);
   });
   it("should decode a valid jpeg image", () => {
-    const decoded = ImageClaim.decode("data:image/jpeg;base64,${base64}");
+    const decoded = ImageClaim.decode(`data:image/jpeg;base64,${base64}`);
     expect(E.isRight(decoded)).toBe(true);
   });
   it("should decode a valid bmp image", () => {
-    const decoded = ImageClaim.decode("data:image/bmp;base64,${base64}");
+    const decoded = ImageClaim.decode(`data:image/bmp;base64,${base64}`);
     expect(E.isRight(decoded)).toBe(true);
   });
   it("should decode an unsupported image", () => {
-    const decoded = ImageClaim.decode("data:image/gif;base64,${base64}");
+    const decoded = ImageClaim.decode(`data:image/gif;base64,${base64}`);
     expect(E.isLeft(decoded)).toBe(true);
   });
 });

--- a/ts/features/itwallet/common/utils/itwClaimsUtils.ts
+++ b/ts/features/itwallet/common/utils/itwClaimsUtils.ts
@@ -162,7 +162,7 @@ const DATE_FORMAT_REGEX = "^\\d{4}-\\d{2}-\\d{2}$";
 /**
  * Regex for the picture URL format which is used to validate the image claim as a base64 encoded png image.
  */
-const PICTURE_URL_REGEX = "^data:image\\/(png|jpg|jpeg|bmp|gif|webp);base64,";
+const PICTURE_URL_REGEX = "^data:image\\/(png|jpg|jpeg|bmp);base64,";
 
 const FISCAL_CODE_WITH_PREFIX =
   "(TINIT-[A-Z]{6}[0-9LMNPQRSTUV]{2}[ABCDEHLMPRST][0-9LMNPQRSTUV]{2}[A-Z][0-9LMNPQRSTUV]{3}[A-Z])";

--- a/ts/features/itwallet/common/utils/itwClaimsUtils.ts
+++ b/ts/features/itwallet/common/utils/itwClaimsUtils.ts
@@ -162,15 +162,7 @@ const DATE_FORMAT_REGEX = "^\\d{4}-\\d{2}-\\d{2}$";
 /**
  * Regex for the picture URL format which is used to validate the image claim as a base64 encoded png image.
  */
-const PICTURE_URL_REGEX = "^data:image\\/png;base64,";
-
-/**
- * Regex for the picture without URL format which is used to validate the image claim as a base64 encoded png image.
- * This is needed until the issuer adds the URL to the image claim.
- * TODO [SIW-1378]: remove this regex when the issuer adds the URL schema to the image claim.
- */
-const PICTURE_WITHOUT_URL_REGEX =
-  "(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)";
+const PICTURE_URL_REGEX = "^data:image\\/(png|jpg|jpeg|bmp|gif|webp);base64,";
 
 const FISCAL_CODE_WITH_PREFIX =
   "(TINIT-[A-Z]{6}[0-9LMNPQRSTUV]{2}[ABCDEHLMPRST][0-9LMNPQRSTUV]{2}[A-Z][0-9LMNPQRSTUV]{3}[A-Z])";
@@ -241,9 +233,6 @@ export const PlainTextClaim = t.string;
 
 export const ImageClaim = PatternString(PICTURE_URL_REGEX);
 
-// TODO [SIW-1378]: remove this decoder when the issuer adds the URL schema to the image claim.
-export const ImageClaimNoUrl = PatternString(PICTURE_WITHOUT_URL_REGEX);
-
 /**
  * Decoder type for the claim field of the credential.
  * It includes all the possible types of claims and fallbacks to string.
@@ -261,8 +250,6 @@ export const ClaimValue = t.union([
   DateClaim,
   // Otherwise parse an image
   ImageClaim,
-  // Otherwise parse an image without URL
-  ImageClaimNoUrl,
   // Otherwise parse a fiscal code
   FiscalCodeClaim,
   // Otherwise fallback to string

--- a/ts/features/itwallet/issuance/components/ItwRequiredClaimsList.tsx
+++ b/ts/features/itwallet/issuance/components/ItwRequiredClaimsList.tsx
@@ -22,7 +22,6 @@ import {
   extractFiscalCode,
   FiscalCodeClaim,
   ImageClaim,
-  ImageClaimNoUrl,
   PlaceOfBirthClaim,
   PlainTextClaim
 } from "../../common/utils/itwClaimsUtils";
@@ -96,7 +95,7 @@ export const getClaimDisplayValue = (
           );
         } else if (EvidenceClaim.is(decoded)) {
           return decoded[0].record.source.organization_name;
-        } else if (ImageClaim.is(decoded) || ImageClaimNoUrl.is(decoded)) {
+        } else if (ImageClaim.is(decoded)) {
           return decoded;
         } else if (DrivingPrivilegesClaim.is(decoded)) {
           return decoded.map(e => e.driving_privilege);


### PR DESCRIPTION
## Short description
This PR removes the workaround for decoding image claims that lack a proper URL schema. It also adds support for multiple types of images according to the mapped [Image](https://reactnative.dev/docs/image#source) component. 
`gif`, `webp`, `psd` are not included because they are either platform specific (`psd`) or require additional setup (`gif` and `webp` on Android).

## List of changes proposed in this pull request
- Remove the `ImageClaimNoUrl` decoder and its usage; 
- Add supports for multiple image formats (`png`, `jpg`, `jpeg`, `bmp`);
- Add tests for the `ImageClaim` decoder.

## How to test
Static tests and check if the image claim is rendered properly after the issuer adds the URL schema.
