### PR TITLE
fix(IT Wallet): [SIW-1548] Error screen instead of loading screen while issuing credential

### DIFF
--- a/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialPreviewScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialPreviewScreen.tsx
@@ -26,7 +26,7 @@ import { StoredCredential } from "../../common/utils/itwTypesUtils";
 import {
   selectCredentialOption,
   selectCredentialTypeOption,
-  selectIsLoading
+  selectIsIssuing
 } from "../../machine/credential/selectors";
 import { ItwCredentialIssuanceMachineContext } from "../../machine/provider";
 
@@ -37,13 +37,13 @@ export const ItwIssuanceCredentialPreviewScreen = () => {
   const credentialOption = ItwCredentialIssuanceMachineContext.useSelector(
     selectCredentialOption
   );
-  const isLoading =
-    ItwCredentialIssuanceMachineContext.useSelector(selectIsLoading);
+  const isIssuing =
+    ItwCredentialIssuanceMachineContext.useSelector(selectIsIssuing);
 
   useItwDisableGestureNavigation();
   useAvoidHardwareBackButton();
 
-  if (isLoading) {
+  if (isIssuing) {
     return (
       <LoadingScreenContent
         contentTitle={I18n.t(


### PR DESCRIPTION
## Short description
This PR fixes an error which causes an error screen to be displayed instead of a loading one when the issuing of a credential takes more than 4 seconds.

## List of changes proposed in this pull request
- Replace `selectIsLoading` with `selectIsIssuing` selector; 

## How to test
Test a credential issuing, you should be able to see a loading screen instead of an error one when the credential issuing takes more than 4 seconds.