### PR TITLE
chore: [IOBP-1236] Adjust `a11y` RadioGroup item price label

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@babel/plugin-transform-private-property-in-object": "^7.25.9",
     "@babel/plugin-transform-react-jsx": "^7.25.9",
     "@gorhom/bottom-sheet": "^4.1.5",
-    "@pagopa/io-app-design-system": "5.0.6",
+    "@pagopa/io-app-design-system": "5.0.7",
     "@pagopa/io-pagopa-commons": "^3.1.0",
     "@pagopa/io-react-native-cieid": "^0.3.5",
     "@pagopa/io-react-native-crypto": "^1.0.1",

--- a/ts/features/bonus/cgn/screens/merchants/__tests__/__snapshots__/CgnMerchantsCategoriesSelectionScreen.test.tsx.snap
+++ b/ts/features/bonus/cgn/screens/merchants/__tests__/__snapshots__/CgnMerchantsCategoriesSelectionScreen.test.tsx.snap
@@ -386,6 +386,7 @@ exports[`CgnMerchantsCategoriesSelectionScreen should render correctly 1`] = `
                                   {},
                                   {
                                     "flexGrow": 1,
+                                    "gap": 8,
                                     "justifyContent": "flex-start",
                                   },
                                 ]
@@ -414,9 +415,6 @@ exports[`CgnMerchantsCategoriesSelectionScreen should render correctly 1`] = `
                                         "flexBasis": 100,
                                         "flexGrow": 0,
                                         "flexShrink": 1,
-                                      },
-                                      {
-                                        "marginEnd": 8,
                                       },
                                       false,
                                     ]
@@ -478,7 +476,6 @@ exports[`CgnMerchantsCategoriesSelectionScreen should render correctly 1`] = `
                                             "backgroundColor": undefined,
                                             "borderColor": undefined,
                                           },
-                                          false,
                                           false,
                                         ]
                                       }
@@ -576,9 +573,6 @@ exports[`CgnMerchantsCategoriesSelectionScreen should render correctly 1`] = `
                                         "flexGrow": 0,
                                         "flexShrink": 1,
                                       },
-                                      {
-                                        "marginEnd": 0,
-                                      },
                                       false,
                                     ]
                                   }
@@ -639,7 +633,6 @@ exports[`CgnMerchantsCategoriesSelectionScreen should render correctly 1`] = `
                                             "backgroundColor": undefined,
                                             "borderColor": undefined,
                                           },
-                                          false,
                                           false,
                                         ]
                                       }

--- a/ts/features/messages/components/Home/__tests__/__snapshots__/TabNavigationContainer.test.tsx.snap
+++ b/ts/features/messages/components/Home/__tests__/__snapshots__/TabNavigationContainer.test.tsx.snap
@@ -351,6 +351,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                               },
                               {
                                 "flexGrow": 1,
+                                "gap": 8,
                                 "justifyContent": "flex-start",
                               },
                             ]
@@ -379,9 +380,6 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                     "flexBasis": 100,
                                     "flexGrow": 0,
                                     "flexShrink": 1,
-                                  },
-                                  {
-                                    "marginEnd": 8,
                                   },
                                   false,
                                 ]
@@ -443,7 +441,6 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                         "backgroundColor": undefined,
                                         "borderColor": undefined,
                                       },
-                                      false,
                                       false,
                                     ]
                                   }
@@ -554,9 +551,6 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                     "flexGrow": 0,
                                     "flexShrink": 1,
                                   },
-                                  {
-                                    "marginEnd": 0,
-                                  },
                                   false,
                                 ]
                               }
@@ -617,7 +611,6 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is ARCH
                                         "backgroundColor": undefined,
                                         "borderColor": undefined,
                                       },
-                                      false,
                                       false,
                                     ]
                                   }
@@ -1072,6 +1065,7 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                               },
                               {
                                 "flexGrow": 1,
+                                "gap": 8,
                                 "justifyContent": "flex-start",
                               },
                             ]
@@ -1100,9 +1094,6 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                     "flexBasis": 100,
                                     "flexGrow": 0,
                                     "flexShrink": 1,
-                                  },
-                                  {
-                                    "marginEnd": 8,
                                   },
                                   false,
                                 ]
@@ -1164,7 +1155,6 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                         "backgroundColor": undefined,
                                         "borderColor": undefined,
                                       },
-                                      false,
                                       false,
                                     ]
                                   }
@@ -1288,9 +1278,6 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                     "flexGrow": 0,
                                     "flexShrink": 1,
                                   },
-                                  {
-                                    "marginEnd": 0,
-                                  },
                                   false,
                                 ]
                               }
@@ -1351,7 +1338,6 @@ exports[`TabNavigationContainer should match snapshot when shownCategory is INBO
                                         "backgroundColor": undefined,
                                         "borderColor": undefined,
                                       },
-                                      false,
                                       false,
                                     ]
                                   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,9 +3753,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagopa/io-app-design-system@npm:5.0.6":
-  version: 5.0.6
-  resolution: "@pagopa/io-app-design-system@npm:5.0.6"
+"@pagopa/io-app-design-system@npm:5.0.7":
+  version: 5.0.7
+  resolution: "@pagopa/io-app-design-system@npm:5.0.7"
   dependencies:
     "@testing-library/jest-native": ^5.4.2
     "@types/react-test-renderer": ^18.0.0
@@ -3779,7 +3779,7 @@ __metadata:
     react-native-reanimated: "*"
     react-native-safe-area-context: "*"
     react-native-svg: "*"
-  checksum: 3db6abc36b6cc8d9a88eabd2667d02ed19f13bd53fbf96f7396f858280e95bfd24e60bafecbfee8a0989b06aff44d62d32ead6c5fe261432a8b52025aae9e93b
+  checksum: f04a59cf5f75f0cc7e48e2d8155c7b53418d10228f7e4708e5aba028112e3a7bcf75446d4096c720f45d24de1367ee3086ff733b914884044479d54a120549a9
   languageName: node
   linkType: hard
 
@@ -13657,7 +13657,7 @@ __metadata:
     "@babel/runtime": ^7.20.0
     "@gorhom/bottom-sheet": ^4.1.5
     "@jambit/eslint-plugin-typed-redux-saga": ^0.4.0
-    "@pagopa/io-app-design-system": 5.0.6
+    "@pagopa/io-app-design-system": 5.0.7
     "@pagopa/io-pagopa-commons": ^3.1.0
     "@pagopa/io-react-native-cieid": ^0.3.5
     "@pagopa/io-react-native-crypto": ^1.0.1


### PR DESCRIPTION
## Short description
This pull request updates the design system version to resolve the accessibility issue with the price label for the `RadioGroup` items

## List of changes proposed in this pull request
- Update`@pagopa/io-app-design-system` package from `5.0.6` to `5.0.7`

## How to test
- Start a payment workflow using a real device📱
- Turn on TalkBack accessibility tool when you reach the second step of `PAYMENT_CHECKOUT_MAKE` screen
- Ensure that all radio items are correctly spelled