### PR TITLE
fix: [IOBP-1379,IOBP-IOBP-1380] Disable CGN header transparency when screen reader is enabled

### DIFF
--- a/ts/components/BonusCard/BonusCard.tsx
+++ b/ts/components/BonusCard/BonusCard.tsx
@@ -7,7 +7,13 @@ import {
   VSpacer
 } from "@pagopa/io-app-design-system";
 
-import { Fragment, ReactNode, useMemo } from "react";
+import {
+  createRef,
+  Fragment,
+  ReactNode,
+  useLayoutEffect,
+  useMemo
+} from "react";
 import { ImageURISource, StyleSheet, View } from "react-native";
 import {
   heightPercentageToDP,
@@ -15,6 +21,7 @@ import {
 } from "react-native-responsive-screen";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Placeholder from "rn-placeholder";
+import { setAccessibilityFocus } from "../../utils/accessibility";
 import { BonusCardCounter } from "./BonusCardCounter";
 import { BonusCardShape } from "./BonusCardShape";
 import { BonusCardStatus } from "./BonusCardStatus";
@@ -41,6 +48,12 @@ type LoadingStateProps =
 export type BonusCard = LoadingStateProps & BaseProps;
 
 const BonusCardContent = (props: BonusCard) => {
+  const bonusNameHeadingRef = createRef<View>();
+
+  useLayoutEffect(() => {
+    setAccessibilityFocus(bonusNameHeadingRef);
+  }, [bonusNameHeadingRef]);
+
   if (props.isLoading) {
     return <BonusCardSkeleton {...props} />;
   }
@@ -67,7 +80,12 @@ const BonusCardContent = (props: BonusCard) => {
           <VSpacer size={16} />
         </>
       )}
-      <H2 color="blueItalia-850" style={{ textAlign: "center" }}>
+      <H2
+        ref={bonusNameHeadingRef}
+        role="heading"
+        color="blueItalia-850"
+        style={{ textAlign: "center" }}
+      >
         {name}
       </H2>
       <VSpacer size={4} />

--- a/ts/components/BonusCard/BonusCardScreenComponent.tsx
+++ b/ts/components/BonusCard/BonusCardScreenComponent.tsx
@@ -11,6 +11,8 @@ import { SupportRequestParams } from "../../hooks/useStartSupportRequest";
 import { isAndroid } from "../../utils/platform";
 import FocusAwareStatusBar from "../ui/FocusAwareStatusBar";
 import { IOScrollView, IOScrollViewActions } from "../ui/IOScrollView";
+import { isScreenReaderEnabledSelector } from "../../store/reducers/preferences";
+import { useIOSelector } from "../../store/hooks";
 import { BonusCard } from "./BonusCard";
 
 type BaseProps = {
@@ -47,6 +49,8 @@ const BonusCardScreenComponent = ({
   const screenHeight = Dimensions.get("window").height;
   const shouldHideLogo = screenHeight < MIN_HEIGHT_TO_SHOW_FULL_RENDER;
 
+  const screenReaderEnabled = useIOSelector(isScreenReaderEnabledSelector);
+
   const { themeType } = useIOThemeContext();
 
   const isDark = themeType === "dark";
@@ -61,7 +65,7 @@ const BonusCardScreenComponent = ({
 
   useHeaderSecondLevel({
     title: title || "",
-    transparent: true,
+    transparent: !screenReaderEnabled,
     supportRequest: true,
     variant: "neutral",
     backgroundColor,
@@ -70,7 +74,8 @@ const BonusCardScreenComponent = ({
     contextualHelp,
     secondAction: headerAction,
     enableDiscreteTransition: true,
-    animatedRef: animatedScrollViewRef
+    animatedRef: animatedScrollViewRef,
+    ignoreAccessibilityCheck: true
   });
 
   return (


### PR DESCRIPTION
## Short description
This PR fixes a critical bug that occurs when a user has a screen reader enabled while opening the CGN details screen. Previously, the focus was blocked, preventing navigation through gestures within the page.

## List of changes proposed in this pull request
- The only feasible solution for now is to disable header transparency when the screen reader is enabled;
- Added accessibility focus to the bonus card title on the details page.

## How to test
1. Use a real iOS device and enable VoiceOver.
2. Navigate through the CGN details card page.
3. Verify that when VoiceOver is enabled:
   - The header transparency is disabled.
   - You can navigate within the screen using swipe gestures.
4. Double-check that when VoiceOver is disabled, the header transparency remains enabled as expected.

## Preview
|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/87fa125a-3a34-47a0-892f-1f2bfab48a83" />|<video src="https://github.com/user-attachments/assets/d411f8d3-9f3c-4b35-803c-e0e604a5f900" />