### PR TITLE
fix: [IOBP-847] Navigate to the new payment flow from scan notice qr-code

### DIFF
--- a/ts/features/barcode/screens/BarcodeScanScreen.tsx
+++ b/ts/features/barcode/screens/BarcodeScanScreen.tsx
@@ -17,7 +17,6 @@ import {
   AppParamsList,
   IOStackNavigationProp
 } from "../../../navigation/params/AppParamsList";
-import { navigateToPaymentTransactionSummaryScreen } from "../../../store/actions/navigation";
 import { paymentInitializeState } from "../../../store/actions/wallet/payment";
 import { useIODispatch, useIOSelector } from "../../../store/hooks";
 import {
@@ -44,12 +43,15 @@ import { BarcodeFailure } from "../types/failure";
 import { getIOBarcodesByType } from "../utils/getBarcodesByType";
 import { PaymentsBarcodeRoutes } from "../../payments/barcode/navigation/routes";
 import { useHardwareBackButton } from "../../../hooks/useHardwareBackButton";
+import { usePagoPaPayment } from "../../payments/checkout/hooks/usePagoPaPayment";
 
 const BarcodeScanScreen = () => {
   const navigation = useNavigation<IOStackNavigationProp<AppParamsList>>();
   const dispatch = useIODispatch();
   const openDeepLink = useOpenDeepLink();
   const isIdPayEnabled = useIOSelector(isIdPayEnabledSelector);
+
+  const { startPaymentFlowWithRptId } = usePagoPaPayment();
 
   useHardwareBackButton(() => {
     navigation.goBack();
@@ -137,13 +139,11 @@ const BarcodeScanScreen = () => {
           void mixpanelTrack("WALLET_SCAN_POSTE_DATAMATRIX_SUCCESS");
         }
 
-        navigateToPaymentTransactionSummaryScreen({
-          rptId: barcode.rptId,
-          initialAmount: barcode.amount,
-          paymentStartOrigin: isDataMatrix
-            ? "poste_datamatrix_scan"
-            : "qrcode_scan"
+        startPaymentFlowWithRptId(barcode.rptId, {
+          onSuccess: "showTransaction",
+          startOrigin: isDataMatrix ? "poste_datamatrix_scan" : "qrcode_scan"
         });
+
         break;
       case "IDPAY":
         openDeepLink(barcode.authUrl);

--- a/ts/features/payments/barcode/screens/PaymentsBarcodeChoiceScreen.tsx
+++ b/ts/features/payments/barcode/screens/PaymentsBarcodeChoiceScreen.tsx
@@ -71,7 +71,8 @@ const PaymentsBarcodeChoiceScreen = () => {
 
     if (isNewWalletSectionEnabled) {
       startPaymentFlowWithRptId(barcode.rptId, {
-        onSuccess: "showTransaction"
+        onSuccess: "showTransaction",
+        startOrigin: "qrcode_scan"
       });
     } else {
       dispatch(paymentInitializeState());


### PR DESCRIPTION
## Short description
This PR fixes a bug related to the new 'scan' feature in the tab bar, ensuring that when a QR code is scanned, the user is redirected to the new payment flow, fully removing the old flow

## List of changes proposed in this pull request
- Replaced the old and deprecated `navigateToPaymentTransactionSummaryScreen` with the new `startPaymentFlowWithRptId` 

## How to test
- With the app deployed in a production environment, try starting a payment flow from the "scan" tab section by scanning or uploading a QRCode. You should be able to see the new payment flow instead of the previous one.
- If you need a valid qr-code in production, please feel free to contact me in DM, I will provide you a ready to use qr-code notice.
