### PR TITLE
feat(IT Wallet): [SIW-2042] Use IOMarkdown when displaying a remote message inside credential presentation 

### DIFF
--- a/ts/features/itwallet/presentation/details/components/ItwPresentationCredentialStatusAlert.tsx
+++ b/ts/features/itwallet/presentation/details/components/ItwPresentationCredentialStatusAlert.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { Alert, Body } from "@pagopa/io-app-design-system";
+import { Alert } from "@pagopa/io-app-design-system";
 import I18n from "../../../../../i18n.ts";
 import { StoredCredential } from "../../../common/utils/itwTypesUtils.ts";
 import {
@@ -121,7 +121,7 @@ const IssuerDynamicErrorAlert = ({ message }: IssuerDynamicErrorAlertProps) => {
   const bottomSheet = useIOBottomSheetAutoresizableModal(
     {
       title: localizedMessage.title,
-      component: <Body>{localizedMessage.description}</Body>
+      component: <IOMarkdown content={localizedMessage.description} />
     },
     128
   );


### PR DESCRIPTION
## Short description
Replaced the `Body` component with `IOMarkdown` to support markdown formatted errors descriptions when using EC error messages

## List of changes proposed in this pull request
- Replaced the `Body` component with `IOMarkdown` inside `IssuerDynamicErrorAlert`

## How to test
Simulate a remote dynamic error checking that the error description is displayed correctly
