### PR TITLE
fix(Cross): [IOAPPX-363] Discard activity state persistence in Android

### DIFF
--- a/android/app/src/main/java/it/pagopa/io/app/MainActivity.java
+++ b/android/app/src/main/java/it/pagopa/io/app/MainActivity.java
@@ -28,7 +28,9 @@ public class MainActivity extends ReactActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         SplashScreen.show(this, R.style.SplashScreenTheme);
-        super.onCreate(savedInstanceState);
+        // This is needed for react-native-screens to solve the issue described here:
+        // https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704633
+        super.onCreate(null);
         // Fix the problem described here:
         // https://stackoverflow.com/questions/48072438/java-lang-illegalstateexception-only-fullscreen-opaque-activities-can-request-o
         if (android.os.Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {


### PR DESCRIPTION
## Short description
> On Android the View state is not persisted consistently across Activity restarts, which can lead to crashes in those cases. It is recommended to override the native Android method called on Activity restarts in your main Activity, to avoid these crashes. 
[Source](https://github.com/software-mansion/react-native-screens?tab=readme-ov-file#android)

## List of changes proposed in this pull request
- Replace `savedInstanceState` with `null` in `MainActivity.java` to discard any persisted Activity state during the restart process. This should resolve the crashes we are observing in production.
 
## How to test
```
> cd android && ./gradlew clean && cd .. 
> yarn react-native run-android
```
Test that the build works and that there's no regression in the app when restarting it or when swapping between recent apps.
