### PR TITLE
fix(IT Wallet): [SIW-1549] Update copy for credential issuance generic error message 

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3227,9 +3227,14 @@ features:
         body: Non puoi attivare Documenti con un’identità diversa da quella che usi per accedere a IO. Verifica le credenziali di accesso e riprova.
         primaryAction: Ho capito
         secondaryAction: Segnala un problema
-      genericError:
+      genericEidError:
         title: Si è verificato un errore imprevisto
         body: La tua richiesta verso l'ente che emette il documento non è andata a buon fine.
+        primaryAction: Riprova
+        secondaryAction: Chiudi
+      genericCredentialError:
+        title: Documento non disponibile
+        body: Si è verificato un errore oppure potresti non avere diritto al documento. 
         primaryAction: Riprova
         secondaryAction: Chiudi
     unsupportedDevice:

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3227,9 +3227,14 @@ features:
         body: Non puoi attivare Documenti con un’identità diversa da quella che usi per accedere a IO. Verifica le credenziali di accesso e riprova.
         primaryAction: Ho capito
         secondaryAction: Segnala un problema
-      genericError:
+      genericEidError:
         title: Si è verificato un errore imprevisto
         body: La tua richiesta verso l'ente che emette il documento non è andata a buon fine.
+        primaryAction: Riprova
+        secondaryAction: Chiudi
+      genericCredentialError:
+        title: Documento non disponibile
+        body: Si è verificato un errore oppure potresti non avere diritto al documento. 
         primaryAction: Riprova
         secondaryAction: Chiudi
     unsupportedDevice:

--- a/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialFailureScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialFailureScreen.tsx
@@ -57,16 +57,20 @@ const ContentView = ({ failure }: ContentViewProps) => {
     OperationResultScreenContentProps
   > = {
     GENERIC: {
-      title: I18n.t("features.itWallet.issuance.genericError.title"),
-      subtitle: I18n.t("features.itWallet.issuance.genericError.body"),
+      title: I18n.t("features.itWallet.issuance.genericCredentialError.title"),
+      subtitle: I18n.t(
+        "features.itWallet.issuance.genericCredentialError.body"
+      ),
       pictogram: "workInProgress",
       action: {
-        label: I18n.t("features.itWallet.issuance.genericError.primaryAction"),
+        label: I18n.t(
+          "features.itWallet.issuance.genericCredentialError.primaryAction"
+        ),
         onPress: retryIssuance
       },
       secondaryAction: {
         label: I18n.t(
-          "features.itWallet.issuance.genericError.secondaryAction"
+          "features.itWallet.issuance.genericCredentialError.secondaryAction"
         ),
         onPress: closeIssuance
       }

--- a/ts/features/itwallet/issuance/screens/ItwIssuanceEidFailureScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceEidFailureScreen.tsx
@@ -45,18 +45,18 @@ export const ItwIssuanceEidFailureScreen = () => {
         }
       },
       [IssuanceFailureType.ISSUER_GENERIC]: {
-        title: I18n.t("features.itWallet.issuance.genericError.title"),
-        subtitle: I18n.t("features.itWallet.issuance.genericError.body"),
+        title: I18n.t("features.itWallet.issuance.genericEidError.title"),
+        subtitle: I18n.t("features.itWallet.issuance.genericEidError.body"),
         pictogram: "workInProgress",
         action: {
           label: I18n.t(
-            "features.itWallet.issuance.genericError.primaryAction"
+            "features.itWallet.issuance.genericEidError.primaryAction"
           ),
           onPress: closeIssuance // TODO: [SIW-1375] better retry and go back handling logic for the issuance process
         },
         secondaryAction: {
           label: I18n.t(
-            "features.itWallet.issuance.genericError.secondaryAction"
+            "features.itWallet.issuance.genericEidError.secondaryAction"
           ),
           onPress: closeIssuance // TODO: [SIW-1375] better retry and go back handling logic for the issuance process
         }


### PR DESCRIPTION
## Short description
This PR updates the copy for a generic error message in the credential issuance flow.

## List of changes proposed in this pull request
- Change locale by dividing a generic eID and credential error;
- Update usage.

## How to test
With a proxy map the `/credential` call to `500` and check if the error message is rendered properly for both eID and credential.