### PR TITLE
fix: [IOBP-1528] Receipt organization fiscal code mixpanel tracking

### DIFF
--- a/ts/features/payments/common/types/PaymentAnalytics.ts
+++ b/ts/features/payments/common/types/PaymentAnalytics.ts
@@ -24,6 +24,7 @@ export type PaymentAnalyticsData = {
   receiptFirstTimeOpening?: boolean;
   receiptFirstTimeOpeningPDF?: boolean;
   receiptOrganizationName?: string;
+  receiptOrganizationFiscalCode?: string;
   receiptPayerFiscalCode?: string;
 };
 

--- a/ts/features/payments/history/store/reducers/index.ts
+++ b/ts/features/payments/history/store/reducers/index.ts
@@ -231,6 +231,8 @@ const reducer = (
         ...state,
         analyticsData: {
           ...state.analyticsData,
+          receiptOrganizationFiscalCode:
+            action.payload.carts?.[0]?.payee?.taxCode,
           receiptOrganizationName: action.payload.carts?.[0]?.payee?.name,
           receiptPayerFiscalCode: action.payload.infoNotice?.payer?.taxCode
         }

--- a/ts/features/payments/receipts/screens/ReceiptPreviewScreen.tsx
+++ b/ts/features/payments/receipts/screens/ReceiptPreviewScreen.tsx
@@ -40,7 +40,7 @@ const ReceiptPreviewScreen = () => {
     analytics.trackPaymentsDownloadReceiptSuccess({
       organization_name: paymentAnalyticsData?.receiptOrganizationName,
       organization_fiscal_code:
-        paymentAnalyticsData?.verifiedData?.paFiscalCode,
+        paymentAnalyticsData?.receiptOrganizationFiscalCode,
       first_time_opening: paymentAnalyticsData?.receiptFirstTimeOpeningPDF,
       user: paymentAnalyticsData?.receiptUser
     });
@@ -61,7 +61,8 @@ const ReceiptPreviewScreen = () => {
       organization_name: paymentAnalyticsData?.receiptOrganizationName,
       first_time_opening: paymentAnalyticsData?.receiptFirstTimeOpening,
       user: paymentAnalyticsData?.receiptUser,
-      organization_fiscal_code: paymentAnalyticsData?.verifiedData?.paFiscalCode
+      organization_fiscal_code:
+        paymentAnalyticsData?.receiptOrganizationFiscalCode
     });
     // The file name is normalized to remove the .pdf extension on Android devices since it's added by default to the Share module
     const normalizedFilename =


### PR DESCRIPTION
## Short description
This PR fixes the `organization_fiscal_code` mixpanel property not being correctly set in some screens.

## List of changes proposed in this pull request
- Mapped the correct property to the organization's fiscal code when opening a receipt;

## How to test
When you open a receipt preview from the receipt details screen, check that the `organization_fiscal_code` sent to Mixpanel is correctly set.
