### PR TITLE
feat: [IOCOM-1110] Home messages analytics events

### DIFF
--- a/ts/features/itwallet/issuance/screens/ItwIssuanceEidPreviewScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceEidPreviewScreen.tsx
@@ -1,9 +1,16 @@
-import { ContentWrapper } from "@pagopa/io-app-design-system";
+import {
+  ForceScrollDownView,
+  H2,
+  HeaderSecondLevel,
+  IOVisualCostants,
+  VSpacer
+} from "@pagopa/io-app-design-system";
 import * as O from "fp-ts/lib/Option";
 import { constNull, pipe } from "fp-ts/lib/function";
 import React from "react";
+import { StyleSheet, View } from "react-native";
 import LoadingScreenContent from "../../../../components/screens/LoadingScreenContent";
-import { IOScrollViewWithLargeHeader } from "../../../../components/ui/IOScrollViewWithLargeHeader";
+import { FooterActions } from "../../../../components/ui/FooterActions";
 import { useDebugInfo } from "../../../../hooks/useDebugInfo";
 import I18n from "../../../../i18n";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
@@ -49,12 +56,6 @@ const ContentView = ({ eid }: ContentViewProps) => {
   const dispatch = useIODispatch();
   const navigation = useIONavigation();
 
-  React.useLayoutEffect(() => {
-    navigation.setOptions({
-      headerShown: true
-    });
-  }, [navigation]);
-
   useDebugInfo({
     parsedCredential: eid.parsedCredential
   });
@@ -84,31 +85,59 @@ const ContentView = ({ eid }: ContentViewProps) => {
     );
   };
 
+  React.useLayoutEffect(() => {
+    navigation.setOptions({
+      headerShown: true,
+      header: () => (
+        <HeaderSecondLevel
+          title=""
+          type="singleAction"
+          firstAction={{
+            icon: "closeLarge",
+            onPress: dismissDialog.show,
+            accessibilityLabel: I18n.t("global.buttons.close")
+          }}
+        />
+      )
+    });
+  }, [navigation, dismissDialog]);
+
   return (
-    <IOScrollViewWithLargeHeader
-      canGoback={false}
-      title={{
-        label: I18n.t("features.itWallet.issuance.eidPreview.title")
-      }}
-      actions={{
-        type: "TwoButtons",
-        primary: {
-          label: I18n.t(
-            "features.itWallet.issuance.eidPreview.actions.primary"
-          ),
-          onPress: handleSaveToWallet
-        },
-        secondary: {
-          label: I18n.t(
-            "features.itWallet.issuance.eidPreview.actions.secondary"
-          ),
-          onPress: dismissDialog.show
-        }
-      }}
-    >
-      <ContentWrapper>
+    <ForceScrollDownView contentContainerStyle={styles.scroll}>
+      <View style={styles.contentWrapper}>
+        <H2>{I18n.t("features.itWallet.issuance.eidPreview.title")}</H2>
+        <VSpacer size={24} />
         <ItwCredentialClaimsList data={eid} isPreview={true} />
-      </ContentWrapper>
-    </IOScrollViewWithLargeHeader>
+        <VSpacer size={24} />
+      </View>
+      <FooterActions
+        fixed={false}
+        actions={{
+          type: "TwoButtons",
+          primary: {
+            label: I18n.t(
+              "features.itWallet.issuance.eidPreview.actions.primary"
+            ),
+            onPress: handleSaveToWallet
+          },
+          secondary: {
+            label: I18n.t(
+              "features.itWallet.issuance.eidPreview.actions.secondary"
+            ),
+            onPress: dismissDialog.show
+          }
+        }}
+      />
+    </ForceScrollDownView>
   );
 };
+
+const styles = StyleSheet.create({
+  scroll: {
+    flexGrow: 1
+  },
+  contentWrapper: {
+    flexGrow: 1,
+    paddingHorizontal: IOVisualCostants.appMarginDefault
+  }
+});

--- a/ts/features/messages/__mocks__/messages.ts
+++ b/ts/features/messages/__mocks__/messages.ts
@@ -14,7 +14,8 @@ import { UIMessageId } from "../types";
 
 export const defaultRequestPayload = {
   pageSize: 12,
-  filter: { getArchived: false }
+  filter: { getArchived: false },
+  fromUserAction: false
 };
 
 export const defaultRequestError = {
@@ -149,7 +150,8 @@ export const successReloadMessagesPayload: ReloadMessagesPayload = {
     previous: successPayloadMessages[0].id,
     next: successPayloadMessages[2].id
   },
-  filter: defaultRequestPayload.filter
+  filter: defaultRequestPayload.filter,
+  fromUserAction: false
 };
 
 export const successLoadNextPageMessagesPayload: NextPageMessagesSuccessPayload =
@@ -158,7 +160,8 @@ export const successLoadNextPageMessagesPayload: NextPageMessagesSuccessPayload 
     pagination: {
       next: successPayloadMessages[2].id
     },
-    filter: defaultRequestPayload.filter
+    filter: defaultRequestPayload.filter,
+    fromUserAction: false
   };
 
 export const successLoadPreviousPageMessagesPayload: PreviousPageMessagesSuccessPayload =
@@ -167,5 +170,6 @@ export const successLoadPreviousPageMessagesPayload: PreviousPageMessagesSuccess
     pagination: {
       previous: successPayloadMessages[0].id
     },
-    filter: defaultRequestPayload.filter
+    filter: defaultRequestPayload.filter,
+    fromUserAction: false
   };

--- a/ts/features/messages/analytics/index.ts
+++ b/ts/features/messages/analytics/index.ts
@@ -409,3 +409,12 @@ export const trackPullToRefresh = (category: MessageListCategory) => {
   // console.log(`${eventName} ${JSON.stringify(props)}`);
   void mixpanelTrack(eventName, props);
 };
+
+export const trackAutoRefresh = (category: MessageListCategory) => {
+  const eventName = `MESSAGES_${
+    category === "ARCHIVE" ? "ARCHIVE" : "INBOX"
+  }_AUTO_REFRESH`;
+  const props = buildEventProperties("TECH", undefined);
+  // console.log(`${eventName} ${JSON.stringify(props)}`);
+  void mixpanelTrack(eventName, props);
+};

--- a/ts/features/messages/analytics/index.ts
+++ b/ts/features/messages/analytics/index.ts
@@ -400,3 +400,12 @@ export const trackMessageListEndReached = (
   // console.log(`${eventName} ${JSON.stringify(props)}`);
   void mixpanelTrack(eventName, props);
 };
+
+export const trackPullToRefresh = (category: MessageListCategory) => {
+  const eventName = `MESSAGES_${
+    category === "ARCHIVE" ? "ARCHIVE" : "INBOX"
+  }_REFRESH`;
+  const props = buildEventProperties("UX", "action");
+  // console.log(`${eventName} ${JSON.stringify(props)}`);
+  void mixpanelTrack(eventName, props);
+};

--- a/ts/features/messages/analytics/index.ts
+++ b/ts/features/messages/analytics/index.ts
@@ -388,3 +388,15 @@ export const trackArchivedRestoredMessages = (
   // console.log(`${eventName} ${JSON.stringify(props)}`);
   void mixpanelTrack(eventName, props);
 };
+
+export const trackMessageListEndReached = (
+  category: MessageListCategory,
+  willLoadNextMessagePage: boolean
+) => {
+  const eventName = `MESSAGES_${category === "ARCHIVE" ? "ARCHIVE" : "INBOX"}_${
+    willLoadNextMessagePage ? "SCROLL" : "ENDLIST"
+  }`;
+  const props = buildEventProperties("UX", "action");
+  // console.log(`${eventName} ${JSON.stringify(props)}`);
+  void mixpanelTrack(eventName, props);
+};

--- a/ts/features/messages/analytics/index.ts
+++ b/ts/features/messages/analytics/index.ts
@@ -419,7 +419,7 @@ export const trackAutoRefresh = (category: MessageListCategory) => {
   void mixpanelTrack(eventName, props);
 };
 
-export const trackMessagesSearchPage = () => {
+export const trackMessageSearchPage = () => {
   const eventName = `MESSAGES_SEARCH_PAGE`;
   const props = buildEventProperties("UX", "screen_view");
   // console.log(`${eventName} ${JSON.stringify(props)}`);

--- a/ts/features/messages/analytics/index.ts
+++ b/ts/features/messages/analytics/index.ts
@@ -376,3 +376,15 @@ export const trackMessagesPage = (
   // console.log(`${eventName} ${JSON.stringify(props)}`);
   void mixpanelTrack(eventName, props);
 };
+
+export const trackArchivedRestoredMessages = (
+  archived: boolean,
+  messageCount: number
+) => {
+  const eventName = `MESSAGES_${archived ? "ARCHIVED" : "RESTORED"}`;
+  const props = buildEventProperties("UX", "action", {
+    [`count_messages_${archived ? "archived" : "restored"}`]: messageCount
+  });
+  // console.log(`${eventName} ${JSON.stringify(props)}`);
+  void mixpanelTrack(eventName, props);
+};

--- a/ts/features/messages/analytics/index.ts
+++ b/ts/features/messages/analytics/index.ts
@@ -418,3 +418,33 @@ export const trackAutoRefresh = (category: MessageListCategory) => {
   // console.log(`${eventName} ${JSON.stringify(props)}`);
   void mixpanelTrack(eventName, props);
 };
+
+export const trackMessagesSearchPage = () => {
+  const eventName = `MESSAGES_SEARCH_PAGE`;
+  const props = buildEventProperties("UX", "screen_view");
+  // console.log(`${eventName} ${JSON.stringify(props)}`);
+  void mixpanelTrack(eventName, props);
+};
+
+export const trackMessageSearchResult = (resultCount: number) => {
+  const eventName = `MESSAGES_SEARCH_RESULT_PAGE`;
+  const props = buildEventProperties("UX", "screen_view", {
+    count_result_returned: resultCount
+  });
+  // console.log(`${eventName} ${JSON.stringify(props)}`);
+  void mixpanelTrack(eventName, props);
+};
+
+export const trackMessageSearchSelection = () => {
+  const eventName = `MESSAGES_SEARCH_RESULT_SELECTED`;
+  const props = buildEventProperties("UX", "action");
+  // console.log(`${eventName} ${JSON.stringify(props)}`);
+  void mixpanelTrack(eventName, props);
+};
+
+export const trackMessageSearchClosing = () => {
+  const eventName = `MESSAGES_SEARCH_CLOSE`;
+  const props = buildEventProperties("UX", "action");
+  // console.log(`${eventName} ${JSON.stringify(props)}`);
+  void mixpanelTrack(eventName, props);
+};

--- a/ts/features/messages/analytics/index.ts
+++ b/ts/features/messages/analytics/index.ts
@@ -373,7 +373,6 @@ export const trackMessagesPage = (
     count_messages: messageCount,
     fromUserAction
   });
-  // console.log(`${eventName} ${JSON.stringify(props)}`);
   void mixpanelTrack(eventName, props);
 };
 
@@ -385,7 +384,6 @@ export const trackArchivedRestoredMessages = (
   const props = buildEventProperties("UX", "action", {
     [`count_messages_${archived ? "archived" : "restored"}`]: messageCount
   });
-  // console.log(`${eventName} ${JSON.stringify(props)}`);
   void mixpanelTrack(eventName, props);
 };
 
@@ -397,7 +395,6 @@ export const trackMessageListEndReached = (
     willLoadNextMessagePage ? "SCROLL" : "ENDLIST"
   }`;
   const props = buildEventProperties("UX", "action");
-  // console.log(`${eventName} ${JSON.stringify(props)}`);
   void mixpanelTrack(eventName, props);
 };
 
@@ -406,7 +403,6 @@ export const trackPullToRefresh = (category: MessageListCategory) => {
     category === "ARCHIVE" ? "ARCHIVE" : "INBOX"
   }_REFRESH`;
   const props = buildEventProperties("UX", "action");
-  // console.log(`${eventName} ${JSON.stringify(props)}`);
   void mixpanelTrack(eventName, props);
 };
 
@@ -415,14 +411,12 @@ export const trackAutoRefresh = (category: MessageListCategory) => {
     category === "ARCHIVE" ? "ARCHIVE" : "INBOX"
   }_AUTO_REFRESH`;
   const props = buildEventProperties("TECH", undefined);
-  // console.log(`${eventName} ${JSON.stringify(props)}`);
   void mixpanelTrack(eventName, props);
 };
 
 export const trackMessageSearchPage = () => {
   const eventName = `MESSAGES_SEARCH_PAGE`;
   const props = buildEventProperties("UX", "screen_view");
-  // console.log(`${eventName} ${JSON.stringify(props)}`);
   void mixpanelTrack(eventName, props);
 };
 
@@ -431,20 +425,17 @@ export const trackMessageSearchResult = (resultCount: number) => {
   const props = buildEventProperties("UX", "screen_view", {
     count_result_returned: resultCount
   });
-  // console.log(`${eventName} ${JSON.stringify(props)}`);
   void mixpanelTrack(eventName, props);
 };
 
 export const trackMessageSearchSelection = () => {
   const eventName = `MESSAGES_SEARCH_RESULT_SELECTED`;
   const props = buildEventProperties("UX", "action");
-  // console.log(`${eventName} ${JSON.stringify(props)}`);
   void mixpanelTrack(eventName, props);
 };
 
 export const trackMessageSearchClosing = () => {
   const eventName = `MESSAGES_SEARCH_CLOSE`;
   const props = buildEventProperties("UX", "action");
-  // console.log(`${eventName} ${JSON.stringify(props)}`);
   void mixpanelTrack(eventName, props);
 };

--- a/ts/features/messages/components/Home/EmptyList.tsx
+++ b/ts/features/messages/components/Home/EmptyList.tsx
@@ -46,7 +46,8 @@ export const EmptyList = ({ category }: EmptyListProps) => {
             pipe(
               {
                 pageSize,
-                filter: { getArchived: category === "ARCHIVE" }
+                filter: { getArchived: category === "ARCHIVE" },
+                fromUserAction: true
               },
               reloadAllMessages.request,
               dispatch

--- a/ts/features/messages/components/Home/MessageList.tsx
+++ b/ts/features/messages/components/Home/MessageList.tsx
@@ -134,9 +134,9 @@ export const MessageList = React.forwardRef<FlatList, MessageListProps>(
           } else {
             return (
               <WrappedMessageListItem
-                archiveRestoreSourceCategory={category}
                 index={index}
                 message={item}
+                source={category}
               />
             );
           }

--- a/ts/features/messages/components/Home/MessageList.tsx
+++ b/ts/features/messages/components/Home/MessageList.tsx
@@ -22,7 +22,8 @@ import {
   generateMessageListLayoutInfo,
   getLoadNextPageMessagesActionIfAllowed,
   getReloadAllMessagesActionForRefreshIfAllowed,
-  LayoutInfo
+  LayoutInfo,
+  trackMessageListEndReachedIfAllowed
 } from "./homeUtils";
 import { WrappedMessageListItem } from "./WrappedMessageListItem";
 import {
@@ -98,6 +99,11 @@ export const MessageList = React.forwardRef<FlatList, MessageListProps>(
         state,
         category,
         new Date()
+      );
+      trackMessageListEndReachedIfAllowed(
+        category,
+        !!loadNextPageMessages,
+        state
       );
       if (loadNextPageMessages) {
         dispatch(loadNextPageMessages);

--- a/ts/features/messages/components/Home/MessageList.tsx
+++ b/ts/features/messages/components/Home/MessageList.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../store/reducers/allPaginated";
 import { UIMessage } from "../../types";
 import { ItwDiscoveryBanner } from "../../../itwallet/common/components/ItwDiscoveryBanner";
+import { trackPullToRefresh } from "../../analytics";
 import {
   generateMessageListLayoutInfo,
   getLoadNextPageMessagesActionIfAllowed,
@@ -86,6 +87,7 @@ export const MessageList = React.forwardRef<FlatList, MessageListProps>(
     );
 
     const onRefreshCallback = useCallback(() => {
+      trackPullToRefresh(category);
       const state = store.getState();
       const reloadAllMessagesAction =
         getReloadAllMessagesActionForRefreshIfAllowed(state, category);

--- a/ts/features/messages/components/Home/PagerViewContainer.tsx
+++ b/ts/features/messages/components/Home/PagerViewContainer.tsx
@@ -15,7 +15,7 @@ import {
 } from "../../store/reducers/allPaginated";
 import { foldK as foldMessageListCategory } from "../../types/messageListCategory";
 import SectionStatusComponent from "../../../../components/SectionStatus";
-import { trackMessagesPage } from "../../analytics";
+import { trackAutoRefresh, trackMessagesPage } from "../../analytics";
 import { pageSize } from "../../../../config";
 import { MessageList } from "./MessageList";
 import {
@@ -56,6 +56,8 @@ export const PagerViewContainer = React.forwardRef<PagerView>((_, ref) => {
     const loadPreviousPageAction =
       getLoadPreviousPageMessagesActionIfAllowed(state);
     if (loadPreviousPageAction) {
+      const shownCategory = shownMessageCategorySelector(state);
+      trackAutoRefresh(shownCategory);
       dispatch(loadPreviousPageAction);
     }
   }, [dispatch, store]);

--- a/ts/features/messages/components/Home/PagerViewContainer.tsx
+++ b/ts/features/messages/components/Home/PagerViewContainer.tsx
@@ -1,5 +1,5 @@
 import { pipe } from "fp-ts/lib/function";
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useRef } from "react";
 import { FlatList, NativeSyntheticEvent } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
 import PagerView from "react-native-pager-view";
@@ -9,15 +9,21 @@ import { useIODispatch, useIOStore } from "../../../../store/hooks";
 import { setShownMessageCategoryAction } from "../../store/actions";
 import { GlobalState } from "../../../../store/reducers/types";
 import { useTabItemPressWhenScreenActive } from "../../../../hooks/useTabItemPressWhenScreenActive";
-import { shownMessageCategorySelector } from "../../store/reducers/allPaginated";
+import {
+  messageCountForCategorySelector,
+  shownMessageCategorySelector
+} from "../../store/reducers/allPaginated";
 import { foldK as foldMessageListCategory } from "../../types/messageListCategory";
 import SectionStatusComponent from "../../../../components/SectionStatus";
+import { trackMessagesPage } from "../../analytics";
+import { pageSize } from "../../../../config";
 import { MessageList } from "./MessageList";
 import {
   getInitialReloadAllMessagesActionIfNeeded,
   getLoadPreviousPageMessagesActionIfAllowed,
   getMessagesViewPagerInitialPageIndex,
-  messageViewPageIndexToListCategory
+  messageViewPageIndexToListCategory,
+  trackMessagePageOnFocusEventIfAllowed
 } from "./homeUtils";
 import { ArchiveRestoreBar } from "./ArchiveRestoreBar";
 
@@ -65,15 +71,16 @@ export const PagerViewContainer = React.forwardRef<PagerView>((_, ref) => {
   );
   const onPagerViewPageSelected = useCallback(
     (selectionEvent: NativeSyntheticEvent<OnPageSelectedEventData>) => {
-      // Be aware that this callback is triggered when the user swipes
-      // horizontally but also when the TabNavigationContainer uses the
-      // PagerView's ref to switch page
+      // Be aware that this callback is triggered:
+      // - upon first PagerView rendering;
+      // - when the user completes a full horizontal swipe;
+      // - when the TabNavigationContainer uses the PagerView's ref to switch page.
 
       // Also note that this method is called only on an effective page
       // change so if there is none (i.e., the user swipe is not wide
       // enough to move to a new page and the pager view scrolls back
       // to the current displayed page), this callback is not invoked,
-      // thus allowing us not to check for a changed category/page-index
+      // thus allowing us not to check for a changed category/page-index.
 
       const selectedTabIndex = selectionEvent.nativeEvent.position;
       const selectedShownCategory =
@@ -81,22 +88,31 @@ export const PagerViewContainer = React.forwardRef<PagerView>((_, ref) => {
       dispatch(setShownMessageCategoryAction(selectedShownCategory));
 
       // Be aware that the store.state must not be extracted outside of
-      // this useEffect hook, otherwise it will re-run the hook every
-      // time the state changes. Be also aware that
-      // 'setShownMessageCategoryAction(selectedShownCategory)' above
-      // must be called before 'reloadAllMessage.request' below, otherwise
-      // the store will not have the proper 'shownCategory' value
+      // this useEffect hook, otherwise it will re-run the callback on
+      // every state change.
       const state = store.getState();
+
+      // Make sure that the above call to
+      // 'setShownMessageCategoryAction(selectedShownCategory)'
+      // has been done before all the following code below, otherwise
+      // the store will not have the proper 'shownCategory' value
+
+      // Track message category change
+      const messageCount = messageCountForCategorySelector(
+        state,
+        selectedShownCategory
+      );
+      trackMessagesPage(selectedShownCategory, messageCount, pageSize, true);
+
+      // Handle inizial message loading (if needed)
       dispatchReloadAllMessagesIfNeeded(state);
 
-      // As before, in order for the following call to work propertly,
-      // 'setShownMessageCategoryAction(selectedShownCategory)' has to be
-      // called before it (otherwise the 'shownMessageCategory' will be
-      // wrong). It has an internal logic by which it does not dispatch
-      // anything if the previous `dispatchReloadAllMessagesIfNeeded` has
-      // already requested a 'reloadAllMessages.request'
-      // It is called here to refresh the message list when not changing
-      // the screen but only switching between tabs
+      // The following onvoked method has an internal logic by
+      // which it does not dispatch anything if the previous
+      // `dispatchReloadAllMessagesIfNeeded` has already requested
+      // a 'reloadAllMessages.request'. It is called here to refresh
+      // the message list when not changing the screen but only
+      // switching between tabs.
       loadNewlyReceivedMessagesIfNeededCallback();
     },
     [
@@ -109,24 +125,28 @@ export const PagerViewContainer = React.forwardRef<PagerView>((_, ref) => {
   useTabItemPressWhenScreenActive(onTabPressedCallback, false);
   useFocusEffect(
     useCallback(() => {
-      // This is called to automatically refresh after coming back
-      // to this screen from another one. The timeout is needed to avoid
-      // a glitch with the FlatList that does not update the pull-to-refresh
-      // margins after the check has completed (what happens is that the
-      // pull-to-refresh control disappears but the list keeps its blank
-      // view placeholder visible)
+      // This hook has two use-cases:
+      // - to send an analytics event on first landing, when there
+      //   is a change-back using the messages bottom tab and when
+      //   the user navigates back from a message details;
+      // - to check if there are new messages (on the server) when
+      //   there is a change-back using the messages bottom tab and
+      //  when the user navigates back from a message details.
+      // The timeout is needed:
+      // - during onboarding, where a screen is mounted on top of the
+      //   main navigation tab, thus avoiding a momentary focus of
+      //   the selected tab (which is normally the messages one);
+      // - to avoid a glitch with the FlatList that does not update
+      //   the pull-to-refresh margins after the check has completed
+      //   (what happens is that the pull-to-refresh control disappears
+      //   but the list keeps its blank view placeholder visible).
       setTimeout(() => {
+        const state = store.getState();
+        trackMessagePageOnFocusEventIfAllowed(state);
         loadNewlyReceivedMessagesIfNeededCallback();
       }, 100);
-    }, [loadNewlyReceivedMessagesIfNeededCallback])
+    }, [loadNewlyReceivedMessagesIfNeededCallback, store])
   );
-  useEffect(() => {
-    // Upon first component rendering, the PagerView's onPageSelected
-    // callback is not called, so we must dispatch the reload action
-    // for the initial shown message list
-    const state = store.getState();
-    dispatchReloadAllMessagesIfNeeded(state);
-  }, [dispatchReloadAllMessagesIfNeeded, store]);
 
   return (
     <>

--- a/ts/features/messages/components/Home/__tests__/EmptyList.test.tsx
+++ b/ts/features/messages/components/Home/__tests__/EmptyList.test.tsx
@@ -190,7 +190,8 @@ describe("EmptyList", () => {
     expect(mockDispatch.mock.calls[0][0]).toStrictEqual(
       reloadAllMessages.request({
         pageSize,
-        filter: { getArchived: false }
+        filter: { getArchived: false },
+        fromUserAction: true
       })
     );
   });
@@ -205,7 +206,8 @@ describe("EmptyList", () => {
     expect(mockDispatch.mock.calls[0][0]).toStrictEqual(
       reloadAllMessages.request({
         pageSize,
-        filter: { getArchived: true }
+        filter: { getArchived: true },
+        fromUserAction: true
       })
     );
   });

--- a/ts/features/messages/components/Home/__tests__/MessageList.test.tsx
+++ b/ts/features/messages/components/Home/__tests__/MessageList.test.tsx
@@ -32,7 +32,8 @@ describe("MessageList", () => {
     const expectedAction = loadNextPageMessages.request({
       pageSize,
       cursor: "01J0B4PFPP24MBX6K8ZYQXXBDW",
-      filter: { getArchived: false }
+      filter: { getArchived: false },
+      fromUserAction: false
     });
     jest
       .spyOn(homeUtils, "getLoadNextPageMessagesActionIfAllowed")
@@ -54,7 +55,8 @@ describe("MessageList", () => {
     const unexpectedAction = loadNextPageMessages.request({
       pageSize,
       cursor: "01J0B4PFPP24MBX6K8ZYQXXBDW",
-      filter: { getArchived: true }
+      filter: { getArchived: true },
+      fromUserAction: false
     });
     jest
       .spyOn(homeUtils, "getLoadNextPageMessagesActionIfAllowed")
@@ -74,7 +76,8 @@ describe("MessageList", () => {
     const expectedCategory: MessageListCategory = "INBOX";
     const expectedAction = reloadAllMessages.request({
       pageSize,
-      filter: { getArchived: false }
+      filter: { getArchived: false },
+      fromUserAction: false
     });
     jest
       .spyOn(homeUtils, "getReloadAllMessagesActionForRefreshIfAllowed")
@@ -101,7 +104,8 @@ describe("MessageList", () => {
     const expectedCategory: MessageListCategory = "ARCHIVE";
     const expectedAction = reloadAllMessages.request({
       pageSize,
-      filter: { getArchived: true }
+      filter: { getArchived: true },
+      fromUserAction: false
     });
     jest
       .spyOn(homeUtils, "getReloadAllMessagesActionForRefreshIfAllowed")
@@ -128,7 +132,8 @@ describe("MessageList", () => {
     const expectedCategory: MessageListCategory = "INBOX";
     const expectedAction = reloadAllMessages.request({
       pageSize,
-      filter: { getArchived: false }
+      filter: { getArchived: false },
+      fromUserAction: false
     });
     jest
       .spyOn(homeUtils, "getReloadAllMessagesActionForRefreshIfAllowed")

--- a/ts/features/messages/components/Home/__tests__/PagerViewContainer.test.tsx
+++ b/ts/features/messages/components/Home/__tests__/PagerViewContainer.test.tsx
@@ -30,26 +30,28 @@ describe("PagerViewContainer", () => {
     jest.resetAllMocks();
     jest.clearAllMocks();
   });
-  it("should dispatch 'reloadAllMessages.request' upon first rendering for INBOX", () => {
+  /* it("should dispatch 'reloadAllMessages.request' upon first rendering for INBOX", () => {
     renderComponent("INBOX", pot.none, pot.none);
     expect(mockDispatch.mock.calls.length).toBe(1);
     expect(mockDispatch.mock.calls[0][0]).toStrictEqual(
       reloadAllMessages.request({
         pageSize,
-        filter: { getArchived: false }
+        filter: { getArchived: false },
+        fromUserAction: false
       })
     );
-  });
-  it("should dispatch 'reloadAllMessages.request' upon first rendering for ARCHIVE", () => {
+  }); */
+  /* it("should dispatch 'reloadAllMessages.request' upon first rendering for ARCHIVE", () => {
     renderComponent("ARCHIVE", pot.none, pot.none);
     expect(mockDispatch.mock.calls.length).toBe(1);
     expect(mockDispatch.mock.calls[0][0]).toStrictEqual(
       reloadAllMessages.request({
         pageSize,
-        filter: { getArchived: true }
+        filter: { getArchived: true },
+        fromUserAction: false
       })
     );
-  });
+  }); */
   it("should not dispatch 'reloadAllMessages.request' when INBOX has (empty) data, should dispatch both 'setShownMessageCategoryAction('ARCHIVE')' when setting page 1 and 'reloadAllMessages.request'", () => {
     const mockUseRefOutput: React.MutableRefObject<PagerView | null> = {
       current: null
@@ -81,7 +83,8 @@ describe("PagerViewContainer", () => {
     expect(mockDispatch.mock.calls[1][0]).toStrictEqual(
       reloadAllMessages.request({
         pageSize,
-        filter: { getArchived: true }
+        filter: { getArchived: true },
+        fromUserAction: false
       })
     );
   });
@@ -147,7 +150,8 @@ describe("PagerViewContainer", () => {
     expect(mockDispatch.mock.calls[1][0]).toStrictEqual(
       reloadAllMessages.request({
         pageSize,
-        filter: { getArchived: false }
+        filter: { getArchived: false },
+        fromUserAction: false
       })
     );
   });

--- a/ts/features/messages/components/Home/__tests__/PagerViewContainer.test.tsx
+++ b/ts/features/messages/components/Home/__tests__/PagerViewContainer.test.tsx
@@ -30,28 +30,14 @@ describe("PagerViewContainer", () => {
     jest.resetAllMocks();
     jest.clearAllMocks();
   });
-  /* it("should dispatch 'reloadAllMessages.request' upon first rendering for INBOX", () => {
+  it("should not dispatch 'reloadAllMessages.request' upon first rendering for INBOX with useEffect (since it is dispatched by the PagerView's pageSelected callback)", () => {
     renderComponent("INBOX", pot.none, pot.none);
-    expect(mockDispatch.mock.calls.length).toBe(1);
-    expect(mockDispatch.mock.calls[0][0]).toStrictEqual(
-      reloadAllMessages.request({
-        pageSize,
-        filter: { getArchived: false },
-        fromUserAction: false
-      })
-    );
-  }); */
-  /* it("should dispatch 'reloadAllMessages.request' upon first rendering for ARCHIVE", () => {
+    expect(mockDispatch.mock.calls.length).toBe(0);
+  });
+  it("should not dispatch 'reloadAllMessages.request' upon first rendering for ARCHIVE with useEffect (since it is dispatched by the PagerView's pageSelected callback)", () => {
     renderComponent("ARCHIVE", pot.none, pot.none);
-    expect(mockDispatch.mock.calls.length).toBe(1);
-    expect(mockDispatch.mock.calls[0][0]).toStrictEqual(
-      reloadAllMessages.request({
-        pageSize,
-        filter: { getArchived: true },
-        fromUserAction: false
-      })
-    );
-  }); */
+    expect(mockDispatch.mock.calls.length).toBe(0);
+  });
   it("should not dispatch 'reloadAllMessages.request' when INBOX has (empty) data, should dispatch both 'setShownMessageCategoryAction('ARCHIVE')' when setting page 1 and 'reloadAllMessages.request'", () => {
     const mockUseRefOutput: React.MutableRefObject<PagerView | null> = {
       current: null

--- a/ts/features/messages/components/Home/__tests__/WrappedMessageListItem.test.tsx
+++ b/ts/features/messages/components/Home/__tests__/WrappedMessageListItem.test.tsx
@@ -170,13 +170,7 @@ const renderComponent = (
   } as GlobalState;
   const store = createStore(appReducer, stateWithPayment as any);
   return renderScreenWithNavigationStoreContext(
-    () => (
-      <WrappedMessageListItem
-        index={0}
-        archiveRestoreSourceCategory="INBOX"
-        message={message}
-      />
-    ),
+    () => <WrappedMessageListItem index={0} message={message} source="INBOX" />,
     MESSAGES_ROUTES.MESSAGES_HOME,
     {},
     store

--- a/ts/features/messages/components/Home/__tests__/homeUtils.test.ts
+++ b/ts/features/messages/components/Home/__tests__/homeUtils.test.ts
@@ -434,7 +434,8 @@ describe("getLoadNextPageMessagesActionIfNeeded", () => {
       ? loadNextPageMessages.request({
           pageSize,
           cursor: selectedCollectionNextValue,
-          filter: { getArchived: category === "ARCHIVE" }
+          filter: { getArchived: category === "ARCHIVE" },
+          fromUserAction: true
         })
       : undefined;
   };
@@ -542,7 +543,8 @@ describe("getReloadAllMessagesActionForRefreshIfAllowed", () => {
           !isLoadingOrUpdating(inboxPot) && !isLoadingOrUpdating(archivePot)
             ? reloadAllMessages.request({
                 pageSize,
-                filter: { getArchived: category === "ARCHIVE" }
+                filter: { getArchived: category === "ARCHIVE" },
+                fromUserAction: true
               })
             : undefined;
         it(`should return '${
@@ -619,7 +621,8 @@ describe("getLoadNextPreviousPageMessagesActionIfAllowed", () => {
       cursor: previousPageMessageId,
       filter: {
         getArchived: shownCategory === "ARCHIVE"
-      }
+      },
+      fromUserAction: false
     });
   };
   // eslint-disable-next-line sonarjs/cognitive-complexity

--- a/ts/features/messages/components/Home/homeUtils.ts
+++ b/ts/features/messages/components/Home/homeUtils.ts
@@ -29,7 +29,7 @@ import {
 import { isArchivingInProcessingModeSelector } from "../../store/reducers/archiving";
 import { TagEnum } from "../../../../../definitions/backend/MessageCategoryPN";
 import NavigationService from "../../../../navigation/NavigationService";
-import { trackMessagesPage } from "../../analytics";
+import { trackMessageListEndReached, trackMessagesPage } from "../../analytics";
 import { MESSAGES_ROUTES } from "../../navigation/routes";
 import { EnhancedHeight, StandardHeight } from "./DS/MessageListItem";
 import { SkeletonHeight } from "./DS/MessageListItemSkeleton";
@@ -282,5 +282,16 @@ export const trackMessagePageOnFocusEventIfAllowed = (state: GlobalState) => {
     const selectedShownCategory = shownMessageCategorySelector(state);
     const messageCount = messagePagePot.value.page.length;
     trackMessagesPage(selectedShownCategory, messageCount, pageSize, true);
+  }
+};
+
+export const trackMessageListEndReachedIfAllowed = (
+  category: MessageListCategory,
+  willLoadNextPageMessages: boolean,
+  state: GlobalState
+) => {
+  const messagePagePot = messagePagePotFromCategorySelector(category)(state);
+  if (isSomeOrSomeError(messagePagePot)) {
+    trackMessageListEndReached(category, willLoadNextPageMessages);
   }
 };

--- a/ts/features/messages/saga/handleLoadNextPageMessages.ts
+++ b/ts/features/messages/saga/handleLoadNextPageMessages.ts
@@ -18,7 +18,7 @@ export function* handleLoadNextPageMessages(
   getMessages: BackendClient["getMessages"],
   action: ActionType<typeof loadNextPageMessages.request>
 ) {
-  const { filter, pageSize, cursor } = action.payload;
+  const { filter, pageSize, cursor, fromUserAction } = action.payload;
 
   try {
     const response = (yield* call(
@@ -37,7 +37,8 @@ export function* handleLoadNextPageMessages(
         loadNextPageMessagesAction.success({
           messages: items.map(toUIMessage),
           pagination: { next },
-          filter
+          filter,
+          fromUserAction
         }),
       error => {
         const reason = errorToReason(error);

--- a/ts/features/messages/saga/handleLoadPreviousPageMessages.ts
+++ b/ts/features/messages/saga/handleLoadPreviousPageMessages.ts
@@ -15,7 +15,7 @@ export function* handleLoadPreviousPageMessages(
   getMessages: BackendClient["getMessages"],
   action: ActionType<typeof loadPreviousPageMessagesAction.request>
 ) {
-  const { filter, cursor, pageSize } = action.payload;
+  const { filter, cursor, pageSize, fromUserAction } = action.payload;
 
   try {
     const response = (yield* call(
@@ -34,7 +34,8 @@ export function* handleLoadPreviousPageMessages(
         loadPreviousPageMessagesAction.success({
           messages: items.map(toUIMessage),
           pagination: { previous: prev },
-          filter
+          filter,
+          fromUserAction
         }),
       error => {
         const reason = errorToReason(error);

--- a/ts/features/messages/saga/handleReloadAllMessages.ts
+++ b/ts/features/messages/saga/handleReloadAllMessages.ts
@@ -18,7 +18,7 @@ export function* handleReloadAllMessages(
   getMessages: BackendClient["getMessages"],
   action: ActionType<typeof reloadAllMessages.request>
 ) {
-  const { filter, pageSize } = action.payload;
+  const { filter, pageSize, fromUserAction } = action.payload;
 
   try {
     const response: SagaCallReturnType<typeof getMessages> = (yield* call(
@@ -36,7 +36,8 @@ export function* handleReloadAllMessages(
         reloadAllMessagesAction.success({
           messages: items.map(toUIMessage),
           pagination: { previous: prev, next },
-          filter
+          filter,
+          fromUserAction
         }),
       error => {
         const reason = errorToReason(error);

--- a/ts/features/messages/screens/MessagesSearchScreen.tsx
+++ b/ts/features/messages/screens/MessagesSearchScreen.tsx
@@ -30,7 +30,7 @@ import { UIMessage } from "../types";
 import { WrappedMessageListItem } from "../components/Home/WrappedMessageListItem";
 import {
   trackMessageSearchClosing,
-  trackMessagesSearchPage
+  trackMessageSearchPage
 } from "../analytics";
 import { getMessageSearchResult } from "./searchUtils";
 
@@ -86,7 +86,7 @@ export const MessagesSearchScreen = () => {
 
   useFocusEffect(
     useCallback(() => {
-      trackMessagesSearchPage();
+      trackMessageSearchPage();
       searchInputRef.current?.focus();
     }, [])
   );

--- a/ts/features/messages/screens/searchUtils.ts
+++ b/ts/features/messages/screens/searchUtils.ts
@@ -1,0 +1,20 @@
+import { GlobalState } from "../../../store/reducers/types";
+import { trackMessageSearchResult } from "../analytics";
+import { searchMessagesUncachedSelector } from "../store/reducers/allPaginated";
+
+export const getMessageSearchResult = (
+  searchQuery: string,
+  minQueryLength: number,
+  state: GlobalState
+) => {
+  const searchResult = searchMessagesUncachedSelector(
+    state,
+    searchQuery,
+    minQueryLength
+  );
+  const searchResultCount = searchResult.length;
+  if (searchResultCount > 0) {
+    trackMessageSearchResult(searchResultCount);
+  }
+  return searchResult;
+};

--- a/ts/features/messages/store/actions/index.ts
+++ b/ts/features/messages/store/actions/index.ts
@@ -115,11 +115,13 @@ export type LoadMessagesRequestPayload = {
   pageSize: number;
   cursor?: string;
   filter: Filter;
+  fromUserAction: boolean;
 };
 
 type PaginatedMessagesSuccessPayload = {
   messages: ReadonlyArray<UIMessage>;
   filter: Filter;
+  fromUserAction: boolean;
 };
 
 // The data is appended to the state
@@ -165,7 +167,7 @@ export const reloadAllMessages = createAsyncAction(
   "MESSAGES_RELOAD_SUCCESS",
   "MESSAGES_RELOAD_FAILURE"
 )<
-  Pick<LoadMessagesRequestPayload, "pageSize" | "filter">,
+  Pick<LoadMessagesRequestPayload, "pageSize" | "filter" | "fromUserAction">,
   ReloadMessagesPayload,
   MessagesFailurePayload
 >();

--- a/ts/features/messages/store/reducers/__tests__/allPaginated.test.ts
+++ b/ts/features/messages/store/reducers/__tests__/allPaginated.test.ts
@@ -52,7 +52,8 @@ describe("allPaginated reducer", () => {
       const filter = { getArchived: true };
       const actionRequest = reloadAllMessages.request({
         ...defaultRequestPayload,
-        filter
+        filter,
+        fromUserAction: false
       });
       it("should reset only the Archive state to loading", () => {
         expect(
@@ -101,7 +102,8 @@ describe("allPaginated reducer", () => {
       const filter = { getArchived: false };
       const actionRequest = reloadAllMessages.request({
         ...defaultRequestPayload,
-        filter
+        filter,
+        fromUserAction: false
       });
       it("should reset only the Inbox state to loading", () => {
         expect(
@@ -153,7 +155,8 @@ describe("allPaginated reducer", () => {
       const filter = { getArchived: true };
       const actionRequest = loadNextPageMessages.request({
         ...defaultRequestPayload,
-        filter
+        filter,
+        fromUserAction: false
       });
 
       // eslint-disable-next-line sonarjs/no-identical-functions
@@ -215,7 +218,8 @@ describe("allPaginated reducer", () => {
       const filter = { getArchived: false };
       const actionRequest = loadNextPageMessages.request({
         ...defaultRequestPayload,
-        filter
+        filter,
+        fromUserAction: false
       });
 
       // eslint-disable-next-line sonarjs/no-identical-functions
@@ -280,7 +284,8 @@ describe("allPaginated reducer", () => {
       const filter = { getArchived: true };
       const actionRequest = loadPreviousPageMessages.request({
         ...defaultRequestPayload,
-        filter
+        filter,
+        fromUserAction: false
       });
 
       // eslint-disable-next-line sonarjs/no-identical-functions
@@ -335,7 +340,8 @@ describe("allPaginated reducer", () => {
           const actionWithEmptyPagination = loadPreviousPageMessages.success({
             messages: [],
             pagination: {},
-            filter
+            filter,
+            fromUserAction: false
           });
 
           it("should preserve the `previous` Archive cursor", () => {
@@ -370,7 +376,8 @@ describe("allPaginated reducer", () => {
       const filter = { getArchived: false };
       const actionRequest = loadPreviousPageMessages.request({
         ...defaultRequestPayload,
-        filter
+        filter,
+        fromUserAction: false
       });
 
       // eslint-disable-next-line sonarjs/no-identical-functions
@@ -426,7 +433,8 @@ describe("allPaginated reducer", () => {
           const actionWithEmptyPagination = loadPreviousPageMessages.success({
             messages: [],
             pagination: {},
-            filter
+            filter,
+            fromUserAction: false
           });
 
           it("should preserve the `previous` Inbox cursor", () => {
@@ -562,7 +570,11 @@ describe("allPaginated reducer", () => {
     it("should keep its `showCategory` value (reloadAllMessages.request)", () => {
       const allPaginatedFinalState = reducer(
         allPaginatedInitialStateGenerator(),
-        reloadAllMessages.request({ pageSize, filter: { getArchived: true } })
+        reloadAllMessages.request({
+          pageSize,
+          filter: { getArchived: true },
+          fromUserAction: false
+        })
       );
       expect(allPaginatedFinalState.shownCategory).toBe("ARCHIVE");
     });
@@ -572,7 +584,8 @@ describe("allPaginated reducer", () => {
         reloadAllMessages.success({
           messages: [],
           filter: { getArchived: true },
-          pagination: {}
+          pagination: {},
+          fromUserAction: false
         })
       );
       expect(allPaginatedFinalState.shownCategory).toBe("ARCHIVE");
@@ -593,7 +606,8 @@ describe("allPaginated reducer", () => {
         allPaginatedInitialStateGenerator(),
         loadNextPageMessages.request({
           pageSize,
-          filter: { getArchived: true }
+          filter: { getArchived: true },
+          fromUserAction: false
         })
       );
       expect(allPaginatedFinalState.shownCategory).toBe("ARCHIVE");
@@ -604,7 +618,8 @@ describe("allPaginated reducer", () => {
         loadNextPageMessages.success({
           messages: [],
           filter: { getArchived: true },
-          pagination: {}
+          pagination: {},
+          fromUserAction: false
         })
       );
       expect(allPaginatedFinalState.shownCategory).toBe("ARCHIVE");
@@ -625,7 +640,8 @@ describe("allPaginated reducer", () => {
         allPaginatedInitialStateGenerator(),
         loadPreviousPageMessages.request({
           pageSize,
-          filter: { getArchived: true }
+          filter: { getArchived: true },
+          fromUserAction: false
         })
       );
       expect(allPaginatedFinalState.shownCategory).toBe("ARCHIVE");
@@ -636,7 +652,8 @@ describe("allPaginated reducer", () => {
         loadPreviousPageMessages.success({
           messages: [],
           filter: { getArchived: true },
-          pagination: {}
+          pagination: {},
+          fromUserAction: false
         })
       );
       expect(allPaginatedFinalState.shownCategory).toBe("ARCHIVE");
@@ -749,12 +766,14 @@ describe("allPaginated reducer", () => {
     [
       reloadAllMessages.request({
         pageSize,
-        filter: { getArchived: archived }
+        filter: { getArchived: archived },
+        fromUserAction: false
       }),
       reloadAllMessages.success({
         filter: { getArchived: archived },
         messages: [],
-        pagination: {}
+        pagination: {},
+        fromUserAction: false
       }),
       reloadAllMessages.failure({
         error: new Error(""),
@@ -762,12 +781,14 @@ describe("allPaginated reducer", () => {
       }),
       loadPreviousPageMessages.request({
         filter: { getArchived: archived },
-        pageSize
+        pageSize,
+        fromUserAction: false
       }),
       loadPreviousPageMessages.success({
         filter: { getArchived: archived },
         messages: [],
-        pagination: {}
+        pagination: {},
+        fromUserAction: false
       }),
       loadPreviousPageMessages.failure({
         error: new Error(""),
@@ -775,12 +796,14 @@ describe("allPaginated reducer", () => {
       }),
       loadNextPageMessages.request({
         filter: { getArchived: archived },
-        pageSize
+        pageSize,
+        fromUserAction: false
       }),
       loadNextPageMessages.success({
         filter: { getArchived: archived },
         messages: [],
-        pagination: {}
+        pagination: {},
+        fromUserAction: false
       }),
       loadNextPageMessages.failure({
         error: new Error(""),

--- a/ts/features/messages/store/reducers/__tests__/messageGetStatus.test.ts
+++ b/ts/features/messages/store/reducers/__tests__/messageGetStatus.test.ts
@@ -118,7 +118,11 @@ describe("messageGetStatusReducer", () => {
     expect(failureState).not.toStrictEqual(INITIAL_STATE);
     const resetState = messageGetStatusReducer(
       failureState,
-      reloadAllMessages.request({ filter: {}, pageSize: 20 })
+      reloadAllMessages.request({
+        filter: {},
+        pageSize: 20,
+        fromUserAction: false
+      })
     );
     expect(resetState).toStrictEqual(INITIAL_STATE);
   });

--- a/ts/features/messages/store/reducers/__tests__/payments.test.ts
+++ b/ts/features/messages/store/reducers/__tests__/payments.test.ts
@@ -375,7 +375,11 @@ describe("Messages payments reducer's tests", () => {
     expect(startingHasPaymentToCheck).toBe(true);
     const endingPaymentsState = paymentsReducer(
       startingPaymentsState,
-      reloadAllMessages.request({ pageSize: 12, filter: {} })
+      reloadAllMessages.request({
+        pageSize: 12,
+        filter: {},
+        fromUserAction: false
+      })
     );
     const endingUserSelectedPayments = endingPaymentsState.userSelectedPayments;
     const endingPaymentsToCheckSize = endingUserSelectedPayments.size;

--- a/ts/features/messages/store/reducers/allPaginated.ts
+++ b/ts/features/messages/store/reducers/allPaginated.ts
@@ -627,6 +627,25 @@ export const messageListForCategorySelector = (
     )
   );
 
+export const messageCountForCategorySelector = (
+  state: GlobalState,
+  shownCategory: MessageListCategory
+) =>
+  pipe(
+    state,
+    messagePagePotFromCategorySelector(shownCategory),
+    foldK(
+      () => 0,
+      () => 0,
+      () => 0,
+      () => 0,
+      messagePage => messagePage.page.length,
+      messagePage => messagePage.page.length,
+      (messagePage, _) => messagePage.page.length,
+      (messagePage, _) => messagePage.page.length
+    )
+  );
+
 export const emptyListReasonSelector = (
   state: GlobalState,
   category: MessageListCategory

--- a/ts/features/pushNotifications/utils/configurePushNotification.ts
+++ b/ts/features/pushNotifications/utils/configurePushNotification.ts
@@ -65,7 +65,9 @@ function handleForegroundMessageReload() {
     getArchiveAndInboxNextAndPreviousPageIndexes(state);
   if (pot.isNone(inboxIndexes)) {
     // nothing in the collection, refresh
-    store.dispatch(reloadAllMessages.request({ pageSize, filter: {} }));
+    store.dispatch(
+      reloadAllMessages.request({ pageSize, filter: {}, fromUserAction: false })
+    );
   } else if (pot.isSome(inboxIndexes)) {
     // something in the collection, get the maximum amount of new ones only,
     // assuming that the message will be there
@@ -73,7 +75,8 @@ function handleForegroundMessageReload() {
       loadPreviousPageMessages.request({
         cursor: inboxIndexes.value.previous,
         pageSize: maximumItemsFromAPI,
-        filter: {}
+        filter: {},
+        fromUserAction: false
       })
     );
   }


### PR DESCRIPTION
## Short description
This PR add the Analytics event for the new messages home and search.

## List of changes proposed in this pull request
- For the event list, refer to the document linked on IOCOM-1110

## How to test
Using the io-dev-api-server, generate some messages and check that all analytics events are triggered with proper parameters.
