### PR TITLE
fix(IT Wallet): [SIW-1587] Use the status attestation info to get the status in `ItwPresentationCredentialCard`

### DIFF
--- a/ts/features/itwallet/common/utils/itwClaimsUtils.ts
+++ b/ts/features/itwallet/common/utils/itwClaimsUtils.ts
@@ -316,7 +316,8 @@ export const getCredentialExpireDays = (
 };
 
 /**
- * Returns the expire status of a {@see ParsedCredential}
+ * Returns the expire status of a {@link ParsedCredential}, taking into account the **expiration date only**.
+ * Use {@link getCredentialStatus} to also check the status attestation.
  * @param credential the parsed credential claims
  * @param expiringDays the number of days required to mark a credential as "EXPIRING"
  * @returns "VALID" if the credential is valid, "EXPIRING" if there are less than {expiringDays} days left until the expiry day, "EXPIRED" if the expiry date has passed

--- a/ts/features/itwallet/presentation/components/ItwPresentationCredentialCard.tsx
+++ b/ts/features/itwallet/presentation/components/ItwPresentationCredentialCard.tsx
@@ -11,7 +11,7 @@ import { ItwSkeumorphicCard } from "../../common/components/ItwSkeumorphicCard";
 import { CredentialType } from "../../common/utils/itwMocksUtils";
 import { getThemeColorByCredentialType } from "../../common/utils/itwStyleUtils";
 import { StoredCredential } from "../../common/utils/itwTypesUtils";
-import { getCredentialExpireStatus } from "../../common/utils/itwClaimsUtils";
+import { getCredentialStatus } from "../../common/utils/itwClaimsUtils";
 
 type Props = {
   credential: StoredCredential;
@@ -30,9 +30,7 @@ const ItwPresentationCredentialCard = ({ credential }: Props) => {
   const hasSkeumorphicCard =
     credential.credentialType === CredentialType.DRIVING_LICENSE;
 
-  const credentialStatus = getCredentialExpireStatus(
-    credential.parsedCredential
-  );
+  const credentialStatus = getCredentialStatus(credential);
 
   if (hasSkeumorphicCard) {
     return (


### PR DESCRIPTION
## Short description
This PR fixes a small regression causing the ITW credential card to determine the "expire" status without checking the status attestation (only the expiration date in the credential).
When a credential is revoked, the card is not displayed with the red border and the expired badge.

## List of changes proposed in this pull request
- Switched `getCredentialExpireStatus` with `getCredentialStatus`

## How to test
Open the detail of a non-skeumorfic credential that has been revoked.
