### PR TITLE
fix(IT Wallet): [SIW-1537] Duplicate fiscal code in trust issuer screen

### DIFF
--- a/ts/features/itwallet/common/utils/itwClaimsUtils.ts
+++ b/ts/features/itwallet/common/utils/itwClaimsUtils.ts
@@ -31,7 +31,7 @@ export enum WellKnownClaim {
   /**
    * Unique ID must be excluded from every credential and should not rendered in the claims list
    */
-  unique_id = "unique_ID",
+  unique_id = "unique_id",
   /**
    * Claim used to extract expiry date from a credential. This is used to display how many days are left for
    * the credential expiration or to know if the credential is expired
@@ -39,7 +39,7 @@ export enum WellKnownClaim {
   expiry_date = "expiry_date",
   /**
    * Claim used to display a QR Code for the Disability Card. It must be excluded from the common claims list
-   * and rendered using a {@see QRCodeImage}
+   * and rendered using a {@link QRCodeImage}
    */
   link_qr_code = "link_qr_code"
 }


### PR DESCRIPTION
## Short description
This PR fixes the duplicate fiscal code attribute in the trust issuer screen when presenting a eID for obtaining a new credential.

## List of changes proposed in this pull request
- Change the well known claims object `unique_id` attribute to match the one contained in the eID claims list.

## How to test
Obtain a PID and then try to obtain any other credential. The trust issuer screen should shown the fiscal code as required attribute only once.