### PR TITLE
chore: [IOBP-1083] Update `IN_APP_BROWSER_CLOSED_BY_USER` outcome text

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1984,7 +1984,7 @@ wallet:
         subtitle: Potresti avere rimosso pagoPA dai pagamenti automatici di PayPal. Elimina il conto PayPal dal tuo Portafoglio, aggiungilo di nuovo e riprova ad effettuare il pagamento.
       IN_APP_BROWSER_CLOSED_BY_USER:
         title: Hai interrotto il pagamento
-        subtitle: Verifica l’esito dalla sezione Pagamenti. Se intendi pagare, attendi qualche minuto prima di riprovare.
+        subtitle: Verifica l’esito dalla sezione Pagamenti. Se intendi pagare, attendi almeno 15 minuti prima di riprovare.
       INSUFFICIENT_AVAILABILITY_ERROR:
         title: Il saldo della tua carta è insufficiente
         subtitle: Non è stato addebitato alcun importo. Prima di riprovare, aggiungi fondi alla carta o usa un altro metodo di pagamento.

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1984,7 +1984,7 @@ wallet:
         subtitle: Potresti avere rimosso pagoPA dai pagamenti automatici di PayPal. Elimina il conto PayPal dal tuo Portafoglio, aggiungilo di nuovo e riprova ad effettuare il pagamento.
       IN_APP_BROWSER_CLOSED_BY_USER:
         title: Hai interrotto il pagamento
-        subtitle: Verifica l’esito dalla sezione Pagamenti. Se intendi pagare, attendi qualche minuto prima di riprovare.
+        subtitle: Verifica l’esito dalla sezione Pagamenti. Se intendi pagare, attendi almeno 15 minuti prima di riprovare.
       INSUFFICIENT_AVAILABILITY_ERROR:
         title: Il saldo della tua carta è insufficiente
         subtitle: Non è stato addebitato alcun importo. Prima di riprovare, aggiungi fondi alla carta o usa un altro metodo di pagamento.

--- a/ts/features/payments/checkout/screens/___tests___/__snapshots__/WalletPaymentOutcomeScreen.test.tsx.snap
+++ b/ts/features/payments/checkout/screens/___tests___/__snapshots__/WalletPaymentOutcomeScreen.test.tsx.snap
@@ -43598,7 +43598,7 @@ exports[`WalletPaymentOutcomeScreen for all outcomes should render the WalletPay
                                 ]
                               }
                             >
-                              Verifica l’esito dalla sezione Pagamenti. Se intendi pagare, attendi qualche minuto prima di riprovare.
+                              Verifica l’esito dalla sezione Pagamenti. Se intendi pagare, attendi almeno 15 minuti prima di riprovare.
                             </Text>
                             <View
                               style={


### PR DESCRIPTION
## Short description
This pull request includes updates to the subtitle text in the payment verification messages. The changes ensure that users are instructed to wait at least 15 minutes before retrying a payment.

## List of changes proposed in this pull request
- Update text as defined in design
- Update related snapshot

## How to test
- Try to pay something
- Cancel the transaction before select an outcome
- Ensure that outcome message is align with design 

## Preview
https://github.com/user-attachments/assets/12c32c91-c289-4192-9b1f-39580a544c14

