### PR TITLE
feat: [IOBP-1563] Add remote banner specific for payment method PSP screen

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -2,7 +2,7 @@
 
 IO_BACKEND_VERSION=v16.10.2-RELEASE
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=1.0.65
+IO_SERVICES_METADATA_VERSION=IOBP-1562-add-psp-remote-banner
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.4.0
 

--- a/ts/features/payments/checkout/components/WalletPaymentPspBanner.tsx
+++ b/ts/features/payments/checkout/components/WalletPaymentPspBanner.tsx
@@ -1,0 +1,93 @@
+import { Banner, VSpacer } from "@pagopa/io-app-design-system";
+import { openAuthenticationSession } from "@pagopa/io-react-native-login-utils";
+import { useRef } from "react";
+import * as O from "fp-ts/lib/Option";
+
+import Animated, {
+  FadeIn,
+  FadeOut,
+  LinearTransition
+} from "react-native-reanimated";
+
+import { View } from "react-native";
+import { mixpanelTrack } from "../../../../mixpanel";
+import { useIODispatch, useIOSelector } from "../../../../store/hooks";
+import {
+  isPaymentsPspBannerEnabledSelector,
+  paymentsPspBannerConfigSelector
+} from "../../../../store/reducers/backendStatus/remoteConfig";
+import {
+  fallbackForLocalizedMessageKeys,
+  getFullLocale
+} from "../../../../utils/locale";
+import I18n from "../../../../i18n";
+import {
+  isPaymentsPspBannerClosedSelector,
+  walletPaymentSelectedPaymentMethodOptionSelector
+} from "../store/selectors/paymentMethods";
+import { paymentMethodPspBannerClose } from "../store/actions/orchestration";
+
+const WalletPaymentPspBanner = () => {
+  const dispatch = useIODispatch();
+  const bannerViewRef = useRef<View>(null);
+  const selectedPaymentMethodOption = useIOSelector(
+    walletPaymentSelectedPaymentMethodOptionSelector
+  );
+  const selectedPaymentMethod = O.toNullable(selectedPaymentMethodOption);
+  const selectedPaymentMethodName = selectedPaymentMethod?.name ?? "";
+  const isBannerEnabled = useIOSelector(
+    isPaymentsPspBannerEnabledSelector(selectedPaymentMethodName)
+  );
+  const isBannerClosed = useIOSelector(
+    isPaymentsPspBannerClosedSelector(selectedPaymentMethodName)
+  );
+  const bannerConfig = useIOSelector(
+    paymentsPspBannerConfigSelector(selectedPaymentMethodName)
+  );
+  const locale = getFullLocale();
+  const localeFallback = fallbackForLocalizedMessageKeys(locale);
+
+  const handleBannerPress = () => {
+    if (!bannerConfig?.action) {
+      return;
+    }
+    void mixpanelTrack("VOC_USER_EXIT", {
+      screen_name: "PAYMENT_OUTCOMECODE_MESSAGE"
+    });
+    return openAuthenticationSession(bannerConfig.action.url, "");
+  };
+
+  const handleBannerClose = () => {
+    dispatch(paymentMethodPspBannerClose(selectedPaymentMethodName));
+  };
+
+  if (!isBannerEnabled || !bannerConfig || isBannerClosed) {
+    return null;
+  }
+
+  return (
+    <>
+      <VSpacer size={8} />
+      <Animated.View
+        entering={FadeIn.duration(200)}
+        exiting={FadeOut.duration(200)}
+        layout={LinearTransition.duration(200)}
+      >
+        <Banner
+          color="neutral"
+          pictogramName="help"
+          viewRef={bannerViewRef}
+          title={bannerConfig.title?.[localeFallback]}
+          content={bannerConfig.description[localeFallback]}
+          action={bannerConfig.action?.label[localeFallback] ?? ""}
+          onPress={handleBannerPress}
+          onClose={handleBannerClose}
+          labelClose={I18n.t("global.buttons.close")}
+        />
+      </Animated.View>
+      <VSpacer size={16} />
+    </>
+  );
+};
+
+export { WalletPaymentPspBanner };

--- a/ts/features/payments/checkout/screens/WalletPaymentPickPspScreen.tsx
+++ b/ts/features/payments/checkout/screens/WalletPaymentPickPspScreen.tsx
@@ -1,6 +1,7 @@
 import {
   Body,
   H2,
+  IOStyles,
   ListItemHeader,
   RadioGroup,
   RadioItemWithAmount,
@@ -11,6 +12,7 @@ import { useFocusEffect } from "@react-navigation/native";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import Animated, { LinearTransition } from "react-native-reanimated";
 import { Bundle } from "../../../../../definitions/pagopa/ecommerce/Bundle";
 import I18n from "../../../../i18n";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
@@ -35,6 +37,7 @@ import { WalletPaymentPspSortType, WalletPaymentStepEnum } from "../types";
 import { FaultCodeCategoryEnum } from "../types/PspPaymentMethodNotAvailableProblemJson";
 import { WalletPaymentFailure } from "../types/WalletPaymentFailure";
 import { IOScrollView } from "../../../../components/ui/IOScrollView";
+import { WalletPaymentPspBanner } from "../components/WalletPaymentPspBanner";
 
 const WalletPaymentPickPspScreen = () => {
   const dispatch = useIODispatch();
@@ -205,16 +208,22 @@ const WalletPaymentPickPspScreen = () => {
           : undefined
       }
     >
-      <SelectPspHeadingContent />
-      {!isLoading && (
-        <RadioGroup<string>
-          onPress={handlePspSelection}
-          type="radioListItemWithAmount"
-          selectedItem={pspSelected?.idBundle}
-          items={getRadioItemsFromPspList(sortedPspList, showFeaturedPsp)}
-        />
-      )}
-      {isLoading && <WalletPspListSkeleton />}
+      <WalletPaymentPspBanner />
+      <Animated.View
+        style={IOStyles.flex}
+        layout={LinearTransition.duration(200)}
+      >
+        <SelectPspHeadingContent />
+        {!isLoading && (
+          <RadioGroup<string>
+            onPress={handlePspSelection}
+            type="radioListItemWithAmount"
+            selectedItem={pspSelected?.idBundle}
+            items={getRadioItemsFromPspList(sortedPspList, showFeaturedPsp)}
+          />
+        )}
+        {isLoading && <WalletPspListSkeleton />}
+      </Animated.View>
       {sortPspBottomSheet}
     </IOScrollView>
   );

--- a/ts/features/payments/checkout/store/actions/orchestration.ts
+++ b/ts/features/payments/checkout/store/actions/orchestration.ts
@@ -42,9 +42,14 @@ export const paymentCompletedSuccess = createStandardAction(
   "PAYMENTS_PAYMENT_COMPLETED_SUCCESS"
 )<PaymentCompletedSuccessPayload>();
 
+export const paymentMethodPspBannerClose = createStandardAction(
+  "PAYMENTS_PSP_BANNER_CLOSE"
+)<string>();
+
 export type PaymentsCheckoutOrchestrationActions =
   | ActionType<typeof walletPaymentSetCurrentStep>
   | ActionType<typeof initPaymentStateAction>
   | ActionType<typeof selectPaymentMethodAction>
   | ActionType<typeof selectPaymentPspAction>
-  | ActionType<typeof paymentCompletedSuccess>;
+  | ActionType<typeof paymentCompletedSuccess>
+  | ActionType<typeof paymentMethodPspBannerClose>;

--- a/ts/features/payments/checkout/store/reducers/index.ts
+++ b/ts/features/payments/checkout/store/reducers/index.ts
@@ -32,6 +32,7 @@ import {
 import {
   OnPaymentSuccessAction,
   initPaymentStateAction,
+  paymentMethodPspBannerClose,
   selectPaymentMethodAction,
   selectPaymentPspAction,
   walletPaymentSetCurrentStep
@@ -55,6 +56,7 @@ export type PaymentsCheckoutState = {
   transaction: pot.Pot<TransactionInfo, NetworkError | WalletPaymentFailure>;
   authorizationUrl: pot.Pot<string, NetworkError>;
   onSuccess?: OnPaymentSuccessAction;
+  pspBannerClosed: Set<string>;
 };
 
 const INITIAL_STATE: PaymentsCheckoutState = {
@@ -68,7 +70,8 @@ const INITIAL_STATE: PaymentsCheckoutState = {
   selectedPaymentMethod: O.none,
   selectedPsp: O.none,
   transaction: pot.none,
-  authorizationUrl: pot.none
+  authorizationUrl: pot.none,
+  pspBannerClosed: new Set()
 };
 
 // eslint-disable-next-line complexity
@@ -87,6 +90,12 @@ const reducer = (
       return {
         ...state,
         currentStep: _.clamp(action.payload, 1, WALLET_PAYMENT_STEP_MAX)
+      };
+
+    case getType(paymentMethodPspBannerClose):
+      return {
+        ...state,
+        pspBannerClosed: new Set([...state.pspBannerClosed, action.payload])
       };
 
     // Payment verification and details

--- a/ts/features/payments/checkout/store/selectors/paymentMethods.ts
+++ b/ts/features/payments/checkout/store/selectors/paymentMethods.ts
@@ -172,3 +172,9 @@ export const notHasValidPaymentMethodsSelector = createSelector(
     );
   }
 );
+
+export const isPaymentsPspBannerClosedSelector = (paymentMethodName: string) =>
+  createSelector(
+    selectPaymentsCheckoutState,
+    state => state.pspBannerClosed?.has(paymentMethodName) ?? false
+  );

--- a/ts/store/reducers/backendStatus/remoteConfig.ts
+++ b/ts/store/reducers/backendStatus/remoteConfig.ts
@@ -397,6 +397,40 @@ export const isPaymentsFeedbackBannerEnabledSelector = createSelector(
 );
 
 /**
+ * Return the remote feature flag about the payment-method-specific psp banner enabled/disabled
+ * that is shown after a successful payment.
+ */
+export const isPaymentsPspBannerEnabledSelector = (paymentMethodName: string) =>
+  createSelector(remoteConfigSelector, (remoteConfig): boolean =>
+    pipe(
+      remoteConfig,
+      O.map(config =>
+        isVersionSupported(
+          Platform.OS === "ios"
+            ? config.newPaymentSection.pspBanner?.[paymentMethodName]
+                ?.min_app_version.ios
+            : config.newPaymentSection.pspBanner?.[paymentMethodName]
+                ?.min_app_version.android,
+          getAppVersion()
+        )
+      ),
+      O.getOrElse(() => false)
+    )
+  );
+
+/**
+ * Return the remote config about the payment-method-specific psp banner
+ */
+export const paymentsPspBannerConfigSelector = (paymentMethodName: string) =>
+  createSelector(remoteConfigSelector, (remoteConfig): Banner | undefined =>
+    pipe(
+      remoteConfig,
+      O.map(config => config.newPaymentSection.pspBanner?.[paymentMethodName]),
+      O.toUndefined
+    )
+  );
+
+/**
  * Return the remote config about the payment feedback banner
  */
 export const paymentsFeedbackBannerConfigSelector = createSelector(


### PR DESCRIPTION
## ⚠️ This PR depends on https://github.com/pagopa/io-services-metadata/pull/958

## Short description
This PR adds a dismissable remote banner specific for a payment method from the PSP selection screen;

## List of changes proposed in this pull request
- A `WalletPaymentPspBanner` has been added to manage the remote configuration of banners displayed on the PSP selection screen. The banner's visibility can be controlled based on the payment method name, and its dismissal is valid for the entire payment session. Once the payment session ends, the banner may reappear if the remote configuration is enabled.
- An orchestration action `paymentMethodPspBannerClose` has been created to store the payment method names where a dismissal has occurred into a `Set`.

## How to test
- Test this PR by running the io-dev-api server with the following PR: https://github.com/pagopa/io-dev-api-server/pull/477.
- Run `yarn generate`.
- Start a payment flow in the development environment and verify that only the Bancomat Pay payment method displays the banner (you can modify which payment method shows the banner by editing the pspBanner attribute in the dev-server).
- Verify that after dismissing the banner for the first time within the same payment session, the banner is no longer displayed.
- Check that if you initiate a new payment flow in a different session, the banner is displayed again for that payment method.

## Preview

https://github.com/user-attachments/assets/4e29b84a-f4cf-4207-b0e4-3f564c2dba95

