### PR TITLE
chore: [IOAPPX-000] remove main/profile deep link route

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,9 +525,6 @@ The application is able to manage _deep links_. [Deep linking](https://reactnavi
         <tr>
             <td>ioit://main/services</td>
         </tr>
-        <tr>
-            <td>ioit://main/profile</td>
-        </tr>
     </table>
     <h3>wallet</h3>
     <table>

--- a/README.md
+++ b/README.md
@@ -514,6 +514,9 @@ The authentication flow is as follows:
 
 ## Deep linking
 
+> [!note]
+> For an improved user experience, we recommend using the App/Universal Link `https://continua.io.pagopa.it` instead of the custom scheme `ioit://`.
+
 The application is able to manage _deep links_. [Deep linking](https://reactnavigation.org/docs/5.x/deep-linking) allows opening the app or a specific screen once a user clicks on specific URL. The URL scheme for io-app is: `ioit://`.
 <details>
     <summary>Supported URLs</summary>


### PR DESCRIPTION
## Short description
This PR removes `main/profile` deep link route from `README.md` file.
