### PR TITLE
fix: [IOBP-1179] `a11y` banner focus order

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@babel/plugin-transform-private-property-in-object": "^7.25.9",
     "@babel/plugin-transform-react-jsx": "^7.25.9",
     "@gorhom/bottom-sheet": "^4.1.5",
-    "@pagopa/io-app-design-system": "4.5.5",
+    "@pagopa/io-app-design-system": "4.5.6",
     "@pagopa/io-pagopa-commons": "^3.1.0",
     "@pagopa/io-react-native-cieid": "^0.3.5",
     "@pagopa/io-react-native-crypto": "^1.0.1",

--- a/ts/features/design-system/core/DSSelection.tsx
+++ b/ts/features/design-system/core/DSSelection.tsx
@@ -12,7 +12,6 @@ import {
   NativeSwitch,
   RadioGroup,
   RadioItem,
-  SwitchLabel,
   VStack,
   useIOTheme
 } from "@pagopa/io-app-design-system";
@@ -62,8 +61,6 @@ export const DSSelection = () => {
             <NativeSwitchShowroom />
             {/* ListItemSwitch */}
             <ListItemSwitchShowroom />
-            {/* SwitchLabel */}
-            {renderAnimatedSwitch()}
           </VStack>
         </VStack>
       </VStack>
@@ -308,29 +305,17 @@ const AnimatedMessageCheckboxShowroom = () => {
   const toggleSwitch = () => setIsEnabled(previousState => !previousState);
 
   return (
-    <>
-      <DSComponentViewerBox name="AnimatedMessageCheckbox">
-        <View style={[IOStyles.row, IOStyles.alignCenter]}>
-          <AnimatedMessageCheckbox checked={isEnabled} />
-          <HSpacer size={24} />
-          <NativeSwitch onValueChange={toggleSwitch} value={isEnabled} />
-        </View>
-      </DSComponentViewerBox>
-    </>
+    <DSComponentViewerBox name="AnimatedMessageCheckbox">
+      <View style={[IOStyles.row, IOStyles.alignCenter]}>
+        <AnimatedMessageCheckbox checked={isEnabled} />
+        <HSpacer size={24} />
+        <NativeSwitch onValueChange={toggleSwitch} value={isEnabled} />
+      </View>
+    </DSComponentViewerBox>
   );
 };
 
 // SWITCH
-
-const renderAnimatedSwitch = () => (
-  <DSComponentViewerBox name="AnimatedSwitch, dismissed in favor of the native one">
-    <VStack space={componentInnerMargin}>
-      <SwitchLabel label="This is a test" />
-      <SwitchLabel label="This is a test with a very loooong looooooong loooooooong text" />
-    </VStack>
-  </DSComponentViewerBox>
-);
-
 const NativeSwitchShowroom = () => {
   const [isEnabled, setIsEnabled] = useState(false);
   const toggleSwitch = () => setIsEnabled(previousState => !previousState);

--- a/ts/features/itwallet/common/components/__tests__/__snapshots__/ItwFeedbackBanner.test.tsx.snap
+++ b/ts/features/itwallet/common/components/__tests__/__snapshots__/ItwFeedbackBanner.test.tsx.snap
@@ -471,8 +471,36 @@ exports[`ItwFeedbackBanner should match the snapshot 1`] = `
                                 accessibilityElementsHidden={true}
                                 accessibilityLabel="Inizia"
                                 accessibilityRole="button"
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
                                 accessible={true}
+                                collapsable={false}
+                                focusable={true}
                                 importantForAccessibility="no-hide-descendants"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 pointerEvents="none"
                               >
                                 <View

--- a/ts/features/itwallet/common/components/discoveryBanner/__tests__/__snapshots__/ItwDiscoveryBanner.test.tsx.snap
+++ b/ts/features/itwallet/common/components/discoveryBanner/__tests__/__snapshots__/ItwDiscoveryBanner.test.tsx.snap
@@ -472,8 +472,36 @@ exports[`ItwDiscoveryBanner should match snapshot 1`] = `
                                 accessibilityElementsHidden={true}
                                 accessibilityLabel="Inizia"
                                 accessibilityRole="button"
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
                                 accessible={true}
+                                collapsable={false}
+                                focusable={true}
                                 importantForAccessibility="no-hide-descendants"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 pointerEvents="none"
                               >
                                 <View

--- a/ts/features/itwallet/common/components/discoveryBanner/__tests__/__snapshots__/ItwDiscoveryBannerOnboarding.test.tsx.snap
+++ b/ts/features/itwallet/common/components/discoveryBanner/__tests__/__snapshots__/ItwDiscoveryBannerOnboarding.test.tsx.snap
@@ -790,8 +790,36 @@ exports[`ItwDiscoveryBannerOnboarding should match snapshot when isItwDiscoveryB
                                 accessibilityElementsHidden={true}
                                 accessibilityLabel="Inizia"
                                 accessibilityRole="button"
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
                                 accessible={true}
+                                collapsable={false}
+                                focusable={true}
                                 importantForAccessibility="no-hide-descendants"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 pointerEvents="none"
                               >
                                 <View

--- a/ts/features/itwallet/common/components/discoveryBanner/__tests__/__snapshots__/ItwDiscoveryBannerStandalone.test.tsx.snap
+++ b/ts/features/itwallet/common/components/discoveryBanner/__tests__/__snapshots__/ItwDiscoveryBannerStandalone.test.tsx.snap
@@ -822,8 +822,36 @@ exports[`ItwDiscoveryBannerStandalone should match snapshot when isItwDiscoveryB
                                   accessibilityElementsHidden={true}
                                   accessibilityLabel="Inizia"
                                   accessibilityRole="button"
+                                  accessibilityState={
+                                    {
+                                      "busy": undefined,
+                                      "checked": undefined,
+                                      "disabled": undefined,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
                                   accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
                                   importantForAccessibility="no-hide-descendants"
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
                                   pointerEvents="none"
                                 >
                                   <View

--- a/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/RemoteContentBanner.test.tsx.snap
+++ b/ts/features/messages/components/MessageDetail/__tests__/__snapshots__/RemoteContentBanner.test.tsx.snap
@@ -443,8 +443,36 @@ exports[`RemoteContentBanner Should match snapshot 1`] = `
                               accessibilityElementsHidden={true}
                               accessibilityLabel="Learn more"
                               accessibilityRole="button"
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
                               accessible={true}
+                              collapsable={false}
+                              focusable={true}
                               importantForAccessibility="no-hide-descendants"
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
                               pointerEvents="none"
                             >
                               <View

--- a/ts/features/pushNotifications/components/__tests__/__snapshots__/PushNotificationsBanner.test.tsx.snap
+++ b/ts/features/pushNotifications/components/__tests__/__snapshots__/PushNotificationsBanner.test.tsx.snap
@@ -473,8 +473,36 @@ exports[`PushNotificationsBanner should render correctly and call 'trackPushNoti
                                 accessibilityElementsHidden={true}
                                 accessibilityLabel="Turn on push notifications"
                                 accessibilityRole="button"
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
                                 accessible={true}
+                                collapsable={false}
+                                focusable={true}
                                 importantForAccessibility="no-hide-descendants"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 pointerEvents="none"
                               >
                                 <View

--- a/ts/screens/authentication/__tests__/__snapshots__/LandingScreen.test.tsx.snap
+++ b/ts/screens/authentication/__tests__/__snapshots__/LandingScreen.test.tsx.snap
@@ -2439,8 +2439,36 @@ exports[`LandingScreen Should match the snapshot 1`] = `
                                         accessibilityElementsHidden={true}
                                         accessibilityLabel="We give you a hand"
                                         accessibilityRole="button"
+                                        accessibilityState={
+                                          {
+                                            "busy": undefined,
+                                            "checked": undefined,
+                                            "disabled": undefined,
+                                            "expanded": undefined,
+                                            "selected": undefined,
+                                          }
+                                        }
+                                        accessibilityValue={
+                                          {
+                                            "max": undefined,
+                                            "min": undefined,
+                                            "now": undefined,
+                                            "text": undefined,
+                                          }
+                                        }
                                         accessible={true}
+                                        collapsable={false}
+                                        focusable={true}
                                         importantForAccessibility="no-hide-descendants"
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onFocus={[Function]}
+                                        onResponderGrant={[Function]}
+                                        onResponderMove={[Function]}
+                                        onResponderRelease={[Function]}
+                                        onResponderTerminate={[Function]}
+                                        onResponderTerminationRequest={[Function]}
+                                        onStartShouldSetResponder={[Function]}
                                         pointerEvents="none"
                                       >
                                         <View

--- a/ts/screens/profile/__test__/__snapshots__/ProfileMainScreenTopBanner.test.tsx.snap
+++ b/ts/screens/profile/__test__/__snapshots__/ProfileMainScreenTopBanner.test.tsx.snap
@@ -332,8 +332,36 @@ exports[`ProfileMainScreenTopBanner should match snapshot for all possible resul
           accessibilityElementsHidden={true}
           accessibilityLabel="Go to "Your data" section"
           accessibilityRole="button"
+          accessibilityState={
+            {
+              "busy": undefined,
+              "checked": undefined,
+              "disabled": undefined,
+              "expanded": undefined,
+              "selected": undefined,
+            }
+          }
+          accessibilityValue={
+            {
+              "max": undefined,
+              "min": undefined,
+              "now": undefined,
+              "text": undefined,
+            }
+          }
           accessible={true}
+          collapsable={false}
+          focusable={true}
           importantForAccessibility="no-hide-descendants"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onResponderGrant={[Function]}
+          onResponderMove={[Function]}
+          onResponderRelease={[Function]}
+          onResponderTerminate={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
           pointerEvents="none"
         >
           <View

--- a/ts/screens/profile/components/__test__/__snapshots__/SettingsDiscoveryBanner.test.tsx.snap
+++ b/ts/screens/profile/components/__test__/__snapshots__/SettingsDiscoveryBanner.test.tsx.snap
@@ -445,8 +445,36 @@ exports[`settingsDiscoveryBanner should match snapshot 1`] = `
                                 accessibilityElementsHidden={true}
                                 accessibilityLabel="Go to Settings"
                                 accessibilityRole="button"
+                                accessibilityState={
+                                  {
+                                    "busy": undefined,
+                                    "checked": undefined,
+                                    "disabled": undefined,
+                                    "expanded": undefined,
+                                    "selected": undefined,
+                                  }
+                                }
+                                accessibilityValue={
+                                  {
+                                    "max": undefined,
+                                    "min": undefined,
+                                    "now": undefined,
+                                    "text": undefined,
+                                  }
+                                }
                                 accessible={true}
+                                collapsable={false}
+                                focusable={true}
                                 importantForAccessibility="no-hide-descendants"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onFocus={[Function]}
+                                onResponderGrant={[Function]}
+                                onResponderMove={[Function]}
+                                onResponderRelease={[Function]}
+                                onResponderTerminate={[Function]}
+                                onResponderTerminationRequest={[Function]}
+                                onStartShouldSetResponder={[Function]}
                                 pointerEvents="none"
                               >
                                 <View

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,9 +3753,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagopa/io-app-design-system@npm:4.5.5":
-  version: 4.5.5
-  resolution: "@pagopa/io-app-design-system@npm:4.5.5"
+"@pagopa/io-app-design-system@npm:4.5.6":
+  version: 4.5.6
+  resolution: "@pagopa/io-app-design-system@npm:4.5.6"
   dependencies:
     "@testing-library/jest-native": ^5.4.2
     "@types/react-test-renderer": ^18.0.0
@@ -3779,7 +3779,7 @@ __metadata:
     react-native-reanimated: "*"
     react-native-safe-area-context: "*"
     react-native-svg: "*"
-  checksum: 01519ebe0e72a572f1298e26d61d754d8126fae217f2b304a0873376b817f3124cac3d630efd6c6c1208f319363505760bb04d3784ff942ced6903815bf4d415
+  checksum: cc12dc04a4caf3e3632437238ff12860d9e01fb202a4749ae4497cd37f0814d5e6fc73802705015676ded3db5896a9ac4007ee637361b3ed5cdab0d3e470db96
   languageName: node
   linkType: hard
 
@@ -13657,7 +13657,7 @@ __metadata:
     "@babel/runtime": ^7.20.0
     "@gorhom/bottom-sheet": ^4.1.5
     "@jambit/eslint-plugin-typed-redux-saga": ^0.4.0
-    "@pagopa/io-app-design-system": 4.5.5
+    "@pagopa/io-app-design-system": 4.5.6
     "@pagopa/io-pagopa-commons": ^3.1.0
     "@pagopa/io-react-native-cieid": ^0.3.5
     "@pagopa/io-react-native-crypto": ^1.0.1


### PR DESCRIPTION
## Short description
This pull request updates the @pagopa/io-app-design-system to solve the accessibility focus order of the `Banner` component

## List of changes proposed in this pull request
- Updated the `@pagopa/io-app-design-system` package from version `4.5.5` to `4.5.6`
- Removed the unused `SwitchLabel`
- Removed the unnecessary fragment tags around the `AnimatedMessageCheckboxShowroom` component

## How to test
- Using a real device 📱, check the Banner in the `Pagamenti` section
- Turn on the TalkBack accessibility tool
- Ensure that when navigating with the `Tab` and `Shift + Tab` keys, the switch logic for the `Banner` component correctly moves focus (Text -> CTA -> Close Icon)

## Preview
https://github.com/user-attachments/assets/de385151-cd7f-4b31-9a4f-b36e7b84c929

