### PR TITLE
chore: [IOBP-1551] Replace `GradientScrollView` with `IOScrollView`

### DIFF
--- a/ts/features/bonus/cgn/screens/merchants/CgnMerchantDetailScreen.tsx
+++ b/ts/features/bonus/cgn/screens/merchants/CgnMerchantDetailScreen.tsx
@@ -1,7 +1,6 @@
 import {
   ContentWrapper,
   Divider,
-  GradientScrollView,
   H1,
   IOSkeleton,
   IOToast,
@@ -30,6 +29,7 @@ import { Discount } from "../../../../../../definitions/cgn/merchants/Discount";
 import { Merchant } from "../../../../../../definitions/cgn/merchants/Merchant";
 import { isReady } from "../../../../../common/model/RemoteValue";
 import { IOStyles } from "../../../../../components/core/variables/IOStyles";
+import { IOScrollView } from "../../../../../components/ui/IOScrollView";
 import { useHeaderSecondLevel } from "../../../../../hooks/useHeaderSecondLevel";
 import I18n from "../../../../../i18n";
 import { useIODispatch, useIOSelector } from "../../../../../store/hooks";
@@ -203,7 +203,7 @@ const CgnMerchantDetailScreen = () => {
 // ------------------------ render utils
 
 const CgnMerchantDetailScreenSkeleton = () => (
-  <GradientScrollView primaryActionProps={undefined}>
+  <IOScrollView>
     <IOSkeleton
       shape="rectangle"
       width="100%"
@@ -222,7 +222,7 @@ const CgnMerchantDetailScreenSkeleton = () => (
     <IOSkeleton shape="rectangle" width="100%" height={170} radius={8} />
     <VSpacer size={24} />
     <ListItemHeader label="" />
-  </GradientScrollView>
+  </IOScrollView>
 );
 
 // ------------------------ styles - consts - export


### PR DESCRIPTION
## Short description
This pull request includes changes to the `CgnMerchantDetailScreen` file in order to replace the `GradientScrollView` component with the `IOScrollView` component

## List of changes proposed in this pull request
- Replaced the `GradientScrollView` component with the `IOScrollView` component in the `CgnMerchantDetailScreenSkeleton` function

## How to test
Ensure that displayed skeleton has no white gradient shadow when `CGN_MERCHANTS_DETAIL` screen is loading

## Preview

| Old | Now |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/9fd47663-1648-42da-b6a2-db114e5b2d0d"/> | <video src="https://github.com/user-attachments/assets/1595747a-8cd4-437d-a3a6-c6c391c62796"/> | 
