### PR TITLE
chore(Cross): update `codiceIPA` from `PCM` to `5N2TR557`

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -53,7 +53,7 @@ it:
     misureMinimeSicurezza: true
     gdpr: true
   riuso:
-    codiceIPA: PCM
+    codiceIPA: 5N2TR557
 description:
   it:
     genericName: Mobile Application

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -53,7 +53,7 @@ it:
     misureMinimeSicurezza: true
     gdpr: true
   riuso:
-    codiceIPA: 5N2TR557
+    codiceIPA: 5n2tr557
 description:
   it:
     genericName: Mobile Application


### PR DESCRIPTION
## Short description
This PR changes `codiceIPA` from `PCM` to `5n2tr557` that is [the correct one for PagoPA S.p.A.](https://www.indicepa.gov.it/ipa-portale/consultazione/domicilio-digitale/ricerca-domicili-digitali-ente/scheda-area-organizzativa-omogenea/A4UC3BM).

The regression comes from https://github.com/italia/publiccode-issueopener/commit/9db322e077c037de8e7fe24859d8295b00c65da4.
