### PR TITLE
fix(IT Wallet): [SIW-1899] Fix filter tabs padding within wallet home screen

### DIFF
--- a/ts/features/wallet/components/WalletCategoryFilterTabs.tsx
+++ b/ts/features/wallet/components/WalletCategoryFilterTabs.tsx
@@ -1,8 +1,7 @@
 import {
   IOVisualCostants,
   TabItem,
-  TabNavigation,
-  VSpacer
+  TabNavigation
 } from "@pagopa/io-app-design-system";
 import React from "react";
 import { StyleSheet, View } from "react-native";
@@ -64,14 +63,14 @@ const WalletCategoryFilterTabs = () => {
           ))
         ]}
       </TabNavigation>
-      <VSpacer size={16} />
     </View>
   );
 };
 
 const styles = StyleSheet.create({
   container: {
-    marginTop: 8,
+    paddingTop: 8,
+    paddingBottom: 16,
     marginHorizontal: -IOVisualCostants.appMarginDefault * 2,
     paddingHorizontal: IOVisualCostants.appMarginDefault
   }

--- a/ts/features/wallet/components/WalletCategoryFilterTabs.tsx
+++ b/ts/features/wallet/components/WalletCategoryFilterTabs.tsx
@@ -71,6 +71,7 @@ const WalletCategoryFilterTabs = () => {
 
 const styles = StyleSheet.create({
   container: {
+    marginTop: 8,
     marginHorizontal: -IOVisualCostants.appMarginDefault * 2,
     paddingHorizontal: IOVisualCostants.appMarginDefault
   }


### PR DESCRIPTION
## Short description
This PR adjusts paddings in the filter chips within the wallet home screen

## List of changes proposed in this pull request
- Adjusted paddings in `WalletCategoryFilterTabs` component

## How to test
Run the app, check that everything is ok and paddings are [aligned with the Figma design](https://www.figma.com/design/4Pbt3wd9WoPnAXVMkAA6UT/App-IO-2.0---Design-System?node-id=11659-113426&t=lUQmAFWv9kFH888E-4).

## Demo

https://github.com/user-attachments/assets/e34c66c1-90bd-4ac9-8163-1a67eb8a43f2


