### PR TITLE
chore: [IOBP-1174] Align bottom sheet text with design requirements

### DIFF
--- a/locales/de/index.yml
+++ b/locales/de/index.yml
@@ -1529,8 +1529,8 @@ wallet:
     fee: "Transaktionsgebühr"
     idTransaction: "Identifikationscode der Transaktion"
     amountInfo:
-      title: "Siehst du einen anderen Betrag?"
-      message: "pagoPA aktualisiert den Betrag automatisch, um sicherzustellen, dass du genau den Betrag bezahlst, den du schuldest und somit weitere Strafen oder Zinsen vermeidest"
+      title: "Ist der Betrag anders als auf der pagoPA-Benachrichtigung?"
+      message: "Wenn sich der Betrag ändert, bedeutet das, dass die Gläubigerinstitution ihn automatisch aktualisiert hat. So kannst du sicher sein, immer den fälligen Betrag zu bezahlen. Falls er höher ist, könnten Zinsen, Strafen oder Benachrichtigungskosten anfallen.\n\nFür weitere Details wende dich bitte an die Gläubigerinstitution, da pagoPA die Gründe für die Aktualisierung nicht kennt."
       cta: "OK, habe verstanden"
     contextualHelpTitle: "Zusammenfassung der Transaktion"
     errorDetails:

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -1600,8 +1600,8 @@ wallet:
     idTransaction: Transaction identification code
     updatedAmount: Updated amount
     amountInfo:
-      title: Do you see a different amount?
-      message: pagoPA updates the amount in real time, so that you can pay without additional charges or interest. This may happen, for instance, when the institution applies notification fees (if it has sent you a notification with legal value) or if you are late with your payment.
+      title: Is the amount different from the one on the pagoPA notice?
+      message: "If the amount changes, it means that the Payee has automatically updated it. In this way, you can be sure that you are always paying the amount that is due. If it is higher, you may have to pay interest, penalties or notification costs.\n\nPlease contact the Payee for further details, as pagoPA does not know the reasons for the update."
       cta: Ok, va bene
     contextualHelpTitle: Transaction's summary
     contextualHelpContent: !include wallet/wallet_transaction_summary.md

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -1604,8 +1604,8 @@ wallet:
     fee: Costi di transazione
     idTransaction: Codice identificativo della transazione
     amountInfo:
-      title: Vedi un importo diverso?
-      message: pagoPA aggiorna l'importo in tempo reale, per permetterti di pagare evitando more o interessi aggiuntivi. Può succedere, per esempio, quando l'ente applica dei costi di notifica (se ti ha inviato una comunicazione a valore legale) o se sei in ritardo con il pagamento.
+      title: L’importo è diverso da quello riportato sull’avviso pagoPA?
+      message: "Quando l'importo cambia, significa che l'ente creditore l'ha aggiornato automaticamente. In questo modo, hai sempre la certezza di pagare l’importo dovuto. Se è più alto, potrebbero esserci interessi, sanzioni o costi di notifica.\n\nPer ulteriori dettagli contatta l'ente creditore, poiché pagoPA non conosce i motivi dell'aggiornamento."
       cta: Ok, va bene
     contextualHelpTitle: Riepilogo della transazione
     contextualHelpContent: !include wallet/wallet_transaction_summary.md


### PR DESCRIPTION
## Short description
This pull request includes updates to the localization files for German, English, and Italian

## List of changes proposed in this pull request
- Updated the `amountInfo` title and message to clarify that changes in the amount are automatically updated by the creditor institution, and to include additional details on potential reasons for the changes

## How to test
- Try to pay something
- In `PAYMENT_NOTICE_SUMMARY` screen tap on ℹ️
- Ensure the bottom sheet text is align with design requirements

## Preview

| `De` | `En` | `It` |
|--------|--------|--------|
| <img width="464" alt="Screenshot 2025-02-04 at 11 45 35" src="https://github.com/user-attachments/assets/8bd32768-f14c-49a0-8a66-618c97cc7cf7" /> | <img width="448" alt="Screenshot 2025-02-04 at 11 46 08" src="https://github.com/user-attachments/assets/3441cc68-e57a-4e01-b911-022b5f99ce9d" /> | <img width="463" alt="Screenshot 2025-02-04 at 11 46 44" src="https://github.com/user-attachments/assets/9e8137f7-3c3c-43b9-a1b5-e9f04d185bcc" /> | 

