### PR TITLE
[IOPID-2592] Fix wrong navigation on first app install

### DIFF
--- a/ts/sagas/installation.ts
+++ b/ts/sagas/installation.ts
@@ -1,8 +1,8 @@
 /**
  * A saga to manage session invalidation
  */
-import { put, select } from "typed-redux-saga/macro";
-import { sessionInvalid } from "../store/actions/authentication";
+import { call, select } from "typed-redux-saga/macro";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { isFirstRunAfterInstallSelector } from "../store/reducers/installation";
 import { ReduxSagaEffect } from "../types/utils";
 
@@ -20,7 +20,7 @@ export function* previousInstallationDataDeleteSaga(): Generator<
   > = yield* select(isFirstRunAfterInstallSelector);
 
   if (isFirstRunAfterInstall) {
-    // invalidate the session
-    yield* put(sessionInvalid());
+    // remove authentication data from the storage
+    yield* call(AsyncStorage.removeItem, "persist:authentication");
   }
 }


### PR DESCRIPTION
## Short description
Fix behavior where the app navigated to the LandingScreen before obtaining the remoteConfig data

## List of changes proposed in this pull request
- Replaced `put(sessionInvalid())` with `call(AsyncStorage.removeItem, "persist:authentication")` in the `installation` saga. This fixes a wrong startup behavior where in response to the `sessionInvalid` action, the `status` attribute in the startup reducer is set to `notAuthenticated`, causing the app to navigate to the LandingScreen.

## Demo

<details><summary>iOS</summary>

|With `sessionInvalid` action (current implementation)|With `AsyncStorage.removeItem` (proposed scenario)|
|-----------------------------------------------------|----------------------------------|
|<video src="https://github.com/user-attachments/assets/f9aa90e5-5fba-4403-9316-2dd66ae4268d"></video>|<video src="https://github.com/user-attachments/assets/f1a90a72-89a2-4027-91a4-49d691fae6cf"></video>|

</details>
<details><summary>Android</summary>

|With `sessionInvalid` action (current implementation)|With `AsyncStorage.removeItem` (proposed scenario)|
|-----------------------------------------------------|----------------------------------|
|<video src="https://github.com/user-attachments/assets/2d489519-d0a0-42e0-b71e-2013ab15ed43"></video>|<video src="https://github.com/user-attachments/assets/a369ac07-8eba-46c8-b4c9-ccd41a580f64"></video>|

</details>

## How to test
After logging into the app, delete it and reinstall it from scratch (as you can see in the demo videos), ensuring it is unable to download the remoteConfig data. You should remain stuck on the IngressScreen.
