### PR TITLE
chore: [IOBP-1218] `mixpanel` success download receipt event

### DIFF
--- a/ts/features/common/store/reducers/__tests__/__snapshots__/index.test.ts.snap
+++ b/ts/features/common/store/reducers/__tests__/__snapshots__/index.test.ts.snap
@@ -245,6 +245,7 @@ exports[`featuresPersistor should match snapshot 1`] = `
       },
     },
     "history": {
+      "PDFsOpened": Set {},
       "archive": [],
       "receiptsOpened": Set {},
     },

--- a/ts/features/payments/common/types/PaymentAnalytics.ts
+++ b/ts/features/payments/common/types/PaymentAnalytics.ts
@@ -22,6 +22,7 @@ export type PaymentAnalyticsData = {
   transactionsHomeLength?: number;
   receiptUser?: PaymentsAnalyticsReceiptUser;
   receiptFirstTimeOpening?: boolean;
+  receiptFirstTimePDF?: boolean;
   receiptOrganizationName?: string;
   receiptPayerFiscalCode?: string;
 };

--- a/ts/features/payments/common/types/PaymentAnalytics.ts
+++ b/ts/features/payments/common/types/PaymentAnalytics.ts
@@ -22,7 +22,7 @@ export type PaymentAnalyticsData = {
   transactionsHomeLength?: number;
   receiptUser?: PaymentsAnalyticsReceiptUser;
   receiptFirstTimeOpening?: boolean;
-  receiptFirstTimePDF?: boolean;
+  receiptFirstTimeOpeningPDF?: boolean;
   receiptOrganizationName?: string;
   receiptPayerFiscalCode?: string;
 };

--- a/ts/features/payments/history/store/__tests__/store.test.ts
+++ b/ts/features/payments/history/store/__tests__/store.test.ts
@@ -28,7 +28,8 @@ describe("Test Wallet payment history reducers and selectors", () => {
     const globalState = appReducer(undefined, applicationChangeState("active"));
     expect(globalState.features.payments.history).toStrictEqual({
       archive: [],
-      receiptsOpened: new Set()
+      receiptsOpened: new Set(),
+      PDFsOpened: new Set()
     });
     expect(selectPaymentsHistoryArchive(globalState)).toStrictEqual([]);
     expect(selectOngoingPaymentHistory(globalState)).toBeUndefined();

--- a/ts/features/payments/history/store/reducers/index.ts
+++ b/ts/features/payments/history/store/reducers/index.ts
@@ -243,7 +243,7 @@ const reducer = (
         ...state,
         analyticsData: {
           ...state.analyticsData,
-          receiptFirstTimePDF: isFirstTimePDFOpening
+          receiptFirstTimeOpeningPDF: isFirstTimePDFOpening
         },
         PDFsOpened: new Set(state.PDFsOpened).add(action.payload.transactionId)
       };

--- a/ts/features/payments/receipts/analytics/index.ts
+++ b/ts/features/payments/receipts/analytics/index.ts
@@ -70,6 +70,16 @@ export const trackPaymentsSaveAndShareReceipt = (
     })
   );
 };
+export const trackPaymentsDownloadReceiptSuccess = (
+  props: Partial<PaymentReceiptAnalyticsProps>
+) => {
+  void mixpanelTrack(
+    "DOWNLOAD_RECEIPT_SUCCESS",
+    buildEventProperties("UX", "screen_view", {
+      ...props
+    })
+  );
+};
 
 export const trackPaymentsDownloadReceiptError = (
   props: Partial<PaymentReceiptAnalyticsProps>

--- a/ts/features/payments/receipts/screens/ReceiptPreviewScreen.tsx
+++ b/ts/features/payments/receipts/screens/ReceiptPreviewScreen.tsx
@@ -41,7 +41,7 @@ const ReceiptPreviewScreen = () => {
       organization_name: paymentAnalyticsData?.receiptOrganizationName,
       organization_fiscal_code:
         paymentAnalyticsData?.verifiedData?.paFiscalCode,
-      first_time_opening: paymentAnalyticsData?.receiptFirstTimePDF,
+      first_time_opening: paymentAnalyticsData?.receiptFirstTimeOpeningPDF,
       user: paymentAnalyticsData?.receiptUser
     });
   });

--- a/ts/features/payments/receipts/screens/ReceiptPreviewScreen.tsx
+++ b/ts/features/payments/receipts/screens/ReceiptPreviewScreen.tsx
@@ -1,24 +1,25 @@
-import { useState } from "react";
-import * as pot from "@pagopa/ts-commons/lib/pot";
-import { Platform, View } from "react-native";
-import Share from "react-native-share";
 import {
   FooterActions,
   FooterActionsMeasurements,
   IOColors,
   IOStyles
 } from "@pagopa/io-app-design-system";
-import Pdf from "react-native-pdf";
+import * as pot from "@pagopa/ts-commons/lib/pot";
 import { RouteProp } from "@react-navigation/native";
+import { useState } from "react";
+import { Platform, View } from "react-native";
+import Pdf from "react-native-pdf";
+import Share from "react-native-share";
+import { OperationResultScreenContent } from "../../../../components/screens/OperationResultScreenContent";
+import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
+import I18n from "../../../../i18n";
+import { useIOSelector } from "../../../../store/hooks";
+import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
+import { paymentAnalyticsDataSelector } from "../../history/store/selectors";
+import * as analytics from "../analytics";
 import { PaymentsReceiptParamsList } from "../navigation/params";
 import { walletReceiptPotSelector } from "../store/selectors";
-import { useIOSelector } from "../../../../store/hooks";
-import { OperationResultScreenContent } from "../../../../components/screens/OperationResultScreenContent";
-import I18n from "../../../../i18n";
-import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
 import { RECEIPT_DOCUMENT_TYPE_PREFIX } from "../utils";
-import * as analytics from "../analytics";
-import { paymentAnalyticsDataSelector } from "../../history/store/selectors";
 
 export type ReceiptPreviewScreenProps = RouteProp<
   PaymentsReceiptParamsList,
@@ -26,7 +27,7 @@ export type ReceiptPreviewScreenProps = RouteProp<
 >;
 
 const ReceiptPreviewScreen = () => {
-  const [footerActionsMeasurements, setfooterActionsMeasurements] =
+  const [footerActionsMeasurements, setFooterActionsMeasurements] =
     useState<FooterActionsMeasurements>({
       actionBlockHeight: 0,
       safeBottomAreaHeight: 0
@@ -34,6 +35,16 @@ const ReceiptPreviewScreen = () => {
 
   const transactionReceiptPot = useIOSelector(walletReceiptPotSelector);
   const paymentAnalyticsData = useIOSelector(paymentAnalyticsDataSelector);
+
+  useOnFirstRender(() => {
+    analytics.trackPaymentsDownloadReceiptSuccess({
+      organization_name: paymentAnalyticsData?.receiptOrganizationName,
+      organization_fiscal_code:
+        paymentAnalyticsData?.verifiedData?.paFiscalCode,
+      first_time_opening: paymentAnalyticsData?.receiptFirstTimePDF,
+      user: paymentAnalyticsData?.receiptUser
+    });
+  });
 
   useHeaderSecondLevel({
     title: "",
@@ -71,7 +82,7 @@ const ReceiptPreviewScreen = () => {
   const handleFooterActionsMeasurements = (
     values: FooterActionsMeasurements
   ) => {
-    setfooterActionsMeasurements(values);
+    setFooterActionsMeasurements(values);
   };
 
   if (pot.isSome(transactionReceiptPot)) {


### PR DESCRIPTION
## Short description
This pull request focuses on tracking when a user lands on the PDF receipt screen with the event `DOWNLOAD_RECEIPT_SUCCESS`

## List of changes proposed in this pull request
- Updated the `PaymentsHistoryState` type to include a new `PDFsOpened` set and modified the reducer to handle the new `getPaymentsReceiptDownloadAction` action, tracking the first-time opening of PDFs based on its receiptID 
- `trackPaymentsDownloadReceiptSuccess` to track successful receipt downloads in `mixpanel`

## How to test
- Go to Payment section and open a receipt
- Press on `Ottieni ricevuta`
- Ensure that `mixpanel` properties are dispatched correctly (if first time you will see `first_time_opening: true`)
- Go back and open again the same receipt
- Ensure that `first_time_opening` is set to `false`