### PR TITLE
fix: [IABT-1527,IOBP-877] Translated "Rimuovi" into delete payment method button in english

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1416,9 +1416,9 @@ wallet:
   add: add
   delete:
     ios:
-      confirm: Rimuovi metodo
+      confirm: Delete method
     android:
-      confirm: Rimuovi
+      confirm: Delete
     successful: Method removed!
     failed: The method could not be removed from your Wallet
   newPaymentMethod:


### PR DESCRIPTION
## Short description
This PR adds the English locales to the "Rimuovi" confirm button modal into the deletion of a payment method.