### PR TITLE
[IOCOM-1676,IOCOM-1674] Fims minVersion not met error UI

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3915,6 +3915,9 @@ permissionRequest:
         3: Seleziona “Foto” e consenti l’accesso
     cta: Apri Impostazioni
 FIMS:
+  updateApp:
+    header: "Aggiorna l’app per proseguire"
+    body: "Per continuare a utilizzare tutte le funzionalità, scarica la nuova versione di IO dallo store."
   history:
     errorStates:
       dataUnavailable: "Dati non disponibili"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3915,6 +3915,9 @@ permissionRequest:
         3: Seleziona “Foto” e consenti l’accesso
     cta: Apri Impostazioni
 FIMS:
+  updateApp:
+    header: "Aggiorna l’app per proseguire"
+    body: "Per continuare a utilizzare tutte le funzionalità, scarica la nuova versione di IO dallo store."
   history:
     errorStates:
       dataUnavailable: "Dati non disponibili"

--- a/ts/features/fims/common/components/FimsUpdateAppAlert.tsx
+++ b/ts/features/fims/common/components/FimsUpdateAppAlert.tsx
@@ -1,0 +1,56 @@
+import { ActionProp, HeaderSecondLevel } from "@pagopa/io-app-design-system";
+import { useNavigation } from "@react-navigation/native";
+import React from "react";
+import { OperationResultScreenContent } from "../../../../components/screens/OperationResultScreenContent";
+import { useStartSupportRequest } from "../../../../hooks/useStartSupportRequest";
+import I18n from "../../../../i18n";
+import { emptyContextualHelp } from "../../../../utils/emptyContextualHelp";
+import { openAppStoreUrl } from "../../../../utils/url";
+
+export const FimsUpdateAppAlert = () => {
+  const navigation = useNavigation();
+  useOnlySupportRequestHeader();
+  return (
+    <OperationResultScreenContent
+      isHeaderVisible={true}
+      title={I18n.t("FIMS.updateApp.header")}
+      subtitle={I18n.t("FIMS.updateApp.body")}
+      pictogram="updateOS"
+      action={{
+        label: I18n.t("btnUpdateApp"),
+        onPress: () => openAppStoreUrl()
+      }}
+      secondaryAction={{
+        label: I18n.t("global.buttons.close"),
+        onPress: navigation.goBack
+      }}
+    />
+  );
+};
+
+const useOnlySupportRequestHeader = () => {
+  const navigation = useNavigation();
+  const startSupportRequest = useStartSupportRequest({
+    faqCategories: undefined,
+    contextualHelpMarkdown: undefined,
+    contextualHelp: emptyContextualHelp
+  });
+
+  React.useEffect(() => {
+    navigation.setOptions({
+      header: () => (
+        <HeaderSecondLevel
+          title=""
+          type="singleAction"
+          firstAction={{
+            icon: "help" as ActionProp["icon"],
+            onPress: startSupportRequest,
+            accessibilityLabel: I18n.t(
+              "global.accessibility.contextualHelp.open.label"
+            )
+          }}
+        />
+      )
+    });
+  });
+};

--- a/ts/features/fims/history/screens/HistoryScreen.tsx
+++ b/ts/features/fims/history/screens/HistoryScreen.tsx
@@ -1,12 +1,15 @@
 /* eslint-disable functional/immutable-data */
 import { IOToast } from "@pagopa/io-app-design-system";
 import * as React from "react";
-import { OperationResultScreenContent } from "../../../../components/screens/OperationResultScreenContent";
 import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
 import I18n from "../../../../i18n";
 import { useIODispatch, useIOSelector } from "../../../../store/hooks";
 import { fimsRequiresAppUpdateSelector } from "../../../../store/reducers/backendStatus";
-import { openAppStoreUrl } from "../../../../utils/url";
+import {
+  trackHistoryFailure,
+  trackHistoryScreen
+} from "../../common/analytics";
+import { FimsUpdateAppAlert } from "../../common/components/FimsUpdateAppAlert";
 import { FimsHistoryEmptyContent } from "../components/FimsHistoryEmptyContent";
 import { FimsHistoryKoScreen } from "../components/FimsHistoryKoScreen";
 import { FimsHistoryNonEmptyContent } from "../components/FimsHistoryNonEmptyContent";
@@ -16,10 +19,6 @@ import {
   fimsHistoryToUndefinedSelector,
   isFimsHistoryLoadingSelector
 } from "../store/selectors";
-import {
-  trackHistoryFailure,
-  trackHistoryScreen
-} from "../../common/analytics";
 
 export const FimsHistoryScreen = () => {
   const dispatch = useIODispatch();
@@ -77,17 +76,7 @@ export const FimsHistoryScreen = () => {
   // ---------- FAILURE CASES
 
   if (requiresAppUpdate) {
-    return (
-      <OperationResultScreenContent
-        isHeaderVisible
-        title={I18n.t("titleUpdateAppAlert")}
-        pictogram="umbrellaNew"
-        action={{
-          label: I18n.t("btnUpdateApp"),
-          onPress: () => openAppStoreUrl
-        }}
-      />
-    );
+    return <FimsUpdateAppAlert />;
   }
 
   if (historyErrorState === "FULL_KO") {

--- a/ts/features/fims/singleSignOn/screens/FimsFlowHandlerScreen.tsx
+++ b/ts/features/fims/singleSignOn/screens/FimsFlowHandlerScreen.tsx
@@ -6,25 +6,25 @@ import * as React from "react";
 import { View } from "react-native";
 import LoadingScreenContent from "../../../../components/screens/LoadingScreenContent";
 import { OperationResultScreenContent } from "../../../../components/screens/OperationResultScreenContent";
+import { useHardwareBackButton } from "../../../../hooks/useHardwareBackButton";
 import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
 import I18n from "../../../../i18n";
 import { IOStackNavigationRouteProps } from "../../../../navigation/params/AppParamsList";
 import { useIODispatch, useIOSelector } from "../../../../store/hooks";
+import { fimsRequiresAppUpdateSelector } from "../../../../store/reducers/backendStatus";
+import { trackAuthenticationError } from "../../common/analytics";
+import { FimsUpdateAppAlert } from "../../common/components/FimsUpdateAppAlert";
+import { FimsParamsList } from "../../common/navigation";
+import { FimsFlowSuccessBody } from "../components/FimsSuccessBody";
 import {
   fimsCancelOrAbortAction,
   fimsGetConsentsListAction
 } from "../store/actions/";
-import { FimsFlowSuccessBody } from "../components/FimsSuccessBody";
-import { useHardwareBackButton } from "../../../../hooks/useHardwareBackButton";
-import { FimsParamsList } from "../../common/navigation";
 import {
   fimsConsentsDataSelector,
   fimsErrorStateSelector,
   fimsLoadingStateSelector
 } from "../store/selectors";
-import { fimsRequiresAppUpdateSelector } from "../../../../store/reducers/backendStatus";
-import { openAppStoreUrl } from "../../../../utils/url";
-import { trackAuthenticationError } from "../../common/analytics";
 
 export type FimsFlowHandlerScreenRouteParams = {
   ctaText: string;
@@ -79,17 +79,7 @@ export const FimsFlowHandlerScreen = (
   }, [ctaText, ctaUrl, dispatch, requiresAppUpdate]);
 
   if (requiresAppUpdate) {
-    return (
-      <OperationResultScreenContent
-        isHeaderVisible
-        title={I18n.t("titleUpdateAppAlert")}
-        pictogram="umbrellaNew"
-        action={{
-          label: I18n.t("btnUpdateApp"),
-          onPress: () => openAppStoreUrl()
-        }}
-      />
-    );
+    return <FimsUpdateAppAlert />;
   }
 
   if (errorState !== undefined) {


### PR DESCRIPTION
## Short description
addition of said screen.
<img width="250" alt="Screenshot 2024-09-05 at 11 43 51" src="https://github.com/user-attachments/assets/001232cb-f586-45f6-a824-cdddf1d9994a">

## List of changes proposed in this pull request
- required I18n keys
- new FimsUpdateAppAlert component to display in the specified case
- usage of said component

## How to test
using the dev-server, set the `fimsRequiresAppUpdateSelector` to return true in the app's codebase and make sure the displayed screen matches the specified design -- especially the header.
Since the display logic hasn't been changed, no flow test should be necessary, but feel free to do as you wish.