### PR TITLE
fix: [IOBP-1360] Banner error state text align

### DIFF
--- a/ts/components/ui/BannerErrorState.tsx
+++ b/ts/components/ui/BannerErrorState.tsx
@@ -34,9 +34,6 @@ const styles = StyleSheet.create({
     borderCurve: "continuous",
     padding: IOBannerBigSpacing,
     backgroundColor: IOColors["grey-50"]
-  },
-  textCenter: {
-    textAlign: "center"
   }
 });
 
@@ -100,7 +97,7 @@ export const BannerErrorState = ({
         )}
         {label && (
           <>
-            <Body color={colorContent} textStyle={styles.textCenter}>
+            <Body color={colorContent} textStyle={{ textAlign: "center" }}>
               {label}
             </Body>
             {actionText && <VSpacer size={8} />}

--- a/ts/components/ui/BannerErrorState.tsx
+++ b/ts/components/ui/BannerErrorState.tsx
@@ -34,6 +34,9 @@ const styles = StyleSheet.create({
     borderCurve: "continuous",
     padding: IOBannerBigSpacing,
     backgroundColor: IOColors["grey-50"]
+  },
+  textCenter: {
+    textAlign: "center"
   }
 });
 
@@ -97,7 +100,9 @@ export const BannerErrorState = ({
         )}
         {label && (
           <>
-            <Body color={colorContent}>{label}</Body>
+            <Body color={colorContent} textStyle={styles.textCenter}>
+              {label}
+            </Body>
             {actionText && <VSpacer size={8} />}
           </>
         )}


### PR DESCRIPTION
## Short description
This PR fixes the banner error state text alignment to the center.

## List of changes proposed in this pull request
- Added text align center style

## How to test
With the dev-server, simulate an error inside the wallet home screen by throwing an error to one of the API available in that page (CGN, IDPay or Payments)

## Preview
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/4e879464-dcb2-4e14-98fb-3b91b3f709e5" width="300" />|<img src="https://github.com/user-attachments/assets/3a49a847-b471-49df-81f3-354166f7f5f9" width="300" />|
