### PR TITLE
feat(IT Wallet): [SIW-2207] Remote presentation, inactive IT-Wallet failure screen

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -4606,10 +4606,13 @@
             "subtitle": "Attendi qualche secondo"
           },
           "walletInactiveScreen": {
-            "title": "Attiva Documenti su IO per continuare",
-            "subtitle": "Per accedere con IT Wallet ai servizi online è necessario prima attivare la funzionalità Documenti su IO.",
-            "primaryAction": "Inizia",
-            "secondaryAction": "Non ora"
+            "title": "Ottieni IT-Wallet per \ncontinuare",
+            "subtitle": "Per accedere ai servizi online è necessario attivare IT-Wallet utilizzando la tua Carta di Identità Elettronica (CIE) e il PIN.",
+            "primaryAction": "Ottieni IT-Wallet",
+            "secondaryAction": "Non ora",
+            "alert": {
+              "body": "Non potrai completare l'accesso ai servizi online."
+            }
           },
           "missingCredentialsScreen": {
             "title": "Mancano i dati contenuti in {{credentialName}}",

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -4606,10 +4606,13 @@
             "subtitle": "Attendi qualche secondo"
           },
           "walletInactiveScreen": {
-            "title": "Attiva Documenti su IO per continuare",
-            "subtitle": "Per accedere con IT Wallet ai servizi online è necessario prima attivare la funzionalità Documenti su IO.",
-            "primaryAction": "Inizia",
-            "secondaryAction": "Non ora"
+            "title": "Ottieni IT-Wallet per \ncontinuare",
+            "subtitle": "Per accedere ai servizi online è necessario attivare IT-Wallet utilizzando la tua Carta di Identità Elettronica (CIE) e il PIN.",
+            "primaryAction": "Ottieni IT-Wallet",
+            "secondaryAction": "Non ora",
+            "alert": {
+              "body": "Non potrai completare l'accesso ai servizi online."
+            }
           },
           "missingCredentialsScreen": {
             "title": "Mancano i dati contenuti in {{credentialName}}",

--- a/ts/features/itwallet/common/hooks/useItwDismissalDialog.tsx
+++ b/ts/features/itwallet/common/hooks/useItwDismissalDialog.tsx
@@ -3,19 +3,28 @@ import { useHardwareBackButton } from "../../../../hooks/useHardwareBackButton";
 import I18n from "../../../../i18n";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 
+type ItwDismissalDialogProps = {
+  handleDismiss?: () => void;
+  customBodyMessage?: string;
+};
+
 /**
  * Allows to show a dismissal dialog in which the user must confirm the desire to close the current flow.
  * This hook also handles the hardware back button to show the dialog when the user presses the back button.
  * @param handleDismiss - An optionalfunction that will be called when the user confirms the dismissal.
+ * @param customBodyMessage - An optional custom message to be shown in the dialog body.
  * @returns a function that can be used to show the dialog
  */
-export const useItwDismissalDialog = (handleDismiss?: () => void) => {
+export const useItwDismissalDialog = (props?: ItwDismissalDialogProps) => {
   const navigation = useIONavigation();
+
+  const handleDismiss = props?.handleDismiss;
+  const customBodyMessage = props?.customBodyMessage;
 
   const show = () =>
     Alert.alert(
       I18n.t("features.itWallet.generic.alert.title"),
-      I18n.t("features.itWallet.generic.alert.body"),
+      customBodyMessage || I18n.t("features.itWallet.generic.alert.body"),
       [
         {
           text: I18n.t("features.itWallet.generic.alert.confirm"),

--- a/ts/features/itwallet/identification/screens/cie/ItwCieCardReaderScreen.tsx
+++ b/ts/features/itwallet/identification/screens/cie/ItwCieCardReaderScreen.tsx
@@ -174,9 +174,9 @@ export const ItwCieCardReaderScreen = () => {
   const blueColorName = useInteractiveElementDefaultColorName();
   const isScreenReaderEnabled = useScreenReaderEnabled();
 
-  const dismissalDialog = useItwDismissalDialog(() =>
-    machineRef.send({ type: "close" })
-  );
+  const dismissalDialog = useItwDismissalDialog({
+    handleDismiss: () => machineRef.send({ type: "close" })
+  });
 
   const handleAccessibilityAnnouncement = (
     event: Cie.CieEvent | Cie.CieError

--- a/ts/features/itwallet/identification/screens/cieId/ItwCieIdLoginScreen.tsx
+++ b/ts/features/itwallet/identification/screens/cieId/ItwCieIdLoginScreen.tsx
@@ -38,9 +38,9 @@ const ItwCieIdLoginScreen = () => {
   const machineRef = ItwEidIssuanceMachineContext.useActorRef();
   const [isWebViewLoading, setWebViewLoading] = useState(true);
 
-  const dismissalDialog = useItwDismissalDialog(() =>
-    machineRef.send({ type: "back" })
-  );
+  const dismissalDialog = useItwDismissalDialog({
+    handleDismiss: () => machineRef.send({ type: "back" })
+  });
 
   const {
     authUrl,

--- a/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialPreviewScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialPreviewScreen.tsx
@@ -90,10 +90,11 @@ const ContentView = ({ credentialType, credential }: ContentViewProps) => {
   useFocusEffect(() => {
     trackCredentialPreview(mixPanelCredential);
   });
-
-  const dismissDialog = useItwDismissalDialog(() => {
-    machineRef.send({ type: "close" });
-    trackItwExit({ exit_page: route.name, credential: mixPanelCredential });
+  const dismissDialog = useItwDismissalDialog({
+    handleDismiss: () => {
+      machineRef.send({ type: "close" });
+      trackItwExit({ exit_page: route.name, credential: mixPanelCredential });
+    }
   });
 
   const handleSaveToWallet = () => {

--- a/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialTrustIssuerScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialTrustIssuerScreen.tsx
@@ -107,12 +107,14 @@ const ContentView = ({ credentialType, eid }: ContentViewProps) => {
     machineRef.send({ type: "confirm-trust-data" });
   };
 
-  const dismissDialog = useItwDismissalDialog(() => {
-    machineRef.send({ type: "close" });
-    trackItwExit({
-      exit_page: route.name,
-      credential: CREDENTIALS_MAP[credentialType]
-    });
+  const dismissDialog = useItwDismissalDialog({
+    handleDismiss: () => {
+      machineRef.send({ type: "close" });
+      trackItwExit({
+        exit_page: route.name,
+        credential: CREDENTIALS_MAP[credentialType]
+      });
+    }
   });
 
   useHeaderSecondLevel({ title: "", goBack: dismissDialog.show });

--- a/ts/features/itwallet/issuance/screens/ItwIssuanceEidPreviewScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceEidPreviewScreen.tsx
@@ -95,9 +95,11 @@ const ContentView = ({ eid }: ContentViewProps) => {
     parsedCredential: eid.parsedCredential
   });
 
-  const dismissDialog = useItwDismissalDialog(() => {
-    machineRef.send({ type: "close" });
-    trackItwExit({ exit_page: route.name, credential: mixPanelCredential });
+  const dismissDialog = useItwDismissalDialog({
+    handleDismiss: () => {
+      machineRef.send({ type: "close" });
+      trackItwExit({ exit_page: route.name, credential: mixPanelCredential });
+    }
   });
 
   const handleSaveToWallet = () => {

--- a/ts/features/itwallet/presentation/remote/screens/ItwRemoteFailureScreen.tsx
+++ b/ts/features/itwallet/presentation/remote/screens/ItwRemoteFailureScreen.tsx
@@ -15,6 +15,7 @@ import I18n from "../../../../../i18n.ts";
 import { getCredentialNameFromType } from "../../../common/utils/itwCredentialUtils.ts";
 import { useIONavigation } from "../../../../../navigation/params/AppParamsList.ts";
 import { ITW_ROUTES } from "../../../navigation/routes.ts";
+import { useItwDismissalDialog } from "../../../common/hooks/useItwDismissalDialog.tsx";
 
 export const ItwRemoteFailureScreen = () => {
   const failureOption =
@@ -37,6 +38,13 @@ const ContentView = ({ failure }: ContentViewProps) => {
 
   useDebugInfo({
     failure: serializeFailureReason(failure)
+  });
+
+  const dismissalDialog = useItwDismissalDialog({
+    handleDismiss: () => machineRef.send({ type: "close" }),
+    customBodyMessage: I18n.t(
+      "features.itWallet.presentation.remote.walletInactiveScreen.alert.body"
+    )
   });
 
   const getOperationResultScreenContentProps =
@@ -72,7 +80,7 @@ const ContentView = ({ failure }: ContentViewProps) => {
               label: I18n.t(
                 "features.itWallet.presentation.remote.walletInactiveScreen.secondaryAction"
               ),
-              onPress: () => machineRef.send({ type: "close" })
+              onPress: dismissalDialog.show
             }
           };
         case RemoteFailureType.MISSING_CREDENTIALS: {


### PR DESCRIPTION
## Short description
This PR modifies the copy for the `ItwRemoteFailureScreen` in the case of an inactive wallet. 
Show an alert using `useItwDismissalDialog`, in case you want to exit from the remote presentation flow
## List of changes proposed in this pull request
- Updated the copy for the `ItwRemoteFailureScreen` in the wallet inactive case
- Modified `useItwDismissalDialog` to accept a custom body message.

## How to test
Without IT-Wallet scan a valid QR code for remote presentation, check that the screen displayed is correct and clicking get “IT-Wallet” takes you to the activation flow. Clicking “Not now” should display the alert asking for confirmation to close the process or not.




https://github.com/user-attachments/assets/7fbe24b0-7e7d-499f-bf48-58a2feb0ea3e




