### PR TITLE
feat:[IOCOM-2223] persisted dismiss logic for SEND banner

### DIFF
--- a/ts/features/common/store/reducers/__tests__/__snapshots__/index.test.ts.snap
+++ b/ts/features/common/store/reducers/__tests__/__snapshots__/index.test.ts.snap
@@ -300,6 +300,9 @@ exports[`featuresPersistor should match snapshot 1`] = `
     "activation": {
       "kind": "PotNone",
     },
+    "bannerDismiss": {
+      "dismissed": false,
+    },
   },
   "profileSettings": {},
   "services": {

--- a/ts/features/landingScreenMultiBanner/components/LandingScreenBannerPicker.tsx
+++ b/ts/features/landingScreenMultiBanner/components/LandingScreenBannerPicker.tsx
@@ -1,30 +1,28 @@
-import { useCallback } from "react";
+import { useMemo } from "react";
 import { useIODispatch, useIOSelector } from "../../../store/hooks";
-import { landingScreenBannerToRenderSelector } from "../store/selectors";
-import { updateLandingScreenBannerVisibility } from "../store/actions";
-import { landingScreenBannerMap } from "../utils/landingScreenBannerMap";
 import { usePushNotificationsBannerTracking } from "../../pushNotifications/hooks/usePushNotificationsBannerTracking";
+import { updateLandingScreenBannerVisibility } from "../store/actions";
+import { landingScreenBannerToRenderSelector } from "../store/selectors";
+import { landingScreenBannerMap } from "../utils/landingScreenBannerMap";
 
 export const LandingScreenBannerPicker = () => {
   const dispatch = useIODispatch();
   const bannerToRender = useIOSelector(landingScreenBannerToRenderSelector);
+  usePushNotificationsBannerTracking();
 
-  const closeHandler = useCallback(() => {
-    if (bannerToRender) {
+  return useMemo(() => {
+    if (bannerToRender === undefined) {
+      return null;
+    }
+    const entry = landingScreenBannerMap[bannerToRender];
+    const closeHandler = () => {
       dispatch(
         updateLandingScreenBannerVisibility({
           id: bannerToRender,
           enabled: false
         })
       );
-    }
+    };
+    return entry.component(closeHandler);
   }, [bannerToRender, dispatch]);
-
-  usePushNotificationsBannerTracking();
-
-  if (bannerToRender === undefined) {
-    return null;
-  }
-  const entry = landingScreenBannerMap[bannerToRender];
-  return entry?.component(closeHandler);
 };

--- a/ts/features/landingScreenMultiBanner/utils/landingScreenBannerMap.tsx
+++ b/ts/features/landingScreenMultiBanner/utils/landingScreenBannerMap.tsx
@@ -5,9 +5,9 @@ import { isItwPersistedDiscoveryBannerRenderableSelector } from "../../itwallet/
 import { LoginExpirationBanner } from "../../login/preferences/components/LoginExpirationBanner";
 import { isSessionExpirationBannerRenderableSelector } from "../../login/preferences/store/selectors";
 import { PNActivationReminderBanner } from "../../pn/components/PNActivationReminderBanner";
+import { isPnActivationReminderBannerRenderableSelector } from "../../pn/store/reducers/bannerDismiss";
 import { PushNotificationsBanner } from "../../pushNotifications/components/PushNotificationsBanner";
 import { isPushNotificationsBannerRenderableSelector } from "../../pushNotifications/store/selectors";
-import { isPnEnabledSelector } from "../../../store/reducers/backendStatus/remoteConfig";
 
 type ComponentWithCloseHandler = (closeHandler: () => void) => ReactElement;
 type ComponentAndLogic = {
@@ -51,6 +51,6 @@ export const landingScreenBannerMap: BannerMapById = {
     component: closeHandler => (
       <PNActivationReminderBanner handleOnClose={closeHandler} />
     ),
-    isRenderableSelector: isPnEnabledSelector
+    isRenderableSelector: isPnActivationReminderBannerRenderableSelector
   }
 } as const;

--- a/ts/features/pn/components/PNActivationReminderBanner.tsx
+++ b/ts/features/pn/components/PNActivationReminderBanner.tsx
@@ -1,9 +1,12 @@
 import { Banner, IOVisualCostants } from "@pagopa/io-app-design-system";
+import { useCallback } from "react";
 import { StyleSheet, View } from "react-native";
 import I18n from "../../../i18n";
 import { useIONavigation } from "../../../navigation/params/AppParamsList";
-import PN_ROUTES from "../navigation/routes";
+import { useIODispatch } from "../../../store/hooks";
 import { MESSAGES_ROUTES } from "../../messages/navigation/routes";
+import PN_ROUTES from "../navigation/routes";
+import { dismissPnActivationReminderBanner } from "../store/actions";
 
 type Props = {
   handleOnClose: () => void;
@@ -11,6 +14,12 @@ type Props = {
 
 export const PNActivationReminderBanner = ({ handleOnClose }: Props) => {
   const navigation = useIONavigation();
+  const dispatch = useIODispatch();
+
+  const closeHandler = useCallback(() => {
+    dispatch(dismissPnActivationReminderBanner());
+    handleOnClose();
+  }, [dispatch, handleOnClose]);
 
   const navigateToActivationFlow = () =>
     navigation.navigate(MESSAGES_ROUTES.MESSAGES_NAVIGATOR, {
@@ -29,7 +38,7 @@ export const PNActivationReminderBanner = ({ handleOnClose }: Props) => {
         color="neutral"
         onPress={navigateToActivationFlow}
         pictogramName="message"
-        onClose={handleOnClose}
+        onClose={closeHandler}
         labelClose={I18n.t("global.buttons.close")}
       />
     </View>

--- a/ts/features/pn/screens/PnReminderBannerFlow.tsx
+++ b/ts/features/pn/screens/PnReminderBannerFlow.tsx
@@ -14,8 +14,12 @@ import { useIODispatch, useIOSelector } from "../../../store/hooks";
 import { pnMessagingServiceIdSelector } from "../../../store/reducers/backendStatus/remoteConfig";
 import LoadingComponent from "../../fci/components/LoadingComponent";
 import { usePnPreferencesFetcher } from "../hooks/usePnPreferencesFetcher";
-import { pnActivationUpsert } from "../store/actions";
+import {
+  dismissPnActivationReminderBanner,
+  pnActivationUpsert
+} from "../store/actions";
 import { isLoadingPnActivationSelector } from "../store/reducers/activation";
+import { useOnFirstRender } from "../../../utils/hooks/useOnFirstRender";
 
 export const pnBannerFlowStateEnum = {
   FAILURE_DETAILS_FETCH: "FAILURE_DETAILS_FETCH",
@@ -144,6 +148,10 @@ const LoadingScreen = ({ loadingState }: LoadingStateProps) => (
 
 const SuccessScreen = ({ flowState }: SuccessFlowStateProps) => {
   const navigation = useIONavigation();
+  const dispatch = useIODispatch();
+  useOnFirstRender(() => {
+    dispatch(dismissPnActivationReminderBanner());
+  });
   return (
     <OperationResultScreenContent
       testID={`success-${flowState}`}

--- a/ts/features/pn/store/actions/index.ts
+++ b/ts/features/pn/store/actions/index.ts
@@ -20,8 +20,12 @@ export const startPNPaymentStatusTracking = createAction(
 export const cancelPNPaymentStatusTracking = createAction(
   "PN_CANCEL_PAYMENT_STATUS_TRACKING"
 );
+export const dismissPnActivationReminderBanner = createAction(
+  "DISMISS_PN_ACTIVATION_REMINDER_BANNER"
+);
 
 export type PnActions =
   | ActionType<typeof pnActivationUpsert>
   | ActionType<typeof startPNPaymentStatusTracking>
-  | ActionType<typeof cancelPNPaymentStatusTracking>;
+  | ActionType<typeof cancelPNPaymentStatusTracking>
+  | ActionType<typeof dismissPnActivationReminderBanner>;

--- a/ts/features/pn/store/reducers/bannerDismiss.ts
+++ b/ts/features/pn/store/reducers/bannerDismiss.ts
@@ -1,0 +1,44 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { persistReducer } from "redux-persist";
+import { getType } from "typesafe-actions";
+import { Action } from "../../../../store/actions/types";
+import { dismissPnActivationReminderBanner } from "../actions";
+import { GlobalState } from "../../../../store/reducers/types";
+import { isPnEnabledSelector } from "../../../../store/reducers/backendStatus/remoteConfig";
+
+export type PnBannerDismissState = {
+  dismissed: boolean;
+};
+const INITIAL_STATE = {
+  dismissed: false
+};
+
+const pnBannerDismissReducer = (
+  state: PnBannerDismissState = INITIAL_STATE,
+  action: Action
+) => {
+  switch (action.type) {
+    case getType(dismissPnActivationReminderBanner):
+      return {
+        dismissed: true
+      };
+  }
+  return state;
+};
+const persistConfig = {
+  key: "pnBannerDismiss",
+  storage: AsyncStorage,
+  version: -1,
+  whitelist: ["dismissed"]
+};
+export const persistedPnBannerDismissReducer = persistReducer(
+  persistConfig,
+  pnBannerDismissReducer
+);
+export const isPnActivationReminderBannerRenderableSelector = (
+  state: GlobalState
+) => {
+  const isPnEnabled = isPnEnabledSelector(state);
+  const hasBeenDismissed = state.features.pn.bannerDismiss.dismissed === true;
+  return isPnEnabled && !hasBeenDismissed;
+};

--- a/ts/features/pn/store/reducers/index.ts
+++ b/ts/features/pn/store/reducers/index.ts
@@ -1,24 +1,31 @@
 import * as pot from "@pagopa/ts-commons/lib/pot";
+import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
 import * as RA from "fp-ts/lib/ReadonlyArray";
 import { combineReducers } from "redux";
+import { PersistPartial } from "redux-persist";
 import { createSelector } from "reselect";
-import { pipe } from "fp-ts/lib/function";
 import { Action } from "../../../../store/actions/types";
-import { thirdPartyFromIdSelector } from "../../../messages/store/reducers/thirdPartyById";
-import { toPNMessage } from "../types/transformers";
 import { GlobalState } from "../../../../store/reducers/types";
-import { PNMessage } from "../types/types";
-import { getRptIdStringFromPayment } from "../../utils/rptId";
 import { isUserSelectedPaymentSelector } from "../../../messages/store/reducers/payments";
+import { thirdPartyFromIdSelector } from "../../../messages/store/reducers/thirdPartyById";
+import { getRptIdStringFromPayment } from "../../utils/rptId";
+import { toPNMessage } from "../types/transformers";
+import { PNMessage } from "../types/types";
 import { pnActivationReducer, PnActivationState } from "./activation";
+import {
+  persistedPnBannerDismissReducer,
+  PnBannerDismissState
+} from "./bannerDismiss";
 
 export type PnState = {
   activation: PnActivationState;
+  bannerDismiss: PnBannerDismissState & PersistPartial;
 };
 
 export const pnReducer = combineReducers<PnState, Action>({
-  activation: pnActivationReducer
+  activation: pnActivationReducer,
+  bannerDismiss: persistedPnBannerDismissReducer
 });
 
 export const pnMessageFromIdSelector = createSelector(

--- a/ts/store/reducers/index.ts
+++ b/ts/store/reducers/index.ts
@@ -276,6 +276,13 @@ export function createRootReducer(
               itWallet: {
                 ...state.features.itWallet
               },
+              pn: {
+                ...state.features.pn,
+                bannerDismiss: {
+                  ...state.features.pn.bannerDismiss,
+                  dismissed: false
+                }
+              },
               _persist: state.features._persist
             },
             identification: {


### PR DESCRIPTION
## Short description
addition of a persisted state entry for dismiss for the SEND engagement banner

## List of changes proposed in this pull request
- required persisted reducer
- required action
- required selector, and update to the bannerMap
- small refactor the the landingScreenBannerPicker 

complete tests to come 

## How to test
- existing tests should pass
- on banner dismiss or success flow end, the banner should be dismissed
- the dismissal should persist until the asyncStorage is cleared
- the landingScreenBannerPicker should work as usual and intended
- the landing_banners reducer's data should not be impacted other than the standard dismiss.