### PR TITLE
chore(Cross): [IOAPPX-392] Set `largeHeap=true`

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -47,7 +47,7 @@
     <!-- Media permission for Android API Level 33+-->
   <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 
-  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:usesCleartextTraffic="true" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:requestLegacyExternalStorage="true" android:theme="@style/AppTheme">
+  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:usesCleartextTraffic="true" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="false" android:requestLegacyExternalStorage="true" android:theme="@style/AppTheme" android:largeHeap="true">
 
     <!-- START Required by react-native-push-notification -->
 


### PR DESCRIPTION
## Short description
This PR adds the `largeHeap` attribute to the Android Manifest, in order to request more memory for the application.
This should improve the Android Custom Tabs performances on some devices.

## List of changes proposed in this pull request
- `largeHeap=true` on the `application` tag in the Android manifest file

## How to test
Check that the application is properly built
