### PR TITLE
chore: [IOPID-2359] Delete sessionRefresh FF reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "io_session_manager_api": "https://raw.githubusercontent.com/pagopa/io-auth-n-identity-domain/io-session-manager@1.0.0/apps/io-session-manager/api/internal.yaml",
   "io_session_manager_public_api": "https://raw.githubusercontent.com/pagopa/io-auth-n-identity-domain/io-session-manager@1.0.0/apps/io-session-manager/api/public.yaml",
   "io_public_api": "https://raw.githubusercontent.com/pagopa/io-backend/v14.3.0-RELEASE/api_public.yaml",
-  "io_content_specs": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.44/definitions.yml",
+  "io_content_specs": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.45/definitions.yml",
   "io_cgn_specs": "https://raw.githubusercontent.com/pagopa/io-backend/v14.3.0-RELEASE/api_cgn.yaml",
   "io_cgn_merchants_specs": "https://raw.githubusercontent.com/pagopa/io-backend/v14.3.0-RELEASE/api_cgn_operator_search.yaml",
   "api_fci": "https://raw.githubusercontent.com/pagopa/io-backend/v14.3.0-RELEASE/api_io_sign.yaml",


### PR DESCRIPTION
## Short description
Change version of io-services-metadata ref in package.json in order to delete the reference to sessionRefresh. 

> [!Note] 
> This PR depends on https://github.com/pagopa/io-services-metadata/pull/847 and is related to https://github.com/pagopa/io-app/pull/6255
