### PR TITLE
chore(IT Wallet): [SIW-1949] Display email address in the same line in issuance failure screen

### DIFF
--- a/ts/components/screens/OperationResultScreenContent.tsx
+++ b/ts/components/screens/OperationResultScreenContent.tsx
@@ -28,6 +28,7 @@ type OperationResultScreenContentProps = WithTestID<{
   pictogram?: IOPictograms;
   title: string;
   subtitle?: string | Array<BodyProps>;
+  subtitleProps?: Pick<BodyProps, "textBreakStrategy" | "lineBreakStrategyIOS">;
   action?: Pick<
     ButtonSolidProps,
     "label" | "accessibilityLabel" | "onPress" | "testID"
@@ -52,7 +53,8 @@ const OperationResultScreenContent = forwardRef<
       secondaryAction,
       children,
       testID,
-      isHeaderVisible
+      isHeaderVisible,
+      subtitleProps
     },
     ref
   ) => (
@@ -81,7 +83,9 @@ const OperationResultScreenContent = forwardRef<
           <>
             <VSpacer size={8} />
             {typeof subtitle === "string" ? (
-              <Body style={{ textAlign: "center" }}>{subtitle}</Body>
+              <Body style={{ textAlign: "center" }} {...subtitleProps}>
+                {subtitle}
+              </Body>
             ) : (
               <ComposedBodyFromArray body={subtitle} textAlign="center" />
             )}

--- a/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialFailureScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialFailureScreen.tsx
@@ -163,7 +163,12 @@ const ContentView = ({ failure }: ContentViewProps) => {
   });
 
   const resultScreenProps = getOperationResultScreenContentProps();
-  return <OperationResultScreenContent {...resultScreenProps} />;
+  return (
+    <OperationResultScreenContent
+      {...resultScreenProps}
+      subtitleProps={{ textBreakStrategy: "simple" }}
+    />
+  );
 };
 
 type GetCredentialInvalidStatusDetailsParams = {

--- a/ts/features/itwallet/issuance/screens/ItwIssuanceEidFailureScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceEidFailureScreen.tsx
@@ -188,5 +188,10 @@ const ContentView = ({ failure }: ContentViewProps) => {
 
   const resultScreenProps = getOperationResultScreenContentProps();
 
-  return <OperationResultScreenContent {...resultScreenProps} />;
+  return (
+    <OperationResultScreenContent
+      {...resultScreenProps}
+      subtitleProps={{ textBreakStrategy: "simple" }}
+    />
+  );
 };


### PR DESCRIPTION
## Short description
This PR changes the line break strategy in the issuance failure screens to display email addresses in the same line. The issue seems to affect Android devices only.

## List of changes proposed in this pull request
- Added `textBreakStrategy: "simple"` in `ItwIssuanceEidFailureScreen` and `ItwIssuanceCredentialFailureScreen`

## How to test
The easiest way to test it is to mock an error during credential issuance with a message that contains an email address.

|Before|After|
|------|-----|
|<img src="https://github.com/user-attachments/assets/fe546b8e-249a-4955-921f-39106dfa1242" width="240"/>|<img src="https://github.com/user-attachments/assets/ad478750-93a5-4b5c-8024-2d166c4be92d" width="240"/>|