### PR TITLE
feat: [PE-882] CGN new discounts count

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IO_BACKEND_VERSION=v16.4.0-RELEASE
+IO_BACKEND_VERSION=v16.7.3-RELEASE
 # need to change after merge on io-services-metadata
 IO_SERVICES_METADATA_VERSION=1.0.55
 

--- a/ts/features/bonus/cgn/components/merchants/CgnMerchantsListView.tsx
+++ b/ts/features/bonus/cgn/components/merchants/CgnMerchantsListView.tsx
@@ -5,6 +5,7 @@ import { IOStyles } from "../../../../../components/core/variables/IOStyles";
 import { OfflineMerchant } from "../../../../../../definitions/cgn/merchants/OfflineMerchant";
 import { OnlineMerchant } from "../../../../../../definitions/cgn/merchants/OnlineMerchant";
 import { Merchant } from "../../../../../../definitions/cgn/merchants/Merchant";
+import I18n from "../../../../../i18n";
 
 export const CgnMerchantListViewRenderItem =
   (props: {
@@ -22,7 +23,11 @@ export const CgnMerchantListViewRenderItem =
                 <View style={[IOStyles.rowSpaceBetween, IOStyles.alignCenter]}>
                   <Badge
                     variant="purple"
-                    text={String(item.numberOfNewDiscounts)}
+                    text={
+                      item.numberOfNewDiscounts
+                        ? String(item.numberOfNewDiscounts)
+                        : I18n.t("bonus.cgn.merchantsList.news")
+                    }
                   />
                 </View>
               )}

--- a/ts/features/bonus/cgn/components/merchants/CgnMerchantsListView.tsx
+++ b/ts/features/bonus/cgn/components/merchants/CgnMerchantsListView.tsx
@@ -25,7 +25,7 @@ export const CgnMerchantListViewRenderItem =
                     variant="purple"
                     text={
                       item.numberOfNewDiscounts
-                        ? String(item.numberOfNewDiscounts)
+                        ? item.numberOfNewDiscounts.toString()
                         : I18n.t("bonus.cgn.merchantsList.news")
                     }
                   />

--- a/ts/features/bonus/cgn/components/merchants/CgnMerchantsListView.tsx
+++ b/ts/features/bonus/cgn/components/merchants/CgnMerchantsListView.tsx
@@ -5,7 +5,6 @@ import { IOStyles } from "../../../../../components/core/variables/IOStyles";
 import { OfflineMerchant } from "../../../../../../definitions/cgn/merchants/OfflineMerchant";
 import { OnlineMerchant } from "../../../../../../definitions/cgn/merchants/OnlineMerchant";
 import { Merchant } from "../../../../../../definitions/cgn/merchants/Merchant";
-import I18n from "../../../../../i18n";
 
 export const CgnMerchantListViewRenderItem =
   (props: {
@@ -23,7 +22,7 @@ export const CgnMerchantListViewRenderItem =
                 <View style={[IOStyles.rowSpaceBetween, IOStyles.alignCenter]}>
                   <Badge
                     variant="purple"
-                    text={I18n.t("bonus.cgn.merchantsList.news")}
+                    text={String(item.numberOfNewDiscounts)}
                   />
                 </View>
               )}


### PR DESCRIPTION
## Short description
Replaced badge label of "novità" with actual new discounts count. 

## List of changes proposed in this pull request
- change label

## How to test
- to test with dev-api-server you need https://github.com/pagopa/io-dev-api-server/pull/455
- login into the app
- go to carta giovani nazionale trough portafoglio (add the card if necessary)
- go to discount list by pressing "scopri opportunià"
- press "by partner" tab
- check that the badges contain numbers instead of a fixed label
- press "by category" tab
- press on any category
- check that the badges contain numbers instead of a fixed label
