### PR TITLE
chore:moved trustmark position in credential details screen

### DIFF
--- a/ts/features/itwallet/presentation/screens/ItwPresentationCredentialDetailScreen.tsx
+++ b/ts/features/itwallet/presentation/screens/ItwPresentationCredentialDetailScreen.tsx
@@ -110,8 +110,8 @@ const ItwPresentationCredentialDetail = ({
             <ItwPresentationAdditionalInfoSection credential={credential} />
             <ItwPresentationCredentialStatusAlert credential={credential} />
             <ItwPresentationCredentialInfoAlert credential={credential} />
-            <ItwCredentialTrustmark credential={credential} />
             <ItwPresentationClaimsSection credential={credential} />
+            <ItwCredentialTrustmark credential={credential} />
           </VStack>
         </ContentWrapper>
         <ItwPresentationDetailsFooter credential={credential} />


### PR DESCRIPTION
## Short description
This PR change the position of the Trustmark CTA in the credential details screen. Now is under the issuance metadata

## List of changes proposed in this pull request
- Feature A
- Feature B

## How to test
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

![Screenshot 2024-11-28 at 17 26 39](https://github.com/user-attachments/assets/11e7176c-1072-4764-afd6-a0f91e3ab461)
