### PR TITLE
fix(IT Wallet): [SIW-1798] Removes unnecessary rendering of failure screens during issuance flows

### DIFF
--- a/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialFailureScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialFailureScreen.tsx
@@ -1,4 +1,4 @@
-import { pipe } from "fp-ts/lib/function";
+import { constNull, pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
 import React, { useEffect } from "react";
 import {
@@ -39,14 +39,7 @@ export const ItwIssuanceCredentialFailureScreen = () => {
 
   return pipe(
     failureOption,
-    O.fold(
-      () => (
-        <ContentView
-          failure={{ type: CredentialIssuanceFailureTypeEnum.GENERIC }}
-        />
-      ),
-      type => <ContentView failure={type} />
-    )
+    O.fold(constNull, failure => <ContentView failure={failure} />)
   );
 };
 

--- a/ts/features/itwallet/issuance/screens/ItwIssuanceEidPreviewScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceEidPreviewScreen.tsx
@@ -20,14 +20,12 @@ import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { identificationRequest } from "../../../../store/actions/identification";
 import { useIODispatch } from "../../../../store/hooks";
 import { useAvoidHardwareBackButton } from "../../../../utils/useAvoidHardwareBackButton";
-import { ItwGenericErrorContent } from "../../common/components/ItwGenericErrorContent";
 import { useItwDisableGestureNavigation } from "../../common/hooks/useItwDisableGestureNavigation";
 import { useItwDismissalDialog } from "../../common/hooks/useItwDismissalDialog";
 import { StoredCredential } from "../../common/utils/itwTypesUtils";
 import {
   selectEidOption,
-  selectIdentification,
-  selectIsDisplayingPreview
+  selectIdentification
 } from "../../machine/eid/selectors";
 import { ItwEidIssuanceMachineContext } from "../../machine/provider";
 import {
@@ -43,23 +41,17 @@ import IOMarkdown from "../../../../components/IOMarkdown";
 
 export const ItwIssuanceEidPreviewScreen = () => {
   const eidOption = ItwEidIssuanceMachineContext.useSelector(selectEidOption);
-  const isDisplayingPreview = ItwEidIssuanceMachineContext.useSelector(
-    selectIsDisplayingPreview
-  );
 
   useItwDisableGestureNavigation();
   useAvoidHardwareBackButton();
 
-  // In the state machine this screen is mounted before we actually reach the eID preview state.
-  // While in the other states we render the loading screen to avoid accidentally showing the generic error content.
-  if (!isDisplayingPreview) {
-    return <ItwIssuanceLoadingScreen />;
-  }
-
   return pipe(
     eidOption,
     O.fold(
-      () => <ItwGenericErrorContent />,
+      // If there is no eID in the context (None), we can safely assume the issuing phase is still ongoing.
+      // A None eID cannot be stored in the context, as any issuance failure causes the machine to transition
+      // to the Failure state.
+      () => <ItwIssuanceLoadingScreen />,
       eid => <ContentView eid={eid} />
     )
   );

--- a/ts/features/itwallet/machine/eid/selectors.ts
+++ b/ts/features/itwallet/machine/eid/selectors.ts
@@ -38,6 +38,3 @@ export const selectIsLoading = (snapshot: MachineSnapshot) =>
 export const selectIsCieIdEidRequest = (snapshot: MachineSnapshot) =>
   snapshot.context.identification?.mode === "cieId" &&
   snapshot.matches({ Issuance: "RequestingEid" });
-
-export const selectIsDisplayingPreview = (snapshot: MachineSnapshot) =>
-  snapshot.matches({ Issuance: "DisplayingPreview" });


### PR DESCRIPTION
## Short description
This PR addresses an issue where failure screens are rendered with incorrect props on initial load or, in rare cases, are displayed unnecessarily. This update ensures that failure screens render only when appropriate, with the correct failure type.

#### How to reproduce
1. Use a network inspection tool (e.g., Proxyman) to override the response of either the `/eid` or `/credential` endpoints, forcing them to return an error status code.
2. Initiate the eID or credential issuance flow.
3. To verify if the failure screens are rendered twice, insert a `console.log` statement in the `ContentView` component. You should observe:
   - An initial render with a `GENERIC` failure type.
   - A second render with the actual, specific failure type.

This behavior occurs because the first render processes a `None` failure type, which defaults to a `GENERIC` failure. 

## List of changes proposed in this pull request
- Set `constNull` as the default for failure screens when no failure is present in the context, removing the `GENERIC` failure fallback.
- Removed generic errors from the preview screen, which were causing unwanted failure screen renderings during screen transitions.

## How to test
1. Use a network inspection tool (e.g., Proxyman) to override the response of either the `/eid` or `/credential` endpoints, forcing them to return an error status code.
2. Initiate the eID or credential issuance flow.
3. Verify if the failure screens are not rendered twice.
