### PR TITLE
fix: [IOBP-1162] Add missing `a11y` label in `PAYMENTS_HOME`

### DIFF
--- a/ts/features/payments/home/components/PaymentsHomeTransactionsList.tsx
+++ b/ts/features/payments/home/components/PaymentsHomeTransactionsList.tsx
@@ -166,7 +166,10 @@ const PaymentsHomeTransactionsList = ({ enforcedLoadingState }: Props) => {
                 type: "buttonLink",
                 componentProps: {
                   label: I18n.t("features.payments.transactions.button"),
-                  onPress: handleNavigateToTransactionList
+                  onPress: handleNavigateToTransactionList,
+                  accessibilityLabel: I18n.t(
+                    "features.payments.transactions.button"
+                  )
                 }
               }
             : undefined

--- a/ts/features/payments/home/components/PaymentsHomeUserMethodsList.tsx
+++ b/ts/features/payments/home/components/PaymentsHomeUserMethodsList.tsx
@@ -175,7 +175,8 @@ const PaymentsHomeUserMethodsList = ({ enforcedLoadingState }: Props) => {
                 type: "buttonLink",
                 componentProps: {
                   label: I18n.t("features.payments.methods.button"),
-                  onPress: handleOnAddMethodPress
+                  onPress: handleOnAddMethodPress,
+                  accessibilityLabel: I18n.t("features.payments.methods.button")
                 }
               }
             : undefined


### PR DESCRIPTION
## Short description
This pull request includes accessibility improvements to the `PAYMENTS_HOME` screen.


## List of changes proposed in this pull request
- Added missing `accessibilityLabel` to `endElement` prop

## How to test
- Using a real device 📱, go to the `PAYMENTS_HOME` screen
- Turn on the TalkBack accessibility tool
- Tap `Aggiungi` and check if it is read correctly.
- Tap `Vedi tutte` and check if it is read correctly.

