### PR TITLE
feat: [IOPAE-1317] Display an informative message when there are no other results

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2208,7 +2208,11 @@ services:
       cancel: "Cancel"
       clear: "Clear"
     emptyState:
-      title: "Enter the name of an institution,\nnational or local"
+      invalidQuery:
+        title: "Enter the name of an institution,\nnational or local"
+      noResults:
+        title: "No results found"
+        subtitle: "Enter the name of an existing national or local institution."
   details:
     failure:
       title: "There is a temporary problem. Please try again"

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2213,6 +2213,8 @@ services:
       noResults:
         title: "No results found"
         subtitle: "Enter the name of an existing national or local institution."
+    endOfList:
+      description: "Hai ragiunto la fine della lista. \nSe non hai trovato quello di cui avevi bisogno, avvia una nuova ricerca."
   details:
     failure:
       title: "There is a temporary problem. Please try again"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2208,7 +2208,11 @@ services:
       cancel: "Annulla"
       clear: "Cancella"
     emptyState:
-      title: "Inserisci il nome di un ente,\nnazionale o locale"
+      invalidQuery:
+        title: "Inserisci il nome di un ente,\nnazionale o locale"
+      noResults:
+        title: "Nessun risultato trovato"
+        subtitle: "Inserisci il nome di un ente nazionale o locale esistente."
   details:
     failure:
       title: "C'è un problema temporaneo, riprova"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2213,6 +2213,8 @@ services:
       noResults:
         title: "Nessun risultato trovato"
         subtitle: "Inserisci il nome di un ente nazionale o locale esistente."
+    endOfList:
+      description: "Hai ragiunto la fine della lista. \nSe non hai trovato quello di cui avevi bisogno, avvia una nuova ricerca."
   details:
     failure:
       title: "C'è un problema temporaneo, riprova"

--- a/ts/features/services/common/components/EmptyState.tsx
+++ b/ts/features/services/common/components/EmptyState.tsx
@@ -1,8 +1,8 @@
 import {
+  Body,
   H6,
   IOPictograms,
   IOStyles,
-  IOVisualCostants,
   Pictogram,
   VSpacer,
   WithTestID
@@ -11,9 +11,6 @@ import React from "react";
 import { StyleSheet, View } from "react-native";
 
 const styles = StyleSheet.create({
-  container: {
-    marginHorizontal: IOVisualCostants.appMarginDefault
-  },
   text: {
     textAlign: "center"
   }
@@ -22,14 +19,26 @@ const styles = StyleSheet.create({
 export type EmptyStateProps = WithTestID<{
   pictogram: IOPictograms;
   title: string;
+  subtitle?: string;
 }>;
 
-export const EmptyState = ({ pictogram, title, testID }: EmptyStateProps) => (
-  <View style={styles.container} testID={testID}>
+export const EmptyState = ({
+  pictogram,
+  title,
+  subtitle,
+  testID
+}: EmptyStateProps) => (
+  <View testID={testID}>
     <View style={IOStyles.alignCenter}>
       <Pictogram name={pictogram} size={120} />
       <VSpacer size={24} />
     </View>
     <H6 style={styles.text}>{title}</H6>
+    {subtitle && (
+      <>
+        <VSpacer size={8} />
+        <Body style={styles.text}>{subtitle}</Body>
+      </>
+    )}
   </View>
 );

--- a/ts/features/services/search/components/EndOfList.tsx
+++ b/ts/features/services/search/components/EndOfList.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { View } from "react-native";
+import { Icon, IOStyles, Label, VSpacer } from "@pagopa/io-app-design-system";
+
+type EndOfListProps = {
+  description: string;
+};
+
+export const EndOfList = ({ description }: EndOfListProps) => (
+  <>
+    <VSpacer size={24} />
+    <View style={IOStyles.alignCenter}>
+      <Icon name="search" color="grey-300" />
+    </View>
+    <VSpacer size={8} />
+    <Label
+      weight="Regular"
+      fontSize="small"
+      color="grey-700"
+      style={{ textAlign: "center" }}
+    >
+      {description}
+    </Label>
+    <VSpacer size={24} />
+  </>
+);

--- a/ts/features/services/search/hooks/useInstitutionsFetcher.tsx
+++ b/ts/features/services/search/hooks/useInstitutionsFetcher.tsx
@@ -70,6 +70,7 @@ export const useInstitutionsFetcher = () => {
     currentPage,
     data: paginatedInstitutions,
     isError,
+    isLastPage,
     isLoading,
     isUpdating,
     isRefreshing,

--- a/ts/features/services/search/screens/SearchScreen.tsx
+++ b/ts/features/services/search/screens/SearchScreen.tsx
@@ -1,5 +1,11 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Platform, View } from "react-native";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
+import { Platform, View, ViewStyle } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FlashList, ListRenderItemInfo } from "@shopify/flash-list";
@@ -9,8 +15,7 @@ import {
   IOStyles,
   IOToast,
   SearchInput,
-  SearchInputRef,
-  VSpacer
+  SearchInputRef
 } from "@pagopa/io-app-design-system";
 import I18n from "../../../../i18n";
 import { useInstitutionsFetcher } from "../hooks/useInstitutionsFetcher";
@@ -23,7 +28,6 @@ import { SERVICES_ROUTES } from "../../common/navigation/routes";
 import { EmptyState } from "../../common/components/EmptyState";
 import { InstitutionListSkeleton } from "../../common/components/InstitutionListSkeleton";
 import { ListItemSearchInstitution } from "../../common/components/ListItemSearchInstitution";
-import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
 import * as analytics from "../../common/analytics";
 
 const INPUT_PADDING: IOSpacingScale = 16;
@@ -38,6 +42,15 @@ export const SearchScreen = () => {
   const searchInputRef = useRef<SearchInputRef>(null);
   const [query, setQuery] = useState<string>("");
 
+  const containerStyle: ViewStyle = useMemo(
+    () => ({
+      ...IOStyles.horizontalContentPadding,
+      marginTop: insets.top,
+      paddingVertical: INPUT_PADDING
+    }),
+    [insets.top]
+  );
+
   const {
     currentPage,
     data,
@@ -48,10 +61,9 @@ export const SearchScreen = () => {
     isUpdating
   } = useInstitutionsFetcher();
 
-  useOnFirstRender(() => analytics.trackSearchPage());
-
   useFocusEffect(
     useCallback(() => {
+      analytics.trackSearchPage();
       searchInputRef.current?.focus();
     }, [])
   );
@@ -126,14 +138,10 @@ export const SearchScreen = () => {
 
   const renderListFooterComponent = useCallback(() => {
     if (isUpdating) {
-      return (
-        <>
-          <InstitutionListSkeleton />
-          <VSpacer size={16} />
-        </>
-      );
+      return <InstitutionListSkeleton />;
     }
-    return <VSpacer size={16} />;
+
+    return null;
   }, [isUpdating]);
 
   const renderListEmptyComponent = useCallback(() => {
@@ -141,7 +149,17 @@ export const SearchScreen = () => {
       return (
         <EmptyState
           pictogram="searchLens"
-          title={I18n.t("services.search.emptyState.title")}
+          title={I18n.t("services.search.emptyState.invalidQuery.title")}
+        />
+      );
+    }
+
+    if (data?.institutions.length === 0) {
+      return (
+        <EmptyState
+          pictogram="umbrellaNew"
+          title={I18n.t("services.search.emptyState.noResults.title")}
+          subtitle={I18n.t("services.search.emptyState.noResults.subtitle")}
         />
       );
     }
@@ -150,20 +168,12 @@ export const SearchScreen = () => {
       return <InstitutionListSkeleton />;
     }
 
-    return <VSpacer size={16} />;
-  }, [isLoading, query]);
+    return null;
+  }, [isLoading, query, data?.institutions]);
 
   return (
     <>
-      <View
-        style={[
-          {
-            marginTop: insets.top,
-            paddingVertical: INPUT_PADDING
-          },
-          IOStyles.horizontalContentPadding
-        ]}
-      >
+      <View style={containerStyle}>
         <SearchInput
           accessibilityLabel={I18n.t("services.search.input.placeholderShort")}
           autoFocus={true}
@@ -179,20 +189,20 @@ export const SearchScreen = () => {
       </View>
       <FlashList
         ItemSeparatorComponent={() => <Divider />}
+        ListEmptyComponent={renderListEmptyComponent}
+        ListFooterComponent={renderListFooterComponent}
         contentContainerStyle={IOStyles.horizontalContentPadding}
         data={data?.institutions || []}
         estimatedItemSize={LIST_ITEM_HEIGHT}
-        keyExtractor={(item, index) => `institution-${item.id}-${index}`}
-        renderItem={renderItem}
-        onEndReached={handleEndReached}
-        onEndReachedThreshold={0.1}
-        ListEmptyComponent={renderListEmptyComponent}
-        ListFooterComponent={renderListFooterComponent}
         keyboardDismissMode={Platform.select({
           ios: "interactive",
           default: "on-drag"
         })}
         keyboardShouldPersistTaps="handled"
+        keyExtractor={(item, index) => `institution-${item.id}-${index}`}
+        onEndReached={handleEndReached}
+        onEndReachedThreshold={0.1}
+        renderItem={renderItem}
       />
     </>
   );

--- a/ts/features/services/search/screens/SearchScreen.tsx
+++ b/ts/features/services/search/screens/SearchScreen.tsx
@@ -15,7 +15,8 @@ import {
   IOStyles,
   IOToast,
   SearchInput,
-  SearchInputRef
+  SearchInputRef,
+  VSpacer
 } from "@pagopa/io-app-design-system";
 import I18n from "../../../../i18n";
 import { useInstitutionsFetcher } from "../hooks/useInstitutionsFetcher";
@@ -141,7 +142,7 @@ export const SearchScreen = () => {
       return <InstitutionListSkeleton />;
     }
 
-    return null;
+    return <VSpacer size={16} />;
   }, [isUpdating]);
 
   const renderListEmptyComponent = useCallback(() => {

--- a/ts/features/services/search/screens/SearchScreen.tsx
+++ b/ts/features/services/search/screens/SearchScreen.tsx
@@ -30,6 +30,7 @@ import { EmptyState } from "../../common/components/EmptyState";
 import { InstitutionListSkeleton } from "../../common/components/InstitutionListSkeleton";
 import { ListItemSearchInstitution } from "../../common/components/ListItemSearchInstitution";
 import * as analytics from "../../common/analytics";
+import { EndOfList } from "../components/EndOfList";
 
 const INPUT_PADDING: IOSpacingScale = 16;
 const LIST_ITEM_HEIGHT: number = 70;
@@ -58,6 +59,7 @@ export const SearchScreen = () => {
     fetchNextPage,
     fetchPage,
     isError,
+    isLastPage,
     isLoading,
     isUpdating
   } = useInstitutionsFetcher();
@@ -139,11 +141,24 @@ export const SearchScreen = () => {
 
   const renderListFooterComponent = useCallback(() => {
     if (isUpdating) {
-      return <InstitutionListSkeleton />;
+      return (
+        <>
+          <InstitutionListSkeleton />
+          <VSpacer size={16} />
+        </>
+      );
+    }
+
+    if (isLastPage && !!data && data?.institutions.length > 0) {
+      return (
+        <EndOfList
+          description={I18n.t("services.search.endOfList.description")}
+        />
+      );
     }
 
     return <VSpacer size={16} />;
-  }, [isUpdating]);
+  }, [data, isLastPage, isUpdating]);
 
   const renderListEmptyComponent = useCallback(() => {
     if (query.length < MIN_QUERY_LENGTH) {


### PR DESCRIPTION
This PR depends on https://github.com/pagopa/io-app/pull/6119

## Short description
This PR adds an informative message to the bottom of the list. This message informs the user that there are no other results to display.

<details open><summary>Details</summary>
<p>

| search |
| - | 
| <img src="https://github.com/user-attachments/assets/978371a2-7463-478d-9a12-ca3b8a93dd04" width="300"/> |

</p>
</details> 

## List of changes proposed in this pull request
- updated `SearchScreen` to display an information message when there are no results to display

## How to test
Search for an institution and scroll to the bottom of the list. Check the message is displayed correctly.