### PR TITLE
ci: fix android build aab file name

### DIFF
--- a/.github/workflows/release-new-cycle.yml
+++ b/.github/workflows/release-new-cycle.yml
@@ -155,12 +155,12 @@ jobs:
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8
         with:
           name: app-release.aab
-          path: android/app/build/outputs/bundle/release/app-release.aab
+          path: android/app/build/outputs/bundle/release/app-production-release.aab
       - id: upload-android-assets-release
         continue-on-error: true
         run: |
           APP_VERSION=$(node -p -e "require('./package.json').version")
-          gh release upload $APP_VERSION android/app/build/outputs/bundle/release/app-release.aab#android-app-release.aab android/io-app-universal.apk#io-app-universal.apk
+          gh release upload $APP_VERSION android/app/build/outputs/bundle/release/app-production-release.aab#android-app-release.aab android/io-app-universal.apk#io-app-universal.apk
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   release-ios:


### PR DESCRIPTION
## Short description
New cycle release workflow returns error on uploading aab file to github release due to wrong file name