### PR TITLE
chore(IT Wallet): [SIW-1757] Init context synchronously in ITW issuance machines

### DIFF
--- a/ts/features/itwallet/machine/credential/__tests__/machine.test.ts
+++ b/ts/features/itwallet/machine/credential/__tests__/machine.test.ts
@@ -3,6 +3,7 @@ import { AuthorizationDetail } from "@pagopa/io-react-native-wallet";
 import { waitFor } from "@testing-library/react-native";
 import _ from "lodash";
 import {
+  assign,
   createActor,
   fromPromise,
   StateFrom,
@@ -23,7 +24,6 @@ import {
   ObtainCredentialActorInput,
   ObtainCredentialActorOutput,
   ObtainStatusAttestationActorInput,
-  OnInitActorOutput,
   RequestCredentialActorInput,
   RequestCredentialActorOutput
 } from "../actors";
@@ -111,8 +111,8 @@ describe("itwCredentialIssuanceMachine", () => {
   const storeCredential = jest.fn();
   const closeIssuance = jest.fn();
   const handleSessionExpired = jest.fn();
-
   const onInit = jest.fn();
+
   const getWalletAttestation = jest.fn();
   const requestCredential = jest.fn();
   const obtainCredential = jest.fn();
@@ -130,10 +130,10 @@ describe("itwCredentialIssuanceMachine", () => {
       storeWalletInstanceAttestation,
       storeCredential,
       closeIssuance,
-      handleSessionExpired
+      handleSessionExpired,
+      onInit: assign(onInit)
     },
     actors: {
-      onInit: fromPromise<OnInitActorOutput>(onInit),
       getWalletAttestation:
         fromPromise<GetWalletAttestationActorOutput>(getWalletAttestation),
       requestCredential: fromPromise<
@@ -156,7 +156,7 @@ describe("itwCredentialIssuanceMachine", () => {
   });
 
   beforeEach(() => {
-    onInit.mockImplementation(() => Promise.resolve({} as OnInitActorOutput));
+    onInit.mockImplementation(() => ({}));
     hasValidWalletInstanceAttestation.mockImplementation(() => false);
   });
 
@@ -303,11 +303,9 @@ describe("itwCredentialIssuanceMachine", () => {
   });
 
   it("Should skip WIA obtainment if still valid", async () => {
-    onInit.mockImplementation(() =>
-      Promise.resolve({
-        walletInstanceAttestation: T_WIA
-      })
-    );
+    onInit.mockImplementation(() => ({
+      walletInstanceAttestation: T_WIA
+    }));
     hasValidWalletInstanceAttestation.mockImplementation(() => true);
     getWalletAttestation.mockImplementation(() => Promise.resolve(T_WIA));
     requestCredential.mockImplementation(() =>
@@ -455,11 +453,9 @@ describe("itwCredentialIssuanceMachine", () => {
   });
 
   it("Should go to failure if credential request fails", async () => {
-    onInit.mockImplementation(() =>
-      Promise.resolve({
-        walletInstanceAttestation: T_WIA
-      })
-    );
+    onInit.mockImplementation(() => ({
+      walletInstanceAttestation: T_WIA
+    }));
     hasValidWalletInstanceAttestation.mockImplementation(() => true);
 
     const actor = createActor(mockedMachine);

--- a/ts/features/itwallet/machine/credential/__tests__/machine.test.ts
+++ b/ts/features/itwallet/machine/credential/__tests__/machine.test.ts
@@ -156,7 +156,7 @@ describe("itwCredentialIssuanceMachine", () => {
   });
 
   beforeEach(() => {
-    onInit.mockImplementation(() => ({}));
+    onInit.mockImplementation(() => ({ walletInstanceAttestation: undefined }));
     hasValidWalletInstanceAttestation.mockImplementation(() => false);
   });
 

--- a/ts/features/itwallet/machine/credential/actions.ts
+++ b/ts/features/itwallet/machine/credential/actions.ts
@@ -1,21 +1,22 @@
 import { IOToast } from "@pagopa/io-app-design-system";
-import { ActionArgs, assertEvent } from "xstate";
+import { ActionArgs, assertEvent, assign } from "xstate";
 import I18n from "../../../../i18n";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import ROUTES from "../../../../navigation/routes";
 import { checkCurrentSession } from "../../../../store/actions/authentication";
-import { useIODispatch } from "../../../../store/hooks";
+import { useIOStore } from "../../../../store/hooks";
 import { assert } from "../../../../utils/assert";
 import { CREDENTIALS_MAP, trackSaveCredentialSuccess } from "../../analytics";
 import { itwCredentialsStore } from "../../credentials/store/actions";
 import { ITW_ROUTES } from "../../navigation/routes";
 import { itwWalletInstanceAttestationStore } from "../../walletInstance/store/actions";
+import { itwWalletInstanceAttestationSelector } from "../../walletInstance/store/reducers";
 import { Context } from "./context";
 import { CredentialIssuanceEvents } from "./events";
 
 export default (
   navigation: ReturnType<typeof useIONavigation>,
-  dispatch: ReturnType<typeof useIODispatch>,
+  store: ReturnType<typeof useIOStore>,
   toast: IOToast
 ) => ({
   navigateToTrustIssuerScreen: () => {
@@ -71,7 +72,7 @@ export default (
       context.walletInstanceAttestation,
       "walletInstanceAttestation is undefined"
     );
-    dispatch(
+    store.dispatch(
       itwWalletInstanceAttestationStore(context.walletInstanceAttestation)
     );
   },
@@ -84,7 +85,7 @@ export default (
     CredentialIssuanceEvents
   >) => {
     assert(context.credential, "credential is undefined");
-    dispatch(itwCredentialsStore([context.credential]));
+    store.dispatch(itwCredentialsStore([context.credential]));
   },
 
   closeIssuance: ({
@@ -104,5 +105,17 @@ export default (
   },
 
   handleSessionExpired: () =>
-    dispatch(checkCurrentSession.success({ isSessionValid: false }))
+    store.dispatch(checkCurrentSession.success({ isSessionValid: false })),
+
+  onInit: assign<
+    Context,
+    CredentialIssuanceEvents,
+    unknown,
+    CredentialIssuanceEvents,
+    any
+  >(() => ({
+    walletInstanceAttestation: itwWalletInstanceAttestationSelector(
+      store.getState()
+    )
+  }))
 });

--- a/ts/features/itwallet/machine/credential/actors.ts
+++ b/ts/features/itwallet/machine/credential/actors.ts
@@ -9,12 +9,7 @@ import { getCredentialStatusAttestation } from "../../common/utils/itwCredential
 import { StoredCredential } from "../../common/utils/itwTypesUtils";
 import { itwCredentialsEidSelector } from "../../credentials/store/selectors";
 import { itwIntegrityKeyTagSelector } from "../../issuance/store/selectors";
-import { itwWalletInstanceAttestationSelector } from "../../walletInstance/store/reducers";
 import { type Context } from "./context";
-
-export type OnInitActorOutput = {
-  walletInstanceAttestation: string | undefined;
-};
 
 export type GetWalletAttestationActorOutput = Awaited<
   ReturnType<typeof itwAttestationUtils.getAttestation>
@@ -37,16 +32,6 @@ export type ObtainCredentialActorOutput = Awaited<
 export type ObtainStatusAttestationActorInput = Pick<Context, "credential">;
 
 export default (store: ReturnType<typeof useIOStore>) => {
-  const onInit = fromPromise<OnInitActorOutput>(async () => {
-    const walletInstanceAttestation = itwWalletInstanceAttestationSelector(
-      store.getState()
-    );
-
-    return {
-      walletInstanceAttestation
-    };
-  });
-
   const getWalletAttestation = fromPromise<GetWalletAttestationActorOutput>(
     async () => {
       const sessionToken = sessionTokenSelector(store.getState());
@@ -134,7 +119,6 @@ export default (store: ReturnType<typeof useIOStore>) => {
   });
 
   return {
-    onInit,
     getWalletAttestation,
     requestCredential,
     obtainCredential,

--- a/ts/features/itwallet/machine/credential/machine.ts
+++ b/ts/features/itwallet/machine/credential/machine.ts
@@ -6,7 +6,6 @@ import {
   ObtainCredentialActorInput,
   ObtainCredentialActorOutput,
   ObtainStatusAttestationActorInput,
-  OnInitActorOutput,
   RequestCredentialActorInput,
   RequestCredentialActorOutput
 } from "./actors";
@@ -32,10 +31,10 @@ export const itwCredentialIssuanceMachine = setup({
     storeCredential: notImplemented,
     closeIssuance: notImplemented,
     setFailure: assign(({ event }) => ({ failure: mapEventToFailure(event) })),
-    handleSessionExpired: notImplemented
+    handleSessionExpired: notImplemented,
+    onInit: notImplemented
   },
   actors: {
-    onInit: fromPromise<OnInitActorOutput>(notImplemented),
     getWalletAttestation:
       fromPromise<GetWalletAttestationActorOutput>(notImplemented),
     requestCredential: fromPromise<
@@ -59,15 +58,7 @@ export const itwCredentialIssuanceMachine = setup({
   id: "itwCredentialIssuanceMachine",
   context: { ...InitialContext },
   initial: "Idle",
-  invoke: {
-    src: "onInit",
-    onDone: {
-      actions: assign(({ event }) => ({
-        walletInstanceAttestation: event.output.walletInstanceAttestation
-      }))
-    },
-    target: ".Idle"
-  },
+  entry: "onInit",
   states: {
     Idle: {
       description:

--- a/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
+++ b/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
@@ -1,13 +1,12 @@
 import { waitFor } from "@testing-library/react-native";
 import _ from "lodash";
-import { createActor, fromPromise, StateFrom } from "xstate";
+import { assign, createActor, fromPromise, StateFrom } from "xstate";
 import { idps } from "../../../../../utils/idps";
 import { ItwStoredCredentialsMocks } from "../../../common/utils/itwMocksUtils";
 import { StoredCredential } from "../../../common/utils/itwTypesUtils";
 import { ItwTags } from "../../tags";
 import {
   GetWalletAttestationActorParams,
-  OnInitActorOutput,
   RequestEidActorParams,
   StartCieAuthFlowActorParams
 } from "../actors";
@@ -39,8 +38,8 @@ describe("itwEidIssuanceMachine", () => {
   const setWalletInstanceToValid = jest.fn();
   const handleSessionExpired = jest.fn();
   const abortIdentification = jest.fn();
-
   const onInit = jest.fn();
+
   const createWalletInstance = jest.fn();
   const getWalletAttestation = jest.fn();
   const requestEid = jest.fn();
@@ -72,10 +71,10 @@ describe("itwEidIssuanceMachine", () => {
       setWalletInstanceToOperational,
       setWalletInstanceToValid,
       handleSessionExpired,
-      abortIdentification
+      abortIdentification,
+      onInit: assign(onInit)
     },
     actors: {
-      onInit: fromPromise<OnInitActorOutput>(onInit),
       createWalletInstance: fromPromise<string>(createWalletInstance),
       getWalletAttestation: fromPromise<
         string,
@@ -99,7 +98,10 @@ describe("itwEidIssuanceMachine", () => {
   });
 
   beforeEach(() => {
-    onInit.mockImplementation(() => Promise.resolve({} as OnInitActorOutput));
+    onInit.mockImplementation(() => ({
+      integrityKeyTag: undefined,
+      walletInstanceAttestation: undefined
+    }));
     hasValidWalletInstanceAttestation.mockImplementation(() => false);
   });
 

--- a/ts/features/itwallet/machine/eid/actions.ts
+++ b/ts/features/itwallet/machine/eid/actions.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { IOToast } from "@pagopa/io-app-design-system";
-import { ActionArgs } from "xstate";
+import { ActionArgs, assign } from "xstate";
+import * as O from "fp-ts/lib/Option";
 import I18n from "../../../../i18n";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import ROUTES from "../../../../navigation/routes";
@@ -16,6 +17,8 @@ import {
 import { ItwLifecycleState } from "../../lifecycle/store/reducers";
 import { ITW_ROUTES } from "../../navigation/routes";
 import { itwWalletInstanceAttestationStore } from "../../walletInstance/store/actions";
+import { itwWalletInstanceAttestationSelector } from "../../walletInstance/store/reducers";
+import { itwIntegrityKeyTagSelector } from "../../issuance/store/selectors";
 import { Context } from "./context";
 import { EidIssuanceEvents } from "./events";
 
@@ -175,5 +178,18 @@ export const createEidIssuanceActionsImplementation = (
   resetWalletInstance: () => {
     store.dispatch(itwLifecycleWalletReset());
     toast.success(I18n.t("features.itWallet.issuance.eidResult.success.toast"));
-  }
+  },
+
+  onInit: assign<Context, EidIssuanceEvents, unknown, EidIssuanceEvents, any>(
+    () => {
+      const state = store.getState();
+      const storedIntegrityKeyTag = itwIntegrityKeyTagSelector(state);
+      const walletInstanceAttestation =
+        itwWalletInstanceAttestationSelector(state);
+      return {
+        integrityKeyTag: O.toUndefined(storedIntegrityKeyTag),
+        walletInstanceAttestation
+      };
+    }
+  )
 });

--- a/ts/features/itwallet/machine/eid/actions.ts
+++ b/ts/features/itwallet/machine/eid/actions.ts
@@ -5,7 +5,7 @@ import I18n from "../../../../i18n";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import ROUTES from "../../../../navigation/routes";
 import { checkCurrentSession } from "../../../../store/actions/authentication";
-import { useIODispatch } from "../../../../store/hooks";
+import { useIOStore } from "../../../../store/hooks";
 import { assert } from "../../../../utils/assert";
 import { itwCredentialsStore } from "../../credentials/store/actions";
 import { itwStoreIntegrityKeyTag } from "../../issuance/store/actions";
@@ -21,7 +21,7 @@ import { EidIssuanceEvents } from "./events";
 
 export const createEidIssuanceActionsImplementation = (
   navigation: ReturnType<typeof useIONavigation>,
-  dispatch: ReturnType<typeof useIODispatch>,
+  store: ReturnType<typeof useIOStore>,
   toast: IOToast
 ) => ({
   navigateToTosScreen: () => {
@@ -124,20 +124,22 @@ export const createEidIssuanceActionsImplementation = (
   },
 
   setWalletInstanceToOperational: () => {
-    dispatch(
+    store.dispatch(
       itwLifecycleStateUpdated(ItwLifecycleState.ITW_LIFECYCLE_OPERATIONAL)
     );
   },
 
   setWalletInstanceToValid: () => {
-    dispatch(itwLifecycleStateUpdated(ItwLifecycleState.ITW_LIFECYCLE_VALID));
+    store.dispatch(
+      itwLifecycleStateUpdated(ItwLifecycleState.ITW_LIFECYCLE_VALID)
+    );
   },
 
   storeIntegrityKeyTag: ({
     context
   }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
     assert(context.integrityKeyTag, "integrityKeyTag is undefined");
-    dispatch(itwStoreIntegrityKeyTag(context.integrityKeyTag));
+    store.dispatch(itwStoreIntegrityKeyTag(context.integrityKeyTag));
   },
 
   storeWalletInstanceAttestation: ({
@@ -147,7 +149,7 @@ export const createEidIssuanceActionsImplementation = (
       context.walletInstanceAttestation,
       "walletInstanceAttestation is undefined"
     );
-    dispatch(
+    store.dispatch(
       itwWalletInstanceAttestationStore(context.walletInstanceAttestation)
     );
   },
@@ -156,13 +158,13 @@ export const createEidIssuanceActionsImplementation = (
     context
   }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
     assert(context.eid, "eID is undefined");
-    dispatch(itwCredentialsStore([context.eid]));
+    store.dispatch(itwCredentialsStore([context.eid]));
   },
 
   requestAssistance: () => {},
 
   handleSessionExpired: () =>
-    dispatch(checkCurrentSession.success({ isSessionValid: false })),
+    store.dispatch(checkCurrentSession.success({ isSessionValid: false })),
 
   abortIdentification: ({
     context
@@ -171,7 +173,7 @@ export const createEidIssuanceActionsImplementation = (
   },
 
   resetWalletInstance: () => {
-    dispatch(itwLifecycleWalletReset());
+    store.dispatch(itwLifecycleWalletReset());
     toast.success(I18n.t("features.itWallet.issuance.eidResult.success.toast"));
   }
 });

--- a/ts/features/itwallet/machine/eid/actors.ts
+++ b/ts/features/itwallet/machine/eid/actors.ts
@@ -15,13 +15,7 @@ import * as issuanceUtils from "../../common/utils/itwIssuanceUtils";
 import { StoredCredential } from "../../common/utils/itwTypesUtils";
 import { itwIntegrityKeyTagSelector } from "../../issuance/store/selectors";
 import { itwLifecycleStoresReset } from "../../lifecycle/store/actions";
-import { itwWalletInstanceAttestationSelector } from "../../walletInstance/store/reducers";
 import type { CieAuthContext, IdentificationContext } from "./context";
-
-export type OnInitActorOutput = {
-  integrityKeyTag: string | undefined;
-  walletInstanceAttestation: string | undefined;
-};
 
 export type RequestEidActorParams = {
   identification: IdentificationContext | undefined;
@@ -45,18 +39,6 @@ export type GetWalletAttestationActorParams = {
 export const createEidIssuanceActorsImplementation = (
   store: ReturnType<typeof useIOStore>
 ) => ({
-  onInit: fromPromise<OnInitActorOutput>(async () => {
-    const walletInstanceAttestation = itwWalletInstanceAttestationSelector(
-      store.getState()
-    );
-    const storedIntegrityKeyTag = itwIntegrityKeyTagSelector(store.getState());
-
-    return {
-      integrityKeyTag: O.toUndefined(storedIntegrityKeyTag),
-      walletInstanceAttestation
-    };
-  }),
-
   createWalletInstance: fromPromise<string>(async () => {
     const sessionToken = sessionTokenSelector(store.getState());
     assert(sessionToken, "sessionToken is undefined");

--- a/ts/features/itwallet/machine/eid/machine.ts
+++ b/ts/features/itwallet/machine/eid/machine.ts
@@ -4,7 +4,6 @@ import { StoredCredential } from "../../common/utils/itwTypesUtils";
 import { ItwTags } from "../tags";
 import {
   GetWalletAttestationActorParams,
-  OnInitActorOutput,
   StartCieAuthFlowActorParams,
   type RequestEidActorParams
 } from "./actors";
@@ -49,10 +48,10 @@ export const itwEidIssuanceMachine = setup({
     handleSessionExpired: notImplemented,
     abortIdentification: notImplemented,
     resetWalletInstance: notImplemented,
-    setFailure: assign(({ event }) => ({ failure: mapEventToFailure(event) }))
+    setFailure: assign(({ event }) => ({ failure: mapEventToFailure(event) })),
+    onInit: notImplemented
   },
   actors: {
-    onInit: fromPromise<OnInitActorOutput>(notImplemented),
     createWalletInstance: fromPromise<string>(notImplemented),
     revokeWalletInstance: fromPromise<void>(notImplemented),
     getWalletAttestation: fromPromise<string, GetWalletAttestationActorParams>(
@@ -76,16 +75,7 @@ export const itwEidIssuanceMachine = setup({
   id: "itwEidIssuanceMachine",
   context: { ...InitialContext },
   initial: "Idle",
-  invoke: {
-    src: "onInit",
-    onDone: {
-      actions: assign(({ event }) => ({
-        integrityKeyTag: event.output.integrityKeyTag,
-        walletInstanceAttestation: event.output.walletInstanceAttestation
-      }))
-    },
-    target: ".Idle"
-  },
+  entry: "onInit",
   states: {
     Idle: {
       description: "The machine is in idle, ready to start the issuance flow",

--- a/ts/features/itwallet/machine/provider.tsx
+++ b/ts/features/itwallet/machine/provider.tsx
@@ -2,7 +2,7 @@ import { useIOToast } from "@pagopa/io-app-design-system";
 import { createActorContext } from "@xstate/react";
 import * as React from "react";
 import { useIONavigation } from "../../../navigation/params/AppParamsList";
-import { useIODispatch, useIOStore } from "../../../store/hooks";
+import { useIOStore } from "../../../store/hooks";
 import { itwBypassIdentityMatch } from "../../../config";
 import createCredentialIssuanceActionsImplementation from "./credential/actions";
 import createCredentialIssuanceActorsImplementation from "./credential/actors";
@@ -27,7 +27,6 @@ export const ItwCredentialIssuanceMachineContext = createActorContext(
 
 export const ItWalletIssuanceMachineProvider = (props: Props) => {
   const store = useIOStore();
-  const dispatch = useIODispatch();
   const navigation = useIONavigation();
   const toast = useIOToast();
 
@@ -35,11 +34,7 @@ export const ItWalletIssuanceMachineProvider = (props: Props) => {
     guards: createEidIssuanceGuardsImplementation(store, {
       bypassIdentityMatch: itwBypassIdentityMatch
     }),
-    actions: createEidIssuanceActionsImplementation(
-      navigation,
-      dispatch,
-      toast
-    ),
+    actions: createEidIssuanceActionsImplementation(navigation, store, toast),
     actors: createEidIssuanceActorsImplementation(store)
   });
 
@@ -47,7 +42,7 @@ export const ItWalletIssuanceMachineProvider = (props: Props) => {
     guards: createCredentialIssuanceGuardsImplementation(),
     actions: createCredentialIssuanceActionsImplementation(
       navigation,
-      dispatch,
+      store,
       toast
     ),
     actors: createCredentialIssuanceActorsImplementation(store)


### PR DESCRIPTION
## Short description
This PR uses **actions** instead of async actors to initialize the context in both the eID and credential issuance machine. The rationale is to prevent race conditions that might happen when the machine is in idle state and immediately receives an event: sometimes the context is not yet initialized when the event is received.

Since the initialization phase only reads values from the Redux store to inject them in the machine context, it is not necessary to use a promise actor, so an action might be more appropriate.

## List of changes proposed in this pull request
- Moved the context initialization logic from actors to actions
- Updated issuance tests

## How to test
To ensure no regression was introduced, it is necessary to test all the issuance flows:
- Wallet activation + eID
- Standard credentials issuance
- MDL async flow (following the deep link)
