### PR TITLE
fix(IT Wallet): [SIW-1917] Fix crash in credentials onboarding screen

### DIFF
--- a/ts/features/itwallet/common/store/reducers/__tests__/__snapshots__/index.test.ts.snap
+++ b/ts/features/itwallet/common/store/reducers/__tests__/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`itWalletReducer should match snapshot 1`] = `
+exports[`itWalletReducer should match snapshot [if this test fails, remember to add a migration to the store before updating the snapshot] 1`] = `
 {
   "credentials": {
     "credentials": [],

--- a/ts/features/itwallet/common/store/reducers/__tests__/index.test.ts
+++ b/ts/features/itwallet/common/store/reducers/__tests__/index.test.ts
@@ -2,7 +2,7 @@ import { applicationChangeState } from "../../../../../../store/actions/applicat
 import itWalletReducer from "../index";
 
 describe("itWalletReducer", () => {
-  it("should match snapshot", () => {
+  it("should match snapshot [if this test fails, remember to add a migration to the store before updating the snapshot]", () => {
     const itWalletState = itWalletReducer(
       undefined,
       applicationChangeState("active")

--- a/ts/features/itwallet/common/store/reducers/index.ts
+++ b/ts/features/itwallet/common/store/reducers/index.ts
@@ -43,12 +43,15 @@ const itwReducer = combineReducers({
   preferences: preferencesReducer
 });
 
-const CURRENT_REDUX_ITW_STORE_VERSION = 0;
+const CURRENT_REDUX_ITW_STORE_VERSION = 1;
 
 const migrations: MigrationManifest = {
   // Added preferences store
   "0": (state: PersistedState): PersistedState =>
-    _.set(state, "preferences", {})
+    _.set(state, "preferences", {}),
+  // Added requestedCredentials to preferences store
+  "1": (state: PersistedState): PersistedState =>
+    _.set(state, "preferences.requestedCredentials", {})
 };
 
 const itwPersistConfig: PersistConfig = {


### PR DESCRIPTION
## Short description
This PR fixes a crash in the credentials onboarding screen by adding a store migration needed after a store update made in https://github.com/pagopa/io-app/pull/6516 

## List of changes proposed in this pull request
- Added ITW store migration 1
- Updated snapshot test with warning about this problem happening again

## How to test
1. Uninstall the app from your device 
2. Install it again building from https://github.com/pagopa/io-app/commit/a3799e35feefabdcadaa2ee1d32bc287ad5fb58c
3. Activate the Wallet
4. Navigate to the Credentials onboarding screen, check that everything works as expected
5. Update the app building from this branch
6. Navigate to the Credentials onboarding screen again, check that everything works as expected

