### PR TITLE
chore: [IOBP-1414] Adjust a11y discount validity dates label

### DIFF
--- a/ts/features/bonus/cgn/components/merchants/discount/CgnDiscountContent.tsx
+++ b/ts/features/bonus/cgn/components/merchants/discount/CgnDiscountContent.tsx
@@ -46,6 +46,19 @@ export const CgnDiscountContent = ({
           discountDetails.endDate,
           I18n.t("global.dateFormats.shortFormat")
         )}`}
+        accessibilityLabel={
+          I18n.t("bonus.cgn.merchantDetail.discount.validity") +
+          I18n.t("bonus.validity_interval", {
+            from: localeDateFormat(
+              discountDetails.startDate,
+              I18n.t("global.dateFormats.shortFormat")
+            ),
+            to: localeDateFormat(
+              discountDetails.endDate,
+              I18n.t("global.dateFormats.shortFormat")
+            )
+          })
+        }
       />
     )}
   </ContentWrapper>

--- a/ts/features/bonus/cgn/components/merchants/discount/CgnDiscountContent.tsx
+++ b/ts/features/bonus/cgn/components/merchants/discount/CgnDiscountContent.tsx
@@ -46,9 +46,10 @@ export const CgnDiscountContent = ({
           discountDetails.endDate,
           I18n.t("global.dateFormats.shortFormat")
         )}`}
-        accessibilityLabel={
-          I18n.t("bonus.cgn.merchantDetail.discount.validity") +
-          I18n.t("bonus.validity_interval", {
+        accessibilityLabel={`${I18n.t(
+          "bonus.cgn.merchantDetail.discount.validity"
+        )} 
+          ${I18n.t("bonus.validity_interval", {
             from: localeDateFormat(
               discountDetails.startDate,
               I18n.t("global.dateFormats.shortFormat")
@@ -57,8 +58,7 @@ export const CgnDiscountContent = ({
               discountDetails.endDate,
               I18n.t("global.dateFormats.shortFormat")
             )
-          })
-        }
+          })}`}
       />
     )}
   </ContentWrapper>


### PR DESCRIPTION
## Short description
This pull request includes an improvement to the accessibility of the `CgnDiscountContent` component by adding an `accessibilityLabel` to the discount validity information

## List of changes proposed in this pull request
- Added an `accessibilityLabel` to provide a clear and descriptive label for the discount validity dates. This label includes the start and end dates formatted according to the locale's short date format

## How to test
- With Talkback enabled go in `CGN_MERCHANTS_DISCOUNT_SCREEN`
- Tap on `Validità` label
- Verify that the screen reader correctly announces the date, including the `validity_interval` phrase