### PR TITLE
fix: [IOCOM-2279] logout misbehaviour for SEND banner dismissal

### DIFF
--- a/ts/features/pn/reminderBanner/reducer/__test__/bannerDismiss.test.ts
+++ b/ts/features/pn/reminderBanner/reducer/__test__/bannerDismiss.test.ts
@@ -1,5 +1,10 @@
+import { createStore } from "redux";
 import { PersistPartial } from "redux-persist";
 import { applicationChangeState } from "../../../../../store/actions/application";
+import {
+  logoutFailure,
+  logoutSuccess
+} from "../../../../../store/actions/authentication";
 import { isPnEnabledSelector } from "../../../../../store/reducers/backendStatus/remoteConfig";
 import { GlobalState } from "../../../../../store/reducers/types";
 import { dismissPnActivationReminderBanner } from "../../../store/actions";
@@ -43,6 +48,19 @@ describe("persistedPnBannerDismissReducer", () => {
     // @ts-expect-error: action type is not supported
     const state = persistedPnBannerDismissReducer(initialState, action);
     expect(state).toEqual(initialState);
+  });
+  ["success", "failure"].forEach(type => {
+    it(`should reset state on logout ${type}`, () => {
+      const store = createStore(persistedPnBannerDismissReducer);
+      store.dispatch(dismissPnActivationReminderBanner());
+      expect(store.getState()).toEqual({ dismissed: true });
+      store.dispatch(
+        type === "success"
+          ? logoutSuccess()
+          : logoutFailure({ error: new Error() })
+      );
+      expect(store.getState()).toEqual({ dismissed: false });
+    });
   });
 });
 

--- a/ts/features/pn/reminderBanner/reducer/bannerDismiss.ts
+++ b/ts/features/pn/reminderBanner/reducer/bannerDismiss.ts
@@ -5,6 +5,10 @@ import { Action } from "../../../../store/actions/types";
 import { dismissPnActivationReminderBanner } from "../../store/actions";
 import { GlobalState } from "../../../../store/reducers/types";
 import { isPnEnabledSelector } from "../../../../store/reducers/backendStatus/remoteConfig";
+import {
+  logoutFailure,
+  logoutSuccess
+} from "../../../../store/actions/authentication";
 
 export type PnBannerDismissState = {
   dismissed: boolean;
@@ -22,6 +26,10 @@ const pnBannerDismissReducer = (
       return {
         dismissed: true
       };
+    // this forces the persistence to update, avoiding misbehaviours because of a dirty cache
+    case getType(logoutSuccess):
+    case getType(logoutFailure):
+      return INITIAL_STATE;
   }
   return state;
 };

--- a/ts/features/pn/reminderBanner/reducer/bannerDismiss.ts
+++ b/ts/features/pn/reminderBanner/reducer/bannerDismiss.ts
@@ -26,7 +26,8 @@ const pnBannerDismissReducer = (
       return {
         dismissed: true
       };
-    // this forces the persistence to update, avoiding misbehaviours because of a dirty cache
+    // Logout changes are handled here in order to make
+    // sure that they are immediately persisted
     case getType(logoutSuccess):
     case getType(logoutFailure):
       return INITIAL_STATE;

--- a/ts/store/reducers/index.ts
+++ b/ts/store/reducers/index.ts
@@ -277,6 +277,10 @@ export function createRootReducer(
                 ...state.features.itWallet
               },
               pn: {
+                // Logout changes are already handled in PN's reducer.
+                // This way, we make sure that if the user leaves the application
+                // before the persistance is updated, we do not find ourselves
+                // with a dirty state.
                 ...state.features.pn
               },
               _persist: state.features._persist

--- a/ts/store/reducers/index.ts
+++ b/ts/store/reducers/index.ts
@@ -277,11 +277,7 @@ export function createRootReducer(
                 ...state.features.itWallet
               },
               pn: {
-                ...state.features.pn,
-                bannerDismiss: {
-                  ...state.features.pn.bannerDismiss,
-                  dismissed: false
-                }
+                ...state.features.pn
               },
               _persist: state.features._persist
             },


### PR DESCRIPTION
## Short description
proposed fix for said misbehaviour

## List of changes proposed in this pull request
- updated reducer
- updated root reducer behaviour for SEND's part
- required tests

## How to test
using the dev-server, and using physical devices and emulators, make sure that after the following sequence:
- login
- banner dismissal
- quit+reopen app (banner should still not be shown)
- logout, login again without quitting the app (banner should now be shown)
- quit and reopen app

the banner correctly gets shown
