### PR TITLE
fix: [PE-681] CGN hide discount badge if 0 

### DIFF
--- a/ts/features/bonus/cgn/components/merchants/CgnModuleDiscount.tsx
+++ b/ts/features/bonus/cgn/components/merchants/CgnModuleDiscount.tsx
@@ -146,9 +146,9 @@ export const CgnModuleDiscount = ({ onPress, discount }: Props) => {
                   <HSpacer size={8} />
                 </>
               )}
-              {discount.discount && (
+              {discount.discount ? (
                 <Badge variant="purple" outline text={`-${normalizedValue}%`} />
-              )}
+              ) : null}
             </View>
             <VSpacer size={8} />
             <H6>{discount.name}</H6>


### PR DESCRIPTION
## Short description
If the discount amount is set to 0% by the operator, do not show the badge

## List of changes proposed in this pull request
- change conditional rendering

## How to test
- start api dev server setting this value to 0 https://github.com/pagopa/io-dev-api-server/blob/f368eb22c588c2c7cfe8c7c995f447e167a59a51/src/payloads/features/cgn/merchants.ts#L165
- login into app
- go to can card trough wallet (add it if necessary)
- go to discover opportunities
- go to detail of any provider
