### PR TITLE
chore: [IOBP-1180] Add priority to remote feature flag for the IDPay feature

### DIFF
--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -86,6 +86,7 @@ import {
   sessionTokenSelector
 } from "../store/reducers/authentication";
 import {
+  isIdPayEnabledSelector,
   isPnEnabledSelector,
   remoteConfigSelector
 } from "../store/reducers/backendStatus/remoteConfig";
@@ -566,10 +567,11 @@ export function* initializeApplicationSaga(
     yield* fork(watchPnSaga, sessionToken);
   }
 
-  const idPayTestEnabled: ReturnType<typeof isIdPayTestEnabledSelector> =
-    yield* select(isIdPayTestEnabledSelector);
+  const idPayEnabled: ReturnType<typeof isIdPayEnabledSelector> = yield* select(
+    isIdPayEnabledSelector
+  );
 
-  if (idPayTestEnabled) {
+  if (idPayEnabled) {
     // Start watching for IDPay actions
     yield* fork(watchIDPaySaga, bpdToken);
   }

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -91,7 +91,6 @@ import {
   remoteConfigSelector
 } from "../store/reducers/backendStatus/remoteConfig";
 import { IdentificationResult } from "../store/reducers/identification";
-import { isIdPayTestEnabledSelector } from "../store/reducers/persistedPreferences";
 import {
   isProfileFirstOnBoarding,
   profileSelector

--- a/ts/store/reducers/backendStatus/remoteConfig.ts
+++ b/ts/store/reducers/backendStatus/remoteConfig.ts
@@ -281,7 +281,7 @@ export const isIdPayEnabledSelector = createSelector(
   remoteConfigSelector,
   isIdPayTestEnabledSelector,
   (remoteConfig, isIdPayTestEnabled): boolean =>
-    isIdPayTestEnabled &&
+    isIdPayTestEnabled ||
     pipe(
       remoteConfig,
       O.map(config =>


### PR DESCRIPTION
## Short description
This PR prioritizes the remote feature flag instead of the local feature flag to enable/disable the IDPay feature. Within this implementation, is possible to have both the remote FF and local FF giving high priority to the remote settings. The local feature flag is still needed because the IDPay feature will be disabled in a second interaction when the "Guidonia" bonus ends.

## List of changes proposed in this pull request
- Edited the startup saga to see if the IDPay feature is enabled from the remote configuration
- Edited the `isIdPayEnabledSelector` logic that is true if the local FF is true or the remote FF is true

## How to test
- Edit the `dev-server` -> `backend.ts` file and set the `min_app_version` to the `idPay` attribute to a value lower or equal than the current app version and check that the bonuses cards are visible from the wallet section.
