### PR TITLE
chore: [IOBP-1559] `payment_status` always set to `paid` – removed from analytics

### DIFF
--- a/ts/features/payments/history/store/reducers/index.ts
+++ b/ts/features/payments/history/store/reducers/index.ts
@@ -223,7 +223,6 @@ const reducer = (
       receiptsAnalytics.trackPaymentsOpenReceipt({
         organization_name: action.payload.carts?.[0]?.payee?.name,
         organization_fiscal_code: action.payload.carts?.[0]?.payee?.taxCode,
-        payment_status: "paid",
         first_time_opening: state.analyticsData?.receiptFirstTimeOpening,
         user: state.analyticsData?.receiptUser
       });

--- a/ts/features/payments/receipts/components/HideReceiptButton.tsx
+++ b/ts/features/payments/receipts/components/HideReceiptButton.tsx
@@ -23,9 +23,7 @@ const HideReceiptButton = (props: Props) => {
       organization_name: paymentAnalyticsData?.receiptOrganizationName,
       first_time_opening: paymentAnalyticsData?.receiptFirstTimeOpening,
       user: paymentAnalyticsData?.receiptUser,
-      organization_fiscal_code:
-        paymentAnalyticsData?.verifiedData?.paFiscalCode,
-      payment_status: "paid"
+      organization_fiscal_code: paymentAnalyticsData?.verifiedData?.paFiscalCode
     });
   };
 
@@ -34,9 +32,7 @@ const HideReceiptButton = (props: Props) => {
       organization_name: paymentAnalyticsData?.receiptOrganizationName,
       first_time_opening: paymentAnalyticsData?.receiptFirstTimeOpening,
       user: paymentAnalyticsData?.receiptUser,
-      organization_fiscal_code:
-        paymentAnalyticsData?.verifiedData?.paFiscalCode,
-      payment_status: "paid"
+      organization_fiscal_code: paymentAnalyticsData?.verifiedData?.paFiscalCode
     });
   };
 

--- a/ts/features/payments/receipts/screens/ReceiptDetailsScreen.tsx
+++ b/ts/features/payments/receipts/screens/ReceiptDetailsScreen.tsx
@@ -94,9 +94,7 @@ const ReceiptDetailsScreen = () => {
       organization_name: paymentAnalyticsData?.receiptOrganizationName,
       first_time_opening: paymentAnalyticsData?.receiptFirstTimeOpening,
       user: paymentAnalyticsData?.receiptUser,
-      organization_fiscal_code:
-        paymentAnalyticsData?.verifiedData?.paFiscalCode,
-      payment_status: "paid"
+      organization_fiscal_code: paymentAnalyticsData?.verifiedData?.paFiscalCode
     });
     toast.error(I18n.t("features.payments.transactions.receipt.error"));
   };
@@ -113,8 +111,7 @@ const ReceiptDetailsScreen = () => {
       organization_fiscal_code:
         paymentAnalyticsData?.verifiedData?.paFiscalCode,
       first_time_opening: paymentAnalyticsData?.receiptFirstTimeOpening,
-      user: paymentAnalyticsData?.receiptUser,
-      payment_status: "paid"
+      user: paymentAnalyticsData?.receiptUser
     });
     dispatch(
       getPaymentsReceiptDownloadAction.request({

--- a/ts/features/payments/receipts/screens/ReceiptPreviewScreen.tsx
+++ b/ts/features/payments/receipts/screens/ReceiptPreviewScreen.tsx
@@ -60,7 +60,6 @@ const ReceiptPreviewScreen = () => {
       return;
     }
     analytics.trackPaymentsSaveAndShareReceipt({
-      payment_status: "paid",
       organization_name: paymentAnalyticsData?.receiptOrganizationName,
       first_time_opening: paymentAnalyticsData?.receiptFirstTimeOpening,
       user: paymentAnalyticsData?.receiptUser,


### PR DESCRIPTION
## Short description
This pull request focus on removing the `payment_status` that is set to `paid` from various analytics tracking calls across B&P stream

## List of changes proposed in this pull request
-  Removed the `payment_status` field from the B&P mixpanel tracking

## How to test
Ensure that property `payment_status: "paid"` is no more tracked