### PR TITLE
chore: [IOPLT-949] Filters HttpClientErrors events from Sentry

### DIFF
--- a/ts/App.tsx
+++ b/ts/App.tsx
@@ -47,6 +47,7 @@ Sentry.init({
   beforeSendTransaction(event) {
     return removeUserFromEvent(event);
   },
+  ignoreErrors: ["HTTPClientError"],
   integrations: integrations => [...integrations, navigationIntegration],
   enabled: !isDevEnv,
   // https://sentry.zendesk.com/hc/en-us/articles/23337524872987-Why-is-the-the-message-in-my-error-being-truncated


### PR DESCRIPTION
## Short description
This PR aims to filter error events to track on Sentry, in order to ignore error generated by the OS Http client when opening a in-app browser instance

## List of changes proposed in this pull request
- Changes on sentry init callback

## How to test
Nothing should be changed in terms of app functionalities, just sentry ignoring related events
