### PR TITLE
fix: [PE-937] a11y on `CgnCard` expiry date

### DIFF
--- a/ts/features/bonus/cgn/components/CgnCard.tsx
+++ b/ts/features/bonus/cgn/components/CgnCard.tsx
@@ -1,10 +1,10 @@
 import { H6, IOColors, BodySmall, Tag } from "@pagopa/io-app-design-system";
-import { format } from "date-fns";
 import { Image, StyleSheet, View } from "react-native";
 import cgnLogo from "../../../../../img/bonus/cgn/cgn_logo.png";
 import eycaLogo from "../../../../../img/bonus/cgn/eyca_logo.png";
 import CgnCardShape from "../../../../../img/features/cgn/cgn_card.svg";
 import I18n from "../../../../i18n";
+import { format } from "../../../../utils/dates";
 
 export type CgnCardProps = {
   expireDate?: Date;
@@ -51,6 +51,12 @@ export const CgnCard = ({ expireDate, withEycaLogo }: CgnCardProps) => {
     </View>
   );
 
+  const accessibleExpireDate = expireDate
+    ? I18n.t("bonusCard.validUntil", {
+        endDate: format(expireDate, "MMMM, YYYY")
+      })
+    : "";
+
   return (
     <View style={styles.container}>
       <View style={styles.card}>
@@ -74,7 +80,11 @@ export const CgnCard = ({ expireDate, withEycaLogo }: CgnCardProps) => {
         >
           {I18n.t("bonus.cgn.departmentName")}
         </BodySmall>
-        <BodySmall weight="Semibold" color="blueItalia-850">
+        <BodySmall
+          weight="Semibold"
+          color="blueItalia-850"
+          accessibilityLabel={accessibleExpireDate}
+        >
           {expireDate &&
             I18n.t("bonusCard.validUntil", {
               endDate: format(expireDate, "MM/YY")


### PR DESCRIPTION
## Short description
This PR fixes the a11y text on the expiry date of the CgnCard component, replacing it with more accessible text that contains the full month and full year.

## List of changes proposed in this pull request
- Formatted the accessibilityLabel with the full month and full year in order to be more accessible.

## How to test
Inside the wallet home screen, open the SR on your device and check that the CGN validity is more accessible with full month and full year as values.
