### PR TITLE
ci: [IOAPPX-483] updates actions/cache due to github deprecation

### DIFF
--- a/.github/actions/setup-composite/action.yml
+++ b/.github/actions/setup-composite/action.yml
@@ -11,7 +11,7 @@ runs:
       with:
         node-version-file: ".node-version"
     - id: yarn-cache
-      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
         path: |
           **/node_modules

--- a/.github/workflows/distribute-beta.yml
+++ b/.github/workflows/distribute-beta.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           node-version-file: ".node-version"
       - id: yarn-cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version-file: ".node-version"
       - id: yarn-cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         env:
           cache-name: cache-node-modules
         with:
@@ -68,7 +68,7 @@ jobs:
         with:
           node-version-file: ".node-version"
       - id: yarn-cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         env:
           cache-name: cache-node-modules
         with:
@@ -166,7 +166,7 @@ jobs:
         with:
           node-version-file: ".node-version"
       - id: yarn-cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/release-new-cycle.yml
+++ b/.github/workflows/release-new-cycle.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           node-version-file: ".node-version"
       - id: yarn-cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         env:
           cache-name: cache-node-modules
         with:
@@ -83,7 +83,7 @@ jobs:
         with:
           node-version-file: ".node-version"
       - id: yarn-cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         env:
           cache-name: cache-node-modules
         with:
@@ -181,7 +181,7 @@ jobs:
         with:
           node-version-file: ".node-version"
       - id: yarn-cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version-file: ".node-version"
       - id: yarn-cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         env:
           cache-name: cache-node-modules
         with:
@@ -62,7 +62,7 @@ jobs:
         with:
           node-version-file: ".node-version"
       - id: yarn-cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         env:
           cache-name: cache-node-modules
         with:
@@ -160,7 +160,7 @@ jobs:
         with:
           node-version-file: ".node-version"
       - id: yarn-cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/staticcheck.yaml
+++ b/.github/workflows/staticcheck.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           node-version-file: ".node-version"
       - id: yarn-cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -30,7 +30,7 @@ jobs:
           yarn run postinstall
         shell: bash
       - id: cache-cocoapods
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ios/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
@@ -42,7 +42,7 @@ jobs:
       - id: detox-rebuild-framework-cache
         run: yarn detox rebuild-framework-cache
       - id: cache-detox-build
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ios/build
           key: ${{ runner.os }}-detox-build

--- a/.github/workflows/weekly-jobs.yml
+++ b/.github/workflows/weekly-jobs.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version-file: '.node-version'
       - id: yarn-cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         env:
           cache-name: cache-node-modules
         with:


### PR DESCRIPTION
## Short description

This pull updates the actions/cache action from version v3.3.1(deprecated) to v4.2.0