### PR TITLE
fix: [IOBP-1082] Typo in Zendesk assistance json remote path  

### DIFF
--- a/ts/api/content.ts
+++ b/ts/api/content.ts
@@ -151,7 +151,7 @@ type GetZendeskPaymentConfigT = IGetApiRequestType<
 
 const getZendeskPaymentConfig: GetZendeskPaymentConfigT = {
   method: "get",
-  url: () => "/assistanceTools/payment/zendeskOutcomeMapping.json",
+  url: () => "/assistanceTools/payments/zendeskOutcomeMapping.json",
   query: _ => ({}),
   headers: () => ({}),
   response_decoder: basicResponseDecoder(ZendeskSubcategoriesErrors)

--- a/ts/features/payments/checkout/hooks/usePaymentFailureSupportModal.tsx
+++ b/ts/features/payments/checkout/hooks/usePaymentFailureSupportModal.tsx
@@ -92,12 +92,6 @@ const usePaymentFailureSupportModal = ({
     "";
 
   const zendeskAssistanceLogAndStart = () => {
-    if (!isReady(zendeskPaymentCategory)) {
-      return;
-    }
-    const { payments } = zendeskPaymentCategory.value;
-    const subCategory = getSubCategoryFromFaultCode(payments, faultCodeDetail);
-
     resetCustomFields();
     // attach the main zendesk category to the ticket
     addTicketCustomField(
@@ -105,10 +99,17 @@ const usePaymentFailureSupportModal = ({
       defaultZendeskPaymentCategory.value
     );
 
-    if (subCategory) {
-      // if a subcategory is found, we attach its id and value to the ticket
-      const { value, zendeskSubCategoryId } = subCategory;
-      addTicketCustomField(zendeskSubCategoryId, value);
+    if (isReady(zendeskPaymentCategory)) {
+      const { payments } = zendeskPaymentCategory.value;
+      const subCategory = getSubCategoryFromFaultCode(
+        payments,
+        faultCodeDetail
+      );
+      if (subCategory) {
+        // if a subcategory is found, we attach its id and value to the ticket
+        const { value, zendeskSubCategoryId } = subCategory;
+        addTicketCustomField(zendeskSubCategoryId, value);
+      }
     }
 
     addTicketCustomField(zendeskPaymentOrgFiscalCode, organizationFiscalCode);


### PR DESCRIPTION
> [!NOTE]
> To test this PR [check this](https://github.com/pagopa/io-dev-api-server/pull/450) 

## Short description
This pull request update the URL path and improve the handling of Zendesk payment categories. The most important changes include modifying the URL for the Zendesk payment configuration and refactoring the code for checking and adding subcategories in the payment failure support modal.

## List of changes proposed in this pull request
- Changed the URL path in the `getZendeskPaymentConfig` object from `/assistanceTools/payment/zendeskOutcomeMapping.json` to `/assistanceTools/payments/zendeskOutcomeMapping.json`
- Refactored the `zendeskAssistanceLogAndStart` function to improve the handling of the `zendeskPaymentCategory` check and the addition of subcategories to the ticket. The new code ensures that the subcategory is only processed if `zendeskPaymentCategory` is ready and a subcategory is found.
