### PR TITLE
fix: [IOCOM-1808] Update io-react-native-login-utils

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -108,7 +108,7 @@ PODS:
     - JOSESwift (~> 2.3)
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - pagopa-io-react-native-login-utils (1.0.5):
+  - pagopa-io-react-native-login-utils (1.0.6):
     - React-Core
   - pagopa-react-native-zendesk (0.3.29):
     - RCT-Folly (= 2021.07.22.00)
@@ -1044,7 +1044,7 @@ SPEC CHECKSUMS:
   pagopa-io-react-native-http-client: cbdfb83c92432efb0de22b7c3c85cffa391870f8
   pagopa-io-react-native-integrity: ca77804cefb1cd75d04053652472bcb938ce4b18
   pagopa-io-react-native-jwt: 662d4e722715996758b079774abea1996b057467
-  pagopa-io-react-native-login-utils: c7e8a4908c1239ce834fe1d16dd22ccc7c7f5536
+  pagopa-io-react-native-login-utils: a445c97d7d7dc86b089079029a1340f4c682128c
   pagopa-react-native-zendesk: 60a26f8a8072234789c34bb7c8a769c156eb57dc
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 264adaca1d8b1a9c078761891898d4142df05313

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@pagopa/io-react-native-http-client": "1.0.5",
     "@pagopa/io-react-native-integrity": "^0.3.0",
     "@pagopa/io-react-native-jwt": "^1.2.0",
-    "@pagopa/io-react-native-login-utils": "1.0.5",
+    "@pagopa/io-react-native-login-utils": "1.0.6",
     "@pagopa/io-react-native-wallet": "^0.17.1",
     "@pagopa/io-react-native-zendesk": "^0.3.29",
     "@pagopa/react-native-cie": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2100,10 +2100,10 @@
     abab "^2.0.6"
     zod "^3.22.4"
 
-"@pagopa/io-react-native-login-utils@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-login-utils/-/io-react-native-login-utils-1.0.5.tgz#02179a4cbeed17376b028a5ce506bdbf0b1b6e39"
-  integrity sha512-vtVH42V+1TydYDv4M7RpbTKbD/SOQx7HS7woaQ++UOwgoG+H28SmszK5O7AVIR4lkpiPgF75rq0HOkdNonReHA==
+"@pagopa/io-react-native-login-utils@1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-login-utils/-/io-react-native-login-utils-1.0.6.tgz#b211e953eb05b76b43effc0d9d7be79767c361f9"
+  integrity sha512-Dx1WPdqFaB76Wv8WgkLCIQoj9ADZeWyfe/GTnGWQKeIWnTe5v3socbEDdax9fh0asxizuTVzTVj962H2nCQxwg==
 
 "@pagopa/io-react-native-wallet@^0.17.1":
   version "0.17.1"


### PR DESCRIPTION
## Short description
bump of said dep's version

## List of changes proposed in this pull request
- version upgrade

## How to test
with both an iOS and an Android physical device, start a flow that uses the inAppBrowser (FIMS flow was used for this purpose) -- and make sure nothing breaks.