### PR TITLE
refactor: [IOBP-1362] Removed self declaration DPR link text into IDPay prerequisites screen

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -5066,14 +5066,10 @@
         }
       },
       "multiPrerequisites": {
-        "header": "Dichiari inoltre di:",
-        "body": "L’autodichiarazione è resa ai sensi del",
-        "link": "Dpr 28 dicembre 2000 n. 445 art 46 e 47"
+        "header": "Dichiari inoltre di:"
       },
       "boolPrerequisites": {
-        "header": "Per aderire, dichiari di:",
-        "body": "L’autodichiarazione è resa ai sensi del",
-        "link": "Dpr 28 dicembre 2000 n. 445 art 46 e 47"
+        "header": "Per aderire, dichiari di:"
       }
     },
     "configuration": {

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -5066,14 +5066,10 @@
                 }
             },
             "multiPrerequisites": {
-                "header": "Dichiari inoltre di:",
-                "body": "L’autodichiarazione è resa ai sensi del",
-                "link": "Dpr 28 dicembre 2000 n. 445 art 46 e 47"
+                "header": "Dichiari inoltre di:"
             },
             "boolPrerequisites": {
-                "header": "Per aderire, dichiari di:",
-                "body": "L’autodichiarazione è resa ai sensi del",
-                "link": "Dpr 28 dicembre 2000 n. 445 art 46 e 47"
+                "header": "Per aderire, dichiari di:"
             }
         },
         "configuration": {

--- a/ts/features/idpay/onboarding/screens/BoolValuePrerequisitesScreen.tsx
+++ b/ts/features/idpay/onboarding/screens/BoolValuePrerequisitesScreen.tsx
@@ -4,9 +4,7 @@ import { SelfDeclarationBoolDTO } from "../../../../../definitions/idpay/SelfDec
 import LoadingSpinnerOverlay from "../../../../components/LoadingSpinnerOverlay";
 import { IOScrollViewWithLargeHeader } from "../../../../components/ui/IOScrollViewWithLargeHeader";
 import I18n from "../../../../i18n";
-import { dpr28Dec2000Url } from "../../../../urls";
 import { emptyContextualHelp } from "../../../../utils/emptyContextualHelp";
-import { openWebUrl } from "../../../../utils/url";
 import { isLoadingSelector } from "../../common/machine/selectors";
 import { IdPayOnboardingMachineContext } from "../machine/provider";
 import {
@@ -46,20 +44,6 @@ const InitiativeSelfDeclarationsScreen = () => {
         label: I18n.t("idpay.onboarding.boolPrerequisites.header"),
         section: I18n.t("idpay.onboarding.navigation.header")
       }}
-      description={[
-        {
-          text: I18n.t("idpay.onboarding.boolPrerequisites.body")
-        },
-        {
-          text: "\n"
-        },
-        {
-          text: I18n.t("idpay.onboarding.boolPrerequisites.link"),
-          weight: "Semibold",
-          asLink: true,
-          onPress: () => openWebUrl(dpr28Dec2000Url)
-        }
-      ]}
       goBack={goBackOnPress}
       contextualHelp={emptyContextualHelp}
       headerActionsProp={{ showHelp: true }}

--- a/ts/features/idpay/onboarding/screens/InputFormVerificationScreen.tsx
+++ b/ts/features/idpay/onboarding/screens/InputFormVerificationScreen.tsx
@@ -5,9 +5,7 @@ import { SelfDeclarationTextDTO } from "../../../../../definitions/idpay/SelfDec
 import LoadingSpinnerOverlay from "../../../../components/LoadingSpinnerOverlay";
 import { IOScrollViewWithLargeHeader } from "../../../../components/ui/IOScrollViewWithLargeHeader";
 import I18n from "../../../../i18n";
-import { dpr28Dec2000Url } from "../../../../urls";
 import { emptyContextualHelp } from "../../../../utils/emptyContextualHelp";
-import { openWebUrl } from "../../../../utils/url";
 import { isLoadingSelector } from "../../common/machine/selectors";
 import { IdPayOnboardingMachineContext } from "../machine/provider";
 import {
@@ -67,20 +65,6 @@ const InputFormVerificationContent = ({
           label: I18n.t("idpay.onboarding.boolPrerequisites.header"),
           section: I18n.t("idpay.onboarding.navigation.header")
         }}
-        description={[
-          {
-            text: I18n.t("idpay.onboarding.boolPrerequisites.body")
-          },
-          {
-            text: "\n"
-          },
-          {
-            text: I18n.t("idpay.onboarding.boolPrerequisites.link"),
-            weight: "Semibold",
-            asLink: true,
-            onPress: () => openWebUrl(dpr28Dec2000Url)
-          }
-        ]}
         goBack={goBackOnPress}
         contextualHelp={emptyContextualHelp}
         headerActionsProp={{ showHelp: true }}

--- a/ts/features/idpay/onboarding/screens/MultiValuePrerequisitesScreen.tsx
+++ b/ts/features/idpay/onboarding/screens/MultiValuePrerequisitesScreen.tsx
@@ -90,23 +90,6 @@ const MultiValuePrerequisiteItemScreenContent = ({
           label: I18n.t("global.buttons.continue")
         }
       }}
-      description={[
-        {
-          text: I18n.t("idpay.onboarding.multiPrerequisites.body")
-        },
-        {
-          text: "\n"
-        },
-        {
-          //  TODO: Add a proper `onPress` function to the following link.
-          //  It was a `<Link>` without anything else before
-          text: I18n.t("idpay.onboarding.multiPrerequisites.link"),
-          weight: "Semibold",
-          asLink: true,
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          onPress: () => {}
-        }
-      ]}
     >
       <H6>{selfDeclaration.description}</H6>
       <RadioGroup<string>

--- a/ts/urls.ts
+++ b/ts/urls.ts
@@ -1,6 +1,4 @@
 // IO urls
-export const dpr28Dec2000Url =
-  "https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:2000-12-28;445";
 
 export const PRIVACY_URL_BODY = "app-content/tos_privacy.html";
 export const IO_SUPPLIERS_URL_BODY = "app-content/fornitori";


### PR DESCRIPTION
## Short description
This PR removes the self-declaration DPR text and link from the prerequisites screen in IDPay onboarding.

## List of changes proposed in this pull request
- Removed the description from `BoolValuePrerequisitesScreen`, `InputFormVerificationScreen` and `MultiValuePrerequisitesScreen`
- Removed from the codebase the unused URL link `dpr28Dec2000Url`
- Removed unused locales

## How to test
With the dev-server server started, start an IDPay onboarding from the developer section selecting the `Iniziativa GUIDONIA` from the list and checks that the DPR text link isn't shown anymore.

## Preview
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/940eb99a-75d6-46b8-9f44-3cdfe98b5f1a" width="300" />|<img src="https://github.com/user-attachments/assets/d0420fec-ed3d-4d79-bffe-8b9ec32e32de" width="300" />|
