### PR TITLE
fix: [IOBP-1039] Payments home screen loading UI glitch

### DIFF
--- a/ts/features/payments/wallet/store/reducers/index.ts
+++ b/ts/features/payments/wallet/store/reducers/index.ts
@@ -11,7 +11,7 @@ export type PaymentsWalletState = {
 };
 
 const INITIAL_STATE: PaymentsWalletState = {
-  userMethods: pot.none
+  userMethods: pot.noneLoading
 };
 
 const paymentsWalletReducer = (


### PR DESCRIPTION
## Short description
This PR fixes a UI glitch when tapping for the first time the "Payments" tab.

## List of changes proposed in this pull request
- Added the initial state to `noneLoading` in order to show the skeleton for the first time the user enter in this screen.

## How to test
- Open the `Payments` section tab for the first time and check that nothing is flickering.

## Preview
|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/98ddb81b-2504-4d09-851d-40ee8d21b069" />|<video src="https://github.com/user-attachments/assets/c44c570c-e9e2-4120-823d-85ecaa232313" />
