### PR TITLE
fix: [IOCOM-2160] Service link accessibility role in message details

### DIFF
--- a/ts/features/messages/components/MessageDetail/MessageDetailsHeader.tsx
+++ b/ts/features/messages/components/MessageDetail/MessageDetailsHeader.tsx
@@ -9,7 +9,7 @@ import { localeDateFormat } from "../../../../utils/locale";
 import I18n from "../../../../i18n";
 import { logosForService } from "../../../services/common/utils";
 import { useIOSelector } from "../../../../store/hooks";
-import { serviceByIdPotSelector } from "../../../services/details/store/reducers";
+import { serviceByIdPotSelector, serviceByIdSelector } from "../../../services/details/store/reducers";
 import { gapBetweenItemsInAGrid } from "../../utils";
 import { UIMessageId } from "../../types";
 import { OrganizationHeader } from "./OrganizationHeader";
@@ -53,11 +53,7 @@ export const MessageDetailsHeader = ({
   serviceId,
   ...rest
 }: MessageDetailsHeaderProps) => {
-  const service = pipe(
-    useIOSelector(state => serviceByIdPotSelector(state, serviceId)),
-    pot.toOption,
-    O.toUndefined
-  );
+  const service = useIOSelector(state => serviceByIdSelector(state, serviceId));
 
   return (
     <>

--- a/ts/features/messages/components/MessageDetail/OrganizationHeader.tsx
+++ b/ts/features/messages/components/MessageDetail/OrganizationHeader.tsx
@@ -68,7 +68,7 @@ export const OrganizationHeader = ({
           {organizationName}
         </Body>
         <BodySmall
-          color={theme["interactiveElem-default"]}
+          asLink={true}
           onPress={navigateToServiceDetails}
           weight="Semibold"
         >


### PR DESCRIPTION
## Short description
This PR fixes the accessibility role of the service link, in the message details' screen.

## List of changes proposed in this pull request
- Added asLink property, that enables the accessibility role
- Removed color property (since it is the default one)

## How to test
Using a real device (both Android and iOS), check that the service link is announced with the "link" role, on the message details' screen.