### PR TITLE
chore: [IOBP-1561] Adjust `payment_method_selected` mixpanel property

### DIFF
--- a/ts/features/payments/home/components/PaymentsHomeUserMethodsList.tsx
+++ b/ts/features/payments/home/components/PaymentsHomeUserMethodsList.tsx
@@ -73,22 +73,24 @@ const PaymentsHomeUserMethodsList = ({ enforcedLoadingState }: Props) => {
     }
   }, [dispatch, paymentMethodsPot]);
 
-  const handleOnMethodPress = (walletId: string, isExpired: boolean) => () => {
-    analytics.trackPaymentWalletMethodDetail({
-      payment_method_selected: paymentAnalyticsData?.selectedPaymentMethod,
-      payment_method_status: isExpired ? "invalid" : "valid"
-    });
+  const handleOnMethodPress =
+    (walletId: string, isExpired: boolean, payment_method_selected?: string) =>
+    () => {
+      analytics.trackPaymentWalletMethodDetail({
+        payment_method_selected,
+        payment_method_status: isExpired ? "invalid" : "valid"
+      });
 
-    navigation.navigate(
-      PaymentsMethodDetailsRoutes.PAYMENT_METHOD_DETAILS_NAVIGATOR,
-      {
-        screen: PaymentsMethodDetailsRoutes.PAYMENT_METHOD_DETAILS_SCREEN,
-        params: {
-          walletId
+      navigation.navigate(
+        PaymentsMethodDetailsRoutes.PAYMENT_METHOD_DETAILS_NAVIGATOR,
+        {
+          screen: PaymentsMethodDetailsRoutes.PAYMENT_METHOD_DETAILS_SCREEN,
+          params: {
+            walletId
+          }
         }
-      }
-    );
-  };
+      );
+    };
 
   const handleOnAddMethodPress = () => {
     analytics.trackPaymentWalletAddStart({
@@ -114,7 +116,8 @@ const PaymentsHomeUserMethodsList = ({ enforcedLoadingState }: Props) => {
       ...getPaymentCardPropsFromWalletInfo(method),
       onPress: handleOnMethodPress(
         method.walletId,
-        getPaymentCardPropsFromWalletInfo(method)?.isExpired ?? false
+        getPaymentCardPropsFromWalletInfo(method)?.isExpired ?? false,
+        method.details?.type
       )
     })
   );


### PR DESCRIPTION
## Short description
This pull request includes changes to the `PaymentsHomeUserMethodsList` component to enhance the tracking of selected payment methods. The modifications involve updating the `handleOnMethodPress` function to accept an additional parameter for the selected payment method and adjusting the corresponding calls to this function

## List of changes proposed in this pull request
- Updated the `handleOnMethodPress` function to accept an optional `payment_method_selected` parameter for improved analytics tracking
- Modified `handleOnMethodPress` to pass the `method.details?.type` as the `payment_method_selected` parameter

## How to test
Ensure that the `payment_method_selected` now is defined when pressing a card from carousel in `Pagamenti` screen