### PR TITLE
refactor: [IOBP-1202] Icon for `PAYMENT_CANCELED` cta

### DIFF
--- a/ts/components/screens/OperationResultScreenContent.tsx
+++ b/ts/components/screens/OperationResultScreenContent.tsx
@@ -31,11 +31,11 @@ type OperationResultScreenContentProps = WithTestID<{
   subtitleProps?: Pick<BodyProps, "textBreakStrategy" | "lineBreakStrategyIOS">;
   action?: Pick<
     ButtonSolidProps,
-    "label" | "accessibilityLabel" | "onPress" | "testID"
+    "label" | "accessibilityLabel" | "onPress" | "testID" | "icon"
   >;
   secondaryAction?: Pick<
     ButtonLinkProps,
-    "label" | "accessibilityLabel" | "onPress" | "testID"
+    "label" | "accessibilityLabel" | "onPress" | "testID" | "icon"
   >;
   isHeaderVisible?: boolean;
 }>;

--- a/ts/features/payments/checkout/components/WalletPaymentFailureDetail.tsx
+++ b/ts/features/payments/checkout/components/WalletPaymentFailureDetail.tsx
@@ -110,6 +110,7 @@ const WalletPaymentFailureDetail = ({ failure }: Props) => {
     accessibilityLabel: I18n.t(
       "wallet.payment.failure.PAYMENT_CANCELED.action"
     ),
+    icon: "categLearning",
     onPress: handleDiscoverMore
   };
 


### PR DESCRIPTION
## Short description
This pull request includes updates to the `OperationResultScreenContent` and `WalletPaymentFailureDetail` components to enhance the user interface by adding icons to actions

## List of changes proposed in this pull request
- Added the `icon` property to the `action` and `secondaryAction` props to allow the inclusion of icons in buttons
- Added an `icon` property with the value `"categLearning"` for better visual indication

## How to test
At payment verify phase, try to recreate a `PAYMENT_CANCELED` error and ensure the outcome is aligned with [design requirements](https://www.figma.com/design/KY9BpP4LaSSd18fuYMwxYK/branch/AGn2SCNf81WNpAt8eCm7GG/Paga-un-avviso-pagoPA?node-id=2750-12850&t=ker70SekwtX08w91-0)
