### PR TITLE
fix: [IOPID-2949] keep `cie` and `connectivityStatus` after logout

### DIFF
--- a/ts/store/reducers/index.ts
+++ b/ts/store/reducers/index.ts
@@ -203,6 +203,10 @@ export function createRootReducer(
 
               _persist: state.authentication._persist
             },
+            // cie status must be kept
+            cie: {
+              ...state.cie
+            },
             // backend status must be kept
             backendInfo: state.backendInfo,
             remoteConfig: state.remoteConfig,
@@ -223,6 +227,10 @@ export function createRootReducer(
               _persist: state.entities._persist
             },
             features: {
+              // connectivityStatus must be kept
+              connectivityStatus: {
+                ...state.features.connectivityStatus
+              },
               appFeedback: {
                 ...appFeedbackInitialState,
                 _persist: state.features.appFeedback._persist


### PR DESCRIPTION
## Short description
This PR fixes a regression where logging in after a logout would freeze until the `connectivityStatus` was updated.

Bonus Fix: It also ensures the `cie` status is preserved. Without this, citizens were not given the option to choose between EIC+PIN and CieID login methods.

<details><summary>Details</summary>
<p>

| ❌ | ✅ |
| - | - |
| <video src="https://github.com/user-attachments/assets/c62a5894-2076-4043-9d81-803704d60caa" /> | <video src="https://github.com/user-attachments/assets/1660169d-f57a-4ec8-ba85-7f921088a019" />

</p>

</details> 

## List of changes proposed in this pull request
- Keep `cie` and `connectivityStatus` after a logout.

## How to test

1. Launch the app and perform a successful login.
2. Logout from the app.
3. Attempt to log in again.

✅ You should be able to access the app immediately without encountering any blocking or frozen screen.
