### PR TITLE
chore: [IOAPPX-494] Update node binary script detection on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,6 @@ $ yarn run-ios
 The React Native documentation provides a [useful guide](https://reactnative.dev/docs/running-on-device) for running projects on physical devices.
 > [!IMPORTANT]  
 > For building the app on an iOS physical device, a few additional steps are necessary:
-> - Navigate to `Build Phases` in Xcode and expand `Bundle React Native code and images`. Update the `NODE_BINARY` variable with the path to your Node.js environment. You can find the correct path by running `which node` in a terminal from the app's root directory;
 > - If you're not part of the PagoPA S.p.A. organization then you must change the `Bundle Identifier` to something unique. This adjustment can be made in the `Signing (Debug)`
 > section of Xcode;
 > - In order to test the CIE authentication flow, run `yarn cie-ios:prod` before building the app. The process can be reverted by running `yarn cie-ios:dev`.

--- a/ios/ItaliaApp.xcodeproj/project.pbxproj
+++ b/ios/ItaliaApp.xcodeproj/project.pbxproj
@@ -456,7 +456,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh\n";
+			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
 		352F3B8D397ADE20251EED97 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## Short description
This PR updates the node binary detection script on iOS according to the one provided directly from React Native for the current version of the app.

## List of changes proposed in this pull request
- Update the `project.pbxproj` with the new script which automatically detects and create a `.xcode.env.local` file which contains the result of `which node`;
- Update `README.md` instructions to build the app accordingly.

## How to test
Try to run a iOS build from Xcode without manually changing the `node` path.