### PR TITLE
chore: [IOBP-1085] Removed delete transaction API request when closing in-app browser

### DIFF
--- a/ts/features/payments/checkout/hooks/useWalletPaymentAuthorizationModal.tsx
+++ b/ts/features/payments/checkout/hooks/useWalletPaymentAuthorizationModal.tsx
@@ -10,13 +10,9 @@ import { WALLET_WEBVIEW_OUTCOME_SCHEMA } from "../../common/utils/const";
 import { storePaymentOutcomeToHistory } from "../../history/store/actions";
 import {
   WalletPaymentAuthorizePayload,
-  paymentsDeleteTransactionAction,
   paymentsStartPaymentAuthorizationAction
 } from "../store/actions/networking";
-import {
-  walletPaymentAuthorizationUrlSelector,
-  walletPaymentTransactionSelector
-} from "../store/selectors/transaction";
+import { walletPaymentAuthorizationUrlSelector } from "../store/selectors/transaction";
 import {
   WalletPaymentOutcome,
   WalletPaymentOutcomeEnum
@@ -41,8 +37,6 @@ export const useWalletPaymentAuthorizationModal = ({
   const authorizationUrlPot = useIOSelector(
     walletPaymentAuthorizationUrlSelector
   );
-  const transactionPot = useIOSelector(walletPaymentTransactionSelector);
-
   const [isPendingAuthorization, setIsPendingAuthorization] =
     React.useState<boolean>(false);
   const isLoading = pot.isLoading(authorizationUrlPot);
@@ -91,13 +85,6 @@ export const useWalletPaymentAuthorizationModal = ({
             handleAuthorizationOutcome(
               WalletPaymentOutcomeEnum.IN_APP_BROWSER_CLOSED_BY_USER
             );
-            if (pot.isSome(transactionPot)) {
-              dispatch(
-                paymentsDeleteTransactionAction.request(
-                  transactionPot.value.transactionId
-                )
-              );
-            }
           }
         )
       ),
@@ -108,7 +95,6 @@ export const useWalletPaymentAuthorizationModal = ({
     isLoading,
     isPendingAuthorization,
     authorizationUrlPot,
-    transactionPot,
     handleAuthorizationResult,
     handleAuthorizationOutcome,
     dispatch


### PR DESCRIPTION
## Short description
This PR removes the delete transaction API request when the user closes the in-app browser during the payment flow.

## List of changes proposed in this pull request
- Removed the API request trigger when closing the payment flow form the in-app browser.

## How to test
- Start a payment flow with the dev-server started;
- Reach the final step when the in-app browser appears;
- Tap on "Cancel" button and check that the API request to delete the transaction isn't fired;
