### PR TITLE
fix: [IOBP-1363] IDPay multi value prerequisites value mapping

### DIFF
--- a/ts/features/idpay/onboarding/screens/MultiValuePrerequisitesScreen.tsx
+++ b/ts/features/idpay/onboarding/screens/MultiValuePrerequisitesScreen.tsx
@@ -54,17 +54,17 @@ const MultiValuePrerequisiteItemScreenContent = ({
 }: MultiValuePrerequisiteItemScreenContentProps) => {
   const machine = IdPayOnboardingMachineContext.useActorRef();
 
-  const [selectedValue, setSelectedValue] = useState<string | undefined>(
-    undefined
-  );
+  const [selectedValueIndex, setSelectedValueIndex] = useState<
+    number | undefined
+  >(undefined);
 
   const handleContinuePress = () => {
-    if (selectedValue !== undefined) {
+    if (selectedValueIndex !== undefined) {
       machine.send({
         type: "select-multi-consent",
         data: {
           _type: selfDeclaration._type,
-          value: selectedValue,
+          value: selfDeclaration.value[selectedValueIndex],
           code: selfDeclaration.code
         }
       });
@@ -86,20 +86,20 @@ const MultiValuePrerequisiteItemScreenContent = ({
         type: "SingleButton",
         primary: {
           onPress: handleContinuePress,
-          disabled: selectedValue === undefined,
+          disabled: selectedValueIndex === undefined,
           label: I18n.t("global.buttons.continue")
         }
       }}
     >
       <H6>{selfDeclaration.description}</H6>
-      <RadioGroup<string>
+      <RadioGroup<number>
         type="radioListItem"
         items={selfDeclaration.value.map((answer, index) => ({
-          id: index.toString(),
+          id: index,
           value: answer
         }))}
-        selectedItem={selectedValue}
-        onPress={value => setSelectedValue(value)}
+        selectedItem={selectedValueIndex}
+        onPress={value => setSelectedValueIndex(value)}
       />
     </IOScrollViewWithLargeHeader>
   );


### PR DESCRIPTION
## Short description
This PR fixes a blocking bug in the IDPay multi-value prerequisites screen that, previously, the value mapped was wrong since the value to map isn't the index of the array but the value provided from the API response.

## List of changes proposed in this pull request
- Edited the `selectedValue` with the `selectedValueIndex` as it indicates the index of the selected value;
- Mapped the correct value when the user continues to the next page.