### PR TITLE
feat(IT Wallet): [SIW-2208] Remote presentation, update copy eID expired screen

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -4625,7 +4625,7 @@
           },
           "eidExpiredScreen": {
             "title": "Verifica la tua identità",
-            "subtitle": "È un passaggio di verifica necessario per continuare ad usare Documenti su IO per autenticarti.",
+            "subtitle": "È un passaggio di verifica necessario per continuare ad usare IT-Wallet e per autenticarti.",
             "primaryAction": "Inizia",
             "secondaryAction": "Annulla"
           }

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -4625,7 +4625,7 @@
           },
           "eidExpiredScreen": {
             "title": "Verifica la tua identità",
-            "subtitle": "È un passaggio di verifica necessario per continuare ad usare Documenti su IO per autenticarti.",
+            "subtitle": "È un passaggio di verifica necessario per continuare ad usare IT-Wallet e per autenticarti.",
             "primaryAction": "Inizia",
             "secondaryAction": "Annulla"
           }


### PR DESCRIPTION
## Short description
This PR updates the copy for the screen indicating that the user's eID has expired in the remote presentation flow.

## List of changes proposed in this pull request
- Update copy in `ItwRemoteFailureScreen`, `EID_EXPIRED` case

## How to test
Verify that the error screen is the same as the one on Figma


https://github.com/user-attachments/assets/fee391f8-cdef-446b-8709-148c1d53f977

