### PR TITLE
fix: [IOBP-997] Missing success toast on hide receipt

### DIFF
--- a/ts/features/payments/bizEventsTransaction/saga/handleDisableBizEventsTransactionReceipt.ts
+++ b/ts/features/payments/bizEventsTransaction/saga/handleDisableBizEventsTransactionReceipt.ts
@@ -33,6 +33,9 @@ export function* handleDisableBizEventsTransactionReceipt(
   };
 
   const handleHideReceiptSuccess = () => {
+    IOToast.success(
+      I18n.t("features.payments.transactions.receipt.delete.successful")
+    );
     analytics.trackHideReceiptSuccess({
       organization_name: paymentsAnalyticsData?.receiptOrganizationName,
       first_time_opening: paymentsAnalyticsData?.receiptFirstTimeOpening,


### PR DESCRIPTION
## Short description
This PR adds missing success toast notification when a receipt is successfully hidden

## List of changes proposed in this pull request
-  Added a success toast notification when a receipt is successfully hidden.

## How to test
- Try to hide a receipt
- Verify that a toast notification is displayed

## Preview
https://github.com/user-attachments/assets/ad40631d-48f9-4911-a257-2790d4ca0a3a

