### PR TITLE
fix: [IOBP-1037] Remove asterisks from card transaction info

### DIFF
--- a/ts/features/payments/bizEventsTransaction/components/PaymentsBizEventsTransactionInfoSection.tsx
+++ b/ts/features/payments/bizEventsTransaction/components/PaymentsBizEventsTransactionInfoSection.tsx
@@ -25,7 +25,7 @@ import { clipboardSetStringWithFeedback } from "../../../../utils/clipboard";
 import { format } from "../../../../utils/dates";
 import { capitalizeTextName } from "../../../../utils/strings";
 import { WalletTransactionReceiptDivider } from "../../transaction/components/WalletTransactionReceiptDivider";
-import { getPayerInfoLabel } from "../utils";
+import { getPayerInfoLabel, removeAsterisks } from "../utils";
 
 type PaymentsBizEventsTransactionInfoSectionProps = {
   transaction?: NoticeDetailResponse;
@@ -196,13 +196,15 @@ const renderPaymentMethod = (walletInfo: WalletInfo) => {
     return (
       <ListItemInfo
         label={I18n.t("transaction.details.info.paymentMethod")}
-        value={`${capitalize(walletInfo.brand)} •••• ${
+        value={`${capitalize(walletInfo.brand)} •••• ${removeAsterisks(
           walletInfo.blurredNumber
-        }`}
+        )}`}
         accessibilityLabel={I18n.t("wallet.methodDetails.a11y.credit.hpan", {
           circuit: walletInfo.brand,
           // we space the hpan to make the screen reader read it digit by digit
-          spacedHpan: walletInfo.blurredNumber.split("").join(" ")
+          spacedHpan: removeAsterisks(walletInfo.blurredNumber)
+            .split("")
+            .join(" ")
         })}
         paymentLogoIcon={walletInfo.brand as IOLogoPaymentType}
       />

--- a/ts/features/payments/bizEventsTransaction/utils/index.ts
+++ b/ts/features/payments/bizEventsTransaction/utils/index.ts
@@ -141,3 +141,6 @@ export const restoreTransactionAtIndex = (
     restoreItem,
     ...transactions.slice(index)
   ]);
+
+export const removeAsterisks = (text: string): string =>
+  text.replace(/\*/g, "");


### PR DESCRIPTION
## Short description
This pull request add a new utility function and its integration into the `PaymentsBizEventsTransactionInfoSection` component to handle the removal of asterisks from payment information


## List of changes proposed in this pull request
- Add `removeAsterisks` function that replaces asterisks in a given string with an empty string
- Apply the new `removeAsterisks` utility function to the wallet information to remove asterisks from the blurred number display

## How to test
- Mock a `blurredNumber` with some `*` and the card number at the end
- Verify that `*` are not render