### PR TITLE
fix: [IOBP-1361] CGN webview referer unused header

### DIFF
--- a/ts/features/bonus/cgn/screens/merchants/CgnMerchantLandingWebview.tsx
+++ b/ts/features/bonus/cgn/screens/merchants/CgnMerchantLandingWebview.tsx
@@ -43,7 +43,6 @@ const CgnMerchantLandingWebview: FunctionComponent<Props> = () => {
         source={{
           uri: landingPageUrl as string,
           headers: {
-            referer: landingPageReferrer,
             "X-PagoPa-CGN-Referer": landingPageReferrer
           }
         }}


### PR DESCRIPTION
## Short description
This PR removes the `referer` unused custom header from CGN's webview. The correct referrer header is `X-PagoPa-CGN-Referer`

