### PR TITLE
fix: [IOCOM-1948] Proper Authorization header's value for FIMS history

### DIFF
--- a/ts/features/fims/history/saga/handleExportFimsHistorySaga.ts
+++ b/ts/features/fims/history/saga/handleExportFimsHistorySaga.ts
@@ -14,7 +14,7 @@ export function* handleExportFimsHistorySaga(
   action: ActionType<typeof fimsHistoryExport.request>
 ) {
   const exportHistoryRequest = exportHistory({
-    Bearer: bearerToken
+    Bearer: `Bearer ${bearerToken}`
   });
 
   try {

--- a/ts/features/fims/history/saga/handleGetFimsHistorySaga.ts
+++ b/ts/features/fims/history/saga/handleGetFimsHistorySaga.ts
@@ -23,7 +23,7 @@ export function* handleGetFimsHistorySaga(
   );
 
   const getHistoryRequest = getFimsHistory({
-    Bearer: bearerToken,
+    Bearer: `Bearer ${bearerToken}`,
     "Accept-Language": preferredLanguage,
     page: action.payload.continuationToken
   });
@@ -42,7 +42,7 @@ export function* handleGetFimsHistorySaga(
     trackFailureIfNeeded(resultAction);
     yield* put(resultAction);
   } catch (e) {
-    const reason = JSON.stringify(e);
+    const reason = `${e} ${JSON.stringify(e)}`;
     trackHistoryFailure(reason);
     yield* put(fimsHistoryGet.failure(reason));
   }


### PR DESCRIPTION
## Short description
This PR fixes the format for the value of the Authorization headers on FIMS history

## List of changes proposed in this pull request
- Header's value computed as `Bearer ${token}`

## How to test
Using the production environment, check that the FIMS history section works as expected
