### PR TITLE
ci: update `actions/cache` to `v4.2.0`

### DIFF
--- a/.github/workflows/staticcheck.yaml
+++ b/.github/workflows/staticcheck.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           node-version-file: ".node-version"
       - id: yarn-cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         env:
           cache-name: cache-node-modules
         with:


### PR DESCRIPTION
## Short description
This pull updates the `actions/cache` action from version `v3.3.1`([deprecated](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down)) to `v4.2.0`