### PR TITLE
chore(IT Wallet): [SIW-1716] Add action to ITWallet upcoming banner

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -106,3 +106,5 @@ ITW_IPZS_PRIVACY_URL='https://io.italia.it/informativa-ipzs'
 ITW_PRIVACY_URL='https://io.italia.it/informativa-sperimentazione'
 # ITW Trial TOS URL
 ITW_TOS_URL='https://io.italia.it/tos-sperimentazione'
+# ITW Documents on IO URL
+ITW_DOCUMENTS_ON_IO_URL='https://io.italia.it/documenti-su-io'

--- a/.env.production
+++ b/.env.production
@@ -106,3 +106,5 @@ ITW_IPZS_PRIVACY_URL='https://io.italia.it/informativa-ipzs'
 ITW_PRIVACY_URL='https://io.italia.it/informativa-sperimentazione'
 # ITW Trial TOS URL
 ITW_TOS_URL='https://io.italia.it/tos-sperimentazione'
+# ITW Documents on IO URL
+ITW_DOCUMENTS_ON_IO_URL='https://io.italia.it/documenti-su-io'

--- a/ts/config.ts
+++ b/ts/config.ts
@@ -270,3 +270,8 @@ export const itwTosUrl: string = pipe(
   t.string.decode,
   E.getOrElse(() => "https://io.italia.it/tos-sperimentazione")
 );
+export const itwDocumentsOnIOUrl: string = pipe(
+  Config.ITW_DOCUMENTS_ON_IO_URL,
+  t.string.decode,
+  E.getOrElse(() => "https://io.italia.it/documenti-su-io")
+);

--- a/ts/features/itwallet/common/components/ItwUpcomingWalletBanner.tsx
+++ b/ts/features/itwallet/common/components/ItwUpcomingWalletBanner.tsx
@@ -1,9 +1,10 @@
 import React from "react";
 import { Banner, IOSpacer, VSpacer } from "@pagopa/io-app-design-system";
+import { Linking } from "react-native";
 import I18n from "../../../../i18n";
 import { useIOSelector } from "../../../../store/hooks";
 import { trialStatusSelector } from "../../../trialSystem/store/reducers";
-import { itwTrialId } from "../../../../config";
+import { itwDocumentsOnIOUrl, itwTrialId } from "../../../../config";
 import { SubscriptionStateEnum } from "../../../../../definitions/trial_system/SubscriptionState";
 
 type ItwUpcomingWalletBannerProps = {
@@ -30,6 +31,10 @@ export const ItwUpcomingWalletBanner = ({
         content={I18n.t(
           "features.itWallet.discovery.upcomingWalletBanner.content"
         )}
+        action={I18n.t(
+          "features.itWallet.discovery.upcomingWalletBanner.action"
+        )}
+        onPress={() => Linking.openURL(itwDocumentsOnIOUrl)}
       />
       {bottomSpacing && <VSpacer size={bottomSpacing} />}
     </>


### PR DESCRIPTION
## Short description
This PR add action to `ItwUpcomingWalletBanner`. Clicking the banner the user will be redirected to the following page: https://io.italia.it/documenti-su-io

## List of changes proposed in this pull request
- Add `action` to `ItwUpcomingWalletBanner` component with the correct link 
- The `ITW_DOCUMENTS_ON_IO_URL` variable has been added to both `.env.local` and `.env.production` 

## How to test
Using the `io-dev-api-server`, simulate a state other than SubscriptionStateEnum.ACTIVE and verify that clicking on the banner redirects to the correct page (https://io.italia.it/documenti-su-io)



https://github.com/user-attachments/assets/aef47420-7751-414d-963f-4e5e08904315


