### PR TITLE
fix: [IOBP-867] Regression of generic error page into verify payment screen

### DIFF
--- a/ts/features/payments/checkout/saga/networking/handleWalletPaymentCreateTransaction.ts
+++ b/ts/features/payments/checkout/saga/networking/handleWalletPaymentCreateTransaction.ts
@@ -61,6 +61,8 @@ export function* handleWalletPaymentCreateTransaction(
         )
       );
     } else if (status === 400) {
+      // Handling unhandled error from third-party services (GEC) during payment verification.
+      // This is not an internal backend error from pagoPA, but rather a third-party service error and should be handled differently.
       handleError(paymentAnalyticsData, action.payload.onError);
       yield* put(
         paymentsCreateTransactionAction.failure({

--- a/ts/features/payments/checkout/saga/networking/handleWalletPaymentCreateTransaction.ts
+++ b/ts/features/payments/checkout/saga/networking/handleWalletPaymentCreateTransaction.ts
@@ -60,8 +60,7 @@ export function* handleWalletPaymentCreateTransaction(
           newTransactionResult.right.value
         )
       );
-    } else if (status !== 401) {
-      // The 401 status is handled by the withPaymentsSessionToken
+    } else if (status === 400) {
       handleError(paymentAnalyticsData, action.payload.onError);
       yield* put(
         paymentsCreateTransactionAction.failure({
@@ -69,6 +68,13 @@ export function* handleWalletPaymentCreateTransaction(
             new Error(`Error: ${newTransactionResult.right.status}`)
           )
         })
+      );
+    } else if (status !== 401) {
+      // The 401 status is handled by the withPaymentsSessionToken
+      yield* put(
+        paymentsCreateTransactionAction.failure(
+          newTransactionResult.right.value
+        )
       );
     }
   } catch (e) {

--- a/ts/features/payments/checkout/saga/networking/handleWalletPaymentGetDetails.ts
+++ b/ts/features/payments/checkout/saga/networking/handleWalletPaymentGetDetails.ts
@@ -35,6 +35,8 @@ export function* handleWalletPaymentGetDetails(
     if (res.status === 200) {
       yield* put(paymentsGetPaymentDetailsAction.success(res.value));
     } else if (res.status === 400) {
+      // Handling unhandled error from third-party services (GEC) during payment verification.
+      // This is not an internal backend error from pagoPA, but rather a third-party service error and should be handled differently.
       yield* put(
         paymentsGetPaymentDetailsAction.failure({
           ...getGenericError(new Error(`Error: ${res.status}`))

--- a/ts/features/payments/checkout/saga/networking/handleWalletPaymentGetDetails.ts
+++ b/ts/features/payments/checkout/saga/networking/handleWalletPaymentGetDetails.ts
@@ -34,13 +34,15 @@ export function* handleWalletPaymentGetDetails(
     const res = getPaymentRequestInfoResult.right;
     if (res.status === 200) {
       yield* put(paymentsGetPaymentDetailsAction.success(res.value));
-    } else if (res.status !== 401) {
-      // The 401 status is handled by the withPaymentsSessionToken
+    } else if (res.status === 400) {
       yield* put(
         paymentsGetPaymentDetailsAction.failure({
           ...getGenericError(new Error(`Error: ${res.status}`))
         })
       );
+    } else if (res.status !== 401) {
+      // The 401 status is handled by the withPaymentsSessionToken
+      yield* put(paymentsGetPaymentDetailsAction.failure(res.value));
     }
   } catch (e) {
     yield* put(


### PR DESCRIPTION
## Short description
This PR fixes a regression bug in the payment notice detail screen (formerly called "verify" screen) that instead showing the correct error page, it shows a generic error screen.

## List of changes proposed in this pull request
- Edited error status handling passing the error value in the failure action instead a generic one.

## How to test
- With the `pagoPA test env` feature flag enabled, open the Payments section
- Start a payment with the following notice code and CF:
    - 302000000000000000
    - 77777777777
- Then you should be able to see the "notice code already paid" error instead a generic one.


## Preview

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/67976d05-311e-46d0-b368-a2c6f3f9b2b7" />|<video src="https://github.com/user-attachments/assets/eb218455-ee76-4ea0-9ee2-3cd64d97d6f2" />|
