### PR TITLE
fix: [IOBP-902] Payment header opacity on scroll

### DIFF
--- a/ts/features/payments/details/components/PaymentsMethodDetailsBaseScreenComponent.tsx
+++ b/ts/features/payments/details/components/PaymentsMethodDetailsBaseScreenComponent.tsx
@@ -7,6 +7,7 @@ import {
 } from "@pagopa/io-app-design-system";
 import * as React from "react";
 import Animated, {
+  useAnimatedRef,
   useAnimatedScrollHandler,
   useSharedValue
 } from "react-native-reanimated";
@@ -39,6 +40,7 @@ const PaymentsMethodDetailsBaseScreenComponent = ({
   const translationY = useSharedValue(0);
   const [titleHeight, setTitleHeight] = React.useState(0);
   const blueHeaderColor = isDSenabled ? IOColors["blueIO-600"] : IOColors.blue;
+  const animatedScrollViewRef = useAnimatedRef<Animated.ScrollView>();
 
   useHeaderSecondLevel({
     title: headerTitle,
@@ -50,7 +52,9 @@ const PaymentsMethodDetailsBaseScreenComponent = ({
     scrollValues: {
       contentOffsetY: translationY,
       triggerOffset: titleHeight
-    }
+    },
+    enableDiscreteTransition: true,
+    animatedRef: animatedScrollViewRef
   });
 
   const scrollHandler = useAnimatedScrollHandler(event => {
@@ -76,6 +80,7 @@ const PaymentsMethodDetailsBaseScreenComponent = ({
         paddingBottom: 48,
         backgroundColor: IOColors.white
       }}
+      ref={animatedScrollViewRef}
     >
       <FocusAwareStatusBar
         backgroundColor={blueHeaderColor}


### PR DESCRIPTION
## Short description
This pull request introduces enhancements to the `PaymentsMethodDetailsBaseScreenComponent` make the header solid on scroll without opacity.

## List of changes proposed in this pull request
- Apply to `enableDiscreteTransition` to ScrollView component

## How to test
- Tap on _Pagamenti_
- Open a payment card
- Check the header on scroll to be solid every time 

## Preview
<img width="467" alt="Screenshot 2024-10-29 at 15 28 15" src="https://github.com/user-attachments/assets/caabd04a-f0e0-4b38-960b-04b6cb3fa148">
