### PR TITLE
[SIW-1901] Deferred issuance for credential

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "io_session_manager_api": "https://raw.githubusercontent.com/pagopa/io-auth-n-identity-domain/io-session-manager@1.0.0/apps/io-session-manager/api/internal.yaml",
   "io_session_manager_public_api": "https://raw.githubusercontent.com/pagopa/io-auth-n-identity-domain/io-session-manager@1.0.0/apps/io-session-manager/api/public.yaml",
   "io_public_api": "https://raw.githubusercontent.com/pagopa/io-backend/v16.4.0-RELEASE/api_public.yaml",
-  "io_content_specs": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.50/definitions.yml",
+  "io_content_specs": "https://raw.githubusercontent.com/pagopa/io-services-metadata/1.0.51/definitions.yml",
   "io_cgn_specs": "https://raw.githubusercontent.com/pagopa/io-backend/v16.4.0-RELEASE/api_cgn.yaml",
   "io_cgn_merchants_specs": "https://raw.githubusercontent.com/pagopa/io-backend/v16.4.0-RELEASE/api_cgn_operator_search.yaml",
   "api_fci": "https://raw.githubusercontent.com/pagopa/io-backend/v16.4.0-RELEASE/api_io_sign.yaml",

--- a/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialFailureScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialFailureScreen.tsx
@@ -26,6 +26,9 @@ import {
 } from "../../machine/credential/selectors";
 import { ItwCredentialIssuanceMachineContext } from "../../machine/provider";
 import { useCredentialEventsTracking } from "../hooks/useCredentialEventsTracking";
+import { useIOSelector } from "../../../../store/hooks";
+import { itwDeferredIssuanceScreenContentSelector } from "../../../../store/reducers/backendStatus/remoteConfig";
+import { getFullLocale } from "../../../../utils/locale";
 
 export const ItwIssuanceCredentialFailureScreen = () => {
   const failureOption =
@@ -59,6 +62,10 @@ const ContentView = ({ failure }: ContentViewProps) => {
   );
   const issuerConf = ItwCredentialIssuanceMachineContext.useSelector(
     selectIssuerConfigurationOption
+  );
+  const locale = getFullLocale();
+  const deferredIssuanceScreenContent = useIOSelector(
+    itwDeferredIssuanceScreenContentSelector
   );
 
   const invalidStatusDetails = getCredentialInvalidStatusDetails(failure, {
@@ -109,12 +116,12 @@ const ContentView = ({ failure }: ContentViewProps) => {
         // NOTE: only the mDL supports the async flow, so this error message is specific to mDL
         case CredentialIssuanceFailureType.ASYNC_ISSUANCE:
           return {
-            title: I18n.t(
-              "features.itWallet.issuance.asyncCredentialError.title"
-            ),
-            subtitle: I18n.t(
-              "features.itWallet.issuance.asyncCredentialError.body"
-            ),
+            title:
+              deferredIssuanceScreenContent?.title?.[locale] ??
+              I18n.t("features.itWallet.issuance.asyncCredentialError.title"),
+            subtitle:
+              deferredIssuanceScreenContent?.description?.[locale] ??
+              I18n.t("features.itWallet.issuance.asyncCredentialError.body"),
             pictogram: "pending",
             action: {
               label: I18n.t(

--- a/ts/store/reducers/backendStatus/remoteConfig.ts
+++ b/ts/store/reducers/backendStatus/remoteConfig.ts
@@ -416,3 +416,16 @@ export const itwDisabledCredentialsSelector = createSelector(
       O.getOrElse(() => emptyArray)
     )
 );
+
+/**
+ * Return the remote config content for the deferred issuance screen content.
+ */
+export const itwDeferredIssuanceScreenContentSelector = createSelector(
+  remoteConfigSelector,
+  remoteConfig =>
+    pipe(
+      remoteConfig,
+      O.map(config => config.itw.deferred_issuance_screen_content),
+      O.toUndefined
+    )
+);


### PR DESCRIPTION
## Short description
This PR introduces the handling of remote configuration for the `ItwIssuanceCredentialFailureScreen`. If a `deferred_issuance_screen_content` is present in `itw` config, the title and description from the remote config are used. Otherwise, fallback values are used.

## List of changes proposed in this pull request
- add a new selector `itwDeferredIssuanceScreenContentSelector` in remote config 

## How to test
Using a proxy, add the following object to the `itw` remote config. Also, check the normal scenario without this object to ensure fallback values are used correctly.

```
      "deferred_issuance_screen_content": {
        "title": {
          "it-IT": "La Motorizzazione Civile ha preso in carico la tua richiesta",
          "en-EN": "La Motorizzazione Civile ha preso in carico la tua richiesta"
        },
        "description": {
          "it-IT": "Riceverai un messaggio in app per continuare appena La Motorizzazione Civile l'avrà elaborata.\n\nIn periodi di alta richiesta il processo potrebbe richiede alcune ore o alcuni giorni.",
          "en-EN": "Riceverai un messaggio in app per continuare appena La Motorizzazione Civile l'avrà elaborata.\n\nIn periodi di alta richiesta il processo potrebbe richiede alcune ore o alcuni giorni."
        }
      }
```
