### PR TITLE
fix: [IOCOM-2097] Special link support removed from IOMarkdown on messages and services

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -2206,6 +2206,7 @@ messageDetails:
     actions:
       call: Call
       email: Send email
+  markdownLinkUnsupported: "This link is not supported"
 messagePDFPreview:
   title: "PDF Preview"
   singleBtn: "Save or share"

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -2206,6 +2206,7 @@ messageDetails:
     actions:
       call: Fai una chiamata
       email: Scrivi un'email
+  markdownLinkUnsupported: "Questo link non è supportato"
 messagePDFPreview:
   title: "Anteprima PDF"
   singleBtn: "Salva o condividi"

--- a/ts/components/ui/Markdown/handlers/__test__/link.test.ts
+++ b/ts/components/ui/Markdown/handlers/__test__/link.test.ts
@@ -1,5 +1,11 @@
 import * as E from "fp-ts/lib/Either";
-import { deriveCustomHandledLink, removeFIMSPrefixFromUrl } from "../link";
+import {
+  deriveCustomHandledLink,
+  isHttpsLink,
+  isIoFIMSLink,
+  isIoInternalLink,
+  removeFIMSPrefixFromUrl
+} from "../link";
 
 const loadingCases: ReadonlyArray<
   [input: string, expectedResult: ReturnType<typeof deriveCustomHandledLink>]
@@ -98,4 +104,103 @@ describe("removeFIMSPrefixFromUrl", () => {
       expect(result).toEqual(expectedResult);
     }
   );
+});
+
+describe("isHttpsLink", () => {
+  ["https://", "hTtPs://", "HTTPS://"].forEach(protocol => {
+    it(`should return true for '${protocol}'`, () => {
+      const isHttps = isHttpsLink(`${protocol}whatever`);
+      expect(isHttps).toBe(true);
+    });
+  });
+  [
+    "https:/",
+    "https:",
+    "https",
+    "http://",
+    "ioit://",
+    "iohandledlink://",
+    "iosso://",
+    "clipboard://",
+    "clipboard:",
+    "sms://",
+    "sms:",
+    "tel://",
+    "tel:",
+    "mailto://",
+    "mailto:",
+    "copy://",
+    "copy:"
+  ].forEach(protocol => {
+    it(`should return false for '${protocol}'`, () => {
+      const isHttps = isHttpsLink(`${protocol}whatever`);
+      expect(isHttps).toBe(false);
+    });
+  });
+});
+
+describe("isIoFIMSLink", () => {
+  ["iosso://", "iOsSo://", "IOSSO://"].forEach(protocol => {
+    it(`should return true for '${protocol}'`, () => {
+      const isIOFIMSLink = isIoFIMSLink(`${protocol}whatever`);
+      expect(isIOFIMSLink).toBe(true);
+    });
+  });
+  [
+    "iosso:/",
+    "iosso:",
+    "iosso",
+    "https://",
+    "http://",
+    "ioit://",
+    "iohandledlink://",
+    "clipboard://",
+    "clipboard:",
+    "sms://",
+    "sms:",
+    "tel://",
+    "tel:",
+    "mailto://",
+    "mailto:",
+    "copy://",
+    "copy:"
+  ].forEach(protocol => {
+    it(`should return false for '${protocol}'`, () => {
+      const isIOFIMSLink = isIoFIMSLink(`${protocol}whatever`);
+      expect(isIOFIMSLink).toBe(false);
+    });
+  });
+});
+
+describe("isIoInternalLink", () => {
+  ["ioit://", "iOiT://", "IOIT://"].forEach(protocol => {
+    it(`should return true for '${protocol}'`, () => {
+      const isIOLink = isIoInternalLink(`${protocol}whatever`);
+      expect(isIOLink).toBe(true);
+    });
+  });
+  [
+    "ioit:/",
+    "ioit:",
+    "ioit",
+    "https://",
+    "http://",
+    "iosso://",
+    "iohandledlink://",
+    "clipboard://",
+    "clipboard:",
+    "sms://",
+    "sms:",
+    "tel://",
+    "tel:",
+    "mailto://",
+    "mailto:",
+    "copy://",
+    "copy:"
+  ].forEach(protocol => {
+    it(`should return false for '${protocol}'`, () => {
+      const isIOLink = isIoInternalLink(`${protocol}whatever`);
+      expect(isIOLink).toBe(false);
+    });
+  });
 });

--- a/ts/components/ui/Markdown/handlers/link.ts
+++ b/ts/components/ui/Markdown/handlers/link.ts
@@ -10,10 +10,13 @@ import {
 import { openWebUrl } from "../../../../utils/url";
 
 export const isIoInternalLink = (href: string): boolean =>
-  href.startsWith(IO_INTERNAL_LINK_PREFIX);
+  href.toLowerCase().startsWith(IO_INTERNAL_LINK_PREFIX);
 
 export const isIoFIMSLink = (href: string): boolean =>
-  href.startsWith(IO_FIMS_LINK_PREFIX);
+  href.toLowerCase().startsWith(IO_FIMS_LINK_PREFIX);
+
+export const isHttpsLink = (href: string): boolean =>
+  href.toLowerCase().startsWith("https://");
 
 export const removeFIMSPrefixFromUrl = (fimsUrlWithProtocol: string) => {
   // eslint-disable-next-line no-useless-escape

--- a/ts/features/common/components/IOMarkdown/__test__/customRules.test.tsx
+++ b/ts/features/common/components/IOMarkdown/__test__/customRules.test.tsx
@@ -1,0 +1,57 @@
+import { IOToast } from "@pagopa/io-app-design-system";
+import * as URL from "../../../../../utils/url";
+import { testable } from "../customRules";
+import I18n from "../../../../../i18n";
+
+describe("customRules", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+  describe("handleOpenLink", () => {
+    const linkToMock = jest.fn();
+    it("should call input function for ioit:// protocol", () => {
+      testable!.handleOpenLink(linkToMock, "ioit://whatever");
+      expect(linkToMock).toHaveBeenCalledWith("/whatever");
+    });
+    it("should call 'openWebUrl' for https:// protocol", () => {
+      const spyOnMockedOpenWebUrl = jest
+        .spyOn(URL, "openWebUrl")
+        .mockImplementation((_url, _onError) => undefined);
+      const spyOnIOToastError = jest.spyOn(IOToast, "error");
+      testable!.handleOpenLink(linkToMock, "https://whatever");
+      expect(spyOnMockedOpenWebUrl.mock.calls.length).toBe(1);
+      expect(spyOnMockedOpenWebUrl.mock.calls[0].length).toBe(2);
+      expect(spyOnMockedOpenWebUrl.mock.calls[0][0]).toBe("https://whatever");
+      expect(spyOnMockedOpenWebUrl.mock.calls[0][1]).toBeDefined();
+      const errorFunction = spyOnMockedOpenWebUrl.mock
+        .calls[0][1] as () => void;
+      errorFunction();
+      expect(spyOnIOToastError).toHaveBeenCalledWith(
+        I18n.t("global.jserror.title")
+      );
+    });
+    [
+      "http://",
+      "iosso://",
+      "iohandledlink://",
+      "clipboard://",
+      "clipboard:",
+      "sms://",
+      "sms:",
+      "tel://",
+      "tel:",
+      "mailto://",
+      "mailto:",
+      "copy://",
+      "copy:"
+    ].forEach(protocol => {
+      it(`should display a warning toast for ${protocol} protocol`, () => {
+        const spyOnIOToastError = jest.spyOn(IOToast, "warning");
+        testable!.handleOpenLink(linkToMock, `${protocol}whatever`);
+        expect(spyOnIOToastError).toHaveBeenCalledWith(
+          I18n.t("messageDetails.markdownLinkUnsupported")
+        );
+      });
+    });
+  });
+});

--- a/ts/features/common/components/IOMarkdown/customRules.tsx
+++ b/ts/features/common/components/IOMarkdown/customRules.tsx
@@ -5,7 +5,10 @@ import {
   TxtLinkNode
 } from "@textlint/ast-node-types";
 import { Body, IOToast, MdH1, MdH2, MdH3 } from "@pagopa/io-app-design-system";
-import { isIoInternalLink } from "../../../../components/ui/Markdown/handlers/link";
+import {
+  isHttpsLink,
+  isIoInternalLink
+} from "../../../../components/ui/Markdown/handlers/link";
 import { handleInternalLink } from "../../../../utils/internalLink";
 import { openWebUrl } from "../../../../utils/url";
 import I18n from "../../../../i18n";
@@ -18,6 +21,7 @@ import {
   Renderer
 } from "../../../../components/IOMarkdown/types";
 import { extractAllLinksFromRootNode } from "../../../../components/IOMarkdown/markdownRenderer";
+import { isTestEnv } from "../../../../utils/environment";
 
 const HEADINGS_MAP = {
   1: MdH1,
@@ -31,10 +35,12 @@ const HEADINGS_MAP = {
 const handleOpenLink = (linkTo: (path: string) => void, url: string) => {
   if (isIoInternalLink(url)) {
     handleInternalLink(linkTo, url);
-  } else {
+  } else if (isHttpsLink(url)) {
     openWebUrl(url, () => {
       IOToast.error(I18n.t("global.jserror.title"));
     });
+  } else {
+    IOToast.warning(I18n.t("messageDetails.markdownLinkUnsupported"));
   }
 };
 
@@ -85,3 +91,5 @@ export const generatePreconditionsRules =
   (): Partial<IOMarkdownRenderRules> => ({
     Html: (_html: TxtHtmlNode) => undefined
   });
+
+export const testable = isTestEnv ? { handleOpenLink } : undefined;


### PR DESCRIPTION
## Short description
This PR removes (broken) support for non https links on IOMarkdown, on messages and services
<video src="https://github.com/user-attachments/assets/217bc4db-86de-4c36-be06-14894a4b7e97" />

## List of changes proposed in this pull request
- Link filtering to only work for ioit and https links

## How to test
Using the io-dev-api-server, check that:
- ioit links work
- https links work
- any other type of link does not work
