### PR TITLE
chore: [PE-868] CGN Update cta when card is expired

### DIFF
--- a/locales/de/index.yml
+++ b/locales/de/index.yml
@@ -2379,7 +2379,7 @@ bonus:
         alert:
           title: "Karte deaktivieren"
           message: "La Carta verrà disattivata e non potrai più accedere alle opportunità disponibili."
-        expired: Elimina Carta Giovani Nazionale
+        expired: Rimuovi dal Portafoglio
     otp:
       error: "Aufgrund eines technischen Problems war es uns nicht möglich, einen Rabattcode zu generieren. Bitte versuche es erneut."
       code:

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2883,7 +2883,7 @@ bonus:
         alert:
           title: "Vuoi rimuovere Carta Giovani dal Portafoglio?"
           message: "La Carta verrà disattivata e non potrai più accedere alle opportunità disponibili."
-        expired: Elimina Carta Giovani Nazionale
+        expired: Rimuovi dal Portafoglio
     otp:
       error: "Per un problema tecnico non siamo riusciti a generare un codice sconto. Ti chiediamo di riprovare."
       code:


### PR DESCRIPTION
## Short description
This pull request includes changes to locales files to update the text for remove button when CGN card is expired.

## List of changes proposed in this pull request
- Changed the expired card cta message from "Elimina Carta Giovani Nazionale" to "Rimuovi dal Portafoglio".

## How to test
- From dev-server mock an expired `cgn` response
- Add `cgn` to your wallet
- Tap on it
- Check the remove cta text, press on it  
- Ensure alert is also aligned with design