### PR TITLE
fix: [IOBP-953] Capitalize transaction fields

### DIFF
--- a/ts/features/payments/bizEventsTransaction/components/PaymentsBizEventsTransactionInfoSection.tsx
+++ b/ts/features/payments/bizEventsTransaction/components/PaymentsBizEventsTransactionInfoSection.tsx
@@ -22,6 +22,7 @@ import { WalletInfo } from "../../../../../definitions/pagopa/biz-events/WalletI
 import { getPayerInfoLabel } from "../utils";
 import { NoticeDetailResponse } from "../../../../../definitions/pagopa/biz-events/NoticeDetailResponse";
 import { OriginEnum } from "../../../../../definitions/pagopa/biz-events/InfoNotice";
+import { capitalizeTextName } from "../../../../utils/strings";
 
 type PaymentsBizEventsTransactionInfoSectionProps = {
   transaction?: NoticeDetailResponse;
@@ -99,7 +100,9 @@ const PaymentsBizEventsTransactionInfoSection = ({
                     label={I18n.t("transaction.details.info.headedTo")}
                     value={
                       transactionInfo.walletInfo?.maskedEmail ??
-                      transactionInfo.walletInfo?.accountHolder
+                      capitalizeTextName(
+                        transactionInfo.walletInfo?.accountHolder ?? ""
+                      )
                     }
                   />
                   <Divider />

--- a/ts/features/payments/bizEventsTransaction/utils/__tests__/index.test.ts
+++ b/ts/features/payments/bizEventsTransaction/utils/__tests__/index.test.ts
@@ -89,6 +89,18 @@ describe("getPayerInfoLabel", () => {
     const result = getPayerInfoLabel(payer);
     expect(result).toBe("John Doe\n(123456789)");
   });
+
+  it("should return only the name if taxCode is empty string", () => {
+    const payer = { name: "John Doe", taxCode: "" };
+    const result = getPayerInfoLabel(payer);
+    expect(result).toBe("John Doe");
+  });
+
+  it("should return capitalize string", () => {
+    const payer = { name: "john doe", taxCode: "123456789" };
+    const result = getPayerInfoLabel(payer);
+    expect(result).toBe("John Doe\n(123456789)");
+  });
 });
 
 describe("calculateTotalAmount", () => {

--- a/ts/features/payments/bizEventsTransaction/utils/index.ts
+++ b/ts/features/payments/bizEventsTransaction/utils/index.ts
@@ -1,6 +1,7 @@
 import { SectionListData } from "react-native";
 import { NoticeListItem } from "../../../../../definitions/pagopa/biz-events/NoticeListItem";
 import { InfoNotice } from "../../../../../definitions/pagopa/biz-events/InfoNotice";
+import { capitalizeTextName } from "../../../../utils/strings";
 
 export const RECEIPT_DOCUMENT_TYPE_PREFIX = "data:application/pdf;base64,";
 
@@ -64,7 +65,7 @@ export const getPayerInfoLabel = (payer: InfoNotice["payer"]): string => {
     return "";
   }
 
-  const name = payer.name ? payer.name.trim() : "";
+  const name = payer.name ? capitalizeTextName(payer.name).trim() : "";
   const taxCode = payer.taxCode ? payer.taxCode.trim() : "";
 
   const payerInfo = name ? (taxCode ? `${name}\n(${taxCode})` : name) : taxCode;


### PR DESCRIPTION
## Short description
This pull request includes importing and utilizing a new utility function for text capitalization, and updating the test cases to cover new scenarios.

## List of changes proposed in this pull request
- Apply `capitalizeTextName` to `getPayerInfoLabel` function
- Update test suite of `getPayerInfoLabel` to handle uppercase string

## How to test
- Go in `Pagamenti`
- Tap on a transaction
- Check _Eseguita da_ and _Metodo intestato a_ field to be capitalize (Edit `PaymentsBizEventsTransactionInfoSection` file with custom string and check results)