### PR TITLE
fix(IT Wallet): [SIW-1766] Enable banners with empty wallet

### DIFF
--- a/ts/features/newWallet/components/WalletCardsContainer.tsx
+++ b/ts/features/newWallet/components/WalletCardsContainer.tsx
@@ -54,7 +54,12 @@ const WalletCardsContainer = () => {
   if (cards.length === 0) {
     // In this case we can display the empty state: we do not have cards to display and
     // the wallet is not in a loading state anymore
-    return <WalletEmptyScreenContent />;
+    return (
+      <View style={IOStyles.flex}>
+        <ItwBanners />
+        <WalletEmptyScreenContent />
+      </View>
+    );
   }
 
   const shouldRender = (filter: WalletCardCategoryFilter) =>
@@ -66,8 +71,7 @@ const WalletCardsContainer = () => {
       layout={LinearTransition.duration(200)}
     >
       <View testID="walletCardsContainerTestID">
-        <ItwUpcomingWalletBanner bottomSpacing={24} />
-        <ItwDiscoveryBanner ignoreMargins={true} closable={false} />
+        <ItwBanners />
         {shouldRender("itw") && <ItwCardsContainer isStacked={stackCards} />}
         {shouldRender("other") && (
           <OtherCardsContainer isStacked={stackCards} />
@@ -173,5 +177,15 @@ const OtherCardsContainer = ({
     />
   );
 };
+
+/**
+ * Wrapper components for ITW banners.
+ */
+const ItwBanners = () => (
+  <>
+    <ItwUpcomingWalletBanner bottomSpacing={24} />
+    <ItwDiscoveryBanner ignoreMargins={true} closable={false} />
+  </>
+);
 
 export { WalletCardsContainer };


### PR DESCRIPTION
## Short description
This PR adds the activation/coming soon banners when the wallet is empty.

## List of changes proposed in this pull request
- Wrap the banners in a single component;
- Add the wrapper inside the empty wallet return case and replace it everywhere else.

## How to test
Test that the banner are correctly shown based on the trial system status both when the wallet is empty and when it's not.