### PR TITLE
[IABT-1545] Hide Pictogram on Onboarding Pin Screen on small device

### DIFF
--- a/ts/components/screens/PinCreation/PinCreation.tsx
+++ b/ts/components/screens/PinCreation/PinCreation.tsx
@@ -5,7 +5,6 @@ import {
   ContentWrapper,
   IOStyles,
   NumberPad,
-  Pictogram,
   VSpacer
 } from "@pagopa/io-app-design-system";
 import { Millisecond } from "@pagopa/ts-commons/lib/units";
@@ -33,6 +32,7 @@ import { setAccessibilityFocus } from "../../../utils/accessibility";
 import { useOnFirstRender } from "../../../utils/hooks/useOnFirstRender";
 import { ContextualHelpPropsMarkdown } from "../BaseScreenComponent";
 import { PIN_LENGTH_SIX } from "../../../utils/constants";
+import PictogramOnSmallDevice from "../../../screens/authentication/components/PictogramOnSmallDevice";
 import usePinValidationBottomSheet from "./usePinValidationBottomSheet";
 import { PinCaouselItemProps, PinCarouselItem } from "./PinCarouselItem";
 
@@ -223,9 +223,7 @@ export const PinCreation = ({ isOnboarding = false }: Props) => {
     <View testID="pin-creation-screen" style={IOStyles.flex}>
       <View style={[IOStyles.flex, IOStyles.centerJustified]}>
         <VSpacer size={8} />
-        <View style={IOStyles.alignCenter}>
-          <Pictogram name="key" size={64} />
-        </View>
+        <PictogramOnSmallDevice name="key" size={64} />
         <VSpacer size={8} />
         <Carousel
           ref={carouselRef}

--- a/ts/screens/authentication/NewOptInScreen.tsx
+++ b/ts/screens/authentication/NewOptInScreen.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Dimensions, View } from "react-native";
+import { View } from "react-native";
 import {
   Badge,
   ContentWrapper,
@@ -7,7 +7,6 @@ import {
   GradientScrollView,
   H3,
   IOStyles,
-  Pictogram,
   VSpacer
 } from "@pagopa/io-app-design-system";
 import { Route, useFocusEffect, useRoute } from "@react-navigation/native";
@@ -27,13 +26,12 @@ import {
 import { useSecuritySuggestionsBottomSheet } from "../../hooks/useSecuritySuggestionBottomSheet";
 import { setAccessibilityFocus } from "../../utils/accessibility";
 import { useHeaderSecondLevel } from "../../hooks/useHeaderSecondLevel";
+import PictogramOnSmallDevice from "./components/PictogramOnSmallDevice";
 
 const contextualHelpMarkdown: ContextualHelpPropsMarkdown = {
   title: "authentication.opt_in.contextualHelpTitle",
   body: "authentication.opt_in.contextualHelpContent"
 };
-
-export const MIN_HEIGHT_TO_SHOW_FULL_RENDER = 820;
 
 export type ChosenIdentifier = {
   identifier: "SPID" | "CIE";
@@ -95,15 +93,7 @@ const NewOptInScreen = () => {
       }}
     >
       <ContentWrapper>
-        {/*
-          if the device height is > 820 then the pictogram will be visible,
-          otherwise it will not be visible
-          */}
-        {Dimensions.get("screen").height > MIN_HEIGHT_TO_SHOW_FULL_RENDER && (
-          <View style={IOStyles.selfCenter} testID="pictogram-test">
-            <Pictogram name="passcode" size={120} />
-          </View>
-        )}
+        <PictogramOnSmallDevice name="passcode" />
         <VSpacer size={24} />
         <View style={IOStyles.selfCenter}>
           <Badge

--- a/ts/screens/authentication/components/PictogramOnSmallDevice.tsx
+++ b/ts/screens/authentication/components/PictogramOnSmallDevice.tsx
@@ -1,0 +1,37 @@
+import {
+  IOColors,
+  IOPictograms,
+  IOPictogramSizeScale,
+  IOStyles,
+  Pictogram
+} from "@pagopa/io-app-design-system";
+import React from "react";
+import { Dimensions, View } from "react-native";
+
+export const MIN_HEIGHT_TO_SHOW_FULL_RENDER = 820;
+
+type IOPictogramsProps = {
+  name: IOPictograms;
+  color?: IOColors;
+  pictogramStyle?: "default" | "light-content" | "dark-content";
+  size?: IOPictogramSizeScale | "100%";
+};
+
+/**
+ * if the device height is > 800 then the pictogram will be visible,
+ * otherwise it will not be visible
+ * @param pictogramName
+ * @returns Pictogram JSX element
+ */
+
+const PictogramOnSmallDevice = (Props: IOPictogramsProps) => (
+  <>
+    {Dimensions.get("screen").height > MIN_HEIGHT_TO_SHOW_FULL_RENDER && (
+      <View style={IOStyles.selfCenter} testID="pictogram-test">
+        <Pictogram {...Props} />
+      </View>
+    )}
+  </>
+);
+
+export default PictogramOnSmallDevice;


### PR DESCRIPTION
## Short description
In order to hide Pictogram on Onboarding Pin Screen on small device I transferred the logic already existing in the opt-in screen into a component (`PictogramOnSmallDevice`) 

## List of changes proposed in this pull request
- Create component `PictogramOnSmallDevice` to hide pictogram on small device
- Use component on Onboarding Pin screen and Opt-in Screen

## Demo

https://github.com/user-attachments/assets/f35d3ed0-6d06-415c-943f-426947a23c1d

## How to test
Run the application on small device (example: iPhone SE, iPhone 13 mini...) and then run the flow as first onboarding. (Follow the video instruction)