### PR TITLE
chore: [IOCOM-1949] FIMS `iossoapi` protocol

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -111,7 +111,7 @@ PODS:
     - JOSESwift (~> 2.3)
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - pagopa-io-react-native-login-utils (1.0.7):
+  - pagopa-io-react-native-login-utils (1.0.8):
     - React-Core
   - pagopa-react-native-zendesk (0.3.29):
     - RCT-Folly (= 2021.07.22.00)
@@ -1058,7 +1058,7 @@ SPEC CHECKSUMS:
   pagopa-io-react-native-http-client: cbdfb83c92432efb0de22b7c3c85cffa391870f8
   pagopa-io-react-native-integrity: ca77804cefb1cd75d04053652472bcb938ce4b18
   pagopa-io-react-native-jwt: 27f6cb1ea58ea1df6778c67f23a932b90dc7e9a2
-  pagopa-io-react-native-login-utils: 6ba1c399fda70e9f92a29244bea33b22958869af
+  pagopa-io-react-native-login-utils: 090a98354cdbbf176059a1aa4163120468ee4356
   pagopa-react-native-zendesk: 60a26f8a8072234789c34bb7c8a769c156eb57dc
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: 264adaca1d8b1a9c078761891898d4142df05313

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@pagopa/io-react-native-http-client": "1.0.5",
     "@pagopa/io-react-native-integrity": "^0.3.0",
     "@pagopa/io-react-native-jwt": "^1.3.0",
-    "@pagopa/io-react-native-login-utils": "^1.0.7",
+    "@pagopa/io-react-native-login-utils": "^1.0.8",
     "@pagopa/io-react-native-wallet": "^0.26.0",
     "@pagopa/io-react-native-zendesk": "^0.3.29",
     "@pagopa/react-native-cie": "^1.3.0",

--- a/ts/features/fims/singleSignOn/saga/handleFimsGetRedirectUrlAndOpenIAB.ts
+++ b/ts/features/fims/singleSignOn/saga/handleFimsGetRedirectUrlAndOpenIAB.ts
@@ -149,7 +149,12 @@ export function* handleFimsGetRedirectUrlAndOpenIAB(
   yield* call(computeAndTrackInAppBrowserOpening, action);
 
   try {
-    yield* call(openAuthenticationSession, inAppBrowserRedirectUrl, "", true);
+    yield* call(
+      openAuthenticationSession,
+      inAppBrowserRedirectUrl,
+      "iossoapi",
+      true
+    );
   } catch (error: unknown) {
     yield* call(handleInAppBrowserErrorIfNeeded, error);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2272,10 +2272,10 @@
     js-base64 "^3.7.7"
     zod "^3.22.4"
 
-"@pagopa/io-react-native-login-utils@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-login-utils/-/io-react-native-login-utils-1.0.7.tgz#b92f9e04e15f724743367ff1bfd33a9ceddcd308"
-  integrity sha512-+I8uT3w/4XkuPC4+Gmy/6LvR3CpUpjjHL6B4qgZQ15EVHtfI97zo3blC4ETPpWdx1T8e37AKu9ZEJIHjOexm/w==
+"@pagopa/io-react-native-login-utils@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-react-native-login-utils/-/io-react-native-login-utils-1.0.8.tgz#dc5911f756cbf9fa76529041c1422aaecd85c8b2"
+  integrity sha512-gQY3Bkqtov0i9bZ3CV9ukPQYn9kOP6CaxUfbIyf1ZPOvXqAvDSqcbiM/Bdzkp3DneCrfvPMl9mkZ23af4Tu0fQ==
 
 "@pagopa/io-react-native-wallet@^0.26.0":
   version "0.26.0"


### PR DESCRIPTION
## Short description
This PR adds support for `iossoapi` protocol when using the InApp Browser on FIMS

## List of changes proposed in this pull request
- latest react-native-login-utils library 
- `iossoapi` protocol added to the InApp Browser callback

## How to test
Using the related io-dev-api-server, check that the InApp Browser from FIMS is closeable using the related web page button.
