### PR TITLE
fix: [PE-737] CGN capitalize text apostrophe case

### DIFF
--- a/ts/utils/__tests__/string.test.ts
+++ b/ts/utils/__tests__/string.test.ts
@@ -27,6 +27,22 @@ describe("capitalize", () => {
   it("should return a string where each word has first char in uppercase-5", () => {
     expect(capitalize("   hello,world   ", ",")).toEqual("   Hello,World   ");
   });
+
+  it("should return a string where each word has the first char in uppercase even after an apostrophe", () => {
+    expect(capitalize("Capit'Alize")).toEqual("Capit'Alize");
+  });
+
+  it("should return a string where each word has the first char in uppercase even after an apostrophe-2", () => {
+    expect(capitalize("capit'alize")).toEqual("Capit'alize");
+  });
+
+  it("should return a string where each word has the first char in uppercase even after an apostrophe-3", () => {
+    expect(capitalize("capit'alize")).toEqual("Capit'alize");
+  });
+
+  it("should return a string where each word has the first char in uppercase even after an apostrophe-4", () => {
+    expect(capitalize("Capit'alize")).toEqual("Capit'alize");
+  });
 });
 
 describe("isStringNullyOrEmpty", () => {

--- a/ts/utils/strings.ts
+++ b/ts/utils/strings.ts
@@ -30,19 +30,24 @@ export function isTextIncludedCaseInsensitive(
  * @param text
  * @param separator
  */
-export function capitalize(text: string, separator: string = " ") {
-  return text
-    .split(separator)
-    .reduce(
-      (acc: string, curr: string, index: number) =>
-        `${acc}${index === 0 ? "" : separator}${curr.replace(
-          new RegExp(curr.trimLeft(), "ig"),
-          _.capitalize(curr.trimLeft())
-        )}`,
-      ""
-    );
-}
+export function capitalize(text: string, separator: string = " "): string {
+  // Match leading and trailing spaces
+  const leadingSpacesMatch = /^\s*/.exec(text);
+  const trailingSpacesMatch = /\s*$/.exec(text);
 
+  const leadingSpaces = leadingSpacesMatch ? leadingSpacesMatch[0] : "";
+  const trailingSpaces = trailingSpacesMatch ? trailingSpacesMatch[0] : "";
+
+  // Capitalize the words between the separators
+  const capitalizedText = text
+    .trim() // Remove leading/trailing spaces for processing
+    .split(separator)
+    .map(token => token.charAt(0).toUpperCase() + token.slice(1))
+    .join(separator);
+
+  // Re-add the leading and trailing spaces
+  return `${leadingSpaces}${capitalizedText}${trailingSpaces}`;
+}
 /**
  * Convert the EnteBEneficiario content type in a readable string
  * @param e organization data


### PR DESCRIPTION
## Short description
This PR updates the `capitalize` function to correctly handle words with apostrophes, ensuring that words like _Dall'Ara_ remain _Dall'Ara_ and not _Dall'ara_.
## List of changes proposed in this pull request
- Added new test cases to ensure the function works as expected with apostrophes. 
- Updated the `capitalize` function to correctly handle words with apostrophes.
- Used RegExp.exec() to match and preserve leading and trailing spaces.

## How to test

1. Ensure your development environment is set up and the project is running.
2. Run the test suite to verify the changes
3. Check that all tests pass, including the new test cases for words with apostrophes and leading/trailing spaces.

Or

1. Modify the CgnOwnershipInformation file with a hardcoded word containing an apostrophe.
2. Verify that the CgnOwnershipInformation component correctly capitalizes words with apostrophes when rendered.

##Preview
![Screenshot 2024-10-17 at 09 41 56](https://github.com/user-attachments/assets/637139cb-5dce-4d57-bd4f-10cd0490ed49)


