### PR TITLE
feat: [IOBP-1047] Add store review when a payment is completed

### DIFF
--- a/ts/features/payments/checkout/screens/WalletPaymentOutcomeScreen.tsx
+++ b/ts/features/payments/checkout/screens/WalletPaymentOutcomeScreen.tsx
@@ -44,6 +44,7 @@ import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
 import { getPaymentsLatestBizEventsTransactionsAction } from "../../bizEventsTransaction/store/actions";
 import { usePaymentReversedInfoBottomSheet } from "../hooks/usePaymentReversedInfoBottomSheet";
 import { WalletPaymentStepEnum } from "../types";
+import { requestAppReview } from "../../../../utils/storeReview";
 
 type WalletPaymentOutcomeScreenNavigationParams = {
   outcome: WalletPaymentOutcome;
@@ -237,6 +238,10 @@ const WalletPaymentOutcomeScreen = () => {
         ? "DUPLICATED"
         : undefined;
     const rptId = paymentOngoingHistory?.rptId;
+
+    if (kind === "COMPLETED") {
+      requestAppReview();
+    }
 
     if (kind && rptId) {
       dispatch(paymentCompletedSuccess({ rptId, kind }));


### PR DESCRIPTION
## Short description
This PR adds the store review request when a payment is completed.

## List of changes proposed in this pull request
- Invoked the API to request a store review when the payment outcome is completed and SUCCESS.

## How to test
Start a payment flow with the dev-server and simulate a successful outcome from the in-app browser dropdown list. After that, check that the request to leave a review on the store dialog appears.

## Preview

https://github.com/user-attachments/assets/c9fdc561-e21e-4d8f-8ab3-c127047197c2


