### PR TITLE
fix(IT Wallet): [SIW-1761] Crash when integrity service is not available 

### DIFF
--- a/ts/features/itwallet/lifecycle/saga/checkWalletInstanceStateSaga.ts
+++ b/ts/features/itwallet/lifecycle/saga/checkWalletInstanceStateSaga.ts
@@ -48,15 +48,19 @@ export function* checkWalletInstanceStateSaga(): Generator<
 > {
   // We start the warming up process of the integrity service on Android
   // TODO: consider the result of the operation to decide whether to proceed or not [SIW-1759]
-  yield* call(ensureIntegrityServiceIsReady);
+  try {
+    yield* call(ensureIntegrityServiceIsReady);
 
-  const isItwOperationalOrValid = yield* select(
-    itwLifecycleIsOperationalOrValid
-  );
-  const integrityKeyTag = yield* select(itwIntegrityKeyTagSelector);
+    const isItwOperationalOrValid = yield* select(
+      itwLifecycleIsOperationalOrValid
+    );
+    const integrityKeyTag = yield* select(itwIntegrityKeyTagSelector);
 
-  // Only operational or valid wallet instances can be revoked.
-  if (isItwOperationalOrValid && O.isSome(integrityKeyTag)) {
-    yield* call(getAttestationOrResetWalletInstance, integrityKeyTag.value);
+    // Only operational or valid wallet instances can be revoked.
+    if (isItwOperationalOrValid && O.isSome(integrityKeyTag)) {
+      yield* call(getAttestationOrResetWalletInstance, integrityKeyTag.value);
+    }
+  } catch (e) {
+    // Ignore the error, the integrity service is not available and an error will occur if the wallet requests an attestation
   }
 }


### PR DESCRIPTION
## Short description
This PR fixes a crash which happens when the integrity service is not available. 

## List of changes proposed in this pull request
- Catch the error when calling `ensureIntegrityServiceIsReady` on a device which doesn't support it.

## How to test
Start the app on the simulator, you shouldn't see any error after the startup saga.
