### PR TITLE
chore: [IOBP-757] Apply info copy component into transaction details screen

### DIFF
--- a/ts/features/payments/bizEventsTransaction/screens/PaymentsTransactionBizEventsCartItemDetailsScreen.tsx
+++ b/ts/features/payments/bizEventsTransaction/screens/PaymentsTransactionBizEventsCartItemDetailsScreen.tsx
@@ -1,20 +1,22 @@
-import * as React from "react";
-import { ScrollView } from "react-native";
 import {
   Divider,
   H6,
   IOStyles,
-  ListItemInfo
+  ListItemInfo,
+  ListItemInfoCopy
 } from "@pagopa/io-app-design-system";
 import { RouteProp, useRoute } from "@react-navigation/native";
-import { PaymentsTransactionBizEventsParamsList } from "../navigation/params";
-import I18n from "../../../../i18n";
+import * as React from "react";
+import { ScrollView } from "react-native";
 import { CartItem } from "../../../../../definitions/pagopa/biz-events/CartItem";
 import { UserDetail } from "../../../../../definitions/pagopa/biz-events/UserDetail";
-import { formatAmountText } from "../utils";
 import { IOScrollViewWithLargeHeader } from "../../../../components/ui/IOScrollViewWithLargeHeader";
-import * as analytics from "../analytics";
+import I18n from "../../../../i18n";
+import { clipboardSetStringWithFeedback } from "../../../../utils/clipboard";
 import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
+import * as analytics from "../analytics";
+import { PaymentsTransactionBizEventsParamsList } from "../navigation/params";
+import { formatAmountText } from "../utils";
 
 export type PaymentsTransactionBizEventsCartItemDetailsScreenParams = {
   cartItem: CartItem;
@@ -67,7 +69,7 @@ const PaymentsTransactionBizEventsCartItemDetailsScreen = () => {
           </>
         )}
         {cartItem.debtor &&
-          (cartItem.debtor.name || cartItem.debtor.taxCode) && (
+          (cartItem.debtor.name ?? cartItem.debtor.taxCode) && (
             <>
               <ListItemInfo
                 label={I18n.t("transaction.details.operation.debtor")}
@@ -78,18 +80,28 @@ const PaymentsTransactionBizEventsCartItemDetailsScreen = () => {
           )}
         {cartItem.refNumberValue && (
           <>
-            <ListItemInfo
+            <ListItemInfoCopy
+              onPress={() =>
+                clipboardSetStringWithFeedback(cartItem.refNumberValue)
+              }
               label={I18n.t("transaction.details.operation.noticeCode")}
+              accessibilityLabel={I18n.t(
+                "transaction.details.operation.noticeCode"
+              )}
               value={cartItem.refNumberValue}
             />
             <Divider />
           </>
         )}
         {cartItem.payee && (
-          <ListItemInfo
-            numberOfLines={4}
+          <ListItemInfoCopy
+            onPress={() =>
+              clipboardSetStringWithFeedback(cartItem.payee?.taxCode ?? "")
+            }
             label={I18n.t("transaction.details.operation.taxCode")}
-            value={cartItem.payee.taxCode}
+            accessibilityLabel={I18n.t("transaction.details.operation.taxCode")}
+            value={cartItem.payee?.taxCode}
+            numberOfLines={4}
           />
         )}
       </ScrollView>

--- a/ts/features/payments/transaction/screens/PaymentsTransactionOperationDetails.tsx
+++ b/ts/features/payments/transaction/screens/PaymentsTransactionOperationDetails.tsx
@@ -4,7 +4,8 @@ import {
   Divider,
   H6,
   IOStyles,
-  ListItemInfo
+  ListItemInfo,
+  ListItemInfoCopy
 } from "@pagopa/io-app-design-system";
 import { RouteProp, useRoute } from "@react-navigation/native";
 import { PaymentsTransactionParamsList } from "../navigation/params";
@@ -13,6 +14,7 @@ import { formatNumberCentsToAmount } from "../../../../utils/stringBuilder";
 import { cleanTransactionDescription } from "../../../../utils/payment";
 import I18n from "../../../../i18n";
 import { IOScrollViewWithLargeHeader } from "../../../../components/ui/IOScrollViewWithLargeHeader";
+import { clipboardSetStringWithFeedback } from "../../../../utils/clipboard";
 
 const styles = StyleSheet.create({
   scrollViewContainer: {
@@ -93,18 +95,24 @@ const WalletTransactionOperationDetailsScreen = () => {
         )}
         {operationDetails.IUV && (
           <>
-            <ListItemInfo
+            <ListItemInfoCopy
               label={I18n.t("transaction.details.operation.iuv")}
               value={operationDetails.IUV}
+              onPress={() =>
+                clipboardSetStringWithFeedback(operationDetails.IUV ?? "")
+              }
+              accessibilityLabel={I18n.t("transaction.details.operation.iuv")}
             />
             <Divider />
           </>
         )}
         {operationSubject && (
-          <ListItemInfo
+          <ListItemInfoCopy
             numberOfLines={4}
             label={I18n.t("transaction.details.operation.subject")}
             value={operationSubject}
+            onPress={() => clipboardSetStringWithFeedback(operationSubject)}
+            accessibilityLabel={I18n.t("transaction.details.operation.subject")}
           />
         )}
       </ScrollView>


### PR DESCRIPTION
## Short description
This pull request is adding clipboard functionality to certain items in transaction details screen.

## List of changes proposed in this pull request
- Replace `ListItemInfo` component with `ListItemInfoCopy`

## How to test
- Navigate to the _Pagamenti_ section
- Select any receipt
- Tap on its details
- Verify that the **Tax Code**, **Codice Avviso**,  **IUV** and **Oggetto del pagamento** fields are copyable
- Confirm that the copied values match the original information accurately

## Preview
|             |   |
:-------------------------:|:-------------------------:
<img width="476" alt="Screenshot 2024-11-05 at 08 58 53" src="https://github.com/user-attachments/assets/a2d334ce-e2f4-403a-9378-f06bc8e45f21">  | <img width="476" alt="Screenshot 2024-11-05 at 08 59 08" src="https://github.com/user-attachments/assets/608c2f2a-9935-4cd3-a438-376c5fa98355">

