### PR TITLE
feat(IT Wallet): [SIW-2279]  Add Informative Offline Usage Banner

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -4293,6 +4293,11 @@
             "content": "Da oggi puoi aggiungere al Portafoglio di IO la versione digitale dei tuoi documenti!",
             "action": "Inizia"
           },
+          "homeWithOffline": {
+            "title": "Novità: Documenti su IO, anche offline",
+            "content": "Da oggi puoi aggiungere al Portafoglio di IO i tuoi documenti digitali, disponibili anche senza connessione a internet.",
+            "action": "Attiva Documenti su IO"
+          },
           "homeActive": {
             "title": "Riattiva Documenti su IO",
             "content": "Per ragioni di sicurezza, quando cambi dispositivo o rimuovi l’app, devi aggiungere di nuovo i tuoi documenti al Portafoglio.",
@@ -4319,6 +4324,11 @@
           "title": "Documenti su IO è già attiva",
           "content": "Continua ad aggiungere le versioni digitali dei tuoi documenti al Portafoglio.",
           "action": "Vai al Portafoglio"
+        },
+        "offlineBanner": {
+          "title": "Novità: i tuoi documenti anche offline",
+          "content": "Da oggi puoi usare i tuoi documenti su IO anche senza connessione a internet.",
+          "action": "Scopri di più"
         }
       },
       "identification": {

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -4293,6 +4293,11 @@
             "content": "Da oggi puoi aggiungere al Portafoglio di IO la versione digitale dei tuoi documenti!",
             "action": "Inizia"
           },
+          "homeWithOffline": {
+            "title": "Novità: Documenti su IO, anche offline",
+            "content": "Da oggi puoi aggiungere al Portafoglio di IO i tuoi documenti digitali, disponibili anche senza connessione a internet.",
+            "action": "Attiva Documenti su IO"
+          },
           "homeActive": {
             "title": "Riattiva Documenti su IO",
             "content": "Per ragioni di sicurezza, quando cambi dispositivo o rimuovi l’app, devi aggiungere di nuovo i tuoi documenti al Portafoglio.",
@@ -4319,6 +4324,11 @@
           "title": "Documenti su IO è già attiva",
           "content": "Continua ad aggiungere le versioni digitali dei tuoi documenti al Portafoglio.",
           "action": "Vai al Portafoglio"
+        },
+        "offlineBanner": {
+          "title": "Novità: i tuoi documenti anche offline",
+          "content": "Da oggi puoi usare i tuoi documenti su IO anche senza connessione a internet.",
+          "action": "Scopri di più"
         }
       },
       "identification": {

--- a/ts/features/itwallet/common/components/ItwOfflineWalletBanner.tsx
+++ b/ts/features/itwallet/common/components/ItwOfflineWalletBanner.tsx
@@ -1,0 +1,33 @@
+import { Banner } from "@pagopa/io-app-design-system";
+import I18n from "../../../../i18n";
+import { useIOSelector } from "../../../../store/hooks";
+import { isItwOfflineAccessEnabledSelector } from "../../../../store/reducers/persistedPreferences.ts";
+import { itwLifecycleIsValidSelector } from "../../lifecycle/store/selectors";
+
+export const ItwOfflineWalletBanner = () => {
+  const isOfflineAccessEnabled = useIOSelector(
+    isItwOfflineAccessEnabledSelector
+  );
+  const isWalletValid = useIOSelector(itwLifecycleIsValidSelector);
+
+  // Show the banner only if offline access is enabled and the wallet is valid
+  if (!isOfflineAccessEnabled || !isWalletValid) {
+    return null;
+  }
+
+  const handlePress = () => {
+    // TODO: [SIW-2309] Implement action when the FAQ are ready
+  };
+
+  return (
+    <Banner
+      testID="itwOfflineWalletBannerTestID"
+      title={I18n.t("features.itWallet.discovery.offlineBanner.title")}
+      content={I18n.t("features.itWallet.discovery.offlineBanner.content")}
+      action={I18n.t("features.itWallet.discovery.offlineBanner.action")}
+      pictogramName="notification"
+      color="neutral"
+      onPress={handlePress}
+    />
+  );
+};

--- a/ts/features/itwallet/common/components/discoveryBanner/ItwDiscoveryBanner.tsx
+++ b/ts/features/itwallet/common/components/discoveryBanner/ItwDiscoveryBanner.tsx
@@ -11,9 +11,10 @@ import {
   trackITWalletBannerVisualized
 } from "../../../analytics";
 import { ITW_ROUTES } from "../../../navigation/routes";
-import { useIODispatch } from "../../../../../store/hooks";
+import { useIODispatch, useIOSelector } from "../../../../../store/hooks";
 import { itwCloseDiscoveryBanner } from "../../store/actions/preferences";
 import { useItwDiscoveryBannerType } from "../../hooks/useItwDiscoveryBannerType.ts";
+import { isItwOfflineAccessEnabledSelector } from "../../../../../store/reducers/persistedPreferences.ts";
 
 /**
  * to use in flows where we want to handle the banner's visibility logic externally
@@ -38,6 +39,9 @@ export const ItwDiscoveryBanner = ({
   const navigation = useIONavigation();
   const route = useRoute();
   const bannerType = useItwDiscoveryBannerType();
+  const isOfflineAccessEnabled = useIOSelector(
+    isItwOfflineAccessEnabledSelector
+  );
 
   const trackBannerProperties = useMemo(
     () => ({
@@ -67,11 +71,24 @@ export const ItwDiscoveryBanner = ({
   };
 
   const bannerConfig = {
-    onboarding: {
-      content: I18n.t("features.itWallet.discovery.banner.home.content"),
-      title: I18n.t("features.itWallet.discovery.banner.home.title"),
-      action: I18n.t("features.itWallet.discovery.banner.home.action")
-    },
+    // TODO: Once offline access is fully integrated, the "homeWithOffline" copy can be merged into "home" and this dynamic logic can be removed.
+    onboarding: isOfflineAccessEnabled
+      ? {
+          content: I18n.t(
+            "features.itWallet.discovery.banner.homeWithOffline.content"
+          ),
+          title: I18n.t(
+            "features.itWallet.discovery.banner.homeWithOffline.title"
+          ),
+          action: I18n.t(
+            "features.itWallet.discovery.banner.homeWithOffline.action"
+          )
+        }
+      : {
+          content: I18n.t("features.itWallet.discovery.banner.home.content"),
+          title: I18n.t("features.itWallet.discovery.banner.home.title"),
+          action: I18n.t("features.itWallet.discovery.banner.home.action")
+        },
     reactivating: {
       content: I18n.t("features.itWallet.discovery.banner.homeActive.content"),
       title: I18n.t("features.itWallet.discovery.banner.homeActive.title"),

--- a/ts/features/wallet/components/WalletCardsContainer.tsx
+++ b/ts/features/wallet/components/WalletCardsContainer.tsx
@@ -18,6 +18,7 @@ import {
   shouldRenderWalletEmptyStateSelector
 } from "../store/selectors";
 import { withWalletCategoryFilter } from "../utils";
+import { ItwOfflineWalletBanner } from "../../itwallet/common/components/ItwOfflineWalletBanner.tsx";
 import { WalletCardSkeleton } from "./WalletCardSkeleton";
 import { WalletCardsCategoryContainer } from "./WalletCardsCategoryContainer";
 import { WalletCardsCategoryRetryErrorBanner } from "./WalletCardsCategoryRetryErrorBanner";
@@ -69,6 +70,7 @@ const WalletCardsContainer = () => {
       style={IOStyles.flex}
       layout={LinearTransition.duration(200)}
     >
+      <ItwOfflineWalletBanner />
       <ItwWalletNotAvailableBanner />
       <ItwDiscoveryBannerStandalone />
       {walletContent}

--- a/ts/features/wallet/components/__tests__/WalletCardsContainer.test.tsx
+++ b/ts/features/wallet/components/__tests__/WalletCardsContainer.test.tsx
@@ -30,6 +30,7 @@ import {
 } from "../WalletCardsContainer";
 import I18n from "../../../../i18n";
 import { ITW_ROUTES } from "../../../itwallet/navigation/routes";
+import * as persistedSelectors from "../../../../store/reducers/persistedPreferences.ts";
 
 jest.spyOn(Alert, "alert");
 jest.mock("react-native-reanimated", () => ({
@@ -509,6 +510,32 @@ describe("OtherWalletCardsContainer", () => {
 
     expect(AppReview.requestReview).toHaveBeenCalledTimes(1);
   });
+
+  it.each`
+    isWalletValid | isOfflineEnabled | shouldRenderBanner
+    ${true}       | ${true}          | ${true}
+    ${false}      | ${true}          | ${false}
+    ${true}       | ${false}         | ${false}
+  `(
+    "should render banner: $shouldRenderBanner when wallet valid: $isWalletValid and offline enabled: $isOfflineEnabled",
+    ({ isWalletValid, isOfflineEnabled, shouldRenderBanner }) => {
+      jest
+        .spyOn(itwLifecycleSelectors, "itwLifecycleIsValidSelector")
+        .mockImplementation(() => isWalletValid);
+
+      jest
+        .spyOn(persistedSelectors, "isItwOfflineAccessEnabledSelector")
+        .mockImplementation(() => isOfflineEnabled);
+
+      const { queryByTestId } = renderComponent(WalletCardsContainer);
+
+      if (shouldRenderBanner) {
+        expect(queryByTestId(`itwOfflineWalletBannerTestID`)).not.toBeNull();
+      } else {
+        expect(queryByTestId(`itwOfflineWalletBannerTestID`)).toBeNull();
+      }
+    }
+  );
 });
 
 const renderComponent = (component: ComponentType<any>) => {


### PR DESCRIPTION
## Short description
This PR adds the banner related to the offline usage of the wallet.

## List of changes proposed in this pull request
- Change the copy of `ItwDiscoveryBanner` when the banner type is `onboarding` and `isItwOfflineAccessEnabledSelector` is `true`
- Add a new banner `ItwOfflineWalletBanner`, which is rendered when `isItwOfflineAccessEnabledSelector` is `true` and the wallet is valid (`itwLifecycleIsValidSelector` is `true`)
- Add test in` ItwWalletCardsContainer.test.tsx`


## How to test
Enable offline access in the "Documenti su IO" playground. If you have already activated "Documenti su IO," you should see the new banner informing you about offline usage. If you do not have it activated, you should see the updated copy of the discovery banner.

**Active and valid WI**

<img width="399" alt="Screenshot 2025-04-28 at 15 40 36" src="https://github.com/user-attachments/assets/dcb0b69a-0ad6-42db-94b9-a9ec0c94a0f7" />


**Never any WI**

<img width="399" alt="Screenshot 2025-04-28 at 15 38 20" src="https://github.com/user-attachments/assets/5371a82a-99eb-4877-ad6b-efbc36274811" />