### PR TITLE
feat: [IOBP-964] Add zendesk payment subcategories

### DIFF
--- a/ts/api/content.ts
+++ b/ts/api/content.ts
@@ -8,6 +8,7 @@ import {
   createFetchRequestForApi,
   IGetApiRequestType
 } from "@pagopa/ts-commons/lib/requests";
+import { unknown } from "io-ts";
 import { BonusesAvailable } from "../../definitions/content/BonusesAvailable";
 import { ContextualHelp } from "../../definitions/content/ContextualHelp";
 import { Municipality as MunicipalityMedadata } from "../../definitions/content/Municipality";
@@ -140,6 +141,16 @@ const getZendeskConfigT: GetZendeskConfigT = {
   headers: () => ({}),
   response_decoder: basicResponseDecoder(Zendesk)
 };
+
+// TODO: update with new definition from related PR
+const getZendeskPaymentConfig: any = {
+  method: "get",
+  url: () => "/assistanceTools/paymentMap.json",
+  query: (_: any) => ({}),
+  headers: () => ({}),
+  response_decoder: basicResponseDecoder(unknown)
+};
+
 /**
  * A client for the static content
  */
@@ -157,6 +168,10 @@ export function ContentClient(fetchApi: typeof fetch = defaultRetryingFetch()) {
     getCobadgeServices: createFetchRequestForApi(getCobadgeServicesT, options),
     getVersionInfo: createFetchRequestForApi(getVersionInfoT, options),
     getIdps: createFetchRequestForApi(getIdpsT, options),
-    getZendeskConfig: createFetchRequestForApi(getZendeskConfigT, options)
+    getZendeskConfig: createFetchRequestForApi(getZendeskConfigT, options),
+    getZendeskPaymentConfig: createFetchRequestForApi(
+      getZendeskPaymentConfig,
+      options
+    )
   };
 }

--- a/ts/api/content.ts
+++ b/ts/api/content.ts
@@ -142,11 +142,18 @@ const getZendeskConfigT: GetZendeskConfigT = {
   response_decoder: basicResponseDecoder(Zendesk)
 };
 
+type GetZendeskPaymentConfigT = IGetApiRequestType<
+  void,
+  never,
+  never,
+  BasicResponseType<any>
+>;
+
 // TODO: update with new definition from related PR
-const getZendeskPaymentConfig: any = {
+const getZendeskPaymentConfig: GetZendeskPaymentConfigT = {
   method: "get",
   url: () => "/assistanceTools/paymentMap.json",
-  query: (_: any) => ({}),
+  query: _ => ({}),
   headers: () => ({}),
   response_decoder: basicResponseDecoder(unknown)
 };

--- a/ts/features/payments/checkout/utils/index.ts
+++ b/ts/features/payments/checkout/utils/index.ts
@@ -9,6 +9,7 @@ import {
   PaymentAnalyticsSelectedPspFlag
 } from "../../common/types/PaymentAnalytics";
 import { WalletPaymentStepEnum } from "../types";
+import { zendeskCategoryId } from "../../../../utils/supportAssistance";
 
 export const WALLET_PAYMENT_SHOW_OTHER_CHANNELS_URL =
   "https://www.pagopa.gov.it/it/cittadini/dove-pagare/";
@@ -77,4 +78,23 @@ export const isDueDateValid = (date: string): string | undefined => {
   const tenYearsFromNow = new Date();
   tenYearsFromNow.setFullYear(tenYearsFromNow.getFullYear() + YEARS_TO_EXPIRE);
   return new Date(date) > tenYearsFromNow ? undefined : formattedDate;
+};
+
+export const getSubCategoryFromFaultCode = (data: any, statusCode: string) => {
+  // check if there is a subcategory array that includes passed element
+  const subcategoryKey = Object.keys(data.subcategories).find(key =>
+    data.subcategories[key].includes(statusCode)
+  );
+  // if there is, return the mapped subcategory with the zendesk category id
+  if (subcategoryKey) {
+    return {
+      value: subcategoryKey,
+      zendeskCategoryId: data.subcategoryId
+    };
+  }
+  // if not, return the parent category
+  return {
+    value: "pagamenti_pagopa",
+    zendeskCategoryId
+  };
 };

--- a/ts/features/zendesk/analytics/index.ts
+++ b/ts/features/zendesk/analytics/index.ts
@@ -7,6 +7,7 @@ import { zendeskEnabled } from "../../../config";
 import { getNetworkErrorMessage } from "../../../utils/errors";
 import {
   getZendeskConfig,
+  getZendeskPaymentConfig,
   zendeskSelectedCategory,
   zendeskSupportCancel,
   zendeskSupportCompleted,
@@ -22,6 +23,8 @@ const trackZendesk =
       case getType(zendeskSupportCancel):
       case getType(getZendeskConfig.request):
       case getType(getZendeskConfig.success):
+      case getType(getZendeskPaymentConfig.success):
+      case getType(getZendeskPaymentConfig.request):
         return mp.track(action.type);
       case getType(zendeskSupportStart):
         return mp.track(action.type, {
@@ -38,6 +41,7 @@ const trackZendesk =
           category: action.payload.value
         });
       case getType(getZendeskConfig.failure):
+      case getType(getZendeskPaymentConfig.failure):
         return mp.track(action.type, {
           reason: getNetworkErrorMessage(action.payload)
         });

--- a/ts/features/zendesk/saga/index.ts
+++ b/ts/features/zendesk/saga/index.ts
@@ -11,7 +11,8 @@ import {
   zendeskStartPolling,
   zendeskSupportCompleted,
   zendeskSupportStart,
-  getZendeskToken
+  getZendeskToken,
+  getZendeskPaymentConfig
 } from "../store/actions";
 import { ContentClient } from "../../../api/content";
 import { dismissSupport } from "../../../utils/supportAssistance";
@@ -33,6 +34,7 @@ import { isDevEnv } from "./../../../utils/environment";
 import { zendeskSupport } from "./orchestration";
 import { handleGetZendeskConfig } from "./networking/handleGetZendeskConfig";
 import { handleHasOpenedTickets } from "./networking/handleHasOpenedTickets";
+import { handleGetZendeskPaymentConfig } from "./networking/handleGetZendeskPaymentConfig";
 
 const ZENDESK_GET_SESSION_POLLING_INTERVAL = ((isDevEnv ? 10 : 60) *
   1000) as Millisecond;
@@ -87,6 +89,12 @@ export function* watchZendeskSupportSaga() {
     getZendeskConfig.request,
     handleGetZendeskConfig,
     contentClient.getZendeskConfig
+  );
+
+  yield* takeLatest(
+    getZendeskPaymentConfig.request,
+    handleGetZendeskPaymentConfig,
+    contentClient.getZendeskPaymentConfig
   );
 
   yield* takeLatest(zendeskRequestTicketNumber.request, handleHasOpenedTickets);

--- a/ts/features/zendesk/saga/networking/handleGetZendeskPaymentConfig.ts
+++ b/ts/features/zendesk/saga/networking/handleGetZendeskPaymentConfig.ts
@@ -1,0 +1,47 @@
+import { readableReport } from "@pagopa/ts-commons/lib/reporters";
+import * as E from "fp-ts/lib/Either";
+import { call, put } from "typed-redux-saga/macro";
+import { ContentClient } from "../../../../api/content";
+import { SagaCallReturnType } from "../../../../types/utils";
+import { getGenericError, getNetworkError } from "../../../../utils/errors";
+import { getZendeskPaymentConfig } from "../../store/actions";
+
+// retrieve the zendesk config from the CDN
+export function* handleGetZendeskPaymentConfig(
+  getZendeskPaymentConfigClient: ReturnType<
+    typeof ContentClient
+  >["getZendeskPaymentConfig"]
+) {
+  try {
+    const getZendeskPaymentConfigResult: SagaCallReturnType<
+      typeof getZendeskPaymentConfigClient
+    > = yield* call(getZendeskPaymentConfigClient);
+    if (E.isRight(getZendeskPaymentConfigResult)) {
+      if (getZendeskPaymentConfigResult.right.status === 200) {
+        yield* put(
+          getZendeskPaymentConfig.success(
+            getZendeskPaymentConfigResult.right.value
+          )
+        );
+      } else {
+        yield* put(
+          getZendeskPaymentConfig.failure(
+            getGenericError(
+              Error(
+                `response status ${getZendeskPaymentConfigResult.right.status}`
+              )
+            )
+          )
+        );
+      }
+    } else {
+      getZendeskPaymentConfig.failure(
+        getGenericError(
+          Error(readableReport(getZendeskPaymentConfigResult.left))
+        )
+      );
+    }
+  } catch (e) {
+    yield* put(getZendeskPaymentConfig.failure(getNetworkError(e)));
+  }
+}

--- a/ts/features/zendesk/screens/ZendeskSupportHelpCenter.tsx
+++ b/ts/features/zendesk/screens/ZendeskSupportHelpCenter.tsx
@@ -63,6 +63,7 @@ import ZENDESK_ROUTES from "../navigation/routes";
 import {
   ZendeskStartPayload,
   getZendeskConfig,
+  getZendeskPaymentConfig,
   getZendeskToken,
   zendeskSupportCancel
 } from "../store/actions";
@@ -330,6 +331,7 @@ const ZendeskSupportHelpCenter = () => {
    */
   useEffect(() => {
     dispatch(getZendeskConfig.request());
+    dispatch(getZendeskPaymentConfig.request());
   }, [dispatch]);
 
   // add the signatureRequestId to the ticket custom fields

--- a/ts/features/zendesk/store/actions/index.ts
+++ b/ts/features/zendesk/store/actions/index.ts
@@ -95,6 +95,15 @@ export const getZendeskConfig = createAsyncAction(
   "ZENDESK_CONFIG_FAILURE"
 )<void, Zendesk, NetworkError>();
 
+/**
+ * Request the zendesk payment config
+ */
+export const getZendeskPaymentConfig = createAsyncAction(
+  "ZENDESK_PAYMENT_CONFIG_REQUEST",
+  "ZENDESK_PAYMENT_CONFIG_SUCCESS",
+  "ZENDESK_PAYMENT_CONFIG_FAILURE"
+)<void, any, NetworkError>();
+
 // user selected a category
 export const zendeskSelectedCategory = createStandardAction(
   "ZENDESK_SELECTED_CATEGORY"
@@ -127,4 +136,5 @@ export type ZendeskSupportActions =
   | ActionType<typeof getZendeskConfig>
   | ActionType<typeof zendeskSelectedCategory>
   | ActionType<typeof zendeskRequestTicketNumber>
-  | ActionType<typeof zendeskSelectedSubcategory>;
+  | ActionType<typeof zendeskSelectedSubcategory>
+  | ActionType<typeof getZendeskPaymentConfig>;

--- a/ts/features/zendesk/store/reducers/__tests__/index.test.ts
+++ b/ts/features/zendesk/store/reducers/__tests__/index.test.ts
@@ -24,7 +24,8 @@ import { ZendeskState } from "../index";
 
 const INITIAL_STATE: ZendeskState = {
   zendeskConfig: remoteUndefined,
-  ticketNumber: pot.none
+  ticketNumber: pot.none,
+  zendeskMap: remoteUndefined
 };
 
 const mockCategory: ZendeskCategory = {

--- a/ts/features/zendesk/store/reducers/index.ts
+++ b/ts/features/zendesk/store/reducers/index.ts
@@ -20,7 +20,8 @@ import {
   zendeskStartPolling,
   zendeskStopPolling,
   zendeskSupportStart,
-  getZendeskToken
+  getZendeskToken,
+  getZendeskPaymentConfig
 } from "../actions";
 import { GlobalState } from "../../../../store/reducers/types";
 import { ZendeskSubCategory } from "../../../../../definitions/content/ZendeskSubCategory";
@@ -47,11 +48,13 @@ export type ZendeskState = {
   ticketNumber: pot.Pot<number, Error>;
   getSessionPollingRunning?: boolean;
   getZendeskTokenStatus?: ZendeskTokenStatusEnum | "401";
+  zendeskMap: any;
 };
 
 const INITIAL_STATE: ZendeskState = {
   zendeskConfig: remoteUndefined,
-  ticketNumber: pot.none
+  ticketNumber: pot.none,
+  zendeskMap: remoteUndefined
 };
 
 const reducer = (
@@ -135,6 +138,21 @@ const reducer = (
         ...state,
         ticketNumber: pot.toError(state.ticketNumber, action.payload)
       };
+    case getType(getZendeskPaymentConfig.request):
+      return {
+        ...state,
+        zendeskMap: remoteLoading
+      };
+    case getType(getZendeskPaymentConfig.success):
+      return {
+        ...state,
+        zendeskMap: remoteReady(action.payload)
+      };
+    case getType(getZendeskPaymentConfig.failure):
+      return {
+        ...state,
+        zendeskMap: remoteError(action.payload)
+      };
   }
   return state;
 };
@@ -166,6 +184,11 @@ export const zendeskSelectedSubcategorySelector = createSelector(
 export const zendeskTicketNumberSelector = createSelector(
   [(state: GlobalState) => state.assistanceTools.zendesk.ticketNumber],
   (ticketNumber: pot.Pot<number, Error>): pot.Pot<number, Error> => ticketNumber
+);
+
+export const zendeskMapSelector = createSelector(
+  [(state: GlobalState) => state.assistanceTools.zendesk.zendeskMap],
+  (zendeskMap: any): any => zendeskMap.value
 );
 
 export default reducer;

--- a/ts/utils/supportAssistance.ts
+++ b/ts/utils/supportAssistance.ts
@@ -115,14 +115,7 @@ export const zendeskidentityProviderId = "4414310934673";
 export const zendeskCurrentAppVersionId = "4414316660369";
 export const zendeskVersionsHistoryId = "4419641151505";
 export const zendeskFciId = "14874226407825";
-export const zendeskPaymentCategory: ZendeskCategory = {
-  value: "pagamenti_pagopa",
-  description: {
-    "it-IT": "Pagamento pagoPA",
-    "en-EN": "pagoPA payment",
-    "de-DE": "pagoPA-Zahlung"
-  }
-};
+
 export const zendeskPaymentMethodCategory: ZendeskCategory = {
   value: "metodo_di_pagamento",
   description: {


### PR DESCRIPTION
> [!WARNING]
> this PR depends on https://github.com/pagopa/io-services-metadata/pull/892
> this PR depends on https://github.com/pagopa/io-dev-api-server/pull/446

## Short description
This pull request includes the addition of a new API request type for fetching `Zendesk` payment configuration, updates to the Redux store and sagas to handle this new configuration, and modifications to the payment failure support modal to utilize the new configuration.

## List of changes proposed in this pull request
-  Added a new type `GetZendeskPaymentConfigT` and a corresponding API request `getZendeskPaymentConfig` to fetch the Zendesk payment configuration
- `handleGetZendeskPaymentConfig` to manage the side effects of fetching the Zendesk payment configuration and integrated it into the `watchZendeskSupportSaga`
- Updated the payment failure support modal to dispatch the `getZendeskPaymentConfig` action and utilize the fetched configuration to set custom fields for Zendesk tickets

## How to test
Ensure that the outcomes are accurately mapped to the corresponding subcategory when opening a ticket