### PR TITLE
fix: assistance flow actionsheet contains extra space on header

### DIFF
--- a/ts/components/ui/IOScrollView.tsx
+++ b/ts/components/ui/IOScrollView.tsx
@@ -245,6 +245,13 @@ export const IOScrollView = ({
     )
   }));
 
+  const ignoreSafeAreaMargin = React.useMemo(() => {
+    if (alertProps !== undefined) {
+      return true;
+    }
+    return headerConfig?.ignoreSafeAreaMargin;
+  }, [headerConfig?.ignoreSafeAreaMargin, alertProps]);
+
   /* Set custom header with `react-navigation` library using
      `useLayoutEffect` hook */
 
@@ -259,7 +266,7 @@ export const IOScrollView = ({
         header: () => (
           <HeaderSecondLevel
             {...headerConfig}
-            ignoreSafeAreaMargin={!!alertProps}
+            ignoreSafeAreaMargin={ignoreSafeAreaMargin}
             scrollValues={scrollValues}
           />
         ),
@@ -271,7 +278,7 @@ export const IOScrollView = ({
     navigation,
     scrollPositionAbsolute,
     snapOffset,
-    alertProps
+    ignoreSafeAreaMargin
   ]);
 
   const RefreshControlComponent = refreshControlProps ? (

--- a/ts/components/ui/IOScrollViewWithLargeHeader.tsx
+++ b/ts/components/ui/IOScrollViewWithLargeHeader.tsx
@@ -64,6 +64,7 @@ export const IOScrollViewWithLargeHeader = forwardRef<View, Props>(
       contextualHelp,
       contextualHelpMarkdown,
       faqCategories,
+      ignoreSafeAreaMargin = false,
       includeContentMargins = false,
       headerActionsProp = {},
       excludeEndContentMargin,
@@ -90,6 +91,7 @@ export const IOScrollViewWithLargeHeader = forwardRef<View, Props>(
     };
 
     const headerProps: ComponentProps<typeof HeaderSecondLevel> = {
+      ignoreSafeAreaMargin,
       ...useHeaderProps(
         canGoback
           ? {


### PR DESCRIPTION
## Short description
This PR fixes a minor issue caused by latest fix on header-status banner integration.

## How to test
Check the UI resiliency with or without a Status banner or in any screen presented as an ActionSheet