### PR TITLE
fix: missing app logo file on publicode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,18 +1,18 @@
-# This repository adheres to the publiccode.yml standard by including this 
+# This repository adheres to the publiccode.yml standard by including this
 # metadata file that makes public software easily discoverable.
 # More info at https://github.com/italia/publiccode.yml
 
-publiccodeYmlVersion: '0.2'
+publiccodeYmlVersion: "0.2"
 name: IO
-logo: "img/app-logo.svg"
-releaseDate: '2024-11-18'
-url: 'https://github.com/pagopa/io-app'
+logo: "img/io-app-icon.png"
+releaseDate: "2024-11-18"
+url: "https://github.com/pagopa/io-app"
 applicationSuite: IO
-landingURL: 'https://io.italia.it/'
+landingURL: "https://io.italia.it/"
 softwareVersion: 2.77.0-rc.3
 developmentStatus: beta
 softwareType: standalone/mobile
-roadmap: 'https://io.italia.it/'
+roadmap: "https://io.italia.it/"
 platforms:
   - ios
   - android
@@ -41,7 +41,7 @@ localisation:
     - it
     - en
 it:
-  countryExtensionVersion: '0.2'
+  countryExtensionVersion: "0.2"
   piattaforme:
     spid: true
     pagopa: true
@@ -88,7 +88,7 @@ description:
 
       - fungere da _reference implementation_ delle integrazioni con la
       piattaforma di Cittadinanza Digitale
-    documentation: 'https://github.com/pagopa/io-app'
+    documentation: "https://github.com/pagopa/io-app"
     features:
       - Messaggi
       - Pagamenti


### PR DESCRIPTION
## Short description
Thisd PR fixes an error on publicode_validation action due to the recent app logo changes

## How to test
Check publicode validation run
