### PR TITLE
chore(IT Wallet): [SIW-1990] Persist user preference for hiding claim values in credential details

### DIFF
--- a/ts/features/itwallet/common/store/actions/preferences.ts
+++ b/ts/features/itwallet/common/store/actions/preferences.ts
@@ -1,8 +1,5 @@
 import { ActionType, createStandardAction } from "typesafe-actions";
-import {
-  ItwAuthLevel,
-  ItwClaimValuesHiddenByCredential
-} from "../../utils/itwTypesUtils.ts";
+import { ItwAuthLevel } from "../../utils/itwTypesUtils.ts";
 
 export const itwCloseFeedbackBanner = createStandardAction(
   "ITW_CLOSE_FEEDBACK_BANNER"
@@ -28,9 +25,9 @@ export const itwSetAuthLevel = createStandardAction("ITW_SET_AUTH_LEVEL")<
   ItwAuthLevel | undefined
 >();
 
-export const itwSetClaimValuesHiddenByCredential = createStandardAction(
-  "ITW_SET_CLAIM_VALUES_HIDDEN_BY_CREDENTIAL"
-)<ItwClaimValuesHiddenByCredential>();
+export const itwSetClaimValuesHidden = createStandardAction(
+  "ITW_SET_CLAIM_VALUES_HIDDEN"
+)<boolean>();
 
 export type ItwPreferencesActions =
   | ActionType<typeof itwCloseFeedbackBanner>
@@ -39,4 +36,4 @@ export type ItwPreferencesActions =
   | ActionType<typeof itwUnflagCredentialAsRequested>
   | ActionType<typeof itwSetReviewPending>
   | ActionType<typeof itwSetAuthLevel>
-  | ActionType<typeof itwSetClaimValuesHiddenByCredential>;
+  | ActionType<typeof itwSetClaimValuesHidden>;

--- a/ts/features/itwallet/common/store/actions/preferences.ts
+++ b/ts/features/itwallet/common/store/actions/preferences.ts
@@ -1,5 +1,8 @@
 import { ActionType, createStandardAction } from "typesafe-actions";
-import { ItwAuthLevel } from "../../utils/itwTypesUtils.ts";
+import {
+  ItwAuthLevel,
+  ItwClaimValuesHiddenByCredential
+} from "../../utils/itwTypesUtils.ts";
 
 export const itwCloseFeedbackBanner = createStandardAction(
   "ITW_CLOSE_FEEDBACK_BANNER"
@@ -25,10 +28,15 @@ export const itwSetAuthLevel = createStandardAction("ITW_SET_AUTH_LEVEL")<
   ItwAuthLevel | undefined
 >();
 
+export const itwSetClaimValuesHiddenByCredential = createStandardAction(
+  "ITW_SET_CLAIM_VALUES_HIDDEN_BY_CREDENTIAL"
+)<ItwClaimValuesHiddenByCredential>();
+
 export type ItwPreferencesActions =
   | ActionType<typeof itwCloseFeedbackBanner>
   | ActionType<typeof itwCloseDiscoveryBanner>
   | ActionType<typeof itwFlagCredentialAsRequested>
   | ActionType<typeof itwUnflagCredentialAsRequested>
   | ActionType<typeof itwSetReviewPending>
-  | ActionType<typeof itwSetAuthLevel>;
+  | ActionType<typeof itwSetAuthLevel>
+  | ActionType<typeof itwSetClaimValuesHiddenByCredential>;

--- a/ts/features/itwallet/common/store/reducers/__tests__/preferences.test.ts
+++ b/ts/features/itwallet/common/store/reducers/__tests__/preferences.test.ts
@@ -6,7 +6,7 @@ import {
   itwCloseFeedbackBanner,
   itwFlagCredentialAsRequested,
   itwSetAuthLevel,
-  itwSetClaimValuesHiddenByCredential,
+  itwSetClaimValuesHidden,
   itwUnflagCredentialAsRequested
 } from "../../actions/preferences";
 import reducer, {
@@ -14,7 +14,6 @@ import reducer, {
   ItwPreferencesState
 } from "../preferences";
 import { itwLifecycleStoresReset } from "../../../../lifecycle/store/actions";
-import { CredentialType } from "../../../utils/itwMocksUtils.ts";
 
 describe("IT Wallet preferences reducer", () => {
   const INITIAL_STATE: ItwPreferencesState = {
@@ -112,18 +111,13 @@ describe("IT Wallet preferences reducer", () => {
     });
   });
 
-  it("should handle itwSetClaimValuesHiddenByCredential action", () => {
-    const action = itwSetClaimValuesHiddenByCredential({
-      credentialType: CredentialType.DRIVING_LICENSE,
-      hidden: true
-    });
+  it("should handle itwSetClaimValuesHidden action", () => {
+    const action = itwSetClaimValuesHidden(true);
     const newState = reducer(INITIAL_STATE, action);
 
     expect(newState).toEqual({
       ...newState,
-      claimValuesHiddenByCredential: {
-        [CredentialType.DRIVING_LICENSE]: true
-      }
+      claimValuesHidden: true
     });
   });
 });

--- a/ts/features/itwallet/common/store/reducers/__tests__/preferences.test.ts
+++ b/ts/features/itwallet/common/store/reducers/__tests__/preferences.test.ts
@@ -6,6 +6,7 @@ import {
   itwCloseFeedbackBanner,
   itwFlagCredentialAsRequested,
   itwSetAuthLevel,
+  itwSetClaimValuesHiddenByCredential,
   itwUnflagCredentialAsRequested
 } from "../../actions/preferences";
 import reducer, {
@@ -13,6 +14,7 @@ import reducer, {
   ItwPreferencesState
 } from "../preferences";
 import { itwLifecycleStoresReset } from "../../../../lifecycle/store/actions";
+import { CredentialType } from "../../../utils/itwMocksUtils.ts";
 
 describe("IT Wallet preferences reducer", () => {
   const INITIAL_STATE: ItwPreferencesState = {
@@ -107,6 +109,21 @@ describe("IT Wallet preferences reducer", () => {
     expect(newState).toEqual({
       ...newState,
       authLevel: "L2"
+    });
+  });
+
+  it("should handle itwSetClaimValuesHiddenByCredential action", () => {
+    const action = itwSetClaimValuesHiddenByCredential({
+      credentialType: CredentialType.DRIVING_LICENSE,
+      hidden: true
+    });
+    const newState = reducer(INITIAL_STATE, action);
+
+    expect(newState).toEqual({
+      ...newState,
+      claimValuesHiddenByCredential: {
+        [CredentialType.DRIVING_LICENSE]: true
+      }
     });
   });
 });

--- a/ts/features/itwallet/common/store/reducers/preferences.ts
+++ b/ts/features/itwallet/common/store/reducers/preferences.ts
@@ -6,7 +6,7 @@ import {
   itwCloseFeedbackBanner,
   itwFlagCredentialAsRequested,
   itwSetAuthLevel,
-  itwSetClaimValuesHiddenByCredential,
+  itwSetClaimValuesHidden,
   itwSetReviewPending,
   itwUnflagCredentialAsRequested
 } from "../actions/preferences";
@@ -26,8 +26,8 @@ export type ItwPreferencesState = {
   isPendingReview?: boolean;
   // Indicates the SPID/CIE authentication level used to obtain the eid
   authLevel?: ItwAuthLevel;
-  // Indicates whether the claim values should be hidden for a specific credential type
-  claimValuesHiddenByCredential?: { [credentialType: string]: boolean };
+  // Indicates whether the claim values should be hidden in credential details
+  claimValuesHidden?: boolean;
 };
 
 export const itwPreferencesInitialState: ItwPreferencesState = {
@@ -90,13 +90,10 @@ const reducer = (
       };
     }
 
-    case getType(itwSetClaimValuesHiddenByCredential): {
+    case getType(itwSetClaimValuesHidden): {
       return {
         ...state,
-        claimValuesHiddenByCredential: {
-          ...state.claimValuesHiddenByCredential,
-          [action.payload.credentialType]: action.payload.hidden
-        }
+        claimValuesHidden: action.payload
       };
     }
 

--- a/ts/features/itwallet/common/store/reducers/preferences.ts
+++ b/ts/features/itwallet/common/store/reducers/preferences.ts
@@ -6,6 +6,7 @@ import {
   itwCloseFeedbackBanner,
   itwFlagCredentialAsRequested,
   itwSetAuthLevel,
+  itwSetClaimValuesHiddenByCredential,
   itwSetReviewPending,
   itwUnflagCredentialAsRequested
 } from "../actions/preferences";
@@ -25,6 +26,8 @@ export type ItwPreferencesState = {
   isPendingReview?: boolean;
   // Indicates the SPID/CIE authentication level used to obtain the eid
   authLevel?: ItwAuthLevel;
+  // Indicates whether the claim values should be hidden for a specific credential type
+  claimValuesHiddenByCredential?: { [credentialType: string]: boolean };
 };
 
 export const itwPreferencesInitialState: ItwPreferencesState = {
@@ -84,6 +87,16 @@ const reducer = (
       return {
         ...state,
         authLevel: action.payload
+      };
+    }
+
+    case getType(itwSetClaimValuesHiddenByCredential): {
+      return {
+        ...state,
+        claimValuesHiddenByCredential: {
+          ...state.claimValuesHiddenByCredential,
+          [action.payload.credentialType]: action.payload.hidden
+        }
       };
     }
 

--- a/ts/features/itwallet/common/store/selectors/preferences.ts
+++ b/ts/features/itwallet/common/store/selectors/preferences.ts
@@ -61,3 +61,16 @@ export const itwIsPendingReviewSelector = (state: GlobalState) =>
  */
 export const itwAuthLevelSelector = (state: GlobalState) =>
   state.features.itWallet.preferences.authLevel;
+
+/**
+ * Returns whether claim values are hidden for a specific credential type.
+ * If the mapping object doesn't exist or the credential type is not present, it defaults to false.
+ */
+export const itwIsClaimValueHiddenByCredentialSelector = (
+  credentialType: string
+) =>
+  createSelector(
+    [itwPreferencesSelector],
+    preferences =>
+      preferences.claimValuesHiddenByCredential?.[credentialType] ?? false
+  );

--- a/ts/features/itwallet/common/store/selectors/preferences.ts
+++ b/ts/features/itwallet/common/store/selectors/preferences.ts
@@ -63,14 +63,7 @@ export const itwAuthLevelSelector = (state: GlobalState) =>
   state.features.itWallet.preferences.authLevel;
 
 /**
- * Returns whether claim values are hidden for a specific credential type.
- * If the mapping object doesn't exist or the credential type is not present, it defaults to false.
+ * Returns whether claim values are hidden in credentials detail. Defaults to false.
  */
-export const itwIsClaimValueHiddenByCredentialSelector = (
-  credentialType: string
-) =>
-  createSelector(
-    [itwPreferencesSelector],
-    preferences =>
-      preferences.claimValuesHiddenByCredential?.[credentialType] ?? false
-  );
+export const itwIsClaimValueHiddenSelector = (state: GlobalState) =>
+  state.features.itWallet.preferences.claimValuesHidden ?? false;

--- a/ts/features/itwallet/common/utils/itwTypesUtils.ts
+++ b/ts/features/itwallet/common/utils/itwTypesUtils.ts
@@ -105,11 +105,3 @@ export type ItwCredentialStatus =
   | ItwJwtCredentialStatus;
 
 export type ItwAuthLevel = "L2" | "L3";
-
-/**
- * Defines the payload structure for setting claim values visibility by credential type.
- */
-export type ItwClaimValuesHiddenByCredential = {
-  credentialType: string;
-  hidden: boolean;
-};

--- a/ts/features/itwallet/common/utils/itwTypesUtils.ts
+++ b/ts/features/itwallet/common/utils/itwTypesUtils.ts
@@ -105,3 +105,11 @@ export type ItwCredentialStatus =
   | ItwJwtCredentialStatus;
 
 export type ItwAuthLevel = "L2" | "L3";
+
+/**
+ * Defines the payload structure for setting claim values visibility by credential type.
+ */
+export type ItwClaimValuesHiddenByCredential = {
+  credentialType: string;
+  hidden: boolean;
+};

--- a/ts/features/itwallet/presentation/details/components/ItwPresentationClaimsSection.tsx
+++ b/ts/features/itwallet/presentation/details/components/ItwPresentationClaimsSection.tsx
@@ -17,8 +17,8 @@ import {
 import { getCredentialStatus } from "../../../common/utils/itwCredentialStatusUtils.ts";
 import { StoredCredential } from "../../../common/utils/itwTypesUtils.ts";
 import { useIODispatch, useIOSelector } from "../../../../../store/hooks.ts";
-import { itwIsClaimValueHiddenByCredentialSelector } from "../../../common/store/selectors/preferences.ts";
-import { itwSetClaimValuesHiddenByCredential } from "../../../common/store/actions/preferences.ts";
+import { itwIsClaimValueHiddenSelector } from "../../../common/store/selectors/preferences.ts";
+import { itwSetClaimValuesHidden } from "../../../common/store/actions/preferences.ts";
 
 type ItwPresentationClaimsSectionProps = {
   credential: StoredCredential;
@@ -38,17 +38,10 @@ export const ItwPresentationClaimsSection = ({
     exclude: [WellKnownClaim.unique_id, WellKnownClaim.content]
   });
 
-  const valuesHidden = useIOSelector(
-    itwIsClaimValueHiddenByCredentialSelector(credential.credentialType)
-  );
+  const valuesHidden = useIOSelector(itwIsClaimValueHiddenSelector);
 
-  const handleToggleClaimVisibility = (hidden: boolean) => {
-    dispatch(
-      itwSetClaimValuesHiddenByCredential({
-        credentialType: credential.credentialType,
-        hidden
-      })
-    );
+  const handleToggleClaimVisibility = () => {
+    dispatch(itwSetClaimValuesHidden(!valuesHidden));
   };
 
   const renderHideValuesToggle = () => (
@@ -63,7 +56,7 @@ export const ItwPresentationClaimsSection = ({
       <IconButton
         testID="toggle-claim-visibility"
         icon={valuesHidden ? "eyeHide" : "eyeShow"}
-        onPress={() => handleToggleClaimVisibility(!valuesHidden)}
+        onPress={handleToggleClaimVisibility}
         accessibilityLabel={I18n.t(
           "features.itWallet.presentation.credentialDetails.actions.hideClaimValues"
         )}

--- a/ts/features/itwallet/presentation/details/components/ItwPresentationClaimsSection.tsx
+++ b/ts/features/itwallet/presentation/details/components/ItwPresentationClaimsSection.tsx
@@ -4,7 +4,7 @@ import {
   IconButton,
   IOStyles
 } from "@pagopa/io-app-design-system";
-import { Fragment, useMemo, useState } from "react";
+import { Fragment, useMemo } from "react";
 import { View } from "react-native";
 import I18n from "../../../../../i18n.ts";
 import { ItwCredentialClaim } from "../../../common/components/ItwCredentialClaim.tsx";
@@ -16,6 +16,9 @@ import {
 } from "../../../common/utils/itwClaimsUtils.ts";
 import { getCredentialStatus } from "../../../common/utils/itwCredentialStatusUtils.ts";
 import { StoredCredential } from "../../../common/utils/itwTypesUtils.ts";
+import { useIODispatch, useIOSelector } from "../../../../../store/hooks.ts";
+import { itwIsClaimValueHiddenByCredentialSelector } from "../../../common/store/selectors/preferences.ts";
+import { itwSetClaimValuesHiddenByCredential } from "../../../common/store/actions/preferences.ts";
 
 type ItwPresentationClaimsSectionProps = {
   credential: StoredCredential;
@@ -24,7 +27,7 @@ type ItwPresentationClaimsSectionProps = {
 export const ItwPresentationClaimsSection = ({
   credential
 }: ItwPresentationClaimsSectionProps) => {
-  const [valuesHidden, setValuesHidden] = useState(false);
+  const dispatch = useIODispatch();
 
   const credentialStatus = useMemo(
     () => getCredentialStatus(credential),
@@ -34,6 +37,19 @@ export const ItwPresentationClaimsSection = ({
   const claims = parseClaims(credential.parsedCredential, {
     exclude: [WellKnownClaim.unique_id, WellKnownClaim.content]
   });
+
+  const valuesHidden = useIOSelector(
+    itwIsClaimValueHiddenByCredentialSelector(credential.credentialType)
+  );
+
+  const handleToggleClaimVisibility = (hidden: boolean) => {
+    dispatch(
+      itwSetClaimValuesHiddenByCredential({
+        credentialType: credential.credentialType,
+        hidden
+      })
+    );
+  };
 
   const renderHideValuesToggle = () => (
     <View
@@ -47,7 +63,7 @@ export const ItwPresentationClaimsSection = ({
       <IconButton
         testID="toggle-claim-visibility"
         icon={valuesHidden ? "eyeHide" : "eyeShow"}
-        onPress={() => setValuesHidden(_ => !_)}
+        onPress={() => handleToggleClaimVisibility(!valuesHidden)}
         accessibilityLabel={I18n.t(
           "features.itWallet.presentation.credentialDetails.actions.hideClaimValues"
         )}


### PR DESCRIPTION
## Short description
This PR allows users to save and persist their preference for displaying claim values in credential details

## List of changes proposed in this pull request
- Add a new action (`itwSetClaimValuesHidden`) and selector (`itwIsClaimValueHiddenSelector`) to manage the hidden state of claim values in credentials detail screen.
- Updated the `ItwPresentationClaimsSection` component to dispatch the action and retrieve the state from the store

## How to test
Hide the claim values, exit from the credential details or close the app, and verify that the selected display preference is retained


https://github.com/user-attachments/assets/f47c6a7e-bf9d-4638-8a13-f22d919fd2b2




