### PR TITLE
fix(IT Wallet): [SIW-1845] Hide trustmark when a credential is invalid

### DIFF
--- a/ts/features/itwallet/common/utils/itwCredentialUtils.ts
+++ b/ts/features/itwallet/common/utils/itwCredentialUtils.ts
@@ -80,6 +80,9 @@ export const tagPropsByStatus: { [key in ItwCredentialStatus]?: Tag } = {
   }
 };
 
+/**
+ * List of statuses that make a credential valid, especially for UI purposes.
+ */
 export const validCredentialStatuses: Array<ItwCredentialStatus> = [
   "valid",
   "expiring",

--- a/ts/features/itwallet/presentation/components/ItwCredentialTrustmark.tsx
+++ b/ts/features/itwallet/presentation/components/ItwCredentialTrustmark.tsx
@@ -52,13 +52,14 @@ import {
   CREDENTIALS_MAP,
   trackWalletCredentialShowTrustmark
 } from "../../analytics";
-import { getCredentialStatus } from "../../common/utils/itwClaimsUtils";
 import {
   generateTrustmarkUrl,
-  getCredentialNameFromType
+  getCredentialNameFromType,
+  validCredentialStatuses
 } from "../../common/utils/itwCredentialUtils";
-import { CredentialType } from "../../common/utils/itwMocksUtils";
 import { StoredCredential } from "../../common/utils/itwTypesUtils";
+import { useIOSelector } from "../../../../store/hooks";
+import { itwCredentialStatusSelector } from "../../credentials/store/selectors";
 
 type ItwCredentialTrustmarkProps = WithTestID<{
   credential: StoredCredential;
@@ -68,17 +69,6 @@ type ButtonSize = {
   width: LayoutRectangle["width"];
   height: LayoutRectangle["height"];
 };
-
-const trustmarkEnabledCredentials = [
-  CredentialType.DRIVING_LICENSE,
-  CredentialType.EUROPEAN_DISABILITY_CARD,
-  CredentialType.EUROPEAN_HEALTH_INSURANCE_CARD
-];
-
-const shouldDisplayTrustmark = (credential: StoredCredential) =>
-  trustmarkEnabledCredentials.includes(
-    credential.credentialType as CredentialType
-  ) && getCredentialStatus(credential) !== "expired";
 
 /* VISUAL PARAMETERS */
 
@@ -105,6 +95,10 @@ export const ItwCredentialTrustmark = ({
   testID,
   credential
 }: ItwCredentialTrustmarkProps) => {
+  const { status = "valid" } = useIOSelector(state =>
+    itwCredentialStatusSelector(state, credential.credentialType)
+  );
+
   /* Bottom sheet for the QR code */
   const trustmarkBottomSheet = useIOBottomSheetAutoresizableModal({
     title: I18n.t("features.itWallet.presentation.trustmark.title"),
@@ -281,7 +275,8 @@ export const ItwCredentialTrustmark = ({
   const { onPressIn, onPressOut, animatedScaleStyle } =
     useSpringPressScaleAnimation();
 
-  if (!shouldDisplayTrustmark(credential)) {
+  // Hide trustmark when the credential is not valid
+  if (!validCredentialStatuses.includes(status)) {
     return null;
   }
 


### PR DESCRIPTION
## Short description
This PR fixes the issue of the trustmark being displayed even when a credential is invalid.

## List of changes proposed in this pull request
- Modified render condition of `ItwCredentialTrustmark` component

## How to test
Mock an invalid status for a credential, access the detail screen and ensure the trustmark button is not shown.
