### PR TITLE
chore: [IOBP-1231] Removed total amount from IdPayCard if reward type is `EXPENSE`

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -19,7 +19,7 @@ declare -a apis=(
   "./definitions/pagopa/cobadge/configuration https://raw.githubusercontent.com/pagopa/io-services-metadata/$IO_SERVICES_METADATA_VERSION/pagopa/cobadge/abi_definitions.yml"
   "./definitions/pagopa/privative/configuration https://raw.githubusercontent.com/pagopa/io-services-metadata/$IO_SERVICES_METADATA_VERSION/pagopa/privative/definitions.yml"
   # IDPay APIs
-  "./definitions/idpay https://raw.githubusercontent.com/pagopa/cstar-infrastructure/v11.7.1/src/domains/idpay-app/api/idpay_appio_full/openapi.appio.full.yml"
+  "./definitions/idpay https://raw.githubusercontent.com/pagopa/cstar-infrastructure/v12.2.1/src/domains/idpay-app/api/idpay_appio_full/openapi.appio.full.yml"
   # Services APIs
   "./definitions/services https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_services_app_backend.yaml"
   # Lollipop APIs

--- a/ts/features/idpay/wallet/components/IdPayCard.tsx
+++ b/ts/features/idpay/wallet/components/IdPayCard.tsx
@@ -1,9 +1,13 @@
+import * as pot from "@pagopa/ts-commons/lib/pot";
 import { Avatar, Body, H3, H6, VSpacer } from "@pagopa/io-app-design-system";
 import { format } from "date-fns";
 import { ImageURISource, StyleSheet, View } from "react-native";
 import WalletCardShape from "../../../../../img/features/idpay/wallet_card.svg";
 import I18n from "../../../../i18n";
 import { formatNumberCentsToAmount } from "../../../../utils/stringBuilder";
+import { useIOSelector } from "../../../../store/hooks";
+import { idPayWalletInitiativeListSelector } from "../store/reducers";
+import { InitiativeRewardTypeEnum } from "../../../../../definitions/idpay/InitiativeDTO";
 
 export type IdPayCardProps = {
   name: string;
@@ -15,42 +19,59 @@ export type IdPayCardProps = {
 /**
  * Component that renders the ID PAy card in the wallet
  */
-export const IdPayCard = (props: IdPayCardProps) => (
-  <View style={styles.container}>
-    <View style={styles.card}>
-      <WalletCardShape />
-    </View>
-    <View style={styles.content}>
-      <View>
-        <View style={styles.header}>
-          <H6
-            color="blueItalia-850"
-            ellipsizeMode="tail"
-            numberOfLines={1}
-            style={{
-              width: "80%"
-            }}
-          >
-            {props.name}
-          </H6>
-          <Avatar size="small" logoUri={props.avatarSource} />
-        </View>
-        <VSpacer size={16} />
-        <Body weight="Semibold" color="black">
-          Disponibile
-        </Body>
-        <H3 color="blueItalia-500">
-          {formatNumberCentsToAmount(props.amount, true, "right")}
-        </H3>
+export const IdPayCard = (props: IdPayCardProps) => {
+  const initiativeListPot = useIOSelector(idPayWalletInitiativeListSelector);
+  const initiativeCardDetails = pot.getOrElse(
+    pot.map(initiativeListPot, initiativeList =>
+      initiativeList.find(
+        initiative => initiative.initiativeName === props.name
+      )
+    ),
+    undefined
+  );
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.card}>
+        <WalletCardShape />
       </View>
-      <Body weight="Semibold" color="blueItalia-850">
-        {I18n.t("bonusCard.validUntil", {
-          endDate: format(props.expireDate, "MM/YY")
-        })}
-      </Body>
+      <View style={styles.content}>
+        <View>
+          <View style={styles.header}>
+            <H6
+              color="blueItalia-850"
+              ellipsizeMode="tail"
+              numberOfLines={1}
+              style={{
+                width: "80%"
+              }}
+            >
+              {props.name}
+            </H6>
+            <Avatar size="small" logoUri={props.avatarSource} />
+          </View>
+          {initiativeCardDetails?.initiativeRewardType !==
+            InitiativeRewardTypeEnum.EXPENSE && (
+            <>
+              <VSpacer size={16} />
+              <Body weight="Semibold" color="black">
+                Disponibile
+              </Body>
+              <H3 color="blueItalia-500">
+                {formatNumberCentsToAmount(props.amount, true, "right")}
+              </H3>
+            </>
+          )}
+        </View>
+        <Body weight="Semibold" color="blueItalia-850">
+          {I18n.t("bonusCard.validUntil", {
+            endDate: format(props.expireDate, "MM/YY")
+          })}
+        </Body>
+      </View>
     </View>
-  </View>
-);
+  );
+};
 
 const styles = StyleSheet.create({
   container: {

--- a/ts/features/idpay/wallet/components/IdPayCard.tsx
+++ b/ts/features/idpay/wallet/components/IdPayCard.tsx
@@ -57,7 +57,7 @@ export const IdPayCard = (props: IdPayCardProps) => {
               <Body weight="Semibold" color="black">
                 Disponibile
               </Body>
-              <H3 color="blueItalia-500">
+              <H3 testID="idpay-card-amount" color="blueItalia-500">
                 {formatNumberCentsToAmount(props.amount, true, "right")}
               </H3>
             </>

--- a/ts/features/idpay/wallet/components/__tests__/IdPayCard.test.tsx
+++ b/ts/features/idpay/wallet/components/__tests__/IdPayCard.test.tsx
@@ -1,18 +1,110 @@
-import { render } from "@testing-library/react-native";
-import { IdPayCard } from "../IdPayCard";
+import * as pot from "@pagopa/ts-commons/lib/pot";
+import configureMockStore from "redux-mock-store";
+import { IdPayCard, IdPayCardProps } from "../IdPayCard";
+import { appReducer } from "../../../../../store/reducers";
+
+import { applicationChangeState } from "../../../../../store/actions/application";
+import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
+import { GlobalState } from "../../../../../store/reducers/types";
+import { IDPayDetailsRoutes } from "../../../details/navigation";
+import { WalletDTO } from "../../../../../../definitions/idpay/WalletDTO";
+import {
+  InitiativeRewardTypeEnum,
+  StatusEnum
+} from "../../../../../../definitions/idpay/InitiativeDTO";
+import { formatNumberCentsToAmount } from "../../../../../utils/stringBuilder";
+
+const IDPAY_INITIATIVE_ID_MOCK = "1";
+const IDPAY_INITIATIVE_NAME = "18 app";
+const IDPAY_INITIATIVE_END_DATE_MOCK = new Date(2023, 11, 2);
+const IDPAY_INITIATIVE_AMOUNT_CENTS_MOCK = 9999;
+
+const idPayCardProps: IdPayCardProps = {
+  name: IDPAY_INITIATIVE_NAME,
+  amount: IDPAY_INITIATIVE_AMOUNT_CENTS_MOCK,
+  avatarSource: {
+    uri: "https://vtlogo.com/wp-content/uploads/2021/08/18app-vector-logo.png"
+  },
+  expireDate: new Date(2023, 11, 2)
+};
+
+const baseInitiativeCardDetails: WalletDTO = {
+  initiativeList: [
+    {
+      initiativeId: IDPAY_INITIATIVE_ID_MOCK,
+      endDate: IDPAY_INITIATIVE_END_DATE_MOCK,
+      nInstr: 1,
+      status: StatusEnum.NOT_REFUNDABLE_ONLY_IBAN,
+      initiativeName: IDPAY_INITIATIVE_NAME,
+      amountCents: IDPAY_INITIATIVE_AMOUNT_CENTS_MOCK
+    }
+  ]
+};
 
 describe("IdPayCard", () => {
   it("should match the snapshot", () => {
-    const component = render(
-      <IdPayCard
-        name="18 app"
-        amount={9999}
-        avatarSource={{
-          uri: "https://vtlogo.com/wp-content/uploads/2021/08/18app-vector-logo.png"
-        }}
-        expireDate={new Date(2023, 11, 2)}
-      />
+    const { component } = renderComponent(
+      idPayCardProps,
+      InitiativeRewardTypeEnum.REFUND
     );
     expect(component).toMatchSnapshot();
   });
+
+  it("should hide total amount if reward type is EXPENSE", () => {
+    const {
+      component: { queryByTestId }
+    } = renderComponent(idPayCardProps, InitiativeRewardTypeEnum.EXPENSE);
+    expect(queryByTestId("idpay-card-amount")).toBeNull();
+  });
+
+  it("should show total amount if reward type is not EXPENSE", () => {
+    const {
+      component: { queryByTestId }
+    } = renderComponent(idPayCardProps, InitiativeRewardTypeEnum.DISCOUNT);
+    expect(queryByTestId("idpay-card-amount")).toHaveTextContent(
+      formatNumberCentsToAmount(
+        IDPAY_INITIATIVE_AMOUNT_CENTS_MOCK,
+        true,
+        "right"
+      )
+    );
+  });
 });
+
+const renderComponent = (
+  props: IdPayCardProps,
+  rewardType: InitiativeRewardTypeEnum
+) => {
+  const globalState = appReducer(undefined, applicationChangeState("active"));
+  const mockStore = configureMockStore<GlobalState>();
+  const store: ReturnType<typeof mockStore> = mockStore({
+    ...globalState,
+    features: {
+      ...globalState.features,
+      idPay: {
+        ...globalState.features.idPay,
+        wallet: {
+          ...globalState.features.idPay.wallet,
+          initiatives: pot.some({
+            initiativeList: baseInitiativeCardDetails.initiativeList.map(
+              initiative => ({
+                ...initiative,
+                initiativeRewardType: rewardType
+              })
+            )
+          })
+        }
+      }
+    }
+  } as GlobalState);
+
+  return {
+    component: renderScreenWithNavigationStoreContext<GlobalState>(
+      () => <IdPayCard {...props} />,
+      IDPayDetailsRoutes.IDPAY_DETAILS_MAIN,
+      {},
+      store
+    ),
+    store
+  };
+};

--- a/ts/features/idpay/wallet/components/__tests__/__snapshots__/IdPayCard.test.tsx.snap
+++ b/ts/features/idpay/wallet/components/__tests__/__snapshots__/IdPayCard.test.tsx.snap
@@ -4,191 +4,536 @@ exports[`IdPayCard should match the snapshot 1`] = `
 <View
   style={
     {
-      "aspectRatio": 1.6,
+      "flex": 1,
     }
   }
 >
-  <View
+  <RNCSafeAreaProvider
+    onInsetsChange={[Function]}
     style={
-      {
-        "bottom": 0,
-        "left": 0,
-        "position": "absolute",
-        "right": 0,
-        "top": 0,
-      }
+      [
+        {
+          "flex": 1,
+        },
+        undefined,
+      ]
     }
   >
-    <SvgMock />
-  </View>
-  <View
-    style={
-      {
-        "flex": 1,
-        "justifyContent": "space-between",
-        "paddingBottom": 16,
-        "paddingLeft": 16,
-        "paddingRight": 12,
-        "paddingTop": 12,
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "#FFFFFF",
+            "flex": 1,
+          },
+          undefined,
+        ]
       }
-    }
-  >
-    <View>
+    >
       <View
+        collapsable={false}
+        pointerEvents="box-none"
         style={
           {
-            "alignItems": "center",
-            "flexDirection": "row",
-            "justifyContent": "space-between",
+            "zIndex": 1,
           }
         }
       >
-        <Text
-          allowFontScaling={true}
-          dynamicTypeRamp="headline"
-          ellipsizeMode="tail"
-          maxFontSizeMultiplier={1.5}
-          numberOfLines={1}
-          style={
-            [
-              {},
-              {
-                "color": "#001F3D",
-                "fontFamily": "Titillio",
-                "fontSize": 16,
-                "fontStyle": "normal",
-                "fontWeight": "600",
-                "lineHeight": 24,
-              },
-              {
-                "width": "80%",
-              },
-            ]
-          }
-        >
-          18 app
-        </Text>
         <View
-          accessibilityIgnoresInvertColors={true}
-          style={
-            [
-              {
-                "borderColor": "rgba(14,15,19,0.1)",
-                "borderCurve": "continuous",
-                "borderWidth": 1,
-                "overflow": "hidden",
-              },
-              {
-                "backgroundColor": "#FFFFFF",
-                "borderRadius": 8,
-                "height": 44,
-                "padding": 6,
-                "width": 44,
-              },
-            ]
-          }
+          accessibilityElementsHidden={false}
+          importantForAccessibility="auto"
+          onLayout={[Function]}
+          pointerEvents="box-none"
+          style={null}
         >
           <View
+            collapsable={false}
+            pointerEvents="box-none"
             style={
-              [
-                {
-                  "backgroundColor": "#FFFFFF",
-                  "borderCurve": "continuous",
-                  "overflow": "hidden",
-                },
-                {
-                  "borderRadius": 2,
-                },
-              ]
+              {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "zIndex": 0,
+              }
             }
           >
-            <Image
-              accessibilityIgnoresInvertColors={true}
-              onError={[Function]}
-              source={
-                {
-                  "uri": "https://vtlogo.com/wp-content/uploads/2021/08/18app-vector-logo.png",
-                }
-              }
+            <View
+              collapsable={false}
               style={
                 {
-                  "height": "100%",
-                  "resizeMode": "contain",
-                  "width": "100%",
+                  "backgroundColor": "#FFFFFF",
+                  "borderBottomColor": "rgb(216, 216, 216)",
+                  "flex": 1,
+                  "shadowColor": "rgb(216, 216, 216)",
+                  "shadowOffset": {
+                    "height": 0.5,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.85,
+                  "shadowRadius": 0,
                 }
               }
             />
           </View>
+          <View
+            collapsable={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "height": 44,
+                "maxHeight": undefined,
+                "minHeight": undefined,
+                "opacity": undefined,
+                "transform": undefined,
+              }
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                {
+                  "height": 0,
+                }
+              }
+            />
+            <View
+              pointerEvents="box-none"
+              style={
+                {
+                  "alignItems": "stretch",
+                  "flex": 1,
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginStart": 0,
+                    "opacity": 1,
+                  }
+                }
+              />
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "justifyContent": "center",
+                    "marginHorizontal": 16,
+                    "maxWidth": 718,
+                    "opacity": 1,
+                  }
+                }
+              >
+                <Text
+                  accessibilityRole="header"
+                  aria-level="1"
+                  collapsable={false}
+                  numberOfLines={1}
+                  onLayout={[Function]}
+                  style={
+                    {
+                      "color": "rgb(28, 28, 30)",
+                      "fontSize": 17,
+                      "fontWeight": "600",
+                    }
+                  }
+                >
+                  IDPAY_DETAILS_MAIN
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-end",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginEnd": 0,
+                    "opacity": 1,
+                  }
+                }
+              />
+            </View>
+          </View>
         </View>
       </View>
-      <View
+      <RNSScreenContainer
+        onLayout={[Function]}
         style={
           {
-            "height": 16,
+            "flex": 1,
           }
         }
-      />
-      <Text
-        allowFontScaling={true}
-        dynamicTypeRamp="body"
-        maxFontSizeMultiplier={1.5}
-        style={
-          [
-            {},
-            {
-              "color": "#0E0F13",
-              "fontFamily": "Titillio",
-              "fontSize": 16,
-              "fontStyle": "normal",
-              "fontWeight": "600",
-              "lineHeight": 24,
-            },
-          ]
-        }
       >
-        Disponibile
-      </Text>
-      <Text
-        allowFontScaling={true}
-        dynamicTypeRamp="title2"
-        maxFontSizeMultiplier={1.5}
-        style={
-          [
-            {},
+        <RNSScreen
+          activityState={2}
+          collapsable={false}
+          gestureResponseDistance={
             {
-              "color": "#0066CC",
-              "fontFamily": "Titillio",
-              "fontSize": 22,
-              "fontStyle": "normal",
-              "fontWeight": "600",
-              "lineHeight": 33,
-            },
-          ]
-        }
-      >
-        99.99 €
-      </Text>
+              "bottom": -1,
+              "end": -1,
+              "start": -1,
+              "top": -1,
+            }
+          }
+          onGestureCancel={[Function]}
+          pointerEvents="box-none"
+          sheetAllowedDetents="large"
+          sheetCornerRadius={-1}
+          sheetExpandsWhenScrolledToEdge={true}
+          sheetGrabberVisible={false}
+          sheetLargestUndimmedDetent="all"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "zIndex": undefined,
+            }
+          }
+        >
+          <View
+            collapsable={false}
+            style={
+              {
+                "opacity": 1,
+              }
+            }
+          />
+          <View
+            accessibilityElementsHidden={false}
+            closing={false}
+            collapsable={false}
+            gestureVelocityImpact={0.3}
+            importantForAccessibility="auto"
+            onClose={[Function]}
+            onGestureBegin={[Function]}
+            onGestureCanceled={[Function]}
+            onGestureEnd={[Function]}
+            onOpen={[Function]}
+            onTransition={[Function]}
+            pointerEvents="box-none"
+            style={
+              [
+                {
+                  "display": "flex",
+                  "overflow": undefined,
+                },
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+              ]
+            }
+            transitionSpec={
+              {
+                "close": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+                "open": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              pointerEvents="box-none"
+              style={
+                {
+                  "flex": 1,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                enabled={false}
+                handlerTag={1}
+                handlerType="PanGestureHandler"
+                needsOffscreenAlphaCompositing={false}
+                onGestureHandlerEvent={[Function]}
+                onGestureHandlerStateChange={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "transform": [
+                      {
+                        "translateX": 0,
+                      },
+                      {
+                        "translateX": 0,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  pointerEvents="box-none"
+                  style={
+                    [
+                      {
+                        "flex": 1,
+                        "overflow": "hidden",
+                      },
+                      [
+                        {
+                          "backgroundColor": "#FFFFFF",
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "flex": 1,
+                        "flexDirection": "column-reverse",
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                        }
+                      }
+                    >
+                      <View
+                        style={
+                          {
+                            "aspectRatio": 1.6,
+                          }
+                        }
+                      >
+                        <View
+                          style={
+                            {
+                              "bottom": 0,
+                              "left": 0,
+                              "position": "absolute",
+                              "right": 0,
+                              "top": 0,
+                            }
+                          }
+                        >
+                          <SvgMock />
+                        </View>
+                        <View
+                          style={
+                            {
+                              "flex": 1,
+                              "justifyContent": "space-between",
+                              "paddingBottom": 16,
+                              "paddingLeft": 16,
+                              "paddingRight": 12,
+                              "paddingTop": 12,
+                            }
+                          }
+                        >
+                          <View>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                  "flexDirection": "row",
+                                  "justifyContent": "space-between",
+                                }
+                              }
+                            >
+                              <Text
+                                allowFontScaling={true}
+                                dynamicTypeRamp="headline"
+                                ellipsizeMode="tail"
+                                maxFontSizeMultiplier={1.5}
+                                numberOfLines={1}
+                                style={
+                                  [
+                                    {},
+                                    {
+                                      "color": "#001F3D",
+                                      "fontFamily": "Titillio",
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "600",
+                                      "lineHeight": 24,
+                                    },
+                                    {
+                                      "width": "80%",
+                                    },
+                                  ]
+                                }
+                              >
+                                18 app
+                              </Text>
+                              <View
+                                accessibilityIgnoresInvertColors={true}
+                                style={
+                                  [
+                                    {
+                                      "borderColor": "rgba(14,15,19,0.1)",
+                                      "borderCurve": "continuous",
+                                      "borderWidth": 1,
+                                      "overflow": "hidden",
+                                    },
+                                    {
+                                      "backgroundColor": "#FFFFFF",
+                                      "borderRadius": 8,
+                                      "height": 44,
+                                      "padding": 6,
+                                      "width": 44,
+                                    },
+                                  ]
+                                }
+                              >
+                                <View
+                                  style={
+                                    [
+                                      {
+                                        "backgroundColor": "#FFFFFF",
+                                        "borderCurve": "continuous",
+                                        "overflow": "hidden",
+                                      },
+                                      {
+                                        "borderRadius": 2,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  <Image
+                                    accessibilityIgnoresInvertColors={true}
+                                    onError={[Function]}
+                                    source={
+                                      {
+                                        "uri": "https://vtlogo.com/wp-content/uploads/2021/08/18app-vector-logo.png",
+                                      }
+                                    }
+                                    style={
+                                      {
+                                        "height": "100%",
+                                        "resizeMode": "contain",
+                                        "width": "100%",
+                                      }
+                                    }
+                                  />
+                                </View>
+                              </View>
+                            </View>
+                            <View
+                              style={
+                                {
+                                  "height": 16,
+                                }
+                              }
+                            />
+                            <Text
+                              allowFontScaling={true}
+                              dynamicTypeRamp="body"
+                              maxFontSizeMultiplier={1.5}
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "color": "#0E0F13",
+                                    "fontFamily": "Titillio",
+                                    "fontSize": 16,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "600",
+                                    "lineHeight": 24,
+                                  },
+                                ]
+                              }
+                            >
+                              Disponibile
+                            </Text>
+                            <Text
+                              allowFontScaling={true}
+                              dynamicTypeRamp="title2"
+                              maxFontSizeMultiplier={1.5}
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "color": "#0066CC",
+                                    "fontFamily": "Titillio",
+                                    "fontSize": 22,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "600",
+                                    "lineHeight": 33,
+                                  },
+                                ]
+                              }
+                              testID="idpay-card-amount"
+                            >
+                              99.99 €
+                            </Text>
+                          </View>
+                          <Text
+                            allowFontScaling={true}
+                            dynamicTypeRamp="body"
+                            maxFontSizeMultiplier={1.5}
+                            style={
+                              [
+                                {},
+                                {
+                                  "color": "#001F3D",
+                                  "fontFamily": "Titillio",
+                                  "fontSize": 16,
+                                  "fontStyle": "normal",
+                                  "fontWeight": "600",
+                                  "lineHeight": 24,
+                                },
+                              ]
+                            }
+                          >
+                            Valida fino al 12/23
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RNSScreen>
+      </RNSScreenContainer>
     </View>
-    <Text
-      allowFontScaling={true}
-      dynamicTypeRamp="body"
-      maxFontSizeMultiplier={1.5}
-      style={
-        [
-          {},
-          {
-            "color": "#001F3D",
-            "fontFamily": "Titillio",
-            "fontSize": 16,
-            "fontStyle": "normal",
-            "fontWeight": "600",
-            "lineHeight": 24,
-          },
-        ]
-      }
-    >
-      Valida fino al 12/23
-    </Text>
-  </View>
+  </RNCSafeAreaProvider>
 </View>
 `;


### PR DESCRIPTION
## Short description
This PR removes the total amount label from the IdPayCard shown in the wallet home screen if the IdPay initiative is of the `EXPENSE` type.

## List of changes proposed in this pull request
- Updated the IDPay openAPI version;
- Added a conditional render inside the `IdPayCard` to show the total amount;

## How to test
With the dev-server started, onboard a new IDPay EXPENSE type and check that you don't see the total amount inside the wallet home page.
