### PR TITLE
refactor: [IOBP-1168] Replaced `GradientScrollView` with `IOScrollView` into PSP selection screen

### DIFF
--- a/ts/features/payments/checkout/screens/WalletPaymentPickPspScreen.tsx
+++ b/ts/features/payments/checkout/screens/WalletPaymentPickPspScreen.tsx
@@ -1,6 +1,5 @@
 import {
   Body,
-  GradientScrollView,
   H2,
   ListItemHeader,
   RadioGroup,
@@ -35,6 +34,7 @@ import {
 import { WalletPaymentPspSortType, WalletPaymentStepEnum } from "../types";
 import { FaultCodeCategoryEnum } from "../types/PspPaymentMethodNotAvailableProblemJson";
 import { WalletPaymentFailure } from "../types/WalletPaymentFailure";
+import { IOScrollView } from "../../../../components/ui/IOScrollView";
 
 const WalletPaymentPickPspScreen = () => {
   const dispatch = useIODispatch();
@@ -189,15 +189,18 @@ const WalletPaymentPickPspScreen = () => {
   );
 
   return (
-    <GradientScrollView
-      primaryActionProps={
+    <IOScrollView
+      actions={
         canContinue
           ? {
-              label: I18n.t("wallet.payment.psp.continueButton"),
-              accessibilityLabel: I18n.t("wallet.payment.psp.continueButton"),
-              onPress: handleContinue,
-              disabled: isLoading,
-              loading: isLoading
+              type: "SingleButton",
+              primary: {
+                label: I18n.t("wallet.payment.psp.continueButton"),
+                accessibilityLabel: I18n.t("wallet.payment.psp.continueButton"),
+                onPress: handleContinue,
+                disabled: isLoading,
+                loading: isLoading
+              }
             }
           : undefined
       }
@@ -213,7 +216,7 @@ const WalletPaymentPickPspScreen = () => {
       )}
       {isLoading && <WalletPspListSkeleton />}
       {sortPspBottomSheet}
-    </GradientScrollView>
+    </IOScrollView>
   );
 };
 


### PR DESCRIPTION
## Short description
This PR replaces the `GradientScrollView` with `IOScrollView` component in order to hide the gradient at the bottom and allowing to see the entire PSP list.

## List of changes proposed in this pull request
- Replaced the `GradientScrollView` with `IOScrollView`;

## How to test
Start a payment flow and reach the PSP selection step;

## Preview
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/d09c89a0-1658-4824-a8ce-09cd91807241" width="350px" />|<img src="https://github.com/user-attachments/assets/7d7e4a17-7ff4-44bb-ad15-2361392d81da" width="350px" />|


