### PR TITLE
chore: [IOBP-1165] Remove transparent header in `PAYMENT_METHOD_DETAILS_SCREEN`

### DIFF
--- a/ts/features/payments/details/components/PaymentsMethodDetailsBaseScreenComponent.tsx
+++ b/ts/features/payments/details/components/PaymentsMethodDetailsBaseScreenComponent.tsx
@@ -55,7 +55,6 @@ const PaymentsMethodDetailsBaseScreenComponent = ({
     variant: "contrast",
     faqCategories: ["wallet_methods"],
     supportRequest: true,
-    transparent: true,
     scrollValues: {
       contentOffsetY: translationY,
       triggerOffset: titleHeight
@@ -116,8 +115,8 @@ const styles = StyleSheet.create({
     width: "100%"
   },
   blueHeader: {
-    paddingTop: "105%",
-    marginTop: "-75%",
+    marginTop: -300,
+    paddingTop: 300,
     marginBottom: "15%"
   }
 });


### PR DESCRIPTION
## Short description
This pull request enhances the accessibility of the header in the `PAYMENT_METHOD_DETAILS_SCREEN` screen. The implementation follows a similar approach to PR https://github.com/pagopa/io-app/pull/6418 to ensure consistency and improve the user experience.

## List of changes proposed in this pull request
- Removed the `transparent` property from the component's configuration
- Modified the `blueHeader` style by changing the `paddingTop` and `marginTop` properties to use fixed values instead of percentages

## How to test
- Using a real device 📱, go to the `PAYMENT_METHOD_DETAILS_SCREEN` screen
- Turn on the TalkBack accessibility tool
- Tap on each header action and verify that all elements are correctly read by screen readers

## Preview
@thisisjp this change will also adjust the Android card position relative to the top header. Could this be a design issue?
| Old (iOS-Android)| New (iOS-Android)|
|--------|--------|
| <img width="373" alt="Screenshot 2025-02-03 at 10 15 14" src="https://github.com/user-attachments/assets/b44fad1a-c4e5-4a0c-ac3d-fc3857b2b05a" />| <img width="379" alt="Screenshot 2025-02-03 at 10 13 49" src="https://github.com/user-attachments/assets/023fe124-b68c-4806-a538-defed74939dd" /> |
| <img width="436" alt="Screenshot 2025-02-03 at 10 15 02" src="https://github.com/user-attachments/assets/c7d9fdfa-d09a-4cbf-a26f-351c44dab1d5" />  | <img width="436" alt="Screenshot 2025-02-03 at 10 14 21" src="https://github.com/user-attachments/assets/21deaad9-4d7a-4306-9a16-b061639614ef" /> | 





