### PR TITLE
chore(IT Wallet): [SIW-2022] Increased serialization for unexpected errors during eID issuance

### DIFF
--- a/ts/features/itwallet/issuance/hooks/useEidEventsTracking.ts
+++ b/ts/features/itwallet/issuance/hooks/useEidEventsTracking.ts
@@ -55,7 +55,7 @@ export const useEidEventsTracking = ({ failure, identification }: Params) => {
     }
 
     if (failure.type === IssuanceFailureType.UNEXPECTED) {
-      /* 
+      /*
        * Some errors have an empty object as `failure.reason`, but `failure.reason.message` is still defined.
        * In these cases, we use the `serializeFailureReason` function to provide a more informative message on Mixpanel.
        * To maintain compatibility with the existing failure tracking, we keep the original `failure` object when `failure.reason` is not empty.


### PR DESCRIPTION
## Short description
This PR aims to enhance the reason for errors during eID issuance that fall under `IssuanceFailureType.UNEXPECTED `in the Mixpanel tracking.

Some unexpected errors in the reason field on Mixpanel report as `{"jsEngine":"hermes"}`. Unfortunately, this error is not descriptive, making it difficult to understand what the actual issue was.

## List of changes proposed in this pull request
- Added a check within the `trackItwIdRequestUnexpectedFailure` function to verify if `failure.reason` is `empty`
If `failure.reason` is `empty`, the `serializeFailureReason` function (already used in the `useItwFailureSupportModal` hook) is utilized; otherwise, the current behavior is maintained.

## How to test
**Testing with Non-Empty Object**

- Using `io-react-native-wallet` package locally, you can simulate an unexpected error by throwing
`throw new AuthorizationIdpError("access_denied", "ErrorCode nr21: Timeout during user authentication");`
- The error is unexpected and the reason is the same before and after the change

**Testing Serialization Enhancement**
- I was able to replicate the situation described in the support tickets using Charles Proxy, where the error was `Network request failed`. In detail, the error appears as `{"reason": [TypeError: Network request failed], "type": "UNEXPECTED"}`. Previously, this error was reported on Mixpanel with the reason as `{"jsEngine":"hermes"}`.
- This type of error, along with others in Mixpanel that have `{“jsEngine”: “hermes”}` as reason, probably has an empty object as `failure.reason`, but `failure.reason.message` is populated. With the recent changes, the reason on Mixpanel should now correctly show the reason

