### PR TITLE
fix(IT Wallet): [SIW-1535] Credential duplication after renewal

### DIFF
--- a/ts/features/itwallet/credentials/saga/__tests__/handleWalletCredentialsRehydration.test.ts
+++ b/ts/features/itwallet/credentials/saga/__tests__/handleWalletCredentialsRehydration.test.ts
@@ -27,7 +27,7 @@ describe("ITW handleWalletCredentialsRehydration saga", () => {
       .put(
         walletAddCards([
           {
-            key: "1",
+            key: `ITW_${CredentialType.PID}`,
             type: "itw",
             category: "itw",
             credentialType: CredentialType.PID
@@ -66,19 +66,19 @@ describe("ITW handleWalletCredentialsRehydration saga", () => {
       .put(
         walletAddCards([
           {
-            key: "1",
+            key: `ITW_${CredentialType.PID}`,
             type: "itw",
             category: "itw",
             credentialType: CredentialType.PID
           },
           {
-            key: "2",
+            key: `ITW_${CredentialType.DRIVING_LICENSE}`,
             type: "itw",
             category: "itw",
             credentialType: CredentialType.DRIVING_LICENSE
           },
           {
-            key: "3",
+            key: `ITW_${CredentialType.EUROPEAN_DISABILITY_CARD}`,
             type: "itw",
             category: "itw",
             credentialType: CredentialType.EUROPEAN_DISABILITY_CARD
@@ -112,7 +112,7 @@ describe("ITW handleWalletCredentialsRehydration saga", () => {
       .not.put(
         walletAddCards([
           {
-            key: "2",
+            key: `ITW_${CredentialType.DRIVING_LICENSE}`,
             type: "itw",
             category: "itw",
             credentialType: CredentialType.DRIVING_LICENSE

--- a/ts/features/itwallet/credentials/saga/checkCredentialsStatusAttestation.ts
+++ b/ts/features/itwallet/credentials/saga/checkCredentialsStatusAttestation.ts
@@ -10,11 +10,11 @@ import {
   shouldRequestStatusAttestation,
   getCredentialStatusAttestation
 } from "../../common/utils/itwCredentialStatusAttestationUtils";
-import { itwCredentialsMultipleUpdate } from "../store/actions";
 import { ReduxSagaEffect } from "../../../../types/utils";
 import { itwLifecycleIsValidSelector } from "../../lifecycle/store/selectors";
 import { walletAddCards } from "../../../newWallet/store/actions/cards";
 import { getCredentialStatus } from "../../common/utils/itwClaimsUtils";
+import { itwCredentialsStore } from "../store/actions";
 
 const canGetStatusAttestation = (credential: StoredCredential) =>
   credential.credentialType === CredentialType.DRIVING_LICENSE;
@@ -80,7 +80,7 @@ export function* checkCredentialsStatusAttestation() {
     )
   );
 
-  yield* put(itwCredentialsMultipleUpdate(updatedCredentials));
+  yield* put(itwCredentialsStore(updatedCredentials));
   yield* put(
     walletAddCards(
       updatedCredentials.map(c => ({

--- a/ts/features/itwallet/credentials/saga/checkCredentialsStatusAttestation.ts
+++ b/ts/features/itwallet/credentials/saga/checkCredentialsStatusAttestation.ts
@@ -84,7 +84,7 @@ export function* checkCredentialsStatusAttestation() {
   yield* put(
     walletAddCards(
       updatedCredentials.map(c => ({
-        key: c.keyTag,
+        key: `ITW_${c.credentialType}`,
         type: "itw",
         category: "itw",
         credentialType: c.credentialType,

--- a/ts/features/itwallet/credentials/saga/checkCredentialsStatusAttestation.ts
+++ b/ts/features/itwallet/credentials/saga/checkCredentialsStatusAttestation.ts
@@ -12,8 +12,6 @@ import {
 } from "../../common/utils/itwCredentialStatusAttestationUtils";
 import { ReduxSagaEffect } from "../../../../types/utils";
 import { itwLifecycleIsValidSelector } from "../../lifecycle/store/selectors";
-import { walletAddCards } from "../../../newWallet/store/actions/cards";
-import { getCredentialStatus } from "../../common/utils/itwClaimsUtils";
 import { itwCredentialsStore } from "../store/actions";
 
 const canGetStatusAttestation = (credential: StoredCredential) =>
@@ -81,15 +79,4 @@ export function* checkCredentialsStatusAttestation() {
   );
 
   yield* put(itwCredentialsStore(updatedCredentials));
-  yield* put(
-    walletAddCards(
-      updatedCredentials.map(c => ({
-        key: `ITW_${c.credentialType}`,
-        type: "itw",
-        category: "itw",
-        credentialType: c.credentialType,
-        status: getCredentialStatus(c)
-      }))
-    )
-  );
 }

--- a/ts/features/itwallet/credentials/saga/handleItwCredentialsRemoveSaga.ts
+++ b/ts/features/itwallet/credentials/saga/handleItwCredentialsRemoveSaga.ts
@@ -11,7 +11,7 @@ import { itwCredentialsRemove } from "../store/actions";
 export function* handleItwCredentialsRemoveSaga(
   itwCredentialsRemoveAction: ReturnType<typeof itwCredentialsRemove>
 ) {
-  const { keyTag } = itwCredentialsRemoveAction.payload;
+  const { credentialType, keyTag } = itwCredentialsRemoveAction.payload;
   yield* call(deleteKey, keyTag);
-  yield* put(walletRemoveCards([keyTag]));
+  yield* put(walletRemoveCards([`ITW_${credentialType}`]));
 }

--- a/ts/features/itwallet/credentials/saga/handleItwCredentialsStoreSaga.ts
+++ b/ts/features/itwallet/credentials/saga/handleItwCredentialsStoreSaga.ts
@@ -1,21 +1,26 @@
 import { put } from "typed-redux-saga/macro";
-import { walletUpsertCard } from "../../../newWallet/store/actions/cards";
+import { walletAddCards } from "../../../newWallet/store/actions/cards";
 import { itwCredentialsStore } from "../store/actions";
+import { getCredentialStatus } from "../../common/utils/itwClaimsUtils";
 
 /**
  * This saga handles the credential store action and ensures the consistency between stored credentials and wallet state.
  * @param itwCredentialsRemoveAction
  */
-export function* handleItwCredentialsStoreSaga(
-  itwCredentialsStoreAction: ReturnType<typeof itwCredentialsStore>
-) {
-  const { keyTag, credentialType } = itwCredentialsStoreAction.payload;
+export function* handleItwCredentialsStoreSaga({
+  payload
+}: ReturnType<typeof itwCredentialsStore>) {
+  const credentials = Array.isArray(payload) ? payload : [payload];
+
   yield* put(
-    walletUpsertCard({
-      key: keyTag,
-      type: "itw",
-      category: "itw",
-      credentialType
-    })
+    walletAddCards(
+      credentials.map(c => ({
+        key: `ITW_${c.credentialType}`,
+        type: "itw",
+        category: "itw",
+        credentialType: c.credentialType,
+        status: getCredentialStatus(c)
+      }))
+    )
   );
 }

--- a/ts/features/itwallet/credentials/saga/handleItwCredentialsStoreSaga.ts
+++ b/ts/features/itwallet/credentials/saga/handleItwCredentialsStoreSaga.ts
@@ -7,14 +7,12 @@ import { getCredentialStatus } from "../../common/utils/itwClaimsUtils";
  * This saga handles the credential store action and ensures the consistency between stored credentials and wallet state.
  * @param itwCredentialsRemoveAction
  */
-export function* handleItwCredentialsStoreSaga({
-  payload
-}: ReturnType<typeof itwCredentialsStore>) {
-  const credentials = Array.isArray(payload) ? payload : [payload];
-
+export function* handleItwCredentialsStoreSaga(
+  itwCredentialsStoreAction: ReturnType<typeof itwCredentialsStore>
+) {
   yield* put(
     walletAddCards(
-      credentials.map(c => ({
+      itwCredentialsStoreAction.payload.map(c => ({
         key: `ITW_${c.credentialType}`,
         type: "itw",
         category: "itw",

--- a/ts/features/itwallet/credentials/saga/handleWalletCredentialsRehydration.ts
+++ b/ts/features/itwallet/credentials/saga/handleWalletCredentialsRehydration.ts
@@ -13,7 +13,7 @@ const mapCredentialsToWalletCards = (
   credentials: Array<StoredCredential>
 ): Array<WalletCard> =>
   credentials.map(credential => ({
-    key: credential.keyTag,
+    key: `ITW_${credential.credentialType}`,
     type: "itw",
     category: "itw",
     credentialType: credential.credentialType as CredentialType

--- a/ts/features/itwallet/credentials/store/actions/index.ts
+++ b/ts/features/itwallet/credentials/store/actions/index.ts
@@ -1,23 +1,18 @@
 import { ActionType, createStandardAction } from "typesafe-actions";
 import { StoredCredential } from "../../../common/utils/itwTypesUtils";
 
+/**
+ * This action stores one or multiple credentials using the credential type as key.
+ * The new credential completely overwrites the previous one.
+ */
 export const itwCredentialsStore = createStandardAction(
   "ITW_CREDENTIALS_STORE"
-)<StoredCredential>();
+)<StoredCredential | Array<StoredCredential>>();
 
 export const itwCredentialsRemove = createStandardAction(
   "ITW_CREDENTIALS_REMOVE"
 )<StoredCredential>();
 
-/**
- * This action updates multiple credentials using their type as key.
- * The new credential completely overwrites the previous one.
- */
-export const itwCredentialsMultipleUpdate = createStandardAction(
-  "ITW_CREDENTIALS_MULTIPLE_UPDATE"
-)<Array<StoredCredential>>();
-
 export type ItwCredentialsActions =
   | ActionType<typeof itwCredentialsStore>
-  | ActionType<typeof itwCredentialsRemove>
-  | ActionType<typeof itwCredentialsMultipleUpdate>;
+  | ActionType<typeof itwCredentialsRemove>;

--- a/ts/features/itwallet/credentials/store/actions/index.ts
+++ b/ts/features/itwallet/credentials/store/actions/index.ts
@@ -7,7 +7,7 @@ import { StoredCredential } from "../../../common/utils/itwTypesUtils";
  */
 export const itwCredentialsStore = createStandardAction(
   "ITW_CREDENTIALS_STORE"
-)<StoredCredential | Array<StoredCredential>>();
+)<Array<StoredCredential>>();
 
 export const itwCredentialsRemove = createStandardAction(
   "ITW_CREDENTIALS_REMOVE"

--- a/ts/features/itwallet/credentials/store/reducers/__tests__/index.test.ts
+++ b/ts/features/itwallet/credentials/store/reducers/__tests__/index.test.ts
@@ -106,4 +106,30 @@ describe("ITW credentials reducer", () => {
       credentials: []
     });
   });
+
+  it("should overwrite a credential of the same type without duplication", () => {
+    const newMockedCredential = {
+      ...mockedCredential,
+      keyTag: "0d634e7b-40bf-4986-934a-7b18051290e6"
+    };
+    const mockedCredential2 = {
+      ...mockedCredential,
+      credentialType: CredentialType.EUROPEAN_HEALTH_INSURANCE_CARD,
+      keyTag: "fe1233cb-ed98-4619-abe6-54603f97a998"
+    };
+
+    const targetSate = pipe(
+      undefined,
+      curriedAppReducer(applicationChangeState("active")),
+      curriedAppReducer(itwCredentialsStore(mockedEid)),
+      curriedAppReducer(itwCredentialsStore(mockedCredential)),
+      curriedAppReducer(itwCredentialsStore(mockedCredential2)),
+      curriedAppReducer(itwCredentialsStore(newMockedCredential))
+    );
+
+    expect(targetSate.features.itWallet.credentials.credentials).toEqual([
+      O.some(newMockedCredential),
+      O.some(mockedCredential2)
+    ]);
+  });
 });

--- a/ts/features/itwallet/credentials/store/reducers/__tests__/index.test.ts
+++ b/ts/features/itwallet/credentials/store/reducers/__tests__/index.test.ts
@@ -48,7 +48,7 @@ describe("ITW credentials reducer", () => {
     const targetSate = pipe(
       undefined,
       curriedAppReducer(applicationChangeState("active")),
-      curriedAppReducer(itwCredentialsStore(mockedEid))
+      curriedAppReducer(itwCredentialsStore([mockedEid]))
     );
 
     expect(targetSate.features.itWallet.credentials.eid).toEqual(
@@ -61,8 +61,8 @@ describe("ITW credentials reducer", () => {
     const targetSate = pipe(
       undefined,
       curriedAppReducer(applicationChangeState("active")),
-      curriedAppReducer(itwCredentialsStore(mockedEid)),
-      curriedAppReducer(itwCredentialsStore(mockedCredential))
+      curriedAppReducer(itwCredentialsStore([mockedEid])),
+      curriedAppReducer(itwCredentialsStore([mockedCredential]))
     );
 
     expect(targetSate.features.itWallet.credentials.eid).toEqual(
@@ -77,7 +77,7 @@ describe("ITW credentials reducer", () => {
     const targetSate = pipe(
       undefined,
       curriedAppReducer(applicationChangeState("active")),
-      curriedAppReducer(itwCredentialsStore(mockedEid)),
+      curriedAppReducer(itwCredentialsStore([mockedEid])),
       curriedAppReducer(
         itwCredentialsStore([mockedCredential, mockedCredential2])
       )
@@ -111,7 +111,7 @@ describe("ITW credentials reducer", () => {
     const targetSate = pipe(
       undefined,
       curriedAppReducer(applicationChangeState("active")),
-      curriedAppReducer(itwCredentialsStore(mockedCredential))
+      curriedAppReducer(itwCredentialsStore([mockedCredential]))
     );
 
     expect(targetSate.features.itWallet.credentials.eid).toEqual(O.none);
@@ -122,7 +122,7 @@ describe("ITW credentials reducer", () => {
     const targetSate = pipe(
       undefined,
       curriedAppReducer(applicationChangeState("active")),
-      curriedAppReducer(itwCredentialsStore(mockedEid)),
+      curriedAppReducer(itwCredentialsStore([mockedEid])),
       curriedAppReducer(itwCredentialsRemove(mockedEid))
     );
 
@@ -135,8 +135,8 @@ describe("ITW credentials reducer", () => {
     const targetSate = pipe(
       undefined,
       curriedAppReducer(applicationChangeState("active")),
-      curriedAppReducer(itwCredentialsStore(mockedEid)),
-      curriedAppReducer(itwCredentialsStore(mockedCredential)),
+      curriedAppReducer(itwCredentialsStore([mockedEid])),
+      curriedAppReducer(itwCredentialsStore([mockedCredential])),
       curriedAppReducer(itwCredentialsRemove(mockedCredential))
     );
 
@@ -150,8 +150,8 @@ describe("ITW credentials reducer", () => {
     const targetSate = pipe(
       undefined,
       curriedAppReducer(applicationChangeState("active")),
-      curriedAppReducer(itwCredentialsStore(mockedEid)),
-      curriedAppReducer(itwCredentialsStore(mockedCredential)),
+      curriedAppReducer(itwCredentialsStore([mockedEid])),
+      curriedAppReducer(itwCredentialsStore([mockedCredential])),
       curriedAppReducer(itwLifecycleStoresReset())
     );
 
@@ -176,11 +176,11 @@ describe("ITW credentials reducer", () => {
     const targetSate = pipe(
       undefined,
       curriedAppReducer(applicationChangeState("active")),
-      curriedAppReducer(itwCredentialsStore(mockedEid)),
+      curriedAppReducer(itwCredentialsStore([mockedEid])),
       curriedAppReducer(
         itwCredentialsStore([mockedCredential, mockedCredential2])
       ),
-      curriedAppReducer(itwCredentialsStore(credentialUpdate))
+      curriedAppReducer(itwCredentialsStore([credentialUpdate]))
     );
 
     expect(targetSate.features.itWallet.credentials.eid).toEqual(

--- a/ts/features/itwallet/credentials/store/reducers/index.ts
+++ b/ts/features/itwallet/credentials/store/reducers/index.ts
@@ -22,12 +22,8 @@ const reducer = (
 ): ItwCredentialsState => {
   switch (action.type) {
     case getType(itwCredentialsStore): {
-      const credentialsToStore = Array.isArray(action.payload)
-        ? action.payload
-        : [action.payload];
-
       const { [CredentialType.PID]: eid, ...otherCredentials } =
-        credentialsToStore.reduce(
+        action.payload.reduce(
           (acc, c) => ({ ...acc, [c.credentialType]: c }),
           {} as { [K in CredentialType]?: StoredCredential }
         );

--- a/ts/features/itwallet/lifecycle/store/selectors/__tests__/index.test.ts
+++ b/ts/features/itwallet/lifecycle/store/selectors/__tests__/index.test.ts
@@ -56,9 +56,9 @@ describe("IT Wallet lifecycle selectors", () => {
         itwStoreIntegrityKeyTag("9556271b-2e1c-414d-b9a5-50ed8c2743e3")
       ),
       curriedAppReducer(
-        itwCredentialsStore({
-          credentialType: CredentialType.PID
-        } as StoredCredential)
+        itwCredentialsStore([
+          { credentialType: CredentialType.PID }
+        ] as Array<StoredCredential>)
       )
     );
 

--- a/ts/features/itwallet/machine/credential/actions.ts
+++ b/ts/features/itwallet/machine/credential/actions.ts
@@ -82,7 +82,7 @@ export default (
     dispatch(itwCredentialsStore(context.credential));
     dispatch(
       walletUpsertCard({
-        key: context.credential.keyTag,
+        key: `ITW_${context.credentialType}`,
         type: "itw",
         category: "itw",
         credentialType: context.credentialType

--- a/ts/features/itwallet/machine/credential/actions.ts
+++ b/ts/features/itwallet/machine/credential/actions.ts
@@ -77,7 +77,7 @@ export default (
   >) => {
     assert(context.credential, "credential is undefined");
 
-    dispatch(itwCredentialsStore(context.credential));
+    dispatch(itwCredentialsStore([context.credential]));
   },
 
   closeIssuance: () => {

--- a/ts/features/itwallet/machine/eid/actions.ts
+++ b/ts/features/itwallet/machine/eid/actions.ts
@@ -137,7 +137,7 @@ export const createEidIssuanceActionsImplementation = (
     dispatch(itwCredentialsStore(context.eid));
     dispatch(
       walletUpsertCard({
-        key: context.eid.keyTag,
+        key: `ITW_${CredentialType.PID}`,
         type: "itw",
         category: "itw",
         credentialType: CredentialType.PID

--- a/ts/features/itwallet/machine/eid/actions.ts
+++ b/ts/features/itwallet/machine/eid/actions.ts
@@ -132,7 +132,7 @@ export const createEidIssuanceActionsImplementation = (
   }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
     assert(context.eid, "eID is undefined");
 
-    dispatch(itwCredentialsStore(context.eid));
+    dispatch(itwCredentialsStore([context.eid]));
   },
 
   requestAssistance: () => {},


### PR DESCRIPTION
## Short description
This PR fixes a bug that happens when there is a credential in the wallet and that same credential is renewed. The bug is caused by:
- Always appending new credentials to `features.itWallet.credentials.credentials` array
- Using the unique key tag as the key for wallet cards

## List of changes proposed in this pull request
- Overwrite credentials of the same type when dispatching `ITW_CREDENTIALS_STORE`
- `ITW_{credential_type}` is used as key for wallet cards to avoid duplicates
- Removed `ITW_CREDENTIALS_MULTIPLE_UPDATE` action: now it is safe to dispatch `ITW_CREDENTIALS_STORE` to store a credential or an array of credentials and overwrite previous instances

## How to test
Currently one way to test this is to renew the driving license after it's been revoked, and then navigate to the wallet screen. Without the fix two driving license cards will appear, with the fix only one.
