### PR TITLE
chore(Cross): [IOAPPX-388] Remove Slack message on E2E failure

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -100,12 +100,12 @@ jobs:
           path: './_io-dev-api-server_'
       - id: run-e2e-tests
         run: bash ./.github/scripts/run-e2e-tests.sh ${{ matrix.test }}
-      - id: notify-test-failure
-        if: failure()
-        uses: ./.github/actions/notify-e2e
-        env:
-          TEST: ${{ matrix.name }}
-          IO_APP_SLACK_HELPER_BOT_TOKEN: ${{ secrets.IO_APP_SLACK_HELPER_BOT_TOKEN }}
+#     - id: notify-test-failure
+#        if: failure()
+#        uses: ./.github/actions/notify-e2e
+#        env:
+#         TEST: ${{ matrix.name }}
+#          IO_APP_SLACK_HELPER_BOT_TOKEN: ${{ secrets.IO_APP_SLACK_HELPER_BOT_TOKEN }}
       - id: upload-artifacts
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v.3.1.2        
         if: always()


### PR DESCRIPTION
## Short description
This PR comments the workflow part which sends a Slack message on E2E failure. Currently E2E test are broken, thus our monitor channel gets spammed with these message. 
It can be reintroduced when we fix the E2E tests.

## List of changes proposed in this pull request
- Comment `notify-test-failure` in `test-e2e.yml` workflow.

## How to test
N/A
