### PR TITLE
fix: [IOBP-811] Payment manual input a11y focus crash on android

### DIFF
--- a/ts/features/payments/checkout/screens/WalletPaymentInputFiscalCodeScreen.tsx
+++ b/ts/features/payments/checkout/screens/WalletPaymentInputFiscalCodeScreen.tsx
@@ -19,13 +19,11 @@ import * as O from "fp-ts/lib/Option";
 import { flow, pipe } from "fp-ts/lib/function";
 import React from "react";
 import {
-  AccessibilityInfo,
   Keyboard,
   KeyboardAvoidingView,
   Platform,
   SafeAreaView,
-  View,
-  findNodeHandle
+  View
 } from "react-native";
 import BaseScreenComponent from "../../../../components/screens/BaseScreenComponent";
 import I18n from "../../../../i18n";
@@ -37,15 +35,16 @@ import ROUTES from "../../../../navigation/routes";
 import { paymentInitializeState } from "../../../../store/actions/wallet/payment";
 import { useIODispatch } from "../../../../store/hooks";
 import themeVariables from "../../../../theme/variables";
+import { setAccessibilityFocus } from "../../../../utils/accessibility";
 import { emptyContextualHelp } from "../../../../utils/emptyContextualHelp";
+import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
 import {
   decodeOrganizationFiscalCode,
   validateOrganizationFiscalCode
 } from "../../common/utils/validation";
+import * as analytics from "../analytics";
 import { usePagoPaPayment } from "../hooks/usePagoPaPayment";
 import { PaymentsCheckoutParamsList } from "../navigation/params";
-import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
-import * as analytics from "../analytics";
 
 export type WalletPaymentInputFiscalCodeScreenNavigationParams = {
   paymentNoticeNumber: O.Option<PaymentNoticeNumberFromString>;
@@ -76,10 +75,7 @@ const WalletPaymentInputFiscalCodeScreen = () => {
 
   const textInputWrappperRef = React.useRef<View>(null);
   const focusTextInput = () => {
-    const textInputA11yWrapper = findNodeHandle(textInputWrappperRef.current);
-    if (textInputA11yWrapper) {
-      AccessibilityInfo.setAccessibilityFocus(textInputA11yWrapper);
-    }
+    setAccessibilityFocus(textInputWrappperRef);
   };
 
   const navigateToTransactionSummary = () => {
@@ -137,7 +133,7 @@ const WalletPaymentInputFiscalCodeScreen = () => {
             <VSpacer size={16} />
             <Body>{I18n.t("wallet.payment.manual.fiscalCode.subtitle")}</Body>
             <VSpacer size={16} />
-            <View ref={textInputWrappperRef}>
+            <View accessible ref={textInputWrappperRef}>
               <TextInputValidation
                 placeholder={I18n.t(
                   "wallet.payment.manual.fiscalCode.placeholder"

--- a/ts/features/payments/checkout/screens/WalletPaymentInputNoticeNumberScreen.tsx
+++ b/ts/features/payments/checkout/screens/WalletPaymentInputNoticeNumberScreen.tsx
@@ -13,29 +13,28 @@ import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
 import React from "react";
 import {
-  AccessibilityInfo,
   Keyboard,
   KeyboardAvoidingView,
   Platform,
   SafeAreaView,
-  View,
-  findNodeHandle
+  View
 } from "react-native";
 import BaseScreenComponent from "../../../../components/screens/BaseScreenComponent";
+import I18n from "../../../../i18n";
 import {
   AppParamsList,
   IOStackNavigationProp
 } from "../../../../navigation/params/AppParamsList";
 import themeVariables from "../../../../theme/variables";
+import { setAccessibilityFocus } from "../../../../utils/accessibility";
 import { emptyContextualHelp } from "../../../../utils/emptyContextualHelp";
+import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
 import {
   decodePaymentNoticeNumber,
   validatePaymentNoticeNumber
 } from "../../common/utils/validation";
-import { PaymentsCheckoutRoutes } from "../navigation/routes";
-import I18n from "../../../../i18n";
-import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
 import * as analytics from "../analytics";
+import { PaymentsCheckoutRoutes } from "../navigation/routes";
 
 type InputState = {
   noticeNumberText: string;
@@ -68,9 +67,8 @@ const WalletPaymentInputNoticeNumberScreen = () => {
     );
 
   const focusTextInput = () => {
-    const textInputA11yWrapper = findNodeHandle(textInputWrappperRef.current);
-    if (textInputA11yWrapper && O.isNone(inputState.noticeNumber)) {
-      AccessibilityInfo.setAccessibilityFocus(textInputA11yWrapper);
+    if (O.isNone(inputState.noticeNumber)) {
+      setAccessibilityFocus(textInputWrappperRef);
     }
   };
 
@@ -89,7 +87,7 @@ const WalletPaymentInputNoticeNumberScreen = () => {
             <VSpacer size={16} />
             <Body>{I18n.t("wallet.payment.manual.noticeNumber.subtitle")}</Body>
             <VSpacer size={16} />
-            <View ref={textInputWrappperRef}>
+            <View accessible ref={textInputWrappperRef}>
               <TextInputValidation
                 placeholder={I18n.t(
                   "wallet.payment.manual.noticeNumber.placeholder"


### PR DESCRIPTION
updated the payment flow's manual input screens to follow a11y best practices, in order to avoid crashes on android

## List of changes proposed in this pull request
- set view wrappers to accessible
- included usage of utility functions
- small refactors

## How to test
with both android and iOS, make sure that the manual input payment flow (both fiscal code and notice number)  work as intended. (see https://github.com/pagopa/io-app/pull/5556 for reference) 

especially, make sure that the `continue` button correctly moves a11y focus when the textInput has not been completely filled or does not dontain correct data.