### PR TITLE
refactor: [IOBP-1091] Paid in app empty state screen

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3240,6 +3240,8 @@ features:
         empty:
           title: Nessuna ricevuta trovata
           subtitle: Se stai cercando la ricevuta di un avviso pagoPA che hai pagato in passato, rivolgiti all’ente creditore.
+        emptyPayer: 
+          title: Qui vedrai le ricevute dei pagamenti fatti in app
     details:
       payPal:
         banner:

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3240,6 +3240,8 @@ features:
         empty:
           title: Nessuna ricevuta trovata
           subtitle: Se stai cercando la ricevuta di un avviso pagoPA che hai pagato in passato, rivolgiti all’ente creditore.
+        emptyPayer: 
+          title: Qui vedrai le ricevute dei pagamenti fatti in app
     details:
       payPal:
         banner:

--- a/ts/features/payments/receipts/screens/ReceiptListScreen.tsx
+++ b/ts/features/payments/receipts/screens/ReceiptListScreen.tsx
@@ -40,6 +40,11 @@ export type ReceiptListScreenProps = RouteProp<
   "PAYMENT_RECEIPT_DETAILS"
 >;
 
+type OperationResultEmptyProps = Pick<
+  OperationResultScreenContentProps,
+  "title" | "subtitle" | "pictogram"
+>;
+
 const AnimatedSectionList = Animated.createAnimatedComponent(
   SectionList as new () => SectionList<NoticeListItem>
 );
@@ -164,11 +169,6 @@ const ReceiptListScreen = () => {
       )}
     </>
   );
-
-  type OperationResultEmptyProps = Pick<
-    OperationResultScreenContentProps,
-    "title" | "subtitle" | "pictogram"
-  >;
 
   const emptyProps: OperationResultEmptyProps =
     noticeCategory === "payer"

--- a/ts/features/payments/receipts/screens/ReceiptListScreen.tsx
+++ b/ts/features/payments/receipts/screens/ReceiptListScreen.tsx
@@ -1,6 +1,5 @@
 import {
   Divider,
-  IOPictograms,
   IOStyles,
   ListItemHeader
 } from "@pagopa/io-app-design-system";
@@ -13,25 +12,28 @@ import Animated, {
   useSharedValue
 } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useIODispatch, useIOSelector } from "../../../../store/hooks";
-import { PaymentsReceiptParamsList } from "../navigation/params";
-import { getPaymentsReceiptAction } from "../store/actions";
-import { walletReceiptListPotSelector } from "../store/selectors";
-import { useIONavigation } from "../../../../navigation/params/AppParamsList";
-import { isPaymentsTransactionsEmptySelector } from "../../home/store/selectors";
-import { ReceiptListItemTransaction } from "../components/ReceiptListItemTransaction";
-import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
-import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
-import { groupTransactionsByMonth } from "../utils";
-import I18n from "../../../../i18n";
-import { PaymentsReceiptRoutes } from "../navigation/routes";
 import { NoticeListItem } from "../../../../../definitions/pagopa/biz-events/NoticeListItem";
+import {
+  OperationResultScreenContent,
+  OperationResultScreenContentProps
+} from "../../../../components/screens/OperationResultScreenContent";
+import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
+import I18n from "../../../../i18n";
+import { useIONavigation } from "../../../../navigation/params/AppParamsList";
+import { useIODispatch, useIOSelector } from "../../../../store/hooks";
+import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
+import { isPaymentsTransactionsEmptySelector } from "../../home/store/selectors";
 import * as analytics from "../analytics";
-import { ReceiptsCategoryFilter } from "../types";
-import { OperationResultScreenContent } from "../../../../components/screens/OperationResultScreenContent";
 import { ReceiptFadeInOutAnimationView } from "../components/ReceiptFadeInOutAnimationView";
+import { ReceiptListItemTransaction } from "../components/ReceiptListItemTransaction";
 import { ReceiptLoadingList } from "../components/ReceiptLoadingList";
 import { ReceiptSectionListHeader } from "../components/ReceiptSectionListHeader";
+import { PaymentsReceiptParamsList } from "../navigation/params";
+import { PaymentsReceiptRoutes } from "../navigation/routes";
+import { getPaymentsReceiptAction } from "../store/actions";
+import { walletReceiptListPotSelector } from "../store/selectors";
+import { ReceiptsCategoryFilter } from "../types";
+import { groupTransactionsByMonth } from "../utils";
 
 export type ReceiptListScreenProps = RouteProp<
   PaymentsReceiptParamsList,
@@ -163,11 +165,12 @@ const ReceiptListScreen = () => {
     </>
   );
 
-  const emptyProps: {
-    title: string;
-    subtitle?: string;
-    pictogram: IOPictograms;
-  } =
+  type OperationResultEmptyProps = Pick<
+    OperationResultScreenContentProps,
+    "title" | "subtitle" | "pictogram"
+  >;
+
+  const emptyProps: OperationResultEmptyProps =
     noticeCategory === "payer"
       ? {
           title: I18n.t("features.payments.transactions.list.emptyPayer.title"),

--- a/ts/features/payments/receipts/screens/ReceiptListScreen.tsx
+++ b/ts/features/payments/receipts/screens/ReceiptListScreen.tsx
@@ -1,5 +1,6 @@
 import {
   Divider,
+  IOPictograms,
   IOStyles,
   ListItemHeader
 } from "@pagopa/io-app-design-system";
@@ -59,7 +60,6 @@ const ReceiptListScreen = () => {
 
   const transactionsPot = useIOSelector(walletReceiptListPotSelector);
   const isEmpty = useIOSelector(isPaymentsTransactionsEmptySelector);
-
   const isLoading = pot.isLoading(transactionsPot);
 
   const handleNavigateToTransactionDetails = (transaction: NoticeListItem) => {
@@ -163,14 +163,27 @@ const ReceiptListScreen = () => {
     </>
   );
 
+  const emptyProps: {
+    title: string;
+    subtitle?: string;
+    pictogram: IOPictograms;
+  } =
+    noticeCategory === "payer"
+      ? {
+          title: I18n.t("features.payments.transactions.list.emptyPayer.title"),
+          pictogram: "empty"
+        }
+      : {
+          title: I18n.t("features.payments.transactions.list.empty.title"),
+          subtitle: I18n.t(
+            "features.payments.transactions.list.empty.subtitle"
+          ),
+          pictogram: "emptyArchive"
+        };
+
   const EmptyStateList = isEmpty ? (
     <ReceiptFadeInOutAnimationView>
-      <OperationResultScreenContent
-        isHeaderVisible
-        title={I18n.t("features.payments.transactions.list.empty.title")}
-        subtitle={I18n.t("features.payments.transactions.list.empty.subtitle")}
-        pictogram="emptyArchive"
-      />
+      <OperationResultScreenContent isHeaderVisible {...emptyProps} />
     </ReceiptFadeInOutAnimationView>
   ) : undefined;
 


### PR DESCRIPTION
## Short description
This pull request includes updates to localization files and enhancements to the `ReceiptListScreen` component. The most important changes is refactoring the empty state logic in the receipt list screen.

## List of changes proposed in this pull request
- Refactored the empty state logic to use a new `emptyProps` object based on the `noticeCategory`.
- Added `emptyPayer` locale for displaying payment receipts made in the app.

## How to test
- In `Pagamenti` tap on `Vedi tutte`
- Ensure that the `Pagate in app` tab is display correct empty state

## Preview
https://github.com/user-attachments/assets/8501fe55-1370-4613-9543-b929aa9907d6

