### PR TITLE
fix(Cross): [IOAPPX-000] Check for more than one message in linter workflows

### DIFF
--- a/.github/workflows/pr-title-conventional-commit-linter.yml
+++ b/.github/workflows/pr-title-conventional-commit-linter.yml
@@ -46,12 +46,13 @@ jobs:
         id: find_comment
         run: |
           EXISTING_COMMENT=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
-            --jq ".[] | select(.body | startswith(\"$COMMENT_TITLE\")) | .id")
-          echo "EXISTING_COMMENT_ID=$EXISTING_COMMENT" >> $GITHUB_ENV
-          COMMENT_COUNT=$(echo "$EXISTING_COMMENT_IDS" | wc -l)
+            --jq ".[] | select(.body | startswith(\"$COMMENT_TITLE\")) | .id")          
+          COMMENT_COUNT=$(echo "$EXISTING_COMMENT" | wc -l)
           if [ "$COMMENT_COUNT" -gt 1 ]; then
             echo "Multiple comments found with the same title. Please review the comments."
             exit 2
+          else
+            echo "EXISTING_COMMENT_ID=$EXISTING_COMMENT" >> $GITHUB_ENV
           fi
 
       - name: Add or Update Comment

--- a/.github/workflows/pr-title-conventional-commit-linter.yml
+++ b/.github/workflows/pr-title-conventional-commit-linter.yml
@@ -48,6 +48,11 @@ jobs:
           EXISTING_COMMENT=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
             --jq ".[] | select(.body | startswith(\"$COMMENT_TITLE\")) | .id")
           echo "EXISTING_COMMENT_ID=$EXISTING_COMMENT" >> $GITHUB_ENV
+          COMMENT_COUNT=$(echo "$EXISTING_COMMENT_IDS" | wc -l)
+          if [ "$COMMENT_COUNT" -gt 1 ]; then
+            echo "Multiple comments found with the same title. Please review the comments."
+            exit 2
+          fi
 
       - name: Add or Update Comment
         run: |

--- a/.github/workflows/pr-title-linter-and-linker.yml
+++ b/.github/workflows/pr-title-linter-and-linker.yml
@@ -35,7 +35,13 @@ jobs:
         run: |
           EXISTING_COMMENT=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
             --jq ".[] | select(.body | startswith(\"$COMMENT_TITLE\")) | .id")          
-          echo "EXISTING_COMMENT_ID=$EXISTING_COMMENT" >> $GITHUB_ENV
+          COMMENT_COUNT=$(echo "$EXISTING_COMMENT" | wc -l)
+          if [ "$COMMENT_COUNT" -gt 1 ]; then
+            echo "Multiple comments found with the same title. Please review the comments."
+            exit 2
+          else
+            echo "EXISTING_COMMENT_ID=$EXISTING_COMMENT" >> $GITHUB_ENV
+          fi
 
       - name: Create or Update Jira Link Comment
         run: |


### PR DESCRIPTION
## Short description
This pull request includes changes to two GitHub Actions workflow files to handle cases where multiple comments with the same title are found. The changes ensure that the workflows exit with a [specific error message](https://github.com/pagopa/io-app/actions/runs/13245583583/job/36971175921) if such a situation is detected  avoiding [this error](https://github.com/pagopa/io-app/actions/runs/13245489050/job/36970864682).

## List of changes proposed in this pull request
* [`.github/workflows/pr-title-conventional-commit-linter.yml`](diffhunk://#diff-de57f78a94808c565c7223c76a3f918609a1e89cc3284597286690c944e9e2cbR50-R56): Added logic to count existing comments with the same title and exit with an error message if more than one is found.
* [`.github/workflows/pr-title-linter-and-linker.yml`](diffhunk://#diff-36369bf33364c44d17cf895448fcaf596aed0e847b72d72cd44e9afb93118076R38-R44): Added logic to count existing comments with the same title and exit with an error message if more than one is found.

## How to test
- Test the actual behavior with a valid title and an invalid one.
- Then add a new comment with the same title as the workflow lint message (ex: "PR Title Validation for conventional commit type") and check that the workflow fails with [the message](https://github.com/pagopa/io-app/actions/runs/13245583583/job/36971175921):
![image](https://github.com/user-attachments/assets/26e8840f-f67c-4183-a9fe-e768b0c7440e)

