### PR TITLE
chore(Cross): [IOAPPX-401] Update JDK version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,10 @@ jobs:
           fetch-depth: 0
       - id: setup
         uses: ./.github/actions/setup-composite
-      - id: setup-jdk-11
+      - id: setup-jdk-17
         uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 #v3.11.0
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: gradle
       - id: setup-android-sdk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           distribution: 'temurin'
           cache: gradle
       - id: setup-android-sdk
-        uses: android-actions/setup-android@7c5672355aaa8fde5f97a91aa9a99616d1ace6bc #v2.0.10
+        uses: android-actions/setup-android@00854ea68c109d98c75d956347303bf7c45b0277 #v3.2.1
       - id: setup-ruby
         uses: ruby/setup-ruby@d2b39ad0b52eca07d23f3aa14fdf2a3fcc1f411c #v1.149.0
         with:


### PR DESCRIPTION
## Short description
This PR updates the JDK version in the release workflow which is supposed to fix an issue we currently have while publishing on Android via GitHub Actions.

## List of changes proposed in this pull request
- Bump JDK version in `setup-jdk` to version 17;
- Bump `setup-android` to version `3.2.1`;

## How to test
N/A