### PR TITLE
chore: [IOBP-948] Remove transaction details screen title

### DIFF
--- a/ts/features/payments/bizEventsTransaction/components/PaymentsBizEventsTransactionHeadingSection.tsx
+++ b/ts/features/payments/bizEventsTransaction/components/PaymentsBizEventsTransactionHeadingSection.tsx
@@ -1,11 +1,5 @@
 import _ from "lodash";
-import {
-  Body,
-  H2,
-  IOStyles,
-  useIOTheme,
-  VSpacer
-} from "@pagopa/io-app-design-system";
+import { Body, IOStyles, VSpacer } from "@pagopa/io-app-design-system";
 import { useNavigation } from "@react-navigation/native";
 import React from "react";
 import { View } from "react-native";
@@ -32,8 +26,6 @@ export const PaymentsBizEventsTransactionHeadingSection = ({
 }: Props) => {
   const navigation =
     useNavigation<PaymentsTransactionBizEventsStackNavigation>();
-
-  const theme = useIOTheme();
 
   const transactionInfo = transaction?.infoNotice;
 
@@ -90,14 +82,6 @@ export const PaymentsBizEventsTransactionHeadingSection = ({
 
   return (
     <View style={[IOStyles.horizontalContentPadding, IOStyles.bgWhite]}>
-      <H2
-        color={theme["textHeading-default"]}
-        accessibilityLabel={I18n.t("transaction.details.title")}
-        accessibilityRole="header"
-      >
-        {I18n.t("transaction.details.title")}
-      </H2>
-      <VSpacer size={16} />
       <PaymentsBizEventsTransactionCartList
         carts={transaction?.carts}
         loading={isLoading}


### PR DESCRIPTION
## Short description
This PR removes the title inside the transaction details screen.

## List of changes proposed in this pull request
- Removed the `H2` title inside the heading of the transaction details screen

## How to test
Open a transaction details from the Payment screen.

## Preview
|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/6d15145f-44df-4d34-9935-00fdd941d328" />|<video src="https://github.com/user-attachments/assets/4f2122e0-3294-42c3-b72c-27c32519d9ce" />|