### PR TITLE
chore: [IOBP-940] Map payment outcome 19 in the mixpanel events

### DIFF
--- a/ts/features/payments/checkout/analytics/index.ts
+++ b/ts/features/payments/checkout/analytics/index.ts
@@ -66,6 +66,8 @@ export const getPaymentAnalyticsEventFromFailureOutcome = (
       return "PAYMENT_REVERSAL_ERROR";
     case WalletPaymentOutcomeEnum.IN_APP_BROWSER_CLOSED_BY_USER:
       return "PAYMENT_WEBVIEW_USER_CANCELLATION";
+    case WalletPaymentOutcomeEnum.PAYPAL_REMOVED_ERROR:
+      return "PAYMENT_METHOD_AUTHORIZATION_ERROR";
     default:
       return outcome;
   }


### PR DESCRIPTION
## Short description
This PR maps the payment outcome 19 in the mixpanel events with the value `PAYMENT_METHOD_AUTHORIZATION_ERROR`.

## List of changes proposed in this pull request
- Added a case inside the switch of the mixpanel mapping outcome to handle outcome 19 (`WalletPaymentOutcomeEnum.PAYPAL_REMOVED_ERROR`)
