### PR TITLE
chore(IDPay): [IOBP-1205] Removed the missing configuration alert for `EXPENSE` initiatives

### DIFF
--- a/ts/features/idpay/details/components/MissingConfigurationAlert.tsx
+++ b/ts/features/idpay/details/components/MissingConfigurationAlert.tsx
@@ -59,6 +59,7 @@ const MissingConfigurationAlert = (props: Props) => {
     <>
       <Alert
         ref={viewRef}
+        testID="missing-configuration-alert"
         content={I18n.t(
           `idpay.initiative.details.initiativeDetailsScreen.configured.errorAlerts.${status}.content`
         )}

--- a/ts/features/idpay/details/screens/IdPayInitiativeDetailsScreen.tsx
+++ b/ts/features/idpay/details/screens/IdPayInitiativeDetailsScreen.tsx
@@ -247,10 +247,6 @@ const IdPayInitiativeDetailsScreen = () => {
             case InitiativeRewardTypeEnum.EXPENSE:
               return (
                 <ContentWrapper>
-                  <MissingConfigurationAlert
-                    initiativeId={initiativeId}
-                    status={initiative.status}
-                  />
                   <VSpacer size={8} />
                   <InitiativeTimelineComponent
                     initiativeId={initiativeId}

--- a/ts/features/idpay/details/screens/__tests__/IdPayInitiativeDetailsScreen.test.tsx
+++ b/ts/features/idpay/details/screens/__tests__/IdPayInitiativeDetailsScreen.test.tsx
@@ -118,6 +118,32 @@ describe("Test IdPayInitiativeDetailsScreen screen", () => {
       )
     ).toBeTruthy();
   });
+
+  it("should not render the banner missing configuration Alert for REFUND initiatives that have status not undefined", () => {
+    const { component } = renderComponent(
+      pot.some({
+        ...mockedInitiative,
+        initiativeRewardType: InitiativeRewardTypeEnum.EXPENSE,
+        status: StatusEnum.NOT_REFUNDABLE_ONLY_IBAN
+      })
+    );
+    expect(component).toBeTruthy();
+    expect(component).not.toBeNull();
+    expect(component.getByTestId("missing-configuration-alert")).toBeNull();
+  });
+
+  it("should render the banner missing configuration Alert for REFUND initiatives with status not undefined", () => {
+    const { component } = renderComponent(
+      pot.some({
+        ...mockedInitiative,
+        initiativeRewardType: InitiativeRewardTypeEnum.REFUND,
+        status: StatusEnum.NOT_REFUNDABLE_ONLY_IBAN
+      })
+    );
+    expect(component).toBeTruthy();
+    expect(component).not.toBeNull();
+    expect(component.getByTestId("missing-configuration-alert")).toBeTruthy();
+  });
 });
 
 const renderComponent = (

--- a/ts/features/idpay/details/screens/__tests__/IdPayInitiativeDetailsScreen.test.tsx
+++ b/ts/features/idpay/details/screens/__tests__/IdPayInitiativeDetailsScreen.test.tsx
@@ -119,7 +119,7 @@ describe("Test IdPayInitiativeDetailsScreen screen", () => {
     ).toBeTruthy();
   });
 
-  it("should not render the banner missing configuration Alert for REFUND initiatives that have status not undefined", () => {
+  it("should not render the banner missing configuration Alert for EXPENSE initiatives that have status not undefined", () => {
     const { component } = renderComponent(
       pot.some({
         ...mockedInitiative,

--- a/ts/features/idpay/details/screens/__tests__/IdPayInitiativeDetailsScreen.test.tsx
+++ b/ts/features/idpay/details/screens/__tests__/IdPayInitiativeDetailsScreen.test.tsx
@@ -129,7 +129,7 @@ describe("Test IdPayInitiativeDetailsScreen screen", () => {
     );
     expect(component).toBeTruthy();
     expect(component).not.toBeNull();
-    expect(component.getByTestId("missing-configuration-alert")).toBeNull();
+    expect(component.queryByTestId("missing-configuration-alert")).toBeNull();
   });
 
   it("should render the banner missing configuration Alert for REFUND initiatives with status not undefined", () => {


### PR DESCRIPTION
## Short description
This PR removes the missing configuration alert for initiatives of type `EXPENSE`

## List of changes proposed in this pull request
- Added tests to check if the alert should be shown or not;
- Removed the component `MissingConfigurationAlert` from the content render of IDPay details screen;

## How to test
- Open an IDPay expense initiative that has the `status` of value `NOT_REFUNDABLE_ONLY_INSTRUMENT`;
- Check that there isn't any alert showing a message;
- Double-check that the other initiatives of type `REFUND`, if `status` is `NOT_REFUNDABLE_ONLY_INSTRUMENT`, should show the correct alert.

## Preview
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/1665c8dc-61bc-454b-b0d8-3008c2b4dbe3" width="350px" />|<img src="https://github.com/user-attachments/assets/0488398b-3f3a-4293-9fa0-47efbf6558d5" width="350px" />|
