### PR TITLE
chore(IT Wallet): [SIW-1538] Add navigation on credential renewal

### DIFF
--- a/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialTrustIssuerScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialTrustIssuerScreen.tsx
@@ -34,6 +34,7 @@ import {
 import { itwCredentialsEidSelector } from "../../credentials/store/selectors";
 import {
   selectCredentialTypeOption,
+  selectIsIssuing,
   selectIsLoading,
   selectRequestedCredentialOption
 } from "../../machine/credential/selectors";
@@ -42,9 +43,12 @@ import {
   ItwRequestedClaimsList,
   RequiredClaim
 } from "../components/ItwRequiredClaimsList";
+import LoadingScreenContent from "../../../../components/screens/LoadingScreenContent";
 
 const ItwIssuanceCredentialTrustIssuerScreen = () => {
   const eidOption = useIOSelector(itwCredentialsEidSelector);
+  const isLoading =
+    ItwCredentialIssuanceMachineContext.useSelector(selectIsLoading);
   const requestedCredentialOption =
     ItwCredentialIssuanceMachineContext.useSelector(
       selectRequestedCredentialOption
@@ -55,6 +59,12 @@ const ItwIssuanceCredentialTrustIssuerScreen = () => {
 
   useItwDisableGestureNavigation();
   useAvoidHardwareBackButton();
+
+  if (isLoading) {
+    return (
+      <LoadingScreenContent contentTitle={I18n.t("global.genericWaiting")} />
+    );
+  }
 
   return pipe(
     sequenceS(O.Monad)({
@@ -80,8 +90,8 @@ type ContentViewProps = {
  */
 const ContentView = ({ credentialType, eid }: ContentViewProps) => {
   const machineRef = ItwCredentialIssuanceMachineContext.useActorRef();
-  const isLoading =
-    ItwCredentialIssuanceMachineContext.useSelector(selectIsLoading);
+  const isIssuing =
+    ItwCredentialIssuanceMachineContext.useSelector(selectIsIssuing);
 
   const handleContinuePress = () => {
     machineRef.send({ type: "confirm-trust-data" });
@@ -171,7 +181,7 @@ const ContentView = ({ credentialType, eid }: ContentViewProps) => {
           primary: {
             label: I18n.t("global.buttons.continue"),
             onPress: handleContinuePress,
-            loading: isLoading
+            loading: isIssuing
           },
           secondary: {
             label: I18n.t("global.buttons.cancel"),

--- a/ts/features/itwallet/machine/credential/__tests__/machine.test.ts
+++ b/ts/features/itwallet/machine/credential/__tests__/machine.test.ts
@@ -169,7 +169,8 @@ describe("itwCredentialIssuanceMachine", () => {
 
     actor.send({
       type: "select-credential",
-      credentialType: "MDL"
+      credentialType: "MDL",
+      skipNavigation: true
     });
 
     expect(actor.getSnapshot().value).toStrictEqual("WalletInitialization");
@@ -290,7 +291,8 @@ describe("itwCredentialIssuanceMachine", () => {
 
     actor.send({
       type: "select-credential",
-      credentialType: "MDL"
+      credentialType: "MDL",
+      skipNavigation: true
     });
 
     expect(actor.getSnapshot().value).toStrictEqual("WalletInitialization");
@@ -340,7 +342,8 @@ describe("itwCredentialIssuanceMachine", () => {
 
     actor.send({
       type: "select-credential",
-      credentialType: "MDL"
+      credentialType: "MDL",
+      skipNavigation: true
     });
 
     expect(actor.getSnapshot().value).toStrictEqual("WalletInitialization");

--- a/ts/features/itwallet/machine/credential/__tests__/machine.test.ts
+++ b/ts/features/itwallet/machine/credential/__tests__/machine.test.ts
@@ -178,6 +178,7 @@ describe("itwCredentialIssuanceMachine", () => {
       credentialType: "MDL"
     });
     expect(actor.getSnapshot().tags).toStrictEqual(new Set([ItwTags.Loading]));
+    expect(navigateToTrustIssuerScreen).toHaveBeenCalledTimes(0);
     await waitFor(() => expect(initializeWallet).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(requestCredential).toHaveBeenCalledTimes(1));
 
@@ -209,7 +210,7 @@ describe("itwCredentialIssuanceMachine", () => {
     });
 
     expect(actor.getSnapshot().value).toStrictEqual("ObtainingCredential");
-    expect(actor.getSnapshot().tags).toStrictEqual(new Set([ItwTags.Loading]));
+    expect(actor.getSnapshot().tags).toStrictEqual(new Set([ItwTags.Issuing]));
     await waitFor(() => expect(obtainCredential).toHaveBeenCalledTimes(1));
 
     expect(actor.getSnapshot().value).toStrictEqual(
@@ -300,6 +301,7 @@ describe("itwCredentialIssuanceMachine", () => {
       credentialType: "MDL"
     });
     expect(actor.getSnapshot().tags).toStrictEqual(new Set([ItwTags.Loading]));
+    expect(navigateToTrustIssuerScreen).toHaveBeenCalledTimes(0);
     await waitFor(() => expect(initializeWallet).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(requestCredential).toHaveBeenCalledTimes(0));
 
@@ -351,6 +353,7 @@ describe("itwCredentialIssuanceMachine", () => {
       credentialType: "MDL"
     });
     expect(actor.getSnapshot().tags).toStrictEqual(new Set([ItwTags.Loading]));
+    expect(navigateToTrustIssuerScreen).toHaveBeenCalledTimes(0);
     await waitFor(() => expect(initializeWallet).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(requestCredential).toHaveBeenCalledTimes(1));
 
@@ -423,7 +426,7 @@ describe("itwCredentialIssuanceMachine", () => {
     });
 
     expect(actor.getSnapshot().value).toStrictEqual("ObtainingCredential");
-    expect(actor.getSnapshot().tags).toStrictEqual(new Set([ItwTags.Loading]));
+    expect(actor.getSnapshot().tags).toStrictEqual(new Set([ItwTags.Issuing]));
     await waitFor(() => expect(obtainCredential).toHaveBeenCalledTimes(1));
 
     expect(actor.getSnapshot().value).toStrictEqual("Failure");
@@ -440,5 +443,36 @@ describe("itwCredentialIssuanceMachine", () => {
 
     expect(actor.getSnapshot().value).toStrictEqual("Failure");
     expect(closeIssuance).toHaveBeenCalledTimes(1);
+  });
+
+  it("Should navigate to the next screen if skipNavigation is false", () => {
+    const actor = createActor(mockedMachine);
+    actor.start();
+
+    initializeWallet.mockImplementation(() =>
+      Promise.resolve({
+        walletInstanceAttestation: T_WIA_CONTEXT.walletAttestation,
+        wiaCryptoContext: T_WIA_CONTEXT.wiaCryptoContext
+      })
+    );
+
+    requestCredential.mockImplementation(() =>
+      Promise.resolve({
+        clientId: T_CLIENT_ID,
+        codeVerifier: T_CODE_VERIFIER,
+        credentialDefinition: T_CREDENTIAL_DEFINITION,
+        requestedCredential: T_REQUESTED_CREDENTIAL,
+        issuerConf: T_ISSUER_CONFIG
+      })
+    );
+
+    actor.send({
+      type: "select-credential",
+      credentialType: "MDL",
+      skipNavigation: false
+    });
+
+    expect(actor.getSnapshot().value).toStrictEqual("WalletInitialization");
+    expect(navigateToTrustIssuerScreen).toHaveBeenCalledTimes(1);
   });
 });

--- a/ts/features/itwallet/machine/credential/events.ts
+++ b/ts/features/itwallet/machine/credential/events.ts
@@ -4,9 +4,10 @@ export type Reset = {
   type: "reset";
 };
 
-export type SelecteCredential = {
+export type SelectCredential = {
   type: "select-credential";
   credentialType: string;
+  skipNavigation: boolean;
 };
 
 export type ConfirmTrustData = {
@@ -31,7 +32,7 @@ export type Close = {
 
 export type CredentialIssuanceEvents =
   | Reset
-  | SelecteCredential
+  | SelectCredential
   | ConfirmTrustData
   | AddToWallet
   | Retry

--- a/ts/features/itwallet/machine/credential/machine.ts
+++ b/ts/features/itwallet/machine/credential/machine.ts
@@ -60,12 +60,24 @@ export const itwCredentialIssuanceMachine = setup({
     Idle: {
       entry: assign(() => InitialContext),
       on: {
-        "select-credential": {
-          target: "WalletInitialization",
-          actions: assign(({ event }) => ({
-            credentialType: event.credentialType
-          }))
-        }
+        "select-credential": [
+          {
+            guard: ({ event }) => !event.skipNavigation,
+            target: "WalletInitialization",
+            actions: [
+              assign(({ event }) => ({
+                credentialType: event.credentialType
+              })),
+              "navigateToTrustIssuerScreen"
+            ]
+          },
+          {
+            target: "WalletInitialization",
+            actions: assign(({ event }) => ({
+              credentialType: event.credentialType
+            }))
+          }
+        ]
       }
     },
     WalletInitialization: {
@@ -128,7 +140,7 @@ export const itwCredentialIssuanceMachine = setup({
       }
     },
     ObtainingCredential: {
-      tags: [ItwTags.Loading],
+      tags: [ItwTags.Issuing],
       invoke: {
         src: "obtainCredential",
         input: ({ context }) => ({

--- a/ts/features/itwallet/machine/credential/selectors.ts
+++ b/ts/features/itwallet/machine/credential/selectors.ts
@@ -8,6 +8,9 @@ type MachineSnapshot = StateFrom<ItwCredentialIssuanceMachine>;
 export const selectIsLoading = (snapshot: MachineSnapshot) =>
   snapshot.hasTag(ItwTags.Loading);
 
+export const selectIsIssuing = (snapshot: MachineSnapshot) =>
+  snapshot.hasTag(ItwTags.Issuing);
+
 export const selectCredentialTypeOption = (snapshot: MachineSnapshot) =>
   O.fromNullable(snapshot.context.credentialType);
 

--- a/ts/features/itwallet/machine/tags.ts
+++ b/ts/features/itwallet/machine/tags.ts
@@ -1,3 +1,4 @@
 export enum ItwTags {
-  Loading = "Loading"
+  Loading = "Loading",
+  Issuing = "Issuing"
 }

--- a/ts/features/itwallet/navigation/ItwStackNavigator.tsx
+++ b/ts/features/itwallet/navigation/ItwStackNavigator.tsx
@@ -130,6 +130,7 @@ const InnerNavigator = () => {
       <Stack.Screen
         name={ITW_ROUTES.ISSUANCE.CREDENTIAL_TRUST_ISSUER}
         component={ItwIssuanceCredentialTrustIssuerScreen}
+        options={hiddenHeader}
       />
       <Stack.Screen
         name={ITW_ROUTES.ISSUANCE.CREDENTIAL_PREVIEW}

--- a/ts/features/itwallet/onboarding/screens/WalletCardOnboardingScreen.tsx
+++ b/ts/features/itwallet/onboarding/screens/WalletCardOnboardingScreen.tsx
@@ -83,7 +83,11 @@ const ItwCredentialOnboardingSection = () => {
     if (isCredentialIssuancePending) {
       return;
     }
-    machineRef.send({ type: "select-credential", credentialType: type });
+    machineRef.send({
+      type: "select-credential",
+      credentialType: type,
+      skipNavigation: true
+    });
   };
   // List of available credentials to show to the user
   const availableCredentials = [

--- a/ts/features/itwallet/playgrounds/screens/ItwPlayground.tsx
+++ b/ts/features/itwallet/playgrounds/screens/ItwPlayground.tsx
@@ -60,7 +60,11 @@ const ItwPlayground = () => {
 
   const handleStartCredentialIssuance =
     (credentialType: CredentialType) => () => {
-      credentialMachineRef.send({ type: "select-credential", credentialType });
+      credentialMachineRef.send({
+        type: "select-credential",
+        credentialType,
+        skipNavigation: true
+      });
     };
 
   return (

--- a/ts/features/itwallet/playgrounds/screens/ItwPlayground.tsx
+++ b/ts/features/itwallet/playgrounds/screens/ItwPlayground.tsx
@@ -63,7 +63,7 @@ const ItwPlayground = () => {
       credentialMachineRef.send({
         type: "select-credential",
         credentialType,
-        skipNavigation: true
+        skipNavigation: false
       });
     };
 

--- a/ts/features/itwallet/presentation/components/ItwPresentationAlertsSection.tsx
+++ b/ts/features/itwallet/presentation/components/ItwPresentationAlertsSection.tsx
@@ -21,7 +21,8 @@ export const ItwPresentationAlertsSection = ({ credential }: Props) => {
   const beginCredentialIssuance = () => {
     machineRef.send({
       type: "select-credential",
-      credentialType: credential.credentialType as CredentialType
+      credentialType: credential.credentialType,
+      skipNavigation: false
     });
   };
 


### PR DESCRIPTION
## Short description
This PR adds a navigation action for the credential renewal started from the credential details screen. The navigation allows to visualize the loading state correctly

## List of changes proposed in this pull request
- Added `skipNavigation` flag to `selected-credential` event
- Added navigation to the trust issuer screen if `skipNavigation` is set to false
- Added loading component in `ItwIssuanceCredentialTrustIssuerScreen`
- Added tests

## How to test
From the details screen of an expired credential, tap on "Update" button in the expired alert.

## Preview

https://github.com/user-attachments/assets/b0293e6b-f5df-427e-98ca-11225131e92b



