### PR TITLE
fix: [IOPAE-1688] Fix infinite scroll on the services home page

### DIFF
--- a/ts/features/services/home/screens/ServicesHomeScreen.tsx
+++ b/ts/features/services/home/screens/ServicesHomeScreen.tsx
@@ -87,29 +87,25 @@ export const ServicesHomeScreen = () => {
     [navigation]
   );
 
-  const renderListHeaderComponent = () => (
-    <>
-      <SearchInputComponent />
-      <FeaturedServiceList />
-      <FeaturedInstitutionList />
-      <ListItemHeader label={I18n.t("services.home.institutions.title")} />
-    </>
-  );
-
-  const SearchInputComponent = useCallback(
+  const renderListHeaderComponent = useCallback(
     () => (
-      <SearchInput
-        accessibilityLabel={I18n.t("services.search.input.placeholder")}
-        cancelButtonLabel={I18n.t("services.search.input.cancel")}
-        clearAccessibilityLabel={I18n.t("services.search.input.clear")}
-        placeholder={I18n.t("services.search.input.placeholder")}
-        pressable={{
-          onPress: () => {
-            analytics.trackSearchStart({ source: "search_bar" });
-            navigateToSearch();
-          }
-        }}
-      />
+      <>
+        <SearchInput
+          accessibilityLabel={I18n.t("services.search.input.placeholder")}
+          cancelButtonLabel={I18n.t("services.search.input.cancel")}
+          clearAccessibilityLabel={I18n.t("services.search.input.clear")}
+          placeholder={I18n.t("services.search.input.placeholder")}
+          pressable={{
+            onPress: () => {
+              analytics.trackSearchStart({ source: "search_bar" });
+              navigateToSearch();
+            }
+          }}
+        />
+        <FeaturedServiceList />
+        <FeaturedInstitutionList />
+        <ListItemHeader label={I18n.t("services.home.institutions.title")} />
+      </>
     ),
     [navigateToSearch]
   );
@@ -146,23 +142,10 @@ export const ServicesHomeScreen = () => {
     refresh();
   }, [dispatch, refresh]);
 
-  const handleEndReached = useCallback(
-    ({ distanceFromEnd }: { distanceFromEnd: number }) => {
-      // Managed behavior:
-      // at the end of data load, in case of response error,
-      // the footer is removed from total list length and
-      // `onEndReached` is triggered continuously causing an endless loop.
-      // Implemented solution:
-      // this guard is needed to avoid endless loop
-      if (distanceFromEnd === 0) {
-        return;
-      }
-
-      analytics.trackInstitutionsScroll();
-      fetchNextPage(currentPage + 1);
-    },
-    [currentPage, fetchNextPage]
-  );
+  const handleEndReached = useCallback(() => {
+    analytics.trackInstitutionsScroll();
+    fetchNextPage(currentPage + 1);
+  }, [currentPage, fetchNextPage]);
 
   const navigateToInstitution = useCallback(
     ({ fiscal_code, id, name }: Institution) => {

--- a/ts/features/services/home/store/reducers/__tests__/store.test.ts
+++ b/ts/features/services/home/store/reducers/__tests__/store.test.ts
@@ -1,15 +1,13 @@
 import * as pot from "@pagopa/ts-commons/lib/pot";
+import MockDate from "mockdate";
 import { Action, createStore } from "redux";
 import {
   featuredInstitutionsSelector,
   featuredServicesSelector,
   isErrorFeaturedInstitutionsSelector,
   isErrorFeaturedServicesSelector,
-  isErrorPaginatedInstitutionsSelector,
   isLoadingFeaturedInstitutionsSelector,
   isLoadingFeaturedServicesSelector,
-  isLoadingPaginatedInstitutionsSelector,
-  isUpdatingPaginatedInstitutionsSelector,
   paginatedInstitutionsCurrentPageSelector,
   paginatedInstitutionsLastPageSelector,
   paginatedInstitutionsSelector
@@ -81,6 +79,9 @@ const MOCK_NETWORK_ERROR: NetworkError = {
   value: new Error("response status code 500")
 };
 
+const MOCKED_DATE = new Date();
+MockDate.set(MOCKED_DATE);
+
 describe("Services home paginatedInstitutions reducer", () => {
   it("should have initial state", () => {
     const state = appReducer(undefined, applicationChangeState("active"));
@@ -129,7 +130,10 @@ describe("Services home paginatedInstitutions reducer", () => {
           offset: 0,
           limit: 3
         },
-        MOCK_NETWORK_ERROR
+        {
+          reason: MOCK_NETWORK_ERROR,
+          time: MOCKED_DATE
+        }
       )
     );
   });
@@ -198,7 +202,10 @@ describe("Services home paginatedInstitutions reducer", () => {
           offset: 3,
           limit: 3
         },
-        MOCK_NETWORK_ERROR
+        {
+          reason: MOCK_NETWORK_ERROR,
+          time: MOCKED_DATE
+        }
       )
     );
   });
@@ -251,128 +258,6 @@ describe("Services home paginatedInstitutions selectors", () => {
           )
         )
       ).toBeUndefined();
-    });
-  });
-
-  describe("isLoadingPaginatedInstitutionsSelector", () => {
-    it("should return true when pot.loading", () => {
-      const isLoading = isLoadingPaginatedInstitutionsSelector(
-        appReducer(
-          {} as GlobalState,
-          paginatedInstitutionsGet.request({ offset: 0, limit: 3 })
-        )
-      );
-      expect(isLoading).toStrictEqual(true);
-    });
-
-    it("should return false when not pot.loading", () => {
-      expect(
-        isLoadingPaginatedInstitutionsSelector(
-          appReducer(undefined, {} as Action)
-        )
-      ).toStrictEqual(false);
-
-      expect(
-        isLoadingPaginatedInstitutionsSelector(
-          appReducer(
-            {} as GlobalState,
-            paginatedInstitutionsGet.success({
-              institutions: MOCK_INSTITUTIONS,
-              count: 23,
-              offset: 0,
-              limit: 3
-            })
-          )
-        )
-      ).toStrictEqual(false);
-    });
-  });
-
-  describe("isUpdatingPaginatedInstitutionsSelector", () => {
-    it("should return true when pot.updating", () => {
-      const state = appReducer(undefined, applicationChangeState("active"));
-      const store = createStore(appReducer, state as any);
-
-      store.dispatch(
-        paginatedInstitutionsGet.success({
-          institutions: MOCK_INSTITUTIONS,
-          count: 23,
-          offset: 0,
-          limit: 3
-        })
-      );
-      store.dispatch(paginatedInstitutionsGet.request({ offset: 3, limit: 3 }));
-
-      const isUpdating = isUpdatingPaginatedInstitutionsSelector(
-        store.getState()
-      );
-
-      expect(isUpdating).toStrictEqual(true);
-    });
-
-    it("should return false when not pot.updating", () => {
-      expect(
-        isUpdatingPaginatedInstitutionsSelector(
-          appReducer(undefined, {} as Action)
-        )
-      ).toStrictEqual(false);
-
-      expect(
-        isUpdatingPaginatedInstitutionsSelector(
-          appReducer(
-            {} as GlobalState,
-            paginatedInstitutionsGet.request({ offset: 0, limit: 3 })
-          )
-        )
-      ).toStrictEqual(false);
-
-      expect(
-        isUpdatingPaginatedInstitutionsSelector(
-          appReducer(
-            {} as GlobalState,
-            paginatedInstitutionsGet.success({
-              institutions: MOCK_INSTITUTIONS,
-              count: 23,
-              offset: 0,
-              limit: 3
-            })
-          )
-        )
-      ).toStrictEqual(false);
-    });
-  });
-
-  describe("isErrorPaginatedInstitutionsSelector", () => {
-    it("should return true when pot.error", () => {
-      const isError = isErrorPaginatedInstitutionsSelector(
-        appReducer(
-          {} as GlobalState,
-          paginatedInstitutionsGet.failure(MOCK_NETWORK_ERROR)
-        )
-      );
-      expect(isError).toStrictEqual(true);
-    });
-
-    it("should return false when not pot.error", () => {
-      expect(
-        isErrorPaginatedInstitutionsSelector(
-          appReducer(undefined, {} as Action)
-        )
-      ).toStrictEqual(false);
-
-      expect(
-        isErrorPaginatedInstitutionsSelector(
-          appReducer(
-            {} as GlobalState,
-            paginatedInstitutionsGet.success({
-              institutions: MOCK_INSTITUTIONS,
-              count: 23,
-              offset: 0,
-              limit: 3
-            })
-          )
-        )
-      ).toStrictEqual(false);
     });
   });
 

--- a/ts/features/services/home/store/reducers/index.ts
+++ b/ts/features/services/home/store/reducers/index.ts
@@ -15,10 +15,18 @@ import {
   paginatedInstitutionsGet
 } from "../actions";
 
+export type PaginatedInstitutionsError = {
+  reason: NetworkError;
+  time: Date;
+};
+
 export type ServicesHomeState = {
   featuredInstitutions: pot.Pot<Institutions, NetworkError>;
   featuredServices: pot.Pot<FeaturedServices, NetworkError>;
-  paginatedInstitutions: pot.Pot<InstitutionsResource, NetworkError>;
+  paginatedInstitutions: pot.Pot<
+    InstitutionsResource,
+    PaginatedInstitutionsError
+  >;
 };
 
 const INITIAL_STATE: ServicesHomeState = {
@@ -75,10 +83,10 @@ const homeReducer = (
     case getType(paginatedInstitutionsGet.failure):
       return {
         ...state,
-        paginatedInstitutions: pot.toError(
-          state.paginatedInstitutions,
-          action.payload
-        )
+        paginatedInstitutions: pot.toError(state.paginatedInstitutions, {
+          reason: action.payload,
+          time: new Date()
+        })
       };
 
     // Get FeaturedInstitutions actions
@@ -185,15 +193,6 @@ export const featuredServicesSelector = createSelector(
       []
     )
 );
-
-export const isLoadingPaginatedInstitutionsSelector = (state: GlobalState) =>
-  pipe(state, paginatedInstitutionsPotSelector, pot.isLoading);
-
-export const isUpdatingPaginatedInstitutionsSelector = (state: GlobalState) =>
-  pipe(state, paginatedInstitutionsPotSelector, pot.isUpdating);
-
-export const isErrorPaginatedInstitutionsSelector = (state: GlobalState) =>
-  pipe(state, paginatedInstitutionsPotSelector, pot.isError);
 
 export const isLoadingFeaturedInstitutionsSelector = (state: GlobalState) =>
   pipe(state, featuredInstitutionsPotSelector, pot.isLoading);


### PR DESCRIPTION
## Short description
This PR removes the control introduced in #5849 because when the user scrolls quickly down, the _distanceFromEnd_ value returned by the _onEndReached_ function becomes zero, preventing the next page from loading.
Additionally, if there was an error in the call to retrieve the institutions, we block the call and wait for a short period before allowing the request to be sent again.

## List of changes proposed in this pull request
- updated reducer
- removed `isLoadingPaginatedInstitutionsSelector`, `isUpdatingPaginatedInstitutionsSelector` and `isErrorPaginatedInstitutionsSelector`
- refactored `useInstitutionsFetcher` hook
- updated tests

## How to test
Navigate to the services home screen and scroll down quickly. Check that the next pages load correctly.
