### PR TITLE
fix: [IOCOM-1687] Fix a race condition on message details loading

### DIFF
--- a/ts/features/messages/components/Home/homeUtils.ts
+++ b/ts/features/messages/components/Home/homeUtils.ts
@@ -50,7 +50,7 @@ export const getInitialReloadAllMessagesActionIfNeeded = (
   pipe(state, shownMessageCategorySelector, category =>
     pipe(
       state,
-      isArchivingInProcessingModeSelector,
+      isDoingAnAsyncOperationOnMessages,
       B.fold(
         () =>
           pipe(

--- a/ts/features/messages/store/reducers/archiving.ts
+++ b/ts/features/messages/store/reducers/archiving.ts
@@ -13,7 +13,7 @@ import { duplicateSetAndRemove, duplicateSetAndToggle } from "../../utils";
 import { GlobalState } from "../../../../store/reducers/types";
 import { MessageListCategory } from "../../types/messageListCategory";
 
-type ArchivingStatus = "disabled" | "enabled" | "processing";
+export type ArchivingStatus = "disabled" | "enabled" | "processing";
 
 export type ProcessingResult = {
   type: "success" | "warning" | "error";


### PR DESCRIPTION
## Short description
This PR fixes a race condition that prevented loading message details

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/08598397-2bd6-4e61-8d82-6e6b981792e0" />|<video src="https://github.com/user-attachments/assets/13360807-8925-4f67-bddd-25ddfa320b20" />|

## List of changes proposed in this pull request
- Prevents initial loading of (archived) messages if the system is busy doing an asynchronous home messages operation
- The race condition happened if the first archived message retrieval request was fired during an inbox messages asynchronous operation. In such case, the latter was cancelled by the former (since the saga is handled using a `takeLatest`) and the (former's) pot state was not being updated from the loading state.

## How to test
Using the io-dev-api-server, set some delay on the messages list retrieval. Load the inbox, do a pull-to-refresh but switch to the archive tab before it finished. Select a message from the archived list. You should be able to load its details.
