### PR TITLE
chore: [IOBP-1487] Enhance Mixpanel analytics for payment events

### DIFF
--- a/ts/features/payments/receipts/saga/handleDisableReceipt.ts
+++ b/ts/features/payments/receipts/saga/handleDisableReceipt.ts
@@ -39,7 +39,9 @@ export function* handleDisableReceipt(
     analytics.trackHideReceiptSuccess({
       organization_name: paymentsAnalyticsData?.receiptOrganizationName,
       first_time_opening: paymentsAnalyticsData?.receiptFirstTimeOpening,
-      user: paymentsAnalyticsData?.receiptUser
+      user: paymentsAnalyticsData?.receiptUser,
+      organization_fiscal_code:
+        paymentsAnalyticsData?.verifiedData?.paFiscalCode
     });
   };
 

--- a/ts/features/payments/receipts/screens/ReceiptDetailsScreen.tsx
+++ b/ts/features/payments/receipts/screens/ReceiptDetailsScreen.tsx
@@ -93,7 +93,10 @@ const ReceiptDetailsScreen = () => {
     analytics.trackPaymentsDownloadReceiptError({
       organization_name: paymentAnalyticsData?.receiptOrganizationName,
       first_time_opening: paymentAnalyticsData?.receiptFirstTimeOpening,
-      user: paymentAnalyticsData?.receiptUser
+      user: paymentAnalyticsData?.receiptUser,
+      organization_fiscal_code:
+        paymentAnalyticsData?.verifiedData?.paFiscalCode,
+      payment_status: "paid"
     });
     toast.error(I18n.t("features.payments.transactions.receipt.error"));
   };

--- a/ts/features/payments/receipts/screens/ReceiptPreviewScreen.tsx
+++ b/ts/features/payments/receipts/screens/ReceiptPreviewScreen.tsx
@@ -60,7 +60,8 @@ const ReceiptPreviewScreen = () => {
       payment_status: "paid",
       organization_name: paymentAnalyticsData?.receiptOrganizationName,
       first_time_opening: paymentAnalyticsData?.receiptFirstTimeOpening,
-      user: paymentAnalyticsData?.receiptUser
+      user: paymentAnalyticsData?.receiptUser,
+      organization_fiscal_code: paymentAnalyticsData?.verifiedData?.paFiscalCode
     });
     // The file name is normalized to remove the .pdf extension on Android devices since it's added by default to the Share module
     const normalizedFilename =


### PR DESCRIPTION
## Short description
This pull request enhances Mixpanel analytics for receipt-related actions by including the missing `organization_fiscal_code` field. These updates ensure compliance with tracking requirements.

## List of changes proposed in this pull request
- Added missing mixpanel property for `HIDE_RECEIPT_SUCCESS`, `DOWNLOAD_RECEIPT_FAILURE` and `SAVE_AND_SHARE_RECEIPT` events

## How to test
Verify that all relevant properties are correctly tracked in the analytics events