### PR TITLE
chore: [IOPID-2196] Revert old PR to delete local FF to activate new scan and settings sections

### DIFF
--- a/ts/boot/__tests__/__snapshots__/persistedStore.test.ts.snap
+++ b/ts/boot/__tests__/__snapshots__/persistedStore.test.ts.snap
@@ -108,6 +108,7 @@ exports[`Check the addition for new fields to the persisted store. If one of thi
   "isFingerprintEnabled": undefined,
   "isIdPayTestEnabled": false,
   "isMixpanelEnabled": null,
+  "isNewScanSectionEnabled": false,
   "isPagoPATestEnabled": false,
   "isPnTestEnabled": false,
   "preferredCalendar": undefined,

--- a/ts/boot/configureStoreAndPersistor.ts
+++ b/ts/boot/configureStoreAndPersistor.ts
@@ -53,7 +53,7 @@ import { configureReactotron } from "./configureRectotron";
 /**
  * Redux persist will migrate the store to the current version
  */
-const CURRENT_REDUX_STORE_VERSION = 34;
+const CURRENT_REDUX_STORE_VERSION = 35;
 
 // see redux-persist documentation:
 // https://github.com/rt2zz/redux-persist/blob/master/docs/migrations.md
@@ -429,7 +429,15 @@ const migrations: MigrationManifest = {
     omit(state, "persistedPreferences.isItWalletTestEnabled"),
   // removes show scan section and hide profile local FF
   "34": (state: PersistedState) =>
-    omit(state, "persistedPreferences.isNewScanSectionEnabled")
+    omit(state, "persistedPreferences.isNewScanSectionEnabled"),
+  // as a result of the PR revert, the data above was reinserted
+  // PR: https://github.com/pagopa/io-app/pull/6145
+  "35": (state: PersistedState) =>
+    merge(state, {
+      persistedPreferences: {
+        isNewScanSectionEnabled: false
+      }
+    })
 };
 
 const isDebuggingInChrome = isDevEnv && !!window.navigator.userAgent;

--- a/ts/screens/profile/DeveloperModeSection.tsx
+++ b/ts/screens/profile/DeveloperModeSection.tsx
@@ -36,6 +36,7 @@ import { sessionExpired } from "../../store/actions/authentication";
 import { setDebugModeEnabled } from "../../store/actions/debug";
 import {
   preferencesIdPayTestSetEnabled,
+  preferencesNewScanSectionSetEnabled,
   preferencesPagoPaTestEnvironmentSetEnabled,
   preferencesPnTestEnvironmentSetEnabled
 } from "../../store/actions/persistedPreferences";
@@ -48,6 +49,7 @@ import {
 import { isDebugModeEnabledSelector } from "../../store/reducers/debug";
 import {
   isIdPayTestEnabledSelector,
+  isNewScanSectionLocallyEnabledSelector,
   isPagoPATestEnabledSelector,
   isPnTestEnabledSelector
 } from "../../store/reducers/persistedPreferences";
@@ -305,12 +307,24 @@ const DesignSystemSection = () => {
     isAutomaticSessionRefreshToggleActiveSelector
   );
 
+  const isNewScanSectionLocallyEnabled = useIOSelector(
+    isNewScanSectionLocallyEnabledSelector
+  );
+
   const dispatchAutomaticSessionRefresh = React.useCallback(
     (enabled: boolean) => {
       dispatch(setAutomaticSessionRefresh({ enabled }));
     },
     [dispatch]
   );
+
+  const onNewScanSectionToggle = (enabled: boolean) => {
+    dispatch(
+      preferencesNewScanSectionSetEnabled({
+        isNewScanSectionEnabled: enabled
+      })
+    );
+  };
 
   return (
     <ContentWrapper>
@@ -336,6 +350,11 @@ const DesignSystemSection = () => {
         }
       />
       <Divider />
+      <ListItemSwitch
+        label={I18n.t("profile.main.newScanSection")}
+        value={isNewScanSectionLocallyEnabled}
+        onSwitchValueChange={onNewScanSectionToggle}
+      />
       <ListItemSwitch
         label={I18n.t("profile.main.sessionRefresh")}
         value={isAutomaticSessionRefreshToggleActive}

--- a/ts/store/actions/persistedPreferences.ts
+++ b/ts/store/actions/persistedPreferences.ts
@@ -49,6 +49,10 @@ export const preferencesDesignSystemSetEnabled = createStandardAction(
   "PREFERENCES_DESIGN_SYSTEM_SET_ENABLED"
 )<{ isDesignSystemEnabled: boolean }>();
 
+export const preferencesNewScanSectionSetEnabled = createStandardAction(
+  "PREFERENCES_NEW_SCAN_SECTION_SET_ENABLED"
+)<{ isNewScanSectionEnabled: boolean }>();
+
 export type PersistedPreferencesActions = ActionType<
   | typeof preferenceFingerprintIsEnabledSaveSuccess
   | typeof preferredCalendarSaveSuccess
@@ -61,4 +65,5 @@ export type PersistedPreferencesActions = ActionType<
   | typeof preferencesPnTestEnvironmentSetEnabled
   | typeof preferencesIdPayTestSetEnabled
   | typeof preferencesDesignSystemSetEnabled
+  | typeof preferencesNewScanSectionSetEnabled
 >;

--- a/ts/store/reducers/backendStatus.ts
+++ b/ts/store/reducers/backendStatus.ts
@@ -31,7 +31,10 @@ import { isStringNullyOrEmpty } from "../../utils/strings";
 import { backendStatusLoadSuccess } from "../actions/backendStatus";
 import { Action } from "../actions/types";
 
-import { isIdPayTestEnabledSelector } from "./persistedPreferences";
+import {
+  isIdPayTestEnabledSelector,
+  isNewScanSectionLocallyEnabledSelector
+} from "./persistedPreferences";
 import { GlobalState } from "./types";
 import { isPropertyWithMinAppVersionEnabled } from "./featureFlagWithMinAppVersionStatus";
 
@@ -474,9 +477,12 @@ export const isNewPaymentSectionEnabledSelector = createSelector(
 // It will be possible to delete this control and all the code it carries
 // it carries when isNewPaymentSectionEnabledSelector and
 // isNewScanSectionLocallyEnabled will be deleted
-export const isSettingsVisibleAndHideProfileSelector =
-  isNewPaymentSectionEnabledSelector;
-
+export const isSettingsVisibleAndHideProfileSelector = createSelector(
+  isNewPaymentSectionEnabledSelector,
+  isNewScanSectionLocallyEnabledSelector,
+  (isNewPaymentSectionEnabled, isNewScanSectionLocallyEnabled) =>
+    isNewPaymentSectionEnabled && isNewScanSectionLocallyEnabled
+);
 // systems could be consider dead when we have no updates for at least DEAD_COUNTER_THRESHOLD times
 export const DEAD_COUNTER_THRESHOLD = 2;
 

--- a/ts/store/reducers/persistedPreferences.ts
+++ b/ts/store/reducers/persistedPreferences.ts
@@ -19,7 +19,8 @@ import {
   serviceAlertDisplayedOnceSuccess,
   preferencesPnTestEnvironmentSetEnabled,
   preferencesIdPayTestSetEnabled,
-  preferencesDesignSystemSetEnabled
+  preferencesDesignSystemSetEnabled,
+  preferencesNewScanSectionSetEnabled
 } from "../actions/persistedPreferences";
 import { Action } from "../actions/types";
 import { differentProfileLoggedIn } from "../actions/crossSessions";
@@ -44,6 +45,7 @@ export type PersistedPreferencesState = Readonly<{
   // changing the variable value later). Typescript cannot detect this so
   // be sure to handle such case when reading and using this value
   isDesignSystemEnabled: boolean;
+  isNewScanSectionEnabled?: boolean;
 }>;
 
 export const initialPreferencesState: PersistedPreferencesState = {
@@ -57,7 +59,8 @@ export const initialPreferencesState: PersistedPreferencesState = {
   isMixpanelEnabled: null,
   isPnTestEnabled: false,
   isIdPayTestEnabled: false,
-  isDesignSystemEnabled: false
+  isDesignSystemEnabled: false,
+  isNewScanSectionEnabled: false
 };
 
 export default function preferencesReducer(
@@ -153,6 +156,13 @@ export default function preferencesReducer(
     };
   }
 
+  if (isActionOf(preferencesNewScanSectionSetEnabled, action)) {
+    return {
+      ...state,
+      isNewScanSectionEnabled: action.payload.isNewScanSectionEnabled
+    };
+  }
+
   return state;
 }
 
@@ -194,6 +204,9 @@ export const isIdPayTestEnabledSelector = (state: GlobalState) =>
 // we must make sure that the signature's return type is respected
 export const isDesignSystemEnabledSelector = (state: GlobalState) =>
   state.persistedPreferences.isDesignSystemEnabled ?? false;
+
+export const isNewScanSectionLocallyEnabledSelector = (state: GlobalState) =>
+  !!state.persistedPreferences?.isNewScanSectionEnabled;
 
 // returns the preferred language as an Option from the persisted store
 export const preferredLanguageSelector = createSelector<


### PR DESCRIPTION
## Short description
This PR is a revert of PR #6145

## Demo

https://github.com/user-attachments/assets/fb46f2ce-eba2-43b1-b7f0-84ce3130a254

## How to test
Run the application and use a switch in profile section to activate/deactivate the feature 