### PR TITLE
FIMS verbose debug errorScreen

### DIFF
--- a/ts/features/fims/singleSignOn/saga/handleFimsGetRedirectUrlAndOpenIAB.ts
+++ b/ts/features/fims/singleSignOn/saga/handleFimsGetRedirectUrlAndOpenIAB.ts
@@ -45,9 +45,13 @@ export function* handleFimsGetRedirectUrlAndOpenIAB(
 ) {
   const oidcProviderDomain = yield* select(fimsDomainSelector);
   if (!oidcProviderDomain) {
-    logToMixPanel(`missing FIMS, domain is ${oidcProviderDomain}`);
+    const debugMessage = `missing FIMS, domain is ${oidcProviderDomain}`;
+    logToMixPanel(debugMessage);
     yield* put(
-      fimsGetRedirectUrlAndOpenIABAction.failure("missing FIMS domain")
+      fimsGetRedirectUrlAndOpenIABAction.failure({
+        standardMessage: "missing FIMS domain",
+        debugMessage
+      })
     );
     return;
   }
@@ -55,13 +59,13 @@ export function* handleFimsGetRedirectUrlAndOpenIAB(
 
   const acceptUrl = buildAbsoluteUrl(maybeAcceptUrl ?? "", oidcProviderDomain);
   if (!acceptUrl) {
-    logToMixPanel(
-      `unable to accept grants, could not buld url. obtained URL: ${maybeAcceptUrl}`
-    );
+    const debugMessage = `unable to accept grants, could not buld url. obtained URL: ${maybeAcceptUrl}`;
+    logToMixPanel(debugMessage);
     yield* put(
-      fimsGetRedirectUrlAndOpenIABAction.failure(
-        "unable to accept grants: invalid URL"
-      )
+      fimsGetRedirectUrlAndOpenIABAction.failure({
+        standardMessage: "unable to accept grants: invalid URL",
+        debugMessage
+      })
     );
     return;
   }
@@ -81,15 +85,15 @@ export function* handleFimsGetRedirectUrlAndOpenIAB(
       yield* call(deallocateFimsAndRenewFastLoginSession);
       return;
     }
-    logToMixPanel(
-      `could not get RelyingParty redirect URL, ${formatHttpClientResponseForMixPanel(
-        rpRedirectResponse
-      )}`
-    );
+    const debugMessage = `could not get RelyingParty redirect URL, ${formatHttpClientResponseForMixPanel(
+      rpRedirectResponse
+    )}`;
+    logToMixPanel(debugMessage);
     yield* put(
-      fimsGetRedirectUrlAndOpenIABAction.failure(
-        "could not get RelyingParty redirect URL"
-      )
+      fimsGetRedirectUrlAndOpenIABAction.failure({
+        standardMessage: "could not get RelyingParty redirect URL",
+        debugMessage
+      })
     );
     return;
   }
@@ -114,18 +118,18 @@ export function* handleFimsGetRedirectUrlAndOpenIAB(
   );
 
   if (!inAppBrowserRedirectUrl) {
-    logToMixPanel(
-      `IAB url call failed or without a valid redirect, code: ${
-        inAppBrowserUrlResponse.type === "failure"
-          ? // eslint-disable-next-line sonarjs/no-nested-template-literals
-            `${inAppBrowserUrlResponse.code}, message: ${inAppBrowserUrlResponse.message}`
-          : inAppBrowserUrlResponse.status
-      }`
-    );
+    const debugMessage = `IAB url call failed or without a valid redirect, code: ${
+      inAppBrowserUrlResponse.type === "failure"
+        ? // eslint-disable-next-line sonarjs/no-nested-template-literals
+          `${inAppBrowserUrlResponse.code}, message: ${inAppBrowserUrlResponse.message}`
+        : inAppBrowserUrlResponse.status
+    }`;
+    logToMixPanel(debugMessage);
     yield* put(
-      fimsGetRedirectUrlAndOpenIABAction.failure(
-        "IAB url call failed or without a valid redirect"
-      )
+      fimsGetRedirectUrlAndOpenIABAction.failure({
+        standardMessage: "IAB url call failed or without a valid redirect",
+        debugMessage
+      })
     );
     return;
   }
@@ -219,13 +223,14 @@ function* postToRelyingPartyWithImplicitCodeFlow(
   );
   if (E.isLeft(formPostDataEither)) {
     const errorMessage = formPostDataEither.left;
-    logToMixPanel(
-      `Form extraction from HTML page failed, implicit code flow: ${errorMessage}`
-    );
+    const debugMessage = `Form extraction from HTML page failed, implicit code flow: ${errorMessage}`;
+    logToMixPanel(debugMessage);
     yield* put(
-      fimsGetRedirectUrlAndOpenIABAction.failure(
-        "Could not process redirection page, Implicit code flow"
-      )
+      fimsGetRedirectUrlAndOpenIABAction.failure({
+        standardMessage:
+          "Could notprocess redirection page, Implicit code flow",
+        debugMessage
+      })
     );
     return undefined;
   }
@@ -242,13 +247,14 @@ function* postToRelyingPartyWithImplicitCodeFlow(
   );
   if (E.isLeft(lollipopSignatureEither)) {
     const errorMessage = lollipopSignatureEither.left;
-    logToMixPanel(
-      `Could not sign request with LolliPoP, Implicit code flow: ${errorMessage}`
-    );
+    const debugMessage = `Could not sign request with LolliPoP, Implicit code flow: ${errorMessage}`;
+    logToMixPanel(debugMessage);
     yield* put(
-      fimsGetRedirectUrlAndOpenIABAction.failure(
-        "could not sign request with LolliPoP, Implicit code flow"
-      )
+      fimsGetRedirectUrlAndOpenIABAction.failure({
+        standardMessage:
+          "could not sign request with LolliPoP, Implicit code flow",
+        debugMessage
+      })
     );
     return undefined;
   }
@@ -279,13 +285,14 @@ function* redirectToRelyingPartyWithAuthorizationCodeFlow(
 ): Generator<ReduxSagaEffect, RelyingPartyOutput | undefined, any> {
   const relyingPartyRedirectUrl = rpRedirectResponse.headers.location;
   if (!relyingPartyRedirectUrl || relyingPartyRedirectUrl.trim().length === 0) {
-    logToMixPanel(
-      `could not find valid Location header for Relying Party redirect url, authorization code flow: ${!!relyingPartyRedirectUrl}`
-    );
+    const debugMessage = `could not find valid Location header for Relying Party redirect url, authorization code flow: ${!!relyingPartyRedirectUrl}`;
+    logToMixPanel(debugMessage);
     yield* put(
-      fimsGetRedirectUrlAndOpenIABAction.failure(
-        "Could not find valid Location header, Authorization code flow"
-      )
+      fimsGetRedirectUrlAndOpenIABAction.failure({
+        standardMessage:
+          "Could not find valid Location header, Authorization code flow",
+        debugMessage
+      })
     );
     return undefined;
   }
@@ -295,13 +302,13 @@ function* redirectToRelyingPartyWithAuthorizationCodeFlow(
   );
   const state = lollipopParamsMap?.get("state");
   if (!lollipopParamsMap || !state) {
-    logToMixPanel(
-      `could not extract lollipop params or state from RelyingParty URL, params: ${!!lollipopParamsMap}, state: ${!!state}`
-    );
+    const debugMessage = `could not extract lollipop params or state from RelyingParty URL, params: ${!!lollipopParamsMap}, state: ${!!state}`;
+    logToMixPanel(debugMessage);
     yield* put(
-      fimsGetRedirectUrlAndOpenIABAction.failure(
-        "could not extract data from RelyingParty URL"
-      )
+      fimsGetRedirectUrlAndOpenIABAction.failure({
+        standardMessage: "could not extract data from RelyingParty URL",
+        debugMessage
+      })
     );
     return undefined;
   }
@@ -314,13 +321,14 @@ function* redirectToRelyingPartyWithAuthorizationCodeFlow(
   );
   if (E.isLeft(lollipopSignatureEither)) {
     const errorMessage = lollipopSignatureEither.left;
-    logToMixPanel(
-      `Could not sign request with LolliPoP, Authorization code flow: ${errorMessage}`
-    );
+    const debugMessage = `Could not sign request with LolliPoP, Authorization code flow: ${errorMessage}`;
+    logToMixPanel(debugMessage);
     yield* put(
-      fimsGetRedirectUrlAndOpenIABAction.failure(
-        "could not sign request with LolliPoP, Authorization code flow"
-      )
+      fimsGetRedirectUrlAndOpenIABAction.failure({
+        standardMessage:
+          "could not sign request with LolliPoP, Authorization code flow",
+        debugMessage
+      })
     );
     return undefined;
   }

--- a/ts/features/fims/singleSignOn/store/actions/index.ts
+++ b/ts/features/fims/singleSignOn/store/actions/index.ts
@@ -4,6 +4,7 @@ import {
   createStandardAction
 } from "typesafe-actions";
 import { ConsentData } from "../../types";
+import { FimsErrorStateType } from "../reducers";
 
 type FimsGetConsentsListRequestType = {
   ctaUrl: string;
@@ -17,14 +18,14 @@ export const fimsGetConsentsListAction = createAsyncAction(
   "FIMS_GET_CONSENTS_LIST_REQUEST",
   "FIMS_GET_CONSENTS_LIST_SUCCESS",
   "FIMS_GET_CONSENTS_LIST_FAILURE"
-)<FimsGetConsentsListRequestType, ConsentData, string>();
+)<FimsGetConsentsListRequestType, ConsentData, FimsErrorStateType>();
 
 // note: IAB==InAppBrowser
 export const fimsGetRedirectUrlAndOpenIABAction = createAsyncAction(
   "FIMS_GET_REDIRECT_URL_REQUEST",
   "FIMS_GET_REDIRECT_URL_SUCCESS",
   "FIMS_GET_REDIRECT_URL_FAILURE"
-)<FimsGetRedirectUrlAndOpenIABRequestType, void, string>();
+)<FimsGetRedirectUrlAndOpenIABRequestType, void, FimsErrorStateType>();
 
 export const fimsCancelOrAbortAction = createStandardAction(
   "FIMS_CANCEL_OR_ABORT"

--- a/ts/features/fims/singleSignOn/store/reducers/index.ts
+++ b/ts/features/fims/singleSignOn/store/reducers/index.ts
@@ -20,9 +20,14 @@ export type FimsFlowStateTags =
   | "abort"
   | "fastLogin_forced_restart";
 
+export type FimsErrorStateType = {
+  standardMessage: string;
+  debugMessage: string;
+};
+
 export type FimsSSOState = {
   currentFlowState: FimsFlowStateTags;
-  consentsData: pot.Pot<ConsentData, string>; // string -> errMessage
+  consentsData: pot.Pot<ConsentData, FimsErrorStateType>;
   relyingPartyUrl?: string;
 };
 


### PR DESCRIPTION
## Short description
Addition of debug-only verbose FIMS error logging, in order to ease development by third parties

![image](https://github.com/user-attachments/assets/921f9d33-1e5e-4871-ae43-8d2b16cd28d8)|![image](https://github.com/user-attachments/assets/887f2fd5-b8ac-4919-82e4-1d5ebd9e1f60)

## List of changes proposed in this pull request
- updated saga to return the debug message as well as the standard one
- updated fims errorState selector to return the correct message depending on the state of the debug mode

## How to test
using the dev-server, set ` consentsEndpointFailureStatusCode` to  any error status code, and check that with both the debug mode enabled and not, the screen behaves as expected