### PR TITLE
[IOPLT-639] Handle the new status messages on redux selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.67.0-rc.3",
   "io_backend_api": "https://raw.githubusercontent.com/pagopa/io-backend/v13.39.1-RELEASE/api_backend.yaml",
   "io_public_api": "https://raw.githubusercontent.com/pagopa/io-backend/v13.39.1-RELEASE/api_public.yaml",
-  "io_content_specs": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.36/definitions.yml",
+  "io_content_specs": "https://raw.githubusercontent.com/pagopa/io-services-metadata/IOPLT-638-status-alert-new-payload/definitions.yml",
   "io_cgn_specs": "https://raw.githubusercontent.com/pagopa/io-backend/v13.39.1-RELEASE/api_cgn.yaml",
   "io_cgn_merchants_specs": "https://raw.githubusercontent.com/pagopa/io-backend/v13.39.1-RELEASE/api_cgn_operator_search.yaml",
   "api_fci": "https://raw.githubusercontent.com/pagopa/io-backend/v13.39.1-RELEASE/api_io_sign.yaml",

--- a/ts/store/reducers/backendStatus.ts
+++ b/ts/store/reducers/backendStatus.ts
@@ -30,7 +30,8 @@ import { getAppVersion, isVersionSupported } from "../../utils/appVersion";
 import { isStringNullyOrEmpty } from "../../utils/strings";
 import { backendStatusLoadSuccess } from "../actions/backendStatus";
 import { Action } from "../actions/types";
-
+import { StatusMessages } from "../../../definitions/content/StatusMessages";
+import { StatusMessage } from "../../../definitions/content/StatusMessage";
 import {
   isIdPayTestEnabledSelector,
   isNewScanSectionLocallyEnabledSelector
@@ -550,4 +551,28 @@ const sectionStatusUncachedSelector = (
   pipe(
     state.backendStatus.status,
     O.chainNullableK(status => status.sections[sectionStatusKey])
+  );
+
+const statusMessagesSelector = createSelector(
+  backendStatusSelector,
+  (backendStatus): StatusMessages | undefined =>
+    pipe(
+      backendStatus,
+      O.map(bs => bs.statusMessages),
+      O.toUndefined
+    )
+);
+
+export const statusMessageByRouteSelector = (routeName: string) =>
+  createSelector(
+    statusMessagesSelector,
+    (statusMessages): ReadonlyArray<StatusMessage> | undefined =>
+      pipe(
+        statusMessages,
+        O.fromNullable,
+        O.map(({ items }) =>
+          items.filter(message => message.routes.includes(routeName))
+        ),
+        O.toUndefined
+      )
   );


### PR DESCRIPTION
> [!note]
> This PR depends on pagopa/io-services-metadata#818

## Short description
This PR adds the selectors to support the new status messages specs on io-services-metadata

## List of changes proposed in this pull request
- update content specs
- adds new backend status selectors

## How to test
Check updating io-dev-api-server payload that data are stored and obtained properly
