### PR TITLE
chore(IT Wallet): [SIW-2012] Notify the user 30 days before credential expiration

### DIFF
--- a/ts/features/itwallet/common/utils/__tests__/itwCredentialStatusUtils.test.ts
+++ b/ts/features/itwallet/common/utils/__tests__/itwCredentialStatusUtils.test.ts
@@ -3,6 +3,10 @@ import { getCredentialStatus } from "../itwCredentialStatusUtils";
 import { ItwStoredCredentialsMocks } from "../itwMocksUtils";
 import { StoredCredential } from "../itwTypesUtils";
 
+const options: Parameters<typeof getCredentialStatus>[1] = {
+  expiringDays: 14
+};
+
 describe("getCredentialStatus", () => {
   afterEach(() => {
     MockDate.reset();
@@ -26,7 +30,7 @@ describe("getCredentialStatus", () => {
         storedStatusAttestation: { credentialStatus: "invalid" }
       };
 
-      expect(getCredentialStatus(mockCredential)).toEqual("expired");
+      expect(getCredentialStatus(mockCredential, options)).toEqual("expired");
     });
 
     it("should return the digital document expired status", () => {
@@ -47,7 +51,9 @@ describe("getCredentialStatus", () => {
         storedStatusAttestation: { credentialStatus: "valid" }
       };
 
-      expect(getCredentialStatus(mockCredential)).toEqual("jwtExpired");
+      expect(getCredentialStatus(mockCredential, options)).toEqual(
+        "jwtExpired"
+      );
     });
 
     // Physical document wins
@@ -68,7 +74,7 @@ describe("getCredentialStatus", () => {
         storedStatusAttestation: { credentialStatus: "invalid" }
       };
 
-      expect(getCredentialStatus(mockCredential)).toEqual("expired");
+      expect(getCredentialStatus(mockCredential, options)).toEqual("expired");
     });
 
     it("should return jwtExpired when only JWT data are available", () => {
@@ -81,7 +87,9 @@ describe("getCredentialStatus", () => {
         }
       };
 
-      expect(getCredentialStatus(mockCredential)).toEqual("jwtExpired");
+      expect(getCredentialStatus(mockCredential, options)).toEqual(
+        "jwtExpired"
+      );
     });
   });
 
@@ -104,7 +112,7 @@ describe("getCredentialStatus", () => {
         storedStatusAttestation: { credentialStatus: "valid" }
       };
 
-      expect(getCredentialStatus(mockCredential)).toEqual("expiring");
+      expect(getCredentialStatus(mockCredential, options)).toEqual("expiring");
     });
 
     it("should return the digital document expiring status", () => {
@@ -125,7 +133,9 @@ describe("getCredentialStatus", () => {
         storedStatusAttestation: { credentialStatus: "valid" }
       };
 
-      expect(getCredentialStatus(mockCredential)).toEqual("jwtExpiring");
+      expect(getCredentialStatus(mockCredential, options)).toEqual(
+        "jwtExpiring"
+      );
     });
 
     // Digital document wins
@@ -147,7 +157,9 @@ describe("getCredentialStatus", () => {
         storedStatusAttestation: { credentialStatus: "valid" }
       };
 
-      expect(getCredentialStatus(mockCredential)).toEqual("jwtExpiring");
+      expect(getCredentialStatus(mockCredential, options)).toEqual(
+        "jwtExpiring"
+      );
     });
 
     // Physical document wins
@@ -169,7 +181,7 @@ describe("getCredentialStatus", () => {
         storedStatusAttestation: { credentialStatus: "valid" }
       };
 
-      expect(getCredentialStatus(mockCredential)).toEqual("expiring");
+      expect(getCredentialStatus(mockCredential, options)).toEqual("expiring");
     });
 
     it("should return jwtExpiring when only JWT data are available", () => {
@@ -182,7 +194,9 @@ describe("getCredentialStatus", () => {
         }
       };
 
-      expect(getCredentialStatus(mockCredential)).toEqual("jwtExpiring");
+      expect(getCredentialStatus(mockCredential, options)).toEqual(
+        "jwtExpiring"
+      );
     });
   });
 
@@ -204,7 +218,7 @@ describe("getCredentialStatus", () => {
         storedStatusAttestation: { credentialStatus: "invalid" }
       };
 
-      expect(getCredentialStatus(mockCredential)).toEqual("invalid");
+      expect(getCredentialStatus(mockCredential, options)).toEqual("invalid");
     });
 
     it("should return the physical document invalid status over any digital document status", () => {
@@ -224,7 +238,7 @@ describe("getCredentialStatus", () => {
         storedStatusAttestation: { credentialStatus: "invalid" }
       };
 
-      expect(getCredentialStatus(mockCredential)).toEqual("invalid");
+      expect(getCredentialStatus(mockCredential, options)).toEqual("invalid");
     });
   });
 
@@ -247,7 +261,7 @@ describe("getCredentialStatus", () => {
         storedStatusAttestation: { credentialStatus: "valid" }
       };
 
-      expect(getCredentialStatus(mockCredential)).toEqual("valid");
+      expect(getCredentialStatus(mockCredential, options)).toEqual("valid");
     });
 
     it("should return valid when the credential does not have an expiration date and it is not invalid for other reasons", () => {
@@ -268,7 +282,7 @@ describe("getCredentialStatus", () => {
         storedStatusAttestation: { credentialStatus: "valid" }
       };
 
-      expect(getCredentialStatus(mockCredential)).toEqual("valid");
+      expect(getCredentialStatus(mockCredential, options)).toEqual("valid");
     });
 
     it("should return valid when only JWT data are available", () => {
@@ -281,7 +295,7 @@ describe("getCredentialStatus", () => {
         }
       };
 
-      expect(getCredentialStatus(mockCredential)).toEqual("valid");
+      expect(getCredentialStatus(mockCredential, options)).toEqual("valid");
     });
   });
 
@@ -293,7 +307,7 @@ describe("getCredentialStatus", () => {
           credentialStatus: "unknown"
         }
       };
-      expect(getCredentialStatus(mockCredential)).toEqual("unknown");
+      expect(getCredentialStatus(mockCredential, options)).toEqual("unknown");
     });
   });
 });

--- a/ts/features/itwallet/common/utils/itwCredentialStatusUtils.ts
+++ b/ts/features/itwallet/common/utils/itwCredentialStatusUtils.ts
@@ -25,7 +25,7 @@ export const getCredentialStatus = (
   credential: StoredCredential,
   options: GetCredentialStatusOptions = {}
 ): ItwCredentialStatus => {
-  const { expiringDays = 14 } = options;
+  const { expiringDays = 30 } = options;
   const {
     jwt,
     parsedCredential,

--- a/ts/features/itwallet/common/utils/itwCredentialStatusUtils.ts
+++ b/ts/features/itwallet/common/utils/itwCredentialStatusUtils.ts
@@ -5,9 +5,12 @@ import * as O from "fp-ts/lib/Option";
 import { getCredentialExpireDate } from "./itwClaimsUtils";
 import { ItwCredentialStatus, StoredCredential } from "./itwTypesUtils";
 
+const DEFAULT_EXPIRING_DAYS = 30;
+
 type GetCredentialStatusOptions = {
   /**
    * Number of days before expiration required to mark a credential as "EXPIRING".
+   * @default 30
    */
   expiringDays?: number;
 };
@@ -25,7 +28,7 @@ export const getCredentialStatus = (
   credential: StoredCredential,
   options: GetCredentialStatusOptions = {}
 ): ItwCredentialStatus => {
-  const { expiringDays = 30 } = options;
+  const { expiringDays = DEFAULT_EXPIRING_DAYS } = options;
   const {
     jwt,
     parsedCredential,

--- a/ts/features/itwallet/credentials/store/selectors/index.ts
+++ b/ts/features/itwallet/credentials/store/selectors/index.ts
@@ -126,12 +126,7 @@ export const itwCredentialsEidStatusSelector = createSelector(
     pipe(
       eidOption,
       // eID does not have status attestation nor expiry date, so it safe to assume its status is based on the JWT only
-      O.map(
-        eid =>
-          getCredentialStatus(eid, {
-            expiringDays: 14
-          }) as ItwJwtCredentialStatus
-      ),
+      O.map(eid => getCredentialStatus(eid) as ItwJwtCredentialStatus),
       O.toUndefined
     )
 );

--- a/ts/features/itwallet/credentials/store/selectors/index.ts
+++ b/ts/features/itwallet/credentials/store/selectors/index.ts
@@ -14,7 +14,6 @@ import {
 } from "../../../common/utils/itwCredentialStatusUtils";
 import { CredentialType } from "../../../common/utils/itwMocksUtils";
 import {
-  ItwCredentialStatus,
   ItwJwtCredentialStatus,
   StoredCredential
 } from "../../../common/utils/itwTypesUtils";

--- a/ts/features/itwallet/credentials/store/selectors/index.ts
+++ b/ts/features/itwallet/credentials/store/selectors/index.ts
@@ -14,6 +14,7 @@ import {
 } from "../../../common/utils/itwCredentialStatusUtils";
 import { CredentialType } from "../../../common/utils/itwMocksUtils";
 import {
+  ItwCredentialStatus,
   ItwJwtCredentialStatus,
   StoredCredential
 } from "../../../common/utils/itwTypesUtils";
@@ -126,7 +127,12 @@ export const itwCredentialsEidStatusSelector = createSelector(
     pipe(
       eidOption,
       // eID does not have status attestation nor expiry date, so it safe to assume its status is based on the JWT only
-      O.map(eid => getCredentialStatus(eid) as ItwJwtCredentialStatus),
+      O.map(
+        eid =>
+          getCredentialStatus(eid, {
+            expiringDays: 14
+          }) as ItwJwtCredentialStatus
+      ),
       O.toUndefined
     )
 );


### PR DESCRIPTION
## Short description
This PR increases the notification period of expiring credentials to 30 days.

## List of changes proposed in this pull request
- Increased default value to 30 in `getCredentialStatus`

## How to test
Use credentials that are about to expire or mock the `expiry_date` claim.
