### PR TITLE
fix: [IOCOM-1881] Push notification status on Android 12 or less

### DIFF
--- a/ts/features/pushNotifications/store/reducers/userBehaviour.ts
+++ b/ts/features/pushNotifications/store/reducers/userBehaviour.ts
@@ -16,7 +16,7 @@ export const userBehaviourReducer = (
 ): UserBehaviourState => {
   switch (action.type) {
     case getType(setEngagementScreenShown):
-      return { ...state, engagementScreenShown: false };
+      return { ...state, engagementScreenShown: true };
   }
   return state;
 };

--- a/ts/features/pushNotifications/store/reducers/userBehaviour.ts
+++ b/ts/features/pushNotifications/store/reducers/userBehaviour.ts
@@ -16,7 +16,7 @@ export const userBehaviourReducer = (
 ): UserBehaviourState => {
   switch (action.type) {
     case getType(setEngagementScreenShown):
-      return { ...state, engagementScreenShown: true };
+      return { ...state, engagementScreenShown: false };
   }
   return state;
 };

--- a/ts/features/pushNotifications/utils/index.ts
+++ b/ts/features/pushNotifications/utils/index.ts
@@ -4,7 +4,7 @@ import * as E from "fp-ts/lib/Either";
 import * as T from "fp-ts/lib/Task";
 import * as TE from "fp-ts/lib/TaskEither";
 import { v4 as uuid } from "uuid";
-import { Platform, PermissionsAndroid } from "react-native";
+import { PermissionsAndroid } from "react-native";
 import PushNotificationIOS from "@react-native-community/push-notification-ios";
 import PushNotification from "react-native-push-notification";
 import NotificationsUtils from "react-native-notifications-utils";
@@ -17,46 +17,27 @@ export enum AuthorizationStatus {
   Provisional = 3
 }
 
-const isAndroid7NougatAPI24OrMore = (Platform.Version as number) >= 24;
-const successfulBooleanTaskEither = () => TE.fromEither(E.right(true));
-
 const checkPermissionAndroid = () =>
-  pipe(
-    isAndroid7NougatAPI24OrMore,
-    B.fold(successfulBooleanTaskEither, () =>
-      TE.tryCatch(
-        () =>
-          PermissionsAndroid.check(
-            PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS
-          ),
-        E.toError
-      )
-    )
+  new Promise<boolean>(resolve =>
+    PushNotification.checkPermissions(data => {
+      // On Android, only 'alert' has a value
+      console.log(`=== ${!!data.alert}`);
+      resolve(!!data.alert);
+    })
   );
 
 const checkPermissioniOS = () =>
-  pipe(
-    () =>
-      new Promise<boolean>((resolve, _) => {
-        PushNotificationIOS.checkPermissions(({ authorizationStatus }) => {
-          resolve(
-            authorizationStatus === AuthorizationStatus.Authorized ||
-              authorizationStatus === AuthorizationStatus.Provisional
-          );
-        });
-      }),
-    TE.fromTask
+  new Promise<boolean>(resolve =>
+    PushNotificationIOS.checkPermissions(({ authorizationStatus }) => {
+      resolve(
+        authorizationStatus !== AuthorizationStatus.NotDetermined &&
+          authorizationStatus !== AuthorizationStatus.StatusDenied
+      );
+    })
   );
 
 export const checkNotificationPermissions = () =>
-  pipe(
-    isIos,
-    B.fold(
-      () => checkPermissionAndroid(),
-      () => checkPermissioniOS()
-    ),
-    TE.getOrElse(() => T.of(false))
-  )();
+  isIos ? checkPermissioniOS() : checkPermissionAndroid();
 
 const requestPermissioniOS = () =>
   pipe(
@@ -77,21 +58,16 @@ const requestPermissioniOS = () =>
 
 const requestPermissionAndroid = () =>
   pipe(
-    isAndroid7NougatAPI24OrMore,
-    B.fold(successfulBooleanTaskEither, () =>
-      pipe(
-        TE.tryCatch(
-          () =>
-            PermissionsAndroid.request(
-              PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS
-            ),
-          E.toError
+    TE.tryCatch(
+      () =>
+        PermissionsAndroid.request(
+          PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS
         ),
-        TE.map(
-          permissionStatus =>
-            permissionStatus === PermissionsAndroid.RESULTS.GRANTED
-        )
-      )
+      E.toError
+    ),
+    TE.map(
+      permissionStatus =>
+        permissionStatus === PermissionsAndroid.RESULTS.GRANTED
     )
   );
 

--- a/ts/features/pushNotifications/utils/index.ts
+++ b/ts/features/pushNotifications/utils/index.ts
@@ -21,7 +21,6 @@ const checkPermissionAndroid = () =>
   new Promise<boolean>(resolve =>
     PushNotification.checkPermissions(data => {
       // On Android, only 'alert' has a value
-      console.log(`=== ${!!data.alert}`);
       resolve(!!data.alert);
     })
   );


### PR DESCRIPTION
## Short description
This PR changes the method used to check push notification permissions, in order to properly read the status on devices running Android 12 or lower.

## List of changes proposed in this pull request
- Android utility function code switched from `PermissionAndroid.check` to `PushNotification.checkPermission`
- Check for Android 24 or lower has been removed (since min supported version is 25)
- Improved iOS permission check by checking when notification are disabled instead of enabled
- Refactored utility function to improve readability

## How to test
Using the io-dev-api-server, check that Android devices (all versions) correctly report the push notification permission status.
