### PR TITLE
fix(IDPay): [IOBP-1203] Show some IDPay features not needed under local feature flag

### DIFF
--- a/ts/features/barcode/screens/BarcodeScanScreen.tsx
+++ b/ts/features/barcode/screens/BarcodeScanScreen.tsx
@@ -46,11 +46,12 @@ import { usePagoPaPayment } from "../../payments/checkout/hooks/usePagoPaPayment
 import { FCI_ROUTES } from "../../fci/navigation/routes";
 import { paymentAnalyticsDataSelector } from "../../payments/history/store/selectors";
 import { ITW_REMOTE_ROUTES } from "../../itwallet/presentation/remote/navigation/routes.ts";
+import { isIdPayLocallyEnabledSelector } from "../../../store/reducers/persistedPreferences.ts";
 
 const BarcodeScanScreen = () => {
   const navigation = useNavigation<IOStackNavigationProp<AppParamsList>>();
   const openDeepLink = useOpenDeepLink();
-  const isIdPayEnabled = useIOSelector(isIdPayEnabledSelector);
+  const isIdPayEnabled = useIOSelector(isIdPayLocallyEnabledSelector);
   const paymentAnalyticsData = useIOSelector(paymentAnalyticsDataSelector);
 
   const { startPaymentFlowWithRptId } = usePagoPaPayment();

--- a/ts/features/barcode/screens/BarcodeScanScreen.tsx
+++ b/ts/features/barcode/screens/BarcodeScanScreen.tsx
@@ -17,10 +17,7 @@ import {
   IOStackNavigationProp
 } from "../../../navigation/params/AppParamsList";
 import { useIOSelector } from "../../../store/hooks";
-import {
-  barcodesScannerConfigSelector,
-  isIdPayEnabledSelector
-} from "../../../store/reducers/backendStatus/remoteConfig";
+import { barcodesScannerConfigSelector } from "../../../store/reducers/backendStatus/remoteConfig";
 import { emptyContextualHelp } from "../../../utils/emptyContextualHelp";
 import { useIOBottomSheetAutoresizableModal } from "../../../utils/hooks/bottomSheet";
 import { IdPayPaymentRoutes } from "../../idpay/payment/navigation/routes";

--- a/ts/screens/profile/DeveloperModeSection.tsx
+++ b/ts/screens/profile/DeveloperModeSection.tsx
@@ -43,7 +43,7 @@ import {
 } from "../../store/reducers/authentication";
 import { isDebugModeEnabledSelector } from "../../store/reducers/debug";
 import {
-  isIdPayTestEnabledSelector,
+  isIdPayLocallyEnabledSelector,
   isIOMarkdownEnabledLocallySelector,
   isPagoPATestEnabledSelector,
   isPnTestEnabledSelector
@@ -349,7 +349,7 @@ const DesignSystemSection = () => {
 
 const PlaygroundsSection = () => {
   const navigation = useIONavigation();
-  const isIdPayTestEnabled = useIOSelector(isIdPayTestEnabledSelector);
+  const isIdPayTestEnabled = useIOSelector(isIdPayLocallyEnabledSelector);
 
   const playgroundsNavListItems: ReadonlyArray<PlaygroundsNavListItem> = [
     {
@@ -453,7 +453,7 @@ const DeveloperTestEnvironmentSection = ({
   const dispatch = useIODispatch();
   const isPagoPATestEnabled = useIOSelector(isPagoPATestEnabledSelector);
   const isPnTestEnabled = useIOSelector(isPnTestEnabledSelector);
-  const isIdPayTestEnabled = useIOSelector(isIdPayTestEnabledSelector);
+  const isIdPayTestEnabled = useIOSelector(isIdPayLocallyEnabledSelector);
 
   const onPagoPAEnvironmentToggle = (enabled: boolean) => {
     if (enabled) {

--- a/ts/screens/profile/SecurityScreen.tsx
+++ b/ts/screens/profile/SecurityScreen.tsx
@@ -19,7 +19,10 @@ import { identificationRequest } from "../../store/actions/identification";
 import { preferenceFingerprintIsEnabledSaveSuccess } from "../../store/actions/persistedPreferences";
 import { useIODispatch, useIOSelector } from "../../store/hooks";
 import { isIdPayEnabledSelector } from "../../store/reducers/backendStatus/remoteConfig";
-import { isFingerprintEnabledSelector } from "../../store/reducers/persistedPreferences";
+import {
+  isFingerprintEnabledSelector,
+  isIdPayLocallyEnabledSelector
+} from "../../store/reducers/persistedPreferences";
 import { getFlowType } from "../../utils/analytics";
 import {
   biometricAuthenticationRequest,
@@ -51,7 +54,7 @@ const SecurityScreen = (): ReactElement => {
   const dispatch = useIODispatch();
   const isFingerprintEnabled = useIOSelector(isFingerprintEnabledSelector);
   const isIdPayCodeOnboarded = useIOSelector(isIdPayCodeOnboardedSelector);
-  const isIdPayEnabled = useIOSelector(isIdPayEnabledSelector);
+  const isIdPayEnabled = useIOSelector(isIdPayLocallyEnabledSelector);
   const isFimsHistoryEnabled = useIOSelector(fimsIsHistoryEnabledSelector);
   const navigation = useIONavigation();
   const [isBiometricDataAvailable, setIsBiometricDataAvailable] =

--- a/ts/screens/profile/SecurityScreen.tsx
+++ b/ts/screens/profile/SecurityScreen.tsx
@@ -18,7 +18,6 @@ import ROUTES from "../../navigation/routes";
 import { identificationRequest } from "../../store/actions/identification";
 import { preferenceFingerprintIsEnabledSaveSuccess } from "../../store/actions/persistedPreferences";
 import { useIODispatch, useIOSelector } from "../../store/hooks";
-import { isIdPayEnabledSelector } from "../../store/reducers/backendStatus/remoteConfig";
 import {
   isFingerprintEnabledSelector,
   isIdPayLocallyEnabledSelector

--- a/ts/store/reducers/backendStatus/remoteConfig.ts
+++ b/ts/store/reducers/backendStatus/remoteConfig.ts
@@ -19,7 +19,7 @@ import { getAppVersion, isVersionSupported } from "../../../utils/appVersion";
 import { backendStatusLoadSuccess } from "../../actions/backendStatus";
 import { Action } from "../../actions/types";
 import { isPropertyWithMinAppVersionEnabled } from "../featureFlagWithMinAppVersionStatus";
-import { isIdPayTestEnabledSelector } from "../persistedPreferences";
+import { isIdPayLocallyEnabledSelector } from "../persistedPreferences";
 import { GlobalState } from "../types";
 
 export type RemoteConfigState = O.Option<BackendStatus["config"]>;
@@ -279,7 +279,7 @@ export const isFciEnabledSelector = createSelector(
 
 export const isIdPayEnabledSelector = createSelector(
   remoteConfigSelector,
-  isIdPayTestEnabledSelector,
+  isIdPayLocallyEnabledSelector,
   (remoteConfig, isIdPayTestEnabled): boolean =>
     isIdPayTestEnabled ||
     pipe(

--- a/ts/store/reducers/persistedPreferences.ts
+++ b/ts/store/reducers/persistedPreferences.ts
@@ -205,8 +205,8 @@ export const isMixpanelEnabled = (state: GlobalState): boolean | null =>
 export const isPnTestEnabledSelector = (state: GlobalState) =>
   state.persistedPreferences.isPnTestEnabled;
 
-export const isIdPayTestEnabledSelector = (state: GlobalState) =>
-  !!state.persistedPreferences?.isIdPayTestEnabled;
+export const isIdPayLocallyEnabledSelector = (state: GlobalState) =>
+  state.persistedPreferences?.isIdPayTestEnabled;
 
 // 'isDesignSystemEnabled' has been introduced without a migration
 // (PR https://github.com/pagopa/io-app/pull/4427) so there are cases


### PR DESCRIPTION
## Short description
This PR moves certain IDPay features under a local feature flag, as they are not yet needed in production. These features will be controlled by a local feature flag instead of a remote one, while all required functionalities remain under a remote feature flag.

## List of changes proposed in this pull request
- Renamed the local feature flag selector in `isIdPayLocallyEnabledSelector`

## How to test
1. Keep the app’s local feature flag disabled and the remote feature flag enabled (via dev-server).
2. Verify that IDPay cards are displayed in the Wallet section.
3. Check that in Security & Access, the "IDPay Code" option is not visible.
4. In the Scan section, when tapping on "Digita", no bottom sheet appears asking what to insert.
5. Then, enable the local feature flag and ensure all these features are displayed as expected.

