### PR TITLE
chore(IT Wallet): [SIW-1996] Bypass the screen capture block in dev mode

### DIFF
--- a/ts/utils/hooks/__tests__/usePreventScreenCapture.test.tsx
+++ b/ts/utils/hooks/__tests__/usePreventScreenCapture.test.tsx
@@ -8,6 +8,11 @@ import { applicationChangeState } from "../../../store/actions/application";
 import { renderScreenWithNavigationStoreContext } from "../../testWrapper";
 import { usePreventScreenCapture } from "../usePreventScreenCapture";
 
+jest.mock("../../environment", () => ({
+  ...jest.requireActual("../../environment"),
+  isDevEnv: false
+}));
+
 jest.mock("react-native-screenshot-prevent", () => ({
   enableSecureView: jest.fn(),
   disableSecureView: jest.fn()

--- a/ts/utils/hooks/usePreventScreenCapture.ts
+++ b/ts/utils/hooks/usePreventScreenCapture.ts
@@ -2,6 +2,7 @@ import { useFocusEffect } from "@react-navigation/native";
 import { useCallback, useMemo, useRef } from "react";
 import RNScreenshotPrevent from "react-native-screenshot-prevent";
 import uuid from "react-native-uuid";
+import { isDevEnv } from "../environment";
 
 const activeTags: Set<string> = new Set();
 
@@ -37,6 +38,10 @@ export function usePreventScreenCapture(key?: string) {
 
   useFocusEffect(
     useCallback(() => {
+      if (isDevEnv) {
+        return;
+      }
+
       clearTimeout(timeoutRef.current);
 
       preventScreenCapture(tag);


### PR DESCRIPTION
## Short description
This PR enables the screen capture in dev mode even when `usePreventScreenCapture` is used. This is useful for recording the screen during development.

## List of changes proposed in this pull request
- Check the value of `isDevEnv` in `usePreventScreenCapture`

## How to test
Take a screenshot in the credential detail screen while in dev mode: screenshots should be allowed.