### PR TITLE
fix: [IOCOM-1927] Remove error Toast on InApp Browser opening on FIMS

### DIFF
--- a/ts/features/fims/singleSignOn/saga/handleFimsGetRedirectUrlAndOpenIAB.ts
+++ b/ts/features/fims/singleSignOn/saga/handleFimsGetRedirectUrlAndOpenIAB.ts
@@ -6,10 +6,7 @@ import {
   isCancelledFailure,
   nativeRequest
 } from "@pagopa/io-react-native-http-client";
-import {
-  LoginUtilsError,
-  openAuthenticationSession
-} from "@pagopa/io-react-native-login-utils";
+import { openAuthenticationSession } from "@pagopa/io-react-native-login-utils";
 import * as E from "fp-ts/lib/Either";
 import { Parser as HTMLParser2 } from "htmlparser2";
 import {
@@ -18,7 +15,6 @@ import {
 } from "react-native-url-polyfill";
 import { call, put, select } from "typed-redux-saga/macro";
 import { ActionType } from "typesafe-actions";
-import { IOToast } from "@pagopa/io-app-design-system";
 import { fimsDomainSelector } from "../../../../store/reducers/backendStatus/remoteConfig";
 import { ReduxSagaEffect } from "../../../../types/utils";
 import { LollipopConfig } from "../../../lollipop";
@@ -32,7 +28,6 @@ import { fimsGetRedirectUrlAndOpenIABAction } from "../store/actions";
 import { serviceByIdSelector } from "../../../services/details/store/reducers";
 import { fimsCtaTextSelector } from "../store/selectors";
 import { trackInAppBrowserOpening } from "../../common/analytics";
-import I18n from "../../../../i18n";
 import {
   deallocateFimsAndRenewFastLoginSession,
   deallocateFimsResourcesAndNavigateBack
@@ -151,7 +146,10 @@ export function* handleFimsGetRedirectUrlAndOpenIAB(
   try {
     yield* call(openAuthenticationSession, inAppBrowserRedirectUrl, "", true);
   } catch (error: unknown) {
-    yield* call(handleInAppBrowserErrorIfNeeded, error);
+    // At the time of writing, openAuthenticationSession returns
+    // different kind of structures for error's instances so we
+    // are not able to distinguish between normal closing of the
+    // InApp Browser on both systems and other kind of errors.
   }
 }
 
@@ -490,27 +488,3 @@ function* computeAndTrackInAppBrowserOpening(
     ctaText
   );
 }
-
-function* handleInAppBrowserErrorIfNeeded(error: unknown) {
-  if (!isInAppBrowserClosedError(error)) {
-    const debugMessage = `IAB opening failed: ${inAppBrowserErrorToHumanReadable(
-      error
-    )}`;
-    yield* call(computeAndTrackAuthenticationError, debugMessage);
-    yield* call(IOToast.error, I18n.t("FIMS.consentsScreen.inAppBrowserError"));
-  }
-}
-
-const inAppBrowserErrorToHumanReadable = (error: unknown) => {
-  if (isLoginUtilsError(error)) {
-    return `${error.code} ${error.userInfo?.error}`;
-  }
-  return JSON.stringify(error);
-};
-
-const isLoginUtilsError = (error: unknown): error is LoginUtilsError =>
-  (error as LoginUtilsError).userInfo !== undefined;
-
-const isInAppBrowserClosedError = (error: unknown) =>
-  isLoginUtilsError(error) &&
-  error.userInfo?.error === "NativeAuthSessionClosed";


### PR DESCRIPTION
## Short description
This PR removes the error Toast that was shown if the InApp Browser somehow failed
This has been done since the login-utils library is not up to date with the error handling and does not allow to check for errors on both systems with the same syntax.

## List of changes proposed in this pull request
- Empty error handling

## How to test
Using the io-dev-api-server, check that the FIMS flow works correctly
