### PR TITLE
chore: [IOBP-1149] Hide download receipt button if the transaction is of cart type

### DIFF
--- a/ts/features/payments/home/components/PaymentsHomeTransactionsList.tsx
+++ b/ts/features/payments/home/components/PaymentsHomeTransactionsList.tsx
@@ -67,7 +67,7 @@ const PaymentsHomeTransactionsList = ({ enforcedLoadingState }: Props) => {
   }, [dispatch, latestTransactionsPot]);
 
   const handleNavigateToTransactionDetails = useCallback(
-    ({ eventId, isPayer }: NoticeListItem) => {
+    ({ eventId, isPayer, isCart }: NoticeListItem) => {
       if (eventId === undefined) {
         return;
       }
@@ -75,7 +75,8 @@ const PaymentsHomeTransactionsList = ({ enforcedLoadingState }: Props) => {
         screen: PaymentsReceiptRoutes.PAYMENT_RECEIPT_DETAILS,
         params: {
           transactionId: eventId,
-          isPayer
+          isPayer,
+          isCart
         }
       });
     },

--- a/ts/features/payments/receipts/components/ReceiptInfoSection.tsx
+++ b/ts/features/payments/receipts/components/ReceiptInfoSection.tsx
@@ -15,7 +15,6 @@ import { capitalize } from "lodash";
 import { StyleSheet, View } from "react-native";
 import Placeholder from "rn-placeholder";
 
-import { OriginEnum } from "../../../../../definitions/pagopa/biz-events/InfoNotice";
 import { NoticeDetailResponse } from "../../../../../definitions/pagopa/biz-events/NoticeDetailResponse";
 import { WalletInfo } from "../../../../../definitions/pagopa/biz-events/WalletInfo";
 import { IOStyles } from "../../../../components/core/variables/IOStyles";
@@ -29,6 +28,7 @@ import { ReceiptDivider } from "./ReceiptDivider";
 type Props = {
   transaction?: NoticeDetailResponse;
   loading?: boolean;
+  showUnavailableReceiptBanner?: boolean;
 };
 
 const styles = StyleSheet.create({
@@ -46,7 +46,11 @@ const styles = StyleSheet.create({
 /**
  * Component that shows the biz-events transaction info
  */
-const ReceiptInfoSection = ({ transaction, loading }: Props) => {
+const ReceiptInfoSection = ({
+  transaction,
+  loading,
+  showUnavailableReceiptBanner
+}: Props) => {
   const theme = useIOTheme();
   const backgroundColor = IOColors[theme["appBackground-primary"]];
 
@@ -178,11 +182,14 @@ const ReceiptInfoSection = ({ transaction, loading }: Props) => {
             </>
           )}
         </View>
-        {transactionInfo?.origin === OriginEnum.PM && (
-          <Alert
-            variant="info"
-            content={I18n.t("transaction.details.bannerImported.content")}
-          />
+        {showUnavailableReceiptBanner && (
+          <>
+            <Alert
+              variant="info"
+              content={I18n.t("transaction.details.bannerImported.content")}
+            />
+            <VSpacer size={12} />
+          </>
         )}
       </View>
     </>

--- a/ts/features/payments/receipts/components/___tests___/ReceiptInfoSection.test.tsx
+++ b/ts/features/payments/receipts/components/___tests___/ReceiptInfoSection.test.tsx
@@ -39,7 +39,11 @@ describe("ReceiptInfoSection", () => {
 
   it("renders transaction information correctly when transaction data is provided", () => {
     const { getByText } = render(
-      <ReceiptInfoSection transaction={mockTransaction} loading={false} />
+      <ReceiptInfoSection
+        transaction={mockTransaction}
+        loading={false}
+        showUnavailableReceiptBanner
+      />
     );
 
     // Payer Info

--- a/ts/features/payments/receipts/screens/ReceiptDetailsScreen.tsx
+++ b/ts/features/payments/receipts/screens/ReceiptDetailsScreen.tsx
@@ -32,6 +32,7 @@ import {
 export type ReceiptDetailsScreenParams = {
   transactionId: string;
   isPayer?: boolean;
+  isCart?: boolean;
 };
 
 export type ReceiptDetailsScreenProps = RouteProp<
@@ -61,7 +62,7 @@ const ReceiptDetailsScreen = () => {
   const dispatch = useIODispatch();
   const navigation = useIONavigation();
   const route = useRoute<ReceiptDetailsScreenProps>();
-  const { transactionId, isPayer } = route.params;
+  const { transactionId, isPayer, isCart } = route.params;
   const paymentAnalyticsData = useIOSelector(paymentAnalyticsDataSelector);
   const transactionDetailsPot = useIOSelector(walletReceiptDetailsPotSelector);
   const transactionReceiptPot = useIOSelector(walletReceiptPotSelector);
@@ -151,12 +152,15 @@ const ReceiptDetailsScreen = () => {
     );
   }
 
+  const showGenerateReceiptButton =
+    transactionDetails?.infoNotice?.origin !== OriginEnum.PM && !isCart;
+
   return (
     <IOScrollView
       includeContentMargins={false}
       animatedRef={animatedScrollViewRef}
       actions={
-        transactionDetails?.infoNotice?.origin !== OriginEnum.PM
+        showGenerateReceiptButton
           ? {
               type: "SingleButton",
               primary: {
@@ -181,6 +185,7 @@ const ReceiptDetailsScreen = () => {
         />
         <WalletTransactionInfoSection
           transaction={transactionDetails}
+          showUnavailableReceiptBanner={!showGenerateReceiptButton}
           loading={isLoading}
         />
         <HideReceiptButton transactionId={transactionId} />

--- a/ts/features/payments/receipts/screens/ReceiptListScreen.tsx
+++ b/ts/features/payments/receipts/screens/ReceiptListScreen.tsx
@@ -77,7 +77,8 @@ const ReceiptListScreen = () => {
       screen: PaymentsReceiptRoutes.PAYMENT_RECEIPT_DETAILS,
       params: {
         transactionId: transaction.eventId,
-        isPayer: transaction.isPayer
+        isPayer: transaction.isPayer,
+        isCart: transaction.isCart
       }
     });
   };


### PR DESCRIPTION
## Short description
This PR hides the "Download receipt" button inside a receipt detail page if the transaction is a cart type. By definition a `cart type` transaction is a receipt with more than one item in the list.

## List of changes proposed in this pull request
- Hide the download button and show the unavailable receipt banner if `isCart`;

## How to test
- Start the dev-server;
- Open the `Payments` section;
- Open a detail of transaction marked as `Pagamento multiplo` and check that there isn't visible the download button and there is a banner explaining it.

## Preview

https://github.com/user-attachments/assets/8c22aeac-4e2d-48e3-9b2a-1737220ca877


