### PR TITLE
fix: [IOBP-900] Remove parenthesis from tax code in payment screen 

### DIFF
--- a/ts/features/payments/bizEventsTransaction/utils/__tests__/index.test.ts
+++ b/ts/features/payments/bizEventsTransaction/utils/__tests__/index.test.ts
@@ -66,10 +66,16 @@ describe("getPayerInfoLabel", () => {
     expect(result).toBe("123456789");
   });
 
+  it("should return only the taxCode if name is empty string", () => {
+    const payer = { taxCode: "123456789", name: "" };
+    const result = getPayerInfoLabel(payer);
+    expect(result).toBe("123456789");
+  });
+
   it("should return name and taxCode formatted correctly", () => {
     const payer = { name: "John Doe", taxCode: "123456789" };
     const result = getPayerInfoLabel(payer);
-    expect(result).toBe("John Doe\n123456789");
+    expect(result).toBe("John Doe\n(123456789)");
   });
 
   it("should return an empty string if both name and taxCode are not provided", () => {
@@ -81,7 +87,7 @@ describe("getPayerInfoLabel", () => {
   it("should trim extra spaces", () => {
     const payer = { name: "  John Doe  ", taxCode: "  123456789  " };
     const result = getPayerInfoLabel(payer);
-    expect(result).toBe("John Doe\n123456789");
+    expect(result).toBe("John Doe\n(123456789)");
   });
 });
 

--- a/ts/features/payments/bizEventsTransaction/utils/__tests__/index.test.ts
+++ b/ts/features/payments/bizEventsTransaction/utils/__tests__/index.test.ts
@@ -63,13 +63,13 @@ describe("getPayerInfoLabel", () => {
   it("should return only the taxCode if name is not provided", () => {
     const payer = { taxCode: "123456789" };
     const result = getPayerInfoLabel(payer);
-    expect(result).toBe("(123456789)");
+    expect(result).toBe("123456789");
   });
 
   it("should return name and taxCode formatted correctly", () => {
     const payer = { name: "John Doe", taxCode: "123456789" };
     const result = getPayerInfoLabel(payer);
-    expect(result).toBe("John Doe\n(123456789)");
+    expect(result).toBe("John Doe\n123456789");
   });
 
   it("should return an empty string if both name and taxCode are not provided", () => {
@@ -81,7 +81,7 @@ describe("getPayerInfoLabel", () => {
   it("should trim extra spaces", () => {
     const payer = { name: "  John Doe  ", taxCode: "  123456789  " };
     const result = getPayerInfoLabel(payer);
-    expect(result).toBe("John Doe\n(123456789)");
+    expect(result).toBe("John Doe\n123456789");
   });
 });
 

--- a/ts/features/payments/bizEventsTransaction/utils/index.ts
+++ b/ts/features/payments/bizEventsTransaction/utils/index.ts
@@ -67,8 +67,7 @@ export const getPayerInfoLabel = (payer: InfoNotice["payer"]): string => {
   const name = payer.name ? payer.name.trim() : "";
   const taxCode = payer.taxCode ? payer.taxCode.trim() : "";
 
-  const payerInfo =
-    name && taxCode ? `${name}\n${taxCode}` : `${name}${taxCode}`;
+  const payerInfo = name ? (taxCode ? `${name}\n(${taxCode})` : name) : taxCode;
 
   return payerInfo.trim();
 };

--- a/ts/features/payments/bizEventsTransaction/utils/index.ts
+++ b/ts/features/payments/bizEventsTransaction/utils/index.ts
@@ -65,7 +65,7 @@ export const getPayerInfoLabel = (payer: InfoNotice["payer"]): string => {
   }
 
   const name = payer.name ? payer.name.trim() : "";
-  const taxCode = payer.taxCode ? `(${payer.taxCode.trim()})` : "";
+  const taxCode = payer.taxCode ? payer.taxCode.trim() : "";
 
   const payerInfo =
     name && taxCode ? `${name}\n${taxCode}` : `${name}${taxCode}`;


### PR DESCRIPTION
## Short description
This pull request includes changes to the `getPayerInfoLabel` function and its corresponding tests to improve the formatting of the payer's tax code. The main change is the removal of parentheses around the tax code in the output.

## List of changes proposed in this pull request
- Remove parenthesis from `getPayerInfoLabel` function 
- Update `getPayerInfoLabel` test

## How to test
- Go into `Pagamenti`
- Tap on a payment from the list
- Check the tax code under the  payer name

## Preview
<img width="499" alt="Screenshot 2024-10-21 at 17 59 33" src="https://github.com/user-attachments/assets/0a356ef3-64d9-4531-8d74-4c7521ef5f69">

