### PR TITLE
chore: [IOBP-829] Add payment error outcome screens for the outcome `18` and `19`

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1899,6 +1899,14 @@ wallet:
         subtitle: Il metodo verrà salvato nel Portafoglio, così la prossima volta potrai pagare più facilmente.
         primaryAction: Aggiungi carta
         secondaryAction: Usa altri metodi
+      PAYMENT_REVERSED:
+        title: Il pagamento non è andato a buon fine
+        subtitle: L’importo autorizzato è stato rimborsato sul tuo metodo di pagamento. Il trasferimento di denaro potrebbe richiedere del tempo.
+        primaryAction: Scopri di più
+        secondaryAction: Chiudi
+      PAYPAL_REMOVED_ERROR:
+        title: Autorizzazione negata
+        subtitle: Potresti avere rimosso pagoPA dai pagamenti automatici di PayPal. Elimina il conto PayPal dal tuo Portafoglio, aggiungilo di nuovo e riprova ad effettuare il pagamento.
     support:
       button: "Contatta l'assistenza"
       supportTitle: Contatta l'assistenza
@@ -3157,6 +3165,19 @@ features:
         explainationContent: "Quando hai salvato questo metodo, hai autorizzato {{pspBusinessName}} a gestire le transazioni eseguite tramite “PayPal pagamento veloce”.\n\nSe vuoi usare un altro gestore, aggiungi nuovamente il metodo al tuo Portafoglio.\n\nPer revocare l’autorizzazione, rimuovi il metodo dal Portafoglio.\n\nUsa l’app PayPal per modificare la carta o conto bancario su cui addebitare le spese."
     errors:
       transactionCreationError: C’è un problema con i sistemi di pagamento.
+    checkout:
+      bottomSheet:
+        PAYMENT_REVERSED:
+          title: Cosa fare se il pagamento non va a buon fine?
+          payNotice:
+            title: Paga l’avviso
+            content: Ricorda di pagare l’avviso entro le scadenze previste dall’ente. Se non riesci tramite IO, scopri gli altri canali abilitati a pagoPA.
+          waitRefund:
+            title: Attendi il rimborso
+            content: Di solito l’importo viene riaccreditato entro pochi minuti. In altri casi, il trasferimento di denaro sul tuo conto o carta potrebbe richiedere più tempo.
+          contactSupport:
+            title: Contatta l’assistenza
+            content: Se dopo 5 giorni lavorativi non hai ancora ricevuto il rimborso, contatta l’assistenza.
   itWallet:
     credentialName:
       eid: Identità Digitale

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1899,6 +1899,14 @@ wallet:
         subtitle: Il metodo verrà salvato nel Portafoglio, così la prossima volta potrai pagare più facilmente.
         primaryAction: Aggiungi carta
         secondaryAction: Usa altri metodi
+      PAYMENT_REVERSED:
+        title: Il pagamento non è andato a buon fine
+        subtitle: L’importo autorizzato è stato rimborsato sul tuo metodo di pagamento. Il trasferimento di denaro potrebbe richiedere del tempo.
+        primaryAction: Scopri di più
+        secondaryAction: Chiudi
+      PAYPAL_REMOVED_ERROR:
+        title: Autorizzazione negata
+        subtitle: Potresti avere rimosso pagoPA dai pagamenti automatici di PayPal. Elimina il conto PayPal dal tuo Portafoglio, aggiungilo di nuovo e riprova ad effettuare il pagamento.
     support:
       button: "Contatta l'assistenza"
       supportTitle: Contatta l'assistenza
@@ -3157,6 +3165,19 @@ features:
         explainationContent: "Quando hai salvato questo metodo, hai autorizzato {{pspBusinessName}} a gestire le transazioni eseguite tramite “PayPal pagamento veloce”.\n\nSe vuoi usare un altro gestore, aggiungi nuovamente il metodo al tuo Portafoglio.\n\nPer revocare l’autorizzazione, rimuovi il metodo dal Portafoglio.\n\nUsa l’app PayPal per modificare la carta o conto bancario su cui addebitare le spese."
     errors:
       transactionCreationError: C’è un problema con i sistemi di pagamento.
+    checkout:
+      bottomSheet:
+        PAYMENT_REVERSED:
+          title: Cosa fare se il pagamento non va a buon fine?
+          payNotice:
+            title: Paga l’avviso
+            content: Ricorda di pagare l’avviso entro le scadenze previste dall’ente. Se non riesci tramite IO, scopri gli altri canali abilitati a pagoPA.
+          waitRefund:
+            title: Attendi il rimborso
+            content: Di solito l’importo viene riaccreditato entro pochi minuti. In altri casi, il trasferimento di denaro sul tuo conto o carta potrebbe richiedere più tempo.
+          contactSupport:
+            title: Contatta l’assistenza
+            content: Se dopo 5 giorni lavorativi non hai ancora ricevuto il rimborso, contatta l’assistenza.
   itWallet:
     credentialName:
       eid: Identità Digitale

--- a/ts/features/payments/checkout/hooks/usePaymentReversedInfoBottomSheet.tsx
+++ b/ts/features/payments/checkout/hooks/usePaymentReversedInfoBottomSheet.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { VSpacer } from "@pagopa/io-app-design-system";
+import { useIOBottomSheetAutoresizableModal } from "../../../../utils/hooks/bottomSheet";
+import I18n from "../../../../i18n";
+import { ParagraphWithTitle } from "../../common/components/ParagraphWithTitle";
+
+export const usePaymentReversedInfoBottomSheet = () => {
+  const getModalContent = () => (
+    <>
+      <ParagraphWithTitle
+        title={I18n.t(
+          "features.payments.checkout.bottomSheet.PAYMENT_REVERSED.payNotice.title"
+        )}
+        body={I18n.t(
+          "features.payments.checkout.bottomSheet.PAYMENT_REVERSED.payNotice.content"
+        )}
+      />
+      <VSpacer size={24} />
+      <ParagraphWithTitle
+        title={I18n.t(
+          "features.payments.checkout.bottomSheet.PAYMENT_REVERSED.waitRefund.title"
+        )}
+        body={I18n.t(
+          "features.payments.checkout.bottomSheet.PAYMENT_REVERSED.waitRefund.content"
+        )}
+      />
+      <VSpacer size={24} />
+      <ParagraphWithTitle
+        title={I18n.t(
+          "features.payments.checkout.bottomSheet.PAYMENT_REVERSED.contactSupport.title"
+        )}
+        body={I18n.t(
+          "features.payments.checkout.bottomSheet.PAYMENT_REVERSED.contactSupport.content"
+        )}
+      />
+      <VSpacer size={24} />
+    </>
+  );
+
+  const modal = useIOBottomSheetAutoresizableModal({
+    component: getModalContent(),
+    title: I18n.t(
+      "features.payments.checkout.bottomSheet.PAYMENT_REVERSED.title"
+    )
+  });
+
+  return { ...modal };
+};

--- a/ts/features/payments/checkout/screens/WalletPaymentOutcomeScreen.tsx
+++ b/ts/features/payments/checkout/screens/WalletPaymentOutcomeScreen.tsx
@@ -37,6 +37,7 @@ import { getPaymentPhaseFromStep } from "../utils";
 import { paymentCompletedSuccess } from "../store/actions/orchestration";
 import { walletPaymentSelectedPspSelector } from "../store/selectors/psps";
 import { PaymentsCheckoutRoutes } from "../navigation/routes";
+import { usePaymentReversedInfoBottomSheet } from "../hooks/usePaymentReversedInfoBottomSheet";
 
 type WalletPaymentOutcomeScreenNavigationParams = {
   outcome: WalletPaymentOutcome;
@@ -66,6 +67,8 @@ const WalletPaymentOutcomeScreen = () => {
   const supportModal = usePaymentFailureSupportModal({
     outcome
   });
+
+  const reversedPaymentModal = usePaymentReversedInfoBottomSheet();
 
   // TODO: This is a workaround to disable swipe back gesture on this screen
   // .. it should be removed as soon as the migration to react-navigation v6 is completed (https://pagopa.atlassian.net/browse/IOBP-522)
@@ -120,6 +123,10 @@ const WalletPaymentOutcomeScreen = () => {
     }
 
     navigation.pop();
+  };
+
+  const handleShowMoreOnReversedPayment = () => {
+    reversedPaymentModal.present();
   };
 
   const closeSuccessAction: OperationResultScreenContentProps["action"] = {
@@ -184,6 +191,14 @@ const WalletPaymentOutcomeScreen = () => {
         );
       }
     };
+
+  const paymentReversedAction: OperationResultScreenContentProps["action"] = {
+    label: I18n.t("wallet.payment.outcome.PAYMENT_REVERSED.primaryAction"),
+    accessibilityLabel: I18n.t(
+      "wallet.payment.outcome.PAYMENT_REVERSED.primaryAction"
+    ),
+    onPress: handleShowMoreOnReversedPayment
+  };
 
   useOnFirstRender(() => {
     const kind =
@@ -355,6 +370,23 @@ const WalletPaymentOutcomeScreen = () => {
           action: onboardPaymentMethodAction,
           secondaryAction: onboardPaymentMethodCloseAction
         };
+      case WalletPaymentOutcomeEnum.PAYMENT_REVERSED:
+        return {
+          pictogram: "attention",
+          title: I18n.t("wallet.payment.outcome.PAYMENT_REVERSED.title"),
+          subtitle: I18n.t("wallet.payment.outcome.PAYMENT_REVERSED.subtitle"),
+          action: paymentReversedAction,
+          secondaryAction: closeFailureAction
+        };
+      case WalletPaymentOutcomeEnum.PAYPAL_REMOVED_ERROR:
+        return {
+          pictogram: "attention",
+          title: I18n.t("wallet.payment.outcome.PAYPAL_REMOVED_ERROR.title"),
+          subtitle: I18n.t(
+            "wallet.payment.outcome.PAYPAL_REMOVED_ERROR.subtitle"
+          ),
+          action: closeFailureAction
+        };
     }
   };
 
@@ -366,6 +398,7 @@ const WalletPaymentOutcomeScreen = () => {
         {requiresFeedback && <WalletPaymentFeebackBanner />}
       </OperationResultScreenContent>
       {supportModal.bottomSheet}
+      {reversedPaymentModal.bottomSheet}
     </>
   );
 };

--- a/ts/features/payments/checkout/types/PaymentOutcomeEnum.ts
+++ b/ts/features/payments/checkout/types/PaymentOutcomeEnum.ts
@@ -19,7 +19,9 @@ export enum WalletPaymentOutcomeEnum {
   INVALID_SESSION = "14", // transaction failed
   METHOD_NOT_ENABLED = "15", // payment method not enabled
   WAITING_CONFIRMATION_EMAIL = "17", // waiting for confirmation email
-  PAYMENT_METHODS_NOT_AVAILABLE = "18" // payment methods not available
+  PAYMENT_REVERSED = "18", // "Storno"
+  PAYPAL_REMOVED_ERROR = "19", // error while executing the payment with PayPal
+  PAYMENT_METHODS_NOT_AVAILABLE = "20" // payment methods not available
 }
 
 export type WalletPaymentOutcome = t.TypeOf<typeof WalletPaymentOutcome>;

--- a/ts/features/payments/common/components/ParagraphWithTitle.tsx
+++ b/ts/features/payments/common/components/ParagraphWithTitle.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Body, VSpacer } from "@pagopa/io-app-design-system";
+import { View } from "react-native";
+
+type ParagraphWithTitleProps = {
+  title: string;
+  body: string | React.ReactNode;
+};
+
+export const ParagraphWithTitle = ({
+  title,
+  body
+}: ParagraphWithTitleProps) => (
+  <View>
+    <Body weight="Semibold" color="black">
+      {title}
+    </Body>
+    <VSpacer size={8} />
+    <Body>{body}</Body>
+  </View>
+);

--- a/ts/features/payments/transaction/components/PaymentsLegacyAttachmentBottomSheet.tsx
+++ b/ts/features/payments/transaction/components/PaymentsLegacyAttachmentBottomSheet.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { View } from "react-native";
-import { Body, VSpacer } from "@pagopa/io-app-design-system";
+import { VSpacer } from "@pagopa/io-app-design-system";
 import {
   IOBottomSheetModal,
   useIOBottomSheetAutoresizableModal
 } from "../../../../utils/hooks/bottomSheet";
 import I18n from "../../../../i18n";
+import { ParagraphWithTitle } from "../../common/components/ParagraphWithTitle";
 
 /**
  * This custom hook, usePaymentsLegacyAttachmentBottomSheet, is designed to display a bottom sheet
@@ -37,20 +38,5 @@ const usePaymentsLegacyAttachmentBottomSheet = (): IOBottomSheetModal =>
       </View>
     )
   });
-
-type ParagraphWithTitleProps = {
-  title: string;
-  body: string;
-};
-
-const ParagraphWithTitle = ({ title, body }: ParagraphWithTitleProps) => (
-  <View>
-    <Body weight="Semibold" color="black">
-      {title}
-    </Body>
-    <VSpacer size={8} />
-    <Body>{body}</Body>
-  </View>
-);
 
 export { usePaymentsLegacyAttachmentBottomSheet };


### PR DESCRIPTION
## Short description
This PR adds the screens for the payment outcome with outcomes 18 and 19, displaying the correct screens for each. For the outcome 18 screen, the primary action is expected to open a bottom sheet containing information on why this type of error was received.

## List of changes proposed in this pull request
- Added a common `ParagraphWithTitle` component that is used in different features of `payments` domain;
- Added locales for the outcome 18 and 19;
- Added the `usePaymentReversedInfoBottomSheet` custom hook to show the bottom sheet with the info about the outcome 18;
- Handled outcome 18 and 19 as: `PAYMENT_REVERSED` and `PAYPAL_REMOVED_ERROR`

## How to test
- Start a payment flow from the payments tab with the dev-server started
- Simulate the final error outcome of the payment choosing from the drop-down the `PAYPAL_REMOVED_ERROR` or `PAYMENT_REVERSED` outcome;

## Preview
|Outcome 18 | Outcome 19|
|-|-|
|<video src="https://github.com/user-attachments/assets/fea38c3f-9abe-4100-9652-0fb17cef13ca" width="300" />|<img width="347" alt="image" src="https://github.com/user-attachments/assets/be7ca3d0-9e41-416b-aba7-2cebc8d7ec10">|


