### PR TITLE
chore: [IOBP-1194,IOBP-1196] a11y focus improvements on Barcode scan screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@babel/plugin-transform-private-property-in-object": "^7.25.9",
     "@babel/plugin-transform-react-jsx": "^7.25.9",
     "@gorhom/bottom-sheet": "^4.1.5",
-    "@pagopa/io-app-design-system": "5.0.0",
+    "@pagopa/io-app-design-system": "5.0.1",
     "@pagopa/io-pagopa-commons": "^3.1.0",
     "@pagopa/io-react-native-cieid": "^0.3.5",
     "@pagopa/io-react-native-crypto": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@babel/plugin-transform-private-property-in-object": "^7.25.9",
     "@babel/plugin-transform-react-jsx": "^7.25.9",
     "@gorhom/bottom-sheet": "^4.1.5",
-    "@pagopa/io-app-design-system": "5.0.1",
+    "@pagopa/io-app-design-system": "5.0.2",
     "@pagopa/io-pagopa-commons": "^3.1.0",
     "@pagopa/io-react-native-cieid": "^0.3.5",
     "@pagopa/io-react-native-crypto": "^1.0.1",

--- a/ts/features/barcode/components/BarcodeScanBaseScreenComponent.tsx
+++ b/ts/features/barcode/components/BarcodeScanBaseScreenComponent.tsx
@@ -17,6 +17,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState
 } from "react";
 import { AppState, StyleSheet, View } from "react-native";
@@ -25,6 +26,7 @@ import {
   SafeAreaView,
   useSafeAreaInsets
 } from "react-native-safe-area-context";
+import { Millisecond } from "@pagopa/ts-commons/lib/units";
 import { ToolEnum } from "../../../../definitions/content/AssistanceToolConfig";
 import { BaseHeader } from "../../../components/screens/BaseHeader";
 import {
@@ -67,6 +69,7 @@ import {
   IOBarcodeType
 } from "../types/IOBarcode";
 import { BarcodeFailure } from "../types/failure";
+import { setAccessibilityFocus } from "../../../utils/accessibility";
 import { CameraPermissionView } from "./CameraPermissionView";
 
 type HelpProps = {
@@ -140,6 +143,7 @@ const BarcodeScanBaseScreenComponent = ({
   const insets = useSafeAreaInsets();
   const navigation = useNavigation<IOStackNavigationProp<AppParamsList>>();
   const route = useRoute();
+  const scanItemRef = useRef<View>(null);
 
   const currentScreenName = useIOSelector(currentRouteSelector);
 
@@ -163,11 +167,17 @@ const BarcodeScanBaseScreenComponent = ({
     const subscription = AppState.addEventListener("change", nextAppState => {
       setIsAppInBackground(nextAppState !== "active");
     });
-
     return () => {
       subscription.remove();
     };
   }, []);
+
+  useFocusEffect(
+    useCallback(
+      () => setAccessibilityFocus(scanItemRef, 200 as Millisecond),
+      []
+    )
+  );
 
   useFocusEffect(
     useCallback(() => {
@@ -313,6 +323,7 @@ const BarcodeScanBaseScreenComponent = ({
       <View style={styles.navigationContainer}>
         <TabNavigation tabAlignment="stretch" selectedIndex={0} color="dark">
           <TabItem
+            ref={scanItemRef}
             testID="barcodeScanBaseScreenTabScan"
             label={I18n.t("barcodeScan.tabs.scan")}
             accessibilityLabel={I18n.t("barcodeScan.tabs.a11y.scan")}
@@ -344,6 +355,10 @@ const BarcodeScanBaseScreenComponent = ({
           />
           {/* FIXME: replace with new header */}
           <BaseHeader
+            accessibilityEvents={{
+              avoidNavigationEventsUsage: true,
+              disableAccessibilityFocus: true
+            }}
             hideSafeArea={true}
             dark={true}
             backgroundColor={"transparent"}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,9 +3753,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagopa/io-app-design-system@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@pagopa/io-app-design-system@npm:5.0.0"
+"@pagopa/io-app-design-system@npm:5.0.1":
+  version: 5.0.1
+  resolution: "@pagopa/io-app-design-system@npm:5.0.1"
   dependencies:
     "@testing-library/jest-native": ^5.4.2
     "@types/react-test-renderer": ^18.0.0
@@ -3779,7 +3779,7 @@ __metadata:
     react-native-reanimated: "*"
     react-native-safe-area-context: "*"
     react-native-svg: "*"
-  checksum: 3eef5c88e732f01f54fff37418b33373a388acd540d0bab7f8d1e1e186c8553340e7ef825520cb8f75330131580c4c4a571cfdfca292ce8b88e2e9d7f6dc04bb
+  checksum: 20c580f450c45bb01b6ee9c67fba863e37e42b4e05020a2e2eacb5dde796a835f6063729c6ff62208f5527723d574c9933a4cb15e9cb127a9de71b607eddd64f
   languageName: node
   linkType: hard
 
@@ -13657,7 +13657,7 @@ __metadata:
     "@babel/runtime": ^7.20.0
     "@gorhom/bottom-sheet": ^4.1.5
     "@jambit/eslint-plugin-typed-redux-saga": ^0.4.0
-    "@pagopa/io-app-design-system": 5.0.0
+    "@pagopa/io-app-design-system": 5.0.1
     "@pagopa/io-pagopa-commons": ^3.1.0
     "@pagopa/io-react-native-cieid": ^0.3.5
     "@pagopa/io-react-native-crypto": ^1.0.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,9 +3753,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagopa/io-app-design-system@npm:5.0.1":
-  version: 5.0.1
-  resolution: "@pagopa/io-app-design-system@npm:5.0.1"
+"@pagopa/io-app-design-system@npm:5.0.2":
+  version: 5.0.2
+  resolution: "@pagopa/io-app-design-system@npm:5.0.2"
   dependencies:
     "@testing-library/jest-native": ^5.4.2
     "@types/react-test-renderer": ^18.0.0
@@ -3779,7 +3779,7 @@ __metadata:
     react-native-reanimated: "*"
     react-native-safe-area-context: "*"
     react-native-svg: "*"
-  checksum: 20c580f450c45bb01b6ee9c67fba863e37e42b4e05020a2e2eacb5dde796a835f6063729c6ff62208f5527723d574c9933a4cb15e9cb127a9de71b607eddd64f
+  checksum: f9ae39263ca0379b6776b681ea0334b95b319668e34e859ac378d344c5f0b7aac197234391ddea70e9e80bac6f01ccc5f6aaada562251c77d07ed38b5a8de99b
   languageName: node
   linkType: hard
 
@@ -13657,7 +13657,7 @@ __metadata:
     "@babel/runtime": ^7.20.0
     "@gorhom/bottom-sheet": ^4.1.5
     "@jambit/eslint-plugin-typed-redux-saga": ^0.4.0
-    "@pagopa/io-app-design-system": 5.0.1
+    "@pagopa/io-app-design-system": 5.0.2
     "@pagopa/io-pagopa-commons": ^3.1.0
     "@pagopa/io-react-native-cieid": ^0.3.5
     "@pagopa/io-react-native-crypto": ^1.0.1


### PR DESCRIPTION
## Short description
This PR fixes and improves the accessibility focus issue when opening the Barcode scan screen. Now it announces and focuses on the "Scan" tab when opening the screen and focusing it back.

## List of changes proposed in this pull request
- Updated the `io-app-design-system` library with the version `5.0.2` which supports the TabItem `ref` prop;
- Disabled the automatic accessibility focus on the `BaseHeader` component;
- Set the accessibility focus to the "Scan" tab item at every screen focus with a 200ms delay which is necessary due iOS behaviors.

## How to test
- Run `yarn install` and check that the `io-app-design-system` library has the version `5.0.2`
- With the SR enabled, open the barcode scan screen both from "Scan" tab and "Payments" tab;
- Check that the "Scan" tab item is announced and focuesed at the first render and when navigating back from the next screens;

## Preview
|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/610a515b-aa34-43ef-99a9-0c3d51f14ae0" />|<video src="https://github.com/user-attachments/assets/ab6bae26-205c-4cd5-b61e-cecaa55a6dea" />|

