### PR TITLE
chore(IT Wallet): [SIW-1784] Typo in identification mode selection screen

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3298,7 +3298,7 @@ features:
         action: Scopri di più
     identification:
       mode:
-        title: Verfica la tua identità
+        title: Verifica la tua identità
         description: È un passaggio necessario per garantire la sicurezza dei tuoi dati.
         header: Scegli come identificarti
         method:

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3298,7 +3298,7 @@ features:
         action: Scopri di più
     identification:
       mode:
-        title: Verfica la tua identità
+        title: Verifica la tua identità
         description: È un passaggio necessario per garantire la sicurezza dei tuoi dati.
         header: Scegli come identificarti
         method:


### PR DESCRIPTION
## Short description
This PR fixes a typo in the identification mode selection screen.

## List of changes proposed in this pull request
- Update IT/EN locales;

## How to test
Static check should be enough but this can be tested by running `yarn generate:locales` and by opening the identification mode screen by trying to activate the wallet:
<img src="https://github.com/user-attachments/assets/01acedc9-9476-414b-9ca4-f3f34c4c24d5" height="400">

