### PR TITLE
fix: setup-ruby on CI failure

### DIFF
--- a/.github/workflows/distribute-beta.yml
+++ b/.github/workflows/distribute-beta.yml
@@ -12,7 +12,7 @@ jobs:
       - id: setup
         uses: ./.github/actions/setup-composite
       - id: setup-ruby
-        uses: ruby/setup-ruby@d2b39ad0b52eca07d23f3aa14fdf2a3fcc1f411c #v1.149.0
+        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf #v1.204.0
         with:
           bundler-cache: true
       - id: build-release-android
@@ -35,7 +35,7 @@ jobs:
       - id: setup
         uses: ./.github/actions/setup-composite
       - id: setup-ruby
-        uses: ruby/setup-ruby@5f19ec79cedfadb78ab837f95b87734d0003c899 #v1.173.0
+        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf #v1.204.0
         with:
           bundler-cache: true
       - id: prepare-ios-build

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -67,7 +67,7 @@ jobs:
       - id: setup-android-sdk
         uses: android-actions/setup-android@00854ea68c109d98c75d956347303bf7c45b0277 #v3.2.1
       - id: setup-ruby
-        uses: ruby/setup-ruby@d2b39ad0b52eca07d23f3aa14fdf2a3fcc1f411c #v1.149.0
+        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf #v1.204.0
         with:
           bundler-cache: true
       - id: build-release-android
@@ -135,7 +135,7 @@ jobs:
       - id: setup
         uses: ./.github/actions/setup-composite
       - id: setup-ruby
-        uses: ruby/setup-ruby@5f19ec79cedfadb78ab837f95b87734d0003c899 #v1.173.0
+        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf #v1.204.0
         with:
           bundler-cache: true
       - id: prepare-ios-build

--- a/.github/workflows/release-new-cycle.yml
+++ b/.github/workflows/release-new-cycle.yml
@@ -77,7 +77,7 @@ jobs:
       - id: setup-android-sdk
         uses: android-actions/setup-android@00854ea68c109d98c75d956347303bf7c45b0277 #v3.2.1
       - id: setup-ruby
-        uses: ruby/setup-ruby@d2b39ad0b52eca07d23f3aa14fdf2a3fcc1f411c #v1.149.0
+        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf #v1.204.0
         with:
           bundler-cache: true
       - id: build-release-android
@@ -145,7 +145,7 @@ jobs:
       - id: setup
         uses: ./.github/actions/setup-composite
       - id: setup-ruby
-        uses: ruby/setup-ruby@5f19ec79cedfadb78ab837f95b87734d0003c899 #v1.173.0
+        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf #v1.204.0
         with:
           bundler-cache: true
       - id: prepare-ios-build

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -56,7 +56,7 @@ jobs:
       - id: setup-android-sdk
         uses: android-actions/setup-android@00854ea68c109d98c75d956347303bf7c45b0277 #v3.2.1
       - id: setup-ruby
-        uses: ruby/setup-ruby@d2b39ad0b52eca07d23f3aa14fdf2a3fcc1f411c #v1.149.0
+        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf #v1.204.0
         with:
           bundler-cache: true
       - id: build-release-android
@@ -124,7 +124,7 @@ jobs:
       - id: setup
         uses: ./.github/actions/setup-composite
       - id: setup-ruby
-        uses: ruby/setup-ruby@5f19ec79cedfadb78ab837f95b87734d0003c899 #v1.173.0
+        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf #v1.204.0
         with:
           bundler-cache: true
       - id: prepare-ios-build

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           use-cache: 'true'
       - id: setup-ruby
-        uses: ruby/setup-ruby@5f19ec79cedfadb78ab837f95b87734d0003c899 #v1.173.0
+        uses: ruby/setup-ruby@401c19e14f474b54450cd3905bb8b86e2c8509cf #v1.204.0
         with:
           bundler-cache: true
       - id: prepare-dependencies


### PR DESCRIPTION
## Short description
This PR bumps the version of setup-ruby on CI workflows.

ref. https://github.com/ruby/setup-ruby/issues/595