### PR TITLE
fix: [IOCOM-2284] Proper tracking of the CTA decoding failure analytics 

### DIFF
--- a/ts/features/messages/analytics/index.ts
+++ b/ts/features/messages/analytics/index.ts
@@ -81,11 +81,12 @@ export const trackOpenMessage = (
   void mixpanelTrack(eventName, props);
 };
 
-export const trackMessageCTAFrontMatterDecodingError = (
-  serviceId?: ServiceId
+export const trackCTAFrontMatterDecodingError = (
+  reason: string,
+  serviceId: ServiceId
 ) => {
   const eventName = "CTA_FRONT_MATTER_DECODING_ERROR";
-  const props = buildEventProperties("KO", undefined, { serviceId });
+  const props = buildEventProperties("KO", undefined, { reason, serviceId });
   void mixpanelTrack(eventName, props);
 };
 

--- a/ts/features/messages/saga/__test__/handleLoadMessageData.test.ts
+++ b/ts/features/messages/saga/__test__/handleLoadMessageData.test.ts
@@ -1211,6 +1211,7 @@ describe("commonFailureHandling", () => {
 });
 
 describe("computeHasFIMSCTA", () => {
+  const serviceId = "01JQ93ZCD00T8P131AT2ES102D" as ServiceId;
   const fimsCTA2FrontMatter = `---\nit:\n cta_1:\n  text: "Visualizza i documenti"\n  action: "https://relyingParty.url"\n cta_2:\n  text: "Visualizza i requisiti"\n  action: "iosso://https://relyingParty.url"\nen:\n cta_1:\n  text: "View documents"\n  action: "https://relyingParty.url"\n cta_2:\n  text: "View requirements"\n  action: "iosso://https://relyingParty.url"\n---`;
   const unrelatedCTAFrontMatter =
     '---\nit:\n cta_1:\n  text: "Visualizza i documenti"\n  action: "https://relyingParty.url"\n cta_1:\n  text: "Visualizza i requisiti"\n  action: "https://relyingParty.url"\nen:\n cta_1:\n  text: "View documents"\n  action: "https://relyingParty.url"\n cta_1:\n  text: "View requirements"\n  action: "https://relyingParty.url"\n---';
@@ -1219,7 +1220,11 @@ describe("computeHasFIMSCTA", () => {
       markdown: `${fimsCTAFrontMatter}\nThis is the message body`
     } as UIMessageDetails;
 
-    const hasFIMSCTA = testable!.computeHasFIMSCTA(messageDetails, undefined);
+    const hasFIMSCTA = testable!.computeHasFIMSCTA(
+      messageDetails,
+      serviceId,
+      undefined
+    );
 
     expect(hasFIMSCTA).toBe(true);
   });
@@ -1228,7 +1233,11 @@ describe("computeHasFIMSCTA", () => {
       markdown: `${fimsCTA2FrontMatter}\nThis is the message body`
     } as UIMessageDetails;
 
-    const hasFIMSCTA = testable!.computeHasFIMSCTA(messageDetails, undefined);
+    const hasFIMSCTA = testable!.computeHasFIMSCTA(
+      messageDetails,
+      serviceId,
+      undefined
+    );
 
     expect(hasFIMSCTA).toBe(true);
   });
@@ -1237,7 +1246,11 @@ describe("computeHasFIMSCTA", () => {
       markdown: `This is the message body`
     } as UIMessageDetails;
 
-    const hasFIMSCTA = testable!.computeHasFIMSCTA(messageDetails, undefined);
+    const hasFIMSCTA = testable!.computeHasFIMSCTA(
+      messageDetails,
+      serviceId,
+      undefined
+    );
 
     expect(hasFIMSCTA).toBe(false);
   });
@@ -1246,7 +1259,11 @@ describe("computeHasFIMSCTA", () => {
       markdown: `${unrelatedCTAFrontMatter}\nThis is the message body`
     } as UIMessageDetails;
 
-    const hasFIMSCTA = testable!.computeHasFIMSCTA(messageDetails, undefined);
+    const hasFIMSCTA = testable!.computeHasFIMSCTA(
+      messageDetails,
+      serviceId,
+      undefined
+    );
 
     expect(hasFIMSCTA).toBe(false);
   });
@@ -1265,6 +1282,7 @@ describe("computeHasFIMSCTA", () => {
 
     const hasFIMSCTA = testable!.computeHasFIMSCTA(
       messageDetails,
+      serviceId,
       remoteMessage
     );
 
@@ -1285,6 +1303,7 @@ describe("computeHasFIMSCTA", () => {
 
     const hasFIMSCTA = testable!.computeHasFIMSCTA(
       messageDetails,
+      serviceId,
       remoteMessage
     );
 
@@ -1305,6 +1324,7 @@ describe("computeHasFIMSCTA", () => {
 
     const hasFIMSCTA = testable!.computeHasFIMSCTA(
       messageDetails,
+      serviceId,
       remoteMessage
     );
 
@@ -1325,6 +1345,7 @@ describe("computeHasFIMSCTA", () => {
 
     const hasFIMSCTA = testable!.computeHasFIMSCTA(
       messageDetails,
+      serviceId,
       remoteMessage
     );
 

--- a/ts/features/messages/saga/handleLoadMessageData.ts
+++ b/ts/features/messages/saga/handleLoadMessageData.ts
@@ -38,9 +38,13 @@ import {
 import { RemoteContentDetails } from "../../../../definitions/backend/RemoteContentDetails";
 import { MessageGetStatusFailurePhaseType } from "../store/reducers/messageGetStatus";
 import { ServicePublic } from "../../../../definitions/backend/ServicePublic";
-import { ctaFromMessageCTA, unsafeMessageCTAFromInput } from "../utils/ctas";
+
 import { extractContentFromMessageSources } from "../utils";
 import { isFIMSLink } from "../../fims/singleSignOn/utils";
+import {
+  ctasFromLocalizedCTAs,
+  localizedCTAsFromFrontMatter
+} from "../utils/ctas";
 
 export function* handleLoadMessageData(
   action: ActionType<typeof getMessageDataAction.request>
@@ -317,7 +321,12 @@ function* dispatchSuccessAction(
 
   const isPnEnabled = yield* select(isPnEnabledSelector);
 
-  const hasFIMSCTA = computeHasFIMSCTA(messageDetails, thirdPartyMessage);
+  const serviceId = paginatedMessage.serviceId;
+  const hasFIMSCTA = computeHasFIMSCTA(
+    messageDetails,
+    serviceId,
+    thirdPartyMessage
+  );
 
   yield* put(
     getMessageDataAction.success({
@@ -388,6 +397,7 @@ const decodeAndTrackThirdPartyMessageDetailsIfNeeded = (
 
 const computeHasFIMSCTA = (
   messageDetails: UIMessageDetails,
+  serviceId: ServiceId,
   thirdPartyMessage: ThirdPartyMessageWithContent | undefined
 ) => {
   const markdownWithCTAs = extractContentFromMessageSources(
@@ -396,12 +406,15 @@ const computeHasFIMSCTA = (
     messageDetails,
     thirdPartyMessage
   );
-  const unsafeMessageCTA = unsafeMessageCTAFromInput(markdownWithCTAs);
-  const cta = ctaFromMessageCTA(unsafeMessageCTA);
-  if (cta != null && isFIMSLink(cta.cta_1.action)) {
+  const localizedCTAs = localizedCTAsFromFrontMatter(
+    markdownWithCTAs,
+    serviceId
+  );
+  const ctas = ctasFromLocalizedCTAs(localizedCTAs, serviceId);
+  if (ctas != null && isFIMSLink(ctas.cta_1.action)) {
     return true;
   }
-  if (cta?.cta_2 != null && isFIMSLink(cta.cta_2.action)) {
+  if (ctas?.cta_2 != null && isFIMSLink(ctas.cta_2.action)) {
     return true;
   }
   return false;

--- a/ts/features/messages/screens/MessageDetailsScreen.tsx
+++ b/ts/features/messages/screens/MessageDetailsScreen.tsx
@@ -35,7 +35,7 @@ import I18n from "../../../i18n";
 import { messageDetailsByIdSelector } from "../store/reducers/detailsById";
 import { MessageDetailsTagBox } from "../components/MessageDetail/MessageDetailsTagBox";
 import { MessageMarkdown } from "../components/MessageDetail/MessageMarkdown";
-import { cleanMarkdownFromCTAs, getMessageCTA } from "../utils/ctas";
+import { getMessageCTAs, removeCTAsFromMarkdown } from "../utils/ctas";
 import { MessageDetailsReminder } from "../components/MessageDetail/MessageDetailsReminder";
 import { MessageDetailsFooter } from "../components/MessageDetail/MessageDetailsFooter";
 import { MessageDetailsPayment } from "../components/MessageDetail/MessageDetailsPayment";
@@ -116,14 +116,14 @@ export const MessageDetailsScreen = (props: MessageDetailsScreenProps) => {
   const messageMarkdown =
     useIOSelector(state => messageMarkdownSelector(state, messageId)) ?? "";
   const markdownWithNoCTA = useMemo(
-    () => cleanMarkdownFromCTAs(messageMarkdown),
-    [messageMarkdown]
+    () => removeCTAsFromMarkdown(messageMarkdown, serviceId),
+    [messageMarkdown, serviceId]
   );
   const serviceMetadata = useIOSelector(state =>
     serviceMetadataByIdSelector(state, serviceId)
   );
   const maybeCTAs = useMemo(
-    () => getMessageCTA(messageMarkdown, serviceMetadata, serviceId),
+    () => getMessageCTAs(messageMarkdown, serviceId, serviceMetadata),
     [messageMarkdown, serviceId, serviceMetadata]
   );
 

--- a/ts/features/messages/types/MessageCTA.ts
+++ b/ts/features/messages/types/MessageCTA.ts
@@ -18,14 +18,14 @@ const CTASO = t.partial({
 });
 
 export const CTAS = t.intersection([CTASR, CTASO], "CTAS");
+export type CTAS = t.TypeOf<typeof CTAS>;
 
 const props = {
   it: CTAS,
   en: CTAS
 };
-const MessageCTA = t.partial(props);
-export const MessageCTALocales = t.keyof(props);
-export type MessageCTALocales = t.TypeOf<typeof MessageCTALocales>;
-export type CTAS = t.TypeOf<typeof CTAS>;
+const LocalizedCTAs = t.partial(props);
+export type LocalizedCTAs = t.TypeOf<typeof LocalizedCTAs>;
 
-export type MessageCTA = t.TypeOf<typeof MessageCTA>;
+export const LocalizedCTALocales = t.keyof(props);
+export type LocalizedCTALocales = t.TypeOf<typeof LocalizedCTALocales>;

--- a/ts/features/messages/utils/__tests__/ctas.test.ts
+++ b/ts/features/messages/utils/__tests__/ctas.test.ts
@@ -272,7 +272,7 @@ en:
     action: "ioit://services"
 ---`;
     const spyOnAnalytics = jest
-      .spyOn(ANALYTICS, "trackMessageCTAFrontMatterDecodingError")
+      .spyOn(ANALYTICS, "trackCTAFrontMatterDecodingError")
       .mockReturnValue(undefined);
 
     const verifiedCTAOrUndefined = testable!.getCTAsIfValid(
@@ -304,7 +304,7 @@ en:
     action: "ioit://messages"
 ---`;
     const spyOnAnalytics = jest
-      .spyOn(ANALYTICS, "trackMessageCTAFrontMatterDecodingError")
+      .spyOn(ANALYTICS, "trackCTAFrontMatterDecodingError")
       .mockReturnValue(undefined);
 
     const verifiedCTAOrUndefined = testable!.getCTAsIfValid(
@@ -332,7 +332,7 @@ en:
     action: "ioit://services"
 ---`;
     const spyOnAnalytics = jest
-      .spyOn(ANALYTICS, "trackMessageCTAFrontMatterDecodingError")
+      .spyOn(ANALYTICS, "trackCTAFrontMatterDecodingError")
       .mockReturnValue(undefined);
 
     const verifiedCTAOrUndefined = testable!.getCTAsIfValid(
@@ -341,8 +341,11 @@ en:
     );
 
     expect(spyOnAnalytics.mock.calls.length).toBe(1);
-    expect(spyOnAnalytics.mock.calls[0].length).toBe(1);
-    expect(spyOnAnalytics.mock.calls[0][0]).toBe(serviceId);
+    expect(spyOnAnalytics.mock.calls[0].length).toBe(2);
+    expect(spyOnAnalytics.mock.calls[0][0]).toBe(
+      "A failure occoured while decoding from Localized CTAS to specific CTAs"
+    );
+    expect(spyOnAnalytics.mock.calls[0][1]).toBe(serviceId);
     expect(verifiedCTAOrUndefined).toBeUndefined();
   });
   it("should return CTAS from input string with invalid CTA1 action but valid CTA2 action", () => {
@@ -363,7 +366,7 @@ en:
     action: "ioit://services"
 ---`;
     const spyOnAnalytics = jest
-      .spyOn(ANALYTICS, "trackMessageCTAFrontMatterDecodingError")
+      .spyOn(ANALYTICS, "trackCTAFrontMatterDecodingError")
       .mockReturnValue(undefined);
 
     const verifiedCTAOrUndefined = testable!.getCTAsIfValid(
@@ -371,7 +374,13 @@ en:
       serviceId
     );
 
-    expect(spyOnAnalytics.mock.calls.length).toBe(0);
+    expect(spyOnAnalytics.mock.calls.length).toBe(1);
+    expect(spyOnAnalytics.mock.calls[0].length).toBe(2);
+    expect(spyOnAnalytics.mock.calls[0][0]).toBe(
+      "The first CTA does not contain a supported action"
+    );
+    expect(spyOnAnalytics.mock.calls[0][1]).toBe(serviceId);
+
     expect(verifiedCTAOrUndefined).toEqual({
       cta_1: {
         action: "thisIsNotValid",
@@ -385,23 +394,23 @@ en:
   });
   it("should return undefined from input string with valid CTA1 action and invalid CTA2 action", () => {
     const validCTAs = `---
-    it:
-      cta_1:
-        text: "Testo CTA1"
-        action: "ioit://messages"
-      cta_2:
-        text: "Testo CTA2"
-        action: "thisIsNotValid"
-    en:
-      cta_1:
-        text: "CTA1 Text"
-        action: "ioit://messages"
-      cta_2:
-        text: "CTA2 Text"
-        action: "thisIsNotValid"
-    ---`;
+it:
+  cta_1:
+    text: "Testo CTA1"
+    action: "ioit://messages"
+  cta_2:
+    text: "Testo CTA2"
+    action: "thisIsNotValid"
+en:
+  cta_1:
+    text: "CTA1 Text"
+    action: "ioit://messages"
+  cta_2:
+    text: "CTA2 Text"
+    action: "thisIsNotValid"
+---`;
     const spyOnAnalytics = jest
-      .spyOn(ANALYTICS, "trackMessageCTAFrontMatterDecodingError")
+      .spyOn(ANALYTICS, "trackCTAFrontMatterDecodingError")
       .mockReturnValue(undefined);
 
     const verifiedCTAOrUndefined = testable!.getCTAsIfValid(
@@ -410,13 +419,19 @@ en:
     );
 
     expect(spyOnAnalytics.mock.calls.length).toBe(1);
-    expect(spyOnAnalytics.mock.calls[0].length).toBe(1);
-    expect(spyOnAnalytics.mock.calls[0][0]).toBe(serviceId);
-    expect(verifiedCTAOrUndefined).toBeUndefined();
+    expect(spyOnAnalytics.mock.calls[0].length).toBe(2);
+    expect(spyOnAnalytics.mock.calls[0][0]).toBe(
+      "The second CTA does not contain a supported action"
+    );
+    expect(spyOnAnalytics.mock.calls[0][1]).toBe(serviceId);
+    expect(verifiedCTAOrUndefined).toEqual({
+      cta_1: { action: "ioit://messages", text: "Testo CTA1" },
+      cta_2: { action: "thisIsNotValid", text: "Testo CTA2" }
+    });
   });
   it("should return undefined from invalid input string", () => {
     const spyOnAnalytics = jest
-      .spyOn(ANALYTICS, "trackMessageCTAFrontMatterDecodingError")
+      .spyOn(ANALYTICS, "trackCTAFrontMatterDecodingError")
       .mockReturnValue(undefined);
 
     const verifiedCTAOrUndefined = testable!.getCTAsIfValid(
@@ -424,14 +439,12 @@ en:
       serviceId
     );
 
-    expect(spyOnAnalytics.mock.calls.length).toBe(1);
-    expect(spyOnAnalytics.mock.calls[0].length).toBe(1);
-    expect(spyOnAnalytics.mock.calls[0][0]).toBe(serviceId);
+    expect(spyOnAnalytics.mock.calls.length).toBe(0);
     expect(verifiedCTAOrUndefined).toBeUndefined();
   });
   it("should return undefined from undefined input string", () => {
     const spyOnAnalytics = jest
-      .spyOn(ANALYTICS, "trackMessageCTAFrontMatterDecodingError")
+      .spyOn(ANALYTICS, "trackCTAFrontMatterDecodingError")
       .mockReturnValue(undefined);
 
     const verifiedCTAOrUndefined = testable!.getCTAsIfValid(
@@ -439,9 +452,7 @@ en:
       serviceId
     );
 
-    expect(spyOnAnalytics.mock.calls.length).toBe(1);
-    expect(spyOnAnalytics.mock.calls[0].length).toBe(1);
-    expect(spyOnAnalytics.mock.calls[0][0]).toBe(serviceId);
+    expect(spyOnAnalytics.mock.calls.length).toBe(0);
     expect(verifiedCTAOrUndefined).toBeUndefined();
   });
   ioHandledLinks.forEach(action => {
@@ -457,7 +468,7 @@ en:
     action: "${action}"
 ---`;
       const spyOnAnalytics = jest
-        .spyOn(ANALYTICS, "trackMessageCTAFrontMatterDecodingError")
+        .spyOn(ANALYTICS, "trackCTAFrontMatterDecodingError")
         .mockReturnValue(undefined);
 
       const verifiedCTAOrUndefined = testable!.getCTAsIfValid(
@@ -485,9 +496,8 @@ cta_1:
   text: "CTA1 Text"
   action: "iohandledlink://notSupported://whatever"
 ---`;
-    const serviceId = "01JKB81F4HE9WQWJFD7JET9ZFN" as ServiceId;
     const spyOnAnalytics = jest
-      .spyOn(ANALYTICS, "trackMessageCTAFrontMatterDecodingError")
+      .spyOn(ANALYTICS, "trackCTAFrontMatterDecodingError")
       .mockReturnValue(undefined);
 
     const verifiedCTAOrUndefined = testable!.getCTAsIfValid(
@@ -496,13 +506,17 @@ cta_1:
     );
 
     expect(spyOnAnalytics.mock.calls.length).toBe(1);
-    expect(spyOnAnalytics.mock.calls[0].length).toBe(1);
-    expect(spyOnAnalytics.mock.calls[0][0]).toBe(serviceId);
+    expect(spyOnAnalytics.mock.calls[0].length).toBe(2);
+    expect(spyOnAnalytics.mock.calls[0][0]).toBe(
+      "A failure occourred while parsing or extracting front matter"
+    );
+    expect(spyOnAnalytics.mock.calls[0][1]).toBe(serviceId);
     expect(verifiedCTAOrUndefined).toBeUndefined();
   });
 });
 
 describe("areCTAsActionsValid", () => {
+  const serviceId = "01JQ9DQ32A9KE9EF340GQ3Z500" as ServiceId;
   it("should return true if cta1 action is valid, with undefined cta2", () => {
     const ctas: CTAS = {
       cta_1: {
@@ -511,7 +525,11 @@ describe("areCTAsActionsValid", () => {
       }
     };
 
-    const hasValidActions = testable!.areCTAsActionsValid(ctas, undefined);
+    const hasValidActions = testable!.areCTAsActionsValid(
+      ctas,
+      serviceId,
+      undefined
+    );
 
     expect(hasValidActions).toBe(true);
   });
@@ -527,7 +545,11 @@ describe("areCTAsActionsValid", () => {
       }
     };
 
-    const hasValidActions = testable!.areCTAsActionsValid(ctas, undefined);
+    const hasValidActions = testable!.areCTAsActionsValid(
+      ctas,
+      serviceId,
+      undefined
+    );
 
     expect(hasValidActions).toBe(true);
   });
@@ -543,7 +565,11 @@ describe("areCTAsActionsValid", () => {
       }
     };
 
-    const hasValidActions = testable!.areCTAsActionsValid(ctas, undefined);
+    const hasValidActions = testable!.areCTAsActionsValid(
+      ctas,
+      serviceId,
+      undefined
+    );
 
     expect(hasValidActions).toBe(true);
   });
@@ -559,7 +585,11 @@ describe("areCTAsActionsValid", () => {
       }
     };
 
-    const hasValidActions = testable!.areCTAsActionsValid(ctas, undefined);
+    const hasValidActions = testable!.areCTAsActionsValid(
+      ctas,
+      serviceId,
+      undefined
+    );
 
     expect(hasValidActions).toBe(false);
   });

--- a/ts/features/messages/utils/ctas.ts
+++ b/ts/features/messages/utils/ctas.ts
@@ -140,7 +140,7 @@ const getCTAsIfValid = (
     return undefined;
   }
 
-  if (areCTAsActionsValid(ctas, serviceMetadata)) {
+  if (areCTAsActionsValid(ctas, serviceId, serviceMetadata)) {
     return ctas;
   }
 
@@ -199,13 +199,28 @@ export const ctasFromLocalizedCTAs = (
  */
 const areCTAsActionsValid = (
   ctas: CTAS,
+  serviceId: ServiceId,
   serviceMetadata?: ServiceMetadata
 ): boolean => {
   const isCTA1Valid = isCtaActionValid(ctas.cta_1, serviceMetadata);
-  if (isCTA1Valid) {
-    return true;
+  if (!isCTA1Valid) {
+    trackCTAFrontMatterDecodingError(
+      "The first CTA does not contain a supported action",
+      serviceId
+    );
   }
-  return ctas.cta_2 != null && isCtaActionValid(ctas.cta_2, serviceMetadata);
+
+  if (ctas.cta_2 == null) {
+    return isCTA1Valid;
+  }
+  const isCTA2Valid = isCtaActionValid(ctas.cta_2, serviceMetadata);
+  if (!isCTA2Valid) {
+    trackCTAFrontMatterDecodingError(
+      "The second CTA does not contain a supported action",
+      serviceId
+    );
+  }
+  return isCTA1Valid || isCTA2Valid;
 };
 
 /**

--- a/ts/features/messages/utils/ctas.ts
+++ b/ts/features/messages/utils/ctas.ts
@@ -264,7 +264,6 @@ const containsFrontMatterHeader = (
   try {
     return FM.test(input);
   } catch {
-    // TODO check this one, is it raised every time?
     trackCTAFrontMatterDecodingError(
       "A failure occoured while testing for front matter",
       serviceId

--- a/ts/features/messages/utils/ctas.ts
+++ b/ts/features/messages/utils/ctas.ts
@@ -1,7 +1,3 @@
-/**
- * Generic utilities for messages
- */
-
 import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/lib/Option";
 import { Predicate } from "fp-ts/lib/Predicate";
@@ -16,9 +12,14 @@ import {
   deriveCustomHandledLink,
   isIoInternalLink
 } from "../../../components/ui/Markdown/handlers/link";
-import { trackMessageCTAFrontMatterDecodingError } from "../analytics";
+import { trackCTAFrontMatterDecodingError } from "../analytics";
 import { localeFallback } from "../../../i18n";
-import { CTA, CTAS, MessageCTA, MessageCTALocales } from "../types/MessageCTA";
+import {
+  CTA,
+  CTAS,
+  LocalizedCTAs,
+  LocalizedCTALocales
+} from "../types/MessageCTA";
 import {
   getInternalRoute,
   handleInternalLink
@@ -68,10 +69,10 @@ const internalRoutePredicates: Map<
  * return the locale supported by the app. If the remote locale is not supported
  * a fallback will be returned
  */
-export const getRemoteLocale = (): Extract<Locales, MessageCTALocales> =>
+export const getRemoteLocale = (): Extract<Locales, LocalizedCTALocales> =>
   pipe(
     getLocalePrimaryWithFallback(),
-    MessageCTALocales.decode,
+    LocalizedCTALocales.decode,
     E.getOrElseW(() => localeFallback.locale)
   );
 
@@ -82,88 +83,112 @@ export const getRemoteLocale = (): Extract<Locales, MessageCTALocales> =>
  * @param serviceMetadata
  * @param serviceId
  */
-export const getMessageCTA = (
+export const getMessageCTAs = (
   markdown: MessageBodyMarkdown | string,
-  serviceMetadata?: ServiceMetadata,
-  serviceId?: ServiceId
-): CTAS | undefined => getCTAIfValid(markdown, serviceMetadata, serviceId);
+  serviceId: ServiceId,
+  serviceMetadata?: ServiceMetadata
+): CTAS | undefined => getCTAsIfValid(markdown, serviceId, serviceMetadata);
 
 /**
  * extract the CTAs from a string given in serviceMetadata such as the front-matter of the message
  * if some CTAs are been found, the localized version will be returned
  * @param serviceMetadata
  */
-export const getServiceCTA = (
+export const getServiceCTAs = (
+  serviceId: ServiceId,
   serviceMetadata?: ServiceMetadata
-): CTAS | undefined => getCTAIfValid(serviceMetadata?.cta, serviceMetadata);
+): CTAS | undefined => {
+  const serviceCta = serviceMetadata?.cta;
+  return serviceCta != null
+    ? getCTAsIfValid(serviceCta, serviceId, serviceMetadata)
+    : undefined;
+};
 
 /**
  * remove the cta front-matter if it is nested inside the markdown
  * @param markdown
  */
-export const cleanMarkdownFromCTAs = (
-  markdown: MessageBodyMarkdown | string
+export const removeCTAsFromMarkdown = (
+  markdownText: MessageBodyMarkdown | string,
+  serviceId: ServiceId
 ): string => {
-  const isValidMarkdown = safeContainsFrontMatter(markdown);
-  if (!isValidMarkdown) {
-    return markdown;
+  const isValidFrontMatterHeader = containsFrontMatterHeader(
+    markdownText,
+    serviceId
+  );
+  if (!isValidFrontMatterHeader) {
+    return markdownText;
   }
-  return safeExtractBodyAfterFrontMatter(markdown);
+  return extractBodyAfterFrontMatter(markdownText, serviceId);
 };
 
-const getCTAIfValid = (
-  text: string | undefined,
-  serviceMetadata?: ServiceMetadata,
-  serviceId?: ServiceId
+const getCTAsIfValid = (
+  frontMatterText: string | undefined,
+  serviceId: ServiceId,
+  serviceMetadata?: ServiceMetadata
 ): CTAS | undefined => {
-  const unsafeMessageCTA = unsafeMessageCTAFromInput(text);
-  if (unsafeMessageCTA == null) {
-    trackMessageCTAFrontMatterDecodingError(serviceId);
+  const localizedCTAs = localizedCTAsFromFrontMatter(
+    frontMatterText,
+    serviceId
+  );
+  if (localizedCTAs == null) {
     return undefined;
   }
 
-  const safeCTAS = ctaFromMessageCTA(unsafeMessageCTA);
-  if (safeCTAS == null) {
-    trackMessageCTAFrontMatterDecodingError(serviceId);
+  const ctas = ctasFromLocalizedCTAs(localizedCTAs, serviceId);
+  if (ctas == null) {
     return undefined;
   }
 
-  if (hasCtaValidActions(safeCTAS, serviceMetadata)) {
-    return safeCTAS;
+  if (areCTAsActionsValid(ctas, serviceMetadata)) {
+    return ctas;
   }
 
   return undefined;
 };
 
-export const unsafeMessageCTAFromInput = (
-  input: string | undefined
-): MessageCTA | undefined => {
-  if (input == null) {
+export const localizedCTAsFromFrontMatter = (
+  frontMatterText: string | undefined,
+  serviceId: ServiceId
+): LocalizedCTAs | undefined => {
+  if (frontMatterText == null) {
     return undefined;
   }
-  const isValidFrontMatter = safeContainsFrontMatter(input);
-  if (!isValidFrontMatter) {
+  const isValidFrontMatterHeader = containsFrontMatterHeader(
+    frontMatterText,
+    serviceId
+  );
+  if (!isValidFrontMatterHeader) {
     return undefined;
   }
   try {
-    const frontMatter = FM<MessageCTA>(input);
+    const frontMatter = FM<LocalizedCTAs>(frontMatterText);
     return frontMatter.attributes;
   } catch {
+    trackCTAFrontMatterDecodingError(
+      "A failure occourred while parsing or extracting front matter",
+      serviceId
+    );
     return undefined;
   }
 };
 
-export const ctaFromMessageCTA = (
-  messageCTA: MessageCTA | undefined
+export const ctasFromLocalizedCTAs = (
+  localizedCTAs: LocalizedCTAs | undefined,
+  serviceId: ServiceId
 ): CTAS | undefined => {
-  if (messageCTA == null) {
+  if (localizedCTAs == null) {
     return undefined;
   }
-  const unsafeCTAs = messageCTA[getRemoteLocale()];
-  const decodedCTAS = CTAS.decode(unsafeCTAs);
-  if (E.isRight(decodedCTAS)) {
-    return decodedCTAS.right;
+  const typeUncheckedCTAs = localizedCTAs[getRemoteLocale()];
+  const decodedCTAsResult = CTAS.decode(typeUncheckedCTAs);
+  if (E.isRight(decodedCTAsResult)) {
+    return decodedCTAsResult.right;
   }
+  trackCTAFrontMatterDecodingError(
+    "A failure occoured while decoding from Localized CTAS to specific CTAs",
+    serviceId
+  );
   return undefined;
 };
 
@@ -172,7 +197,7 @@ export const ctaFromMessageCTA = (
  * @param ctas
  * @param serviceMetadata
  */
-const hasCtaValidActions = (
+const areCTAsActionsValid = (
   ctas: CTAS,
   serviceMetadata?: ServiceMetadata
 ): boolean => {
@@ -217,31 +242,47 @@ const isCtaActionValid = (
   return E.isRight(maybeCustomHandledAction);
 };
 
-const safeContainsFrontMatter = (input: string): boolean => {
+const containsFrontMatterHeader = (
+  input: string,
+  serviceId: ServiceId
+): boolean => {
   try {
     return FM.test(input);
   } catch {
+    // TODO check this one, is it raised every time?
+    trackCTAFrontMatterDecodingError(
+      "A failure occoured while testing for front matter",
+      serviceId
+    );
     return false;
   }
 };
 
-const safeExtractBodyAfterFrontMatter = (input: string): string => {
+const extractBodyAfterFrontMatter = (
+  text: string,
+  serviceId: ServiceId
+): string => {
   try {
-    const frontMatter = FM(input);
+    const frontMatter = FM(text);
     return frontMatter.body;
-  } catch {
-    return input;
+  } catch (e) {
+    trackCTAFrontMatterDecodingError(
+      "A failure occourred while parsing or extracting body from input with front matter",
+      serviceId
+    );
+    return text;
   }
 };
 
 export const testable = isTestEnv
   ? {
-      getCTAIfValid,
-      hasCtaValidActions,
+      areCTAsActionsValid,
+      containsFrontMatterHeader,
+      ctasFromLocalizedCTAs,
+      extractBodyAfterFrontMatter,
+      getCTAsIfValid,
       hasMetadataTokenName,
       internalRoutePredicates,
-      isCtaActionValid,
-      safeContainsFrontMatter,
-      safeExtractBodyAfterFrontMatter
+      isCtaActionValid
     }
   : undefined;

--- a/ts/features/services/details/screens/ServiceDetailsScreen.tsx
+++ b/ts/features/services/details/screens/ServiceDetailsScreen.tsx
@@ -7,7 +7,7 @@ import { IOStackNavigationRouteProps } from "../../../../navigation/params/AppPa
 import { useIODispatch, useIOSelector } from "../../../../store/hooks";
 import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
 import { logosForService } from "../../common/utils";
-import { getServiceCTA, handleCtaAction } from "../../../messages/utils/ctas";
+import { getServiceCTAs, handleCtaAction } from "../../../messages/utils/ctas";
 import { useFIMSFromServiceId } from "../../../fims/common/hooks";
 import { ServiceDetailsScreenComponent } from "../components/ServiceDetailsScreenComponent";
 import { CTA } from "../../../messages/types/MessageCTA";
@@ -83,8 +83,8 @@ export const ServiceDetailsScreen = ({ route }: ServiceDetailsScreenProps) => {
   );
 
   const serviceCtas = useMemo(
-    () => getServiceCTA(serviceMetadata),
-    [serviceMetadata]
+    () => getServiceCTAs(serviceId, serviceMetadata),
+    [serviceId, serviceMetadata]
   );
 
   const { startFIMSAuthenticationFlow } = useFIMSFromServiceId(serviceId);


### PR DESCRIPTION
## Short description
This PR fixes the tracking of the CTA decoding failure event, which was sent even for messages and services with no CTAs.

## List of changes proposed in this pull request
- Such event is sent only when an exception or a failure occurs.

## How to test
CI tests should succeed. Using the io-dev-api-server, check that the event is not raised for normal messages.
