### PR TITLE
fix(IT Wallet): [SIW-2083] Fix async issuance double navigation within issuer trust screen

### DIFF
--- a/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialAsyncContinuationScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialAsyncContinuationScreen.tsx
@@ -161,7 +161,6 @@ const WrappedItwIssuanceCredentialTrustIssuerScreen = ({
   const machineRef = ItwCredentialIssuanceMachineContext.useActorRef();
 
   // Transition the credential machine to the correct state when the credential selection screen is bypassed.
-  // During this transition we should not render ItwIssuanceCredentialTrustIssuerScreen to avoid the generic error screen.
   useOnFirstRender(() =>
     machineRef.send({
       type: "select-credential",

--- a/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialAsyncContinuationScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialAsyncContinuationScreen.tsx
@@ -1,24 +1,23 @@
-import { useCallback, useState } from "react";
-import * as t from "io-ts";
+import { useFocusEffect } from "@react-navigation/native";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
-import { useFocusEffect } from "@react-navigation/native";
-import I18n from "../../../../i18n";
+import * as t from "io-ts";
+import { useCallback } from "react";
 import { OperationResultScreenContent } from "../../../../components/screens/OperationResultScreenContent";
+import I18n from "../../../../i18n";
 import {
   IOStackNavigationRouteProps,
   useIONavigation
 } from "../../../../navigation/params/AppParamsList";
 import { useIOSelector } from "../../../../store/hooks";
 import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
+import { CREDENTIALS_MAP, trackItwHasAlreadyCredential } from "../../analytics";
+import { getCredentialStatus } from "../../common/utils/itwCredentialStatusUtils";
 import { itwCredentialByTypeSelector } from "../../credentials/store/selectors";
-import { ItwParamsList } from "../../navigation/ItwParamsList";
-import { ITW_ROUTES } from "../../navigation/routes";
 import { itwLifecycleIsValidSelector } from "../../lifecycle/store/selectors";
 import { ItwCredentialIssuanceMachineContext } from "../../machine/provider";
-import { getCredentialStatus } from "../../common/utils/itwCredentialStatusUtils";
-import LoadingScreenContent from "../../../../components/screens/LoadingScreenContent";
-import { CREDENTIALS_MAP, trackItwHasAlreadyCredential } from "../../analytics";
+import { ItwParamsList } from "../../navigation/ItwParamsList";
+import { ITW_ROUTES } from "../../navigation/routes";
 import { ItwIssuanceCredentialTrustIssuerScreen } from "./ItwIssuanceCredentialTrustIssuerScreen";
 
 export type ItwIssuanceCredentialAsyncContinuationNavigationParams = {
@@ -160,23 +159,17 @@ const WrappedItwIssuanceCredentialTrustIssuerScreen = ({
   credentialType: string;
 }) => {
   const machineRef = ItwCredentialIssuanceMachineContext.useActorRef();
-  const [isMachineReady, setIsMachineReady] = useState(false);
 
   // Transition the credential machine to the correct state when the credential selection screen is bypassed.
   // During this transition we should not render ItwIssuanceCredentialTrustIssuerScreen to avoid the generic error screen.
-  useOnFirstRender(() => {
+  useOnFirstRender(() =>
     machineRef.send({
       type: "select-credential",
       credentialType,
       skipNavigation: true,
       asyncContinuation: true
-    });
-    setIsMachineReady(true);
-  });
-
-  return isMachineReady ? (
-    <ItwIssuanceCredentialTrustIssuerScreen />
-  ) : (
-    <LoadingScreenContent contentTitle={I18n.t("global.genericWaiting")} />
+    })
   );
+
+  return <ItwIssuanceCredentialTrustIssuerScreen />;
 };

--- a/ts/features/itwallet/machine/credential/__tests__/machine.test.ts
+++ b/ts/features/itwallet/machine/credential/__tests__/machine.test.ts
@@ -210,7 +210,7 @@ describe("itwCredentialIssuanceMachine", () => {
 
     expect(actor.getSnapshot().value).toStrictEqual("Idle");
     expect(actor.getSnapshot().context).toStrictEqual(InitialContext);
-    expect(actor.getSnapshot().tags).toStrictEqual(new Set());
+    expect(actor.getSnapshot().tags).toStrictEqual(new Set([ItwTags.Loading]));
 
     actor.send({
       type: "select-credential",
@@ -354,7 +354,7 @@ describe("itwCredentialIssuanceMachine", () => {
       ...InitialContext,
       walletInstanceAttestation: T_WIA
     });
-    expect(actor.getSnapshot().tags).toStrictEqual(new Set());
+    expect(actor.getSnapshot().tags).toStrictEqual(new Set([ItwTags.Loading]));
 
     actor.send({
       type: "select-credential",
@@ -416,9 +416,7 @@ describe("itwCredentialIssuanceMachine", () => {
       type: "close"
     });
 
-    expect(actor.getSnapshot().value).toStrictEqual(
-      "DisplayingCredentialPreview"
-    );
+    expect(actor.getSnapshot().value).toStrictEqual("Completed");
     expect(storeCredential).toHaveBeenCalledTimes(0);
     expect(navigateToWallet).toHaveBeenCalledTimes(0);
     expect(closeIssuance).toHaveBeenCalledTimes(1);
@@ -431,7 +429,7 @@ describe("itwCredentialIssuanceMachine", () => {
     await waitFor(() => expect(onInit).toHaveBeenCalledTimes(1));
 
     expect(actor.getSnapshot().value).toStrictEqual("Idle");
-    expect(actor.getSnapshot().tags).toStrictEqual(new Set());
+    expect(actor.getSnapshot().tags).toStrictEqual(new Set([ItwTags.Loading]));
 
     /**
      * Initialize wallet and start credential issuance
@@ -486,7 +484,7 @@ describe("itwCredentialIssuanceMachine", () => {
     await waitFor(() => expect(onInit).toHaveBeenCalledTimes(1));
 
     expect(actor.getSnapshot().value).toStrictEqual("Idle");
-    expect(actor.getSnapshot().tags).toStrictEqual(new Set());
+    expect(actor.getSnapshot().tags).toStrictEqual(new Set([ItwTags.Loading]));
 
     /**
      * Initialize wallet and start credential issuance
@@ -548,7 +546,7 @@ describe("itwCredentialIssuanceMachine", () => {
       type: "close"
     });
 
-    expect(actor.getSnapshot().value).toStrictEqual("DisplayingTrustIssuer");
+    expect(actor.getSnapshot().value).toStrictEqual("Completed");
     expect(closeIssuance).toHaveBeenCalledTimes(1);
   });
 

--- a/ts/features/itwallet/machine/credential/events.ts
+++ b/ts/features/itwallet/machine/credential/events.ts
@@ -1,9 +1,5 @@
 import { ErrorActorEvent } from "xstate";
 
-export type Reset = {
-  type: "reset";
-};
-
 export type SelectCredential = {
   type: "select-credential";
   credentialType: string;
@@ -32,7 +28,6 @@ export type Close = {
 };
 
 export type CredentialIssuanceEvents =
-  | Reset
   | SelectCredential
   | ConfirmTrustData
   | AddToWallet

--- a/ts/features/itwallet/machine/credential/machine.ts
+++ b/ts/features/itwallet/machine/credential/machine.ts
@@ -72,6 +72,7 @@ export const itwCredentialIssuanceMachine = setup({
   entry: "onInit",
   states: {
     Idle: {
+      tags: [ItwTags.Loading],
       description:
         "Waits for a credential selection in order to proceed with the issuance",
       on: {
@@ -107,6 +108,7 @@ export const itwCredentialIssuanceMachine = setup({
       }
     },
     CheckingWalletInstanceAttestation: {
+      tags: [ItwTags.Loading],
       description:
         "This is a state with the only purpose of checking the WIA and decide weather to get a new one or not",
       always: [

--- a/ts/features/itwallet/machine/credential/machine.ts
+++ b/ts/features/itwallet/machine/credential/machine.ts
@@ -172,7 +172,13 @@ export const itwCredentialIssuanceMachine = setup({
       }
     },
     DisplayingTrustIssuer: {
-      entry: ["navigateToTrustIssuerScreen", "trackCredentialIssuingDataShare"],
+      entry: ["trackCredentialIssuingDataShare"],
+      always: {
+        // If we are in the async continuation flow means we are already showing the trust issuer screen
+        // but on a different route. We need to avoid a navigation to show a "double" navigation animation.
+        guard: ({ context }) => !context.isAsyncContinuation,
+        actions: "navigateToTrustIssuerScreen"
+      },
       on: {
         "confirm-trust-data": {
           actions: "trackCredentialIssuingDataShareAccepted",

--- a/ts/features/itwallet/machine/credential/machine.ts
+++ b/ts/features/itwallet/machine/credential/machine.ts
@@ -72,9 +72,9 @@ export const itwCredentialIssuanceMachine = setup({
   entry: "onInit",
   states: {
     Idle: {
-      tags: [ItwTags.Loading],
       description:
         "Waits for a credential selection in order to proceed with the issuance",
+      tags: [ItwTags.Loading],
       on: {
         "select-credential": [
           {
@@ -108,9 +108,9 @@ export const itwCredentialIssuanceMachine = setup({
       }
     },
     CheckingWalletInstanceAttestation: {
-      tags: [ItwTags.Loading],
       description:
         "This is a state with the only purpose of checking the WIA and decide weather to get a new one or not",
+      tags: [ItwTags.Loading],
       always: [
         {
           guard: not("hasValidWalletInstanceAttestation"),
@@ -187,7 +187,8 @@ export const itwCredentialIssuanceMachine = setup({
           target: "Issuance"
         },
         close: {
-          actions: ["closeIssuance"]
+          target: "Completed",
+          actions: "closeIssuance"
         }
       }
     },
@@ -261,9 +262,13 @@ export const itwCredentialIssuanceMachine = setup({
           ]
         },
         close: {
-          actions: ["closeIssuance"]
+          target: "Completed",
+          actions: "closeIssuance"
         }
       }
+    },
+    Completed: {
+      type: "final"
     },
     Failure: {
       entry: ["navigateToFailureScreen"],
@@ -279,10 +284,7 @@ export const itwCredentialIssuanceMachine = setup({
       ],
       on: {
         close: {
-          actions: ["closeIssuance"]
-        },
-        reset: {
-          target: "Idle"
+          actions: "closeIssuance"
         },
         retry: {
           target: "#itwCredentialIssuanceMachine.RequestingCredential"

--- a/ts/features/itwallet/machine/eid/events.ts
+++ b/ts/features/itwallet/machine/eid/events.ts
@@ -3,10 +3,6 @@ import { SpidIdp } from "../../../../../definitions/content/SpidIdp";
 
 export type IdentificationMode = "spid" | "ciePin" | "cieId";
 
-export type Reset = {
-  type: "reset";
-};
-
 export type Start = {
   type: "start";
 };
@@ -87,7 +83,6 @@ export type StartReissuing = {
 };
 
 export type EidIssuanceEvents =
-  | Reset
   | Start
   | AcceptTos
   | AcceptIpzsPrivacy

--- a/ts/features/itwallet/presentation/remote/machine/events.ts
+++ b/ts/features/itwallet/presentation/remote/machine/events.ts
@@ -1,9 +1,5 @@
 import { ItwRemoteRequestPayload } from "../Utils/itwRemoteTypeUtils.ts";
 
-export type Reset = {
-  type: "reset";
-};
-
 export type Start = {
   type: "start";
   payload: ItwRemoteRequestPayload;
@@ -26,7 +22,6 @@ export type Close = {
 };
 
 export type RemoteEvents =
-  | Reset
   | Start
   | GoToWalletActivation
   | GoToIdentificationMode


### PR DESCRIPTION
## Short description
This PR fixes a bug which causes a double navigation within the async issuance flow.

### Preview

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/85abaf8b-6f69-43f6-a497-d730fbe8b83a" /> |  <video src="https://github.com/user-attachments/assets/d2007033-296a-4c12-930a-ae5917bad043" /> |


## List of changes proposed in this pull request
- Simplified `ItwIssuanceCredentialAsyncContinuationScreen`
- Fixed `DisplayingTrustIssuer` state actions within the credential's issuance machine
- Removed unused `reset` event from machines
- Added `Loading` tag to `Idle` and `CheckingWalletInstanceAttestation`
- Added `Completed` state

## How to test
Check if there aren't regressions in the credential issuance flow.
Check if there isn't a double navigation when using the async issuance flow.
