### PR TITLE
chore: [IOPAE-1950]: Revert keyExtractor in the services search

### DIFF
--- a/ts/features/services/search/screens/SearchScreen.tsx
+++ b/ts/features/services/search/screens/SearchScreen.tsx
@@ -215,7 +215,7 @@ export const SearchScreen = () => {
           default: "on-drag"
         })}
         keyboardShouldPersistTaps="handled"
-        keyExtractor={item => item.id}
+        keyExtractor={(item, index) => `institution-${item.id}-${index}`}
         onEndReached={handleEndReached}
         onEndReachedThreshold={0.5}
         renderItem={renderItem}


### PR DESCRIPTION
## Short description
This PR reverts the recent change to the keyExtractor in the services search to prevent blank spaces when potential duplicate results are returned by AI Search.

## List of changes proposed in this pull request
- updated keyExtractor

## How to test
Using `io-dev-api-server`, navigate to the services tab. Check that the search works as expected
