### PR TITLE
chore(IT Wallet): [SIW-1765] Remove secondary CTA on integrity error

### DIFF
--- a/ts/features/itwallet/issuance/screens/ItwIssuanceEidFailureScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceEidFailureScreen.tsx
@@ -102,12 +102,6 @@ export const ItwIssuanceEidFailureScreen = () => {
             "features.itWallet.unsupportedDevice.error.primaryAction"
           ),
           onPress: () => closeIssuance() // TODO: [SIW-1375] better retry and go back handling logic for the issuance process
-        },
-        secondaryAction: {
-          label: I18n.t(
-            "features.itWallet.unsupportedDevice.error.secondaryAction"
-          ),
-          onPress: () => undefined
         }
       },
       [IssuanceFailureType.NOT_MATCHING_IDENTITY]: {


### PR DESCRIPTION
## Short description
This PR removes the secondary CTA on integrity error temporary, until we have an actual URL with FAQ for the citizien. 

## How to test
Remap the answer of the `/api/v1/wallet/token` endpoint to `409 Conflict` and try to active a wallet from scratch. It is important that you don't have an active wallet instance before testing it and this can be ensured by resetting the wallet from the developer options, documenti su IO and reset wallet instance.
