### PR TITLE
chore: [IOBP-1516] Add CGN webview landing page debug error logger

### DIFF
--- a/ts/screens/profile/CgnLandingPlayground.tsx
+++ b/ts/screens/profile/CgnLandingPlayground.tsx
@@ -41,7 +41,7 @@ const CgnLandingPlayground = () => {
   const [reloadKey, setReloadKey] = useState(0);
 
   useHeaderSecondLevel({
-    title: "CGN Landing Playground"
+    title: ""
   });
 
   return (


### PR DESCRIPTION
## Short description
This PR adds the error debug logger when the debug mode is enabled when showing the `WebviewComponent` that is used for the CGN merchants landing page discount;

## List of changes proposed in this pull request
- Dispatched the debug data log when there is any error inside the webview render;

## How to test
- Enable the debug mode;
- Open the `CGN Landing Page` playground screen;
- Type any invalid URL and a not-empty Referer;
- Check that the debug icon at the top of the screen is shown with a log;

## Preview
https://github.com/user-attachments/assets/53935a68-8144-4d34-b7f2-111d04bcc0e1


