### PR TITLE
fix(Cross): [IOAPPX-431] Fix alignment of the dot separator in the `MessageListItem`

### DIFF
--- a/ts/features/messages/components/Home/DS/MessageListItem.tsx
+++ b/ts/features/messages/components/Home/DS/MessageListItem.tsx
@@ -146,8 +146,7 @@ export const MessageListItem = ({
         </View>
         <View style={styles.serviceNameAndMessageTitleContainer}>
           <Body numberOfLines={2} style={IOStyles.flex}>
-            <Label weight="Semibold">{serviceName}</Label>
-            <LabelMini color="grey-700">{" • "}</LabelMini>
+            <Label weight="Semibold">{`${serviceName} · `}</Label>
             <Label weight="Regular">{messageTitle}</Label>
           </Body>
           {!isRead && (

--- a/ts/features/messages/components/Home/DS/MessageListItem.tsx
+++ b/ts/features/messages/components/Home/DS/MessageListItem.tsx
@@ -8,7 +8,6 @@ import {
   IOStyles,
   IOVisualCostants,
   Label,
-  LabelMini,
   LabelSmall,
   Tag,
   WithTestID

--- a/ts/features/messages/components/Home/__tests__/__snapshots__/WrappedMessageListItem.test.tsx.snap
+++ b/ts/features/messages/components/Home/__tests__/__snapshots__/WrappedMessageListItem.test.tsx.snap
@@ -688,27 +688,7 @@ exports[`WrappedMessageListItem should match snapshot, from SEND, read message 1
                                         ]
                                       }
                                     >
-                                      Service name
-                                    </Text>
-                                    <Text
-                                      allowFontScaling={false}
-                                      dynamicTypeRamp="footnote"
-                                      maxFontSizeMultiplier={1.25}
-                                      style={
-                                        [
-                                          {},
-                                          {
-                                            "color": "#555C70",
-                                            "fontFamily": "Titillium Sans Pro",
-                                            "fontSize": 12,
-                                            "fontStyle": "normal",
-                                            "fontWeight": "600",
-                                            "lineHeight": 18,
-                                          },
-                                        ]
-                                      }
-                                    >
-                                       • 
+                                      Service name · 
                                     </Text>
                                     <Text
                                       allowFontScaling={false}
@@ -1656,27 +1636,7 @@ exports[`WrappedMessageListItem should match snapshot, from SEND, unread message
                                         ]
                                       }
                                     >
-                                      Service name
-                                    </Text>
-                                    <Text
-                                      allowFontScaling={false}
-                                      dynamicTypeRamp="footnote"
-                                      maxFontSizeMultiplier={1.25}
-                                      style={
-                                        [
-                                          {},
-                                          {
-                                            "color": "#555C70",
-                                            "fontFamily": "Titillium Sans Pro",
-                                            "fontSize": 12,
-                                            "fontStyle": "normal",
-                                            "fontWeight": "600",
-                                            "lineHeight": 18,
-                                          },
-                                        ]
-                                      }
-                                    >
-                                       • 
+                                      Service name · 
                                     </Text>
                                     <Text
                                       allowFontScaling={false}
@@ -2800,27 +2760,7 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, contains p
                                         ]
                                       }
                                     >
-                                      Service name
-                                    </Text>
-                                    <Text
-                                      allowFontScaling={false}
-                                      dynamicTypeRamp="footnote"
-                                      maxFontSizeMultiplier={1.25}
-                                      style={
-                                        [
-                                          {},
-                                          {
-                                            "color": "#555C70",
-                                            "fontFamily": "Titillium Sans Pro",
-                                            "fontSize": 12,
-                                            "fontStyle": "normal",
-                                            "fontWeight": "600",
-                                            "lineHeight": 18,
-                                          },
-                                        ]
-                                      }
-                                    >
-                                       • 
+                                      Service name · 
                                     </Text>
                                     <Text
                                       allowFontScaling={false}
@@ -3799,27 +3739,7 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, contains p
                                         ]
                                       }
                                     >
-                                      Service name
-                                    </Text>
-                                    <Text
-                                      allowFontScaling={false}
-                                      dynamicTypeRamp="footnote"
-                                      maxFontSizeMultiplier={1.25}
-                                      style={
-                                        [
-                                          {},
-                                          {
-                                            "color": "#555C70",
-                                            "fontFamily": "Titillium Sans Pro",
-                                            "fontSize": 12,
-                                            "fontStyle": "normal",
-                                            "fontWeight": "600",
-                                            "lineHeight": 18,
-                                          },
-                                        ]
-                                      }
-                                    >
-                                       • 
+                                      Service name · 
                                     </Text>
                                     <Text
                                       allowFontScaling={false}
@@ -4853,27 +4773,7 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, contains u
                                         ]
                                       }
                                     >
-                                      Service name
-                                    </Text>
-                                    <Text
-                                      allowFontScaling={false}
-                                      dynamicTypeRamp="footnote"
-                                      maxFontSizeMultiplier={1.25}
-                                      style={
-                                        [
-                                          {},
-                                          {
-                                            "color": "#555C70",
-                                            "fontFamily": "Titillium Sans Pro",
-                                            "fontSize": 12,
-                                            "fontStyle": "normal",
-                                            "fontWeight": "600",
-                                            "lineHeight": 18,
-                                          },
-                                        ]
-                                      }
-                                    >
-                                       • 
+                                      Service name · 
                                     </Text>
                                     <Text
                                       allowFontScaling={false}
@@ -5723,27 +5623,7 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, contains u
                                         ]
                                       }
                                     >
-                                      Service name
-                                    </Text>
-                                    <Text
-                                      allowFontScaling={false}
-                                      dynamicTypeRamp="footnote"
-                                      maxFontSizeMultiplier={1.25}
-                                      style={
-                                        [
-                                          {},
-                                          {
-                                            "color": "#555C70",
-                                            "fontFamily": "Titillium Sans Pro",
-                                            "fontSize": 12,
-                                            "fontStyle": "normal",
-                                            "fontWeight": "600",
-                                            "lineHeight": 18,
-                                          },
-                                        ]
-                                      }
-                                    >
-                                       • 
+                                      Service name · 
                                     </Text>
                                     <Text
                                       allowFontScaling={false}
@@ -6527,27 +6407,7 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, not a paym
                                         ]
                                       }
                                     >
-                                      Service name
-                                    </Text>
-                                    <Text
-                                      allowFontScaling={false}
-                                      dynamicTypeRamp="footnote"
-                                      maxFontSizeMultiplier={1.25}
-                                      style={
-                                        [
-                                          {},
-                                          {
-                                            "color": "#555C70",
-                                            "fontFamily": "Titillium Sans Pro",
-                                            "fontSize": 12,
-                                            "fontStyle": "normal",
-                                            "fontWeight": "600",
-                                            "lineHeight": 18,
-                                          },
-                                        ]
-                                      }
-                                    >
-                                       • 
+                                      Service name · 
                                     </Text>
                                     <Text
                                       allowFontScaling={false}
@@ -7276,27 +7136,7 @@ exports[`WrappedMessageListItem should match snapshot, not from SEND, not a paym
                                         ]
                                       }
                                     >
-                                      Service name
-                                    </Text>
-                                    <Text
-                                      allowFontScaling={false}
-                                      dynamicTypeRamp="footnote"
-                                      maxFontSizeMultiplier={1.25}
-                                      style={
-                                        [
-                                          {},
-                                          {
-                                            "color": "#555C70",
-                                            "fontFamily": "Titillium Sans Pro",
-                                            "fontSize": 12,
-                                            "fontStyle": "normal",
-                                            "fontWeight": "600",
-                                            "lineHeight": 18,
-                                          },
-                                        ]
-                                      }
-                                    >
-                                       • 
+                                      Service name · 
                                     </Text>
                                     <Text
                                       allowFontScaling={false}


### PR DESCRIPTION
## Short description
This PR fixes the wrong alignment of the dot separator in the `MessageListItem`. Previously it was rendered with a smaller font size, resulting in an off-centre separator. This visual problem was more noticeable when the user set a larger text size.
 
## List of changes proposed in this pull request
- Uniform size of the bottom section of the `MessageListItem`

### Preview
| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 Pro - 2024-11-18 at 13 33 45](https://github.com/user-attachments/assets/df6ca247-6e08-4ae1-a9b8-831040fd05d2) | ![Simulator Screenshot - iPhone 16 Pro - 2024-11-18 at 13 33 07](https://github.com/user-attachments/assets/d194a941-aeb6-4c8e-98d5-a27215a23e0f) |


## How to test
N/A