### PR TITLE
fix: [IOBP-853] Receipt Share & Save button feature

### DIFF
--- a/ts/features/payments/bizEventsTransaction/screens/PaymentsTransactionBizEventsPreviewScreen.tsx
+++ b/ts/features/payments/bizEventsTransaction/screens/PaymentsTransactionBizEventsPreviewScreen.tsx
@@ -47,26 +47,11 @@ const PaymentsTransactionBizEventsPreviewScreen = () => {
     }
     try {
       await Share.open({
-        activityItemSources: [
-          {
-            item: {
-              default: {
-                content: `${I18n.t(
-                  "features.payments.transactions.receipt.title"
-                )}.pdf`,
-                type: "url"
-              }
-            },
-            placeholderItem: {
-              content: `${I18n.t(
-                "features.payments.transactions.receipt.title"
-              )}.pdf`,
-              type: "url"
-            }
-          }
-        ],
         type: "application/pdf",
-        url: `${RECEIPT_DOCUMENT_TYPE_PREFIX}${transactionReceiptFile}`
+        url: `${RECEIPT_DOCUMENT_TYPE_PREFIX}${transactionReceiptFile}`,
+        filename: `${I18n.t(
+          "features.payments.transactions.receipt.title"
+        )}.pdf`
       });
     } catch (err) {
       // Don't do anything if the user cancels the share action

--- a/ts/features/payments/bizEventsTransaction/screens/PaymentsTransactionBizEventsPreviewScreen.tsx
+++ b/ts/features/payments/bizEventsTransaction/screens/PaymentsTransactionBizEventsPreviewScreen.tsx
@@ -45,17 +45,12 @@ const PaymentsTransactionBizEventsPreviewScreen = () => {
     if (!transactionReceiptFile) {
       return;
     }
-    try {
-      await Share.open({
-        type: "application/pdf",
-        url: `${RECEIPT_DOCUMENT_TYPE_PREFIX}${transactionReceiptFile}`,
-        filename: `${I18n.t(
-          "features.payments.transactions.receipt.title"
-        )}.pdf`
-      });
-    } catch (err) {
-      // Don't do anything if the user cancels the share action
-    }
+    await Share.open({
+      type: "application/pdf",
+      url: `${RECEIPT_DOCUMENT_TYPE_PREFIX}${transactionReceiptFile}`,
+      filename: `${I18n.t("features.payments.transactions.receipt.title")}.pdf`,
+      failOnCancel: false
+    });
   };
 
   const handleFooterActionsMeasurements = (

--- a/ts/features/payments/bizEventsTransaction/screens/PaymentsTransactionBizEventsPreviewScreen.tsx
+++ b/ts/features/payments/bizEventsTransaction/screens/PaymentsTransactionBizEventsPreviewScreen.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as pot from "@pagopa/ts-commons/lib/pot";
-import { View } from "react-native";
+import { Platform, View } from "react-native";
 import Share from "react-native-share";
 
 import { IOColors, IOStyles } from "@pagopa/io-app-design-system";
@@ -48,7 +48,9 @@ const PaymentsTransactionBizEventsPreviewScreen = () => {
     await Share.open({
       type: "application/pdf",
       url: `${RECEIPT_DOCUMENT_TYPE_PREFIX}${transactionReceiptFile}`,
-      filename: `${I18n.t("features.payments.transactions.receipt.title")}.pdf`,
+      filename: `${I18n.t("features.payments.transactions.receipt.title")}${
+        Platform.OS === "ios" ? ".pdf" : ""
+      }`,
       failOnCancel: false
     });
   };


### PR DESCRIPTION
## Short description
This PR fixes the save & share feature allowing the user to share correctly the PDF receipt from the payment details screen.

Thanks to @mastro993 for the hint!

## List of changes proposed in this pull request
- Replaced `activityItemSources` with the property `filename`

## How to test
- Try to share any PDF receipt from the payment detail screen and you should be able to do it.
