### PR TITLE
chore: [IOPID-2690] Support back navigation from `CieIdLoginScreen` and `CieConsentDataUsageScreen`

### DIFF
--- a/ts/features/cieLogin/components/CieIdLoginWebView.tsx
+++ b/ts/features/cieLogin/components/CieIdLoginWebView.tsx
@@ -37,6 +37,7 @@ import {
   IO_LOGIN_CIE_SOURCE_APP,
   IO_LOGIN_CIE_URL_SCHEME
 } from "../../../utils/cie";
+import { useOnboardingAbortAlert } from "../../../utils/hooks/useOnboardingAbortAlert";
 
 export type WebViewLoginNavigationProps = {
   spidLevel: SpidLevel;
@@ -270,20 +271,17 @@ const CieIdLoginWebView = ({ spidLevel, isUat }: CieIdLoginProps) => {
     [navigateToCieIdAuthenticationError]
   );
 
+  const { showAlert } = useOnboardingAbortAlert();
+
   const headerProps: HeaderSecondLevelHookProps = useMemo(() => {
-    if (webviewSource && !authenticatedUrl && !isLoadingWebView) {
-      return { title: "", goBack: navigateToLandingScreen };
+    if (webviewSource && !isLoadingWebView) {
+      return { title: "", goBack: () => showAlert(navigateToLandingScreen) };
     }
     return {
       title: "",
       canGoBack: false
     };
-  }, [
-    authenticatedUrl,
-    isLoadingWebView,
-    navigateToLandingScreen,
-    webviewSource
-  ]);
+  }, [isLoadingWebView, navigateToLandingScreen, showAlert, webviewSource]);
 
   useHeaderSecondLevel(headerProps);
 

--- a/ts/features/messages/components/Home/__tests__/__snapshots__/TabNavigationContainer.test.tsx.snap
+++ b/ts/features/messages/components/Home/__tests__/__snapshots__/TabNavigationContainer.test.tsx.snap
@@ -441,7 +441,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                       false,
                                       {
                                         "backgroundColor": undefined,
-                                        "borderColor": "#BBC2D6",
+                                        "borderColor": undefined,
                                       },
                                       false,
                                       false,
@@ -524,7 +524,6 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                   </RNSVGSvgView>
                                   <Text
                                     allowFontScaling={true}
-                                    dynamicTypeRamp="footnote"
                                     maxFontSizeMultiplier={1.5}
                                     style={
                                       [
@@ -535,7 +534,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                           "fontSize": 14,
                                           "fontStyle": "normal",
                                           "fontWeight": "600",
-                                          "lineHeight": 21,
+                                          "lineHeight": undefined,
                                         },
                                       ]
                                     }
@@ -686,7 +685,6 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                   </RNSVGSvgView>
                                   <Text
                                     allowFontScaling={true}
-                                    dynamicTypeRamp="footnote"
                                     maxFontSizeMultiplier={1.5}
                                     style={
                                       [
@@ -697,7 +695,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                           "fontSize": 14,
                                           "fontStyle": "normal",
                                           "fontWeight": "600",
-                                          "lineHeight": 21,
+                                          "lineHeight": undefined,
                                         },
                                       ]
                                     }
@@ -1260,7 +1258,6 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                   </RNSVGSvgView>
                                   <Text
                                     allowFontScaling={true}
-                                    dynamicTypeRamp="footnote"
                                     maxFontSizeMultiplier={1.5}
                                     style={
                                       [
@@ -1271,7 +1268,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                           "fontSize": 14,
                                           "fontStyle": "normal",
                                           "fontWeight": "600",
-                                          "lineHeight": 21,
+                                          "lineHeight": undefined,
                                         },
                                       ]
                                     }
@@ -1352,7 +1349,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                       false,
                                       {
                                         "backgroundColor": undefined,
-                                        "borderColor": "#BBC2D6",
+                                        "borderColor": undefined,
                                       },
                                       false,
                                       false,
@@ -1422,7 +1419,6 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                   </RNSVGSvgView>
                                   <Text
                                     allowFontScaling={true}
-                                    dynamicTypeRamp="footnote"
                                     maxFontSizeMultiplier={1.5}
                                     style={
                                       [
@@ -1433,7 +1429,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                           "fontSize": 14,
                                           "fontStyle": "normal",
                                           "fontWeight": "600",
-                                          "lineHeight": 21,
+                                          "lineHeight": undefined,
                                         },
                                       ]
                                     }

--- a/ts/features/messages/components/Home/__tests__/__snapshots__/TabNavigationContainer.test.tsx.snap
+++ b/ts/features/messages/components/Home/__tests__/__snapshots__/TabNavigationContainer.test.tsx.snap
@@ -441,7 +441,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                       false,
                                       {
                                         "backgroundColor": undefined,
-                                        "borderColor": undefined,
+                                        "borderColor": "#BBC2D6",
                                       },
                                       false,
                                       false,
@@ -524,6 +524,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                   </RNSVGSvgView>
                                   <Text
                                     allowFontScaling={true}
+                                    dynamicTypeRamp="footnote"
                                     maxFontSizeMultiplier={1.5}
                                     style={
                                       [
@@ -534,7 +535,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                           "fontSize": 14,
                                           "fontStyle": "normal",
                                           "fontWeight": "600",
-                                          "lineHeight": undefined,
+                                          "lineHeight": 21,
                                         },
                                       ]
                                     }
@@ -685,6 +686,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                   </RNSVGSvgView>
                                   <Text
                                     allowFontScaling={true}
+                                    dynamicTypeRamp="footnote"
                                     maxFontSizeMultiplier={1.5}
                                     style={
                                       [
@@ -695,7 +697,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                           "fontSize": 14,
                                           "fontStyle": "normal",
                                           "fontWeight": "600",
-                                          "lineHeight": undefined,
+                                          "lineHeight": 21,
                                         },
                                       ]
                                     }
@@ -1258,6 +1260,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                   </RNSVGSvgView>
                                   <Text
                                     allowFontScaling={true}
+                                    dynamicTypeRamp="footnote"
                                     maxFontSizeMultiplier={1.5}
                                     style={
                                       [
@@ -1268,7 +1271,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                           "fontSize": 14,
                                           "fontStyle": "normal",
                                           "fontWeight": "600",
-                                          "lineHeight": undefined,
+                                          "lineHeight": 21,
                                         },
                                       ]
                                     }
@@ -1349,7 +1352,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                       false,
                                       {
                                         "backgroundColor": undefined,
-                                        "borderColor": undefined,
+                                        "borderColor": "#BBC2D6",
                                       },
                                       false,
                                       false,
@@ -1419,6 +1422,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                   </RNSVGSvgView>
                                   <Text
                                     allowFontScaling={true}
+                                    dynamicTypeRamp="footnote"
                                     maxFontSizeMultiplier={1.5}
                                     style={
                                       [
@@ -1429,7 +1433,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                           "fontSize": 14,
                                           "fontStyle": "normal",
                                           "fontWeight": "600",
-                                          "lineHeight": undefined,
+                                          "lineHeight": 21,
                                         },
                                       ]
                                     }

--- a/ts/navigation/AuthenticationNavigator.tsx
+++ b/ts/navigation/AuthenticationNavigator.tsx
@@ -130,6 +130,7 @@ const AuthenticationStackNavigator = () => (
     <Stack.Screen
       name={ROUTES.CIE_CONSENT_DATA_USAGE}
       component={CieConsentDataUsageScreen}
+      options={{ headerShown: true }}
     />
 
     <Stack.Group

--- a/ts/screens/authentication/cie/CieConsentDataUsageScreen.tsx
+++ b/ts/screens/authentication/cie/CieConsentDataUsageScreen.tsx
@@ -24,7 +24,7 @@ import { originSchemasWhiteList } from "../originSchemasWhiteList";
 import ROUTES from "../../../navigation/routes";
 import { useIONavigation } from "../../../navigation/params/AppParamsList";
 import { useOnboardingAbortAlert } from "../../../utils/hooks/useOnboardingAbortAlert";
-import { useHardwareBackButton } from "../../../hooks/useHardwareBackButton";
+import { useHeaderSecondLevel } from "../../../hooks/useHeaderSecondLevel";
 
 export type CieConsentDataUsageScreenNavigationParams = {
   cieConsentUri: string;
@@ -76,14 +76,11 @@ const CieConsentDataUsageScreen = () => {
       navigateToLandingScreen();
       return true;
     }
-    showAlert();
+    showAlert(navigateToLandingScreen);
     return true;
   }, [hasError, navigateToLandingScreen, showAlert]);
 
-  useHardwareBackButton(() => {
-    showAbortAlert();
-    return true;
-  });
+  useHeaderSecondLevel({ title: "", goBack: showAbortAlert });
 
   const handleWebViewError = useCallback(() => setHasError(true), []);
 

--- a/ts/utils/__tests__/hooks/useOnbardingAbortAlert.test.ts
+++ b/ts/utils/__tests__/hooks/useOnbardingAbortAlert.test.ts
@@ -1,0 +1,65 @@
+import { Alert } from "react-native";
+import { createStore } from "redux";
+import { useOnboardingAbortAlert } from "../../hooks/useOnboardingAbortAlert";
+import { appReducer } from "../../../store/reducers";
+import { applicationChangeState } from "../../../store/actions/application";
+import { renderScreenWithNavigationStoreContext } from "../../testWrapper";
+import { abortOnboarding } from "../../../store/actions/onboarding";
+import * as dispatch from "../../../store/hooks";
+
+describe("useOnboardingAbortAlert", () => {
+  beforeAll(() => {
+    jest.spyOn(Alert, "alert");
+  });
+
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should show alert with correct title and description", () => {
+    renderHook();
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      "Do you really want to log out?",
+      "You will have to log in again to use the app",
+      expect.any(Array)
+    );
+  });
+
+  it("should show alert with correct buttons", () => {
+    renderHook();
+
+    const buttons = (Alert.alert as jest.Mock).mock.calls[0][2];
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0].text).toBe("Cancel");
+    expect(buttons[0].style).toBe("cancel");
+    expect(buttons[1].text).toBe("Exit");
+    expect(buttons[1].style).toBe("default");
+  });
+});
+
+it("should dispatch abortOnboarding action when exit button is pressed", () => {
+  const dispatchMock = jest.fn();
+  jest.spyOn(dispatch, "useIODispatch").mockReturnValue(dispatchMock);
+
+  renderHook();
+
+  const buttons = (Alert.alert as jest.Mock).mock.calls[0][2];
+  buttons[1].onPress();
+  expect(dispatchMock).toHaveBeenCalledWith(abortOnboarding());
+});
+
+const renderHook = () => {
+  const Component = () => {
+    const { showAlert } = useOnboardingAbortAlert();
+    showAlert();
+    return null;
+  };
+  const globalState = appReducer(undefined, applicationChangeState("active"));
+  return renderScreenWithNavigationStoreContext(
+    Component,
+    "TEST",
+    {},
+    createStore(appReducer, globalState as any)
+  );
+};

--- a/ts/utils/__tests__/hooks/useOnbardingAbortAlert.test.ts
+++ b/ts/utils/__tests__/hooks/useOnbardingAbortAlert.test.ts
@@ -8,11 +8,11 @@ import { abortOnboarding } from "../../../store/actions/onboarding";
 import * as dispatch from "../../../store/hooks";
 
 describe("useOnboardingAbortAlert", () => {
-  beforeAll(() => {
+  beforeEach(() => {
     jest.spyOn(Alert, "alert");
   });
 
-  afterAll(() => {
+  afterEach(() => {
     jest.clearAllMocks();
   });
 
@@ -36,17 +36,30 @@ describe("useOnboardingAbortAlert", () => {
     expect(buttons[1].text).toBe("Exit");
     expect(buttons[1].style).toBe("default");
   });
-});
 
-it("should dispatch abortOnboarding action when exit button is pressed", () => {
-  const dispatchMock = jest.fn();
-  jest.spyOn(dispatch, "useIODispatch").mockReturnValue(dispatchMock);
+  it("should dispatch abortOnboarding action when exit button is pressed", () => {
+    const dispatchMock = jest.fn();
+    jest.spyOn(dispatch, "useIODispatch").mockReturnValue(dispatchMock);
 
-  renderHook();
+    renderHook();
 
-  const buttons = (Alert.alert as jest.Mock).mock.calls[0][2];
-  buttons[1].onPress();
-  expect(dispatchMock).toHaveBeenCalledWith(abortOnboarding());
+    const buttons = (Alert.alert as jest.Mock).mock.calls[0][2];
+    buttons[1].onPress();
+    expect(dispatchMock).toHaveBeenCalledWith(abortOnboarding());
+  });
+
+  it("should call the provided callback instead of dispatching abortOnboarding action when exit button is pressed", () => {
+    const dispatchMock = jest.fn();
+    jest.spyOn(dispatch, "useIODispatch").mockReturnValue(dispatchMock);
+    const mockCallback = jest.fn();
+
+    renderHook(mockCallback);
+
+    const buttons = (Alert.alert as jest.Mock).mock.calls[0][2];
+    buttons[1].onPress();
+    expect(dispatchMock).not.toHaveBeenCalledWith(abortOnboarding());
+    expect(mockCallback).toHaveBeenCalled();
+  });
 });
 
 const renderHook = (callback?: () => void) => {

--- a/ts/utils/__tests__/hooks/useOnbardingAbortAlert.test.ts
+++ b/ts/utils/__tests__/hooks/useOnbardingAbortAlert.test.ts
@@ -49,10 +49,10 @@ it("should dispatch abortOnboarding action when exit button is pressed", () => {
   expect(dispatchMock).toHaveBeenCalledWith(abortOnboarding());
 });
 
-const renderHook = () => {
+const renderHook = (callback?: () => void) => {
   const Component = () => {
     const { showAlert } = useOnboardingAbortAlert();
-    showAlert();
+    showAlert(callback);
     return null;
   };
   const globalState = appReducer(undefined, applicationChangeState("active"));

--- a/ts/utils/hooks/useOnboardingAbortAlert.ts
+++ b/ts/utils/hooks/useOnboardingAbortAlert.ts
@@ -5,7 +5,7 @@ import I18n from "../../i18n";
 import { useIODispatch } from "../../store/hooks";
 
 type OnboardingAbortAlertUtils = {
-  showAlert: () => void;
+  showAlert: (callback?: () => void) => void;
 };
 
 /**
@@ -15,25 +15,34 @@ type OnboardingAbortAlertUtils = {
 export const useOnboardingAbortAlert = (): OnboardingAbortAlertUtils => {
   const dispatch = useIODispatch();
 
-  const showAlert = useCallback(() => {
-    Alert.alert(
-      I18n.t("onboarding.alert.title"),
-      I18n.t("onboarding.alert.description"),
-      [
-        {
-          text: I18n.t("global.buttons.cancel"),
-          style: "cancel"
-        },
-        {
-          text: I18n.t("global.buttons.exit"),
-          style: "default",
-          onPress: () => {
-            dispatch(abortOnboarding());
+  const showAlert = useCallback(
+    (callback?: () => void) => {
+      Alert.alert(
+        I18n.t("onboarding.alert.title"),
+        I18n.t("onboarding.alert.description"),
+        [
+          {
+            text: I18n.t("global.buttons.cancel"),
+            style: "cancel"
+          },
+          {
+            text: I18n.t("global.buttons.exit"),
+            style: "default",
+            onPress: () => {
+              // If a callback is provided, we want to handle the logic in the callback
+              // otherwise we want to automatically dispatch the abortOnboarding action
+              if (callback && typeof callback === "function") {
+                callback();
+              } else {
+                dispatch(abortOnboarding());
+              }
+            }
           }
-        }
-      ]
-    );
-  }, [dispatch]);
+        ]
+      );
+    },
+    [dispatch]
+  );
 
   return { showAlert };
 };


### PR DESCRIPTION
## Short description
This PR adds the possibility to go back from `CieIdLoginWebView` and `CieConsentDataUsageScreen`

<details><summary>Details</summary>
<p>

## Android

| Cie | CieID |
| - | - |
| <video src="https://github.com/user-attachments/assets/554a8c5a-0dfa-4c64-aaa8-4dcba98e0229" /> | <video src="https://github.com/user-attachments/assets/6d0a43ce-7c64-4e9f-9957-aeeaa7bf7928" />

## iOS

| Cie | CieID |
| - | - |
| <video src="https://github.com/user-attachments/assets/d656f050-f6af-4c51-8159-72810288b9e2" /> | <video src="https://github.com/user-attachments/assets/ce052883-3f9d-44ee-9584-97d159ce264d" />

</p>
</details> 

## List of changes proposed in this pull request
* [`ts/features/cieLogin/components/CieIdLoginWebView.tsx`](diffhunk://#diff-8525a47a8c535183fa25dcb03b4edd382aaed38fc026f3ff0e12d9cf206d02c8R40): Added the `useOnboardingAbortAlert` hook and updated the `headerProps` to use the `showAlert` method from the hook when navigating back. [[1]](diffhunk://#diff-8525a47a8c535183fa25dcb03b4edd382aaed38fc026f3ff0e12d9cf206d02c8R40) [[2]](diffhunk://#diff-8525a47a8c535183fa25dcb03b4edd382aaed38fc026f3ff0e12d9cf206d02c8R274-R284)
* [`ts/screens/authentication/cie/CieConsentDataUsageScreen.tsx`](diffhunk://#diff-89c251a9a9539e3470c6001c13917f0881272bfa692f61bdc4a6f191b0435fa3L27-R27): Replaced the `useHardwareBackButton` hook with the `useHeaderSecondLevel` hook, and updated the `showAlert` method to include navigation callback. [[1]](diffhunk://#diff-89c251a9a9539e3470c6001c13917f0881272bfa692f61bdc4a6f191b0435fa3L27-R27) [[2]](diffhunk://#diff-89c251a9a9539e3470c6001c13917f0881272bfa692f61bdc4a6f191b0435fa3L79-R83)
* [`ts/utils/hooks/useOnboardingAbortAlert.ts`](diffhunk://#diff-1ff1c2eaf85533773b6b879ffe60014cadc233bfdedae3cd1fa60f274b38a1daL8-R8): Modified the `showAlert` method to accept an optional callback and dispatch the `abortOnboarding` action if no callback is provided. [[1]](diffhunk://#diff-1ff1c2eaf85533773b6b879ffe60014cadc233bfdedae3cd1fa60f274b38a1daL8-R8) [[2]](diffhunk://#diff-1ff1c2eaf85533773b6b879ffe60014cadc233bfdedae3cd1fa60f274b38a1daL18-R19) [[3]](diffhunk://#diff-1ff1c2eaf85533773b6b879ffe60014cadc233bfdedae3cd1fa60f274b38a1daR32-R45)
* [`ts/utils/__tests__/hooks/useOnboardingAbortAlert.test.ts`](diffhunk://#diff-4b4bec9087f67cc00d09dc51404a059bae24a78ad98e066916f1046a78b5b9f9R1-R78): Added tests to verify the alert functionality and the dispatching of the `abortOnboarding` action.
* [`ts/navigation/AuthenticationNavigator.tsx`](diffhunk://#diff-ad2b53460d1d1097a95454f9788b1a4f1a50f7d37cf641c6db1d64e05f3fac7bR133): Enabled the header for the `CieConsentDataUsageScreen` component.

## How to test
Try to login with CIE+PIN and CieID and check if, in the page where you need to accept the data usage, there's the `goBack` button in the navigation header and test it (Take the "Details" demo video as an example).

