### PR TITLE
chore: [IOBP-1606,IOBP-1609] Handled the payments ongoing error during the payment flow

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -2420,6 +2420,14 @@
           "subtitle": "Riprova più tardi. Se il problema persiste, contatta l’assistenza."
         },
         "PAYMENT_ONGOING": {
+          "PAA_PAGAMENTO_IN_CORSO": {
+            "title": "C’è già un’operazione in corso, riprova più tardi",
+            "subtitle": "Se il problema persiste, puoi aprire una segnalazione."
+          },
+          "PPT_PAGAMENTO_IN_CORSO": {
+            "title": "C’è già un’operazione in corso, riprova più tardi",
+            "subtitle": "Se il problema persiste, puoi aprire una segnalazione."
+          },
           "title": "C’è già un’operazione in corso, riprova più tardi",
           "subtitle": "Se il problema persiste, puoi aprire una segnalazione."
         },

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -2420,6 +2420,14 @@
           "subtitle": "Riprova più tardi. Se il problema persiste, contatta l’assistenza."
         },
         "PAYMENT_ONGOING": {
+          "PAA_PAGAMENTO_IN_CORSO": {
+            "title": "C’è già un’operazione in corso, riprova più tardi",
+            "subtitle": "Se il problema persiste, puoi aprire una segnalazione."
+          },
+          "PPT_PAGAMENTO_IN_CORSO": {
+            "title": "C’è già un’operazione in corso, riprova più tardi",
+            "subtitle": "Se il problema persiste, puoi aprire una segnalazione."
+          },
           "title": "C’è già un’operazione in corso, riprova più tardi",
           "subtitle": "Se il problema persiste, puoi aprire una segnalazione."
         },

--- a/ts/features/payments/checkout/analytics/index.ts
+++ b/ts/features/payments/checkout/analytics/index.ts
@@ -106,7 +106,7 @@ export const getPaymentAnalyticsEventFromRequestFailure = (
     case "DOMAIN_UNKNOWN":
       return "PAYMENT_ORGANIZATION_ERROR";
     case "PAYMENT_ONGOING":
-      return "PAYMENT_ONGOING_ERROR";
+      return failure.faultCodeDetail ?? "PAYMENT_ONGOING_ERROR";
     case "PAYMENT_EXPIRED":
       return "PAYMENT_EXPIRED_ERROR";
     case "PAYMENT_CANCELED":

--- a/ts/features/payments/checkout/components/WalletPaymentFailureDetail.tsx
+++ b/ts/features/payments/checkout/components/WalletPaymentFailureDetail.tsx
@@ -134,7 +134,8 @@ const WalletPaymentFailureDetail = ({ failure }: Props) => {
     };
 
   const getPropsFromFailure = ({
-    faultCodeCategory
+    faultCodeCategory,
+    faultCodeDetail
   }: WalletPaymentFailure): OperationResultScreenContentProps => {
     switch (faultCodeCategory) {
       case "PAYMENT_UNAVAILABLE":
@@ -160,6 +161,29 @@ const WalletPaymentFailureDetail = ({ failure }: Props) => {
           secondaryAction: contactSupportAction
         };
       case "PAYMENT_ONGOING":
+        if (faultCodeDetail === "PAA_PAGAMENTO_IN_CORSO") {
+          return {
+            pictogram: "timing",
+            title: I18n.t(
+              "wallet.payment.failure.PAYMENT_ONGOING.PAA_PAGAMENTO_IN_CORSO.title"
+            ),
+            subtitle: I18n.t(
+              "wallet.payment.failure.PAYMENT_ONGOING.PAA_PAGAMENTO_IN_CORSO.subtitle"
+            ),
+            action: closeAction
+          };
+        } else if (faultCodeDetail === "PPT_PAGAMENTO_IN_CORSO") {
+          return {
+            pictogram: "timing",
+            title: I18n.t(
+              "wallet.payment.failure.PAYMENT_ONGOING.PPT_PAGAMENTO_IN_CORSO.title"
+            ),
+            subtitle: I18n.t(
+              "wallet.payment.failure.PAYMENT_ONGOING.PPT_PAGAMENTO_IN_CORSO.subtitle"
+            ),
+            action: closeAction
+          };
+        }
         return {
           pictogram: "timing",
           title: I18n.t("wallet.payment.failure.PAYMENT_ONGOING.title"),


### PR DESCRIPTION
## ⚠️ Waiting for the design and mixpanel events

## Short description
This PR handles the payments ongoing error with a more specific distinction based on the `faultCodeDetails` attribute.

## List of changes proposed in this pull request
- Added the `faultCodeDetails` handling when the `faultCodeCategory` is `PAYMENT_ONGOING`;
- Mapped on mixpanel the correct event based on the `faultCodeDetails` when the category is `PAYMENT_ONGOING`;

## How to test
- Mock the dev-server response when executing the `verify` API to return as response the faultCodeCategory: `PAYMENT_ONGOING` and specify the `faultCodeDetails` between `PPT_PAGAMENTO_IN_CORSO` or `PAA_PAGAMENTO_IN_CORSO`
