### PR TITLE
fix: [IOBP-1021] Show retry banner when all the other cards fetch fails

### DIFF
--- a/ts/features/newWallet/components/WalletCardsContainer.tsx
+++ b/ts/features/newWallet/components/WalletCardsContainer.tsx
@@ -3,6 +3,7 @@ import {
   ListItemHeader,
   VSpacer
 } from "@pagopa/io-app-design-system";
+import * as pot from "@pagopa/ts-commons/lib/pot";
 import { useFocusEffect } from "@react-navigation/native";
 import * as React from "react";
 import { View } from "react-native";
@@ -32,6 +33,8 @@ import {
   selectWalletOtherCards
 } from "../store/selectors";
 import { WalletCardCategoryFilter } from "../types";
+import { paymentsWalletUserMethodsSelector } from "../../payments/wallet/store/selectors";
+import { cgnDetailSelector } from "../../bonus/cgn/store/reducers/details";
 import { WalletCardsCategoryContainer } from "./WalletCardsCategoryContainer";
 import { WalletCardsCategoryRetryErrorBanner } from "./WalletCardsCategoryRetryErrorBanner";
 import { WalletCardSkeleton } from "./WalletCardSkeleton";
@@ -43,18 +46,23 @@ const WalletCardsContainer = () => {
   const isLoading = useIOSelector(selectIsWalletCardsLoading);
   const cards = useIOSelector(selectSortedWalletCards);
   const selectedCategory = useIOSelector(selectWalletCategoryFilter);
+  const paymentMethodsStatus = useIOSelector(paymentsWalletUserMethodsSelector);
+  const cgnStatus = useIOSelector(cgnDetailSelector);
 
   if (isLoading && cards.length === 0) {
     return (
       <>
         <WalletCardSkeleton testID="walletCardSkeletonTestID" cardProps={{}} />
         <VSpacer size={16} />
-        <WalletCardsCategoryRetryErrorBanner />
       </>
     );
   }
 
-  if (cards.length === 0) {
+  if (
+    cards.length === 0 &&
+    pot.isSome(paymentMethodsStatus) &&
+    !pot.isError(cgnStatus)
+  ) {
     // In this case we can display the empty state: we do not have cards to display and
     // the wallet is not in a loading state anymore
     return (
@@ -161,10 +169,6 @@ const OtherCardsContainer = () => {
   const isItwTrialEnabled = useIOSelector(isItwTrialActiveSelector);
   const isItwEnabled = useIOSelector(isItwEnabledSelector);
   const isItwValid = useIOSelector(itwLifecycleIsValidSelector);
-
-  if (cards.length === 0) {
-    return null;
-  }
 
   const displayHeader = isItwTrialEnabled && isItwEnabled && isItwValid;
 

--- a/ts/features/newWallet/saga/__tests__/handleWalletLoadingPlaceholdersTimeout.test.ts
+++ b/ts/features/newWallet/saga/__tests__/handleWalletLoadingPlaceholdersTimeout.test.ts
@@ -50,6 +50,7 @@ describe("handleWalletLoadingPlaceholdersTimeout", () => {
       .next(T_CARDS)
       .put(walletResetPlaceholders(T_CARDS))
       .next()
+      .next()
       .isDone();
   });
 });

--- a/ts/features/newWallet/saga/handleWalletLoadingPlaceholdersTimeout.ts
+++ b/ts/features/newWallet/saga/handleWalletLoadingPlaceholdersTimeout.ts
@@ -15,5 +15,6 @@ export function* handleWalletPlaceholdersTimeout(
     yield* delay(timeoutMs);
     const cards = yield* select(selectWalletCards);
     yield* put(walletResetPlaceholders(cards));
+    yield* put(walletToggleLoadingState(false));
   }
 }

--- a/ts/features/newWallet/screens/__tests__/WalletHomeScreen.test.tsx
+++ b/ts/features/newWallet/screens/__tests__/WalletHomeScreen.test.tsx
@@ -1,4 +1,5 @@
 import _ from "lodash";
+import * as pot from "@pagopa/ts-commons/lib/pot";
 import configureMockStore from "redux-mock-store";
 import ROUTES from "../../../../navigation/routes";
 import { applicationChangeState } from "../../../../store/actions/application";
@@ -89,6 +90,11 @@ const renderComponent = (
           preferences: {},
           placeholders: {
             isLoading
+          }
+        },
+        payments: {
+          wallet: {
+            userMethods: pot.some([])
           }
         }
       }


### PR DESCRIPTION
## Short description
This PR fixes the behavior of the homepage banner in the "wallet" by ensuring the retry banner is displayed even when all API calls of the B&P domain fail. Previously, the retry banner was not shown if the number of onboarded cards was zero. Now, the logic has been updated so that if the number of cards is zero and at least one API call fails, the retry banner will be displayed.

## List of changes proposed in this pull request
- Added a logic inside the `WalletCardsContainer.tsx` to handle this edge-case when no card is available

## How to test
- Test the app on your physical device and check that when you open the app, before opening the "Wallet" tab, disable your internet connection and then tap on the "Wallet tab";
- After that, check that there is visible the backoff-retry banner.
