### PR TITLE
style: [IOAPPX-473] Add dark mode support to the `ItwCredentialCard` component

### DIFF
--- a/ts/features/itwallet/common/components/ItwCredentialCard.tsx
+++ b/ts/features/itwallet/common/components/ItwCredentialCard.tsx
@@ -3,7 +3,7 @@ import { ImageSourcePropType, StyleSheet, View } from "react-native";
 import Color from "color";
 import { AnimatedImage } from "../../../../components/AnimatedImage";
 import {
-  borderColorByStatus,
+  useBorderColorByStatus,
   getCredentialNameFromType,
   tagPropsByStatus,
   validCredentialStatuses
@@ -65,6 +65,7 @@ export const ItwCredentialCard = ({
   status = "valid",
   credentialType
 }: ItwCredentialCard) => {
+  const borderColorMap = useBorderColorByStatus();
   const styleProps = getStyleProps(credentialType, status);
 
   const statusTagProps = tagPropsByStatus[status];
@@ -102,9 +103,7 @@ export const ItwCredentialCard = ({
         credentialType={credentialType}
         colorScheme={styleProps.tagColorScheme}
       />
-      <View
-        style={[styles.border, { borderColor: borderColorByStatus[status] }]}
-      />
+      <View style={[styles.border, { borderColor: borderColorMap[status] }]} />
     </View>
   );
 };
@@ -155,6 +154,7 @@ const styles = StyleSheet.create({
     top: 0,
     bottom: 0,
     borderRadius: 8,
+    borderCurve: "continuous",
     borderWidth: 2
   },
   header: {

--- a/ts/features/itwallet/common/components/ItwSkeumorphicCard/index.tsx
+++ b/ts/features/itwallet/common/components/ItwSkeumorphicCard/index.tsx
@@ -13,7 +13,7 @@ import Animated from "react-native-reanimated";
 import I18n from "../../../../../i18n";
 import { accessibilityLabelByStatus } from "../../utils/itwAccessibilityUtils";
 import {
-  borderColorByStatus,
+  useBorderColorByStatus,
   getCredentialNameFromType,
   tagPropsByStatus,
   validCredentialStatuses
@@ -119,8 +119,10 @@ type CardSideBaseProps = {
 };
 
 const CardSideBase = ({ status, children }: CardSideBaseProps) => {
+  const borderColorMap = useBorderColorByStatus();
+
   const statusTagProps = tagPropsByStatus[status];
-  const borderColor = borderColorByStatus[status];
+  const borderColor = borderColorMap[status];
 
   const dynamicStyle: StyleProp<ViewStyle> = {
     borderColor,

--- a/ts/features/itwallet/common/components/__tests__/__snapshots__/ItwCredentialCard.test.tsx.snap
+++ b/ts/features/itwallet/common/components/__tests__/__snapshots__/ItwCredentialCard.test.tsx.snap
@@ -154,6 +154,7 @@ exports[`ItwCredentialCard should match snapshot when credential type is "Europe
     style={
       [
         {
+          "borderCurve": "continuous",
           "borderRadius": 8,
           "borderWidth": 2,
           "bottom": 0,
@@ -325,6 +326,7 @@ exports[`ItwCredentialCard should match snapshot when credential type is "Europe
     style={
       [
         {
+          "borderCurve": "continuous",
           "borderRadius": 8,
           "borderWidth": 2,
           "bottom": 0,
@@ -496,6 +498,7 @@ exports[`ItwCredentialCard should match snapshot when credential type is "MDL" 1
     style={
       [
         {
+          "borderCurve": "continuous",
           "borderRadius": 8,
           "borderWidth": 2,
           "bottom": 0,
@@ -806,6 +809,7 @@ exports[`ItwCredentialCard should match snapshot when status is "expired" 1`] = 
     style={
       [
         {
+          "borderCurve": "continuous",
           "borderRadius": 8,
           "borderWidth": 2,
           "bottom": 0,
@@ -1102,6 +1106,7 @@ exports[`ItwCredentialCard should match snapshot when status is "expiring" 1`] =
     style={
       [
         {
+          "borderCurve": "continuous",
           "borderRadius": 8,
           "borderWidth": 2,
           "bottom": 0,
@@ -1287,6 +1292,7 @@ exports[`ItwCredentialCard should match snapshot when status is "pending" 1`] = 
     style={
       [
         {
+          "borderCurve": "continuous",
           "borderRadius": 8,
           "borderWidth": 2,
           "bottom": 0,
@@ -1597,6 +1603,7 @@ exports[`ItwCredentialCard should match snapshot when status is "unknown" 1`] = 
     style={
       [
         {
+          "borderCurve": "continuous",
           "borderRadius": 8,
           "borderWidth": 2,
           "bottom": 0,
@@ -1768,6 +1775,7 @@ exports[`ItwCredentialCard should match snapshot when status is "valid" 1`] = `
     style={
       [
         {
+          "borderCurve": "continuous",
           "borderRadius": 8,
           "borderWidth": 2,
           "bottom": 0,

--- a/ts/features/itwallet/common/utils/itwCredentialUtils.ts
+++ b/ts/features/itwallet/common/utils/itwCredentialUtils.ts
@@ -30,17 +30,19 @@ export const getCredentialNameFromType = (
     O.getOrElse(() => withDefault)
   );
 
-export const useBorderColorByStatus: () => { [key in ItwCredentialStatus]: string } = () => {
+export const useBorderColorByStatus: () => {
+  [key in ItwCredentialStatus]: string;
+} = () => {
   const theme = useIOTheme();
 
   return {
-  valid: IOColors[theme["appBackground-primary"]],
-  invalid: IOColors["error-600"],
-  expired: IOColors["error-600"],
-  expiring: IOColors["warning-700"],
-  jwtExpired: IOColors["error-600"],
-  jwtExpiring: IOColors["warning-700"],
-  unknown: IOColors["grey-300"]
+    valid: IOColors[theme["appBackground-primary"]],
+    invalid: IOColors["error-600"],
+    expired: IOColors["error-600"],
+    expiring: IOColors["warning-700"],
+    jwtExpired: IOColors["error-600"],
+    jwtExpiring: IOColors["warning-700"],
+    unknown: IOColors["grey-300"]
   };
 };
 

--- a/ts/features/itwallet/common/utils/itwCredentialUtils.ts
+++ b/ts/features/itwallet/common/utils/itwCredentialUtils.ts
@@ -1,4 +1,4 @@
-import { IOColors, Tag } from "@pagopa/io-app-design-system";
+import { IOColors, Tag, useIOTheme } from "@pagopa/io-app-design-system";
 import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
 import I18n from "../../../../i18n";
@@ -30,14 +30,18 @@ export const getCredentialNameFromType = (
     O.getOrElse(() => withDefault)
   );
 
-export const borderColorByStatus: { [key in ItwCredentialStatus]: string } = {
-  valid: IOColors.white,
+export const useBorderColorByStatus: () => { [key in ItwCredentialStatus]: string } = () => {
+  const theme = useIOTheme();
+
+  return {
+  valid: IOColors[theme["appBackground-primary"]],
   invalid: IOColors["error-600"],
   expired: IOColors["error-600"],
   expiring: IOColors["warning-700"],
   jwtExpired: IOColors["error-600"],
   jwtExpiring: IOColors["warning-700"],
   unknown: IOColors["grey-300"]
+  };
 };
 
 export const tagPropsByStatus: { [key in ItwCredentialStatus]?: Tag } = {

--- a/ts/features/payments/common/components/PaymentCard.tsx
+++ b/ts/features/payments/common/components/PaymentCard.tsx
@@ -204,6 +204,7 @@ const styles = StyleSheet.create({
     backgroundColor: IOColors["grey-100"],
     borderRadius: 8,
     borderWidth: 1,
+    borderCurve: "continuous",
     borderColor: IOColors["grey-200"]
   },
   expiredCard: {

--- a/ts/features/payments/common/components/__tests__/__snapshots__/PaymentCard.test.tsx.snap
+++ b/ts/features/payments/common/components/__tests__/__snapshots__/PaymentCard.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`PaymentCard should match snapshot for loading 1`] = `
       "aspectRatio": 1.6,
       "backgroundColor": "#E8EBF1",
       "borderColor": "#D2D6E3",
+      "borderCurve": "continuous",
       "borderRadius": 8,
       "borderWidth": 1,
       "padding": 16,


### PR DESCRIPTION
## Short description
This PR adds a proper dark mode support to the `ItwCredentialCard` component.

## List of changes proposed in this pull request
- To get the correct theme color values, convert the `borderColorByStatus` function to the `useBorderColorByStatus` hook
- **[extra]** Add smooth corners to the wallet cards (iOS only)

### Preview

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-28 at 10 16 12](https://github.com/user-attachments/assets/efce5f5e-c1ce-4e2e-904e-17b588f78522) | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-28 at 10 14 59](https://github.com/user-attachments/assets/015e561d-fb6d-4c27-8405-3e39b18b30f0) | 


## How to test
Launch the app in your local environment, switch to the dark mode and go to the **Wallet** section of the Design System