### PR TITLE
[IOPID-2051] Add logic to refresh session after 2 minutes of foreground

### DIFF
--- a/locales/de/index.yml
+++ b/locales/de/index.yml
@@ -327,7 +327,6 @@ profile:
       description: "Deine Rechte und Pflichten bei der Nutzung der IO-App"
       loading: "Warte ein paar Sekunden, wir überprüfen dein Profil..."
       removeAccount:
-        title: "Dein Konto löschen"
         error: "Bei der Anfrage zur Kontolöschung ist ein Fehler aufgetreten. Bitte versuche es erneut."
         alert:
           cta:

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -341,7 +341,7 @@ profile:
       subtitle: Qui trovi informazioni sui tuoi diritti e obblighi e sul trattamento dei dati personali.
       loading: Attendi qualche secondo, stiamo verificando il tuo profilo...
       removeAccount:
-        title: Elimina il tuo account
+        title: Elimina il tuo profilo
         description: Elimina il tuo profilo e i tuoi dati personali
         error: Si è verificato un errore nella richiesta di rimozione dell'account, riprova.
         alert:

--- a/ts/sagas/startup/watchApplicationActivitySaga.ts
+++ b/ts/sagas/startup/watchApplicationActivitySaga.ts
@@ -1,16 +1,28 @@
 import { AppStateStatus } from "react-native";
-import { call, fork, put, select, takeLatest } from "typed-redux-saga/macro";
+import {
+  call,
+  fork,
+  put,
+  select,
+  take,
+  takeLatest
+} from "typed-redux-saga/macro";
 import { ActionType, getType } from "typesafe-actions";
 import { backgroundActivityTimeout } from "../../config";
 import NavigationService from "../../navigation/NavigationService";
 import { applicationChangeState } from "../../store/actions/application";
-import { identificationRequest } from "../../store/actions/identification";
+import {
+  identificationRequest,
+  identificationSuccess
+} from "../../store/actions/identification";
 import { ReduxSagaEffect } from "../../types/utils";
 import {
   StartupStatusEnum,
   isStartupLoaded
 } from "../../store/reducers/startup";
 import { handlePendingMessageStateIfAllowedSaga } from "../../features/pushNotifications/sagas/notifications";
+import { isAutomaticSessionRefreshEnabledSelector } from "../../features/fastLogin/store/selectors";
+import { refreshSessionToken } from "../../features/fastLogin/store/actions/tokenRefreshActions";
 
 /**
  * Listen to APP_STATE_CHANGE_ACTION and:
@@ -84,9 +96,26 @@ export function* watchApplicationActivitySaga(): IterableIterator<ReduxSagaEffec
             timestamp: Date.now()
           };
 
+          const isAutomaticSessionRefreshEnabled = yield* select(
+            isAutomaticSessionRefreshEnabledSelector
+          );
+
           if (timeSinceLastStateChange >= backgroundActivityTimeoutMillis) {
             // The app was in background for a long time, request identification
             yield* put(identificationRequest());
+            // if the session refresh feature is active,
+            if (isAutomaticSessionRefreshEnabled) {
+              // after successful identification,
+              yield* take(identificationSuccess);
+              // the regeneration of the session token will be performed.
+              yield* put(
+                refreshSessionToken.request({
+                  withUserInteraction: false,
+                  showIdentificationModalAtStartup: false,
+                  showLoader: true
+                })
+              );
+            }
           }
         }
       }

--- a/ts/screens/profile/DeveloperModeSection.tsx
+++ b/ts/screens/profile/DeveloperModeSection.tsx
@@ -23,7 +23,6 @@ import { AlertModal } from "../../components/ui/AlertModal";
 import { LightModalContext } from "../../components/ui/LightModal";
 import { isPlaygroundsEnabled } from "../../config";
 import {
-  automaticSessionRefreshFFEnabled,
   isAutomaticSessionRefreshToggleActiveSelector,
   isFastLoginEnabledSelector
 } from "../../features/fastLogin/store/selectors";
@@ -308,10 +307,6 @@ const DesignSystemSection = () => {
     isNewScanSectionLocallyEnabledSelector
   );
 
-  const isAutomaticSessionRefreshRemoteFFActive = useIOSelector(
-    automaticSessionRefreshFFEnabled
-  );
-
   const isAutomaticSessionRefreshToggleActive = useIOSelector(
     isAutomaticSessionRefreshToggleActiveSelector
   );
@@ -360,18 +355,11 @@ const DesignSystemSection = () => {
         value={isNewScanSectionLocallyEnabled}
         onSwitchValueChange={onNewScanSectionToggle}
       />
-      {/* this control isAutomaticSessionRefreshRemoteFFActive is a
-      workaround to hide this toogle before this task
-      (https://pagopa.atlassian.net/browse/IOPID-2051)
-      is completed because otherwise nothing would be activated using this toggle
-       */}
-      {isAutomaticSessionRefreshRemoteFFActive && (
-        <ListItemSwitch
-          label={I18n.t("profile.main.sessionRefresh")}
-          value={isAutomaticSessionRefreshToggleActive}
-          onSwitchValueChange={dispatchAutomaticSessionRefresh}
-        />
-      )}
+      <ListItemSwitch
+        label={I18n.t("profile.main.sessionRefresh")}
+        value={isAutomaticSessionRefreshToggleActive}
+        onSwitchValueChange={dispatchAutomaticSessionRefresh}
+      />
     </ContentWrapper>
   );
 };


### PR DESCRIPTION
## List of changes proposed in this pull request
- Add logic to refresh session token after 2 minutes of foreground
- Edit some copy 
- Delete logic to hide switch to enabled/disabled the feature of session refresh 

## Demo 
<p>

| Flow with dev-server | Flow in production |
| - | - |
| WIP | WIP |

</p>


## How to test
Run the application and put the application in the background for at least 2 minutes. When you put it back in foreground the application will be shown the screen to identify you and the token will be refreshed