### PR TITLE
fix(a11y): [IOPID-2096,IOPID-2099] Add explicit accessibility roles

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@babel/plugin-transform-private-property-in-object": "^7.25.9",
     "@babel/plugin-transform-react-jsx": "^7.25.9",
     "@gorhom/bottom-sheet": "^4.1.5",
-    "@pagopa/io-app-design-system": "5.1.2",
+    "@pagopa/io-app-design-system": "5.1.3",
     "@pagopa/io-pagopa-commons": "^3.1.0",
     "@pagopa/io-react-native-cieid": "^0.3.5",
     "@pagopa/io-react-native-crypto": "^1.0.1",

--- a/ts/features/payments/checkout/components/WalletPaymentFeedbackBanner.tsx
+++ b/ts/features/payments/checkout/components/WalletPaymentFeedbackBanner.tsx
@@ -47,7 +47,9 @@ const WalletPaymentFeebackBanner = () => {
         viewRef={bannerViewRef}
         title={feedbackBannerConfig.title?.[localeFallback]}
         content={feedbackBannerConfig.description[localeFallback]}
-        action={feedbackBannerConfig.action?.label[localeFallback]}
+        // Starting from version 5.1.3 of the Design System, the `action` property,
+        // if explicitly configured, cannot have the value `undefined`.
+        action={feedbackBannerConfig.action?.label[localeFallback] ?? ""}
         onPress={handleBannerPress}
       />
     </>

--- a/ts/screens/authentication/LandingScreen.tsx
+++ b/ts/screens/authentication/LandingScreen.tsx
@@ -401,6 +401,7 @@ export const LandingScreen = () => {
           <VSpacer size={SPACE_AROUND_BUTTON_LINK} />
           <View style={IOStyles.selfCenter}>
             <ButtonLink
+              accessibilityRole="link"
               accessibilityLabel={I18n.t("authentication.landing.privacyLink")}
               color="primary"
               label={I18n.t("authentication.landing.privacyLink")}

--- a/ts/screens/authentication/cie/CiePinScreen.tsx
+++ b/ts/screens/authentication/cie/CiePinScreen.tsx
@@ -216,6 +216,7 @@ const CiePinScreen = () => {
             <Body
               weight="Semibold"
               asLink
+              accessibilityRole="button"
               onPress={() => {
                 trackLoginCiePinInfo();
                 present();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3753,9 +3753,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagopa/io-app-design-system@npm:5.1.2":
-  version: 5.1.2
-  resolution: "@pagopa/io-app-design-system@npm:5.1.2"
+"@pagopa/io-app-design-system@npm:5.1.3":
+  version: 5.1.3
+  resolution: "@pagopa/io-app-design-system@npm:5.1.3"
   dependencies:
     "@testing-library/jest-native": ^5.4.2
     "@types/react-test-renderer": ^18.0.0
@@ -3779,7 +3779,7 @@ __metadata:
     react-native-reanimated: "*"
     react-native-safe-area-context: "*"
     react-native-svg: "*"
-  checksum: f44c48403b9e534e6ffc231ac8c7a8a847039a14d172297eb3784e31795b85b9083df9649b80f1231104e60c0aa66385da785c2ca665f755a7d2583bbe372d58
+  checksum: 5ffcd990b34caae4e8c33663a29a4d1978837843eb17c67a5f46e6bd37e48d94d1c600be123b5c6a61b0cf4078ef45dc877794ece57e1d908a258959b340465a
   languageName: node
   linkType: hard
 
@@ -13657,7 +13657,7 @@ __metadata:
     "@babel/runtime": ^7.20.0
     "@gorhom/bottom-sheet": ^4.1.5
     "@jambit/eslint-plugin-typed-redux-saga": ^0.4.0
-    "@pagopa/io-app-design-system": 5.1.2
+    "@pagopa/io-app-design-system": 5.1.3
     "@pagopa/io-pagopa-commons": ^3.1.0
     "@pagopa/io-react-native-cieid": ^0.3.5
     "@pagopa/io-react-native-crypto": ^1.0.1


### PR DESCRIPTION
## Short description
This PR sets the correct accessibility roles in the `LandingScreen` and `CiePinScreen` CTAs

## List of changes proposed in this pull request
- Upgraded DS lib
- Added the "button" `accessibilityRole` in the "Where can I find it?" cta
- Added the "link" `accessibilityRole` in the "Privacy information" cta
- Added the fallback to an empty string in the `WalletPaymentFeebackBanner` action

## Demo
<details><summary>iOS</summary>
<p>

| "Where can I find it" |"Privacy information" |
|--------|--------|
| <video src=""></video> | <video src=""></video> | 

</p>
</details> 

<details><summary>Android</summary>
<p>

| "Where can I find it" |"Privacy information" |
|--------|--------|
| <video src=""></video> | <video src=""></video> | 

</p>
</details> 

## How to test
Start the app and repeat the steps shown in the demo to ensure the announced roles are the correct ones.
