### PR TITLE
fix(Cross): [IOAPPX-361] Runtime crash on Android devices without custom tabs support 

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -104,7 +104,7 @@ PODS:
     - JOSESwift (~> 2.3)
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - pagopa-io-react-native-login-utils (1.0.1):
+  - pagopa-io-react-native-login-utils (1.0.4):
     - React-Core
   - pagopa-react-native-zendesk (0.3.29):
     - RCT-Folly (= 2021.07.22.00)
@@ -1015,7 +1015,7 @@ SPEC CHECKSUMS:
   pagopa-io-react-native-http-client: cbdfb83c92432efb0de22b7c3c85cffa391870f8
   pagopa-io-react-native-integrity: ca77804cefb1cd75d04053652472bcb938ce4b18
   pagopa-io-react-native-jwt: 662d4e722715996758b079774abea1996b057467
-  pagopa-io-react-native-login-utils: 9fb43fd59dcc864a24343209e74bd7429659456a
+  pagopa-io-react-native-login-utils: 5e34d0d51cc56f480747dd3aa1eb5563d294e815
   pagopa-react-native-zendesk: 60a26f8a8072234789c34bb7c8a769c156eb57dc
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 264adaca1d8b1a9c078761891898d4142df05313

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@pagopa/io-react-native-http-client": "1.0.5",
     "@pagopa/io-react-native-integrity": "^0.3.0",
     "@pagopa/io-react-native-jwt": "^1.2.0",
-    "@pagopa/io-react-native-login-utils": "^1.0.1",
+    "@pagopa/io-react-native-login-utils": "^1.0.4",
     "@pagopa/io-react-native-wallet": "^0.15.4",
     "@pagopa/io-react-native-zendesk": "^0.3.29",
     "@pagopa/react-native-cie": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2100,10 +2100,10 @@
     abab "^2.0.6"
     zod "^3.22.4"
 
-"@pagopa/io-react-native-login-utils@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-login-utils/-/io-react-native-login-utils-1.0.1.tgz#cf6bb709f1613419486b7453a15ba63f0e2784ac"
-  integrity sha512-tea892roPm42NQIeTCw4WRSVtfuCkr/i+ussj03PttM3BFdCi6y2Kvg1HITxXcDukLza3b+kENzQFRuKRKhPAQ==
+"@pagopa/io-react-native-login-utils@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-login-utils/-/io-react-native-login-utils-1.0.4.tgz#e37932ef9c17a6fb0871aba43f9c3729b34fd893"
+  integrity sha512-b/1hCKV65mHbHklq1dv8yGuJ2NGfqh0gaqbFKeL1epVmXA9gOfz/O3visjQeXMBO2ArXbDZOalBWvUE+8dWBZw==
 
 "@pagopa/io-react-native-wallet@^0.15.4":
   version "0.15.4"


### PR DESCRIPTION
## Short description
This PR fixes a runtime crash that occurs on Android devices lacking a browser that supports custom tabs when using `io-react-native-login-utils`. Refer to the details of this [PR](https://github.com/pagopa/io-react-native-login-utils/pull/15) for more information.

## List of changes proposed in this pull request
- Update `io-react-native-login-utils` to v1.0.4.

## How to test
- Disable any browser on the Android device;
- Add a payment method or test a payment flow. An error should be shown but the app shouldn't crash. 