### PR TITLE
chore: [IOCOM-1678] FIMS history single listItem error state

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3985,6 +3985,7 @@ permissionRequest:
 FIMS:
   history:
     errorStates:
+      dataUnavailable: "Dati non disponibili"
       ko:
         title: "C’è un problema temporaneo"
         body: "Il caricamento della lista degli accessi non è riuscito"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3985,6 +3985,7 @@ permissionRequest:
 FIMS:
   history:
     errorStates:
+      dataUnavailable: "Dati non disponibili"
       ko:
         title: "C’è un problema temporaneo"
         body: "Il caricamento della lista degli accessi non è riuscito"

--- a/ts/features/fims/history/components/FimsHistoryListItem.tsx
+++ b/ts/features/fims/history/components/FimsHistoryListItem.tsx
@@ -1,18 +1,41 @@
-import { ListItemNav } from "@pagopa/io-app-design-system";
+import {
+  Caption,
+  HSpacer,
+  Icon,
+  LabelSmall,
+  ListItemNav,
+  PressableListItemBase,
+  useIOTheme,
+  VSpacer
+} from "@pagopa/io-app-design-system";
 import { constNull } from "fp-ts/lib/function";
 import * as React from "react";
+import { View } from "react-native";
 import { ServiceId } from "../../../../../definitions/backend/ServiceId";
 import { ServicePublic } from "../../../../../definitions/backend/ServicePublic";
 import { Consent } from "../../../../../definitions/fims/Consent";
+import I18n from "../../../../i18n";
 import { dateToAccessibilityReadableFormat } from "../../../../utils/accessibility";
 import { potFoldWithDefault } from "../../../../utils/pot";
 import { useAutoFetchingServiceByIdPot } from "../../common/utils/hooks";
 import { LoadingFimsHistoryListItem } from "./FimsHistoryLoaders";
 
+// ------- TYPES
+
 type SuccessListItemProps = {
   serviceData: ServicePublic;
   consent: Consent;
 };
+type HistoryListItemProps = {
+  item: Consent;
+};
+
+type FailureListItemProps = {
+  consent: Consent;
+};
+
+// --------- LISTITEMS
+
 const SuccessListItem = ({ serviceData, consent }: SuccessListItemProps) => (
   <ListItemNav
     onPress={constNull}
@@ -24,9 +47,40 @@ const SuccessListItem = ({ serviceData, consent }: SuccessListItemProps) => (
     hideChevron
   />
 );
-type HistoryListItemProps = {
-  item: Consent;
+
+const FailureListItem = ({ consent }: FailureListItemProps) => {
+  const theme = useIOTheme();
+
+  return (
+    <PressableListItemBase>
+      <View
+        style={{
+          paddingVertical: 15
+        }}
+      >
+        <View
+          style={{
+            alignSelf: "flex-start",
+            flexDirection: "row"
+          }}
+        >
+          <Icon name="calendar" size={16} color="grey-300" />
+          <HSpacer size={4} />
+          <Caption color={theme["textBody-tertiary"]}>
+            {dateToAccessibilityReadableFormat(consent.timestamp)}
+          </Caption>
+        </View>
+        <VSpacer size={4} />
+        <LabelSmall weight="Semibold" color="error-600">
+          {I18n.t("FIMS.history.errorStates.dataUnavailable")}
+        </LabelSmall>
+      </View>
+      <Icon name="errorFilled" color="error-600" />
+    </PressableListItemBase>
+  );
 };
+
+// ------- RENDERER
 
 export const FimsHistoryListItem = ({ item }: HistoryListItemProps) => {
   const { serviceData } = useAutoFetchingServiceByIdPot(
@@ -35,6 +89,7 @@ export const FimsHistoryListItem = ({ item }: HistoryListItemProps) => {
 
   return potFoldWithDefault(serviceData, {
     default: LoadingFimsHistoryListItem,
+    noneError: _ => <FailureListItem consent={item} />,
     some: data => <SuccessListItem serviceData={data} consent={item} />,
     someError: data => <SuccessListItem serviceData={data} consent={item} />,
     someLoading: data => <SuccessListItem serviceData={data} consent={item} />

--- a/ts/features/fims/history/components/FimsHistoryListItem.tsx
+++ b/ts/features/fims/history/components/FimsHistoryListItem.tsx
@@ -26,12 +26,8 @@ type SuccessListItemProps = {
   serviceData: ServicePublic;
   consent: Consent;
 };
-type HistoryListItemProps = {
+type BaseHistoryListItemProps = {
   item: Consent;
-};
-
-type FailureListItemProps = {
-  consent: Consent;
 };
 
 // --------- LISTITEMS
@@ -48,7 +44,7 @@ const SuccessListItem = ({ serviceData, consent }: SuccessListItemProps) => (
   />
 );
 
-const FailureListItem = ({ consent }: FailureListItemProps) => {
+const FailureListItem = ({ item }: BaseHistoryListItemProps) => {
   const theme = useIOTheme();
 
   return (
@@ -67,7 +63,7 @@ const FailureListItem = ({ consent }: FailureListItemProps) => {
           <Icon name="calendar" size={16} color="grey-300" />
           <HSpacer size={4} />
           <Caption color={theme["textBody-tertiary"]}>
-            {dateToAccessibilityReadableFormat(consent.timestamp)}
+            {dateToAccessibilityReadableFormat(item.timestamp)}
           </Caption>
         </View>
         <VSpacer size={4} />
@@ -82,14 +78,14 @@ const FailureListItem = ({ consent }: FailureListItemProps) => {
 
 // ------- RENDERER
 
-export const FimsHistoryListItem = ({ item }: HistoryListItemProps) => {
+export const FimsHistoryListItem = ({ item }: BaseHistoryListItemProps) => {
   const { serviceData } = useAutoFetchingServiceByIdPot(
     item.service_id as ServiceId
   );
 
   return potFoldWithDefault(serviceData, {
     default: LoadingFimsHistoryListItem,
-    noneError: _ => <FailureListItem consent={item} />,
+    noneError: _ => <FailureListItem item={item} />,
     some: data => <SuccessListItem serviceData={data} consent={item} />,
     someError: data => <SuccessListItem serviceData={data} consent={item} />,
     someLoading: data => <SuccessListItem serviceData={data} consent={item} />


### PR DESCRIPTION
## Short description
addition of said error state when the service details' fetch fails.
<img width="250" alt="Screenshot 2024-08-30 at 12 38 40" src="https://github.com/user-attachments/assets/d0d1847b-c867-421f-8947-bfedae4302f5">

## List of changes proposed in this pull request
- required I18n entries
- addition of said component and its rendering logic

## How to test
update the dev server's code to return the following line in `src/routers/service.ts, line 58/59`
```ts
                res.status(Math.random() > 0.3 ? 200 : 404).json(service)
```
this way, as long as you have a big enough FIMS history list (dev-server, config.ts, I recommend something around 50),
you should be able to see some failed fetches.
make sure everything works as intended and follows the given design.