### PR TITLE
chore(IT Wallet): [SIW-1769] Reintroduce integrity check KO message 

### DIFF
--- a/ts/features/itwallet/issuance/screens/ItwIssuanceEidFailureScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceEidFailureScreen.tsx
@@ -1,6 +1,7 @@
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
 import React, { useEffect } from "react";
+import { Linking } from "react-native";
 import {
   OperationResultScreenContent,
   OperationResultScreenContentProps
@@ -102,6 +103,13 @@ export const ItwIssuanceEidFailureScreen = () => {
             "features.itWallet.unsupportedDevice.error.primaryAction"
           ),
           onPress: () => closeIssuance() // TODO: [SIW-1375] better retry and go back handling logic for the issuance process
+        },
+        secondaryAction: {
+          label: I18n.t(
+            "features.itWallet.unsupportedDevice.error.secondaryAction"
+          ),
+          onPress: () =>
+            Linking.openURL("https://io.italia.it/documenti-su-io/faq/#n1_12")
         }
       },
       [IssuanceFailureType.NOT_MATCHING_IDENTITY]: {


### PR DESCRIPTION
## Short description
This pull request includes changes to the `ItwIssuanceEidFailureScreen` component to handle unsupported device errors more effectively. The most important changes involve adding a secondary action to the error screen

## List of changes proposed in this pull request
* [`ts/features/itwallet/issuance/screens/ItwIssuanceEidFailureScreen.tsx`](diffhunk://#diff-6e81827f65b8e2bf66539bd0bc1af3eef64bd8a4bd685f383904160bc44cfb2bR106-R112): Added a secondary action to the unsupported device error screen that opens a URL with more information.


## How to test
When obtaining the WI simulate an unsupported device error and check the error screen with the new secondary action button + [link](https://io.italia.it/documenti-su-io/faq/#n1_12)

Preview:

https://github.com/user-attachments/assets/4d9818bf-0e5c-4529-ba7c-ffb8b957e441



