### PR TITLE
refactor: [IOBP-1204] Add `IUV` to label

### DIFF
--- a/locales/de/index.yml
+++ b/locales/de/index.yml
@@ -3208,6 +3208,7 @@ transaction:
       iuv: "IUV"
       subject: "Zahlungsgrund"
       noticeCode: "Kodex der Zahlungsmitteilung/IUV"
+      noticeCodeAccessible: Codice avviso/Identificativo Univoco Versamento
       taxCode: "Steuernummer Körperschaft"
 FIMS:
   updateApp:

--- a/locales/de/index.yml
+++ b/locales/de/index.yml
@@ -3207,7 +3207,7 @@ transaction:
       debtor: "Schuldner"
       iuv: "IUV"
       subject: "Zahlungsgrund"
-      noticeCode: "Kodex der Zahlungsmitteilung"
+      noticeCode: "Kodex der Zahlungsmitteilung/IUV"
       taxCode: "Steuernummer Körperschaft"
 FIMS:
   updateApp:

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -4221,7 +4221,7 @@ transaction:
       debtor: Debitore
       iuv: IUV
       subject: Oggetto del pagamento
-      noticeCode: Codice avviso
+      noticeCode: Codice avviso/IUV
       taxCode: Codice Fiscale Ente
 FIMS:
   updateApp:

--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -4222,6 +4222,7 @@ transaction:
       iuv: IUV
       subject: Oggetto del pagamento
       noticeCode: Codice avviso/IUV
+      noticeCodeAccessible: Codice avviso/Identificativo Univoco Versamento
       taxCode: Codice Fiscale Ente
 FIMS:
   updateApp:

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -4221,7 +4221,7 @@ transaction:
       debtor: Debitore
       iuv: IUV
       subject: Oggetto del pagamento
-      noticeCode: Codice avviso
+      noticeCode: Codice avviso/IUV
       taxCode: Codice Fiscale Ente
 FIMS:
   updateApp:

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -4222,6 +4222,7 @@ transaction:
       iuv: IUV
       subject: Oggetto del pagamento
       noticeCode: Codice avviso/IUV
+      noticeCodeAccessible: Codice avviso/Identificativo Univoco Versamento
       taxCode: Codice Fiscale Ente
 FIMS:
   updateApp:

--- a/ts/features/payments/receipts/screens/ReceiptCartItemDetailsScreen.tsx
+++ b/ts/features/payments/receipts/screens/ReceiptCartItemDetailsScreen.tsx
@@ -84,7 +84,7 @@ const ReceiptCartItemDetailsScreen = () => {
               }
               label={I18n.t("transaction.details.operation.noticeCode")}
               accessibilityLabel={I18n.t(
-                "transaction.details.operation.noticeCode"
+                "transaction.details.operation.noticeCodeAccessible"
               )}
               value={cartItem.refNumberValue}
             />


### PR DESCRIPTION
## Short description
This pull request updates the localization for noticeCode to include the IUV text

## List of changes proposed in this pull request
- Updated the `noticeCode` translation to _Codice avviso/IUV_ and added a new entry for `noticeCodeAccessible` with the value _Codice avviso/Identificativo Univoco Versamento_
- Apply `noticeCodeAccessible` text for the `accessibilityLabel`

## How to test
Ensure that label text in `PAYMENT_RECEIPT_CART_ITEM_DETAILS` now includes `/IUV`

## Preview
![Screenshot 2025-02-13 at 12 59 50](https://github.com/user-attachments/assets/0da9c0b7-17ae-4b05-a425-583741d32666)

