### PR TITLE
fix: [IOBP-1157] Correct `a11y` label in `PAYMENT_NOTICE_SUMMARY`

### DIFF
--- a/ts/features/payments/checkout/screens/WalletPaymentDetailScreen.tsx
+++ b/ts/features/payments/checkout/screens/WalletPaymentDetailScreen.tsx
@@ -322,7 +322,6 @@ const WalletPaymentDetailContent = ({
         testID="wallet-payment-detail-recipient"
         icon={"institution"}
         label={I18n.t("wallet.firstTransactionSummary.recipient")}
-        accessibilityLabel={I18n.t("wallet.firstTransactionSummary.recipient")}
         value={payment.paName}
       />
       <Divider />
@@ -330,7 +329,6 @@ const WalletPaymentDetailContent = ({
         testID="wallet-payment-detail-object"
         icon={"notes"}
         label={I18n.t("wallet.firstTransactionSummary.object")}
-        accessibilityLabel={I18n.t("wallet.firstTransactionSummary.object")}
         value={description}
       />
       <Divider />
@@ -338,7 +336,6 @@ const WalletPaymentDetailContent = ({
         testID="wallet-payment-detail-amount"
         icon={"psp"}
         label={I18n.t("wallet.firstTransactionSummary.amount")}
-        accessibilityLabel={I18n.t("wallet.firstTransactionSummary.amount")}
         value={amount}
         endElement={amountEndElement}
       />
@@ -348,9 +345,6 @@ const WalletPaymentDetailContent = ({
           <ListItemInfo
             icon="calendar"
             label={I18n.t("wallet.firstTransactionSummary.dueDate")}
-            accessibilityLabel={I18n.t(
-              "wallet.firstTransactionSummary.dueDate"
-            )}
             value={dueDate}
           />
           <Divider />
@@ -360,7 +354,6 @@ const WalletPaymentDetailContent = ({
         testID="payment-notice-copy-button"
         icon="docPaymentCode"
         label={I18n.t("payment.noticeCode")}
-        accessibilityLabel={I18n.t("payment.noticeCode")}
         value={formattedPaymentNoticeNumber}
         onPress={() => handleOnCopy(formattedPaymentNoticeNumber)}
       />
@@ -368,7 +361,6 @@ const WalletPaymentDetailContent = ({
       <ListItemInfoCopy
         icon="entityCode"
         label={I18n.t("wallet.firstTransactionSummary.entityCode")}
-        accessibilityLabel={I18n.t("wallet.firstTransactionSummary.entityCode")}
         value={orgFiscalCode}
         onPress={() => handleOnCopy(orgFiscalCode)}
       />


### PR DESCRIPTION
## Short description
This pull request includes accessibility improvements to the `PAYMENT_NOTICE_SUMMARY` screen.

## List of changes proposed in this pull request
- Removed `accessibilityLabel` properties from the `ListItemInfo` components for recipient, object, amount, dueDate, payment notice code, and entity code.

## How to test
- Using a real device 📱, go to the `PAYMENT_NOTICE_SUMMARY` screen
- Turn on the TalkBack accessibility tool
- Tap in each row and check if all are read correctly