### PR TITLE
fix: [IOPID-2543] Add logic to merge data during zendesk polling

### DIFF
--- a/ts/features/zendesk/saga/index.ts
+++ b/ts/features/zendesk/saga/index.ts
@@ -51,7 +51,8 @@ function* zendeskGetSessionPollingLoop(
     const checkSessionResponse = yield* call(
       checkSession,
       getSession,
-      formatRequestedTokenString()
+      formatRequestedTokenString(),
+      true
     );
     if (checkSessionResponse === 401) {
       break;

--- a/ts/sagas/startup/__tests__/watchCheckSessionSaga.test.ts
+++ b/ts/sagas/startup/__tests__/watchCheckSessionSaga.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../watchCheckSessionSaga";
 import { handleSessionExpiredSaga } from "../../../features/fastLogin/saga/utils";
 import { isFastLoginEnabledSelector } from "../../../features/fastLogin/store/selectors";
+import { sessionInfoSelector } from "../../../store/reducers/authentication";
 
 describe("checkSession", () => {
   const getSessionValidity = jest.fn();
@@ -29,7 +30,7 @@ describe("checkSession", () => {
 
     const fields = "(zendeskToken,walletToken,lollipopAssertionRef)";
 
-    testSaga(testableCheckSession!, getSessionValidity, fields)
+    testSaga(testableCheckSession!, getSessionValidity, fields, false)
       .next()
       .call(getSessionValidity, { fields })
       .next(responseOK)
@@ -38,6 +39,8 @@ describe("checkSession", () => {
           isSessionValid: true
         })
       )
+      .next()
+      .select(sessionInfoSelector)
       .next()
       .put(sessionInformationLoadSuccess(responseValue as PublicSession))
       .next()
@@ -49,7 +52,7 @@ describe("checkSession", () => {
 
     const fields = "(zendeskToken,walletToken,lollipopAssertionRef)";
 
-    testSaga(testableCheckSession!, getSessionValidity, fields)
+    testSaga(testableCheckSession!, getSessionValidity, fields, false)
       .next()
       .call(getSessionValidity, { fields })
       .next(responseUnauthorized)
@@ -67,7 +70,7 @@ describe("checkSession", () => {
 
     const fields = undefined;
 
-    testSaga(testableCheckSession!, getSessionValidity, fields)
+    testSaga(testableCheckSession!, getSessionValidity, fields, false)
       .next()
       .call(getSessionValidity, { fields })
       .next(response500)
@@ -89,7 +92,7 @@ describe("checkSession", () => {
 
     const fields = "(zendeskToken,walletToken,lollipopAssertionRef)";
 
-    testSaga(testableCheckSession!, getSessionValidity, fields)
+    testSaga(testableCheckSession!, getSessionValidity, fields, false)
       .next()
       .call(getSessionValidity, { fields })
       .next(responseLeft)

--- a/ts/sagas/startup/watchCheckSessionSaga.ts
+++ b/ts/sagas/startup/watchCheckSessionSaga.ts
@@ -42,9 +42,10 @@ export function* checkSession(
           isSessionValid: response.right.status !== 401
         })
       );
-      const currentSessionInfo = yield* select(sessionInfoSelector);
 
       if (response.right.status === 200) {
+        const currentSessionInfo = yield* select(sessionInfoSelector);
+
         yield* put(
           sessionInformationLoadSuccess(
             mergeOldAndNewValues && O.isSome(currentSessionInfo)

--- a/ts/sagas/startup/watchCheckSessionSaga.ts
+++ b/ts/sagas/startup/watchCheckSessionSaga.ts
@@ -1,8 +1,9 @@
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import { TypeOfApiResponseStatus } from "@pagopa/ts-commons/lib/requests";
 import * as E from "fp-ts/lib/Either";
+import * as O from "fp-ts/lib/Option";
 import { SagaIterator } from "redux-saga";
-import { call, put, takeLatest } from "typed-redux-saga/macro";
+import { call, put, select, takeLatest } from "typed-redux-saga/macro";
 import { getType } from "typesafe-actions";
 import { GetSessionStateT } from "../../../definitions/session_manager/requestTypes";
 import { BackendClient } from "../../api/backend";
@@ -14,10 +15,13 @@ import { ReduxSagaEffect, SagaCallReturnType } from "../../types/utils";
 import { isTestEnv } from "../../utils/environment";
 import { convertUnknownToError } from "../../utils/errors";
 import { handleSessionExpiredSaga } from "../../features/fastLogin/saga/utils";
+import { getOnlyNotAlreadyExistentValues } from "../../features/zendesk/utils";
+import { sessionInfoSelector } from "../../store/reducers/authentication";
 
 export function* checkSession(
   getSessionValidity: ReturnType<typeof BackendClient>["getSession"],
-  fields?: string // the `fields` parameter is optional and it defaults to an empty object
+  fields?: string, // the `fields` parameter is optional and it defaults to an empty object
+  mergeOldAndNewValues: boolean = false
 ): Generator<
   ReduxSagaEffect,
   TypeOfApiResponseStatus<GetSessionStateT> | undefined,
@@ -38,9 +42,19 @@ export function* checkSession(
           isSessionValid: response.right.status !== 401
         })
       );
+      const currentSessionInfo = yield* select(sessionInfoSelector);
 
       if (response.right.status === 200) {
-        yield* put(sessionInformationLoadSuccess(response.right.value));
+        yield* put(
+          sessionInformationLoadSuccess(
+            mergeOldAndNewValues && O.isSome(currentSessionInfo)
+              ? getOnlyNotAlreadyExistentValues(
+                  response.right.value,
+                  currentSessionInfo.value
+                )
+              : response.right.value
+          )
+        );
       }
       return response.right.status;
     }


### PR DESCRIPTION
## Short description
In the as-is when polling, the data in the redux store was overwritten and the zendeskToken was no longer available. This led to an error when sending messages to support, within the chat with support. (only for logged in users)

## Demo
| .env.local | .env.production |
| - | - |
| <video src="https://github.com/user-attachments/assets/4580715e-08f7-488d-9146-27b424efaa97"/> | <video src="https://github.com/user-attachments/assets/6d1b63d3-5c3f-4aa1-baeb-4029dfa2e6e4"/> | 

> [!Warning]
> In order to test this PR using .env.local, you need to use this branch on the dev-server https://github.com/pagopa/io-dev-api-server/pull/445

## How to test
Run the application using or .env.local or .env.production or both
Activate the fast-login settings 
follow the video demo