### PR TITLE
chore(IT Wallet): [SIW-1756] Prepare integrity service at startup

### DIFF
--- a/ts/features/itwallet/common/utils/itwAttestationUtils.ts
+++ b/ts/features/itwallet/common/utils/itwAttestationUtils.ts
@@ -9,7 +9,6 @@ import { SessionToken } from "../../../../types/SessionToken";
 import { createItWalletFetch } from "../../api/client";
 import { regenerateCryptoKey, WIA_KEYTAG } from "./itwCryptoContextUtils";
 import {
-  ensureIntegrityServiceIsReady,
   generateIntegrityHardwareKeyTag,
   getIntegrityContext
 } from "./itwIntegrityUtils";
@@ -18,10 +17,8 @@ import {
  * Getter for the integrity hardware keytag to be used for an {@link IntegrityContext}.
  * @return the integrity hardware keytag to be persisted
  */
-export const getIntegrityHardwareKeyTag = async (): Promise<string> => {
-  await ensureIntegrityServiceIsReady();
-  return await generateIntegrityHardwareKeyTag();
-};
+export const getIntegrityHardwareKeyTag = async (): Promise<string> =>
+  await generateIntegrityHardwareKeyTag();
 
 /**
  * Register a new wallet instance with hardwareKeyTag.

--- a/ts/features/itwallet/lifecycle/saga/__tests__/checkWalletInstanceStateSaga.test.ts
+++ b/ts/features/itwallet/lifecycle/saga/__tests__/checkWalletInstanceStateSaga.test.ts
@@ -11,11 +11,11 @@ import {
 import { ItwLifecycleState } from "../../store/reducers";
 import { GlobalState } from "../../../../../store/reducers/types";
 import { getAttestation } from "../../../common/utils/itwAttestationUtils";
-import { ensureIntegrityServiceIsReady } from "../../../common/utils/itwIntegrityUtils";
 import { StoredCredential } from "../../../common/utils/itwTypesUtils";
 import { sessionTokenSelector } from "../../../../../store/reducers/authentication";
 import { handleWalletInstanceResetSaga } from "../handleWalletInstanceResetSaga";
 import { itwIsWalletInstanceAttestationValidSelector } from "../../../walletInstance/store/reducers";
+import { ensureIntegrityServiceIsReady } from "../../../common/utils/itwIntegrityUtils";
 
 jest.mock("@pagopa/io-react-native-crypto", () => ({
   deleteKey: jest.fn
@@ -35,6 +35,8 @@ describe("checkWalletInstanceStateSaga", () => {
     };
     return expectSaga(checkWalletInstanceStateSaga)
       .withState(store)
+      .provide([[matchers.call.fn(ensureIntegrityServiceIsReady), true]])
+      .call.fn(ensureIntegrityServiceIsReady)
       .not.call.fn(getAttestationOrResetWalletInstance)
       .run();
   });
@@ -55,14 +57,15 @@ describe("checkWalletInstanceStateSaga", () => {
     return expectSaga(checkWalletInstanceStateSaga)
       .withState(store)
       .provide([
-        [matchers.call.fn(ensureIntegrityServiceIsReady), true],
         [matchers.select(sessionTokenSelector), "h94LhbfJCLGH1S3qHj"],
         [matchers.select(itwIsWalletInstanceAttestationValidSelector), false],
         [
           matchers.call.fn(getAttestation),
           "aac6e82a-e27e-4293-9b55-94a9fab22763"
-        ]
+        ],
+        [matchers.call.fn(ensureIntegrityServiceIsReady), true]
       ])
+      .call.fn(ensureIntegrityServiceIsReady)
       .call.fn(getAttestationOrResetWalletInstance)
       .not.call.fn(handleWalletInstanceResetSaga)
       .run();
@@ -84,7 +87,6 @@ describe("checkWalletInstanceStateSaga", () => {
     return expectSaga(checkWalletInstanceStateSaga)
       .withState(store)
       .provide([
-        [matchers.call.fn(ensureIntegrityServiceIsReady), true],
         [matchers.select(sessionTokenSelector), "h94LhbfJCLGH1S3qHj"],
         [matchers.select(itwIsWalletInstanceAttestationValidSelector), false],
         [
@@ -92,8 +94,10 @@ describe("checkWalletInstanceStateSaga", () => {
           throwError(
             new Errors.WalletInstanceRevokedError("Revoked", "Revoked")
           )
-        ]
+        ],
+        [matchers.call.fn(ensureIntegrityServiceIsReady), true]
       ])
+      .call.fn(ensureIntegrityServiceIsReady)
       .call.fn(getAttestationOrResetWalletInstance)
       .call.fn(handleWalletInstanceResetSaga)
       .run();
@@ -115,14 +119,15 @@ describe("checkWalletInstanceStateSaga", () => {
     return expectSaga(checkWalletInstanceStateSaga)
       .withState(store)
       .provide([
-        [matchers.call.fn(ensureIntegrityServiceIsReady), true],
         [matchers.select(sessionTokenSelector), "h94LhbfJCLGH1S3qHj"],
         [matchers.select(itwIsWalletInstanceAttestationValidSelector), false],
         [
           matchers.call.fn(getAttestation),
           "3396d31e-ac6a-4357-8083-cb5d3cda4d74"
-        ]
+        ],
+        [matchers.call.fn(ensureIntegrityServiceIsReady), true]
       ])
+      .call.fn(ensureIntegrityServiceIsReady)
       .call.fn(getAttestationOrResetWalletInstance)
       .not.call.fn(handleWalletInstanceResetSaga)
       .run();
@@ -144,7 +149,6 @@ describe("checkWalletInstanceStateSaga", () => {
     return expectSaga(checkWalletInstanceStateSaga)
       .withState(store)
       .provide([
-        [matchers.call.fn(ensureIntegrityServiceIsReady), true],
         [matchers.select(sessionTokenSelector), "h94LhbfJCLGH1S3qHj"],
         [matchers.select(itwIsWalletInstanceAttestationValidSelector), false],
         [
@@ -152,8 +156,10 @@ describe("checkWalletInstanceStateSaga", () => {
           throwError(
             new Errors.WalletInstanceRevokedError("Revoked", "Revoked")
           )
-        ]
+        ],
+        [matchers.call.fn(ensureIntegrityServiceIsReady), true]
       ])
+      .call.fn(ensureIntegrityServiceIsReady)
       .call.fn(getAttestationOrResetWalletInstance)
       .call.fn(handleWalletInstanceResetSaga)
       .run();
@@ -164,11 +170,9 @@ describe("getAttestationOrResetWalletInstance", () => {
   it("should obtain a new WIA if it doesn't exist or has expired", () =>
     expectSaga(getAttestationOrResetWalletInstance, "")
       .provide([
-        [matchers.call.fn(ensureIntegrityServiceIsReady), true],
         [matchers.select(sessionTokenSelector), "h94LhbfJCLGH1S3qHj"],
         [matchers.select(itwIsWalletInstanceAttestationValidSelector), false]
       ])
-      .call.fn(ensureIntegrityServiceIsReady)
       .call.fn(getAttestation)
       .run());
   it("should skip WIA obtainment if it exists and has not yet expired", () =>
@@ -177,7 +181,6 @@ describe("getAttestationOrResetWalletInstance", () => {
         [matchers.select(sessionTokenSelector), "h94LhbfJCLGH1S3qHj"],
         [matchers.select(itwIsWalletInstanceAttestationValidSelector), true]
       ])
-      .not.call.fn(ensureIntegrityServiceIsReady)
       .not.call.fn(getAttestation)
       .run());
 });

--- a/ts/features/itwallet/lifecycle/saga/checkWalletInstanceStateSaga.ts
+++ b/ts/features/itwallet/lifecycle/saga/checkWalletInstanceStateSaga.ts
@@ -14,6 +14,7 @@ import { handleWalletInstanceResetSaga } from "./handleWalletInstanceResetSaga";
 export function* getAttestationOrResetWalletInstance(integrityKeyTag: string) {
   const sessionToken = yield* select(sessionTokenSelector);
   assert(sessionToken, "Missing session token");
+
   const isWalletInstanceAttestationValid = yield* select(
     itwIsWalletInstanceAttestationValidSelector
   );
@@ -26,7 +27,6 @@ export function* getAttestationOrResetWalletInstance(integrityKeyTag: string) {
   // If the Wallet Instance Attestation is not present or it has expired
   // we need to request a new one
   try {
-    yield* call(ensureIntegrityServiceIsReady);
     yield* call(getAttestation, integrityKeyTag, sessionToken);
   } catch (err) {
     if (
@@ -46,6 +46,10 @@ export function* checkWalletInstanceStateSaga(): Generator<
   ReduxSagaEffect,
   void
 > {
+  // We start the warming up process of the integrity service on Android
+  // TODO: consider the result of the operation to decide whether to proceed or not [SIW-1759]
+  yield* call(ensureIntegrityServiceIsReady);
+
   const isItwOperationalOrValid = yield* select(
     itwLifecycleIsOperationalOrValid
   );

--- a/ts/features/itwallet/machine/eid/actors.ts
+++ b/ts/features/itwallet/machine/eid/actors.ts
@@ -9,7 +9,6 @@ import {
   getIntegrityHardwareKeyTag,
   registerWalletInstance
 } from "../../common/utils/itwAttestationUtils";
-import { ensureIntegrityServiceIsReady } from "../../common/utils/itwIntegrityUtils";
 import { revokeCurrentWalletInstance } from "../../common/utils/itwRevocationUtils";
 import * as issuanceUtils from "../../common/utils/itwIssuanceUtils";
 import { StoredCredential } from "../../common/utils/itwTypesUtils";
@@ -65,7 +64,6 @@ export const createEidIssuanceActorsImplementation = (
     // If there is a stored key tag we assume the wallet instance was already created
     // so we just need to prepare the integrity service and return the existing key tag.
     if (O.isSome(storedIntegrityKeyTag)) {
-      await ensureIntegrityServiceIsReady();
       return storedIntegrityKeyTag.value;
     }
 


### PR DESCRIPTION
## Short description
This PR refactors the usage of `ensureIntegrityServiceIsReady` from `io-react-native-integrity`. 
This functions checks wether or not the integrity service is available on the device and on Android it warms up the integrity service as detailed in the [design review](https://pagopa.atlassian.net/wiki/spaces/SIW/pages/921436266/IO-WALLET-DR-0007+Play+Integrity+API), based on the Google documentation.

Currently the function gets called multiple times when needed, however this is totally unnecessary and also adds up more time to the wallet instance issuance flow.

> [!NOTE]
> A refactor is needed in order to leverage the returned value from this function. It will be handled in another PR.

## List of changes proposed in this pull request
- Remove any usage of `ensureIntegrityServiceIsReady` and move the call at the startup when checking for the validity of the wallet instance. The function is called wether or not a wallet instance already exists;
- Update tests.

## How to test
Test that the existing flows still works as expected.
