### PR TITLE
fix: [IOBP-1006] Prevent infinite navigation 

### DIFF
--- a/ts/features/payments/checkout/store/reducers/index.ts
+++ b/ts/features/payments/checkout/store/reducers/index.ts
@@ -216,7 +216,9 @@ const reducer = (
         ...state,
         pspList: pot.none,
         selectedPaymentMethod: O.none,
-        currentStep: WalletPaymentStepEnum.PICK_PAYMENT_METHOD
+        currentStep: WalletPaymentStepEnum.PICK_PAYMENT_METHOD,
+        selectedPsp: O.none,
+        selectedWallet: O.none
       };
     case getType(paymentsCalculatePaymentFeesAction.failure):
       return {


### PR DESCRIPTION
## Short description
The change reset two new properties, `selectedPsp` and `selectedWallet`, to the state when the `paymentsCalculatePaymentFeesAction` is cancel due to psp list fetching error.

## List of changes proposed in this pull request
- Reset two new properties, `selectedPsp` and `selectedWallet`, to the state when the `paymentsCalculatePaymentFeesAction` is cancel due to psp list fetching error

## How to test
- Start a payment
- Try all possible payment methods

## Preview
### Old
https://github.com/user-attachments/assets/67882b0b-768f-40a0-82f7-a6c2b3d5b1b9
### New
https://github.com/user-attachments/assets/f7dcf59e-9275-4a11-8f00-0371c16c7c1c

