### PR TITLE
fix: [PE-700] CGN detail fix missing swipe back gesture

### DIFF
--- a/ts/navigation/AuthenticatedStackNavigator.tsx
+++ b/ts/navigation/AuthenticatedStackNavigator.tsx
@@ -217,7 +217,7 @@ const AuthenticatedStackNavigator = () => {
       {cgnEnabled && (
         <Stack.Screen
           name={CGN_ROUTES.DETAILS.MAIN}
-          options={hideHeaderOptions}
+          options={{ ...hideHeaderOptions, gestureEnabled: isGestureEnabled }}
           component={CgnDetailsNavigator}
         />
       )}


### PR DESCRIPTION
## Short description
CGN detail screen fix missing swipe back gesture

## How to test
- login into the app on iOS
- go to cgn card detail screen trough wallet (add it if necessary)
- swipe back to check if it goes back to wallet page 
