### PR TITLE
chore: [IOBP-982] Add outcome 99 screen into payment flow

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1982,6 +1982,9 @@ wallet:
       PLAFOND_LIMIT_ERROR:
         title: Hai superato il limite di spesa della tua carta
         subtitle: Non è stato addebitato alcun importo. Prima di riprovare, modifica il limite di spesa o usa un altro metodo di pagamento.
+      BE_NODE_KO:
+        title: Stiamo riscontrando alcuni problemi sui sistemi di pagamento
+        subtitle: Verifica l’esito del pagamento nella sezione Pagamenti, altrimenti attendi qualche minuto prima di riprovare.
     support:
       button: "Contatta l'assistenza"
       supportTitle: Contatta l'assistenza

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1983,6 +1983,9 @@ wallet:
       PLAFOND_LIMIT_ERROR:
         title: Hai superato il limite di spesa della tua carta
         subtitle: Non è stato addebitato alcun importo. Prima di riprovare, modifica il limite di spesa o usa un altro metodo di pagamento.
+      BE_NODE_KO:
+        title: Stiamo riscontrando alcuni problemi sui sistemi di pagamento
+        subtitle: Verifica l’esito del pagamento nella sezione Pagamenti, altrimenti attendi qualche minuto prima di riprovare.
     support:
       button: "Contatta l'assistenza"
       supportTitle: Contatta l'assistenza

--- a/ts/features/payments/checkout/analytics/index.ts
+++ b/ts/features/payments/checkout/analytics/index.ts
@@ -30,6 +30,7 @@ export type PaymentAnalyticsProps = {
   editing: PaymentAnalyticsEditingType;
 };
 
+// eslint-disable-next-line complexity
 export const getPaymentAnalyticsEventFromFailureOutcome = (
   outcome: WalletPaymentOutcomeEnum
 ) => {
@@ -68,6 +69,20 @@ export const getPaymentAnalyticsEventFromFailureOutcome = (
       return "PAYMENT_WEBVIEW_USER_CANCELLATION";
     case WalletPaymentOutcomeEnum.PAYPAL_REMOVED_ERROR:
       return "PAYMENT_METHOD_AUTHORIZATION_ERROR";
+    case WalletPaymentOutcomeEnum.BE_NODE_KO:
+      return "PAYMENT_SLOWDOWN_ERROR";
+    case WalletPaymentOutcomeEnum.INSUFFICIENT_AVAILABILITY_ERROR:
+      return "PAYMENT_INSUFFICIENT_AVAILABILITY_ERROR";
+    case WalletPaymentOutcomeEnum.CVV_ERROR:
+      return "PAYMENT_CVV_ERROR";
+    case WalletPaymentOutcomeEnum.PLAFOND_LIMIT_ERROR:
+      return "PAYMENT_PLAFOND_LIMIT_ERROR";
+    case WalletPaymentOutcomeEnum.KO_RETRIABLE:
+      return "PAYMENT_KO_RETRIABLE";
+    case WalletPaymentOutcomeEnum.ORDER_NOT_PRESENT:
+      return "PAYMENT_ORDER_NOT_PRESENT";
+    case WalletPaymentOutcomeEnum.DUPLICATE_ORDER:
+      return "PAYMENT_DUPLICATE_ORDER";
     default:
       return outcome;
   }

--- a/ts/features/payments/checkout/screens/WalletPaymentOutcomeScreen.tsx
+++ b/ts/features/payments/checkout/screens/WalletPaymentOutcomeScreen.tsx
@@ -459,6 +459,14 @@ const WalletPaymentOutcomeScreen = () => {
           ),
           action: closeFailureAction
         };
+      case WalletPaymentOutcomeEnum.BE_NODE_KO:
+        return {
+          pictogram: "umbrellaNew",
+          title: I18n.t("wallet.payment.outcome.BE_NODE_KO.title"),
+          subtitle: I18n.t("wallet.payment.outcome.BE_NODE_KO.subtitle"),
+          action: closeFailureAction,
+          secondaryAction: contactSupportAction
+        };
     }
   };
 

--- a/ts/features/payments/checkout/screens/WalletPaymentOutcomeScreen.tsx
+++ b/ts/features/payments/checkout/screens/WalletPaymentOutcomeScreen.tsx
@@ -400,8 +400,7 @@ const WalletPaymentOutcomeScreen = () => {
             "wallet.payment.outcome.PAYMENT_METHODS_NOT_AVAILABLE.subtitle"
           ),
           action: onboardPaymentMethodAction,
-          secondaryAction: onboardPaymentMethodCloseAction,
-          isHeaderVisible: true
+          secondaryAction: onboardPaymentMethodCloseAction
         };
       case WalletPaymentOutcomeEnum.PAYMENT_REVERSED:
         return {
@@ -429,8 +428,7 @@ const WalletPaymentOutcomeScreen = () => {
           subtitle: I18n.t(
             "wallet.payment.outcome.IN_APP_BROWSER_CLOSED_BY_USER.subtitle"
           ),
-          action: closeFailureAction,
-          isHeaderVisible: true
+          action: closeFailureAction
         };
       case WalletPaymentOutcomeEnum.INSUFFICIENT_AVAILABILITY_ERROR:
         return {
@@ -474,7 +472,7 @@ const WalletPaymentOutcomeScreen = () => {
 
   return (
     <>
-      <OperationResultScreenContent {...getPropsForOutcome()}>
+      <OperationResultScreenContent isHeaderVisible {...getPropsForOutcome()}>
         {requiresFeedback && <WalletPaymentFeebackBanner />}
       </OperationResultScreenContent>
       {supportModal.bottomSheet}

--- a/ts/features/payments/checkout/screens/___tests___/__snapshots__/WalletPaymentOutcomeScreen.test.tsx.snap
+++ b/ts/features/payments/checkout/screens/___tests___/__snapshots__/WalletPaymentOutcomeScreen.test.tsx.snap
@@ -194,9 +194,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -2294,9 +2294,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -4442,9 +4442,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -6571,9 +6571,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -8685,9 +8685,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -10813,9 +10813,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -13012,9 +13012,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -15183,9 +15183,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -17297,9 +17297,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -19361,9 +19361,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -21509,9 +21509,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -23637,9 +23637,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -25785,9 +25785,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -27984,9 +27984,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -30132,9 +30132,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -32280,9 +32280,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -34436,9 +34436,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -36564,9 +36564,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -38765,9 +38765,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -45235,7 +45235,7 @@ Se dopo 5 giorni lavorativi non hai ancora ricevuto il rimborso, contatta l’as
 </View>
 `;
 
-exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPaymentOutcomeScreen for outcome: 116 1`] = `
+exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPaymentOutcomeScreen for outcome: 99 1`] = `
 <View
   style={
     {
@@ -45429,9 +45429,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -45456,6 +45456,2269 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                             ]
                           }
                           handlerTag={44}
+                          handlerType="NativeViewGestureHandler"
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          waitFor={
+                            [
+                              {
+                                "current": null,
+                              },
+                            ]
+                          }
+                        >
+                          <View>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <RNSVGSvgView
+                                align="xMidYMid"
+                                bbHeight={120}
+                                bbWidth={120}
+                                color="#00C5CA"
+                                focusable={false}
+                                height={120}
+                                meetOrSlice={0}
+                                minX={0}
+                                minY={0}
+                                style={
+                                  [
+                                    {
+                                      "backgroundColor": "transparent",
+                                      "borderWidth": 0,
+                                    },
+                                    {
+                                      "flex": 0,
+                                      "height": 120,
+                                      "width": 120,
+                                    },
+                                  ]
+                                }
+                                tintColor="#00C5CA"
+                                vbHeight={240}
+                                vbWidth={240}
+                                width={120}
+                              >
+                                <RNSVGGroup
+                                  fill={
+                                    {
+                                      "payload": 4278190080,
+                                      "type": 0,
+                                    }
+                                  }
+                                >
+                                  <RNSVGPath
+                                    d="M107.085-.00176c8.154 4.82452 16.613 7.64993 26.423 5.57086.846 1.7059 1.647 3.27854 2.412 4.8689 4.086 8.5651 9.458 16.0907 17.405 21.6793 6.048 4.2559 12.878 6.2728 20.51 7.339 1.008 3.6517 1.818 7.3922 3.078 10.9817 5.993 17.0858 17.144 29.2581 34.774 35.1577.855.2844 1.656.7197 2.835 1.2439-.702 18.9514 6.857 33.6914 23.786 43.3314-2.637 8.77-2.979 17.193 1.701 25.438-4.617 2.275-9.333 1.342-13.779 1.253-24.344-.462-47.364-6.095-68.225-18.792-25.352-15.424-44.395-36.455-55.222-64.0336-9.3681-23.8471-8.1172-47.641 2.457-70.95509.432-.95957 1.089-1.82141 1.863-3.10084l-.018.01777Z"
+                                    fill={
+                                      {
+                                        "payload": 4289392367,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    clipRule={0}
+                                    d="M109.854 11.4438c.308-.7527 1.174-1.1168 1.936-.8134 5.193 2.0678 10.161 3.0476 15.22 3.0476.402 0 .773-.0003 1.13-.0163.594-.0266 1.147.2986 1.406.8271 5.076 10.3451 11.441 18.072 19.412 23.6721 5.074 3.5598 10.843 6.0292 17.921 7.5916.544.12.974.5301 1.115 1.0626.528 1.9974 1.092 4.0131 1.81 6.0443l.001.0035c6.628 18.908 18.825 31.837 36.306 38.6155.542.2103.91.7141.942 1.2888.921 16.9038 8.391 30.6088 21.912 40.2658.666.475.815 1.394.334 2.051-.482.658-1.412.806-2.077.33-14.018-10.012-21.89-24.212-23.082-41.5496-17.882-7.2088-30.368-20.7035-37.146-40.0383-.65-1.8408-1.176-3.6538-1.649-5.407-7.018-1.6462-12.891-4.2005-18.11-7.8623l-.001-.0006c-8.22-5.7753-14.755-13.644-19.945-23.9397-.09.0003-.178.0003-.264.0003h-.015c-5.47 0-10.815-1.0638-16.332-3.2608-.762-.3034-1.131-1.1596-.824-1.9122Z"
+                                    fill={
+                                      {
+                                        "payload": 4278240714,
+                                        "type": 0,
+                                      }
+                                    }
+                                    fillRule={0}
+                                    propList={
+                                      [
+                                        "fill",
+                                        "fillRule",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M30.7695 235.468c-6.1197-6.042-6.1197-15.869 0-21.911l17.2971-17.077 3.8158 3.768-17.2971 17.077c-4.0138 3.962-4.0138 10.413 0 14.375 4.0138 3.963 10.5474 3.963 14.5612 0l3.8158 3.768c-6.1196 6.041-16.0731 6.041-22.1928 0ZM128.876 111.262l-32.2061 31.797 3.8181 3.769 32.207-31.796-3.819-3.77Z"
+                                    fill={
+                                      {
+                                        "payload": 4289392367,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M3.29384 203.162 0 200.523c7.29864-8.876 71.8704-86.54 93.2353-79.565 5.8317 1.901 9.3057 4.949 10.3407 9.045 2.232 8.894-8.2168 19.636-13.2385 24.798l-.9.924-3.0778-2.888.9089-.942c4.1488-4.264 13.8504-14.242 12.1764-20.888-.6569-2.612-3.1948-4.656-7.5506-6.068-7.7126-2.515-37.6721 16.232-88.60056 78.223Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M92.4699 174.411c-9.5755 2.506-18.6921-2.95-22.8319-7.881-3.3478-3.989-2.8888-9.889 1.062-13.434 4.5627-4.096 12.5813-5.091 21.4009 4.389l-3.1228 2.835c-5.7057-6.131-11.4565-7.677-15.4163-4.123-2.2589 2.035-2.5468 5.393-.6479 7.659 4.0588 4.833 13.9133 10.324 23.1378 4.442 2.7899-1.777 4.3733-4.016 4.8413-6.85 1.251-7.623-6.0472-16.721-6.1192-16.81l3.3028-2.63c.351.426 8.5584 10.617 7.0104 20.089-.657 4.016-2.916 7.285-6.7314 9.72-1.9439 1.244-3.9148 2.079-5.8677 2.594h-.018Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M79.0336 194.02c-5.1568 1.351-10.0885.48-14.4803-2.612-4.3558-3.065-6.5517-6.726-6.5337-10.884.036-9.125 11.1415-16.935 11.6185-17.254l2.4388 3.429c-2.7178 1.893-9.7915 8.077-9.8095 13.852 0 2.754 1.548 5.189 4.7518 7.445 4.4638 3.137 9.5305 3.252 15.0742.329 8.7116-4.602 15.0563-15.06 14.9123-19.591l4.2383-.134c.207 6.531-7.2442 18.179-17.1527 23.412-1.7009.898-3.3928 1.564-5.0667 2.008h.009Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M67.0458 207.463c-8.3696 2.185-15.1102-.391-19.169-7.437-3.1769-5.517-3.7979-10.422-1.827-14.571 3.4469-7.268 13.5624-9.125 13.9853-9.205l.747 4.123c-.072.008-8.3876 1.563-10.8894 6.868-1.35 2.843-.783 6.45 1.6739 10.715 3.5278 6.122 9.0985 7.632 17.0181 4.611 6.0477-2.301 11.3664-6.655 15.3892-12.581l3.6359-5.357 3.5278 2.327-3.6358 5.367c-4.5088 6.646-10.5205 11.541-17.3872 14.154-1.0439.399-2.0699.728-3.0688.986Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="m53.3313 224.754-3.0598-2.905c22.9668-23.501 15.4252-17.495 15.6232-17.832l3.6808 2.079c-.189.337 7.0917-5.225-16.2442 18.658Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    clipRule={0}
+                                    d="M93.3641 80.6211c.542.6099.4808 1.5383-.1366 2.0737L59.0022 112.37c-.6174.536-1.5573.475-2.0993-.134-.542-.61-.4809-1.539.1365-2.074l34.2253-29.6758c.6175-.5353 1.5574-.4749 2.0994.1349ZM145.714 157.555c.542.61.481 1.538-.137 2.073l-34.225 29.676c-.618.535-1.558.475-2.1-.135s-.48-1.538.137-2.073l34.225-29.676c.618-.536 1.558-.475 2.1.135Z"
+                                    fill={
+                                      {
+                                        "payload": 4278240714,
+                                        "type": 0,
+                                      }
+                                    }
+                                    fillRule={0}
+                                    propList={
+                                      [
+                                        "fill",
+                                        "fillRule",
+                                      ]
+                                    }
+                                  />
+                                </RNSVGGroup>
+                              </RNSVGSvgView>
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                            </View>
+                            <Text
+                              allowFontScaling={false}
+                              dynamicTypeRamp="title2"
+                              maxFontSizeMultiplier={1.25}
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "color": "#0E0F13",
+                                    "fontFamily": "Titillium Sans Pro",
+                                    "fontSize": 22,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "600",
+                                    "lineHeight": 33,
+                                  },
+                                  {
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Stiamo riscontrando alcuni problemi sui sistemi di pagamento
+                            </Text>
+                            <View
+                              style={
+                                {
+                                  "height": 8,
+                                }
+                              }
+                            />
+                            <Text
+                              allowFontScaling={false}
+                              dynamicTypeRamp="body"
+                              maxFontSizeMultiplier={1.25}
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "color": "#555C70",
+                                    "fontFamily": "Titillium Sans Pro",
+                                    "fontSize": 16,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "400",
+                                    "lineHeight": 24,
+                                  },
+                                  {
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Verifica l’esito del pagamento nella sezione Pagamenti, altrimenti attendi qualche minuto prima di riprovare.
+                            </Text>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                              <View>
+                                <View
+                                  accessibilityLabel="Close"
+                                  accessibilityRole="button"
+                                  accessibilityState={
+                                    {
+                                      "busy": false,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    {
+                                      "alignSelf": "flex-start",
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderRadius": 4,
+                                          "elevation": 0,
+                                          "flexDirection": "row",
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 16,
+                                          "textAlignVertical": "center",
+                                        },
+                                        {
+                                          "overflow": "hidden",
+                                        },
+                                        false,
+                                        {
+                                          "height": 40,
+                                        },
+                                        {
+                                          "backgroundColor": "#0073E6",
+                                        },
+                                        {
+                                          "backgroundColor": undefined,
+                                          "transform": [
+                                            {
+                                              "scale": undefined,
+                                            },
+                                          ],
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "flexDirection": "row",
+                                            "justifyContent": "center",
+                                          },
+                                          false,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityElementsHidden={true}
+                                        accessible={false}
+                                        allowFontScaling={false}
+                                        ellipsizeMode="tail"
+                                        importantForAccessibility="no-hide-descendants"
+                                        maxFontSizeMultiplier={1.25}
+                                        numberOfLines={1}
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#FFFFFF",
+                                              "fontFamily": "Titillium Sans Pro",
+                                              "fontSize": 16,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "700",
+                                              "lineHeight": 20,
+                                            },
+                                            {
+                                              "alignSelf": "center",
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        Close
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                              <View>
+                                <View
+                                  accessibilityLabel="Contatta l'assistenza"
+                                  accessibilityRole="button"
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  hitSlop={
+                                    {
+                                      "bottom": 14,
+                                      "left": 24,
+                                      "right": 24,
+                                      "top": 14,
+                                    }
+                                  }
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  onTouchEnd={[Function]}
+                                  style={
+                                    {
+                                      "alignSelf": "flex-start",
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "elevation": 0,
+                                          "flexDirection": "row",
+                                          "justifyContent": "center",
+                                          "textAlignVertical": "center",
+                                        },
+                                        false,
+                                        {},
+                                        {
+                                          "transform": [
+                                            {
+                                              "scale": undefined,
+                                            },
+                                          ],
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <Text
+                                      accessibilityElementsHidden={true}
+                                      accessible={false}
+                                      allowFontScaling={false}
+                                      ellipsizeMode="tail"
+                                      importantForAccessibility="no-hide-descendants"
+                                      maxFontSizeMultiplier={1.25}
+                                      numberOfLines={1}
+                                      style={
+                                        [
+                                          {},
+                                          {
+                                            "color": "#0E0F13",
+                                            "fontFamily": "Titillium Sans Pro",
+                                            "fontSize": 16,
+                                            "fontStyle": "normal",
+                                            "fontWeight": "700",
+                                            "lineHeight": undefined,
+                                          },
+                                          {
+                                            "color": undefined,
+                                          },
+                                        ]
+                                      }
+                                    >
+                                      Contatta l'assistenza
+                                    </Text>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </RCTScrollView>
+                      </RNCSafeAreaView>
+                      <Modal
+                        accessibilityPositionChangeAnnouncement=""
+                        accessible={false}
+                        backdropComponent={[Function]}
+                        enableDismissOnClose={true}
+                        footerComponent={[Function]}
+                        handleComponent={[Function]}
+                        handleComponentAccessibility={
+                          {
+                            "accessible": false,
+                          }
+                        }
+                        hardwareAccelerated={false}
+                        importantForAccessibility="yes"
+                        onDismiss={[Function]}
+                        snapPoints={
+                          [
+                            10,
+                          ]
+                        }
+                        style={
+                          {
+                            "borderCurve": "continuous",
+                            "borderTopLeftRadius": 24,
+                            "borderTopRightRadius": 24,
+                            "overflow": "hidden",
+                          }
+                        }
+                        visible={true}
+                      >
+                        <RCTScrollView
+                          style={
+                            {
+                              "flex": 1,
+                              "paddingHorizontal": 24,
+                            }
+                          }
+                        >
+                          <View>
+                            <View
+                              onLayout={[Function]}
+                            >
+                              <View
+                                accessibilityLabel="Contatta l'assistenza"
+                                accessible={true}
+                                style={
+                                  {
+                                    "marginHorizontal": -24,
+                                    "paddingHorizontal": 24,
+                                    "paddingVertical": 12,
+                                  }
+                                }
+                              >
+                                <View
+                                  importantForAccessibility="no-hide-descendants"
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "flexDirection": "row",
+                                      "justifyContent": "space-between",
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      {
+                                        "flex": 1,
+                                      }
+                                    }
+                                  >
+                                    <View
+                                      accessibilityElementsHidden={false}
+                                      accessible={true}
+                                      importantForAccessibility="yes"
+                                    >
+                                      <Text
+                                        allowFontScaling={false}
+                                        dynamicTypeRamp="headline"
+                                        maxFontSizeMultiplier={1.25}
+                                        role="heading"
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#555C70",
+                                              "fontFamily": "Titillium Sans Pro",
+                                              "fontSize": 18,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "600",
+                                              "lineHeight": 24,
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        Contatta l'assistenza
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                              <View
+                                accessibilityLabel="Chiedi aiuto in chat"
+                                accessibilityRole="button"
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                                onTouchEnd={[Function]}
+                              >
+                                <View
+                                  accessibilityElementsHidden={true}
+                                  importantForAccessibility="no-hide-descendants"
+                                  style={
+                                    [
+                                      {
+                                        "marginHorizontal": -24,
+                                        "paddingHorizontal": 24,
+                                        "paddingVertical": 12,
+                                      },
+                                      {
+                                        "backgroundColor": undefined,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                          "justifyContent": "space-between",
+                                        },
+                                        {
+                                          "transform": [
+                                            {
+                                              "scale": undefined,
+                                            },
+                                          ],
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        {
+                                          "marginRight": 12,
+                                        }
+                                      }
+                                    >
+                                      <RNSVGSvgView
+                                        accessibilityElementsHidden={true}
+                                        accessibilityLabel=""
+                                        accessible={false}
+                                        align="xMidYMid"
+                                        bbHeight={24}
+                                        bbWidth={24}
+                                        focusable={false}
+                                        height={24}
+                                        importantForAccessibility="no-hide-descendants"
+                                        meetOrSlice={0}
+                                        minX={0}
+                                        minY={0}
+                                        style={
+                                          [
+                                            {
+                                              "backgroundColor": "transparent",
+                                              "borderWidth": 0,
+                                            },
+                                            {
+                                              "color": "#0B3EE3",
+                                            },
+                                            {
+                                              "flex": 0,
+                                              "height": 24,
+                                              "width": 24,
+                                            },
+                                          ]
+                                        }
+                                        tintColor="#0B3EE3"
+                                        vbHeight={24}
+                                        vbWidth={24}
+                                        width={24}
+                                      >
+                                        <RNSVGGroup
+                                          fill={
+                                            {
+                                              "payload": 4278190080,
+                                              "type": 0,
+                                            }
+                                          }
+                                        >
+                                          <RNSVGPath
+                                            clipRule={0}
+                                            d="M0 9c0-4.97056 4.02944-9 9-9 4.9706 0 9 4.02944 9 9 0 4.9706-4.0294 9-9 9H3c-1.65685 0-3-1.3431-3-3V9Zm9-7C5.13401 2 2 5.13401 2 9v6c0 .5523.44772 1 1 1h6c3.866 0 7-3.134 7-7 0-3.86599-3.134-7-7-7ZM4.99808 7C4.44686 7 4 7.44686 4 7.99808c0 .55123.44686.99808.99808.99808h8.00382c.5512 0 .9981-.44685.9981-.99808C14 7.44686 13.5531 7 13.0019 7H4.99808Zm-.00143 4C4.44621 11 4 11.4462 4 11.9966c0 .5505.44621.9967.99665.9967h4.0067c.55044 0 .99665-.4462.99665-.9967C10 11.4462 9.55379 11 9.00335 11h-4.0067ZM21.8292 9.13773c-.3598-.41906-.9911-.46716-1.4102-.10743-.419.35973-.4671.9911-.1074 1.4101a7.00025 7.00025 0 0 1 1.6841 4.8099c.0031 1.2586.0017 4.1954.0007 5.7448-.0004.5514-.4457.9983-.9971.9988-1.7351.0017-5.1759.0043-5.6862-.001-1.759-.0183-3.4799-.5073-4.8248-1.6411-.4222-.356-1.05312-.3022-1.40909.12-.35598.4223-.30224 1.0532.12002 1.4091 1.72917 1.4578 3.94387 2.2111 6.20327 2.11.4038.0061 4.1864.004 6.5962.0019 1.1037-.0009 1.9957-.8955 1.9957-1.9992v-6.6717c.0809-2.2602-.6921-4.4681-2.1652-6.18417Z"
+                                            fill={
+                                              {
+                                                "type": 2,
+                                              }
+                                            }
+                                            fillRule={0}
+                                            propList={
+                                              [
+                                                "fill",
+                                                "fillRule",
+                                              ]
+                                            }
+                                          />
+                                        </RNSVGGroup>
+                                      </RNSVGSvgView>
+                                    </View>
+                                    <View
+                                      style={
+                                        {
+                                          "flexGrow": 1,
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        allowFontScaling={false}
+                                        maxFontSizeMultiplier={1.25}
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#0B3EE3",
+                                              "fontFamily": "Titillium Sans Pro",
+                                              "fontSize": 16,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "700",
+                                              "lineHeight": 20,
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        Chiedi aiuto in chat
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                              <View
+                                accessibilityLabel="Dati aggiuntivi"
+                                accessible={false}
+                                style={
+                                  {
+                                    "marginHorizontal": -24,
+                                    "paddingHorizontal": 24,
+                                    "paddingVertical": 12,
+                                  }
+                                }
+                              >
+                                <View
+                                  importantForAccessibility="auto"
+                                  style={
+                                    {
+                                      "alignItems": "center",
+                                      "flexDirection": "row",
+                                      "justifyContent": "space-between",
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      {
+                                        "flex": 1,
+                                      }
+                                    }
+                                  >
+                                    <View
+                                      accessibilityElementsHidden={true}
+                                      accessible={false}
+                                      importantForAccessibility="no-hide-descendants"
+                                    >
+                                      <Text
+                                        allowFontScaling={false}
+                                        dynamicTypeRamp="headline"
+                                        maxFontSizeMultiplier={1.25}
+                                        role="heading"
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#555C70",
+                                              "fontFamily": "Titillium Sans Pro",
+                                              "fontSize": 18,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "600",
+                                              "lineHeight": 24,
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        Dati aggiuntivi
+                                      </Text>
+                                    </View>
+                                  </View>
+                                  <View
+                                    style={
+                                      {
+                                        "marginLeft": 16,
+                                      }
+                                    }
+                                  >
+                                    <View
+                                      accessibilityLabel="Dati aggiuntivi; undefined"
+                                      accessibilityRole="button"
+                                      accessibilityState={
+                                        {
+                                          "busy": undefined,
+                                          "checked": undefined,
+                                          "disabled": false,
+                                          "expanded": undefined,
+                                          "selected": undefined,
+                                        }
+                                      }
+                                      accessibilityValue={
+                                        {
+                                          "max": undefined,
+                                          "min": undefined,
+                                          "now": undefined,
+                                          "text": undefined,
+                                        }
+                                      }
+                                      accessible={true}
+                                      collapsable={false}
+                                      focusable={true}
+                                      hitSlop={
+                                        {
+                                          "bottom": 14,
+                                          "left": 24,
+                                          "right": 24,
+                                          "top": 14,
+                                        }
+                                      }
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocus={[Function]}
+                                      onResponderGrant={[Function]}
+                                      onResponderMove={[Function]}
+                                      onResponderRelease={[Function]}
+                                      onResponderTerminate={[Function]}
+                                      onResponderTerminationRequest={[Function]}
+                                      onStartShouldSetResponder={[Function]}
+                                      onTouchEnd={[Function]}
+                                      style={
+                                        {
+                                          "alignSelf": "flex-start",
+                                        }
+                                      }
+                                    >
+                                      <View
+                                        style={
+                                          [
+                                            {
+                                              "alignItems": "center",
+                                              "elevation": 0,
+                                              "flexDirection": "row",
+                                              "justifyContent": "center",
+                                              "textAlignVertical": "center",
+                                            },
+                                            false,
+                                            {},
+                                            {
+                                              "transform": [
+                                                {
+                                                  "scale": undefined,
+                                                },
+                                              ],
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        <Text
+                                          accessibilityElementsHidden={true}
+                                          accessible={false}
+                                          allowFontScaling={false}
+                                          ellipsizeMode="tail"
+                                          importantForAccessibility="no-hide-descendants"
+                                          maxFontSizeMultiplier={1.25}
+                                          numberOfLines={1}
+                                          style={
+                                            [
+                                              {},
+                                              {
+                                                "color": "#0E0F13",
+                                                "fontFamily": "Titillium Sans Pro",
+                                                "fontSize": 16,
+                                                "fontStyle": "normal",
+                                                "fontWeight": "700",
+                                                "lineHeight": undefined,
+                                              },
+                                              {
+                                                "color": undefined,
+                                              },
+                                            ]
+                                          }
+                                        >
+                                          Copia tutti
+                                        </Text>
+                                      </View>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                              <View
+                                accessibilityLabel="Codice errore"
+                                accessibilityRole="button"
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                              >
+                                <View
+                                  accessibilityElementsHidden={true}
+                                  importantForAccessibility="no-hide-descendants"
+                                  style={
+                                    [
+                                      {
+                                        "marginHorizontal": -24,
+                                        "paddingHorizontal": 24,
+                                        "paddingVertical": 12,
+                                      },
+                                      {
+                                        "backgroundColor": undefined,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                          "justifyContent": "space-between",
+                                        },
+                                        {
+                                          "transform": [
+                                            {
+                                              "scale": undefined,
+                                            },
+                                          ],
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        {
+                                          "marginRight": 12,
+                                        }
+                                      }
+                                    >
+                                      <RNSVGSvgView
+                                        accessibilityElementsHidden={true}
+                                        accessibilityLabel=""
+                                        accessible={false}
+                                        align="xMidYMid"
+                                        bbHeight={24}
+                                        bbWidth={24}
+                                        focusable={false}
+                                        height={24}
+                                        importantForAccessibility="no-hide-descendants"
+                                        meetOrSlice={0}
+                                        minX={0}
+                                        minY={0}
+                                        style={
+                                          [
+                                            {
+                                              "backgroundColor": "transparent",
+                                              "borderWidth": 0,
+                                            },
+                                            {
+                                              "color": "#99A3C1",
+                                            },
+                                            {
+                                              "flex": 0,
+                                              "height": 24,
+                                              "width": 24,
+                                            },
+                                          ]
+                                        }
+                                        tintColor="#99A3C1"
+                                        vbHeight={24}
+                                        vbWidth={24}
+                                        width={24}
+                                      >
+                                        <RNSVGGroup
+                                          fill={
+                                            {
+                                              "payload": 4278190080,
+                                              "type": 0,
+                                            }
+                                          }
+                                        >
+                                          <RNSVGPath
+                                            clipRule={0}
+                                            d="M14.4021.71856c.1889-.51898.7628-.78657 1.2817-.59768.519.1889.7866.76274.5977 1.28172l-.5525 1.5179c1.7003.89744 3.0382 2.38947 3.7368 4.19934l1.4129-1.41283c.3905-.39053 1.0237-.39053 1.4142 0 .3905.39052.3905 1.02369 0 1.41421l-2.3126 2.31262c.0131.18704.0197.37585.0197.56626v3h3c.5523 0 1 .4477 1 1 0 .5522-.4477 1-1 1h-3v1c0 1.0152-.1891 1.9863-.5341 2.8799l2.827 2.827c.3905.3905.3905 1.0237 0 1.4142-.3905.3905-1.0237.3905-1.4142 0l-2.4114-2.4113c-1.4548 1.9943-3.8097 3.2902-6.4673 3.2902-2.65758 0-5.01249-1.2959-6.46734-3.2902l-2.41134 2.4113c-.39052.3905-1.02369.3905-1.41421 0-.39053-.3905-.39053-1.0237 0-1.4142l2.82696-2.827C4.18913 17.9864 4 17.0153 4 16.0001v-1H1c-.55229 0-1-.4478-1-1 0-.5523.44771-1 1-1h3v-3c0-.19041.00665-.37922.01973-.56626L1.70711 7.12122c-.39053-.39052-.39053-1.02369 0-1.41421.39052-.39053 1.02369-.39053 1.41421 0l1.41283 1.41283c.69874-1.81001 2.03674-3.30212 3.7372-4.19955l-.55238-1.51765c-.18889-.51898.0787-1.09282.59768-1.28172.51897-.18889 1.09282.0787 1.28171.59768l.54524 1.49796c.5957-.14157 1.2173-.21651 1.8564-.21651.6392 0 1.261.07498 1.8569.21661l.5452-1.4981ZM6 10.0001v6c0 2.973 2.16229 5.4409 5 5.917v-11.917H6Zm7 0v11.917c2.8377-.4761 5-2.944 5-5.917v-6h-5Zm4.6586-2.00005c-.8237-2.33038-3.0462-4-5.6586-4-2.61244 0-4.83492 1.66962-5.65859 4H17.6586Z"
+                                            fill={
+                                              {
+                                                "type": 2,
+                                              }
+                                            }
+                                            fillRule={0}
+                                            propList={
+                                              [
+                                                "fill",
+                                                "fillRule",
+                                              ]
+                                            }
+                                          />
+                                        </RNSVGGroup>
+                                      </RNSVGSvgView>
+                                    </View>
+                                    <View
+                                      style={
+                                        {
+                                          "flex": 1,
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        allowFontScaling={false}
+                                        dynamicTypeRamp="footnote"
+                                        maxFontSizeMultiplier={1.25}
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#555C70",
+                                              "fontFamily": "Titillium Sans Pro",
+                                              "fontSize": 14,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "400",
+                                              "lineHeight": 21,
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        Codice errore
+                                      </Text>
+                                      <Text
+                                        allowFontScaling={false}
+                                        dynamicTypeRamp="headline"
+                                        maxFontSizeMultiplier={1.25}
+                                        numberOfLines={2}
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#0073E6",
+                                              "fontFamily": "Titillium Sans Pro",
+                                              "fontSize": 18,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "600",
+                                              "lineHeight": 24,
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        BE_NODE_KO
+                                      </Text>
+                                    </View>
+                                    <View
+                                      style={
+                                        {
+                                          "marginLeft": 12,
+                                        }
+                                      }
+                                    >
+                                      <RNSVGSvgView
+                                        accessibilityElementsHidden={true}
+                                        accessibilityLabel=""
+                                        accessible={false}
+                                        align="xMidYMid"
+                                        bbHeight={24}
+                                        bbWidth={24}
+                                        focusable={false}
+                                        height={24}
+                                        importantForAccessibility="no-hide-descendants"
+                                        meetOrSlice={0}
+                                        minX={0}
+                                        minY={0}
+                                        style={
+                                          [
+                                            {
+                                              "backgroundColor": "transparent",
+                                              "borderWidth": 0,
+                                            },
+                                            {
+                                              "color": "#0073E6",
+                                            },
+                                            {
+                                              "flex": 0,
+                                              "height": 24,
+                                              "width": 24,
+                                            },
+                                          ]
+                                        }
+                                        tintColor="#0073E6"
+                                        vbHeight={24}
+                                        vbWidth={24}
+                                        width={24}
+                                      >
+                                        <RNSVGGroup
+                                          fill={
+                                            {
+                                              "payload": 4278190080,
+                                              "type": 0,
+                                            }
+                                          }
+                                        >
+                                          <RNSVGPath
+                                            clipRule={0}
+                                            d="M12 18h8a2 2 0 0 0 2-2V9h-4a3 3 0 0 1-3-3V2h-3a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Zm9.332-11.987a2 2 0 0 1 .603.987H18a1 1 0 0 1-1-1V2.227a2 2 0 0 1 .406.281l3.926 3.505ZM14 20h-2a4 4 0 0 1-4-4V6H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2Zm2 0h4a4 4 0 0 0 4-4V7.505a4 4 0 0 0-1.336-2.984l-3.926-3.505A4 4 0 0 0 16.074 0H12a4 4 0 0 0-4 4H4a4 4 0 0 0-4 4v12a4 4 0 0 0 4 4h8a4 4 0 0 0 4-4Z"
+                                            fill={
+                                              {
+                                                "type": 2,
+                                              }
+                                            }
+                                            fillRule={0}
+                                            propList={
+                                              [
+                                                "fill",
+                                                "fillRule",
+                                              ]
+                                            }
+                                          />
+                                        </RNSVGGroup>
+                                      </RNSVGSvgView>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                              <View
+                                accessibilityLabel="Codice avviso"
+                                accessibilityRole="button"
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                              >
+                                <View
+                                  accessibilityElementsHidden={true}
+                                  importantForAccessibility="no-hide-descendants"
+                                  style={
+                                    [
+                                      {
+                                        "marginHorizontal": -24,
+                                        "paddingHorizontal": 24,
+                                        "paddingVertical": 12,
+                                      },
+                                      {
+                                        "backgroundColor": undefined,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                          "justifyContent": "space-between",
+                                        },
+                                        {
+                                          "transform": [
+                                            {
+                                              "scale": undefined,
+                                            },
+                                          ],
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        {
+                                          "marginRight": 12,
+                                        }
+                                      }
+                                    >
+                                      <RNSVGSvgView
+                                        accessibilityElementsHidden={true}
+                                        accessibilityLabel=""
+                                        accessible={false}
+                                        align="xMidYMid"
+                                        bbHeight={24}
+                                        bbWidth={24}
+                                        focusable={false}
+                                        height={24}
+                                        importantForAccessibility="no-hide-descendants"
+                                        meetOrSlice={0}
+                                        minX={0}
+                                        minY={0}
+                                        style={
+                                          [
+                                            {
+                                              "backgroundColor": "transparent",
+                                              "borderWidth": 0,
+                                            },
+                                            {
+                                              "color": "#99A3C1",
+                                            },
+                                            {
+                                              "flex": 0,
+                                              "height": 24,
+                                              "width": 24,
+                                            },
+                                          ]
+                                        }
+                                        tintColor="#99A3C1"
+                                        vbHeight={24}
+                                        vbWidth={24}
+                                        width={24}
+                                      >
+                                        <RNSVGGroup
+                                          fill={
+                                            {
+                                              "payload": 4278190080,
+                                              "type": 0,
+                                            }
+                                          }
+                                        >
+                                          <RNSVGPath
+                                            clipRule={0}
+                                            d="M5 2C3.34315 2 2 3.34315 2 5V19C2 20.6569 3.34315 22 5 22H19C20.6569 22 22 20.6569 22 19V10H17C15.3431 10 14 8.65685 14 7V2H5ZM16 2.49902V7C16 7.55229 16.4477 8 17 8H21.501C21.3911 7.83409 21.2641 7.67835 21.1213 7.53553L16.4645 2.87868C16.3216 2.73586 16.1659 2.60893 16 2.49902ZM0 5C0 2.23858 2.23858 0 5 0H14.3431C15.6692 0 16.941 0.526784 17.8787 1.46447L22.5355 6.12132C23.4732 7.059 24 8.33077 24 9.65685V19C24 21.7614 21.7614 24 19 24H5C2.23858 24 0 21.7614 0 19V5ZM5 17.5C5 16.6716 5.67157 16 6.5 16C7.32843 16 8 16.6716 8 17.5C8 18.3284 7.32843 19 6.5 19C5.67157 19 5 18.3284 5 17.5ZM10 17.5C10 16.6716 10.6716 16 11.5 16H14.5C15.3284 16 16 16.6716 16 17.5C16 18.3284 15.3284 19 14.5 19H11.5C10.6716 19 10 18.3284 10 17.5Z"
+                                            fill={
+                                              {
+                                                "type": 2,
+                                              }
+                                            }
+                                            fillRule={0}
+                                            propList={
+                                              [
+                                                "fill",
+                                                "fillRule",
+                                              ]
+                                            }
+                                          />
+                                        </RNSVGGroup>
+                                      </RNSVGSvgView>
+                                    </View>
+                                    <View
+                                      style={
+                                        {
+                                          "flex": 1,
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        allowFontScaling={false}
+                                        dynamicTypeRamp="footnote"
+                                        maxFontSizeMultiplier={1.25}
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#555C70",
+                                              "fontFamily": "Titillium Sans Pro",
+                                              "fontSize": 14,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "400",
+                                              "lineHeight": 21,
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        Codice avviso
+                                      </Text>
+                                      <Text
+                                        allowFontScaling={false}
+                                        dynamicTypeRamp="headline"
+                                        maxFontSizeMultiplier={1.25}
+                                        numberOfLines={2}
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#0073E6",
+                                              "fontFamily": "Titillium Sans Pro",
+                                              "fontSize": 18,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "600",
+                                              "lineHeight": 24,
+                                            },
+                                          ]
+                                        }
+                                      />
+                                    </View>
+                                    <View
+                                      style={
+                                        {
+                                          "marginLeft": 12,
+                                        }
+                                      }
+                                    >
+                                      <RNSVGSvgView
+                                        accessibilityElementsHidden={true}
+                                        accessibilityLabel=""
+                                        accessible={false}
+                                        align="xMidYMid"
+                                        bbHeight={24}
+                                        bbWidth={24}
+                                        focusable={false}
+                                        height={24}
+                                        importantForAccessibility="no-hide-descendants"
+                                        meetOrSlice={0}
+                                        minX={0}
+                                        minY={0}
+                                        style={
+                                          [
+                                            {
+                                              "backgroundColor": "transparent",
+                                              "borderWidth": 0,
+                                            },
+                                            {
+                                              "color": "#0073E6",
+                                            },
+                                            {
+                                              "flex": 0,
+                                              "height": 24,
+                                              "width": 24,
+                                            },
+                                          ]
+                                        }
+                                        tintColor="#0073E6"
+                                        vbHeight={24}
+                                        vbWidth={24}
+                                        width={24}
+                                      >
+                                        <RNSVGGroup
+                                          fill={
+                                            {
+                                              "payload": 4278190080,
+                                              "type": 0,
+                                            }
+                                          }
+                                        >
+                                          <RNSVGPath
+                                            clipRule={0}
+                                            d="M12 18h8a2 2 0 0 0 2-2V9h-4a3 3 0 0 1-3-3V2h-3a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Zm9.332-11.987a2 2 0 0 1 .603.987H18a1 1 0 0 1-1-1V2.227a2 2 0 0 1 .406.281l3.926 3.505ZM14 20h-2a4 4 0 0 1-4-4V6H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2Zm2 0h4a4 4 0 0 0 4-4V7.505a4 4 0 0 0-1.336-2.984l-3.926-3.505A4 4 0 0 0 16.074 0H12a4 4 0 0 0-4 4H4a4 4 0 0 0-4 4v12a4 4 0 0 0 4 4h8a4 4 0 0 0 4-4Z"
+                                            fill={
+                                              {
+                                                "type": 2,
+                                              }
+                                            }
+                                            fillRule={0}
+                                            propList={
+                                              [
+                                                "fill",
+                                                "fillRule",
+                                              ]
+                                            }
+                                          />
+                                        </RNSVGGroup>
+                                      </RNSVGSvgView>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                              <View
+                                accessibilityLabel="Codice Fiscale Ente"
+                                accessibilityRole="button"
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
+                                accessible={true}
+                                collapsable={false}
+                                focusable={true}
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
+                              >
+                                <View
+                                  accessibilityElementsHidden={true}
+                                  importantForAccessibility="no-hide-descendants"
+                                  style={
+                                    [
+                                      {
+                                        "marginHorizontal": -24,
+                                        "paddingHorizontal": 24,
+                                        "paddingVertical": 12,
+                                      },
+                                      {
+                                        "backgroundColor": undefined,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "flexDirection": "row",
+                                          "justifyContent": "space-between",
+                                        },
+                                        {
+                                          "transform": [
+                                            {
+                                              "scale": undefined,
+                                            },
+                                          ],
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        {
+                                          "marginRight": 12,
+                                        }
+                                      }
+                                    >
+                                      <RNSVGSvgView
+                                        accessibilityElementsHidden={true}
+                                        accessibilityLabel=""
+                                        accessible={false}
+                                        align="xMidYMid"
+                                        bbHeight={24}
+                                        bbWidth={24}
+                                        focusable={false}
+                                        height={24}
+                                        importantForAccessibility="no-hide-descendants"
+                                        meetOrSlice={0}
+                                        minX={0}
+                                        minY={0}
+                                        style={
+                                          [
+                                            {
+                                              "backgroundColor": "transparent",
+                                              "borderWidth": 0,
+                                            },
+                                            {
+                                              "color": "#99A3C1",
+                                            },
+                                            {
+                                              "flex": 0,
+                                              "height": 24,
+                                              "width": 24,
+                                            },
+                                          ]
+                                        }
+                                        tintColor="#99A3C1"
+                                        vbHeight={24}
+                                        vbWidth={24}
+                                        width={24}
+                                      >
+                                        <RNSVGGroup
+                                          fill={
+                                            {
+                                              "payload": 4278190080,
+                                              "type": 0,
+                                            }
+                                          }
+                                        >
+                                          <RNSVGPath
+                                            clipRule={0}
+                                            d="M4 4H20C21.1046 4 22 4.89543 22 6V18C22 19.1046 21.1046 20 20 20H4C2.89543 20 2 19.1046 2 18V6C2 4.89543 2.89543 4 4 4ZM0 6C0 3.79086 1.79086 2 4 2H20C22.2091 2 24 3.79086 24 6V18C24 20.2091 22.2091 22 20 22H4C1.79086 22 0 20.2091 0 18V6ZM7.20416 8.26887C7.76751 7.91038 8.48744 7.91038 9.05078 8.26887L11.7771 10.0038C12.0747 10.1932 12.2549 10.5215 12.2549 10.8743V11.5286C12.2549 11.7185 12.1009 11.8725 11.911 11.8725H11.567V15.656C11.567 15.846 11.413 16 11.2231 16H9.84725C9.65729 16 9.5033 15.846 9.5033 15.656V11.8725H6.75165V15.656C6.75165 15.846 6.59765 16 6.40769 16H5.03187C4.84191 16 4.68791 15.846 4.68791 15.656V11.8725H4.34396C4.15399 11.8725 4 11.7185 4 11.5286V10.8743C4 10.5215 4.18024 10.1932 4.47788 10.0038L7.20416 8.26887ZM15 9C14.4477 9 14 9.44772 14 10C14 10.5523 14.4477 11 15 11H17C17.5523 11 18 10.5523 18 10C18 9.44772 17.5523 9 17 9H15ZM14 14C14 13.4477 14.4477 13 15 13H19C19.5523 13 20 13.4477 20 14C20 14.5523 19.5523 15 19 15H15C14.4477 15 14 14.5523 14 14Z"
+                                            fill={
+                                              {
+                                                "type": 2,
+                                              }
+                                            }
+                                            fillRule={0}
+                                            propList={
+                                              [
+                                                "fill",
+                                                "fillRule",
+                                              ]
+                                            }
+                                          />
+                                        </RNSVGGroup>
+                                      </RNSVGSvgView>
+                                    </View>
+                                    <View
+                                      style={
+                                        {
+                                          "flex": 1,
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        allowFontScaling={false}
+                                        dynamicTypeRamp="footnote"
+                                        maxFontSizeMultiplier={1.25}
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#555C70",
+                                              "fontFamily": "Titillium Sans Pro",
+                                              "fontSize": 14,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "400",
+                                              "lineHeight": 21,
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        Codice Fiscale Ente
+                                      </Text>
+                                      <Text
+                                        allowFontScaling={false}
+                                        dynamicTypeRamp="headline"
+                                        maxFontSizeMultiplier={1.25}
+                                        numberOfLines={2}
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#0073E6",
+                                              "fontFamily": "Titillium Sans Pro",
+                                              "fontSize": 18,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "600",
+                                              "lineHeight": 24,
+                                            },
+                                          ]
+                                        }
+                                      />
+                                    </View>
+                                    <View
+                                      style={
+                                        {
+                                          "marginLeft": 12,
+                                        }
+                                      }
+                                    >
+                                      <RNSVGSvgView
+                                        accessibilityElementsHidden={true}
+                                        accessibilityLabel=""
+                                        accessible={false}
+                                        align="xMidYMid"
+                                        bbHeight={24}
+                                        bbWidth={24}
+                                        focusable={false}
+                                        height={24}
+                                        importantForAccessibility="no-hide-descendants"
+                                        meetOrSlice={0}
+                                        minX={0}
+                                        minY={0}
+                                        style={
+                                          [
+                                            {
+                                              "backgroundColor": "transparent",
+                                              "borderWidth": 0,
+                                            },
+                                            {
+                                              "color": "#0073E6",
+                                            },
+                                            {
+                                              "flex": 0,
+                                              "height": 24,
+                                              "width": 24,
+                                            },
+                                          ]
+                                        }
+                                        tintColor="#0073E6"
+                                        vbHeight={24}
+                                        vbWidth={24}
+                                        width={24}
+                                      >
+                                        <RNSVGGroup
+                                          fill={
+                                            {
+                                              "payload": 4278190080,
+                                              "type": 0,
+                                            }
+                                          }
+                                        >
+                                          <RNSVGPath
+                                            clipRule={0}
+                                            d="M12 18h8a2 2 0 0 0 2-2V9h-4a3 3 0 0 1-3-3V2h-3a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Zm9.332-11.987a2 2 0 0 1 .603.987H18a1 1 0 0 1-1-1V2.227a2 2 0 0 1 .406.281l3.926 3.505ZM14 20h-2a4 4 0 0 1-4-4V6H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2Zm2 0h4a4 4 0 0 0 4-4V7.505a4 4 0 0 0-1.336-2.984l-3.926-3.505A4 4 0 0 0 16.074 0H12a4 4 0 0 0-4 4H4a4 4 0 0 0-4 4v12a4 4 0 0 0 4 4h8a4 4 0 0 0 4-4Z"
+                                            fill={
+                                              {
+                                                "type": 2,
+                                              }
+                                            }
+                                            fillRule={0}
+                                            propList={
+                                              [
+                                                "fill",
+                                                "fillRule",
+                                              ]
+                                            }
+                                          />
+                                        </RNSVGGroup>
+                                      </RNSVGSvgView>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                            </View>
+                          </View>
+                        </RCTScrollView>
+                      </Modal>
+                      <Modal
+                        accessibilityPositionChangeAnnouncement=""
+                        accessible={false}
+                        backdropComponent={[Function]}
+                        enableDismissOnClose={true}
+                        footerComponent={[Function]}
+                        handleComponent={[Function]}
+                        handleComponentAccessibility={
+                          {
+                            "accessible": false,
+                          }
+                        }
+                        hardwareAccelerated={false}
+                        importantForAccessibility="yes"
+                        onDismiss={[Function]}
+                        snapPoints={
+                          [
+                            10,
+                          ]
+                        }
+                        style={
+                          {
+                            "borderCurve": "continuous",
+                            "borderTopLeftRadius": 24,
+                            "borderTopRightRadius": 24,
+                            "overflow": "hidden",
+                          }
+                        }
+                        visible={true}
+                      >
+                        <RCTScrollView
+                          style={
+                            {
+                              "flex": 1,
+                              "paddingHorizontal": 24,
+                            }
+                          }
+                        >
+                          <View>
+                            <View
+                              onLayout={[Function]}
+                            >
+                              <View>
+                                <Text
+                                  allowFontScaling={false}
+                                  dynamicTypeRamp="body"
+                                  maxFontSizeMultiplier={1.25}
+                                  style={
+                                    [
+                                      {},
+                                      {
+                                        "color": "#555C70",
+                                        "fontFamily": "Titillium Sans Pro",
+                                        "fontSize": 16,
+                                        "fontStyle": "normal",
+                                        "fontWeight": "400",
+                                        "lineHeight": 24,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <Text
+                                    style={
+                                      {
+                                        "fontWeight": "800",
+                                      }
+                                    }
+                                  >
+                                    Paga l'avviso
+                                  </Text>
+                                  
+Ricorda di pagare l'avviso entro le scadenze previste dall'ente. Se non riesci tramite IO, 
+                                  <Text
+                                    accessibilityRole="link"
+                                    allowFontScaling={false}
+                                    maxFontSizeMultiplier={1.25}
+                                    onPress={[Function]}
+                                    style={
+                                      [
+                                        {
+                                          "textDecorationLine": "underline",
+                                        },
+                                        {
+                                          "color": "#0B3EE3",
+                                          "fontFamily": "Titillium Sans Pro",
+                                          "fontSize": 16,
+                                          "fontStyle": "normal",
+                                          "fontWeight": "600",
+                                          "lineHeight": 24,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    scopri gli altri canali abilitati a pagoPA
+                                  </Text>
+                                </Text>
+                              </View>
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                              <View>
+                                <Text
+                                  allowFontScaling={false}
+                                  dynamicTypeRamp="body"
+                                  maxFontSizeMultiplier={1.25}
+                                  style={
+                                    [
+                                      {},
+                                      {
+                                        "color": "#555C70",
+                                        "fontFamily": "Titillium Sans Pro",
+                                        "fontSize": 16,
+                                        "fontStyle": "normal",
+                                        "fontWeight": "400",
+                                        "lineHeight": 24,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <Text
+                                    style={
+                                      {
+                                        "fontWeight": "800",
+                                      }
+                                    }
+                                  >
+                                    Attendi il rimborso
+                                  </Text>
+                                  
+Di solito l’importo viene riaccreditato entro pochi minuti. In altri casi, il trasferimento di denaro sul tuo conto o carta potrebbe richiedere più tempo.
+                                </Text>
+                              </View>
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                              <View>
+                                <Text
+                                  allowFontScaling={false}
+                                  dynamicTypeRamp="body"
+                                  maxFontSizeMultiplier={1.25}
+                                  style={
+                                    [
+                                      {},
+                                      {
+                                        "color": "#555C70",
+                                        "fontFamily": "Titillium Sans Pro",
+                                        "fontSize": 16,
+                                        "fontStyle": "normal",
+                                        "fontWeight": "400",
+                                        "lineHeight": 24,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <Text
+                                    style={
+                                      {
+                                        "fontWeight": "800",
+                                      }
+                                    }
+                                  >
+                                    Contatta l'assistenza
+                                  </Text>
+                                  
+Se dopo 5 giorni lavorativi non hai ancora ricevuto il rimborso, contatta l’assistenza.
+                                </Text>
+                              </View>
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                            </View>
+                          </View>
+                        </RCTScrollView>
+                      </Modal>
+                    </View>
+                    <View
+                      collapsable={false}
+                      pointerEvents="box-none"
+                      style={{}}
+                    >
+                      <View
+                        accessibilityElementsHidden={false}
+                        importantForAccessibility="auto"
+                        onLayout={[Function]}
+                        pointerEvents="box-none"
+                        style={null}
+                      >
+                        <View
+                          accessibilityRole="header"
+                          style={
+                            [
+                              {
+                                "borderBottomWidth": 1,
+                                "borderColor": "rgba(210,214,227,0)",
+                              },
+                              {},
+                              {
+                                "backgroundColor": "#FFFFFF",
+                              },
+                              {
+                                "backgroundColor": "#FFFFFF",
+                                "borderColor": "transparent",
+                              },
+                            ]
+                          }
+                        >
+                          <View
+                            style={
+                              [
+                                {
+                                  "marginTop": 0,
+                                },
+                                {
+                                  "alignItems": "center",
+                                  "flexDirection": "row",
+                                  "flexGrow": 1,
+                                  "height": 56,
+                                  "justifyContent": "space-between",
+                                  "paddingHorizontal": 24,
+                                },
+                              ]
+                            }
+                          >
+                            <View
+                              style={
+                                {
+                                  "width": 32,
+                                }
+                              }
+                            />
+                            <View
+                              accessibilityElementsHidden={true}
+                              accessibilityLabel=""
+                              accessibilityRole="header"
+                              accessible={false}
+                              importantForAccessibility="no-hide-descendants"
+                              style={
+                                {
+                                  "flexGrow": 1,
+                                  "flexShrink": 1,
+                                  "marginHorizontal": 16,
+                                }
+                              }
+                            >
+                              <Text
+                                accessible={false}
+                                allowFontScaling={false}
+                                maxFontSizeMultiplier={1.25}
+                                numberOfLines={1}
+                                style={
+                                  [
+                                    {},
+                                    {
+                                      "color": "#0E0F13",
+                                      "fontFamily": "Titillium Sans Pro",
+                                      "fontSize": 14,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "600",
+                                      "lineHeight": undefined,
+                                    },
+                                    [
+                                      {
+                                        "color": "#0E0F13",
+                                        "textAlign": "center",
+                                      },
+                                      {
+                                        "opacity": 1,
+                                      },
+                                    ],
+                                  ]
+                                }
+                              />
+                            </View>
+                            <View
+                              style={
+                                [
+                                  {
+                                    "flexDirection": "row",
+                                  },
+                                  {
+                                    "flexShrink": 0,
+                                  },
+                                ]
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "width": 24,
+                                  }
+                                }
+                              />
+                            </View>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RNSScreen>
+      </RNSScreenContainer>
+      <View
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          {
+            "height": 44,
+            "left": 0,
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "zIndex": 1,
+          }
+        }
+      />
+    </View>
+  </RNCSafeAreaProvider>
+</View>
+`;
+
+exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPaymentOutcomeScreen for outcome: 116 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <RNCSafeAreaProvider
+    onInsetsChange={[Function]}
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "#FFFFFF",
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <RNSScreenContainer
+        onLayout={[Function]}
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      >
+        <RNSScreen
+          activityState={2}
+          collapsable={false}
+          gestureResponseDistance={
+            {
+              "bottom": -1,
+              "end": -1,
+              "start": -1,
+              "top": -1,
+            }
+          }
+          onGestureCancel={[Function]}
+          pointerEvents="box-none"
+          sheetAllowedDetents="large"
+          sheetCornerRadius={-1}
+          sheetExpandsWhenScrolledToEdge={true}
+          sheetGrabberVisible={false}
+          sheetLargestUndimmedDetent="all"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            }
+          }
+        >
+          <View
+            collapsable={false}
+            style={
+              {
+                "opacity": 1,
+              }
+            }
+          />
+          <View
+            accessibilityElementsHidden={false}
+            closing={false}
+            gestureVelocityImpact={0.3}
+            importantForAccessibility="auto"
+            onClose={[Function]}
+            onGestureBegin={[Function]}
+            onGestureCanceled={[Function]}
+            onGestureEnd={[Function]}
+            onOpen={[Function]}
+            onTransition={[Function]}
+            pointerEvents="box-none"
+            style={
+              [
+                {
+                  "display": "flex",
+                  "overflow": undefined,
+                },
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+              ]
+            }
+            transitionSpec={
+              {
+                "close": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+                "open": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              pointerEvents="box-none"
+              style={
+                {
+                  "flex": 1,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                handlerTag={45}
+                handlerType="PanGestureHandler"
+                needsOffscreenAlphaCompositing={false}
+                onGestureHandlerEvent={[Function]}
+                onGestureHandlerStateChange={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "transform": [
+                      {
+                        "translateX": 0,
+                      },
+                      {
+                        "translateX": 0,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  pointerEvents="box-none"
+                  style={
+                    [
+                      {
+                        "flex": 1,
+                        "overflow": "hidden",
+                      },
+                      [
+                        {
+                          "backgroundColor": "#FFFFFF",
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "flex": 1,
+                        "flexDirection": "column-reverse",
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                        }
+                      }
+                    >
+                      <RNCSafeAreaView
+                        edges={
+                          {
+                            "bottom": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
+                          }
+                        }
+                        style={
+                          {
+                            "flexGrow": 1,
+                            "marginHorizontal": 24,
+                          }
+                        }
+                      >
+                        <RCTScrollView
+                          centerContent={true}
+                          collapsable={false}
+                          contentContainerStyle={
+                            [
+                              {
+                                "alignContent": "center",
+                                "alignItems": "stretch",
+                                "flex": 1,
+                                "justifyContent": "center",
+                              },
+                              false,
+                            ]
+                          }
+                          handlerTag={46}
                           handlerType="NativeViewGestureHandler"
                           onGestureHandlerEvent={[Function]}
                           onGestureHandlerStateChange={[Function]}
@@ -47488,7 +49751,7 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
             >
               <View
                 collapsable={false}
-                handlerTag={45}
+                handlerTag={47}
                 handlerType="PanGestureHandler"
                 needsOffscreenAlphaCompositing={false}
                 onGestureHandlerEvent={[Function]}
@@ -47543,9 +49806,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -47569,7 +49832,7 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                               false,
                             ]
                           }
-                          handlerTag={46}
+                          handlerTag={48}
                           handlerType="NativeViewGestureHandler"
                           onGestureHandlerEvent={[Function]}
                           onGestureHandlerStateChange={[Function]}
@@ -49644,7 +51907,7 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
             >
               <View
                 collapsable={false}
-                handlerTag={47}
+                handlerTag={49}
                 handlerType="PanGestureHandler"
                 needsOffscreenAlphaCompositing={false}
                 onGestureHandlerEvent={[Function]}
@@ -49699,9 +51962,9 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                         edges={
                           {
                             "bottom": "additive",
-                            "left": "additive",
-                            "right": "additive",
-                            "top": "additive",
+                            "left": "off",
+                            "right": "off",
+                            "top": "off",
                           }
                         }
                         style={
@@ -49725,7 +51988,7 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                               false,
                             ]
                           }
-                          handlerTag={48}
+                          handlerTag={50}
                           handlerType="NativeViewGestureHandler"
                           onGestureHandlerEvent={[Function]}
                           onGestureHandlerStateChange={[Function]}

--- a/ts/features/payments/checkout/types/PaymentOutcomeEnum.ts
+++ b/ts/features/payments/checkout/types/PaymentOutcomeEnum.ts
@@ -23,6 +23,7 @@ export enum WalletPaymentOutcomeEnum {
   PAYPAL_REMOVED_ERROR = "19", // error while executing the payment with PayPal
   PAYMENT_METHODS_NOT_AVAILABLE = "20", // payment methods not available
   IN_APP_BROWSER_CLOSED_BY_USER = "24", // in-app browser closed by user (24 because from 19 to 23 are already used by backend)
+  BE_NODE_KO = "99", // Backend error when the node service is down
   INSUFFICIENT_AVAILABILITY_ERROR = "116", // insufficient availability
   CVV_ERROR = "117", // CVV error
   PLAFOND_LIMIT_ERROR = "121" // plafond limit error


### PR DESCRIPTION
## Short description
This PR adds outcome 99 inside the payment screen when receiving it from the backend.

## List of changes proposed in this pull request
- Created a custom `BE_NODE_KO` that's equals to outcome `99`;
- Mapped the new outcome inside the labels and the screen to show into the `WalletPaymentOutcomeScreen.tsx` file;
- Added missing outcomes to keep track on mixpanel inside the `getPaymentAnalyticsEventFromFailureOutcome` function

## How to test
- Checkout and run the dev-server with this PR: https://github.com/pagopa/io-dev-api-server/pull/438;
- Complete the payment flow and choose from the dropdown the BE_NODE_KO;

## Preview

https://github.com/user-attachments/assets/a062456d-44a1-4f9f-ae3e-a9fb45644d98


