### PR TITLE
[SIW-1426] Allow user to remove IT Wallet credential from wallet

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2181,7 +2181,7 @@ services:
         servicesPreferences:
           value: Who can contact you?
           description: Choose who can contact you
-        settings: 
+        settings:
           value: Settings
           description: Manage your data and preferences
     featured:
@@ -3333,6 +3333,13 @@ features:
           requestAssistance: "Something wrong? Contact {{authSource}}"
           showClaimValues: "Show claim values"
           hideClaimValues: "Hide claim values"
+        dialogs:
+          remove:
+            title: Vuoi rimuovere il documento dal Portafoglio?
+            content: Se cambi idea, potrai riaggiungerlo in seguito.
+            confirm: Sì, rimuovi
+        toast:
+          removed: Fatto! Hai rimosso {{credentialName}}
   trialSystem:
     toast:
       subscribed: Done! You will receive a message when the trial period will begin.

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2181,7 +2181,7 @@ services:
         servicesPreferences:
           value: Chi può scriverti?
           description: Scegli chi può contattarti
-        settings: 
+        settings:
           value: Tutte le impostazioni
           description: Gestisci i tuoi dati e le preferenze d'uso
     featured:
@@ -3333,6 +3333,13 @@ features:
           requestAssistance: "Qualcosa non torna? Contatta {{authSource}}"
           showClaimValues: "Mostra gli attributi del documento"
           hideClaimValues: "Nascondi gli attributi del documento"
+        dialogs:
+          remove:
+            title: Vuoi rimuovere il documento dal Portafoglio?
+            content: Se cambi idea, potrai riaggiungerlo in seguito.
+            confirm: Sì, rimuovi
+        toast:
+          removed: Fatto! Hai rimosso {{credentialName}}
   trialSystem:
     toast:
       subscribed: Fatto! Riceverai un messaggio all’avvio della sperimentazione

--- a/ts/features/itwallet/common/saga/index.ts
+++ b/ts/features/itwallet/common/saga/index.ts
@@ -6,11 +6,13 @@ import { checkWalletInstanceStateSaga } from "../../lifecycle/saga/checkWalletIn
 import { handleWalletCredentialsRehydration } from "../../credentials/saga/handleWalletCredentialsRehydration";
 import { itwTrialId } from "../../../../config";
 import { itwCieIsSupported } from "../../identification/store/actions";
+import { watchItwCredentialsSaga } from "../../credentials/saga";
 
 export function* watchItwSaga(): SagaIterator {
   yield* fork(checkWalletInstanceStateSaga);
   yield* fork(handleWalletCredentialsRehydration);
   yield* fork(watchItwIdentificationSaga);
+  yield* fork(watchItwCredentialsSaga);
 
   // TODO: [SIW-1404] remove this CIE check and move the logic to xstate
   yield* put(itwCieIsSupported.request());

--- a/ts/features/itwallet/credentials/saga/handleItwCredentialsRemoveSaga.ts
+++ b/ts/features/itwallet/credentials/saga/handleItwCredentialsRemoveSaga.ts
@@ -1,0 +1,14 @@
+import { put } from "typed-redux-saga/macro";
+import { walletRemoveCards } from "../../../newWallet/store/actions/cards";
+import { itwCredentialsRemove } from "../store/actions";
+
+/**
+ * This saga handles the credential removal action and ensures the consistency between stored credentials and wallet state.
+ * @param itwCredentialsRemoveAction
+ */
+export function* handleItwCredentialsRemoveSaga(
+  itwCredentialsRemoveAction: ReturnType<typeof itwCredentialsRemove>
+) {
+  const { keyTag } = itwCredentialsRemoveAction.payload;
+  yield* put(walletRemoveCards([keyTag]));
+}

--- a/ts/features/itwallet/credentials/saga/handleItwCredentialsStoreSaga.ts
+++ b/ts/features/itwallet/credentials/saga/handleItwCredentialsStoreSaga.ts
@@ -1,0 +1,21 @@
+import { put } from "typed-redux-saga/macro";
+import { walletUpsertCard } from "../../../newWallet/store/actions/cards";
+import { itwCredentialsStore } from "../store/actions";
+
+/**
+ * This saga handles the credential store action and ensures the consistency between stored credentials and wallet state.
+ * @param itwCredentialsRemoveAction
+ */
+export function* handleItwCredentialsStoreSaga(
+  itwCredentialsStoreAction: ReturnType<typeof itwCredentialsStore>
+) {
+  const { keyTag, credentialType } = itwCredentialsStoreAction.payload;
+  yield* put(
+    walletUpsertCard({
+      key: keyTag,
+      type: "itw",
+      category: "itw",
+      credentialType
+    })
+  );
+}

--- a/ts/features/itwallet/credentials/saga/index.ts
+++ b/ts/features/itwallet/credentials/saga/index.ts
@@ -1,0 +1,10 @@
+import { SagaIterator } from "redux-saga";
+import { takeLeading } from "typed-redux-saga/macro";
+import { itwCredentialsRemove, itwCredentialsStore } from "../store/actions";
+import { handleItwCredentialsRemoveSaga } from "./handleItwCredentialsRemoveSaga";
+import { handleItwCredentialsStoreSaga } from "./handleItwCredentialsStoreSaga";
+
+export function* watchItwCredentialsSaga(): SagaIterator {
+  yield* takeLeading(itwCredentialsStore, handleItwCredentialsStoreSaga);
+  yield* takeLeading(itwCredentialsRemove, handleItwCredentialsRemoveSaga);
+}

--- a/ts/features/itwallet/machine/credential/actions.ts
+++ b/ts/features/itwallet/machine/credential/actions.ts
@@ -5,14 +5,13 @@ import { ActionArgs } from "xstate5";
 import I18n from "../../../../i18n";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import ROUTES from "../../../../navigation/routes";
+import { checkCurrentSession } from "../../../../store/actions/authentication";
 import { useIODispatch } from "../../../../store/hooks";
 import { assert } from "../../../../utils/assert";
-import { walletUpsertCard } from "../../../newWallet/store/actions/cards";
 import * as credentialIssuanceUtils from "../../common/utils/itwCredentialIssuanceUtils";
+import { getCredentialNameFromType } from "../../common/utils/itwCredentialUtils";
 import { itwCredentialsStore } from "../../credentials/store/actions";
 import { ITW_ROUTES } from "../../navigation/routes";
-import { getCredentialNameFromType } from "../../common/utils/itwCredentialUtils";
-import { checkCurrentSession } from "../../../../store/actions/authentication";
 import { Context } from "./context";
 import { CredentialIssuanceEvents } from "./events";
 
@@ -78,17 +77,8 @@ export default (
     CredentialIssuanceEvents
   >) => {
     assert(context.credential, "credential is undefined");
-    assert(context.credentialType, "credentialType is undefined");
 
     dispatch(itwCredentialsStore(context.credential));
-    dispatch(
-      walletUpsertCard({
-        key: context.credential.keyTag,
-        type: "itw",
-        category: "itw",
-        credentialType: context.credentialType
-      })
-    );
   },
 
   disposeWallet: () => {

--- a/ts/features/itwallet/machine/eid/actions.ts
+++ b/ts/features/itwallet/machine/eid/actions.ts
@@ -3,18 +3,16 @@ import { IOToast } from "@pagopa/io-app-design-system";
 import { ActionArgs } from "xstate5";
 import I18n from "../../../../i18n";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
-import { useIODispatch } from "../../../../store/hooks";
 import ROUTES from "../../../../navigation/routes";
-import { ITW_ROUTES } from "../../navigation/routes";
-import { walletUpsertCard } from "../../../newWallet/store/actions/cards";
+import { checkCurrentSession } from "../../../../store/actions/authentication";
+import { useIODispatch } from "../../../../store/hooks";
+import { assert } from "../../../../utils/assert";
+import { disposeWalletAttestation } from "../../common/utils/itwAttestationUtils";
+import { itwCredentialsStore } from "../../credentials/store/actions";
+import { itwStoreIntegrityKeyTag } from "../../issuance/store/actions";
 import { itwLifecycleStateUpdated } from "../../lifecycle/store/actions";
 import { ItwLifecycleState } from "../../lifecycle/store/reducers";
-import { itwStoreIntegrityKeyTag } from "../../issuance/store/actions";
-import { itwCredentialsStore } from "../../credentials/store/actions";
-import { CredentialType } from "../../common/utils/itwMocksUtils";
-import { disposeWalletAttestation } from "../../common/utils/itwAttestationUtils";
-import { checkCurrentSession } from "../../../../store/actions/authentication";
-import { assert } from "../../../../utils/assert";
+import { ITW_ROUTES } from "../../navigation/routes";
 import { Context } from "./context";
 import { EidIssuanceEvents } from "./events";
 
@@ -136,14 +134,6 @@ export const createEidIssuanceActionsImplementation = (
     assert(context.eid, "eID is undefined");
 
     dispatch(itwCredentialsStore(context.eid));
-    dispatch(
-      walletUpsertCard({
-        key: context.eid.keyTag,
-        type: "itw",
-        category: "itw",
-        credentialType: CredentialType.PID
-      })
-    );
   },
 
   requestAssistance: () => {},

--- a/ts/features/itwallet/presentation/components/ItwPresentationDetailFooter.tsx
+++ b/ts/features/itwallet/presentation/components/ItwPresentationDetailFooter.tsx
@@ -2,44 +2,107 @@ import {
   Chip,
   IOStyles,
   ListItemAction,
+  useIOToast,
   VSpacer
 } from "@pagopa/io-app-design-system";
 import React from "react";
-import { Linking, View } from "react-native";
+import { Alert, Linking, View } from "react-native";
 import I18n from "../../../../i18n";
+import { useIONavigation } from "../../../../navigation/params/AppParamsList";
+import { useIODispatch } from "../../../../store/hooks";
 import { format } from "../../../../utils/dates";
-import { IssuerConfiguration } from "../../common/utils/itwTypesUtils";
+import { itwCredentialNameByCredentialType } from "../../common/utils/itwCredentialUtils";
+import { CredentialType } from "../../common/utils/itwMocksUtils";
+import { StoredCredential } from "../../common/utils/itwTypesUtils";
+import { itwCredentialsRemove } from "../../credentials/store/actions";
+
+// TODO: use the real credential update time
+const lastUpdateTime = new Date();
 
 type Props = {
-  lastUpdateTime: Date;
-  issuerConf: IssuerConfiguration;
+  credential: StoredCredential;
 };
 
-export const ItwPresentationDetailFooter = ({
-  lastUpdateTime,
-  issuerConf
-}: Props) => (
-  <View>
-    <ListItemAction
-      variant="primary"
-      icon="message"
-      label={I18n.t(
-        "features.itWallet.presentation.credentialDetails.actions.requestAssistance",
-        { authSource: issuerConf.federation_entity.organization_name }
-      )}
-      accessibilityLabel={I18n.t(
-        "features.itWallet.presentation.credentialDetails.actions.requestAssistance",
-        { authSource: issuerConf.federation_entity.organization_name }
-      )}
-      onPress={() =>
-        Linking.openURL(`mailto:${issuerConf.federation_entity.contacts?.[0]}`)
-      }
-    />
-    <VSpacer size={24} />
-    <Chip color="grey-650" style={IOStyles.selfCenter}>
-      {I18n.t("features.itWallet.presentation.credentialDetails.lastUpdated", {
-        lastUpdateTime: format(lastUpdateTime, "DD MMMM YYYY, HH:mm")
-      })}
-    </Chip>
-  </View>
-);
+export const ItwPresentationDetailFooter = ({ credential }: Props) => {
+  const dispatch = useIODispatch();
+  const navigation = useIONavigation();
+  const toast = useIOToast();
+
+  const handleRemoveCredential = () => {
+    dispatch(itwCredentialsRemove(credential));
+    toast.success(
+      I18n.t("features.itWallet.presentation.credentialDetails.toast.removed", {
+        credentialName:
+          itwCredentialNameByCredentialType[credential.credentialType]
+      })
+    );
+    navigation.pop();
+  };
+
+  const showRemoveCredentialDialog = () =>
+    Alert.alert(
+      I18n.t(
+        "features.itWallet.presentation.credentialDetails.dialogs.remove.title"
+      ),
+      I18n.t(
+        "features.itWallet.presentation.credentialDetails.dialogs.remove.content"
+      ),
+      [
+        {
+          text: I18n.t(
+            "features.itWallet.presentation.credentialDetails.dialogs.remove.confirm"
+          ),
+          style: "destructive",
+          onPress: handleRemoveCredential
+        },
+        {
+          text: I18n.t("global.buttons.cancel"),
+          style: "cancel"
+        }
+      ]
+    );
+
+  const { federation_entity } = credential.issuerConf;
+
+  return (
+    <View>
+      <ListItemAction
+        variant="primary"
+        icon="message"
+        label={I18n.t(
+          "features.itWallet.presentation.credentialDetails.actions.requestAssistance",
+          { authSource: federation_entity.organization_name }
+        )}
+        accessibilityLabel={I18n.t(
+          "features.itWallet.presentation.credentialDetails.actions.requestAssistance",
+          { authSource: federation_entity.organization_name }
+        )}
+        onPress={() =>
+          Linking.openURL(`mailto:${federation_entity.contacts?.[0]}`)
+        }
+      />
+      {credential.credentialType !== CredentialType.PID ? (
+        <ListItemAction
+          variant="danger"
+          icon="trashcan"
+          label={I18n.t(
+            "features.itWallet.presentation.credentialDetails.actions.removeFromWallet"
+          )}
+          accessibilityLabel={I18n.t(
+            "features.itWallet.presentation.credentialDetails.actions.removeFromWallet"
+          )}
+          onPress={showRemoveCredentialDialog}
+        />
+      ) : null}
+      <VSpacer size={24} />
+      <Chip color="grey-650" style={IOStyles.selfCenter}>
+        {I18n.t(
+          "features.itWallet.presentation.credentialDetails.lastUpdated",
+          {
+            lastUpdateTime: format(lastUpdateTime, "DD MMMM YYYY, HH:mm")
+          }
+        )}
+      </Chip>
+    </View>
+  );
+};

--- a/ts/features/itwallet/presentation/components/ItwPresentationDetailFooter.tsx
+++ b/ts/features/itwallet/presentation/components/ItwPresentationDetailFooter.tsx
@@ -83,6 +83,7 @@ export const ItwPresentationDetailFooter = ({ credential }: Props) => {
       />
       {credential.credentialType !== CredentialType.PID ? (
         <ListItemAction
+          testID="removeCredentialActionTestID"
           variant="danger"
           icon="trashcan"
           label={I18n.t(

--- a/ts/features/itwallet/presentation/components/__tests__/ItwPresentationDetailFooter.test.tsx
+++ b/ts/features/itwallet/presentation/components/__tests__/ItwPresentationDetailFooter.test.tsx
@@ -18,7 +18,7 @@ describe("ItwPresentationAlertsSection", () => {
     CredentialType.EUROPEAN_DISABILITY_CARD,
     CredentialType.EUROPEAN_HEALTH_INSURANCE_CARD
   ])(
-    "should render remove credential button if credential type is %p",
+    "should render the remove credential action if credential type is %p",
     credentialType => {
       const { queryByTestId } = renderComponent(credentialType);
 

--- a/ts/features/itwallet/presentation/components/__tests__/ItwPresentationDetailFooter.test.tsx
+++ b/ts/features/itwallet/presentation/components/__tests__/ItwPresentationDetailFooter.test.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { createStore } from "redux";
+import { applicationChangeState } from "../../../../../store/actions/application";
+import { appReducer } from "../../../../../store/reducers";
+import { GlobalState } from "../../../../../store/reducers/types";
+import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
+import {
+  CredentialType,
+  ItwStoredCredentialsMocks
+} from "../../../common/utils/itwMocksUtils";
+import { ItwCredentialIssuanceMachineContext } from "../../../machine/provider";
+import { ITW_ROUTES } from "../../../navigation/routes";
+import { ItwPresentationDetailFooter } from "../ItwPresentationDetailFooter";
+
+describe("ItwPresentationAlertsSection", () => {
+  test.each([
+    CredentialType.DRIVING_LICENSE,
+    CredentialType.EUROPEAN_DISABILITY_CARD,
+    CredentialType.EUROPEAN_HEALTH_INSURANCE_CARD
+  ])(
+    "should render remove credential button if credential type is %p",
+    credentialType => {
+      const { queryByTestId } = renderComponent(credentialType);
+
+      expect(queryByTestId("removeCredentialActionTestID")).not.toBeNull();
+    }
+  );
+
+  it("should not render the remove credential action if credential is EID", () => {
+    const { queryByTestId } = renderComponent(CredentialType.PID);
+
+    expect(queryByTestId("removeCredentialActionTestID")).toBeNull();
+  });
+});
+
+const renderComponent = (credentialType: CredentialType) => {
+  const globalState = appReducer(undefined, applicationChangeState("active"));
+  return renderScreenWithNavigationStoreContext<GlobalState>(
+    () => (
+      <ItwCredentialIssuanceMachineContext.Provider>
+        <ItwPresentationDetailFooter
+          credential={{
+            ...ItwStoredCredentialsMocks.dc,
+            credentialType
+          }}
+        />
+      </ItwCredentialIssuanceMachineContext.Provider>
+    ),
+    ITW_ROUTES.PRESENTATION.CREDENTIAL_DETAIL,
+    {},
+    createStore(appReducer, globalState as any)
+  );
+};

--- a/ts/features/itwallet/presentation/screens/ItwPresentationCredentialDetailScreen.tsx
+++ b/ts/features/itwallet/presentation/screens/ItwPresentationCredentialDetailScreen.tsx
@@ -38,9 +38,6 @@ import { ItwPresentationAlertsSection } from "../components/ItwPresentationAlert
 import { ItwPresentationDetailFooter } from "../components/ItwPresentationDetailFooter";
 import { useDebugInfo } from "../../../../hooks/useDebugInfo";
 
-// TODO: use the real credential update time
-const today = new Date();
-
 export type ItwPresentationCredentialDetailNavigationParams = {
   credentialType: string;
 };
@@ -65,10 +62,12 @@ export const ItwPresentationCredentialDetailScreen = ({ route }: Props) => {
   );
 };
 
+type ContentProps = { credential: StoredCredential };
+
 /**
  * This component renders the entire credential detail.
  */
-const ContentView = ({ credential }: { credential: StoredCredential }) => {
+const ContentView = ({ credential }: ContentProps) => {
   const { screenEndMargin } = useScreenEndMargin();
   const themeColor = getThemeColorByCredentialType(
     credential.credentialType as CredentialType
@@ -121,10 +120,7 @@ const ContentView = ({ credential }: { credential: StoredCredential }) => {
           <Divider />
           <ItwReleaserName credential={credential} />
           <VSpacer size={24} />
-          <ItwPresentationDetailFooter
-            lastUpdateTime={today}
-            issuerConf={credential.issuerConf}
-          />
+          <ItwPresentationDetailFooter credential={credential} />
         </ContentWrapper>
       </ScrollView>
     </>


### PR DESCRIPTION
## Short description
This PR adds the ability for users to remove credentials from their wallet

## List of changes proposed in this pull request
- Handled wallet-stored credentials state consistency in sagas
- Added "Remove from wallet" action in credential's details screen
- Added I18n keys

## How to test
Open the details screen of a credential (not the PID), tap on "Remove from wallet" button. After it's removed, check that credentials is not present in the wallet

## Preview

https://github.com/user-attachments/assets/d836b824-5f2e-4f07-b63a-4e412fd890e1



