### PR TITLE
chore(Cross): [IOAPPX-390] Device-info patch version upgrade

### DIFF
--- a/patches/react-native-device-info+10.8.0.patch
+++ b/patches/react-native-device-info+10.8.0.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/react-native-device-info/lib/typescript/internal/privateTypes.d.ts b/node_modules/react-native-device-info/lib/typescript/internal/privateTypes.d.ts
-index f137e75..0f06706 100644
+index 782d473..0930495 100644
 --- a/node_modules/react-native-device-info/lib/typescript/internal/privateTypes.d.ts
 +++ b/node_modules/react-native-device-info/lib/typescript/internal/privateTypes.d.ts
-@@ -78,12 +78,8 @@ interface ExposedNativeMethods {
+@@ -79,12 +79,8 @@ interface ExposedNativeMethods {
      getInstallReferrerSync: () => string;
      getInstanceId: () => Promise<string>;
      getInstanceIdSync: () => string;
@@ -16,7 +16,7 @@ index f137e75..0f06706 100644
      getMaxMemorySync: () => number;
      getPhoneNumber: () => Promise<string>;
 diff --git a/node_modules/react-native-device-info/src/index.ts b/node_modules/react-native-device-info/src/index.ts
-index 4ec2138..2731038 100644
+index 4f096f6..950af63 100644
 --- a/node_modules/react-native-device-info/src/index.ts
 +++ b/node_modules/react-native-device-info/src/index.ts
 @@ -59,13 +59,6 @@ export const [getAndroidId, getAndroidIdSync] = getSupportedPlatformInfoFunction
@@ -58,7 +58,7 @@ index 4ec2138..2731038 100644
  export const getDeviceId = () =>
    getSupportedPlatformInfoSync({
      defaultValue: 'unknown',
-@@ -895,12 +870,8 @@ const deviceInfoModule: DeviceInfoModule = {
+@@ -903,12 +878,8 @@ const DeviceInfo: DeviceInfoModule = {
    getInstallReferrerSync,
    getInstanceId,
    getInstanceIdSync,
@@ -72,10 +72,10 @@ index 4ec2138..2731038 100644
    getManufacturerSync,
    getMaxMemory,
 diff --git a/node_modules/react-native-device-info/src/internal/privateTypes.ts b/node_modules/react-native-device-info/src/internal/privateTypes.ts
-index fb71735..0a9bb10 100644
+index edf2cae..cb632c6 100644
 --- a/node_modules/react-native-device-info/src/internal/privateTypes.ts
 +++ b/node_modules/react-native-device-info/src/internal/privateTypes.ts
-@@ -83,12 +83,8 @@ interface ExposedNativeMethods {
+@@ -84,12 +84,8 @@ interface ExposedNativeMethods {
    getInstallReferrerSync: () => string;
    getInstanceId: () => Promise<string>;
    getInstanceIdSync: () => string;


### PR DESCRIPTION
## Short description
This PR upgrades the patch file for the react-native-device-info, in order to hide the mismatch warning during package installation.

## List of changes proposed in this pull request
- react-native-device-info@10.8.0.patch upgraded to match the 10.8.0 version

## How to test
Run a `yarn` command from scratch and check that there are no warnings about react-native-device-info patch mismatch
