### PR TITLE
fix: [IOBP-901] Missing header in payment methods

### DIFF
--- a/ts/features/payments/details/screens/PaymentsMethodDetailsScreen.tsx
+++ b/ts/features/payments/details/screens/PaymentsMethodDetailsScreen.tsx
@@ -90,14 +90,20 @@ const PaymentsMethodDetailsScreen = () => {
 };
 
 const getCardHeaderTitle = (details?: UIWalletInfoDetails) => {
-  if (details?.lastFourDigits !== undefined) {
-    const capitalizedCardCircuit = capitalize(
-      details.brand?.toLowerCase() ?? ""
-    );
-    return `${capitalizedCardCircuit} ••${details.lastFourDigits}`;
+  switch (details?.type) {
+    case "BPAY":
+      return "BPAY";
+    case "PAYPAL":
+      return "PayPal";
+    default:
+      if (details?.lastFourDigits !== undefined) {
+        const capitalizedCardCircuit = capitalize(
+          details.brand?.toLowerCase() ?? ""
+        );
+        return `${capitalizedCardCircuit} ••${details.lastFourDigits}`;
+      }
+      return "";
   }
-
-  return "";
 };
 
 export default PaymentsMethodDetailsScreen;

--- a/ts/features/payments/details/screens/PaymentsMethodDetailsScreen.tsx
+++ b/ts/features/payments/details/screens/PaymentsMethodDetailsScreen.tsx
@@ -92,7 +92,7 @@ const PaymentsMethodDetailsScreen = () => {
 const getCardHeaderTitle = (details?: UIWalletInfoDetails) => {
   switch (details?.type) {
     case "BPAY":
-      return "BPAY";
+      return "BANCOMAT Pay";
     case "PAYPAL":
       return "PayPal";
     default:


### PR DESCRIPTION
## Short description
This pull request includes a change to the `PaymentsMethodDetailsScreen` component to enhance the `getCardHeaderTitle` function. The update adds specific handling for BPAY and PayPal payment methods.

## List of changes proposed in this pull request
- Update `getCardHeaderTitle` function to handle missing edge cases

## How to test

### io-dev-server
To test all card cases, update the `generateWalletData` function by adding this line: `generateUserWallet(3)`

### io-app

- Tap in _Portafoglio_
- BPAY or PayPal card
- Verify the correct card header title is displayed
