### PR TITLE
feat(IT Wallet): [SIW-1770] Improve IPZS privacy screen

### DIFF
--- a/ts/features/itwallet/discovery/components/ItwPrivacyWebViewComponent.tsx
+++ b/ts/features/itwallet/discovery/components/ItwPrivacyWebViewComponent.tsx
@@ -1,16 +1,10 @@
 import React from "react";
-import {
-  ContentWrapper,
-  IOStyles,
-  VSpacer
-} from "@pagopa/io-app-design-system";
+import { FooterActions, IOStyles } from "@pagopa/io-app-design-system";
 import WebView from "react-native-webview";
 import { View } from "react-native";
 import { WebViewSource } from "react-native-webview/lib/WebViewTypes";
 import { AVOID_ZOOM_JS, closeInjectedScript } from "../../../../utils/webview";
 import I18n from "../../../../i18n";
-import ItwMarkdown from "../../common/components/ItwMarkdown";
-import { FooterActions } from "../../../../components/ui/FooterActions";
 
 type Props = {
   source: WebViewSource;
@@ -36,13 +30,6 @@ const ItwPrivacyWebViewComponent = ({
       source={source}
       injectedJavaScript={closeInjectedScript(AVOID_ZOOM_JS)}
     />
-
-    <ContentWrapper>
-      <VSpacer size={4} />
-      <ItwMarkdown>
-        {I18n.t("features.itWallet.ipzsPrivacy.warning")}
-      </ItwMarkdown>
-    </ContentWrapper>
     <FooterActions
       fixed={false}
       actions={{

--- a/ts/features/itwallet/discovery/screens/ItwDiscoveryInfoScreen.tsx
+++ b/ts/features/itwallet/discovery/screens/ItwDiscoveryInfoScreen.tsx
@@ -1,5 +1,6 @@
 import {
   ContentWrapper,
+  FooterActions,
   ForceScrollDownView,
   H1,
   VSpacer
@@ -8,7 +9,6 @@ import * as React from "react";
 import { StyleSheet } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
 import { AnimatedImage } from "../../../../components/AnimatedImage";
-import { FooterActions } from "../../../../components/ui/FooterActions";
 import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
 import I18n from "../../../../i18n";
 import { emptyContextualHelp } from "../../../../utils/emptyContextualHelp";

--- a/ts/features/itwallet/discovery/screens/ItwIpzsPrivacyScreen.tsx
+++ b/ts/features/itwallet/discovery/screens/ItwIpzsPrivacyScreen.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
-import { View } from "react-native";
-import { H2, IOStyles, VSpacer } from "@pagopa/io-app-design-system";
+import { ContentWrapper, H2, VSpacer } from "@pagopa/io-app-design-system";
 import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
 import I18n from "../../../../i18n";
 import LoadingSpinnerOverlay from "../../../../components/LoadingSpinnerOverlay";
@@ -8,6 +7,7 @@ import ItwPrivacyWebViewComponent from "../components/ItwPrivacyWebViewComponent
 import { ItwEidIssuanceMachineContext } from "../../machine/provider";
 import { trackOpenItwTosAccepted } from "../../analytics";
 import { itwIpzsPrivacyUrl } from "../../../../config";
+import ItwMarkdown from "../../common/components/ItwMarkdown";
 
 const ItwIpzsPrivacyScreen = () => {
   const [isLoading, setIsLoading] = useState(true);
@@ -35,7 +35,7 @@ const ItwIpzsPrivacyScreen = () => {
 
   return (
     <LoadingSpinnerOverlay isLoading={isLoading}>
-      <View style={IOStyles.horizontalContentPadding}>
+      <ContentWrapper>
         <H2
           accessible={true}
           accessibilityRole="header"
@@ -43,8 +43,11 @@ const ItwIpzsPrivacyScreen = () => {
         >
           {I18n.t("features.itWallet.ipzsPrivacy.title")}
         </H2>
-        <VSpacer size={24} />
-      </View>
+        <VSpacer size={16} />
+        <ItwMarkdown>
+          {I18n.t("features.itWallet.ipzsPrivacy.warning")}
+        </ItwMarkdown>
+      </ContentWrapper>
       <ItwPrivacyWebViewComponent
         source={{
           uri: itwIpzsPrivacyUrl


### PR DESCRIPTION
## Short description
The ipzs privacy screen has been improved by moving the text above the continue button below the title

## List of changes proposed in this pull request
- Move the text above the continue button below the title
- Fix the `FooterActions` import, now using the correct component from the design system package

## How to test
Start the WI flow and navigate into the IPZS policy screen (2nd screen in the flow)

Preview:
![IMAGE 2024-10-28 17:20:15](https://github.com/user-attachments/assets/c05264de-f304-4b7c-8949-c3ceefdfd06a)


