### PR TITLE
[IOPID-2101] fix bottomsheet accessibility on Android

### DIFF
--- a/ts/utils/hooks/bottomSheet.tsx
+++ b/ts/utils/hooks/bottomSheet.tsx
@@ -15,6 +15,7 @@ import { NonEmptyArray } from "fp-ts/lib/NonEmptyArray";
 import * as React from "react";
 import { useCallback, useEffect, useState } from "react";
 import {
+  AccessibilityInfo,
   Dimensions,
   LayoutChangeEvent,
   Modal,
@@ -27,7 +28,6 @@ import { BottomSheetHeader } from "../../components/bottomSheet/BottomSheetHeade
 import { IOStyles } from "../../components/core/variables/IOStyles";
 import { useHardwareBackButtonToDismiss } from "../../hooks/useHardwareBackButton";
 import { TestID } from "../../types/WithTestID";
-import { isScreenReaderEnabled } from "../accessibility";
 
 const screenHeight = Dimensions.get("window").height;
 
@@ -162,9 +162,11 @@ export const useIOBottomSheetModal = ({
   );
 
   useEffect(() => {
-    isScreenReaderEnabled()
-      .then(sre => setIsScreenReaderEnabled(sre))
-      .catch(_ => setIsScreenReaderEnabled(false));
+    const event = AccessibilityInfo.addEventListener(
+      "screenReaderChanged",
+      setIsScreenReaderEnabled
+    );
+    return () => event.remove();
   }, []);
 
   const footerComponent = footer ? (


### PR DESCRIPTION
## Short description
This pull request addresses an accessibility issue related to the BottomSheet component. The modification ensures that the BottomSheet behaves correctly when a screen reader is enabled, specifically for Android devices.

## List of changes proposed in this pull request
- Updated the BottomSheet component to listen for changes in screen reader status using AccessibilityInfo.addEventListener.
- Removed the old implementation where the screen reader status was fetched with a promise and replaced it with an event listener for real-time updates.

## DEMO

<p>

| CURRENT A11Y ON BOTTOMSHEET | NEW A11Y ON BOTTOMSHEET | 
| - | - |
| <video src="https://github.com/user-attachments/assets/2e1904ca-cb3c-414d-8f07-e941d4c65d32"/> | <video src="https://github.com/user-attachments/assets/66f61d61-fcce-4fc5-a7d3-b0a3eab95da5"/> |

</p>

## How to test
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
