### PR TITLE
chore: [IOBP-522] Disable back gesture for outcome screens

### DIFF
--- a/ts/features/payments/checkout/navigation/navigator.tsx
+++ b/ts/features/payments/checkout/navigation/navigator.tsx
@@ -58,7 +58,7 @@ export const PaymentsCheckoutNavigator = () => (
       name={PaymentsCheckoutRoutes.PAYMENT_CHECKOUT_OUTCOME}
       component={WalletPaymentOutcomeScreen}
       options={{
-        gestureEnabled: isGestureEnabled,
+        gestureEnabled: false,
         headerShown: false
       }}
     />


### PR DESCRIPTION
## Short description
This pull request disables gesture navigation for the `WalletPaymentOutcomeScreen` component.

## List of changes proposed in this pull request
- Set `gestureEnabled` to false for PAYMENT_CHECKOUT_OUTCOME screen

## Preview

https://github.com/user-attachments/assets/1025f4aa-0d1f-473a-941a-edea906c52c8
