### PR TITLE
feat: [IOCOM-2184] addition of loading and result UI for SEND banner flow

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -2,6 +2,7 @@
   "accessibility": {
     "doubleTapToActivateHint": "Double tap to activate",
     "buttons": {
+      "navigateBack": "Navigate back",
       "torch": {
         "turnOn": "Turn on the flashlight",
         "turnOff": "Turn off the flashlight"
@@ -3763,7 +3764,55 @@
       "reminderBanner": {
         "title": "Ricevi le tue comunicazioni a valore legale su IO!",
         "body": "Con IO è più semplice, ti basta attivare il servizio SEND.",
-        "cta": "Attiva SEND su IO"
+        "cta": "Attiva SEND su IO",
+        "activationFlow":{
+           "FAILURE_DETAILS_FETCH":{
+              "title": "Non riusciamo ad attivare il servizio SEND",
+              "body": "Riprova più tardi"
+           },
+           "FAILURE_ACTIVATION":{
+              "title": "Non riusciamo ad attivare il servizio SEND",
+              "body": "Riprova più tardi"
+           },
+           "WAITING_USER_INPUT":{
+            "title":"Le comunicazioni a valore legale, ora digitali",
+            "paragraph1":{
+              "title": "SEND su IO: come funziona",
+              "body": "Ricevi in app le comunicazioni a valore legale che ti inviano gli enti pubblici: con il servizio SEND puoi gestirle in tempo reale sul tuo dispositivo e pagare facilmente eventuali costi. "
+            },
+            "paragraph2":{
+              "title": "È facile e veloce",
+              "body": "Attiva il servizio in un tap per ricevere le tue prossime notifiche SEND in app."
+            },
+            "paragraph3":{
+              "pressing":"Premendo ",
+              "activate":"Attiva il servizio ",
+              "readAndUnderstood":"dichiari di aver letto e compreso l’",
+              "privacyInfo":"Informativa Privacy ",
+              "andThe":"e i ",
+              "TOS":"Termini e Condizioni d’uso"
+            },
+            "CTA":"Attiva il servizio"
+           },
+           "SUCCESS_ACTIVATION":{
+            "title":"Hai attivato il servizio SEND!",
+          "body":"Da ora in poi riceverai su IO le tue comunicazioni a valore legale!"
+           },
+           "ALREADY_ACTIVE":{
+            "title":"SEND è già attivo!",
+            "body":"Se un ente ti invia una comunicazioni a valore legale, la ricevi direttamente su IO!"
+           },
+           "LOADING-DATA":{ 
+            "title": "Attendi qualche secondo"
+           },
+           "LOADING-ACTIVATION":{
+            "title": "Stiamo attivando SEND"
+           },
+           "MISSING-SID":{
+              "title": "Non riusciamo ad attivare il servizio SEND",
+              "body": "Riprova più tardi"
+           }
+        }
       },
       "service": {
         "activate": "Attiva il servizio",

--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -3765,53 +3765,53 @@
         "title": "Ricevi le tue comunicazioni a valore legale su IO!",
         "body": "Con IO è più semplice, ti basta attivare il servizio SEND.",
         "cta": "Attiva SEND su IO",
-        "activationFlow":{
-           "FAILURE_DETAILS_FETCH":{
-              "title": "Non riusciamo ad attivare il servizio SEND",
-              "body": "Riprova più tardi"
-           },
-           "FAILURE_ACTIVATION":{
-              "title": "Non riusciamo ad attivare il servizio SEND",
-              "body": "Riprova più tardi"
-           },
-           "WAITING_USER_INPUT":{
-            "title":"Le comunicazioni a valore legale, ora digitali",
-            "paragraph1":{
+        "activationFlow": {
+          "FAILURE_DETAILS_FETCH": {
+            "title": "Non riusciamo ad attivare il servizio SEND",
+            "body": "Riprova più tardi"
+          },
+          "FAILURE_ACTIVATION": {
+            "title": "Non riusciamo ad attivare il servizio SEND",
+            "body": "Riprova più tardi"
+          },
+          "WAITING_USER_INPUT": {
+            "title": "Le comunicazioni a valore legale, ora digitali",
+            "paragraph1": {
               "title": "SEND su IO: come funziona",
               "body": "Ricevi in app le comunicazioni a valore legale che ti inviano gli enti pubblici: con il servizio SEND puoi gestirle in tempo reale sul tuo dispositivo e pagare facilmente eventuali costi. "
             },
-            "paragraph2":{
+            "paragraph2": {
               "title": "È facile e veloce",
               "body": "Attiva il servizio in un tap per ricevere le tue prossime notifiche SEND in app."
             },
-            "paragraph3":{
-              "pressing":"Premendo ",
-              "activate":"Attiva il servizio ",
-              "readAndUnderstood":"dichiari di aver letto e compreso l’",
-              "privacyInfo":"Informativa Privacy ",
-              "andThe":"e i ",
-              "TOS":"Termini e Condizioni d’uso"
+            "paragraph3": {
+              "pressing": "Premendo ",
+              "activate": "Attiva il servizio ",
+              "readAndUnderstood": "dichiari di aver letto e compreso l’",
+              "privacyInfo": "Informativa Privacy ",
+              "andThe": "e i ",
+              "TOS": "Termini e Condizioni d’uso"
             },
-            "CTA":"Attiva il servizio"
-           },
-           "SUCCESS_ACTIVATION":{
-            "title":"Hai attivato il servizio SEND!",
-          "body":"Da ora in poi riceverai su IO le tue comunicazioni a valore legale!"
-           },
-           "ALREADY_ACTIVE":{
-            "title":"SEND è già attivo!",
-            "body":"Se un ente ti invia una comunicazioni a valore legale, la ricevi direttamente su IO!"
-           },
-           "LOADING-DATA":{ 
+            "CTA": "Attiva il servizio"
+          },
+          "SUCCESS_ACTIVATION": {
+            "title": "Hai attivato il servizio SEND!",
+            "body": "Da ora in poi riceverai su IO le tue comunicazioni a valore legale!"
+          },
+          "ALREADY_ACTIVE": {
+            "title": "SEND è già attivo!",
+            "body": "Se un ente ti invia una comunicazioni a valore legale, la ricevi direttamente su IO!"
+          },
+          "LOADING-DATA": {
             "title": "Attendi qualche secondo"
-           },
-           "LOADING-ACTIVATION":{
+          },
+          "LOADING-ACTIVATION": {
             "title": "Stiamo attivando SEND"
-           },
-           "MISSING-SID":{
-              "title": "Non riusciamo ad attivare il servizio SEND",
-              "body": "Riprova più tardi"
-           }
+          },
+          "MISSING-SID": {
+            "title": "Non riusciamo ad attivare il servizio SEND",
+            "body": "Riprova più tardi"
+          }
         }
       },
       "service": {

--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -3800,7 +3800,7 @@
           },
           "ALREADY_ACTIVE": {
             "title": "SEND è già attivo!",
-            "body": "Se un ente ti invia una comunicazioni a valore legale, la ricevi direttamente su IO!"
+            "body": "Se un ente ti invia una comunicazione a valore legale, la ricevi direttamente su IO!"
           },
           "LOADING-DATA": {
             "title": "Attendi qualche secondo"

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -2,6 +2,7 @@
   "accessibility": {
     "doubleTapToActivateHint": "Tocca due volte per attivare",
     "buttons": {
+    "navigateBack": "Torna alla schermata precedente",
       "torch": {
         "turnOn": "Accendi la torcia",
         "turnOff": "Spegni la torcia"
@@ -3763,7 +3764,55 @@
       "reminderBanner": {
         "title": "Ricevi le tue comunicazioni a valore legale su IO!",
         "body": "Con IO è più semplice, ti basta attivare il servizio SEND.",
-        "cta": "Attiva SEND su IO"
+        "cta": "Attiva SEND su IO",
+        "activationFlow":{
+           "FAILURE_DETAILS_FETCH":{
+              "title": "Non riusciamo ad attivare il servizio SEND",
+              "body": "Riprova più tardi"
+           },
+           "FAILURE_ACTIVATION":{
+              "title": "Non riusciamo ad attivare il servizio SEND",
+              "body": "Riprova più tardi"
+           },
+           "WAITING_USER_INPUT":{
+            "title":"Le comunicazioni a valore legale, ora digitali",
+            "paragraph1":{
+              "title": "SEND su IO: come funziona",
+              "body": "Ricevi in app le comunicazioni a valore legale che ti inviano gli enti pubblici: con il servizio SEND puoi gestirle in tempo reale sul tuo dispositivo e pagare facilmente eventuali costi. "
+            },
+            "paragraph2":{
+              "title": "È facile e veloce",
+              "body": "Attiva il servizio in un tap per ricevere le tue prossime notifiche SEND in app."
+            },
+            "paragraph3":{
+              "pressing":"Premendo ",
+              "activate":"Attiva il servizio ",
+              "readAndUnderstood":"dichiari di aver letto e compreso l’",
+              "privacyInfo":"Informativa Privacy ",
+              "andThe":"e i ",
+              "TOS":"Termini e Condizioni d’uso"
+            },
+            "CTA":"Attiva il servizio"
+           },
+           "SUCCESS_ACTIVATION":{
+            "title":"Hai attivato il servizio SEND!",
+          "body":"Da ora in poi riceverai su IO le tue comunicazioni a valore legale!"
+           },
+           "ALREADY_ACTIVE":{
+            "title":"SEND è già attivo!",
+            "body":"Se un ente ti invia una comunicazioni a valore legale, la ricevi direttamente su IO!"
+           },
+           "LOADING-DATA":{ 
+            "title": "Attendi qualche secondo"
+           },
+           "LOADING-ACTIVATION":{
+            "title": "Stiamo attivando SEND"
+           },
+           "MISSING-SID":{
+              "title": "Non riusciamo ad attivare il servizio SEND",
+              "body": "Riprova più tardi"
+           }
+        }
       },
       "service": {
         "activate": "Attiva il servizio",

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -2,7 +2,7 @@
   "accessibility": {
     "doubleTapToActivateHint": "Tocca due volte per attivare",
     "buttons": {
-    "navigateBack": "Torna alla schermata precedente",
+      "navigateBack": "Torna alla schermata precedente",
       "torch": {
         "turnOn": "Accendi la torcia",
         "turnOff": "Spegni la torcia"
@@ -3765,53 +3765,53 @@
         "title": "Ricevi le tue comunicazioni a valore legale su IO!",
         "body": "Con IO è più semplice, ti basta attivare il servizio SEND.",
         "cta": "Attiva SEND su IO",
-        "activationFlow":{
-           "FAILURE_DETAILS_FETCH":{
-              "title": "Non riusciamo ad attivare il servizio SEND",
-              "body": "Riprova più tardi"
-           },
-           "FAILURE_ACTIVATION":{
-              "title": "Non riusciamo ad attivare il servizio SEND",
-              "body": "Riprova più tardi"
-           },
-           "WAITING_USER_INPUT":{
-            "title":"Le comunicazioni a valore legale, ora digitali",
-            "paragraph1":{
+        "activationFlow": {
+          "FAILURE_DETAILS_FETCH": {
+            "title": "Non riusciamo ad attivare il servizio SEND",
+            "body": "Riprova più tardi"
+          },
+          "FAILURE_ACTIVATION": {
+            "title": "Non riusciamo ad attivare il servizio SEND",
+            "body": "Riprova più tardi"
+          },
+          "WAITING_USER_INPUT": {
+            "title": "Le comunicazioni a valore legale, ora digitali",
+            "paragraph1": {
               "title": "SEND su IO: come funziona",
               "body": "Ricevi in app le comunicazioni a valore legale che ti inviano gli enti pubblici: con il servizio SEND puoi gestirle in tempo reale sul tuo dispositivo e pagare facilmente eventuali costi. "
             },
-            "paragraph2":{
+            "paragraph2": {
               "title": "È facile e veloce",
               "body": "Attiva il servizio in un tap per ricevere le tue prossime notifiche SEND in app."
             },
-            "paragraph3":{
-              "pressing":"Premendo ",
-              "activate":"Attiva il servizio ",
-              "readAndUnderstood":"dichiari di aver letto e compreso l’",
-              "privacyInfo":"Informativa Privacy ",
-              "andThe":"e i ",
-              "TOS":"Termini e Condizioni d’uso"
+            "paragraph3": {
+              "pressing": "Premendo ",
+              "activate": "Attiva il servizio ",
+              "readAndUnderstood": "dichiari di aver letto e compreso l’",
+              "privacyInfo": "Informativa Privacy ",
+              "andThe": "e i ",
+              "TOS": "Termini e Condizioni d’uso"
             },
-            "CTA":"Attiva il servizio"
-           },
-           "SUCCESS_ACTIVATION":{
-            "title":"Hai attivato il servizio SEND!",
-          "body":"Da ora in poi riceverai su IO le tue comunicazioni a valore legale!"
-           },
-           "ALREADY_ACTIVE":{
-            "title":"SEND è già attivo!",
-            "body":"Se un ente ti invia una comunicazioni a valore legale, la ricevi direttamente su IO!"
-           },
-           "LOADING-DATA":{ 
+            "CTA": "Attiva il servizio"
+          },
+          "SUCCESS_ACTIVATION": {
+            "title": "Hai attivato il servizio SEND!",
+            "body": "Da ora in poi riceverai su IO le tue comunicazioni a valore legale!"
+          },
+          "ALREADY_ACTIVE": {
+            "title": "SEND è già attivo!",
+            "body": "Se un ente ti invia una comunicazioni a valore legale, la ricevi direttamente su IO!"
+          },
+          "LOADING-DATA": {
             "title": "Attendi qualche secondo"
-           },
-           "LOADING-ACTIVATION":{
+          },
+          "LOADING-ACTIVATION": {
             "title": "Stiamo attivando SEND"
-           },
-           "MISSING-SID":{
-              "title": "Non riusciamo ad attivare il servizio SEND",
-              "body": "Riprova più tardi"
-           }
+          },
+          "MISSING-SID": {
+            "title": "Non riusciamo ad attivare il servizio SEND",
+            "body": "Riprova più tardi"
+          }
         }
       },
       "service": {

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -3800,7 +3800,7 @@
           },
           "ALREADY_ACTIVE": {
             "title": "SEND è già attivo!",
-            "body": "Se un ente ti invia una comunicazioni a valore legale, la ricevi direttamente su IO!"
+            "body": "Se un ente ti invia una comunicazione a valore legale, la ricevi direttamente su IO!"
           },
           "LOADING-DATA": {
             "title": "Attendi qualche secondo"

--- a/ts/features/pn/navigation/navigator.tsx
+++ b/ts/features/pn/navigation/navigator.tsx
@@ -25,6 +25,9 @@ export const PnStackNavigator = () => (
     <Stack.Screen
       name={PN_ROUTES.ACTIVATION_BANNER_FLOW}
       component={PNActivationBannerFlowScreen}
+      options={{
+        headerShown: false
+      }}
     />
   </Stack.Navigator>
 );

--- a/ts/features/pn/screens/PnReminderBannerFlow.tsx
+++ b/ts/features/pn/screens/PnReminderBannerFlow.tsx
@@ -1,15 +1,18 @@
-import { ButtonLink } from "@pagopa/io-app-design-system";
+import { HeaderSecondLevel } from "@pagopa/io-app-design-system";
 import { useState } from "react";
-import { Text, View } from "react-native";
+import { Text } from "react-native";
 import { ServiceId } from "../../../../definitions/backend/ServiceId";
+import { OperationResultScreenContent } from "../../../components/screens/OperationResultScreenContent";
 import {
   IOScrollView,
   IOScrollViewActions
 } from "../../../components/ui/IOScrollView";
+import I18n from "../../../i18n";
 import { useIONavigation } from "../../../navigation/params/AppParamsList";
 import ROUTES from "../../../navigation/routes";
 import { useIODispatch, useIOSelector } from "../../../store/hooks";
 import { pnMessagingServiceIdSelector } from "../../../store/reducers/backendStatus/remoteConfig";
+import LoadingComponent from "../../fci/components/LoadingComponent";
 import { usePnPreferencesFetcher } from "../hooks/usePnPreferencesFetcher";
 import { pnActivationUpsert } from "../store/actions";
 import { isLoadingPnActivationSelector } from "../store/reducers/activation";
@@ -70,6 +73,7 @@ type FlowScreenProps = {
 const PnActivationInputScreen = ({ setFlowState }: FlowScreenProps) => {
   const dispatch = useIODispatch();
   const isLoadingActivation = useIOSelector(isLoadingPnActivationSelector);
+  const navigation = useIONavigation();
   if (isLoadingActivation) {
     return <LoadingScreen loadingState="LOADING-ACTIVATION" />;
   }
@@ -85,20 +89,97 @@ const PnActivationInputScreen = ({ setFlowState }: FlowScreenProps) => {
   };
 
   return (
-    <CtaScreen
-      scrollViewAction={{
-        primary: {
-          label: "ACTIVATE",
-          onPress: enablePN,
-          testID: "enable-pn-cta"
-        },
-        type: "SingleButton"
-      }}
-    />
+    <>
+      <HeaderSecondLevel
+        title=""
+        type="base"
+        goBack={() => navigation.navigate(...navigateHomeParams)}
+        backAccessibilityLabel={I18n.t("accessibility.buttons.navigateBack")}
+      />
+      <CtaScreen
+        scrollViewAction={{
+          primary: {
+            label: "ACTIVATE",
+            onPress: enablePN,
+            testID: "enable-pn-cta"
+          },
+          type: "SingleButton"
+        }}
+      />
+    </>
   );
 };
 
+// ---------------------------- COMPONENT TYPES ---------------------------
+
+type SuccessFlowStateKeys = Extract<
+  PnBannerFlowStateKey,
+  "SUCCESS_ACTIVATION" | "ALREADY_ACTIVE"
+>;
+type SuccessFlowStateProps = { flowState: SuccessFlowStateKeys };
+
+type ErrorFlowStateKeys =
+  | Extract<
+      PnBannerFlowStateKey,
+      "FAILURE_ACTIVATION" | "FAILURE_DETAILS_FETCH"
+    >
+  | "MISSING-SID";
+type ErrorFlowStateProps = {
+  flowState: ErrorFlowStateKeys;
+};
+type LoadingStateProps = {
+  loadingState: "LOADING-ACTIVATION" | "LOADING-DATA";
+};
+
 // ---------------------------- COMPONENTS ---------------------------
+
+const LoadingScreen = ({ loadingState }: LoadingStateProps) => (
+  <LoadingComponent
+    testID={`loading-${loadingState}`}
+    captionTitle={I18n.t(
+      `features.pn.reminderBanner.activationFlow.${loadingState}.title`
+    )}
+  />
+);
+
+const SuccessScreen = ({ flowState }: SuccessFlowStateProps) => {
+  const navigation = useIONavigation();
+  return (
+    <OperationResultScreenContent
+      testID={`success-${flowState}`}
+      title={I18n.t(
+        `features.pn.reminderBanner.activationFlow.${flowState}.title`
+      )}
+      subtitle={I18n.t(
+        `features.pn.reminderBanner.activationFlow.${flowState}.body`
+      )}
+      action={{
+        label: I18n.t("global.buttons.close"),
+        onPress: () => navigation.navigate(...navigateHomeParams)
+      }}
+      pictogram="success"
+    />
+  );
+};
+const ErrorScreen = ({ flowState }: ErrorFlowStateProps) => {
+  const navigation = useIONavigation();
+  return (
+    <OperationResultScreenContent
+      testID={`error-${flowState}`}
+      title={I18n.t(
+        `features.pn.reminderBanner.activationFlow.${flowState}.title`
+      )}
+      subtitle={I18n.t(
+        `features.pn.reminderBanner.activationFlow.${flowState}.body`
+      )}
+      action={{
+        label: I18n.t("global.buttons.close"),
+        onPress: () => navigation.navigate(...navigateHomeParams)
+      }}
+      pictogram="umbrella"
+    />
+  );
+};
 
 const CtaScreen = ({
   scrollViewAction
@@ -111,40 +192,6 @@ const CtaScreen = ({
     </Text>
   </IOScrollView>
 );
-type SuccessFlowStateProps = { flowState: PnBannerFlowStateKey };
-
-type ErrorFlowStateProps = { flowState: PnBannerFlowStateKey | "MISSING-SID" };
-type LoadingStateProps = {
-  loadingState: "LOADING-ACTIVATION" | "LOADING-DATA";
-};
-const LoadingScreen = ({ loadingState }: LoadingStateProps) => (
-  <Text testID={`loading-${loadingState}`}>LOADING: {loadingState}</Text>
-);
-
-const SuccessScreen = ({ flowState }: SuccessFlowStateProps) => {
-  const navigation = useIONavigation();
-  return (
-    <View>
-      <Text testID={`success-${flowState}`}>{flowState}</Text>
-      <ButtonLink
-        onPress={() => navigation.navigate(...navigateHomeParams)}
-        label="GO BACK HOME"
-      />
-    </View>
-  );
-};
-const ErrorScreen = ({ flowState }: ErrorFlowStateProps) => {
-  const navigation = useIONavigation();
-  return (
-    <View>
-      <Text testID={`error-${flowState}`}>{flowState}</Text>
-      <ButtonLink
-        onPress={() => navigation.navigate(...navigateHomeParams)}
-        label="GO BACK HOME"
-      />
-    </View>
-  );
-};
 
 const navigateHomeParams = [
   ROUTES.MAIN,

--- a/ts/features/pn/screens/__test__/__snapshots__/PnReminderBannerFlow.test.tsx.snap
+++ b/ts/features/pn/screens/__test__/__snapshots__/PnReminderBannerFlow.test.tsx.snap
@@ -283,7 +283,7 @@ exports[`PnActivationReminderBannerFlow should match snapshot for state= ALREADY
               <View
                 collapsable={false}
                 enabled={false}
-                handlerTag={5}
+                handlerTag={8}
                 handlerType="PanGestureHandler"
                 needsOffscreenAlphaCompositing={false}
                 onGestureHandlerEvent={[Function]}
@@ -334,116 +334,371 @@ exports[`PnActivationReminderBannerFlow should match snapshot for state= ALREADY
                         }
                       }
                     >
-                      <View>
-                        <Text
-                          testID="success-ALREADY_ACTIVE"
-                        >
-                          ALREADY_ACTIVE
-                        </Text>
-                        <View
-                          accessibilityLabel="GO BACK HOME"
-                          accessibilityRole="button"
-                          accessibilityState={
-                            {
-                              "busy": undefined,
-                              "checked": undefined,
-                              "disabled": false,
-                              "expanded": undefined,
-                              "selected": undefined,
-                            }
+                      <RNCSafeAreaView
+                        edges={
+                          {
+                            "bottom": "additive",
+                            "left": "additive",
+                            "right": "additive",
+                            "top": "additive",
                           }
-                          accessibilityValue={
-                            {
-                              "max": undefined,
-                              "min": undefined,
-                              "now": undefined,
-                              "text": undefined,
-                            }
+                        }
+                        style={
+                          {
+                            "flexGrow": 1,
+                            "marginHorizontal": 24,
                           }
-                          accessible={true}
+                        }
+                        testID="success-ALREADY_ACTIVE"
+                      >
+                        <RCTScrollView
+                          centerContent={true}
                           collapsable={false}
-                          focusable={true}
-                          hitSlop={
-                            {
-                              "bottom": 14,
-                              "left": 24,
-                              "right": 24,
-                              "top": 14,
-                            }
+                          contentContainerStyle={
+                            [
+                              {
+                                "alignContent": "center",
+                                "alignItems": "stretch",
+                                "flex": 1,
+                                "justifyContent": "center",
+                              },
+                              false,
+                            ]
                           }
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onResponderGrant={[Function]}
-                          onResponderMove={[Function]}
-                          onResponderRelease={[Function]}
-                          onResponderTerminate={[Function]}
-                          onResponderTerminationRequest={[Function]}
-                          onStartShouldSetResponder={[Function]}
-                          onTouchEnd={[Function]}
-                          style={
-                            {
-                              "alignSelf": "flex-start",
-                            }
+                          handlerTag={9}
+                          handlerType="NativeViewGestureHandler"
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          waitFor={
+                            [
+                              {
+                                "current": null,
+                              },
+                            ]
                           }
                         >
-                          <View
-                            style={
-                              [
+                          <View>
+                            <View
+                              style={
                                 {
                                   "alignItems": "center",
-                                  "elevation": 0,
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                  "textAlignVertical": "center",
-                                },
-                                false,
-                                {
-                                  "columnGap": 8,
-                                },
-                                {},
-                                {
-                                  "columnGap": 8,
-                                },
-                                false,
-                              ]
-                            }
-                          >
+                                }
+                              }
+                            >
+                              <RNSVGSvgView
+                                align="xMidYMid"
+                                bbHeight={120}
+                                bbWidth={120}
+                                focusable={false}
+                                height={120}
+                                meetOrSlice={0}
+                                minX={0}
+                                minY={0}
+                                style={
+                                  [
+                                    {
+                                      "backgroundColor": "transparent",
+                                      "borderWidth": 0,
+                                    },
+                                    {
+                                      "flex": 0,
+                                      "height": 120,
+                                      "width": 120,
+                                    },
+                                  ]
+                                }
+                                vbHeight={240}
+                                vbWidth={240}
+                                width={120}
+                              >
+                                <RNSVGGroup
+                                  fill={
+                                    {
+                                      "payload": 4278190080,
+                                      "type": 0,
+                                    }
+                                  }
+                                >
+                                  <RNSVGPath
+                                    d="m113.74 163 1.1-8.41 5.3-3.55 5.06-.4 1.57-4.88.83-5.55 5.66-3.03 7.35-.79 5.07 1.07 4.32 5.48 2.47-19.83 3.92-8.98 5.78-5.32 4.53-.75c.29-2.62.44-5.29.44-7.99C167.13 59.71 134.42 27 94.07 27 53.72 27 21 59.71 21 100.07c0 40.36 32.71 73.07 73.07 73.07 7.71 0 15.14-1.2 22.12-3.42l-2.45-6.72Z"
+                                    fill={
+                                      {
+                                        "payload": 4289392367,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M142.56 202.43c-1.34 0-2.8-.15-4.38-.44-11.03-2.03-18.79-11.47-21.33-19.38-1.55-4.83-1.17-8.91 1.04-11.2l2.88 2.78c-1.1 1.15-1.15 3.97-.11 7.2 2.19 6.81 8.83 14.93 18.24 16.67 4.38.81 7.34.32 8.79-1.45 2.45-2.98.69-9.42-.19-11.65l3.72-1.48c.42 1.04 3.94 10.34-.43 15.67-1.79 2.19-4.56 3.29-8.24 3.29l.01-.01Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M146.3 185.03c-3.04 0-6.72-.53-11.06-1.59-17.32-4.23-21.57-16.39-22.56-23.26-.54-3.75.43-7.46 2.67-10.18 2.92-3.55 6.82-4.24 10.97-1.93l-1.94 3.5c-2.44-1.36-4.27-1.06-5.94.97-1.52 1.85-2.18 4.43-1.8 7.07.85 5.87 4.51 16.27 19.55 19.94 10.44 2.55 15.19 1.37 16.16-.59.72-1.45-.4-3.66-1.49-4.54l2.51-3.11c2.54 2.05 4.19 6.14 2.56 9.42-1.41 2.85-4.64 4.28-9.63 4.28v.02Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M152.04 174.91c-4.89 0-11.5-3.06-20.94-9.63-5.64-3.93-8.3-10.28-7.68-18.38.57-7.5 6.31-13.6 13.35-14.17 2.09-.17 6.42-.52 9.73 2.42 2.47 2.19 3.81 5.75 3.99 10.57l-4 .15c-.14-3.69-1.03-6.29-2.65-7.73-1.88-1.67-4.47-1.61-6.75-1.42-5.1.41-9.26 4.92-9.68 10.48-.51 6.7 1.5 11.68 5.98 14.8 9.75 6.79 16.31 9.65 20.07 8.76 1.4-.33 2.45-1.21 3.29-2.76.81-1.49-.55-3.8-1.42-5.05-4.33-6.17-14.65-12.19-18.35-11.63l-.6-3.95c6.01-.92 17.61 6.71 22.22 13.28 3.12 4.44 2.63 7.49 1.67 9.26-1.38 2.55-3.36 4.15-5.88 4.75-.73.17-1.51.26-2.34.26l-.01-.01Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M199.72 163.99c-7.16 0-14.29-1.78-21.16-5.33-6.79-3.51-11.4-10.13-12.34-17.7-.51-4.15.37-9.46 1.22-14.59 1.01-6.09 2.16-12.98.19-15.3-.33-.39-.94-.9-2.49-.9-2.91 0-5.32 1.04-7.39 3.19-7.96 8.27-7.27 29.08-7.26 29.29l-4 .15c-.03-.92-.75-22.73 8.37-32.21 2.82-2.93 6.27-4.41 10.27-4.41 2.38 0 4.24.78 5.54 2.31 3.16 3.73 1.97 10.92.7 18.54-.8 4.85-1.64 9.86-1.2 13.44.79 6.36 4.51 11.69 10.21 14.64 11.84 6.13 24.52 6.48 36.67 1.03l1.64 3.65c-6.25 2.8-12.63 4.2-18.98 4.2h.01ZM194.04 212.26c-6.74 0-14.48-.86-23.27-3.07-13.54-3.42-23.05-8.39-23.44-8.6l1.87-3.54c.37.2 37.68 19.53 67.92 6.96l1.54 3.69c-5.69 2.36-13.86 4.55-24.61 4.55l-.01.01Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M88.22 123.5c-.4 0-.79-.16-1.07-.45L61.92 97.31c-.58-.59-.57-1.54.02-2.12.59-.58 1.54-.57 2.12.02l24.13 24.62 42.36-45.48c.56-.61 1.52-.64 2.12-.08.61.56.64 1.51.08 2.12l-43.43 46.63c-.28.3-.67.47-1.08.48h-.02Z"
+                                    fill={
+                                      {
+                                        "payload": 4278240714,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                </RNSVGGroup>
+                              </RNSVGSvgView>
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                            </View>
                             <Text
-                              accessibilityElementsHidden={true}
-                              accessible={false}
                               allowFontScaling={true}
-                              ellipsizeMode="tail"
-                              importantForAccessibility="no-hide-descendants"
+                              dynamicTypeRamp="title2"
                               maxFontSizeMultiplier={1.5}
-                              numberOfLines={1}
                               style={
                                 [
                                   {},
                                   {
                                     "color": "#0E0F13",
                                     "fontFamily": "Titillio",
-                                    "fontSize": 16,
+                                    "fontSize": 22,
                                     "fontStyle": "normal",
                                     "fontWeight": "700",
-                                    "lineHeight": 20,
+                                    "lineHeight": 33,
                                   },
-                                  [
-                                    {
-                                      "color": undefined,
-                                    },
-                                    {
-                                      "textAlign": "auto",
-                                    },
-                                  ],
+                                  {
+                                    "textAlign": "center",
+                                  },
                                 ]
                               }
                             >
-                              GO BACK HOME
+                              SEND è già attivo!
                             </Text>
+                            <View
+                              style={
+                                {
+                                  "height": 8,
+                                }
+                              }
+                            />
+                            <Text
+                              allowFontScaling={true}
+                              dynamicTypeRamp="body"
+                              maxFontSizeMultiplier={1.5}
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "color": "#555C70",
+                                    "fontFamily": "Titillio",
+                                    "fontSize": 16,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "500",
+                                    "lineHeight": 24,
+                                  },
+                                  {
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Se un ente ti invia una comunicazioni a valore legale, la ricevi direttamente su IO!
+                            </Text>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                              <View>
+                                <View
+                                  accessibilityLabel="Close"
+                                  accessibilityRole="button"
+                                  accessibilityState={
+                                    {
+                                      "busy": false,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    {
+                                      "alignSelf": "auto",
+                                      "flexShrink": 1,
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderCurve": "continuous",
+                                          "borderRadius": 8,
+                                          "elevation": 0,
+                                          "flexDirection": "row",
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 24,
+                                          "textAlignVertical": "center",
+                                        },
+                                        {
+                                          "height": 48,
+                                        },
+                                        {
+                                          "backgroundColor": "#0B3EE3",
+                                          "overflow": "hidden",
+                                        },
+                                        false,
+                                        {},
+                                        false,
+                                        {
+                                          "backgroundColor": undefined,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "flexDirection": "row",
+                                            "justifyContent": "center",
+                                          },
+                                          {
+                                            "columnGap": 8,
+                                          },
+                                          false,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityElementsHidden={true}
+                                        accessible={false}
+                                        allowFontScaling={true}
+                                        ellipsizeMode="tail"
+                                        importantForAccessibility="no-hide-descendants"
+                                        maxFontSizeMultiplier={1.5}
+                                        numberOfLines={1}
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#FFFFFF",
+                                              "fontFamily": "Titillio",
+                                              "fontSize": 16,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "700",
+                                              "lineHeight": 20,
+                                            },
+                                            {
+                                              "alignSelf": "center",
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        Close
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
                           </View>
-                        </View>
-                      </View>
+                        </RCTScrollView>
+                      </RNCSafeAreaView>
                     </View>
                   </View>
                 </View>
@@ -740,7 +995,7 @@ exports[`PnActivationReminderBannerFlow should match snapshot for state= FAILURE
               <View
                 collapsable={false}
                 enabled={false}
-                handlerTag={2}
+                handlerTag={3}
                 handlerType="PanGestureHandler"
                 needsOffscreenAlphaCompositing={false}
                 onGestureHandlerEvent={[Function]}
@@ -791,116 +1046,419 @@ exports[`PnActivationReminderBannerFlow should match snapshot for state= FAILURE
                         }
                       }
                     >
-                      <View>
-                        <Text
-                          testID="error-FAILURE_ACTIVATION"
-                        >
-                          FAILURE_ACTIVATION
-                        </Text>
-                        <View
-                          accessibilityLabel="GO BACK HOME"
-                          accessibilityRole="button"
-                          accessibilityState={
-                            {
-                              "busy": undefined,
-                              "checked": undefined,
-                              "disabled": false,
-                              "expanded": undefined,
-                              "selected": undefined,
-                            }
+                      <RNCSafeAreaView
+                        edges={
+                          {
+                            "bottom": "additive",
+                            "left": "additive",
+                            "right": "additive",
+                            "top": "additive",
                           }
-                          accessibilityValue={
-                            {
-                              "max": undefined,
-                              "min": undefined,
-                              "now": undefined,
-                              "text": undefined,
-                            }
+                        }
+                        style={
+                          {
+                            "flexGrow": 1,
+                            "marginHorizontal": 24,
                           }
-                          accessible={true}
+                        }
+                        testID="error-FAILURE_ACTIVATION"
+                      >
+                        <RCTScrollView
+                          centerContent={true}
                           collapsable={false}
-                          focusable={true}
-                          hitSlop={
-                            {
-                              "bottom": 14,
-                              "left": 24,
-                              "right": 24,
-                              "top": 14,
-                            }
+                          contentContainerStyle={
+                            [
+                              {
+                                "alignContent": "center",
+                                "alignItems": "stretch",
+                                "flex": 1,
+                                "justifyContent": "center",
+                              },
+                              false,
+                            ]
                           }
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onResponderGrant={[Function]}
-                          onResponderMove={[Function]}
-                          onResponderRelease={[Function]}
-                          onResponderTerminate={[Function]}
-                          onResponderTerminationRequest={[Function]}
-                          onStartShouldSetResponder={[Function]}
-                          onTouchEnd={[Function]}
-                          style={
-                            {
-                              "alignSelf": "flex-start",
-                            }
+                          handlerTag={4}
+                          handlerType="NativeViewGestureHandler"
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          waitFor={
+                            [
+                              {
+                                "current": null,
+                              },
+                            ]
                           }
                         >
-                          <View
-                            style={
-                              [
+                          <View>
+                            <View
+                              style={
                                 {
                                   "alignItems": "center",
-                                  "elevation": 0,
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                  "textAlignVertical": "center",
-                                },
-                                false,
-                                {
-                                  "columnGap": 8,
-                                },
-                                {},
-                                {
-                                  "columnGap": 8,
-                                },
-                                false,
-                              ]
-                            }
-                          >
+                                }
+                              }
+                            >
+                              <RNSVGSvgView
+                                align="xMidYMid"
+                                bbHeight={120}
+                                bbWidth={120}
+                                focusable={false}
+                                height={120}
+                                meetOrSlice={0}
+                                minX={0}
+                                minY={0}
+                                style={
+                                  [
+                                    {
+                                      "backgroundColor": "transparent",
+                                      "borderWidth": 0,
+                                    },
+                                    {
+                                      "flex": 0,
+                                      "height": 120,
+                                      "width": 120,
+                                    },
+                                  ]
+                                }
+                                vbHeight={240}
+                                vbWidth={240}
+                                width={120}
+                              >
+                                <RNSVGGroup
+                                  fill={
+                                    {
+                                      "payload": 4278190080,
+                                      "type": 0,
+                                    }
+                                  }
+                                >
+                                  <RNSVGPath
+                                    d="M107.085-.00176c8.154 4.82452 16.613 7.64993 26.423 5.57086.846 1.7059 1.647 3.27854 2.412 4.8689 4.086 8.5651 9.458 16.0907 17.405 21.6793 6.048 4.2559 12.878 6.2728 20.51 7.339 1.008 3.6517 1.818 7.3922 3.078 10.9817 5.993 17.0858 17.144 29.2581 34.774 35.1577.855.2844 1.656.7197 2.835 1.2439-.702 18.9514 6.857 33.6914 23.786 43.3314-2.637 8.77-2.979 17.193 1.701 25.438-4.617 2.275-9.333 1.342-13.779 1.253-24.344-.462-47.364-6.095-68.225-18.792-25.352-15.424-44.395-36.455-55.222-64.0336-9.3681-23.8471-8.1172-47.641 2.457-70.95509.432-.95957 1.089-1.82141 1.863-3.10084l-.018.01777Z"
+                                    fill={
+                                      {
+                                        "payload": 4289392367,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    clipRule={0}
+                                    d="M109.854 11.4438c.308-.7527 1.174-1.1168 1.936-.8134 5.193 2.0678 10.161 3.0476 15.22 3.0476.402 0 .773-.0003 1.13-.0163.594-.0266 1.147.2986 1.406.8271 5.076 10.3451 11.441 18.072 19.412 23.6721 5.074 3.5598 10.843 6.0292 17.921 7.5916.544.12.974.5301 1.115 1.0626.528 1.9974 1.092 4.0131 1.81 6.0443l.001.0035c6.628 18.908 18.825 31.837 36.306 38.6155.542.2103.91.7141.942 1.2888.921 16.9038 8.391 30.6088 21.912 40.2658.666.475.815 1.394.334 2.051-.482.658-1.412.806-2.077.33-14.018-10.012-21.89-24.212-23.082-41.5496-17.882-7.2088-30.368-20.7035-37.146-40.0383-.65-1.8408-1.176-3.6538-1.649-5.407-7.018-1.6462-12.891-4.2005-18.11-7.8623l-.001-.0006c-8.22-5.7753-14.755-13.644-19.945-23.9397-.09.0003-.178.0003-.264.0003h-.015c-5.47 0-10.815-1.0638-16.332-3.2608-.762-.3034-1.131-1.1596-.824-1.9122Z"
+                                    fill={
+                                      {
+                                        "payload": 4278240714,
+                                        "type": 0,
+                                      }
+                                    }
+                                    fillRule={0}
+                                    propList={
+                                      [
+                                        "fill",
+                                        "fillRule",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M30.7695 235.468c-6.1197-6.042-6.1197-15.869 0-21.911l17.2971-17.077 3.8158 3.768-17.2971 17.077c-4.0138 3.962-4.0138 10.413 0 14.375 4.0138 3.963 10.5474 3.963 14.5612 0l3.8158 3.768c-6.1196 6.041-16.0731 6.041-22.1928 0ZM128.876 111.262l-32.2061 31.797 3.8181 3.769 32.207-31.796-3.819-3.77Z"
+                                    fill={
+                                      {
+                                        "payload": 4289392367,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M3.29384 203.162 0 200.523c7.29864-8.876 71.8704-86.54 93.2353-79.565 5.8317 1.901 9.3057 4.949 10.3407 9.045 2.232 8.894-8.2168 19.636-13.2385 24.798l-.9.924-3.0778-2.888.9089-.942c4.1488-4.264 13.8504-14.242 12.1764-20.888-.6569-2.612-3.1948-4.656-7.5506-6.068-7.7126-2.515-37.6721 16.232-88.60056 78.223Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M92.4699 174.411c-9.5755 2.506-18.6921-2.95-22.8319-7.881-3.3478-3.989-2.8888-9.889 1.062-13.434 4.5627-4.096 12.5813-5.091 21.4009 4.389l-3.1228 2.835c-5.7057-6.131-11.4565-7.677-15.4163-4.123-2.2589 2.035-2.5468 5.393-.6479 7.659 4.0588 4.833 13.9133 10.324 23.1378 4.442 2.7899-1.777 4.3733-4.016 4.8413-6.85 1.251-7.623-6.0472-16.721-6.1192-16.81l3.3028-2.63c.351.426 8.5584 10.617 7.0104 20.089-.657 4.016-2.916 7.285-6.7314 9.72-1.9439 1.244-3.9148 2.079-5.8677 2.594h-.018Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M79.0336 194.02c-5.1568 1.351-10.0885.48-14.4803-2.612-4.3558-3.065-6.5517-6.726-6.5337-10.884.036-9.125 11.1415-16.935 11.6185-17.254l2.4388 3.429c-2.7178 1.893-9.7915 8.077-9.8095 13.852 0 2.754 1.548 5.189 4.7518 7.445 4.4638 3.137 9.5305 3.252 15.0742.329 8.7116-4.602 15.0563-15.06 14.9123-19.591l4.2383-.134c.207 6.531-7.2442 18.179-17.1527 23.412-1.7009.898-3.3928 1.564-5.0667 2.008h.009Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M67.0458 207.463c-8.3696 2.185-15.1102-.391-19.169-7.437-3.1769-5.517-3.7979-10.422-1.827-14.571 3.4469-7.268 13.5624-9.125 13.9853-9.205l.747 4.123c-.072.008-8.3876 1.563-10.8894 6.868-1.35 2.843-.783 6.45 1.6739 10.715 3.5278 6.122 9.0985 7.632 17.0181 4.611 6.0477-2.301 11.3664-6.655 15.3892-12.581l3.6359-5.357 3.5278 2.327-3.6358 5.367c-4.5088 6.646-10.5205 11.541-17.3872 14.154-1.0439.399-2.0699.728-3.0688.986Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="m53.3313 224.754-3.0598-2.905c22.9668-23.501 15.4252-17.495 15.6232-17.832l3.6808 2.079c-.189.337 7.0917-5.225-16.2442 18.658Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    clipRule={0}
+                                    d="M93.3641 80.6211c.542.6099.4808 1.5383-.1366 2.0737L59.0022 112.37c-.6174.536-1.5573.475-2.0993-.134-.542-.61-.4809-1.539.1365-2.074l34.2253-29.6758c.6175-.5353 1.5574-.4749 2.0994.1349ZM145.714 157.555c.542.61.481 1.538-.137 2.073l-34.225 29.676c-.618.535-1.558.475-2.1-.135s-.48-1.538.137-2.073l34.225-29.676c.618-.536 1.558-.475 2.1.135Z"
+                                    fill={
+                                      {
+                                        "payload": 4278240714,
+                                        "type": 0,
+                                      }
+                                    }
+                                    fillRule={0}
+                                    propList={
+                                      [
+                                        "fill",
+                                        "fillRule",
+                                      ]
+                                    }
+                                  />
+                                </RNSVGGroup>
+                              </RNSVGSvgView>
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                            </View>
                             <Text
-                              accessibilityElementsHidden={true}
-                              accessible={false}
                               allowFontScaling={true}
-                              ellipsizeMode="tail"
-                              importantForAccessibility="no-hide-descendants"
+                              dynamicTypeRamp="title2"
                               maxFontSizeMultiplier={1.5}
-                              numberOfLines={1}
                               style={
                                 [
                                   {},
                                   {
                                     "color": "#0E0F13",
                                     "fontFamily": "Titillio",
-                                    "fontSize": 16,
+                                    "fontSize": 22,
                                     "fontStyle": "normal",
                                     "fontWeight": "700",
-                                    "lineHeight": 20,
+                                    "lineHeight": 33,
                                   },
-                                  [
-                                    {
-                                      "color": undefined,
-                                    },
-                                    {
-                                      "textAlign": "auto",
-                                    },
-                                  ],
+                                  {
+                                    "textAlign": "center",
+                                  },
                                 ]
                               }
                             >
-                              GO BACK HOME
+                              Non riusciamo ad attivare il servizio SEND
                             </Text>
+                            <View
+                              style={
+                                {
+                                  "height": 8,
+                                }
+                              }
+                            />
+                            <Text
+                              allowFontScaling={true}
+                              dynamicTypeRamp="body"
+                              maxFontSizeMultiplier={1.5}
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "color": "#555C70",
+                                    "fontFamily": "Titillio",
+                                    "fontSize": 16,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "500",
+                                    "lineHeight": 24,
+                                  },
+                                  {
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Riprova più tardi
+                            </Text>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                              <View>
+                                <View
+                                  accessibilityLabel="Close"
+                                  accessibilityRole="button"
+                                  accessibilityState={
+                                    {
+                                      "busy": false,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    {
+                                      "alignSelf": "auto",
+                                      "flexShrink": 1,
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderCurve": "continuous",
+                                          "borderRadius": 8,
+                                          "elevation": 0,
+                                          "flexDirection": "row",
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 24,
+                                          "textAlignVertical": "center",
+                                        },
+                                        {
+                                          "height": 48,
+                                        },
+                                        {
+                                          "backgroundColor": "#0B3EE3",
+                                          "overflow": "hidden",
+                                        },
+                                        false,
+                                        {},
+                                        false,
+                                        {
+                                          "backgroundColor": undefined,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "flexDirection": "row",
+                                            "justifyContent": "center",
+                                          },
+                                          {
+                                            "columnGap": 8,
+                                          },
+                                          false,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityElementsHidden={true}
+                                        accessible={false}
+                                        allowFontScaling={true}
+                                        ellipsizeMode="tail"
+                                        importantForAccessibility="no-hide-descendants"
+                                        maxFontSizeMultiplier={1.5}
+                                        numberOfLines={1}
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#FFFFFF",
+                                              "fontFamily": "Titillio",
+                                              "fontSize": 16,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "700",
+                                              "lineHeight": 20,
+                                            },
+                                            {
+                                              "alignSelf": "center",
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        Close
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
                           </View>
-                        </View>
-                      </View>
+                        </RCTScrollView>
+                      </RNCSafeAreaView>
                     </View>
                   </View>
                 </View>
@@ -1248,116 +1806,419 @@ exports[`PnActivationReminderBannerFlow should match snapshot for state= FAILURE
                         }
                       }
                     >
-                      <View>
-                        <Text
-                          testID="error-FAILURE_DETAILS_FETCH"
-                        >
-                          FAILURE_DETAILS_FETCH
-                        </Text>
-                        <View
-                          accessibilityLabel="GO BACK HOME"
-                          accessibilityRole="button"
-                          accessibilityState={
-                            {
-                              "busy": undefined,
-                              "checked": undefined,
-                              "disabled": false,
-                              "expanded": undefined,
-                              "selected": undefined,
-                            }
+                      <RNCSafeAreaView
+                        edges={
+                          {
+                            "bottom": "additive",
+                            "left": "additive",
+                            "right": "additive",
+                            "top": "additive",
                           }
-                          accessibilityValue={
-                            {
-                              "max": undefined,
-                              "min": undefined,
-                              "now": undefined,
-                              "text": undefined,
-                            }
+                        }
+                        style={
+                          {
+                            "flexGrow": 1,
+                            "marginHorizontal": 24,
                           }
-                          accessible={true}
+                        }
+                        testID="error-FAILURE_DETAILS_FETCH"
+                      >
+                        <RCTScrollView
+                          centerContent={true}
                           collapsable={false}
-                          focusable={true}
-                          hitSlop={
-                            {
-                              "bottom": 14,
-                              "left": 24,
-                              "right": 24,
-                              "top": 14,
-                            }
+                          contentContainerStyle={
+                            [
+                              {
+                                "alignContent": "center",
+                                "alignItems": "stretch",
+                                "flex": 1,
+                                "justifyContent": "center",
+                              },
+                              false,
+                            ]
                           }
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onResponderGrant={[Function]}
-                          onResponderMove={[Function]}
-                          onResponderRelease={[Function]}
-                          onResponderTerminate={[Function]}
-                          onResponderTerminationRequest={[Function]}
-                          onStartShouldSetResponder={[Function]}
-                          onTouchEnd={[Function]}
-                          style={
-                            {
-                              "alignSelf": "flex-start",
-                            }
+                          handlerTag={2}
+                          handlerType="NativeViewGestureHandler"
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          waitFor={
+                            [
+                              {
+                                "current": null,
+                              },
+                            ]
                           }
                         >
-                          <View
-                            style={
-                              [
+                          <View>
+                            <View
+                              style={
                                 {
                                   "alignItems": "center",
-                                  "elevation": 0,
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                  "textAlignVertical": "center",
-                                },
-                                false,
-                                {
-                                  "columnGap": 8,
-                                },
-                                {},
-                                {
-                                  "columnGap": 8,
-                                },
-                                false,
-                              ]
-                            }
-                          >
+                                }
+                              }
+                            >
+                              <RNSVGSvgView
+                                align="xMidYMid"
+                                bbHeight={120}
+                                bbWidth={120}
+                                focusable={false}
+                                height={120}
+                                meetOrSlice={0}
+                                minX={0}
+                                minY={0}
+                                style={
+                                  [
+                                    {
+                                      "backgroundColor": "transparent",
+                                      "borderWidth": 0,
+                                    },
+                                    {
+                                      "flex": 0,
+                                      "height": 120,
+                                      "width": 120,
+                                    },
+                                  ]
+                                }
+                                vbHeight={240}
+                                vbWidth={240}
+                                width={120}
+                              >
+                                <RNSVGGroup
+                                  fill={
+                                    {
+                                      "payload": 4278190080,
+                                      "type": 0,
+                                    }
+                                  }
+                                >
+                                  <RNSVGPath
+                                    d="M107.085-.00176c8.154 4.82452 16.613 7.64993 26.423 5.57086.846 1.7059 1.647 3.27854 2.412 4.8689 4.086 8.5651 9.458 16.0907 17.405 21.6793 6.048 4.2559 12.878 6.2728 20.51 7.339 1.008 3.6517 1.818 7.3922 3.078 10.9817 5.993 17.0858 17.144 29.2581 34.774 35.1577.855.2844 1.656.7197 2.835 1.2439-.702 18.9514 6.857 33.6914 23.786 43.3314-2.637 8.77-2.979 17.193 1.701 25.438-4.617 2.275-9.333 1.342-13.779 1.253-24.344-.462-47.364-6.095-68.225-18.792-25.352-15.424-44.395-36.455-55.222-64.0336-9.3681-23.8471-8.1172-47.641 2.457-70.95509.432-.95957 1.089-1.82141 1.863-3.10084l-.018.01777Z"
+                                    fill={
+                                      {
+                                        "payload": 4289392367,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    clipRule={0}
+                                    d="M109.854 11.4438c.308-.7527 1.174-1.1168 1.936-.8134 5.193 2.0678 10.161 3.0476 15.22 3.0476.402 0 .773-.0003 1.13-.0163.594-.0266 1.147.2986 1.406.8271 5.076 10.3451 11.441 18.072 19.412 23.6721 5.074 3.5598 10.843 6.0292 17.921 7.5916.544.12.974.5301 1.115 1.0626.528 1.9974 1.092 4.0131 1.81 6.0443l.001.0035c6.628 18.908 18.825 31.837 36.306 38.6155.542.2103.91.7141.942 1.2888.921 16.9038 8.391 30.6088 21.912 40.2658.666.475.815 1.394.334 2.051-.482.658-1.412.806-2.077.33-14.018-10.012-21.89-24.212-23.082-41.5496-17.882-7.2088-30.368-20.7035-37.146-40.0383-.65-1.8408-1.176-3.6538-1.649-5.407-7.018-1.6462-12.891-4.2005-18.11-7.8623l-.001-.0006c-8.22-5.7753-14.755-13.644-19.945-23.9397-.09.0003-.178.0003-.264.0003h-.015c-5.47 0-10.815-1.0638-16.332-3.2608-.762-.3034-1.131-1.1596-.824-1.9122Z"
+                                    fill={
+                                      {
+                                        "payload": 4278240714,
+                                        "type": 0,
+                                      }
+                                    }
+                                    fillRule={0}
+                                    propList={
+                                      [
+                                        "fill",
+                                        "fillRule",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M30.7695 235.468c-6.1197-6.042-6.1197-15.869 0-21.911l17.2971-17.077 3.8158 3.768-17.2971 17.077c-4.0138 3.962-4.0138 10.413 0 14.375 4.0138 3.963 10.5474 3.963 14.5612 0l3.8158 3.768c-6.1196 6.041-16.0731 6.041-22.1928 0ZM128.876 111.262l-32.2061 31.797 3.8181 3.769 32.207-31.796-3.819-3.77Z"
+                                    fill={
+                                      {
+                                        "payload": 4289392367,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M3.29384 203.162 0 200.523c7.29864-8.876 71.8704-86.54 93.2353-79.565 5.8317 1.901 9.3057 4.949 10.3407 9.045 2.232 8.894-8.2168 19.636-13.2385 24.798l-.9.924-3.0778-2.888.9089-.942c4.1488-4.264 13.8504-14.242 12.1764-20.888-.6569-2.612-3.1948-4.656-7.5506-6.068-7.7126-2.515-37.6721 16.232-88.60056 78.223Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M92.4699 174.411c-9.5755 2.506-18.6921-2.95-22.8319-7.881-3.3478-3.989-2.8888-9.889 1.062-13.434 4.5627-4.096 12.5813-5.091 21.4009 4.389l-3.1228 2.835c-5.7057-6.131-11.4565-7.677-15.4163-4.123-2.2589 2.035-2.5468 5.393-.6479 7.659 4.0588 4.833 13.9133 10.324 23.1378 4.442 2.7899-1.777 4.3733-4.016 4.8413-6.85 1.251-7.623-6.0472-16.721-6.1192-16.81l3.3028-2.63c.351.426 8.5584 10.617 7.0104 20.089-.657 4.016-2.916 7.285-6.7314 9.72-1.9439 1.244-3.9148 2.079-5.8677 2.594h-.018Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M79.0336 194.02c-5.1568 1.351-10.0885.48-14.4803-2.612-4.3558-3.065-6.5517-6.726-6.5337-10.884.036-9.125 11.1415-16.935 11.6185-17.254l2.4388 3.429c-2.7178 1.893-9.7915 8.077-9.8095 13.852 0 2.754 1.548 5.189 4.7518 7.445 4.4638 3.137 9.5305 3.252 15.0742.329 8.7116-4.602 15.0563-15.06 14.9123-19.591l4.2383-.134c.207 6.531-7.2442 18.179-17.1527 23.412-1.7009.898-3.3928 1.564-5.0667 2.008h.009Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M67.0458 207.463c-8.3696 2.185-15.1102-.391-19.169-7.437-3.1769-5.517-3.7979-10.422-1.827-14.571 3.4469-7.268 13.5624-9.125 13.9853-9.205l.747 4.123c-.072.008-8.3876 1.563-10.8894 6.868-1.35 2.843-.783 6.45 1.6739 10.715 3.5278 6.122 9.0985 7.632 17.0181 4.611 6.0477-2.301 11.3664-6.655 15.3892-12.581l3.6359-5.357 3.5278 2.327-3.6358 5.367c-4.5088 6.646-10.5205 11.541-17.3872 14.154-1.0439.399-2.0699.728-3.0688.986Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="m53.3313 224.754-3.0598-2.905c22.9668-23.501 15.4252-17.495 15.6232-17.832l3.6808 2.079c-.189.337 7.0917-5.225-16.2442 18.658Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    clipRule={0}
+                                    d="M93.3641 80.6211c.542.6099.4808 1.5383-.1366 2.0737L59.0022 112.37c-.6174.536-1.5573.475-2.0993-.134-.542-.61-.4809-1.539.1365-2.074l34.2253-29.6758c.6175-.5353 1.5574-.4749 2.0994.1349ZM145.714 157.555c.542.61.481 1.538-.137 2.073l-34.225 29.676c-.618.535-1.558.475-2.1-.135s-.48-1.538.137-2.073l34.225-29.676c.618-.536 1.558-.475 2.1.135Z"
+                                    fill={
+                                      {
+                                        "payload": 4278240714,
+                                        "type": 0,
+                                      }
+                                    }
+                                    fillRule={0}
+                                    propList={
+                                      [
+                                        "fill",
+                                        "fillRule",
+                                      ]
+                                    }
+                                  />
+                                </RNSVGGroup>
+                              </RNSVGSvgView>
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                            </View>
                             <Text
-                              accessibilityElementsHidden={true}
-                              accessible={false}
                               allowFontScaling={true}
-                              ellipsizeMode="tail"
-                              importantForAccessibility="no-hide-descendants"
+                              dynamicTypeRamp="title2"
                               maxFontSizeMultiplier={1.5}
-                              numberOfLines={1}
                               style={
                                 [
                                   {},
                                   {
                                     "color": "#0E0F13",
                                     "fontFamily": "Titillio",
-                                    "fontSize": 16,
+                                    "fontSize": 22,
                                     "fontStyle": "normal",
                                     "fontWeight": "700",
-                                    "lineHeight": 20,
+                                    "lineHeight": 33,
                                   },
-                                  [
-                                    {
-                                      "color": undefined,
-                                    },
-                                    {
-                                      "textAlign": "auto",
-                                    },
-                                  ],
+                                  {
+                                    "textAlign": "center",
+                                  },
                                 ]
                               }
                             >
-                              GO BACK HOME
+                              Non riusciamo ad attivare il servizio SEND
                             </Text>
+                            <View
+                              style={
+                                {
+                                  "height": 8,
+                                }
+                              }
+                            />
+                            <Text
+                              allowFontScaling={true}
+                              dynamicTypeRamp="body"
+                              maxFontSizeMultiplier={1.5}
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "color": "#555C70",
+                                    "fontFamily": "Titillio",
+                                    "fontSize": 16,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "500",
+                                    "lineHeight": 24,
+                                  },
+                                  {
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Riprova più tardi
+                            </Text>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                              <View>
+                                <View
+                                  accessibilityLabel="Close"
+                                  accessibilityRole="button"
+                                  accessibilityState={
+                                    {
+                                      "busy": false,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    {
+                                      "alignSelf": "auto",
+                                      "flexShrink": 1,
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderCurve": "continuous",
+                                          "borderRadius": 8,
+                                          "elevation": 0,
+                                          "flexDirection": "row",
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 24,
+                                          "textAlignVertical": "center",
+                                        },
+                                        {
+                                          "height": 48,
+                                        },
+                                        {
+                                          "backgroundColor": "#0B3EE3",
+                                          "overflow": "hidden",
+                                        },
+                                        false,
+                                        {},
+                                        false,
+                                        {
+                                          "backgroundColor": undefined,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "flexDirection": "row",
+                                            "justifyContent": "center",
+                                          },
+                                          {
+                                            "columnGap": 8,
+                                          },
+                                          false,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityElementsHidden={true}
+                                        accessible={false}
+                                        allowFontScaling={true}
+                                        ellipsizeMode="tail"
+                                        importantForAccessibility="no-hide-descendants"
+                                        maxFontSizeMultiplier={1.5}
+                                        numberOfLines={1}
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#FFFFFF",
+                                              "fontFamily": "Titillio",
+                                              "fontSize": 16,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "700",
+                                              "lineHeight": 20,
+                                            },
+                                            {
+                                              "alignSelf": "center",
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        Close
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
                           </View>
-                        </View>
-                      </View>
+                        </RCTScrollView>
+                      </RNCSafeAreaView>
                     </View>
                   </View>
                 </View>
@@ -1654,7 +2515,7 @@ exports[`PnActivationReminderBannerFlow should match snapshot for state= SUCCESS
               <View
                 collapsable={false}
                 enabled={false}
-                handlerTag={4}
+                handlerTag={6}
                 handlerType="PanGestureHandler"
                 needsOffscreenAlphaCompositing={false}
                 onGestureHandlerEvent={[Function]}
@@ -1705,116 +2566,371 @@ exports[`PnActivationReminderBannerFlow should match snapshot for state= SUCCESS
                         }
                       }
                     >
-                      <View>
-                        <Text
-                          testID="success-SUCCESS_ACTIVATION"
-                        >
-                          SUCCESS_ACTIVATION
-                        </Text>
-                        <View
-                          accessibilityLabel="GO BACK HOME"
-                          accessibilityRole="button"
-                          accessibilityState={
-                            {
-                              "busy": undefined,
-                              "checked": undefined,
-                              "disabled": false,
-                              "expanded": undefined,
-                              "selected": undefined,
-                            }
+                      <RNCSafeAreaView
+                        edges={
+                          {
+                            "bottom": "additive",
+                            "left": "additive",
+                            "right": "additive",
+                            "top": "additive",
                           }
-                          accessibilityValue={
-                            {
-                              "max": undefined,
-                              "min": undefined,
-                              "now": undefined,
-                              "text": undefined,
-                            }
+                        }
+                        style={
+                          {
+                            "flexGrow": 1,
+                            "marginHorizontal": 24,
                           }
-                          accessible={true}
+                        }
+                        testID="success-SUCCESS_ACTIVATION"
+                      >
+                        <RCTScrollView
+                          centerContent={true}
                           collapsable={false}
-                          focusable={true}
-                          hitSlop={
-                            {
-                              "bottom": 14,
-                              "left": 24,
-                              "right": 24,
-                              "top": 14,
-                            }
+                          contentContainerStyle={
+                            [
+                              {
+                                "alignContent": "center",
+                                "alignItems": "stretch",
+                                "flex": 1,
+                                "justifyContent": "center",
+                              },
+                              false,
+                            ]
                           }
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onResponderGrant={[Function]}
-                          onResponderMove={[Function]}
-                          onResponderRelease={[Function]}
-                          onResponderTerminate={[Function]}
-                          onResponderTerminationRequest={[Function]}
-                          onStartShouldSetResponder={[Function]}
-                          onTouchEnd={[Function]}
-                          style={
-                            {
-                              "alignSelf": "flex-start",
-                            }
+                          handlerTag={7}
+                          handlerType="NativeViewGestureHandler"
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          waitFor={
+                            [
+                              {
+                                "current": null,
+                              },
+                            ]
                           }
                         >
-                          <View
-                            style={
-                              [
+                          <View>
+                            <View
+                              style={
                                 {
                                   "alignItems": "center",
-                                  "elevation": 0,
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                  "textAlignVertical": "center",
-                                },
-                                false,
-                                {
-                                  "columnGap": 8,
-                                },
-                                {},
-                                {
-                                  "columnGap": 8,
-                                },
-                                false,
-                              ]
-                            }
-                          >
+                                }
+                              }
+                            >
+                              <RNSVGSvgView
+                                align="xMidYMid"
+                                bbHeight={120}
+                                bbWidth={120}
+                                focusable={false}
+                                height={120}
+                                meetOrSlice={0}
+                                minX={0}
+                                minY={0}
+                                style={
+                                  [
+                                    {
+                                      "backgroundColor": "transparent",
+                                      "borderWidth": 0,
+                                    },
+                                    {
+                                      "flex": 0,
+                                      "height": 120,
+                                      "width": 120,
+                                    },
+                                  ]
+                                }
+                                vbHeight={240}
+                                vbWidth={240}
+                                width={120}
+                              >
+                                <RNSVGGroup
+                                  fill={
+                                    {
+                                      "payload": 4278190080,
+                                      "type": 0,
+                                    }
+                                  }
+                                >
+                                  <RNSVGPath
+                                    d="m113.74 163 1.1-8.41 5.3-3.55 5.06-.4 1.57-4.88.83-5.55 5.66-3.03 7.35-.79 5.07 1.07 4.32 5.48 2.47-19.83 3.92-8.98 5.78-5.32 4.53-.75c.29-2.62.44-5.29.44-7.99C167.13 59.71 134.42 27 94.07 27 53.72 27 21 59.71 21 100.07c0 40.36 32.71 73.07 73.07 73.07 7.71 0 15.14-1.2 22.12-3.42l-2.45-6.72Z"
+                                    fill={
+                                      {
+                                        "payload": 4289392367,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M142.56 202.43c-1.34 0-2.8-.15-4.38-.44-11.03-2.03-18.79-11.47-21.33-19.38-1.55-4.83-1.17-8.91 1.04-11.2l2.88 2.78c-1.1 1.15-1.15 3.97-.11 7.2 2.19 6.81 8.83 14.93 18.24 16.67 4.38.81 7.34.32 8.79-1.45 2.45-2.98.69-9.42-.19-11.65l3.72-1.48c.42 1.04 3.94 10.34-.43 15.67-1.79 2.19-4.56 3.29-8.24 3.29l.01-.01Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M146.3 185.03c-3.04 0-6.72-.53-11.06-1.59-17.32-4.23-21.57-16.39-22.56-23.26-.54-3.75.43-7.46 2.67-10.18 2.92-3.55 6.82-4.24 10.97-1.93l-1.94 3.5c-2.44-1.36-4.27-1.06-5.94.97-1.52 1.85-2.18 4.43-1.8 7.07.85 5.87 4.51 16.27 19.55 19.94 10.44 2.55 15.19 1.37 16.16-.59.72-1.45-.4-3.66-1.49-4.54l2.51-3.11c2.54 2.05 4.19 6.14 2.56 9.42-1.41 2.85-4.64 4.28-9.63 4.28v.02Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M152.04 174.91c-4.89 0-11.5-3.06-20.94-9.63-5.64-3.93-8.3-10.28-7.68-18.38.57-7.5 6.31-13.6 13.35-14.17 2.09-.17 6.42-.52 9.73 2.42 2.47 2.19 3.81 5.75 3.99 10.57l-4 .15c-.14-3.69-1.03-6.29-2.65-7.73-1.88-1.67-4.47-1.61-6.75-1.42-5.1.41-9.26 4.92-9.68 10.48-.51 6.7 1.5 11.68 5.98 14.8 9.75 6.79 16.31 9.65 20.07 8.76 1.4-.33 2.45-1.21 3.29-2.76.81-1.49-.55-3.8-1.42-5.05-4.33-6.17-14.65-12.19-18.35-11.63l-.6-3.95c6.01-.92 17.61 6.71 22.22 13.28 3.12 4.44 2.63 7.49 1.67 9.26-1.38 2.55-3.36 4.15-5.88 4.75-.73.17-1.51.26-2.34.26l-.01-.01Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M199.72 163.99c-7.16 0-14.29-1.78-21.16-5.33-6.79-3.51-11.4-10.13-12.34-17.7-.51-4.15.37-9.46 1.22-14.59 1.01-6.09 2.16-12.98.19-15.3-.33-.39-.94-.9-2.49-.9-2.91 0-5.32 1.04-7.39 3.19-7.96 8.27-7.27 29.08-7.26 29.29l-4 .15c-.03-.92-.75-22.73 8.37-32.21 2.82-2.93 6.27-4.41 10.27-4.41 2.38 0 4.24.78 5.54 2.31 3.16 3.73 1.97 10.92.7 18.54-.8 4.85-1.64 9.86-1.2 13.44.79 6.36 4.51 11.69 10.21 14.64 11.84 6.13 24.52 6.48 36.67 1.03l1.64 3.65c-6.25 2.8-12.63 4.2-18.98 4.2h.01ZM194.04 212.26c-6.74 0-14.48-.86-23.27-3.07-13.54-3.42-23.05-8.39-23.44-8.6l1.87-3.54c.37.2 37.68 19.53 67.92 6.96l1.54 3.69c-5.69 2.36-13.86 4.55-24.61 4.55l-.01.01Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M88.22 123.5c-.4 0-.79-.16-1.07-.45L61.92 97.31c-.58-.59-.57-1.54.02-2.12.59-.58 1.54-.57 2.12.02l24.13 24.62 42.36-45.48c.56-.61 1.52-.64 2.12-.08.61.56.64 1.51.08 2.12l-43.43 46.63c-.28.3-.67.47-1.08.48h-.02Z"
+                                    fill={
+                                      {
+                                        "payload": 4278240714,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                </RNSVGGroup>
+                              </RNSVGSvgView>
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                            </View>
                             <Text
-                              accessibilityElementsHidden={true}
-                              accessible={false}
                               allowFontScaling={true}
-                              ellipsizeMode="tail"
-                              importantForAccessibility="no-hide-descendants"
+                              dynamicTypeRamp="title2"
                               maxFontSizeMultiplier={1.5}
-                              numberOfLines={1}
                               style={
                                 [
                                   {},
                                   {
                                     "color": "#0E0F13",
                                     "fontFamily": "Titillio",
-                                    "fontSize": 16,
+                                    "fontSize": 22,
                                     "fontStyle": "normal",
                                     "fontWeight": "700",
-                                    "lineHeight": 20,
+                                    "lineHeight": 33,
                                   },
-                                  [
-                                    {
-                                      "color": undefined,
-                                    },
-                                    {
-                                      "textAlign": "auto",
-                                    },
-                                  ],
+                                  {
+                                    "textAlign": "center",
+                                  },
                                 ]
                               }
                             >
-                              GO BACK HOME
+                              Hai attivato il servizio SEND!
                             </Text>
+                            <View
+                              style={
+                                {
+                                  "height": 8,
+                                }
+                              }
+                            />
+                            <Text
+                              allowFontScaling={true}
+                              dynamicTypeRamp="body"
+                              maxFontSizeMultiplier={1.5}
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "color": "#555C70",
+                                    "fontFamily": "Titillio",
+                                    "fontSize": 16,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "500",
+                                    "lineHeight": 24,
+                                  },
+                                  {
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Da ora in poi riceverai su IO le tue comunicazioni a valore legale!
+                            </Text>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                              <View>
+                                <View
+                                  accessibilityLabel="Close"
+                                  accessibilityRole="button"
+                                  accessibilityState={
+                                    {
+                                      "busy": false,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    {
+                                      "alignSelf": "auto",
+                                      "flexShrink": 1,
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderCurve": "continuous",
+                                          "borderRadius": 8,
+                                          "elevation": 0,
+                                          "flexDirection": "row",
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 24,
+                                          "textAlignVertical": "center",
+                                        },
+                                        {
+                                          "height": 48,
+                                        },
+                                        {
+                                          "backgroundColor": "#0B3EE3",
+                                          "overflow": "hidden",
+                                        },
+                                        false,
+                                        {},
+                                        false,
+                                        {
+                                          "backgroundColor": undefined,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "flexDirection": "row",
+                                            "justifyContent": "center",
+                                          },
+                                          {
+                                            "columnGap": 8,
+                                          },
+                                          false,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityElementsHidden={true}
+                                        accessible={false}
+                                        allowFontScaling={true}
+                                        ellipsizeMode="tail"
+                                        importantForAccessibility="no-hide-descendants"
+                                        maxFontSizeMultiplier={1.5}
+                                        numberOfLines={1}
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#FFFFFF",
+                                              "fontFamily": "Titillio",
+                                              "fontSize": 16,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "700",
+                                              "lineHeight": 20,
+                                            },
+                                            {
+                                              "alignSelf": "center",
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        Close
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
                           </View>
-                        </View>
-                      </View>
+                        </RCTScrollView>
+                      </RNCSafeAreaView>
                     </View>
                   </View>
                 </View>
@@ -2111,7 +3227,7 @@ exports[`PnActivationReminderBannerFlow should match snapshot for state= WAITING
               <View
                 collapsable={false}
                 enabled={false}
-                handlerTag={3}
+                handlerTag={5}
                 handlerType="PanGestureHandler"
                 needsOffscreenAlphaCompositing={false}
                 onGestureHandlerEvent={[Function]}
@@ -2162,6 +3278,219 @@ exports[`PnActivationReminderBannerFlow should match snapshot for state= WAITING
                         }
                       }
                     >
+                      <View
+                        accessibilityRole="header"
+                        style={
+                          [
+                            {
+                              "borderBottomWidth": 1,
+                              "borderColor": "rgba(210,214,227,0)",
+                            },
+                            {},
+                            {
+                              "backgroundColor": "#FFFFFF",
+                            },
+                            {
+                              "backgroundColor": "#FFFFFF",
+                              "borderColor": "transparent",
+                            },
+                          ]
+                        }
+                      >
+                        <View
+                          style={
+                            [
+                              {
+                                "marginTop": 0,
+                              },
+                              {
+                                "alignItems": "center",
+                                "flexDirection": "row",
+                                "flexGrow": 1,
+                                "height": 56,
+                                "justifyContent": "space-between",
+                                "paddingHorizontal": 24,
+                              },
+                            ]
+                          }
+                        >
+                          <View
+                            accessibilityLabel="Navigate back"
+                            accessibilityRole="button"
+                            accessibilityState={
+                              {
+                                "busy": undefined,
+                                "checked": undefined,
+                                "disabled": false,
+                                "expanded": undefined,
+                                "selected": undefined,
+                              }
+                            }
+                            accessibilityValue={
+                              {
+                                "max": undefined,
+                                "min": undefined,
+                                "now": undefined,
+                                "text": undefined,
+                              }
+                            }
+                            accessible={true}
+                            collapsable={false}
+                            focusable={true}
+                            hitSlop={8}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onFocus={[Function]}
+                            onResponderGrant={[Function]}
+                            onResponderMove={[Function]}
+                            onResponderRelease={[Function]}
+                            onResponderTerminate={[Function]}
+                            onResponderTerminationRequest={[Function]}
+                            onStartShouldSetResponder={[Function]}
+                          >
+                            <View
+                              style={
+                                [
+                                  {
+                                    "height": 24,
+                                    "width": 24,
+                                  },
+                                  {
+                                    "alignItems": "center",
+                                  },
+                                  {
+                                    "justifyContent": "center",
+                                  },
+                                  false,
+                                ]
+                              }
+                            >
+                              <RNSVGSvgView
+                                accessibilityElementsHidden={true}
+                                accessibilityLabel=""
+                                accessible={false}
+                                align="xMidYMid"
+                                animatedProps={
+                                  {
+                                    "color": undefined,
+                                  }
+                                }
+                                bbHeight={NaN}
+                                bbWidth={NaN}
+                                focusable={false}
+                                height={NaN}
+                                importantForAccessibility="no-hide-descendants"
+                                meetOrSlice={0}
+                                minX={0}
+                                minY={0}
+                                style={
+                                  [
+                                    {
+                                      "backgroundColor": "transparent",
+                                      "borderWidth": 0,
+                                    },
+                                    {
+                                      "color": "#0E0F13",
+                                    },
+                                  ]
+                                }
+                                tintColor="#0E0F13"
+                                vbHeight={24}
+                                vbWidth={24}
+                                width={NaN}
+                              >
+                                <RNSVGGroup
+                                  color="#0E0F13"
+                                  fill={
+                                    {
+                                      "payload": 4278190080,
+                                      "type": 0,
+                                    }
+                                  }
+                                >
+                                  <RNSVGPath
+                                    clipRule={0}
+                                    d="M12.7071.2929c-.3905-.39053-1.0237-.39053-1.4142 0l-11 11c-.39053.3905-.39053 1.0237 0 1.4142l11 11c.3905.3905 1.0237.3905 1.4142 0 .3905-.3905.3905-1.0237 0-1.4142L2.41421 12 12.7071 1.70711c.3905-.39053.3905-1.0237 0-1.41422Z"
+                                    fill={
+                                      {
+                                        "type": 2,
+                                      }
+                                    }
+                                    fillRule={0}
+                                    propList={
+                                      [
+                                        "fill",
+                                        "fillRule",
+                                      ]
+                                    }
+                                  />
+                                </RNSVGGroup>
+                              </RNSVGSvgView>
+                            </View>
+                          </View>
+                          <View
+                            accessibilityElementsHidden={true}
+                            accessibilityLabel=""
+                            accessibilityRole="header"
+                            accessible={false}
+                            importantForAccessibility="yes"
+                            style={
+                              {
+                                "flexGrow": 1,
+                                "flexShrink": 1,
+                                "marginHorizontal": 16,
+                              }
+                            }
+                          >
+                            <Text
+                              accessible={false}
+                              allowFontScaling={true}
+                              maxFontSizeMultiplier={1.5}
+                              numberOfLines={1}
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "color": "#0E0F13",
+                                    "fontFamily": "Titillio",
+                                    "fontSize": 14,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "700",
+                                    "lineHeight": undefined,
+                                  },
+                                  [
+                                    {
+                                      "color": "#0E0F13",
+                                      "textAlign": "center",
+                                    },
+                                    {
+                                      "opacity": 1,
+                                    },
+                                  ],
+                                ]
+                              }
+                            />
+                          </View>
+                          <View
+                            style={
+                              {
+                                "display": "flex",
+                                "flexDirection": "row",
+                                "flexShrink": 0,
+                                "gap": NaN,
+                              }
+                            }
+                          >
+                            <View
+                              style={
+                                {
+                                  "width": 24,
+                                }
+                              }
+                            />
+                          </View>
+                        </View>
+                      </View>
                       <RCTScrollView
                         collapsable={false}
                         contentContainerStyle={
@@ -2741,7 +4070,7 @@ exports[`error screens should display an error screen in case of missing_sid err
               <View
                 collapsable={false}
                 enabled={false}
-                handlerTag={6}
+                handlerTag={10}
                 handlerType="PanGestureHandler"
                 needsOffscreenAlphaCompositing={false}
                 onGestureHandlerEvent={[Function]}
@@ -2792,116 +4121,419 @@ exports[`error screens should display an error screen in case of missing_sid err
                         }
                       }
                     >
-                      <View>
-                        <Text
-                          testID="error-MISSING-SID"
-                        >
-                          MISSING-SID
-                        </Text>
-                        <View
-                          accessibilityLabel="GO BACK HOME"
-                          accessibilityRole="button"
-                          accessibilityState={
-                            {
-                              "busy": undefined,
-                              "checked": undefined,
-                              "disabled": false,
-                              "expanded": undefined,
-                              "selected": undefined,
-                            }
+                      <RNCSafeAreaView
+                        edges={
+                          {
+                            "bottom": "additive",
+                            "left": "additive",
+                            "right": "additive",
+                            "top": "additive",
                           }
-                          accessibilityValue={
-                            {
-                              "max": undefined,
-                              "min": undefined,
-                              "now": undefined,
-                              "text": undefined,
-                            }
+                        }
+                        style={
+                          {
+                            "flexGrow": 1,
+                            "marginHorizontal": 24,
                           }
-                          accessible={true}
+                        }
+                        testID="error-MISSING-SID"
+                      >
+                        <RCTScrollView
+                          centerContent={true}
                           collapsable={false}
-                          focusable={true}
-                          hitSlop={
-                            {
-                              "bottom": 14,
-                              "left": 24,
-                              "right": 24,
-                              "top": 14,
-                            }
+                          contentContainerStyle={
+                            [
+                              {
+                                "alignContent": "center",
+                                "alignItems": "stretch",
+                                "flex": 1,
+                                "justifyContent": "center",
+                              },
+                              false,
+                            ]
                           }
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onResponderGrant={[Function]}
-                          onResponderMove={[Function]}
-                          onResponderRelease={[Function]}
-                          onResponderTerminate={[Function]}
-                          onResponderTerminationRequest={[Function]}
-                          onStartShouldSetResponder={[Function]}
-                          onTouchEnd={[Function]}
-                          style={
-                            {
-                              "alignSelf": "flex-start",
-                            }
+                          handlerTag={11}
+                          handlerType="NativeViewGestureHandler"
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          waitFor={
+                            [
+                              {
+                                "current": null,
+                              },
+                            ]
                           }
                         >
-                          <View
-                            style={
-                              [
+                          <View>
+                            <View
+                              style={
                                 {
                                   "alignItems": "center",
-                                  "elevation": 0,
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                  "textAlignVertical": "center",
-                                },
-                                false,
-                                {
-                                  "columnGap": 8,
-                                },
-                                {},
-                                {
-                                  "columnGap": 8,
-                                },
-                                false,
-                              ]
-                            }
-                          >
+                                }
+                              }
+                            >
+                              <RNSVGSvgView
+                                align="xMidYMid"
+                                bbHeight={120}
+                                bbWidth={120}
+                                focusable={false}
+                                height={120}
+                                meetOrSlice={0}
+                                minX={0}
+                                minY={0}
+                                style={
+                                  [
+                                    {
+                                      "backgroundColor": "transparent",
+                                      "borderWidth": 0,
+                                    },
+                                    {
+                                      "flex": 0,
+                                      "height": 120,
+                                      "width": 120,
+                                    },
+                                  ]
+                                }
+                                vbHeight={240}
+                                vbWidth={240}
+                                width={120}
+                              >
+                                <RNSVGGroup
+                                  fill={
+                                    {
+                                      "payload": 4278190080,
+                                      "type": 0,
+                                    }
+                                  }
+                                >
+                                  <RNSVGPath
+                                    d="M107.085-.00176c8.154 4.82452 16.613 7.64993 26.423 5.57086.846 1.7059 1.647 3.27854 2.412 4.8689 4.086 8.5651 9.458 16.0907 17.405 21.6793 6.048 4.2559 12.878 6.2728 20.51 7.339 1.008 3.6517 1.818 7.3922 3.078 10.9817 5.993 17.0858 17.144 29.2581 34.774 35.1577.855.2844 1.656.7197 2.835 1.2439-.702 18.9514 6.857 33.6914 23.786 43.3314-2.637 8.77-2.979 17.193 1.701 25.438-4.617 2.275-9.333 1.342-13.779 1.253-24.344-.462-47.364-6.095-68.225-18.792-25.352-15.424-44.395-36.455-55.222-64.0336-9.3681-23.8471-8.1172-47.641 2.457-70.95509.432-.95957 1.089-1.82141 1.863-3.10084l-.018.01777Z"
+                                    fill={
+                                      {
+                                        "payload": 4289392367,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    clipRule={0}
+                                    d="M109.854 11.4438c.308-.7527 1.174-1.1168 1.936-.8134 5.193 2.0678 10.161 3.0476 15.22 3.0476.402 0 .773-.0003 1.13-.0163.594-.0266 1.147.2986 1.406.8271 5.076 10.3451 11.441 18.072 19.412 23.6721 5.074 3.5598 10.843 6.0292 17.921 7.5916.544.12.974.5301 1.115 1.0626.528 1.9974 1.092 4.0131 1.81 6.0443l.001.0035c6.628 18.908 18.825 31.837 36.306 38.6155.542.2103.91.7141.942 1.2888.921 16.9038 8.391 30.6088 21.912 40.2658.666.475.815 1.394.334 2.051-.482.658-1.412.806-2.077.33-14.018-10.012-21.89-24.212-23.082-41.5496-17.882-7.2088-30.368-20.7035-37.146-40.0383-.65-1.8408-1.176-3.6538-1.649-5.407-7.018-1.6462-12.891-4.2005-18.11-7.8623l-.001-.0006c-8.22-5.7753-14.755-13.644-19.945-23.9397-.09.0003-.178.0003-.264.0003h-.015c-5.47 0-10.815-1.0638-16.332-3.2608-.762-.3034-1.131-1.1596-.824-1.9122Z"
+                                    fill={
+                                      {
+                                        "payload": 4278240714,
+                                        "type": 0,
+                                      }
+                                    }
+                                    fillRule={0}
+                                    propList={
+                                      [
+                                        "fill",
+                                        "fillRule",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M30.7695 235.468c-6.1197-6.042-6.1197-15.869 0-21.911l17.2971-17.077 3.8158 3.768-17.2971 17.077c-4.0138 3.962-4.0138 10.413 0 14.375 4.0138 3.963 10.5474 3.963 14.5612 0l3.8158 3.768c-6.1196 6.041-16.0731 6.041-22.1928 0ZM128.876 111.262l-32.2061 31.797 3.8181 3.769 32.207-31.796-3.819-3.77Z"
+                                    fill={
+                                      {
+                                        "payload": 4289392367,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M3.29384 203.162 0 200.523c7.29864-8.876 71.8704-86.54 93.2353-79.565 5.8317 1.901 9.3057 4.949 10.3407 9.045 2.232 8.894-8.2168 19.636-13.2385 24.798l-.9.924-3.0778-2.888.9089-.942c4.1488-4.264 13.8504-14.242 12.1764-20.888-.6569-2.612-3.1948-4.656-7.5506-6.068-7.7126-2.515-37.6721 16.232-88.60056 78.223Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M92.4699 174.411c-9.5755 2.506-18.6921-2.95-22.8319-7.881-3.3478-3.989-2.8888-9.889 1.062-13.434 4.5627-4.096 12.5813-5.091 21.4009 4.389l-3.1228 2.835c-5.7057-6.131-11.4565-7.677-15.4163-4.123-2.2589 2.035-2.5468 5.393-.6479 7.659 4.0588 4.833 13.9133 10.324 23.1378 4.442 2.7899-1.777 4.3733-4.016 4.8413-6.85 1.251-7.623-6.0472-16.721-6.1192-16.81l3.3028-2.63c.351.426 8.5584 10.617 7.0104 20.089-.657 4.016-2.916 7.285-6.7314 9.72-1.9439 1.244-3.9148 2.079-5.8677 2.594h-.018Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M79.0336 194.02c-5.1568 1.351-10.0885.48-14.4803-2.612-4.3558-3.065-6.5517-6.726-6.5337-10.884.036-9.125 11.1415-16.935 11.6185-17.254l2.4388 3.429c-2.7178 1.893-9.7915 8.077-9.8095 13.852 0 2.754 1.548 5.189 4.7518 7.445 4.4638 3.137 9.5305 3.252 15.0742.329 8.7116-4.602 15.0563-15.06 14.9123-19.591l4.2383-.134c.207 6.531-7.2442 18.179-17.1527 23.412-1.7009.898-3.3928 1.564-5.0667 2.008h.009Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M67.0458 207.463c-8.3696 2.185-15.1102-.391-19.169-7.437-3.1769-5.517-3.7979-10.422-1.827-14.571 3.4469-7.268 13.5624-9.125 13.9853-9.205l.747 4.123c-.072.008-8.3876 1.563-10.8894 6.868-1.35 2.843-.783 6.45 1.6739 10.715 3.5278 6.122 9.0985 7.632 17.0181 4.611 6.0477-2.301 11.3664-6.655 15.3892-12.581l3.6359-5.357 3.5278 2.327-3.6358 5.367c-4.5088 6.646-10.5205 11.541-17.3872 14.154-1.0439.399-2.0699.728-3.0688.986Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="m53.3313 224.754-3.0598-2.905c22.9668-23.501 15.4252-17.495 15.6232-17.832l3.6808 2.079c-.189.337 7.0917-5.225-16.2442 18.658Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    clipRule={0}
+                                    d="M93.3641 80.6211c.542.6099.4808 1.5383-.1366 2.0737L59.0022 112.37c-.6174.536-1.5573.475-2.0993-.134-.542-.61-.4809-1.539.1365-2.074l34.2253-29.6758c.6175-.5353 1.5574-.4749 2.0994.1349ZM145.714 157.555c.542.61.481 1.538-.137 2.073l-34.225 29.676c-.618.535-1.558.475-2.1-.135s-.48-1.538.137-2.073l34.225-29.676c.618-.536 1.558-.475 2.1.135Z"
+                                    fill={
+                                      {
+                                        "payload": 4278240714,
+                                        "type": 0,
+                                      }
+                                    }
+                                    fillRule={0}
+                                    propList={
+                                      [
+                                        "fill",
+                                        "fillRule",
+                                      ]
+                                    }
+                                  />
+                                </RNSVGGroup>
+                              </RNSVGSvgView>
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                            </View>
                             <Text
-                              accessibilityElementsHidden={true}
-                              accessible={false}
                               allowFontScaling={true}
-                              ellipsizeMode="tail"
-                              importantForAccessibility="no-hide-descendants"
+                              dynamicTypeRamp="title2"
                               maxFontSizeMultiplier={1.5}
-                              numberOfLines={1}
                               style={
                                 [
                                   {},
                                   {
                                     "color": "#0E0F13",
                                     "fontFamily": "Titillio",
-                                    "fontSize": 16,
+                                    "fontSize": 22,
                                     "fontStyle": "normal",
                                     "fontWeight": "600",
-                                    "lineHeight": 20,
+                                    "lineHeight": 33,
                                   },
-                                  [
-                                    {
-                                      "color": undefined,
-                                    },
-                                    {
-                                      "textAlign": "auto",
-                                    },
-                                  ],
+                                  {
+                                    "textAlign": "center",
+                                  },
                                 ]
                               }
                             >
-                              GO BACK HOME
+                              Non riusciamo ad attivare il servizio SEND
                             </Text>
+                            <View
+                              style={
+                                {
+                                  "height": 8,
+                                }
+                              }
+                            />
+                            <Text
+                              allowFontScaling={true}
+                              dynamicTypeRamp="body"
+                              maxFontSizeMultiplier={1.5}
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "color": "#555C70",
+                                    "fontFamily": "Titillio",
+                                    "fontSize": 16,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "400",
+                                    "lineHeight": 24,
+                                  },
+                                  {
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Riprova più tardi
+                            </Text>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                              <View>
+                                <View
+                                  accessibilityLabel="Close"
+                                  accessibilityRole="button"
+                                  accessibilityState={
+                                    {
+                                      "busy": false,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    {
+                                      "alignSelf": "auto",
+                                      "flexShrink": 1,
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderCurve": "continuous",
+                                          "borderRadius": 8,
+                                          "elevation": 0,
+                                          "flexDirection": "row",
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 24,
+                                          "textAlignVertical": "center",
+                                        },
+                                        {
+                                          "height": 48,
+                                        },
+                                        {
+                                          "backgroundColor": "#0B3EE3",
+                                          "overflow": "hidden",
+                                        },
+                                        false,
+                                        {},
+                                        false,
+                                        {
+                                          "backgroundColor": undefined,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "flexDirection": "row",
+                                            "justifyContent": "center",
+                                          },
+                                          {
+                                            "columnGap": 8,
+                                          },
+                                          false,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityElementsHidden={true}
+                                        accessible={false}
+                                        allowFontScaling={true}
+                                        ellipsizeMode="tail"
+                                        importantForAccessibility="no-hide-descendants"
+                                        maxFontSizeMultiplier={1.5}
+                                        numberOfLines={1}
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#FFFFFF",
+                                              "fontFamily": "Titillio",
+                                              "fontSize": 16,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "600",
+                                              "lineHeight": 20,
+                                            },
+                                            {
+                                              "alignSelf": "center",
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        Close
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
                           </View>
-                        </View>
-                      </View>
+                        </RCTScrollView>
+                      </RNCSafeAreaView>
                     </View>
                   </View>
                 </View>
@@ -2916,1273 +4548,6 @@ exports[`error screens should display an error screen in case of missing_sid err
 `;
 
 exports[`error screens should display an error screen in case of preferences error 1`] = `
-<View
-  style={
-    {
-      "flex": 1,
-    }
-  }
->
-  <RNCSafeAreaProvider
-    onInsetsChange={[Function]}
-    style={
-      [
-        {
-          "flex": 1,
-        },
-        undefined,
-      ]
-    }
-  >
-    <View
-      style={
-        [
-          {
-            "backgroundColor": "#FFFFFF",
-            "flex": 1,
-          },
-          undefined,
-        ]
-      }
-    >
-      <View
-        collapsable={false}
-        pointerEvents="box-none"
-        style={
-          {
-            "zIndex": 1,
-          }
-        }
-      >
-        <View
-          accessibilityElementsHidden={false}
-          importantForAccessibility="auto"
-          onLayout={[Function]}
-          pointerEvents="box-none"
-          style={null}
-        >
-          <View
-            collapsable={false}
-            pointerEvents="box-none"
-            style={
-              {
-                "bottom": 0,
-                "left": 0,
-                "opacity": 1,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "zIndex": 0,
-              }
-            }
-          >
-            <View
-              collapsable={false}
-              style={
-                {
-                  "backgroundColor": "#FFFFFF",
-                  "borderBottomColor": "rgb(216, 216, 216)",
-                  "flex": 1,
-                  "shadowColor": "rgb(216, 216, 216)",
-                  "shadowOffset": {
-                    "height": 0.5,
-                    "width": 0,
-                  },
-                  "shadowOpacity": 0.85,
-                  "shadowRadius": 0,
-                }
-              }
-            />
-          </View>
-          <View
-            collapsable={false}
-            pointerEvents="box-none"
-            style={
-              {
-                "height": 44,
-                "maxHeight": undefined,
-                "minHeight": undefined,
-                "opacity": undefined,
-                "transform": undefined,
-              }
-            }
-          >
-            <View
-              pointerEvents="none"
-              style={
-                {
-                  "height": 0,
-                }
-              }
-            />
-            <View
-              pointerEvents="box-none"
-              style={
-                {
-                  "alignItems": "stretch",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <View
-                collapsable={false}
-                pointerEvents="box-none"
-                style={
-                  {
-                    "alignItems": "flex-start",
-                    "flexBasis": 0,
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                    "marginStart": 0,
-                    "opacity": 1,
-                  }
-                }
-              />
-              <View
-                collapsable={false}
-                pointerEvents="box-none"
-                style={
-                  {
-                    "justifyContent": "center",
-                    "marginHorizontal": 16,
-                    "maxWidth": 718,
-                    "opacity": 1,
-                  }
-                }
-              >
-                <Text
-                  accessibilityRole="header"
-                  aria-level="1"
-                  collapsable={false}
-                  numberOfLines={1}
-                  onLayout={[Function]}
-                  style={
-                    {
-                      "color": "rgb(28, 28, 30)",
-                      "fontSize": 17,
-                      "fontWeight": "600",
-                    }
-                  }
-                >
-                  PN_ACTIVATION_BANNER_FLOW
-                </Text>
-              </View>
-              <View
-                collapsable={false}
-                pointerEvents="box-none"
-                style={
-                  {
-                    "alignItems": "flex-end",
-                    "flexBasis": 0,
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                    "marginEnd": 0,
-                    "opacity": 1,
-                  }
-                }
-              />
-            </View>
-          </View>
-        </View>
-      </View>
-      <RNSScreenContainer
-        onLayout={[Function]}
-        style={
-          {
-            "flex": 1,
-          }
-        }
-      >
-        <RNSScreen
-          activityState={2}
-          collapsable={false}
-          gestureResponseDistance={
-            {
-              "bottom": -1,
-              "end": -1,
-              "start": -1,
-              "top": -1,
-            }
-          }
-          onGestureCancel={[Function]}
-          pointerEvents="box-none"
-          sheetAllowedDetents="large"
-          sheetCornerRadius={-1}
-          sheetExpandsWhenScrolledToEdge={true}
-          sheetGrabberVisible={false}
-          sheetLargestUndimmedDetent="all"
-          style={
-            {
-              "bottom": 0,
-              "left": 0,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-              "zIndex": undefined,
-            }
-          }
-        >
-          <View
-            collapsable={false}
-            style={
-              {
-                "opacity": 1,
-              }
-            }
-          />
-          <View
-            accessibilityElementsHidden={false}
-            closing={false}
-            collapsable={false}
-            gestureVelocityImpact={0.3}
-            importantForAccessibility="auto"
-            onClose={[Function]}
-            onGestureBegin={[Function]}
-            onGestureCanceled={[Function]}
-            onGestureEnd={[Function]}
-            onOpen={[Function]}
-            onTransition={[Function]}
-            pointerEvents="box-none"
-            style={
-              [
-                {
-                  "display": "flex",
-                  "overflow": undefined,
-                },
-                {
-                  "bottom": 0,
-                  "left": 0,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                },
-              ]
-            }
-            transitionSpec={
-              {
-                "close": {
-                  "animation": "spring",
-                  "config": {
-                    "damping": 500,
-                    "mass": 3,
-                    "overshootClamping": true,
-                    "restDisplacementThreshold": 10,
-                    "restSpeedThreshold": 10,
-                    "stiffness": 1000,
-                  },
-                },
-                "open": {
-                  "animation": "spring",
-                  "config": {
-                    "damping": 500,
-                    "mass": 3,
-                    "overshootClamping": true,
-                    "restDisplacementThreshold": 10,
-                    "restSpeedThreshold": 10,
-                    "stiffness": 1000,
-                  },
-                },
-              }
-            }
-          >
-            <View
-              collapsable={false}
-              pointerEvents="box-none"
-              style={
-                {
-                  "flex": 1,
-                }
-              }
-            >
-              <View
-                collapsable={false}
-                enabled={false}
-                handlerTag={7}
-                handlerType="PanGestureHandler"
-                needsOffscreenAlphaCompositing={false}
-                onGestureHandlerEvent={[Function]}
-                onGestureHandlerStateChange={[Function]}
-                style={
-                  {
-                    "flex": 1,
-                    "transform": [
-                      {
-                        "translateX": 0,
-                      },
-                      {
-                        "translateX": 0,
-                      },
-                    ],
-                  }
-                }
-              >
-                <View
-                  pointerEvents="box-none"
-                  style={
-                    [
-                      {
-                        "flex": 1,
-                        "overflow": "hidden",
-                      },
-                      [
-                        {
-                          "backgroundColor": "#FFFFFF",
-                        },
-                        undefined,
-                      ],
-                    ]
-                  }
-                >
-                  <View
-                    style={
-                      {
-                        "flex": 1,
-                        "flexDirection": "column-reverse",
-                      }
-                    }
-                  >
-                    <View
-                      style={
-                        {
-                          "flex": 1,
-                        }
-                      }
-                    >
-                      <View>
-                        <Text
-                          testID="error-FAILURE_DETAILS_FETCH"
-                        >
-                          FAILURE_DETAILS_FETCH
-                        </Text>
-                        <View
-                          accessibilityLabel="GO BACK HOME"
-                          accessibilityRole="button"
-                          accessibilityState={
-                            {
-                              "busy": undefined,
-                              "checked": undefined,
-                              "disabled": false,
-                              "expanded": undefined,
-                              "selected": undefined,
-                            }
-                          }
-                          accessibilityValue={
-                            {
-                              "max": undefined,
-                              "min": undefined,
-                              "now": undefined,
-                              "text": undefined,
-                            }
-                          }
-                          accessible={true}
-                          collapsable={false}
-                          focusable={true}
-                          hitSlop={
-                            {
-                              "bottom": 14,
-                              "left": 24,
-                              "right": 24,
-                              "top": 14,
-                            }
-                          }
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onResponderGrant={[Function]}
-                          onResponderMove={[Function]}
-                          onResponderRelease={[Function]}
-                          onResponderTerminate={[Function]}
-                          onResponderTerminationRequest={[Function]}
-                          onStartShouldSetResponder={[Function]}
-                          onTouchEnd={[Function]}
-                          style={
-                            {
-                              "alignSelf": "flex-start",
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              [
-                                {
-                                  "alignItems": "center",
-                                  "elevation": 0,
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                  "textAlignVertical": "center",
-                                },
-                                false,
-                                {
-                                  "columnGap": 8,
-                                },
-                                {},
-                                {
-                                  "columnGap": 8,
-                                },
-                                false,
-                              ]
-                            }
-                          >
-                            <Text
-                              accessibilityElementsHidden={true}
-                              accessible={false}
-                              allowFontScaling={true}
-                              ellipsizeMode="tail"
-                              importantForAccessibility="no-hide-descendants"
-                              maxFontSizeMultiplier={1.5}
-                              numberOfLines={1}
-                              style={
-                                [
-                                  {},
-                                  {
-                                    "color": "#0E0F13",
-                                    "fontFamily": "Titillio",
-                                    "fontSize": 16,
-                                    "fontStyle": "normal",
-                                    "fontWeight": "600",
-                                    "lineHeight": 20,
-                                  },
-                                  [
-                                    {
-                                      "color": undefined,
-                                    },
-                                    {
-                                      "textAlign": "auto",
-                                    },
-                                  ],
-                                ]
-                              }
-                            >
-                              GO BACK HOME
-                            </Text>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </RNSScreen>
-      </RNSScreenContainer>
-    </View>
-  </RNCSafeAreaProvider>
-</View>
-`;
-
-exports[`loading screens + error interop should render the correct loading screen when there is a "activation" loadingState, and there is a preference error  1`] = `
-<View
-  style={
-    {
-      "flex": 1,
-    }
-  }
->
-  <RNCSafeAreaProvider
-    onInsetsChange={[Function]}
-    style={
-      [
-        {
-          "flex": 1,
-        },
-        undefined,
-      ]
-    }
-  >
-    <View
-      style={
-        [
-          {
-            "backgroundColor": "#FFFFFF",
-            "flex": 1,
-          },
-          undefined,
-        ]
-      }
-    >
-      <View
-        collapsable={false}
-        pointerEvents="box-none"
-        style={
-          {
-            "zIndex": 1,
-          }
-        }
-      >
-        <View
-          accessibilityElementsHidden={false}
-          importantForAccessibility="auto"
-          onLayout={[Function]}
-          pointerEvents="box-none"
-          style={null}
-        >
-          <View
-            collapsable={false}
-            pointerEvents="box-none"
-            style={
-              {
-                "bottom": 0,
-                "left": 0,
-                "opacity": 1,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "zIndex": 0,
-              }
-            }
-          >
-            <View
-              collapsable={false}
-              style={
-                {
-                  "backgroundColor": "#FFFFFF",
-                  "borderBottomColor": "rgb(216, 216, 216)",
-                  "flex": 1,
-                  "shadowColor": "rgb(216, 216, 216)",
-                  "shadowOffset": {
-                    "height": 0.5,
-                    "width": 0,
-                  },
-                  "shadowOpacity": 0.85,
-                  "shadowRadius": 0,
-                }
-              }
-            />
-          </View>
-          <View
-            collapsable={false}
-            pointerEvents="box-none"
-            style={
-              {
-                "height": 44,
-                "maxHeight": undefined,
-                "minHeight": undefined,
-                "opacity": undefined,
-                "transform": undefined,
-              }
-            }
-          >
-            <View
-              pointerEvents="none"
-              style={
-                {
-                  "height": 0,
-                }
-              }
-            />
-            <View
-              pointerEvents="box-none"
-              style={
-                {
-                  "alignItems": "stretch",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <View
-                collapsable={false}
-                pointerEvents="box-none"
-                style={
-                  {
-                    "alignItems": "flex-start",
-                    "flexBasis": 0,
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                    "marginStart": 0,
-                    "opacity": 1,
-                  }
-                }
-              />
-              <View
-                collapsable={false}
-                pointerEvents="box-none"
-                style={
-                  {
-                    "justifyContent": "center",
-                    "marginHorizontal": 16,
-                    "maxWidth": 718,
-                    "opacity": 1,
-                  }
-                }
-              >
-                <Text
-                  accessibilityRole="header"
-                  aria-level="1"
-                  collapsable={false}
-                  numberOfLines={1}
-                  onLayout={[Function]}
-                  style={
-                    {
-                      "color": "rgb(28, 28, 30)",
-                      "fontSize": 17,
-                      "fontWeight": "600",
-                    }
-                  }
-                >
-                  PN_ACTIVATION_BANNER_FLOW
-                </Text>
-              </View>
-              <View
-                collapsable={false}
-                pointerEvents="box-none"
-                style={
-                  {
-                    "alignItems": "flex-end",
-                    "flexBasis": 0,
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                    "marginEnd": 0,
-                    "opacity": 1,
-                  }
-                }
-              />
-            </View>
-          </View>
-        </View>
-      </View>
-      <RNSScreenContainer
-        onLayout={[Function]}
-        style={
-          {
-            "flex": 1,
-          }
-        }
-      >
-        <RNSScreen
-          activityState={2}
-          collapsable={false}
-          gestureResponseDistance={
-            {
-              "bottom": -1,
-              "end": -1,
-              "start": -1,
-              "top": -1,
-            }
-          }
-          onGestureCancel={[Function]}
-          pointerEvents="box-none"
-          sheetAllowedDetents="large"
-          sheetCornerRadius={-1}
-          sheetExpandsWhenScrolledToEdge={true}
-          sheetGrabberVisible={false}
-          sheetLargestUndimmedDetent="all"
-          style={
-            {
-              "bottom": 0,
-              "left": 0,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-              "zIndex": undefined,
-            }
-          }
-        >
-          <View
-            collapsable={false}
-            style={
-              {
-                "opacity": 1,
-              }
-            }
-          />
-          <View
-            accessibilityElementsHidden={false}
-            closing={false}
-            collapsable={false}
-            gestureVelocityImpact={0.3}
-            importantForAccessibility="auto"
-            onClose={[Function]}
-            onGestureBegin={[Function]}
-            onGestureCanceled={[Function]}
-            onGestureEnd={[Function]}
-            onOpen={[Function]}
-            onTransition={[Function]}
-            pointerEvents="box-none"
-            style={
-              [
-                {
-                  "display": "flex",
-                  "overflow": undefined,
-                },
-                {
-                  "bottom": 0,
-                  "left": 0,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                },
-              ]
-            }
-            transitionSpec={
-              {
-                "close": {
-                  "animation": "spring",
-                  "config": {
-                    "damping": 500,
-                    "mass": 3,
-                    "overshootClamping": true,
-                    "restDisplacementThreshold": 10,
-                    "restSpeedThreshold": 10,
-                    "stiffness": 1000,
-                  },
-                },
-                "open": {
-                  "animation": "spring",
-                  "config": {
-                    "damping": 500,
-                    "mass": 3,
-                    "overshootClamping": true,
-                    "restDisplacementThreshold": 10,
-                    "restSpeedThreshold": 10,
-                    "stiffness": 1000,
-                  },
-                },
-              }
-            }
-          >
-            <View
-              collapsable={false}
-              pointerEvents="box-none"
-              style={
-                {
-                  "flex": 1,
-                }
-              }
-            >
-              <View
-                collapsable={false}
-                enabled={false}
-                handlerTag={8}
-                handlerType="PanGestureHandler"
-                needsOffscreenAlphaCompositing={false}
-                onGestureHandlerEvent={[Function]}
-                onGestureHandlerStateChange={[Function]}
-                style={
-                  {
-                    "flex": 1,
-                    "transform": [
-                      {
-                        "translateX": 0,
-                      },
-                      {
-                        "translateX": 0,
-                      },
-                    ],
-                  }
-                }
-              >
-                <View
-                  pointerEvents="box-none"
-                  style={
-                    [
-                      {
-                        "flex": 1,
-                        "overflow": "hidden",
-                      },
-                      [
-                        {
-                          "backgroundColor": "#FFFFFF",
-                        },
-                        undefined,
-                      ],
-                    ]
-                  }
-                >
-                  <View
-                    style={
-                      {
-                        "flex": 1,
-                        "flexDirection": "column-reverse",
-                      }
-                    }
-                  >
-                    <View
-                      style={
-                        {
-                          "flex": 1,
-                        }
-                      }
-                    >
-                      <View>
-                        <Text
-                          testID="error-FAILURE_DETAILS_FETCH"
-                        >
-                          FAILURE_DETAILS_FETCH
-                        </Text>
-                        <View
-                          accessibilityLabel="GO BACK HOME"
-                          accessibilityRole="button"
-                          accessibilityState={
-                            {
-                              "busy": undefined,
-                              "checked": undefined,
-                              "disabled": false,
-                              "expanded": undefined,
-                              "selected": undefined,
-                            }
-                          }
-                          accessibilityValue={
-                            {
-                              "max": undefined,
-                              "min": undefined,
-                              "now": undefined,
-                              "text": undefined,
-                            }
-                          }
-                          accessible={true}
-                          collapsable={false}
-                          focusable={true}
-                          hitSlop={
-                            {
-                              "bottom": 14,
-                              "left": 24,
-                              "right": 24,
-                              "top": 14,
-                            }
-                          }
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onResponderGrant={[Function]}
-                          onResponderMove={[Function]}
-                          onResponderRelease={[Function]}
-                          onResponderTerminate={[Function]}
-                          onResponderTerminationRequest={[Function]}
-                          onStartShouldSetResponder={[Function]}
-                          onTouchEnd={[Function]}
-                          style={
-                            {
-                              "alignSelf": "flex-start",
-                            }
-                          }
-                        >
-                          <View
-                            style={
-                              [
-                                {
-                                  "alignItems": "center",
-                                  "elevation": 0,
-                                  "flexDirection": "row",
-                                  "justifyContent": "center",
-                                  "textAlignVertical": "center",
-                                },
-                                false,
-                                {
-                                  "columnGap": 8,
-                                },
-                                {},
-                                {
-                                  "columnGap": 8,
-                                },
-                                false,
-                              ]
-                            }
-                          >
-                            <Text
-                              accessibilityElementsHidden={true}
-                              accessible={false}
-                              allowFontScaling={true}
-                              ellipsizeMode="tail"
-                              importantForAccessibility="no-hide-descendants"
-                              maxFontSizeMultiplier={1.5}
-                              numberOfLines={1}
-                              style={
-                                [
-                                  {},
-                                  {
-                                    "color": "#0E0F13",
-                                    "fontFamily": "Titillio",
-                                    "fontSize": 16,
-                                    "fontStyle": "normal",
-                                    "fontWeight": "600",
-                                    "lineHeight": 20,
-                                  },
-                                  [
-                                    {
-                                      "color": undefined,
-                                    },
-                                    {
-                                      "textAlign": "auto",
-                                    },
-                                  ],
-                                ]
-                              }
-                            >
-                              GO BACK HOME
-                            </Text>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </RNSScreen>
-      </RNSScreenContainer>
-    </View>
-  </RNCSafeAreaProvider>
-</View>
-`;
-
-exports[`loading screens + error interop should render the correct loading screen when there is a "activation" loadingState, and there isn't a preference error  1`] = `
-<View
-  style={
-    {
-      "flex": 1,
-    }
-  }
->
-  <RNCSafeAreaProvider
-    onInsetsChange={[Function]}
-    style={
-      [
-        {
-          "flex": 1,
-        },
-        undefined,
-      ]
-    }
-  >
-    <View
-      style={
-        [
-          {
-            "backgroundColor": "#FFFFFF",
-            "flex": 1,
-          },
-          undefined,
-        ]
-      }
-    >
-      <View
-        collapsable={false}
-        pointerEvents="box-none"
-        style={
-          {
-            "zIndex": 1,
-          }
-        }
-      >
-        <View
-          accessibilityElementsHidden={false}
-          importantForAccessibility="auto"
-          onLayout={[Function]}
-          pointerEvents="box-none"
-          style={null}
-        >
-          <View
-            collapsable={false}
-            pointerEvents="box-none"
-            style={
-              {
-                "bottom": 0,
-                "left": 0,
-                "opacity": 1,
-                "position": "absolute",
-                "right": 0,
-                "top": 0,
-                "zIndex": 0,
-              }
-            }
-          >
-            <View
-              collapsable={false}
-              style={
-                {
-                  "backgroundColor": "#FFFFFF",
-                  "borderBottomColor": "rgb(216, 216, 216)",
-                  "flex": 1,
-                  "shadowColor": "rgb(216, 216, 216)",
-                  "shadowOffset": {
-                    "height": 0.5,
-                    "width": 0,
-                  },
-                  "shadowOpacity": 0.85,
-                  "shadowRadius": 0,
-                }
-              }
-            />
-          </View>
-          <View
-            collapsable={false}
-            pointerEvents="box-none"
-            style={
-              {
-                "height": 44,
-                "maxHeight": undefined,
-                "minHeight": undefined,
-                "opacity": undefined,
-                "transform": undefined,
-              }
-            }
-          >
-            <View
-              pointerEvents="none"
-              style={
-                {
-                  "height": 0,
-                }
-              }
-            />
-            <View
-              pointerEvents="box-none"
-              style={
-                {
-                  "alignItems": "stretch",
-                  "flex": 1,
-                  "flexDirection": "row",
-                }
-              }
-            >
-              <View
-                collapsable={false}
-                pointerEvents="box-none"
-                style={
-                  {
-                    "alignItems": "flex-start",
-                    "flexBasis": 0,
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                    "marginStart": 0,
-                    "opacity": 1,
-                  }
-                }
-              />
-              <View
-                collapsable={false}
-                pointerEvents="box-none"
-                style={
-                  {
-                    "justifyContent": "center",
-                    "marginHorizontal": 16,
-                    "maxWidth": 718,
-                    "opacity": 1,
-                  }
-                }
-              >
-                <Text
-                  accessibilityRole="header"
-                  aria-level="1"
-                  collapsable={false}
-                  numberOfLines={1}
-                  onLayout={[Function]}
-                  style={
-                    {
-                      "color": "rgb(28, 28, 30)",
-                      "fontSize": 17,
-                      "fontWeight": "600",
-                    }
-                  }
-                >
-                  PN_ACTIVATION_BANNER_FLOW
-                </Text>
-              </View>
-              <View
-                collapsable={false}
-                pointerEvents="box-none"
-                style={
-                  {
-                    "alignItems": "flex-end",
-                    "flexBasis": 0,
-                    "flexGrow": 1,
-                    "justifyContent": "center",
-                    "marginEnd": 0,
-                    "opacity": 1,
-                  }
-                }
-              />
-            </View>
-          </View>
-        </View>
-      </View>
-      <RNSScreenContainer
-        onLayout={[Function]}
-        style={
-          {
-            "flex": 1,
-          }
-        }
-      >
-        <RNSScreen
-          activityState={2}
-          collapsable={false}
-          gestureResponseDistance={
-            {
-              "bottom": -1,
-              "end": -1,
-              "start": -1,
-              "top": -1,
-            }
-          }
-          onGestureCancel={[Function]}
-          pointerEvents="box-none"
-          sheetAllowedDetents="large"
-          sheetCornerRadius={-1}
-          sheetExpandsWhenScrolledToEdge={true}
-          sheetGrabberVisible={false}
-          sheetLargestUndimmedDetent="all"
-          style={
-            {
-              "bottom": 0,
-              "left": 0,
-              "position": "absolute",
-              "right": 0,
-              "top": 0,
-              "zIndex": undefined,
-            }
-          }
-        >
-          <View
-            collapsable={false}
-            style={
-              {
-                "opacity": 1,
-              }
-            }
-          />
-          <View
-            accessibilityElementsHidden={false}
-            closing={false}
-            collapsable={false}
-            gestureVelocityImpact={0.3}
-            importantForAccessibility="auto"
-            onClose={[Function]}
-            onGestureBegin={[Function]}
-            onGestureCanceled={[Function]}
-            onGestureEnd={[Function]}
-            onOpen={[Function]}
-            onTransition={[Function]}
-            pointerEvents="box-none"
-            style={
-              [
-                {
-                  "display": "flex",
-                  "overflow": undefined,
-                },
-                {
-                  "bottom": 0,
-                  "left": 0,
-                  "position": "absolute",
-                  "right": 0,
-                  "top": 0,
-                },
-              ]
-            }
-            transitionSpec={
-              {
-                "close": {
-                  "animation": "spring",
-                  "config": {
-                    "damping": 500,
-                    "mass": 3,
-                    "overshootClamping": true,
-                    "restDisplacementThreshold": 10,
-                    "restSpeedThreshold": 10,
-                    "stiffness": 1000,
-                  },
-                },
-                "open": {
-                  "animation": "spring",
-                  "config": {
-                    "damping": 500,
-                    "mass": 3,
-                    "overshootClamping": true,
-                    "restDisplacementThreshold": 10,
-                    "restSpeedThreshold": 10,
-                    "stiffness": 1000,
-                  },
-                },
-              }
-            }
-          >
-            <View
-              collapsable={false}
-              pointerEvents="box-none"
-              style={
-                {
-                  "flex": 1,
-                }
-              }
-            >
-              <View
-                collapsable={false}
-                enabled={false}
-                handlerTag={9}
-                handlerType="PanGestureHandler"
-                needsOffscreenAlphaCompositing={false}
-                onGestureHandlerEvent={[Function]}
-                onGestureHandlerStateChange={[Function]}
-                style={
-                  {
-                    "flex": 1,
-                    "transform": [
-                      {
-                        "translateX": 0,
-                      },
-                      {
-                        "translateX": 0,
-                      },
-                    ],
-                  }
-                }
-              >
-                <View
-                  pointerEvents="box-none"
-                  style={
-                    [
-                      {
-                        "flex": 1,
-                        "overflow": "hidden",
-                      },
-                      [
-                        {
-                          "backgroundColor": "#FFFFFF",
-                        },
-                        undefined,
-                      ],
-                    ]
-                  }
-                >
-                  <View
-                    style={
-                      {
-                        "flex": 1,
-                        "flexDirection": "column-reverse",
-                      }
-                    }
-                  >
-                    <View
-                      style={
-                        {
-                          "flex": 1,
-                        }
-                      }
-                    >
-                      <Text
-                        testID="loading-LOADING-ACTIVATION"
-                      >
-                        LOADING: 
-                        LOADING-ACTIVATION
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              </View>
-            </View>
-          </View>
-        </RNSScreen>
-      </RNSScreenContainer>
-    </View>
-  </RNCSafeAreaProvider>
-</View>
-`;
-
-exports[`loading screens + error interop should render the correct loading screen when there is a "both" loadingState, and there is a preference error  1`] = `
 <View
   style={
     {
@@ -4516,12 +4881,2373 @@ exports[`loading screens + error interop should render the correct loading scree
                         }
                       }
                     >
-                      <Text
+                      <RNCSafeAreaView
+                        edges={
+                          {
+                            "bottom": "additive",
+                            "left": "additive",
+                            "right": "additive",
+                            "top": "additive",
+                          }
+                        }
+                        style={
+                          {
+                            "flexGrow": 1,
+                            "marginHorizontal": 24,
+                          }
+                        }
+                        testID="error-FAILURE_DETAILS_FETCH"
+                      >
+                        <RCTScrollView
+                          centerContent={true}
+                          collapsable={false}
+                          contentContainerStyle={
+                            [
+                              {
+                                "alignContent": "center",
+                                "alignItems": "stretch",
+                                "flex": 1,
+                                "justifyContent": "center",
+                              },
+                              false,
+                            ]
+                          }
+                          handlerTag={13}
+                          handlerType="NativeViewGestureHandler"
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          waitFor={
+                            [
+                              {
+                                "current": null,
+                              },
+                            ]
+                          }
+                        >
+                          <View>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <RNSVGSvgView
+                                align="xMidYMid"
+                                bbHeight={120}
+                                bbWidth={120}
+                                focusable={false}
+                                height={120}
+                                meetOrSlice={0}
+                                minX={0}
+                                minY={0}
+                                style={
+                                  [
+                                    {
+                                      "backgroundColor": "transparent",
+                                      "borderWidth": 0,
+                                    },
+                                    {
+                                      "flex": 0,
+                                      "height": 120,
+                                      "width": 120,
+                                    },
+                                  ]
+                                }
+                                vbHeight={240}
+                                vbWidth={240}
+                                width={120}
+                              >
+                                <RNSVGGroup
+                                  fill={
+                                    {
+                                      "payload": 4278190080,
+                                      "type": 0,
+                                    }
+                                  }
+                                >
+                                  <RNSVGPath
+                                    d="M107.085-.00176c8.154 4.82452 16.613 7.64993 26.423 5.57086.846 1.7059 1.647 3.27854 2.412 4.8689 4.086 8.5651 9.458 16.0907 17.405 21.6793 6.048 4.2559 12.878 6.2728 20.51 7.339 1.008 3.6517 1.818 7.3922 3.078 10.9817 5.993 17.0858 17.144 29.2581 34.774 35.1577.855.2844 1.656.7197 2.835 1.2439-.702 18.9514 6.857 33.6914 23.786 43.3314-2.637 8.77-2.979 17.193 1.701 25.438-4.617 2.275-9.333 1.342-13.779 1.253-24.344-.462-47.364-6.095-68.225-18.792-25.352-15.424-44.395-36.455-55.222-64.0336-9.3681-23.8471-8.1172-47.641 2.457-70.95509.432-.95957 1.089-1.82141 1.863-3.10084l-.018.01777Z"
+                                    fill={
+                                      {
+                                        "payload": 4289392367,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    clipRule={0}
+                                    d="M109.854 11.4438c.308-.7527 1.174-1.1168 1.936-.8134 5.193 2.0678 10.161 3.0476 15.22 3.0476.402 0 .773-.0003 1.13-.0163.594-.0266 1.147.2986 1.406.8271 5.076 10.3451 11.441 18.072 19.412 23.6721 5.074 3.5598 10.843 6.0292 17.921 7.5916.544.12.974.5301 1.115 1.0626.528 1.9974 1.092 4.0131 1.81 6.0443l.001.0035c6.628 18.908 18.825 31.837 36.306 38.6155.542.2103.91.7141.942 1.2888.921 16.9038 8.391 30.6088 21.912 40.2658.666.475.815 1.394.334 2.051-.482.658-1.412.806-2.077.33-14.018-10.012-21.89-24.212-23.082-41.5496-17.882-7.2088-30.368-20.7035-37.146-40.0383-.65-1.8408-1.176-3.6538-1.649-5.407-7.018-1.6462-12.891-4.2005-18.11-7.8623l-.001-.0006c-8.22-5.7753-14.755-13.644-19.945-23.9397-.09.0003-.178.0003-.264.0003h-.015c-5.47 0-10.815-1.0638-16.332-3.2608-.762-.3034-1.131-1.1596-.824-1.9122Z"
+                                    fill={
+                                      {
+                                        "payload": 4278240714,
+                                        "type": 0,
+                                      }
+                                    }
+                                    fillRule={0}
+                                    propList={
+                                      [
+                                        "fill",
+                                        "fillRule",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M30.7695 235.468c-6.1197-6.042-6.1197-15.869 0-21.911l17.2971-17.077 3.8158 3.768-17.2971 17.077c-4.0138 3.962-4.0138 10.413 0 14.375 4.0138 3.963 10.5474 3.963 14.5612 0l3.8158 3.768c-6.1196 6.041-16.0731 6.041-22.1928 0ZM128.876 111.262l-32.2061 31.797 3.8181 3.769 32.207-31.796-3.819-3.77Z"
+                                    fill={
+                                      {
+                                        "payload": 4289392367,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M3.29384 203.162 0 200.523c7.29864-8.876 71.8704-86.54 93.2353-79.565 5.8317 1.901 9.3057 4.949 10.3407 9.045 2.232 8.894-8.2168 19.636-13.2385 24.798l-.9.924-3.0778-2.888.9089-.942c4.1488-4.264 13.8504-14.242 12.1764-20.888-.6569-2.612-3.1948-4.656-7.5506-6.068-7.7126-2.515-37.6721 16.232-88.60056 78.223Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M92.4699 174.411c-9.5755 2.506-18.6921-2.95-22.8319-7.881-3.3478-3.989-2.8888-9.889 1.062-13.434 4.5627-4.096 12.5813-5.091 21.4009 4.389l-3.1228 2.835c-5.7057-6.131-11.4565-7.677-15.4163-4.123-2.2589 2.035-2.5468 5.393-.6479 7.659 4.0588 4.833 13.9133 10.324 23.1378 4.442 2.7899-1.777 4.3733-4.016 4.8413-6.85 1.251-7.623-6.0472-16.721-6.1192-16.81l3.3028-2.63c.351.426 8.5584 10.617 7.0104 20.089-.657 4.016-2.916 7.285-6.7314 9.72-1.9439 1.244-3.9148 2.079-5.8677 2.594h-.018Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M79.0336 194.02c-5.1568 1.351-10.0885.48-14.4803-2.612-4.3558-3.065-6.5517-6.726-6.5337-10.884.036-9.125 11.1415-16.935 11.6185-17.254l2.4388 3.429c-2.7178 1.893-9.7915 8.077-9.8095 13.852 0 2.754 1.548 5.189 4.7518 7.445 4.4638 3.137 9.5305 3.252 15.0742.329 8.7116-4.602 15.0563-15.06 14.9123-19.591l4.2383-.134c.207 6.531-7.2442 18.179-17.1527 23.412-1.7009.898-3.3928 1.564-5.0667 2.008h.009Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M67.0458 207.463c-8.3696 2.185-15.1102-.391-19.169-7.437-3.1769-5.517-3.7979-10.422-1.827-14.571 3.4469-7.268 13.5624-9.125 13.9853-9.205l.747 4.123c-.072.008-8.3876 1.563-10.8894 6.868-1.35 2.843-.783 6.45 1.6739 10.715 3.5278 6.122 9.0985 7.632 17.0181 4.611 6.0477-2.301 11.3664-6.655 15.3892-12.581l3.6359-5.357 3.5278 2.327-3.6358 5.367c-4.5088 6.646-10.5205 11.541-17.3872 14.154-1.0439.399-2.0699.728-3.0688.986Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="m53.3313 224.754-3.0598-2.905c22.9668-23.501 15.4252-17.495 15.6232-17.832l3.6808 2.079c-.189.337 7.0917-5.225-16.2442 18.658Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    clipRule={0}
+                                    d="M93.3641 80.6211c.542.6099.4808 1.5383-.1366 2.0737L59.0022 112.37c-.6174.536-1.5573.475-2.0993-.134-.542-.61-.4809-1.539.1365-2.074l34.2253-29.6758c.6175-.5353 1.5574-.4749 2.0994.1349ZM145.714 157.555c.542.61.481 1.538-.137 2.073l-34.225 29.676c-.618.535-1.558.475-2.1-.135s-.48-1.538.137-2.073l34.225-29.676c.618-.536 1.558-.475 2.1.135Z"
+                                    fill={
+                                      {
+                                        "payload": 4278240714,
+                                        "type": 0,
+                                      }
+                                    }
+                                    fillRule={0}
+                                    propList={
+                                      [
+                                        "fill",
+                                        "fillRule",
+                                      ]
+                                    }
+                                  />
+                                </RNSVGGroup>
+                              </RNSVGSvgView>
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                            </View>
+                            <Text
+                              allowFontScaling={true}
+                              dynamicTypeRamp="title2"
+                              maxFontSizeMultiplier={1.5}
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "color": "#0E0F13",
+                                    "fontFamily": "Titillio",
+                                    "fontSize": 22,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "600",
+                                    "lineHeight": 33,
+                                  },
+                                  {
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Non riusciamo ad attivare il servizio SEND
+                            </Text>
+                            <View
+                              style={
+                                {
+                                  "height": 8,
+                                }
+                              }
+                            />
+                            <Text
+                              allowFontScaling={true}
+                              dynamicTypeRamp="body"
+                              maxFontSizeMultiplier={1.5}
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "color": "#555C70",
+                                    "fontFamily": "Titillio",
+                                    "fontSize": 16,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "400",
+                                    "lineHeight": 24,
+                                  },
+                                  {
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Riprova più tardi
+                            </Text>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                              <View>
+                                <View
+                                  accessibilityLabel="Close"
+                                  accessibilityRole="button"
+                                  accessibilityState={
+                                    {
+                                      "busy": false,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    {
+                                      "alignSelf": "auto",
+                                      "flexShrink": 1,
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderCurve": "continuous",
+                                          "borderRadius": 8,
+                                          "elevation": 0,
+                                          "flexDirection": "row",
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 24,
+                                          "textAlignVertical": "center",
+                                        },
+                                        {
+                                          "height": 48,
+                                        },
+                                        {
+                                          "backgroundColor": "#0B3EE3",
+                                          "overflow": "hidden",
+                                        },
+                                        false,
+                                        {},
+                                        false,
+                                        {
+                                          "backgroundColor": undefined,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "flexDirection": "row",
+                                            "justifyContent": "center",
+                                          },
+                                          {
+                                            "columnGap": 8,
+                                          },
+                                          false,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityElementsHidden={true}
+                                        accessible={false}
+                                        allowFontScaling={true}
+                                        ellipsizeMode="tail"
+                                        importantForAccessibility="no-hide-descendants"
+                                        maxFontSizeMultiplier={1.5}
+                                        numberOfLines={1}
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#FFFFFF",
+                                              "fontFamily": "Titillio",
+                                              "fontSize": 16,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "600",
+                                              "lineHeight": 20,
+                                            },
+                                            {
+                                              "alignSelf": "center",
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        Close
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </RCTScrollView>
+                      </RNCSafeAreaView>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RNSScreen>
+      </RNSScreenContainer>
+    </View>
+  </RNCSafeAreaProvider>
+</View>
+`;
+
+exports[`loading screens + error interop should render the correct loading screen when there is a "activation" loadingState, and there is a preference error  1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <RNCSafeAreaProvider
+    onInsetsChange={[Function]}
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "#FFFFFF",
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          {
+            "zIndex": 1,
+          }
+        }
+      >
+        <View
+          accessibilityElementsHidden={false}
+          importantForAccessibility="auto"
+          onLayout={[Function]}
+          pointerEvents="box-none"
+          style={null}
+        >
+          <View
+            collapsable={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "zIndex": 0,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "borderBottomColor": "rgb(216, 216, 216)",
+                  "flex": 1,
+                  "shadowColor": "rgb(216, 216, 216)",
+                  "shadowOffset": {
+                    "height": 0.5,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.85,
+                  "shadowRadius": 0,
+                }
+              }
+            />
+          </View>
+          <View
+            collapsable={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "height": 44,
+                "maxHeight": undefined,
+                "minHeight": undefined,
+                "opacity": undefined,
+                "transform": undefined,
+              }
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                {
+                  "height": 0,
+                }
+              }
+            />
+            <View
+              pointerEvents="box-none"
+              style={
+                {
+                  "alignItems": "stretch",
+                  "flex": 1,
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginStart": 0,
+                    "opacity": 1,
+                  }
+                }
+              />
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "justifyContent": "center",
+                    "marginHorizontal": 16,
+                    "maxWidth": 718,
+                    "opacity": 1,
+                  }
+                }
+              >
+                <Text
+                  accessibilityRole="header"
+                  aria-level="1"
+                  collapsable={false}
+                  numberOfLines={1}
+                  onLayout={[Function]}
+                  style={
+                    {
+                      "color": "rgb(28, 28, 30)",
+                      "fontSize": 17,
+                      "fontWeight": "600",
+                    }
+                  }
+                >
+                  PN_ACTIVATION_BANNER_FLOW
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-end",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginEnd": 0,
+                    "opacity": 1,
+                  }
+                }
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+      <RNSScreenContainer
+        onLayout={[Function]}
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      >
+        <RNSScreen
+          activityState={2}
+          collapsable={false}
+          gestureResponseDistance={
+            {
+              "bottom": -1,
+              "end": -1,
+              "start": -1,
+              "top": -1,
+            }
+          }
+          onGestureCancel={[Function]}
+          pointerEvents="box-none"
+          sheetAllowedDetents="large"
+          sheetCornerRadius={-1}
+          sheetExpandsWhenScrolledToEdge={true}
+          sheetGrabberVisible={false}
+          sheetLargestUndimmedDetent="all"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "zIndex": undefined,
+            }
+          }
+        >
+          <View
+            collapsable={false}
+            style={
+              {
+                "opacity": 1,
+              }
+            }
+          />
+          <View
+            accessibilityElementsHidden={false}
+            closing={false}
+            collapsable={false}
+            gestureVelocityImpact={0.3}
+            importantForAccessibility="auto"
+            onClose={[Function]}
+            onGestureBegin={[Function]}
+            onGestureCanceled={[Function]}
+            onGestureEnd={[Function]}
+            onOpen={[Function]}
+            onTransition={[Function]}
+            pointerEvents="box-none"
+            style={
+              [
+                {
+                  "display": "flex",
+                  "overflow": undefined,
+                },
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+              ]
+            }
+            transitionSpec={
+              {
+                "close": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+                "open": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              pointerEvents="box-none"
+              style={
+                {
+                  "flex": 1,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                enabled={false}
+                handlerTag={14}
+                handlerType="PanGestureHandler"
+                needsOffscreenAlphaCompositing={false}
+                onGestureHandlerEvent={[Function]}
+                onGestureHandlerStateChange={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "transform": [
+                      {
+                        "translateX": 0,
+                      },
+                      {
+                        "translateX": 0,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  pointerEvents="box-none"
+                  style={
+                    [
+                      {
+                        "flex": 1,
+                        "overflow": "hidden",
+                      },
+                      [
+                        {
+                          "backgroundColor": "#FFFFFF",
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "flex": 1,
+                        "flexDirection": "column-reverse",
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                        }
+                      }
+                    >
+                      <RNCSafeAreaView
+                        edges={
+                          {
+                            "bottom": "additive",
+                            "left": "additive",
+                            "right": "additive",
+                            "top": "additive",
+                          }
+                        }
+                        style={
+                          {
+                            "flexGrow": 1,
+                            "marginHorizontal": 24,
+                          }
+                        }
+                        testID="error-FAILURE_DETAILS_FETCH"
+                      >
+                        <RCTScrollView
+                          centerContent={true}
+                          collapsable={false}
+                          contentContainerStyle={
+                            [
+                              {
+                                "alignContent": "center",
+                                "alignItems": "stretch",
+                                "flex": 1,
+                                "justifyContent": "center",
+                              },
+                              false,
+                            ]
+                          }
+                          handlerTag={15}
+                          handlerType="NativeViewGestureHandler"
+                          onGestureHandlerEvent={[Function]}
+                          onGestureHandlerStateChange={[Function]}
+                          waitFor={
+                            [
+                              {
+                                "current": null,
+                              },
+                            ]
+                          }
+                        >
+                          <View>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <RNSVGSvgView
+                                align="xMidYMid"
+                                bbHeight={120}
+                                bbWidth={120}
+                                focusable={false}
+                                height={120}
+                                meetOrSlice={0}
+                                minX={0}
+                                minY={0}
+                                style={
+                                  [
+                                    {
+                                      "backgroundColor": "transparent",
+                                      "borderWidth": 0,
+                                    },
+                                    {
+                                      "flex": 0,
+                                      "height": 120,
+                                      "width": 120,
+                                    },
+                                  ]
+                                }
+                                vbHeight={240}
+                                vbWidth={240}
+                                width={120}
+                              >
+                                <RNSVGGroup
+                                  fill={
+                                    {
+                                      "payload": 4278190080,
+                                      "type": 0,
+                                    }
+                                  }
+                                >
+                                  <RNSVGPath
+                                    d="M107.085-.00176c8.154 4.82452 16.613 7.64993 26.423 5.57086.846 1.7059 1.647 3.27854 2.412 4.8689 4.086 8.5651 9.458 16.0907 17.405 21.6793 6.048 4.2559 12.878 6.2728 20.51 7.339 1.008 3.6517 1.818 7.3922 3.078 10.9817 5.993 17.0858 17.144 29.2581 34.774 35.1577.855.2844 1.656.7197 2.835 1.2439-.702 18.9514 6.857 33.6914 23.786 43.3314-2.637 8.77-2.979 17.193 1.701 25.438-4.617 2.275-9.333 1.342-13.779 1.253-24.344-.462-47.364-6.095-68.225-18.792-25.352-15.424-44.395-36.455-55.222-64.0336-9.3681-23.8471-8.1172-47.641 2.457-70.95509.432-.95957 1.089-1.82141 1.863-3.10084l-.018.01777Z"
+                                    fill={
+                                      {
+                                        "payload": 4289392367,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    clipRule={0}
+                                    d="M109.854 11.4438c.308-.7527 1.174-1.1168 1.936-.8134 5.193 2.0678 10.161 3.0476 15.22 3.0476.402 0 .773-.0003 1.13-.0163.594-.0266 1.147.2986 1.406.8271 5.076 10.3451 11.441 18.072 19.412 23.6721 5.074 3.5598 10.843 6.0292 17.921 7.5916.544.12.974.5301 1.115 1.0626.528 1.9974 1.092 4.0131 1.81 6.0443l.001.0035c6.628 18.908 18.825 31.837 36.306 38.6155.542.2103.91.7141.942 1.2888.921 16.9038 8.391 30.6088 21.912 40.2658.666.475.815 1.394.334 2.051-.482.658-1.412.806-2.077.33-14.018-10.012-21.89-24.212-23.082-41.5496-17.882-7.2088-30.368-20.7035-37.146-40.0383-.65-1.8408-1.176-3.6538-1.649-5.407-7.018-1.6462-12.891-4.2005-18.11-7.8623l-.001-.0006c-8.22-5.7753-14.755-13.644-19.945-23.9397-.09.0003-.178.0003-.264.0003h-.015c-5.47 0-10.815-1.0638-16.332-3.2608-.762-.3034-1.131-1.1596-.824-1.9122Z"
+                                    fill={
+                                      {
+                                        "payload": 4278240714,
+                                        "type": 0,
+                                      }
+                                    }
+                                    fillRule={0}
+                                    propList={
+                                      [
+                                        "fill",
+                                        "fillRule",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M30.7695 235.468c-6.1197-6.042-6.1197-15.869 0-21.911l17.2971-17.077 3.8158 3.768-17.2971 17.077c-4.0138 3.962-4.0138 10.413 0 14.375 4.0138 3.963 10.5474 3.963 14.5612 0l3.8158 3.768c-6.1196 6.041-16.0731 6.041-22.1928 0ZM128.876 111.262l-32.2061 31.797 3.8181 3.769 32.207-31.796-3.819-3.77Z"
+                                    fill={
+                                      {
+                                        "payload": 4289392367,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M3.29384 203.162 0 200.523c7.29864-8.876 71.8704-86.54 93.2353-79.565 5.8317 1.901 9.3057 4.949 10.3407 9.045 2.232 8.894-8.2168 19.636-13.2385 24.798l-.9.924-3.0778-2.888.9089-.942c4.1488-4.264 13.8504-14.242 12.1764-20.888-.6569-2.612-3.1948-4.656-7.5506-6.068-7.7126-2.515-37.6721 16.232-88.60056 78.223Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M92.4699 174.411c-9.5755 2.506-18.6921-2.95-22.8319-7.881-3.3478-3.989-2.8888-9.889 1.062-13.434 4.5627-4.096 12.5813-5.091 21.4009 4.389l-3.1228 2.835c-5.7057-6.131-11.4565-7.677-15.4163-4.123-2.2589 2.035-2.5468 5.393-.6479 7.659 4.0588 4.833 13.9133 10.324 23.1378 4.442 2.7899-1.777 4.3733-4.016 4.8413-6.85 1.251-7.623-6.0472-16.721-6.1192-16.81l3.3028-2.63c.351.426 8.5584 10.617 7.0104 20.089-.657 4.016-2.916 7.285-6.7314 9.72-1.9439 1.244-3.9148 2.079-5.8677 2.594h-.018Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M79.0336 194.02c-5.1568 1.351-10.0885.48-14.4803-2.612-4.3558-3.065-6.5517-6.726-6.5337-10.884.036-9.125 11.1415-16.935 11.6185-17.254l2.4388 3.429c-2.7178 1.893-9.7915 8.077-9.8095 13.852 0 2.754 1.548 5.189 4.7518 7.445 4.4638 3.137 9.5305 3.252 15.0742.329 8.7116-4.602 15.0563-15.06 14.9123-19.591l4.2383-.134c.207 6.531-7.2442 18.179-17.1527 23.412-1.7009.898-3.3928 1.564-5.0667 2.008h.009Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M67.0458 207.463c-8.3696 2.185-15.1102-.391-19.169-7.437-3.1769-5.517-3.7979-10.422-1.827-14.571 3.4469-7.268 13.5624-9.125 13.9853-9.205l.747 4.123c-.072.008-8.3876 1.563-10.8894 6.868-1.35 2.843-.783 6.45 1.6739 10.715 3.5278 6.122 9.0985 7.632 17.0181 4.611 6.0477-2.301 11.3664-6.655 15.3892-12.581l3.6359-5.357 3.5278 2.327-3.6358 5.367c-4.5088 6.646-10.5205 11.541-17.3872 14.154-1.0439.399-2.0699.728-3.0688.986Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="m53.3313 224.754-3.0598-2.905c22.9668-23.501 15.4252-17.495 15.6232-17.832l3.6808 2.079c-.189.337 7.0917-5.225-16.2442 18.658Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    clipRule={0}
+                                    d="M93.3641 80.6211c.542.6099.4808 1.5383-.1366 2.0737L59.0022 112.37c-.6174.536-1.5573.475-2.0993-.134-.542-.61-.4809-1.539.1365-2.074l34.2253-29.6758c.6175-.5353 1.5574-.4749 2.0994.1349ZM145.714 157.555c.542.61.481 1.538-.137 2.073l-34.225 29.676c-.618.535-1.558.475-2.1-.135s-.48-1.538.137-2.073l34.225-29.676c.618-.536 1.558-.475 2.1.135Z"
+                                    fill={
+                                      {
+                                        "payload": 4278240714,
+                                        "type": 0,
+                                      }
+                                    }
+                                    fillRule={0}
+                                    propList={
+                                      [
+                                        "fill",
+                                        "fillRule",
+                                      ]
+                                    }
+                                  />
+                                </RNSVGGroup>
+                              </RNSVGSvgView>
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                            </View>
+                            <Text
+                              allowFontScaling={true}
+                              dynamicTypeRamp="title2"
+                              maxFontSizeMultiplier={1.5}
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "color": "#0E0F13",
+                                    "fontFamily": "Titillio",
+                                    "fontSize": 22,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "600",
+                                    "lineHeight": 33,
+                                  },
+                                  {
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Non riusciamo ad attivare il servizio SEND
+                            </Text>
+                            <View
+                              style={
+                                {
+                                  "height": 8,
+                                }
+                              }
+                            />
+                            <Text
+                              allowFontScaling={true}
+                              dynamicTypeRamp="body"
+                              maxFontSizeMultiplier={1.5}
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "color": "#555C70",
+                                    "fontFamily": "Titillio",
+                                    "fontSize": 16,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "400",
+                                    "lineHeight": 24,
+                                  },
+                                  {
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              Riprova più tardi
+                            </Text>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                              <View>
+                                <View
+                                  accessibilityLabel="Close"
+                                  accessibilityRole="button"
+                                  accessibilityState={
+                                    {
+                                      "busy": false,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    {
+                                      "alignSelf": "auto",
+                                      "flexShrink": 1,
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderCurve": "continuous",
+                                          "borderRadius": 8,
+                                          "elevation": 0,
+                                          "flexDirection": "row",
+                                          "justifyContent": "center",
+                                          "paddingHorizontal": 24,
+                                          "textAlignVertical": "center",
+                                        },
+                                        {
+                                          "height": 48,
+                                        },
+                                        {
+                                          "backgroundColor": "#0B3EE3",
+                                          "overflow": "hidden",
+                                        },
+                                        false,
+                                        {},
+                                        false,
+                                        {
+                                          "backgroundColor": undefined,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "flexDirection": "row",
+                                            "justifyContent": "center",
+                                          },
+                                          {
+                                            "columnGap": 8,
+                                          },
+                                          false,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityElementsHidden={true}
+                                        accessible={false}
+                                        allowFontScaling={true}
+                                        ellipsizeMode="tail"
+                                        importantForAccessibility="no-hide-descendants"
+                                        maxFontSizeMultiplier={1.5}
+                                        numberOfLines={1}
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#FFFFFF",
+                                              "fontFamily": "Titillio",
+                                              "fontSize": 16,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "600",
+                                              "lineHeight": 20,
+                                            },
+                                            {
+                                              "alignSelf": "center",
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        Close
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </RCTScrollView>
+                      </RNCSafeAreaView>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RNSScreen>
+      </RNSScreenContainer>
+    </View>
+  </RNCSafeAreaProvider>
+</View>
+`;
+
+exports[`loading screens + error interop should render the correct loading screen when there is a "activation" loadingState, and there isn't a preference error  1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <RNCSafeAreaProvider
+    onInsetsChange={[Function]}
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "#FFFFFF",
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          {
+            "zIndex": 1,
+          }
+        }
+      >
+        <View
+          accessibilityElementsHidden={false}
+          importantForAccessibility="auto"
+          onLayout={[Function]}
+          pointerEvents="box-none"
+          style={null}
+        >
+          <View
+            collapsable={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "zIndex": 0,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "borderBottomColor": "rgb(216, 216, 216)",
+                  "flex": 1,
+                  "shadowColor": "rgb(216, 216, 216)",
+                  "shadowOffset": {
+                    "height": 0.5,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.85,
+                  "shadowRadius": 0,
+                }
+              }
+            />
+          </View>
+          <View
+            collapsable={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "height": 44,
+                "maxHeight": undefined,
+                "minHeight": undefined,
+                "opacity": undefined,
+                "transform": undefined,
+              }
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                {
+                  "height": 0,
+                }
+              }
+            />
+            <View
+              pointerEvents="box-none"
+              style={
+                {
+                  "alignItems": "stretch",
+                  "flex": 1,
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginStart": 0,
+                    "opacity": 1,
+                  }
+                }
+              />
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "justifyContent": "center",
+                    "marginHorizontal": 16,
+                    "maxWidth": 718,
+                    "opacity": 1,
+                  }
+                }
+              >
+                <Text
+                  accessibilityRole="header"
+                  aria-level="1"
+                  collapsable={false}
+                  numberOfLines={1}
+                  onLayout={[Function]}
+                  style={
+                    {
+                      "color": "rgb(28, 28, 30)",
+                      "fontSize": 17,
+                      "fontWeight": "600",
+                    }
+                  }
+                >
+                  PN_ACTIVATION_BANNER_FLOW
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-end",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginEnd": 0,
+                    "opacity": 1,
+                  }
+                }
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+      <RNSScreenContainer
+        onLayout={[Function]}
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      >
+        <RNSScreen
+          activityState={2}
+          collapsable={false}
+          gestureResponseDistance={
+            {
+              "bottom": -1,
+              "end": -1,
+              "start": -1,
+              "top": -1,
+            }
+          }
+          onGestureCancel={[Function]}
+          pointerEvents="box-none"
+          sheetAllowedDetents="large"
+          sheetCornerRadius={-1}
+          sheetExpandsWhenScrolledToEdge={true}
+          sheetGrabberVisible={false}
+          sheetLargestUndimmedDetent="all"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "zIndex": undefined,
+            }
+          }
+        >
+          <View
+            collapsable={false}
+            style={
+              {
+                "opacity": 1,
+              }
+            }
+          />
+          <View
+            accessibilityElementsHidden={false}
+            closing={false}
+            collapsable={false}
+            gestureVelocityImpact={0.3}
+            importantForAccessibility="auto"
+            onClose={[Function]}
+            onGestureBegin={[Function]}
+            onGestureCanceled={[Function]}
+            onGestureEnd={[Function]}
+            onOpen={[Function]}
+            onTransition={[Function]}
+            pointerEvents="box-none"
+            style={
+              [
+                {
+                  "display": "flex",
+                  "overflow": undefined,
+                },
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+              ]
+            }
+            transitionSpec={
+              {
+                "close": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+                "open": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              pointerEvents="box-none"
+              style={
+                {
+                  "flex": 1,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                enabled={false}
+                handlerTag={16}
+                handlerType="PanGestureHandler"
+                needsOffscreenAlphaCompositing={false}
+                onGestureHandlerEvent={[Function]}
+                onGestureHandlerStateChange={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "transform": [
+                      {
+                        "translateX": 0,
+                      },
+                      {
+                        "translateX": 0,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  pointerEvents="box-none"
+                  style={
+                    [
+                      {
+                        "flex": 1,
+                        "overflow": "hidden",
+                      },
+                      [
+                        {
+                          "backgroundColor": "#FFFFFF",
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "flex": 1,
+                        "flexDirection": "column-reverse",
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                        }
+                      }
+                    >
+                      <RCTSafeAreaView
+                        style={
+                          {
+                            "alignItems": "center",
+                            "flex": 1,
+                            "justifyContent": "center",
+                          }
+                        }
+                        testID="loading-LOADING-ACTIVATION"
+                      >
+                        <View
+                          accessibilityHint="Wait for the content load"
+                          accessibilityLabel="Loading"
+                          accessibilityRole="progressbar"
+                          accessible={true}
+                          importantForAccessibility="no-hide-descendants"
+                          style={
+                            {
+                              "height": 48,
+                              "width": 48,
+                            }
+                          }
+                          testID="LoadingIndicator"
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "transform": [
+                                  {
+                                    "rotateZ": "0deg",
+                                  },
+                                ],
+                              }
+                            }
+                            testID="LoadingSpinnerAnimatedTestID"
+                          >
+                            <RNSVGSvgView
+                              align="xMidYMid"
+                              bbHeight={48}
+                              bbWidth={48}
+                              fill="none"
+                              focusable={false}
+                              height={48}
+                              meetOrSlice={0}
+                              minX={0}
+                              minY={0}
+                              style={
+                                [
+                                  {
+                                    "backgroundColor": "transparent",
+                                    "borderWidth": 0,
+                                  },
+                                  {
+                                    "flex": 0,
+                                    "height": 48,
+                                    "width": 48,
+                                  },
+                                ]
+                              }
+                              vbHeight={48}
+                              vbWidth={48}
+                              width={48}
+                            >
+                              <RNSVGGroup
+                                fill={null}
+                                propList={
+                                  [
+                                    "fill",
+                                  ]
+                                }
+                              >
+                                <RNSVGDefs>
+                                  <RNSVGLinearGradient
+                                    gradient={
+                                      [
+                                        0,
+                                        736995,
+                                        1,
+                                        -16040221,
+                                      ]
+                                    }
+                                    gradientTransform={null}
+                                    gradientUnits={0}
+                                    name="spinner-secondHalf"
+                                    x1="0%"
+                                    x2="100%"
+                                    y1="0%"
+                                    y2="0%"
+                                  />
+                                  <RNSVGLinearGradient
+                                    gradient={
+                                      [
+                                        0,
+                                        -16040221,
+                                        1,
+                                        -16040221,
+                                      ]
+                                    }
+                                    gradientTransform={null}
+                                    gradientUnits={0}
+                                    name="spinner-firstHalf"
+                                    x1="0%"
+                                    x2="100%"
+                                    y1="0%"
+                                    y2="0%"
+                                  />
+                                </RNSVGDefs>
+                                <RNSVGGroup
+                                  fill={
+                                    {
+                                      "payload": 4278190080,
+                                      "type": 0,
+                                    }
+                                  }
+                                  propList={
+                                    [
+                                      "strokeWidth",
+                                    ]
+                                  }
+                                  strokeWidth={5}
+                                >
+                                  <RNSVGPath
+                                    d="M 2.5 24 A 21.5 21.5 0 0 1 45.5 24"
+                                    fill={
+                                      {
+                                        "payload": 4278190080,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "stroke",
+                                      ]
+                                    }
+                                    stroke={
+                                      {
+                                        "brushRef": "spinner-secondHalf",
+                                        "type": 1,
+                                      }
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M 45.5 24 A 21.5 21.5 0 0 1 2.5 24"
+                                    fill={
+                                      {
+                                        "payload": 4278190080,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "stroke",
+                                      ]
+                                    }
+                                    stroke={
+                                      {
+                                        "brushRef": "spinner-firstHalf",
+                                        "type": 1,
+                                      }
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M 2.5 24 A 21.5 21.5 0 0 1 2.5 22.75"
+                                    fill={
+                                      {
+                                        "payload": 4278190080,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "stroke",
+                                        "strokeLinecap",
+                                      ]
+                                    }
+                                    stroke={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    strokeLinecap={1}
+                                  />
+                                </RNSVGGroup>
+                              </RNSVGGroup>
+                            </RNSVGSvgView>
+                          </View>
+                        </View>
+                        <View
+                          style={
+                            {
+                              "height": 48,
+                            }
+                          }
+                        />
+                        <Text
+                          allowFontScaling={true}
+                          dynamicTypeRamp="title2"
+                          maxFontSizeMultiplier={1.5}
+                          style={
+                            [
+                              {},
+                              {
+                                "color": "#2B2E38",
+                                "fontFamily": "Titillio",
+                                "fontSize": 22,
+                                "fontStyle": "normal",
+                                "fontWeight": "600",
+                                "lineHeight": 33,
+                              },
+                              {
+                                "textAlign": "center",
+                              },
+                            ]
+                          }
+                          testID="LoadingSpinnerCaptionTitleID"
+                        >
+                          Stiamo attivando SEND
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "height": 16,
+                            }
+                          }
+                        />
+                        <Text
+                          allowFontScaling={true}
+                          dynamicTypeRamp="body"
+                          maxFontSizeMultiplier={1.5}
+                          style={
+                            [
+                              {},
+                              {
+                                "color": "#555C70",
+                                "fontFamily": "Titillio",
+                                "fontSize": 16,
+                                "fontStyle": "normal",
+                                "fontWeight": "400",
+                                "lineHeight": 24,
+                              },
+                              {
+                                "textAlign": "center",
+                              },
+                            ]
+                          }
+                          testID="LoadingSpinnerCaptionSubTitleID"
+                        />
+                      </RCTSafeAreaView>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RNSScreen>
+      </RNSScreenContainer>
+    </View>
+  </RNCSafeAreaProvider>
+</View>
+`;
+
+exports[`loading screens + error interop should render the correct loading screen when there is a "both" loadingState, and there is a preference error  1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <RNCSafeAreaProvider
+    onInsetsChange={[Function]}
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "#FFFFFF",
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          {
+            "zIndex": 1,
+          }
+        }
+      >
+        <View
+          accessibilityElementsHidden={false}
+          importantForAccessibility="auto"
+          onLayout={[Function]}
+          pointerEvents="box-none"
+          style={null}
+        >
+          <View
+            collapsable={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "zIndex": 0,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "borderBottomColor": "rgb(216, 216, 216)",
+                  "flex": 1,
+                  "shadowColor": "rgb(216, 216, 216)",
+                  "shadowOffset": {
+                    "height": 0.5,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.85,
+                  "shadowRadius": 0,
+                }
+              }
+            />
+          </View>
+          <View
+            collapsable={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "height": 44,
+                "maxHeight": undefined,
+                "minHeight": undefined,
+                "opacity": undefined,
+                "transform": undefined,
+              }
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                {
+                  "height": 0,
+                }
+              }
+            />
+            <View
+              pointerEvents="box-none"
+              style={
+                {
+                  "alignItems": "stretch",
+                  "flex": 1,
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginStart": 0,
+                    "opacity": 1,
+                  }
+                }
+              />
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "justifyContent": "center",
+                    "marginHorizontal": 16,
+                    "maxWidth": 718,
+                    "opacity": 1,
+                  }
+                }
+              >
+                <Text
+                  accessibilityRole="header"
+                  aria-level="1"
+                  collapsable={false}
+                  numberOfLines={1}
+                  onLayout={[Function]}
+                  style={
+                    {
+                      "color": "rgb(28, 28, 30)",
+                      "fontSize": 17,
+                      "fontWeight": "600",
+                    }
+                  }
+                >
+                  PN_ACTIVATION_BANNER_FLOW
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-end",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginEnd": 0,
+                    "opacity": 1,
+                  }
+                }
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+      <RNSScreenContainer
+        onLayout={[Function]}
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      >
+        <RNSScreen
+          activityState={2}
+          collapsable={false}
+          gestureResponseDistance={
+            {
+              "bottom": -1,
+              "end": -1,
+              "start": -1,
+              "top": -1,
+            }
+          }
+          onGestureCancel={[Function]}
+          pointerEvents="box-none"
+          sheetAllowedDetents="large"
+          sheetCornerRadius={-1}
+          sheetExpandsWhenScrolledToEdge={true}
+          sheetGrabberVisible={false}
+          sheetLargestUndimmedDetent="all"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "zIndex": undefined,
+            }
+          }
+        >
+          <View
+            collapsable={false}
+            style={
+              {
+                "opacity": 1,
+              }
+            }
+          />
+          <View
+            accessibilityElementsHidden={false}
+            closing={false}
+            collapsable={false}
+            gestureVelocityImpact={0.3}
+            importantForAccessibility="auto"
+            onClose={[Function]}
+            onGestureBegin={[Function]}
+            onGestureCanceled={[Function]}
+            onGestureEnd={[Function]}
+            onOpen={[Function]}
+            onTransition={[Function]}
+            pointerEvents="box-none"
+            style={
+              [
+                {
+                  "display": "flex",
+                  "overflow": undefined,
+                },
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+              ]
+            }
+            transitionSpec={
+              {
+                "close": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+                "open": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              pointerEvents="box-none"
+              style={
+                {
+                  "flex": 1,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                enabled={false}
+                handlerTag={19}
+                handlerType="PanGestureHandler"
+                needsOffscreenAlphaCompositing={false}
+                onGestureHandlerEvent={[Function]}
+                onGestureHandlerStateChange={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "transform": [
+                      {
+                        "translateX": 0,
+                      },
+                      {
+                        "translateX": 0,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  pointerEvents="box-none"
+                  style={
+                    [
+                      {
+                        "flex": 1,
+                        "overflow": "hidden",
+                      },
+                      [
+                        {
+                          "backgroundColor": "#FFFFFF",
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "flex": 1,
+                        "flexDirection": "column-reverse",
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                        }
+                      }
+                    >
+                      <RCTSafeAreaView
+                        style={
+                          {
+                            "alignItems": "center",
+                            "flex": 1,
+                            "justifyContent": "center",
+                          }
+                        }
                         testID="loading-LOADING-DATA"
                       >
-                        LOADING: 
-                        LOADING-DATA
-                      </Text>
+                        <View
+                          accessibilityHint="Wait for the content load"
+                          accessibilityLabel="Loading"
+                          accessibilityRole="progressbar"
+                          accessible={true}
+                          importantForAccessibility="no-hide-descendants"
+                          style={
+                            {
+                              "height": 48,
+                              "width": 48,
+                            }
+                          }
+                          testID="LoadingIndicator"
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "transform": [
+                                  {
+                                    "rotateZ": "0deg",
+                                  },
+                                ],
+                              }
+                            }
+                            testID="LoadingSpinnerAnimatedTestID"
+                          >
+                            <RNSVGSvgView
+                              align="xMidYMid"
+                              bbHeight={48}
+                              bbWidth={48}
+                              fill="none"
+                              focusable={false}
+                              height={48}
+                              meetOrSlice={0}
+                              minX={0}
+                              minY={0}
+                              style={
+                                [
+                                  {
+                                    "backgroundColor": "transparent",
+                                    "borderWidth": 0,
+                                  },
+                                  {
+                                    "flex": 0,
+                                    "height": 48,
+                                    "width": 48,
+                                  },
+                                ]
+                              }
+                              vbHeight={48}
+                              vbWidth={48}
+                              width={48}
+                            >
+                              <RNSVGGroup
+                                fill={null}
+                                propList={
+                                  [
+                                    "fill",
+                                  ]
+                                }
+                              >
+                                <RNSVGDefs>
+                                  <RNSVGLinearGradient
+                                    gradient={
+                                      [
+                                        0,
+                                        736995,
+                                        1,
+                                        -16040221,
+                                      ]
+                                    }
+                                    gradientTransform={null}
+                                    gradientUnits={0}
+                                    name="spinner-secondHalf"
+                                    x1="0%"
+                                    x2="100%"
+                                    y1="0%"
+                                    y2="0%"
+                                  />
+                                  <RNSVGLinearGradient
+                                    gradient={
+                                      [
+                                        0,
+                                        -16040221,
+                                        1,
+                                        -16040221,
+                                      ]
+                                    }
+                                    gradientTransform={null}
+                                    gradientUnits={0}
+                                    name="spinner-firstHalf"
+                                    x1="0%"
+                                    x2="100%"
+                                    y1="0%"
+                                    y2="0%"
+                                  />
+                                </RNSVGDefs>
+                                <RNSVGGroup
+                                  fill={
+                                    {
+                                      "payload": 4278190080,
+                                      "type": 0,
+                                    }
+                                  }
+                                  propList={
+                                    [
+                                      "strokeWidth",
+                                    ]
+                                  }
+                                  strokeWidth={5}
+                                >
+                                  <RNSVGPath
+                                    d="M 2.5 24 A 21.5 21.5 0 0 1 45.5 24"
+                                    fill={
+                                      {
+                                        "payload": 4278190080,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "stroke",
+                                      ]
+                                    }
+                                    stroke={
+                                      {
+                                        "brushRef": "spinner-secondHalf",
+                                        "type": 1,
+                                      }
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M 45.5 24 A 21.5 21.5 0 0 1 2.5 24"
+                                    fill={
+                                      {
+                                        "payload": 4278190080,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "stroke",
+                                      ]
+                                    }
+                                    stroke={
+                                      {
+                                        "brushRef": "spinner-firstHalf",
+                                        "type": 1,
+                                      }
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M 2.5 24 A 21.5 21.5 0 0 1 2.5 22.75"
+                                    fill={
+                                      {
+                                        "payload": 4278190080,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "stroke",
+                                        "strokeLinecap",
+                                      ]
+                                    }
+                                    stroke={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    strokeLinecap={1}
+                                  />
+                                </RNSVGGroup>
+                              </RNSVGGroup>
+                            </RNSVGSvgView>
+                          </View>
+                        </View>
+                        <View
+                          style={
+                            {
+                              "height": 48,
+                            }
+                          }
+                        />
+                        <Text
+                          allowFontScaling={true}
+                          dynamicTypeRamp="title2"
+                          maxFontSizeMultiplier={1.5}
+                          style={
+                            [
+                              {},
+                              {
+                                "color": "#2B2E38",
+                                "fontFamily": "Titillio",
+                                "fontSize": 22,
+                                "fontStyle": "normal",
+                                "fontWeight": "600",
+                                "lineHeight": 33,
+                              },
+                              {
+                                "textAlign": "center",
+                              },
+                            ]
+                          }
+                          testID="LoadingSpinnerCaptionTitleID"
+                        >
+                          Attendi qualche secondo
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "height": 16,
+                            }
+                          }
+                        />
+                        <Text
+                          allowFontScaling={true}
+                          dynamicTypeRamp="body"
+                          maxFontSizeMultiplier={1.5}
+                          style={
+                            [
+                              {},
+                              {
+                                "color": "#555C70",
+                                "fontFamily": "Titillio",
+                                "fontSize": 16,
+                                "fontStyle": "normal",
+                                "fontWeight": "400",
+                                "lineHeight": 24,
+                              },
+                              {
+                                "textAlign": "center",
+                              },
+                            ]
+                          }
+                          testID="LoadingSpinnerCaptionSubTitleID"
+                        />
+                      </RCTSafeAreaView>
                     </View>
                   </View>
                 </View>
@@ -4818,7 +7544,7 @@ exports[`loading screens + error interop should render the correct loading scree
               <View
                 collapsable={false}
                 enabled={false}
-                handlerTag={13}
+                handlerTag={20}
                 handlerType="PanGestureHandler"
                 needsOffscreenAlphaCompositing={false}
                 onGestureHandlerEvent={[Function]}
@@ -4869,12 +7595,256 @@ exports[`loading screens + error interop should render the correct loading scree
                         }
                       }
                     >
-                      <Text
+                      <RCTSafeAreaView
+                        style={
+                          {
+                            "alignItems": "center",
+                            "flex": 1,
+                            "justifyContent": "center",
+                          }
+                        }
                         testID="loading-LOADING-DATA"
                       >
-                        LOADING: 
-                        LOADING-DATA
-                      </Text>
+                        <View
+                          accessibilityHint="Wait for the content load"
+                          accessibilityLabel="Loading"
+                          accessibilityRole="progressbar"
+                          accessible={true}
+                          importantForAccessibility="no-hide-descendants"
+                          style={
+                            {
+                              "height": 48,
+                              "width": 48,
+                            }
+                          }
+                          testID="LoadingIndicator"
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "transform": [
+                                  {
+                                    "rotateZ": "0deg",
+                                  },
+                                ],
+                              }
+                            }
+                            testID="LoadingSpinnerAnimatedTestID"
+                          >
+                            <RNSVGSvgView
+                              align="xMidYMid"
+                              bbHeight={48}
+                              bbWidth={48}
+                              fill="none"
+                              focusable={false}
+                              height={48}
+                              meetOrSlice={0}
+                              minX={0}
+                              minY={0}
+                              style={
+                                [
+                                  {
+                                    "backgroundColor": "transparent",
+                                    "borderWidth": 0,
+                                  },
+                                  {
+                                    "flex": 0,
+                                    "height": 48,
+                                    "width": 48,
+                                  },
+                                ]
+                              }
+                              vbHeight={48}
+                              vbWidth={48}
+                              width={48}
+                            >
+                              <RNSVGGroup
+                                fill={null}
+                                propList={
+                                  [
+                                    "fill",
+                                  ]
+                                }
+                              >
+                                <RNSVGDefs>
+                                  <RNSVGLinearGradient
+                                    gradient={
+                                      [
+                                        0,
+                                        736995,
+                                        1,
+                                        -16040221,
+                                      ]
+                                    }
+                                    gradientTransform={null}
+                                    gradientUnits={0}
+                                    name="spinner-secondHalf"
+                                    x1="0%"
+                                    x2="100%"
+                                    y1="0%"
+                                    y2="0%"
+                                  />
+                                  <RNSVGLinearGradient
+                                    gradient={
+                                      [
+                                        0,
+                                        -16040221,
+                                        1,
+                                        -16040221,
+                                      ]
+                                    }
+                                    gradientTransform={null}
+                                    gradientUnits={0}
+                                    name="spinner-firstHalf"
+                                    x1="0%"
+                                    x2="100%"
+                                    y1="0%"
+                                    y2="0%"
+                                  />
+                                </RNSVGDefs>
+                                <RNSVGGroup
+                                  fill={
+                                    {
+                                      "payload": 4278190080,
+                                      "type": 0,
+                                    }
+                                  }
+                                  propList={
+                                    [
+                                      "strokeWidth",
+                                    ]
+                                  }
+                                  strokeWidth={5}
+                                >
+                                  <RNSVGPath
+                                    d="M 2.5 24 A 21.5 21.5 0 0 1 45.5 24"
+                                    fill={
+                                      {
+                                        "payload": 4278190080,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "stroke",
+                                      ]
+                                    }
+                                    stroke={
+                                      {
+                                        "brushRef": "spinner-secondHalf",
+                                        "type": 1,
+                                      }
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M 45.5 24 A 21.5 21.5 0 0 1 2.5 24"
+                                    fill={
+                                      {
+                                        "payload": 4278190080,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "stroke",
+                                      ]
+                                    }
+                                    stroke={
+                                      {
+                                        "brushRef": "spinner-firstHalf",
+                                        "type": 1,
+                                      }
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M 2.5 24 A 21.5 21.5 0 0 1 2.5 22.75"
+                                    fill={
+                                      {
+                                        "payload": 4278190080,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "stroke",
+                                        "strokeLinecap",
+                                      ]
+                                    }
+                                    stroke={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    strokeLinecap={1}
+                                  />
+                                </RNSVGGroup>
+                              </RNSVGGroup>
+                            </RNSVGSvgView>
+                          </View>
+                        </View>
+                        <View
+                          style={
+                            {
+                              "height": 48,
+                            }
+                          }
+                        />
+                        <Text
+                          allowFontScaling={true}
+                          dynamicTypeRamp="title2"
+                          maxFontSizeMultiplier={1.5}
+                          style={
+                            [
+                              {},
+                              {
+                                "color": "#2B2E38",
+                                "fontFamily": "Titillio",
+                                "fontSize": 22,
+                                "fontStyle": "normal",
+                                "fontWeight": "600",
+                                "lineHeight": 33,
+                              },
+                              {
+                                "textAlign": "center",
+                              },
+                            ]
+                          }
+                          testID="LoadingSpinnerCaptionTitleID"
+                        >
+                          Attendi qualche secondo
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "height": 16,
+                            }
+                          }
+                        />
+                        <Text
+                          allowFontScaling={true}
+                          dynamicTypeRamp="body"
+                          maxFontSizeMultiplier={1.5}
+                          style={
+                            [
+                              {},
+                              {
+                                "color": "#555C70",
+                                "fontFamily": "Titillio",
+                                "fontSize": 16,
+                                "fontStyle": "normal",
+                                "fontWeight": "400",
+                                "lineHeight": 24,
+                              },
+                              {
+                                "textAlign": "center",
+                              },
+                            ]
+                          }
+                          testID="LoadingSpinnerCaptionSubTitleID"
+                        />
+                      </RCTSafeAreaView>
                     </View>
                   </View>
                 </View>
@@ -5171,7 +8141,7 @@ exports[`loading screens + error interop should render the correct loading scree
               <View
                 collapsable={false}
                 enabled={false}
-                handlerTag={10}
+                handlerTag={17}
                 handlerType="PanGestureHandler"
                 needsOffscreenAlphaCompositing={false}
                 onGestureHandlerEvent={[Function]}
@@ -5222,12 +8192,256 @@ exports[`loading screens + error interop should render the correct loading scree
                         }
                       }
                     >
-                      <Text
+                      <RCTSafeAreaView
+                        style={
+                          {
+                            "alignItems": "center",
+                            "flex": 1,
+                            "justifyContent": "center",
+                          }
+                        }
                         testID="loading-LOADING-DATA"
                       >
-                        LOADING: 
-                        LOADING-DATA
-                      </Text>
+                        <View
+                          accessibilityHint="Wait for the content load"
+                          accessibilityLabel="Loading"
+                          accessibilityRole="progressbar"
+                          accessible={true}
+                          importantForAccessibility="no-hide-descendants"
+                          style={
+                            {
+                              "height": 48,
+                              "width": 48,
+                            }
+                          }
+                          testID="LoadingIndicator"
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "transform": [
+                                  {
+                                    "rotateZ": "0deg",
+                                  },
+                                ],
+                              }
+                            }
+                            testID="LoadingSpinnerAnimatedTestID"
+                          >
+                            <RNSVGSvgView
+                              align="xMidYMid"
+                              bbHeight={48}
+                              bbWidth={48}
+                              fill="none"
+                              focusable={false}
+                              height={48}
+                              meetOrSlice={0}
+                              minX={0}
+                              minY={0}
+                              style={
+                                [
+                                  {
+                                    "backgroundColor": "transparent",
+                                    "borderWidth": 0,
+                                  },
+                                  {
+                                    "flex": 0,
+                                    "height": 48,
+                                    "width": 48,
+                                  },
+                                ]
+                              }
+                              vbHeight={48}
+                              vbWidth={48}
+                              width={48}
+                            >
+                              <RNSVGGroup
+                                fill={null}
+                                propList={
+                                  [
+                                    "fill",
+                                  ]
+                                }
+                              >
+                                <RNSVGDefs>
+                                  <RNSVGLinearGradient
+                                    gradient={
+                                      [
+                                        0,
+                                        736995,
+                                        1,
+                                        -16040221,
+                                      ]
+                                    }
+                                    gradientTransform={null}
+                                    gradientUnits={0}
+                                    name="spinner-secondHalf"
+                                    x1="0%"
+                                    x2="100%"
+                                    y1="0%"
+                                    y2="0%"
+                                  />
+                                  <RNSVGLinearGradient
+                                    gradient={
+                                      [
+                                        0,
+                                        -16040221,
+                                        1,
+                                        -16040221,
+                                      ]
+                                    }
+                                    gradientTransform={null}
+                                    gradientUnits={0}
+                                    name="spinner-firstHalf"
+                                    x1="0%"
+                                    x2="100%"
+                                    y1="0%"
+                                    y2="0%"
+                                  />
+                                </RNSVGDefs>
+                                <RNSVGGroup
+                                  fill={
+                                    {
+                                      "payload": 4278190080,
+                                      "type": 0,
+                                    }
+                                  }
+                                  propList={
+                                    [
+                                      "strokeWidth",
+                                    ]
+                                  }
+                                  strokeWidth={5}
+                                >
+                                  <RNSVGPath
+                                    d="M 2.5 24 A 21.5 21.5 0 0 1 45.5 24"
+                                    fill={
+                                      {
+                                        "payload": 4278190080,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "stroke",
+                                      ]
+                                    }
+                                    stroke={
+                                      {
+                                        "brushRef": "spinner-secondHalf",
+                                        "type": 1,
+                                      }
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M 45.5 24 A 21.5 21.5 0 0 1 2.5 24"
+                                    fill={
+                                      {
+                                        "payload": 4278190080,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "stroke",
+                                      ]
+                                    }
+                                    stroke={
+                                      {
+                                        "brushRef": "spinner-firstHalf",
+                                        "type": 1,
+                                      }
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M 2.5 24 A 21.5 21.5 0 0 1 2.5 22.75"
+                                    fill={
+                                      {
+                                        "payload": 4278190080,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "stroke",
+                                        "strokeLinecap",
+                                      ]
+                                    }
+                                    stroke={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    strokeLinecap={1}
+                                  />
+                                </RNSVGGroup>
+                              </RNSVGGroup>
+                            </RNSVGSvgView>
+                          </View>
+                        </View>
+                        <View
+                          style={
+                            {
+                              "height": 48,
+                            }
+                          }
+                        />
+                        <Text
+                          allowFontScaling={true}
+                          dynamicTypeRamp="title2"
+                          maxFontSizeMultiplier={1.5}
+                          style={
+                            [
+                              {},
+                              {
+                                "color": "#2B2E38",
+                                "fontFamily": "Titillio",
+                                "fontSize": 22,
+                                "fontStyle": "normal",
+                                "fontWeight": "600",
+                                "lineHeight": 33,
+                              },
+                              {
+                                "textAlign": "center",
+                              },
+                            ]
+                          }
+                          testID="LoadingSpinnerCaptionTitleID"
+                        >
+                          Attendi qualche secondo
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "height": 16,
+                            }
+                          }
+                        />
+                        <Text
+                          allowFontScaling={true}
+                          dynamicTypeRamp="body"
+                          maxFontSizeMultiplier={1.5}
+                          style={
+                            [
+                              {},
+                              {
+                                "color": "#555C70",
+                                "fontFamily": "Titillio",
+                                "fontSize": 16,
+                                "fontStyle": "normal",
+                                "fontWeight": "400",
+                                "lineHeight": 24,
+                              },
+                              {
+                                "textAlign": "center",
+                              },
+                            ]
+                          }
+                          testID="LoadingSpinnerCaptionSubTitleID"
+                        />
+                      </RCTSafeAreaView>
                     </View>
                   </View>
                 </View>
@@ -5524,7 +8738,7 @@ exports[`loading screens + error interop should render the correct loading scree
               <View
                 collapsable={false}
                 enabled={false}
-                handlerTag={11}
+                handlerTag={18}
                 handlerType="PanGestureHandler"
                 needsOffscreenAlphaCompositing={false}
                 onGestureHandlerEvent={[Function]}
@@ -5575,12 +8789,256 @@ exports[`loading screens + error interop should render the correct loading scree
                         }
                       }
                     >
-                      <Text
+                      <RCTSafeAreaView
+                        style={
+                          {
+                            "alignItems": "center",
+                            "flex": 1,
+                            "justifyContent": "center",
+                          }
+                        }
                         testID="loading-LOADING-DATA"
                       >
-                        LOADING: 
-                        LOADING-DATA
-                      </Text>
+                        <View
+                          accessibilityHint="Wait for the content load"
+                          accessibilityLabel="Loading"
+                          accessibilityRole="progressbar"
+                          accessible={true}
+                          importantForAccessibility="no-hide-descendants"
+                          style={
+                            {
+                              "height": 48,
+                              "width": 48,
+                            }
+                          }
+                          testID="LoadingIndicator"
+                        >
+                          <View
+                            collapsable={false}
+                            style={
+                              {
+                                "transform": [
+                                  {
+                                    "rotateZ": "0deg",
+                                  },
+                                ],
+                              }
+                            }
+                            testID="LoadingSpinnerAnimatedTestID"
+                          >
+                            <RNSVGSvgView
+                              align="xMidYMid"
+                              bbHeight={48}
+                              bbWidth={48}
+                              fill="none"
+                              focusable={false}
+                              height={48}
+                              meetOrSlice={0}
+                              minX={0}
+                              minY={0}
+                              style={
+                                [
+                                  {
+                                    "backgroundColor": "transparent",
+                                    "borderWidth": 0,
+                                  },
+                                  {
+                                    "flex": 0,
+                                    "height": 48,
+                                    "width": 48,
+                                  },
+                                ]
+                              }
+                              vbHeight={48}
+                              vbWidth={48}
+                              width={48}
+                            >
+                              <RNSVGGroup
+                                fill={null}
+                                propList={
+                                  [
+                                    "fill",
+                                  ]
+                                }
+                              >
+                                <RNSVGDefs>
+                                  <RNSVGLinearGradient
+                                    gradient={
+                                      [
+                                        0,
+                                        736995,
+                                        1,
+                                        -16040221,
+                                      ]
+                                    }
+                                    gradientTransform={null}
+                                    gradientUnits={0}
+                                    name="spinner-secondHalf"
+                                    x1="0%"
+                                    x2="100%"
+                                    y1="0%"
+                                    y2="0%"
+                                  />
+                                  <RNSVGLinearGradient
+                                    gradient={
+                                      [
+                                        0,
+                                        -16040221,
+                                        1,
+                                        -16040221,
+                                      ]
+                                    }
+                                    gradientTransform={null}
+                                    gradientUnits={0}
+                                    name="spinner-firstHalf"
+                                    x1="0%"
+                                    x2="100%"
+                                    y1="0%"
+                                    y2="0%"
+                                  />
+                                </RNSVGDefs>
+                                <RNSVGGroup
+                                  fill={
+                                    {
+                                      "payload": 4278190080,
+                                      "type": 0,
+                                    }
+                                  }
+                                  propList={
+                                    [
+                                      "strokeWidth",
+                                    ]
+                                  }
+                                  strokeWidth={5}
+                                >
+                                  <RNSVGPath
+                                    d="M 2.5 24 A 21.5 21.5 0 0 1 45.5 24"
+                                    fill={
+                                      {
+                                        "payload": 4278190080,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "stroke",
+                                      ]
+                                    }
+                                    stroke={
+                                      {
+                                        "brushRef": "spinner-secondHalf",
+                                        "type": 1,
+                                      }
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M 45.5 24 A 21.5 21.5 0 0 1 2.5 24"
+                                    fill={
+                                      {
+                                        "payload": 4278190080,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "stroke",
+                                      ]
+                                    }
+                                    stroke={
+                                      {
+                                        "brushRef": "spinner-firstHalf",
+                                        "type": 1,
+                                      }
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M 2.5 24 A 21.5 21.5 0 0 1 2.5 22.75"
+                                    fill={
+                                      {
+                                        "payload": 4278190080,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "stroke",
+                                        "strokeLinecap",
+                                      ]
+                                    }
+                                    stroke={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    strokeLinecap={1}
+                                  />
+                                </RNSVGGroup>
+                              </RNSVGGroup>
+                            </RNSVGSvgView>
+                          </View>
+                        </View>
+                        <View
+                          style={
+                            {
+                              "height": 48,
+                            }
+                          }
+                        />
+                        <Text
+                          allowFontScaling={true}
+                          dynamicTypeRamp="title2"
+                          maxFontSizeMultiplier={1.5}
+                          style={
+                            [
+                              {},
+                              {
+                                "color": "#2B2E38",
+                                "fontFamily": "Titillio",
+                                "fontSize": 22,
+                                "fontStyle": "normal",
+                                "fontWeight": "600",
+                                "lineHeight": 33,
+                              },
+                              {
+                                "textAlign": "center",
+                              },
+                            ]
+                          }
+                          testID="LoadingSpinnerCaptionTitleID"
+                        >
+                          Attendi qualche secondo
+                        </Text>
+                        <View
+                          style={
+                            {
+                              "height": 16,
+                            }
+                          }
+                        />
+                        <Text
+                          allowFontScaling={true}
+                          dynamicTypeRamp="body"
+                          maxFontSizeMultiplier={1.5}
+                          style={
+                            [
+                              {},
+                              {
+                                "color": "#555C70",
+                                "fontFamily": "Titillio",
+                                "fontSize": 16,
+                                "fontStyle": "normal",
+                                "fontWeight": "400",
+                                "lineHeight": 24,
+                              },
+                              {
+                                "textAlign": "center",
+                              },
+                            ]
+                          }
+                          testID="LoadingSpinnerCaptionSubTitleID"
+                        />
+                      </RCTSafeAreaView>
                     </View>
                   </View>
                 </View>

--- a/ts/features/pn/screens/__test__/__snapshots__/PnReminderBannerFlow.test.tsx.snap
+++ b/ts/features/pn/screens/__test__/__snapshots__/PnReminderBannerFlow.test.tsx.snap
@@ -564,7 +564,7 @@ exports[`PnActivationReminderBannerFlow should match snapshot for state= ALREADY
                                 ]
                               }
                             >
-                              Se un ente ti invia una comunicazioni a valore legale, la ricevi direttamente su IO!
+                              Se un ente ti invia una comunicazione a valore legale, la ricevi direttamente su IO!
                             </Text>
                             <View
                               style={


### PR DESCRIPTION
## Short description
Include a summary of the changes.
<img width="250" alt="Screenshot 2025-03-14 at 14 45 41" src="https://github.com/user-attachments/assets/af405a44-de0b-4cf8-9615-4cec96901a83" /><img width="250" alt="Screenshot 2025-03-14 at 14 45 37" src="https://github.com/user-attachments/assets/c6f66492-f0ac-4bf7-9008-ccee655bf351" /><img width="250"   src="https://github.com/user-attachments/assets/b352f051-14f6-43b5-a0c1-889bb1e28e5d"/><img width="250" alt="Screenshot 2025-03-14 at 14 37 37" src="https://github.com/user-attachments/assets/3ad41ac6-c744-46a6-94e7-11ec03ef9fd9" /><img width="250" alt="Screenshot 2025-03-14 at 14 37 02" src="https://github.com/user-attachments/assets/22c5334e-e3b6-4671-8660-b25b39c7600f" /><img width="250" src="https://github.com/user-attachments/assets/f30e1565-adb9-4f63-9f4e-c3328656d2d7"/>


addition of success, failure and loading screens UI for the SEND engagement banner flow


## List of changes proposed in this pull request
- said components
-  required i18n keys
- back navigate header for the `WAITING_USER_INPUT` state
- regeneration of snapshots

## How to test
tests should solve correctly, also make sure that all screens render correctly, and that the "activate send" screen's header tap navigates to MESSAGES_HOME as expected.
