### PR TITLE
fix: [IOBP-810] Map event tracking payment outcome unhandled

### DIFF
--- a/ts/features/payments/checkout/analytics/index.ts
+++ b/ts/features/payments/checkout/analytics/index.ts
@@ -60,6 +60,8 @@ export const getPaymentAnalyticsEventFromFailureOutcome = (
       return "PAYMENT_GENERIC_ERROR";
     case WalletPaymentOutcomeEnum.PAYMENT_METHODS_NOT_AVAILABLE:
       return "PAYMENT_NO_METHOD_SAVED_ERROR";
+    case WalletPaymentOutcomeEnum.WAITING_CONFIRMATION_EMAIL:
+      return "PAYMENT_WAITING_CONFIRMATION_EMAIL_ERROR";
     default:
       return outcome;
   }

--- a/ts/features/payments/checkout/analytics/index.ts
+++ b/ts/features/payments/checkout/analytics/index.ts
@@ -61,7 +61,7 @@ export const getPaymentAnalyticsEventFromFailureOutcome = (
     case WalletPaymentOutcomeEnum.PAYMENT_METHODS_NOT_AVAILABLE:
       return "PAYMENT_NO_METHOD_SAVED_ERROR";
     case WalletPaymentOutcomeEnum.WAITING_CONFIRMATION_EMAIL:
-      return "PAYMENT_WAITING_CONFIRMATION_EMAIL_ERROR";
+      return "PAYMENT_UNKNOWN_OUTCOME_ERROR";
     default:
       return outcome;
   }


### PR DESCRIPTION
## Short description
This PR maps the outcome unhandled from the event tracking mixpanel.

## List of changes proposed in this pull request
- Handled outcome 17 with the label `PAYMENT_WAITING_CONFIRMATION_EMAIL_ERROR`
