### PR TITLE
refactor: [IOBP-1170] Align IDPay screen to design requirements

### DIFF
--- a/ts/features/idpay/details/components/InitiativeRulesInfoBox.tsx
+++ b/ts/features/idpay/details/components/InitiativeRulesInfoBox.tsx
@@ -2,6 +2,7 @@ import {
   Body,
   ButtonSolid,
   ContentWrapper,
+  FooterActions,
   H6,
   HSpacer,
   IOColors,
@@ -27,21 +28,17 @@ const InitiativeRulesInfoBox = (props: Props) => {
       component: <IOMarkdown content={content} />,
       title: I18n.t("idpay.initiative.beneficiaryDetails.infoModal.title"),
       footer: (
-        // TODO: Replace this chunk of code using `FooterActions`
-        <ContentWrapper>
-          <VSpacer size={24} />
-          <ButtonSolid
-            label={I18n.t(
-              "idpay.initiative.beneficiaryDetails.infoModal.button"
-            )}
-            onPress={() => dismiss()}
-            accessibilityLabel={I18n.t(
-              "idpay.initiative.beneficiaryDetails.infoModal.button"
-            )}
-            fullWidth={true}
-          />
-          <VSpacer size={24} />
-        </ContentWrapper>
+        <FooterActions
+          actions={{
+            type: "SingleButton",
+            primary: {
+              label: I18n.t(
+                "idpay.initiative.beneficiaryDetails.infoModal.button"
+              ),
+              onPress: () => dismiss()
+            }
+          }}
+        />
       )
     },
     170

--- a/ts/features/idpay/details/components/InitiativeRulesInfoBox.tsx
+++ b/ts/features/idpay/details/components/InitiativeRulesInfoBox.tsx
@@ -1,7 +1,5 @@
 import {
   Body,
-  ButtonSolid,
-  ContentWrapper,
   FooterActions,
   H6,
   HSpacer,

--- a/ts/features/idpay/onboarding/screens/PDNDPrerequisitesScreen.tsx
+++ b/ts/features/idpay/onboarding/screens/PDNDPrerequisitesScreen.tsx
@@ -1,6 +1,5 @@
 import {
-  ButtonSolid,
-  ContentWrapper,
+  FooterActions,
   ModuleSummary,
   VSpacer
 } from "@pagopa/io-app-design-system";
@@ -57,21 +56,17 @@ export const PDNDPrerequisitesScreen = () => {
         />
       ),
       footer: (
-        // TODO: Replace this chunk of code using `FooterActions`
-        <ContentWrapper>
-          <VSpacer size={16} />
-          <ButtonSolid
-            fullWidth
-            label={I18n.t(
-              "idpay.onboarding.PDNDPrerequisites.prerequisites.info.understoodCTA"
-            )}
-            accessibilityLabel={I18n.t(
-              "idpay.onboarding.PDNDPrerequisites.prerequisites.info.understoodCTA"
-            )}
-            onPress={() => dismiss()}
-          />
-          <VSpacer size={16} />
-        </ContentWrapper>
+        <FooterActions
+          actions={{
+            primary: {
+              label: I18n.t(
+                "idpay.onboarding.PDNDPrerequisites.prerequisites.info.understoodCTA"
+              ),
+              onPress: () => dismiss()
+            },
+            type: "SingleButton"
+          }}
+        />
       )
     },
     162

--- a/ts/features/idpay/payment/navigation/navigator.tsx
+++ b/ts/features/idpay/payment/navigation/navigator.tsx
@@ -24,7 +24,7 @@ const InnerNavigation = () => {
     <IdPayPaymentMachineProvider>
       <Stack.Navigator
         initialRouteName={IdPayPaymentRoutes.IDPAY_PAYMENT_CODE_INPUT}
-        screenOptions={{ gestureEnabled: false, headerShown: false }}
+        screenOptions={{ gestureEnabled: false }}
         screenListeners={{
           beforeRemove: () => {
             // Read more on https://reactnavigation.org/docs/preventing-going-back/
@@ -42,10 +42,12 @@ const InnerNavigation = () => {
         <Stack.Screen
           name={IdPayPaymentRoutes.IDPAY_PAYMENT_AUTHORIZATION}
           component={IDPayPaymentAuthorizationScreen}
+          options={{ headerShown: false }}
         />
         <Stack.Screen
           name={IdPayPaymentRoutes.IDPAY_PAYMENT_RESULT}
           component={IDPayPaymentResultScreen}
+          options={{ headerShown: false }}
         />
       </Stack.Navigator>
     </IdPayPaymentMachineProvider>

--- a/ts/features/idpay/payment/navigation/navigator.tsx
+++ b/ts/features/idpay/payment/navigation/navigator.tsx
@@ -42,7 +42,6 @@ const InnerNavigation = () => {
         <Stack.Screen
           name={IdPayPaymentRoutes.IDPAY_PAYMENT_AUTHORIZATION}
           component={IDPayPaymentAuthorizationScreen}
-          options={{ headerShown: false }}
         />
         <Stack.Screen
           name={IdPayPaymentRoutes.IDPAY_PAYMENT_RESULT}

--- a/ts/features/idpay/payment/screens/IDPayPaymentAuthorizationScreen.tsx
+++ b/ts/features/idpay/payment/screens/IDPayPaymentAuthorizationScreen.tsx
@@ -151,7 +151,6 @@ const AuthorizationScreenContent = ({
     <VSpacer size={24} />
     <ListItemHeader
       label={I18n.t("idpay.payment.authorization.infoDivider")}
-      iconColor="bluegrey"
       iconName="initiatives"
     />
     <ListItemInfo

--- a/ts/features/idpay/payment/screens/IDPayPaymentAuthorizationScreen.tsx
+++ b/ts/features/idpay/payment/screens/IDPayPaymentAuthorizationScreen.tsx
@@ -1,11 +1,8 @@
 import {
-  ContentWrapper,
   Divider,
-  FooterActionsInline,
   H2,
   H6,
-  HSpacer,
-  Icon,
+  ListItemHeader,
   ListItemInfo,
   VSpacer
 } from "@pagopa/io-app-design-system";
@@ -13,10 +10,10 @@ import { RouteProp, useRoute } from "@react-navigation/native";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
 import { useEffect } from "react";
-import { SafeAreaView, View } from "react-native";
+import { View } from "react-native";
 import { AuthPaymentResponseDTO } from "../../../../../definitions/idpay/AuthPaymentResponseDTO";
 import { IOStyles } from "../../../../components/core/variables/IOStyles";
-import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
+import { IOScrollViewWithLargeHeader } from "../../../../components/ui/IOScrollViewWithLargeHeader";
 import I18n from "../../../../i18n";
 import { identificationRequest } from "../../../../store/actions/identification";
 import { useIODispatch } from "../../../../store/hooks";
@@ -92,40 +89,31 @@ const IDPayPaymentAuthorizationScreen = () => {
     return <AuthorizationScreenSkeleton />;
   };
 
-  useHeaderSecondLevel({
-    title: "Autorizza operazione",
-    canGoBack: false,
-    contextualHelp: emptyContextualHelp,
-    supportRequest: true
-  });
-
   return (
-    <>
-      <SafeAreaView style={IOStyles.flex}>
-        <View style={IOStyles.flex}>
-          <ContentWrapper>
-            <H2>{I18n.t("idpay.payment.authorization.header")}</H2>
-            <VSpacer size={24} />
-            {renderContent()}
-          </ContentWrapper>
-        </View>
-      </SafeAreaView>
-      <FooterActionsInline
-        startAction={{
-          color: "primary",
-          label: isCancelling ? "" : I18n.t("global.buttons.deny"),
-          onPress: handleCancel,
-          disabled: isLoading
-        }}
-        endAction={{
-          color: "primary",
+    <IOScrollViewWithLargeHeader
+      canGoback={false}
+      contextualHelp={emptyContextualHelp}
+      headerActionsProp={{ showHelp: true }}
+      title={{
+        label: I18n.t("idpay.payment.authorization.header")
+      }}
+      actions={{
+        type: "TwoButtons",
+        primary: {
           label: I18n.t("global.buttons.confirm"),
           onPress: handleConfirm,
-          loading: isAuthorizing,
-          disabled: isLoading
-        }}
-      />
-    </>
+          disabled: isLoading || isAuthorizing
+        },
+        secondary: {
+          label: I18n.t("global.buttons.deny"),
+          onPress: handleCancel,
+          disabled: isLoading || isCancelling
+        }
+      }}
+      includeContentMargins
+    >
+      {renderContent()}
+    </IOScrollViewWithLargeHeader>
   );
 };
 
@@ -161,25 +149,11 @@ const AuthorizationScreenContent = ({
       accessibilityLabel={I18n.t("idpay.payment.authorization.dateTime")}
     />
     <VSpacer size={24} />
-    {/* TODO:: will be removed in favor of LIST_GROUP_HEADING in future updates */}
-    <View style={[IOStyles.row, IOStyles.alignCenter]}>
-      <Icon name="initiatives" size={24} color="bluegrey" />
-      <HSpacer size={16} />
-      <H6
-        color="bluegrey"
-        style={{
-          // this should not happen, but the current typography adds 4
-          // to paddingBottom because of line height
-          // so we add 4 to paddingTop to compensate, else the text would not be centered
-          // (this was temporarily approved by @dmnplb)
-          paddingTop: 4
-        }}
-      >
-        {I18n.t("idpay.payment.authorization.infoDivider")}
-      </H6>
-    </View>
-    <VSpacer size={16} />
-
+    <ListItemHeader
+      label={I18n.t("idpay.payment.authorization.infoDivider")}
+      iconColor="bluegrey"
+      iconName="initiatives"
+    />
     <ListItemInfo
       label={I18n.t("idpay.payment.authorization.initiativeName")}
       value={data.initiativeName || "-"}
@@ -223,19 +197,11 @@ const AuthorizationScreenSkeleton = () => (
       accessibilityLabel={I18n.t("idpay.payment.authorization.dateTime")}
     />
     <VSpacer size={24} />
-    <View style={[IOStyles.row, IOStyles.alignCenter]}>
-      <Icon name="initiatives" size={24} color="bluegrey" />
-      <HSpacer size={16} />
-      <H6
-        color="bluegrey"
-        style={{
-          // see previous comment
-          paddingTop: 4
-        }}
-      >
-        {I18n.t("idpay.payment.authorization.infoDivider")}
-      </H6>
-    </View>
+    <ListItemHeader
+      label={I18n.t("idpay.payment.authorization.infoDivider")}
+      iconColor="bluegrey"
+      iconName="initiatives"
+    />
     <VSpacer size={16} />
     <ListItemInfo
       label={I18n.t("idpay.payment.authorization.initiativeName")}

--- a/ts/features/idpay/payment/screens/IDPayPaymentCodeInputScreen.tsx
+++ b/ts/features/idpay/payment/screens/IDPayPaymentCodeInputScreen.tsx
@@ -1,20 +1,10 @@
-import {
-  Body,
-  FooterActions,
-  H2,
-  IOColors,
-  IOStyles,
-  IOVisualCostants,
-  TextInput,
-  VSpacer
-} from "@pagopa/io-app-design-system";
+import { TextInput } from "@pagopa/io-app-design-system";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
 import { useState } from "react";
-import { SafeAreaView, StatusBar, StyleSheet, View } from "react-native";
-import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
+import { IOScrollViewWithLargeHeader } from "../../../../components/ui/IOScrollViewWithLargeHeader";
 import I18n from "../../../../i18n";
 import { emptyContextualHelp } from "../../../../utils/emptyContextualHelp";
 import { isLoadingSelector } from "../../common/machine/selectors";
@@ -46,67 +36,49 @@ const IDPayPaymentCodeInputScreen = () => {
       O.map(trxCode => machine.send({ type: "authorize-payment", trxCode }))
     );
 
-  useHeaderSecondLevel({
-    title: I18n.t("idpay.payment.manualInput.title"),
-    canGoBack: true,
-    contextualHelp: emptyContextualHelp,
-    supportRequest: true
-  });
-
   return (
-    <>
-      <StatusBar
-        barStyle={"dark-content"}
-        translucent={false}
-        backgroundColor={IOColors.white}
+    <IOScrollViewWithLargeHeader
+      title={{
+        label: I18n.t("idpay.payment.manualInput.title")
+      }}
+      description={I18n.t("idpay.payment.manualInput.subtitle")}
+      actions={{
+        type: "SingleButton",
+        primary: {
+          label: I18n.t("idpay.payment.manualInput.button"),
+          disabled: !isInputValid || isLoading,
+          onPress: navigateToPaymentAuthorization,
+          loading: isLoading
+        }
+      }}
+      contextualHelp={emptyContextualHelp}
+      headerActionsProp={{ showHelp: true }}
+      includeContentMargins
+    >
+      <TextInput
+        textInputProps={{
+          inputMode: "text",
+          autoCapitalize: "characters",
+          autoCorrect: false
+        }}
+        onChangeText={value => {
+          setInputState({
+            value,
+            code: pipe(
+              value,
+              O.fromNullable,
+              O.filter(NonEmptyString.is),
+              O.map(IDPayTransactionCode.decode)
+            )
+          });
+        }}
+        placeholder={I18n.t("idpay.payment.manualInput.input")}
+        accessibilityLabel={I18n.t("idpay.payment.manualInput.input")}
+        value={inputState.value ?? ""}
+        counterLimit={8}
       />
-      <SafeAreaView style={IOStyles.flex}>
-        <View style={styles.wrapper}>
-          <H2>{I18n.t("idpay.payment.manualInput.title")}</H2>
-          <VSpacer size={16} />
-          <Body>{I18n.t("idpay.payment.manualInput.subtitle")}</Body>
-          <VSpacer size={40} />
-          <TextInput
-            textInputProps={{
-              inputMode: "text",
-              autoCapitalize: "characters",
-              autoCorrect: false
-            }}
-            onChangeText={value => {
-              setInputState({
-                value,
-                code: pipe(
-                  value,
-                  O.fromNullable,
-                  O.filter(NonEmptyString.is),
-                  O.map(IDPayTransactionCode.decode)
-                )
-              });
-            }}
-            placeholder={I18n.t("idpay.payment.manualInput.input")}
-            accessibilityLabel={I18n.t("idpay.payment.manualInput.input")}
-            value={inputState.value ?? ""}
-            counterLimit={8}
-          />
-        </View>
-        <FooterActions
-          actions={{
-            type: "SingleButton",
-            primary: {
-              label: I18n.t("idpay.payment.manualInput.button"),
-              disabled: !isInputValid || isLoading,
-              onPress: navigateToPaymentAuthorization,
-              loading: isLoading
-            }
-          }}
-        />
-      </SafeAreaView>
-    </>
+    </IOScrollViewWithLargeHeader>
   );
 };
-
-const styles = StyleSheet.create({
-  wrapper: { flex: 1, marginHorizontal: IOVisualCostants.appMarginDefault }
-});
 
 export { IDPayPaymentCodeInputScreen };

--- a/ts/features/idpay/unsubscription/navigation/navigator.tsx
+++ b/ts/features/idpay/unsubscription/navigation/navigator.tsx
@@ -11,7 +11,6 @@ export const IdPayUnsubscriptionNavigator = () => (
     initialRouteName={
       IdPayUnsubscriptionRoutes.IDPAY_UNSUBSCRIPTION_CONFIRMATION
     }
-    screenOptions={{ headerShown: false }}
   >
     <Stack.Screen
       name={IdPayUnsubscriptionRoutes.IDPAY_UNSUBSCRIPTION_CONFIRMATION}
@@ -20,6 +19,7 @@ export const IdPayUnsubscriptionNavigator = () => (
     <Stack.Screen
       name={IdPayUnsubscriptionRoutes.IDPAY_UNSUBSCRIPTION_RESULT}
       component={UnsubscriptionResultScreen}
+      options={{ headerShown: false }}
     />
   </Stack.Navigator>
 );

--- a/ts/features/idpay/unsubscription/screens/UnsubscriptionConfirmationScreen.tsx
+++ b/ts/features/idpay/unsubscription/screens/UnsubscriptionConfirmationScreen.tsx
@@ -1,19 +1,15 @@
 import {
   Body,
-  ContentWrapper,
   FooterActionsInline,
-  H2,
   VSpacer
 } from "@pagopa/io-app-design-system";
 import { RouteProp, useRoute } from "@react-navigation/native";
 import { useEffect } from "react";
-import { SafeAreaView, View } from "react-native";
-import { ScrollView } from "react-native-gesture-handler";
+import { View } from "react-native";
 import { InitiativeRewardTypeEnum } from "../../../../../definitions/idpay/InitiativeDTO";
 import LoadingSpinnerOverlay from "../../../../components/LoadingSpinnerOverlay";
-import { IOStyles } from "../../../../components/core/variables/IOStyles";
+import { IOScrollViewWithLargeHeader } from "../../../../components/ui/IOScrollViewWithLargeHeader";
 import { useConfirmationChecks } from "../../../../hooks/useConfirmationChecks";
-import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
 import I18n from "../../../../i18n";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { useIODispatch, useIOSelector } from "../../../../store/hooks";
@@ -134,48 +130,37 @@ const UnsubscriptionConfirmationScreen = () => {
   );
 
   const body = (
-    <SafeAreaView style={IOStyles.flex}>
-      <ScrollView>
-        <ContentWrapper>
-          <VSpacer size={16} />
-          <H2>{I18n.t("idpay.unsubscription.title", { initiativeName })}</H2>
-          <VSpacer size={16} />
-          <Body>{I18n.t("idpay.unsubscription.subtitle")}</Body>
-          <VSpacer size={16} />
-          {unsubscriptionChecks.map((item, index) => (
-            <UnsubscriptionCheckListItem
-              key={index}
-              title={item.title}
-              subtitle={item.subtitle}
-              checked={checks.values[index]}
-              onValueChange={value => checks.setValue(index, value)}
-            />
-          ))}
-          <VSpacer size={48} />
-        </ContentWrapper>
-      </ScrollView>
-      <FooterActionsInline
-        startAction={{
-          color: "primary",
-          label: I18n.t("global.buttons.cancel"),
-          onPress: handleClosePress
-        }}
-        endAction={{
-          color: checks.areFulfilled ? "danger" : "primary",
+    <IOScrollViewWithLargeHeader
+      goBack={handleClosePress}
+      contextualHelp={emptyContextualHelp}
+      headerActionsProp={{
+        showHelp: true
+      }}
+      title={{
+        label: I18n.t("idpay.unsubscription.title", { initiativeName })
+      }}
+      description={I18n.t("idpay.unsubscription.subtitle")}
+      actions={{
+        type: "SingleButton",
+        primary: {
           label: I18n.t("idpay.unsubscription.button.continue"),
           onPress: confirmModal.present,
           disabled: !checks.areFulfilled
-        }}
-      />
-    </SafeAreaView>
+        }
+      }}
+      includeContentMargins
+    >
+      {unsubscriptionChecks.map((item, index) => (
+        <UnsubscriptionCheckListItem
+          key={index}
+          title={item.title}
+          subtitle={item.subtitle}
+          checked={checks.values[index]}
+          onValueChange={value => checks.setValue(index, value)}
+        />
+      ))}
+    </IOScrollViewWithLargeHeader>
   );
-
-  useHeaderSecondLevel({
-    title: I18n.t("idpay.unsubscription.headerTitle"),
-    goBack: handleClosePress,
-    contextualHelp: emptyContextualHelp,
-    supportRequest: true
-  });
 
   return (
     <>

--- a/ts/features/idpay/unsubscription/screens/UnsubscriptionResultScreen.tsx
+++ b/ts/features/idpay/unsubscription/screens/UnsubscriptionResultScreen.tsx
@@ -1,25 +1,16 @@
-import {
-  Body,
-  ButtonOutline,
-  H6,
-  IOPictograms,
-  IOStyles,
-  Pictogram,
-  VSpacer
-} from "@pagopa/io-app-design-system";
-import { SafeAreaView, StyleSheet, View } from "react-native";
+import { IOPictograms } from "@pagopa/io-app-design-system";
+import { OperationResultScreenContent } from "../../../../components/screens/OperationResultScreenContent";
 import I18n from "../../../../i18n";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import ROUTES from "../../../../navigation/routes";
 import { useIODispatch, useIOSelector } from "../../../../store/hooks";
-import themeVariables from "../../../../theme/variables";
-import { isFailureSelector } from "../store/selectors";
 import { idPayUnsubscribeAction } from "../store/actions";
+import { isFailureSelector } from "../store/selectors";
 
 type ScreenContentType = {
   pictogram: IOPictograms;
   title: string;
-  content: string;
+  subtitle: string;
   buttonLabel: string;
 };
 
@@ -28,18 +19,18 @@ const UnsubscriptionResultScreen = () => {
   const navigation = useIONavigation();
   const isFailure = useIOSelector(isFailureSelector);
 
-  const { pictogram, title, content, buttonLabel }: ScreenContentType =
+  const { pictogram, title, subtitle, buttonLabel }: ScreenContentType =
     isFailure
       ? {
           pictogram: "umbrellaNew",
           title: I18n.t("idpay.unsubscription.failure.title"),
-          content: I18n.t("idpay.unsubscription.failure.content"),
+          subtitle: I18n.t("idpay.unsubscription.failure.content"),
           buttonLabel: I18n.t("idpay.unsubscription.failure.button")
         }
       : {
-          pictogram: "completed",
+          pictogram: "success",
           title: I18n.t("idpay.unsubscription.success.title"),
-          content: I18n.t("idpay.unsubscription.success.content"),
+          subtitle: I18n.t("idpay.unsubscription.success.content"),
           buttonLabel: I18n.t("idpay.unsubscription.success.button")
         };
 
@@ -57,37 +48,16 @@ const UnsubscriptionResultScreen = () => {
   };
 
   return (
-    <SafeAreaView style={[IOStyles.flex, { flexGrow: 1 }]}>
-      <View style={[styles.wrapper, IOStyles.horizontalContentPadding]}>
-        <View style={styles.content}>
-          <Pictogram name={pictogram} size={80} />
-          <VSpacer size={16} />
-          <H6>{title}</H6>
-          <VSpacer size={16} />
-          <Body style={{ textAlign: "center" }}>{content}</Body>
-        </View>
-        <ButtonOutline
-          color="primary"
-          label={buttonLabel}
-          accessibilityLabel={buttonLabel}
-          onPress={handleButtonPress}
-          fullWidth={true}
-        />
-      </View>
-    </SafeAreaView>
+    <OperationResultScreenContent
+      pictogram={pictogram}
+      title={title}
+      subtitle={subtitle}
+      action={{
+        label: buttonLabel,
+        onPress: handleButtonPress
+      }}
+    />
   );
 };
-
-const styles = StyleSheet.create({
-  wrapper: {
-    flexGrow: 1
-  },
-  content: {
-    flexGrow: 1,
-    alignItems: "center",
-    justifyContent: "center",
-    paddingHorizontal: themeVariables.contentPadding
-  }
-});
 
 export default UnsubscriptionResultScreen;


### PR DESCRIPTION
## Short description
This pull request is refactoring and improving the consistency of the UI components across various screens in the `idpay` feature replacing custom layout components with standardized ones from the design system and adjusting the navigation options

## List of changes proposed in this pull request
- Replaced custom `ContentWrapper` and `ButtonSolid` components with `FooterActions`
- Replaced `ContentWrapper`, `FooterActionsInline`, and custom header with `IOScrollViewWithLargeHeader` and `ListItemHeader` for a more standardized header and footer layout 

## How to test
Check refactored screen and ensure everything work properly

## Preview

| `IDPAY_UNSUBSCRIPTION_CONFIRMATION` | `IDPAY_UNSUBSCRIPTION_CONFIRMATION` modal | `IDPAY_DETAILS_BENEFICIARY` modal |`IDPAY_PAYMENT_CODE_INPUT`|`IDPAY_PAYMENT_AUTHORIZATION`|
|--------|--------|--------|--------|--------|
| <img  alt="Screenshot 2025-01-31 at 13 44 16" src="https://github.com/user-attachments/assets/ed35adc0-c9ae-4a52-ad91-6b2039f1e105" /> | <img  alt="Screenshot 2025-01-31 at 13 45 04" src="https://github.com/user-attachments/assets/f2a0aaf0-bb68-407b-8eae-a9ed6f45ac5b" />| <img alt="Screenshot 2025-01-31 at 13 43 25" src="https://github.com/user-attachments/assets/4a12ba54-f0ca-4043-a6c4-1be51b8412b4" /> | <img alt="Screenshot 2025-01-31 at 13 46 56" src="https://github.com/user-attachments/assets/20a420b9-c039-4422-b4b3-dbf94e115389" /> | <img alt="Screenshot 2025-01-31 at 13 47 51" src="https://github.com/user-attachments/assets/c027a53e-73ca-4a3c-ab42-028681d166b0" />|

