### PR TITLE
feat: [IOCOM-2334] services reducer and selectors refactor

### DIFF
--- a/ts/features/bonus/cdc/hooks/useSpecialCtaCdc.tsx
+++ b/ts/features/bonus/cdc/hooks/useSpecialCtaCdc.tsx
@@ -7,6 +7,7 @@ import { isCdcAppVersionSupportedSelector } from "../../../../store/reducers/bac
 import { useServicePreferenceByChannel } from "../../../services/details/hooks/useServicePreference";
 import { loadAvailableBonuses } from "../../common/store/actions/availableBonusesTypes";
 import { CDC_ROUTES } from "../navigation/routes";
+import { ServiceId } from "../../../../../definitions/backend/ServiceId";
 /**
  * Hook to handle the CDC activation/deactivation
  */
@@ -31,15 +32,15 @@ const useCdcActivation = () => {
  * This hook determines and returns the appropriate primary action prop
  * for activating and deactivating the CDC service.
  */
-export const useSpecialCtaCdc = ():
-  | IOScrollViewActions["primary"]
-  | undefined => {
+export const useSpecialCtaCdc = (
+  serviceId: ServiceId
+): IOScrollViewActions["primary"] | undefined => {
   const isCdcEnabled = useIOSelector(isCdcAppVersionSupportedSelector);
 
   const { subscribeHandler } = useCdcActivation();
 
   const { isLoadingServicePreferenceByChannel, servicePreferenceByChannel } =
-    useServicePreferenceByChannel("inbox");
+    useServicePreferenceByChannel("inbox", serviceId);
 
   const loading = isLoadingServicePreferenceByChannel;
 

--- a/ts/features/bonus/cgn/hooks/useSpecialCtaCgn.tsx
+++ b/ts/features/bonus/cgn/hooks/useSpecialCtaCgn.tsx
@@ -4,7 +4,10 @@ import { Alert, Platform } from "react-native";
 import { IOToast } from "@pagopa/io-app-design-system";
 import { useIODispatch, useIOSelector } from "../../../../store/hooks";
 import { cgnUnsubscribeSelector } from "../store/reducers/unsubscribe";
-import { fold, isLoading } from "../../../../common/model/RemoteValue";
+import {
+  fold,
+  isLoading as isRemoteLoading
+} from "../../../../common/model/RemoteValue";
 import I18n from "../../../../i18n";
 import * as analytics from "../../../services/common/analytics";
 import { ServiceId } from "../../../../../definitions/services/ServiceId";
@@ -26,7 +29,7 @@ const useCgnActivation = (serviceId: ServiceId) => {
 
   const unsubscriptionStatus = useIOSelector(cgnUnsubscribeSelector);
 
-  const isLoadingCgnActivation = isLoading(unsubscriptionStatus);
+  const isLoadingCgnActivation = isRemoteLoading(unsubscriptionStatus);
 
   useEffect(() => {
     if (!isFirstRender.current) {
@@ -101,7 +104,7 @@ export const useSpecialCtaCgn = (
     useCgnActivation(serviceId);
 
   const { isLoadingServicePreferenceByChannel, servicePreferenceByChannel } =
-    useServicePreferenceByChannel("inbox");
+    useServicePreferenceByChannel("inbox", serviceId);
 
   const isLoading =
     isLoadingServicePreferenceByChannel || isLoadingCgnActivation;

--- a/ts/features/common/store/reducers/__tests__/__snapshots__/index.test.ts.snap
+++ b/ts/features/common/store/reducers/__tests__/__snapshots__/index.test.ts.snap
@@ -308,10 +308,8 @@ exports[`featuresPersistor should match snapshot 1`] = `
   "profileSettings": {},
   "services": {
     "details": {
-      "byId": {},
-      "servicePreference": {
-        "kind": "PotNone",
-      },
+      "dataById": {},
+      "preferencesById": {},
     },
     "home": {
       "featuredInstitutions": {

--- a/ts/features/fci/hooks/useFciCheckService.tsx
+++ b/ts/features/fci/hooks/useFciCheckService.tsx
@@ -6,12 +6,12 @@ import I18n from "../../../i18n";
 import { useIODispatch, useIOSelector } from "../../../store/hooks";
 import { useIOBottomSheetModal } from "../../../utils/hooks/bottomSheet";
 import { upsertServicePreference } from "../../services/details/store/actions/preference";
-import { servicePreferencePotSelector } from "../../services/details/store/reducers";
 import { isServicePreferenceResponseSuccess } from "../../services/details/types/ServicePreferenceResponse";
 import { trackFciUxConversion } from "../analytics";
 import { fciStartSigningRequest } from "../store/actions";
 import { fciEnvironmentSelector } from "../store/reducers/fciEnvironment";
 import { fciMetadataServiceIdSelector } from "../store/reducers/fciMetadata";
+import { servicePreferencePotByIdSelector } from "../../services/details/store/reducers";
 
 /**
  * A hook that returns a function to present the abort signature flow bottom sheet
@@ -19,7 +19,9 @@ import { fciMetadataServiceIdSelector } from "../store/reducers/fciMetadata";
 export const useFciCheckService = () => {
   const dispatch = useIODispatch();
   const fciServiceId = useIOSelector(fciMetadataServiceIdSelector);
-  const servicePreferencePot = useIOSelector(servicePreferencePotSelector);
+  const servicePreferencePot = useIOSelector(state =>
+    servicePreferencePotByIdSelector(state)(fciServiceId)
+  );
   const fciEnvironment = useIOSelector(fciEnvironmentSelector);
   const servicePreferenceValue = pot.getOrElse(servicePreferencePot, undefined);
   const cancelButtonProps: ComponentProps<

--- a/ts/features/fci/screens/valid/FciQtspClausesScreen.tsx
+++ b/ts/features/fci/screens/valid/FciQtspClausesScreen.tsx
@@ -16,7 +16,7 @@ import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { useIODispatch, useIOSelector } from "../../../../store/hooks";
 import { emptyContextualHelp } from "../../../../utils/emptyContextualHelp";
 import { loadServicePreference } from "../../../services/details/store/actions/preference";
-import { servicePreferencePotSelector } from "../../../services/details/store/reducers";
+import { servicePreferencePotByIdSelector } from "../../../services/details/store/reducers";
 import { isServicePreferenceResponseSuccess } from "../../../services/details/types/ServicePreferenceResponse";
 import { trackFciUxConversion } from "../../analytics";
 import GenericErrorComponent from "../../components/GenericErrorComponent";
@@ -43,7 +43,10 @@ const FciQtspClausesScreen = () => {
   const dispatch = useIODispatch();
   const navigation = useIONavigation();
   const [clausesChecked, setClausesChecked] = useState(0);
-  const servicePreferencePot = useIOSelector(servicePreferencePotSelector);
+  const fciServiceId = useIOSelector(fciMetadataServiceIdSelector);
+  const servicePreferencePot = useIOSelector(state =>
+    servicePreferencePotByIdSelector(state)(fciServiceId)
+  );
   const qtspClausesSelector = useIOSelector(fciQtspClausesSelector);
   const qtspPrivacyTextSelector = useIOSelector(fciQtspPrivacyTextSelector);
   const qtspPrivacyUrlSelector = useIOSelector(fciQtspPrivacyUrlSelector);
@@ -53,7 +56,6 @@ const FciQtspClausesScreen = () => {
   const fciPollFilledDocumentError = useIOSelector(
     fciPollFilledDocumentErrorSelector
   );
-  const fciServiceId = useIOSelector(fciMetadataServiceIdSelector);
   const fciEnvironment = useIOSelector(fciEnvironmentSelector);
 
   const servicePreferenceValue = pot.getOrElse(servicePreferencePot, undefined);

--- a/ts/features/fims/common/hooks/__test__/index.test.tsx
+++ b/ts/features/fims/common/hooks/__test__/index.test.tsx
@@ -471,7 +471,7 @@ describe("index", () => {
           features: {
             services: {
               details: {
-                byId: {
+                dataById: {
                   [serviceId]: servicePot
                 }
               }
@@ -502,7 +502,7 @@ describe("index", () => {
         features: {
           services: {
             details: {
-              byId: {
+              dataById: {
                 [serviceId]: pot.some(service)
               }
             }
@@ -575,7 +575,7 @@ const renderAutoFetchHook = (
     features: {
       services: {
         details: {
-          byId: {
+          dataById: {
             [storeServiceId]: servicePot
           }
         }
@@ -594,7 +594,7 @@ const renderFromServiceIdHook = (
     features: {
       services: {
         details: {
-          byId: {
+          dataById: {
             [storeServiceId]: servicePot
           }
         }
@@ -612,7 +612,7 @@ const renderFromAuthenticationFlowHook = (
     features: {
       services: {
         details: {
-          byId: {
+          dataById: {
             [storeServiceId]: servicePot
           }
         }

--- a/ts/features/pn/hooks/usePnPreferencesFetcher.ts
+++ b/ts/features/pn/hooks/usePnPreferencesFetcher.ts
@@ -6,7 +6,7 @@ import { ServiceId } from "../../../../definitions/backend/ServiceId";
 import { useIODispatch, useIOSelector } from "../../../store/hooks";
 import { useOnFirstRender } from "../../../utils/hooks/useOnFirstRender";
 import { loadServicePreference } from "../../services/details/store/actions/preference";
-import { servicePreferencePotSelector } from "../../services/details/store/reducers";
+import { servicePreferencePotByIdSelector } from "../../services/details/store/reducers";
 import { isServicePreferenceResponseSuccess } from "../../services/details/types/ServicePreferenceResponse";
 
 type PnStatus = {
@@ -19,7 +19,7 @@ export const usePnPreferencesFetcher = (pnServiceId: ServiceId): PnStatus => {
   const [hasFetched, setHasFetched] = React.useState<boolean>(false);
   const dispatch = useIODispatch();
   const servicePreferencePot = useIOSelector(state =>
-    servicePreferencePotSelector(state)
+    servicePreferencePotByIdSelector(state)(pnServiceId)
   );
 
   const isError = pot.isError(servicePreferencePot);

--- a/ts/features/pn/hooks/useSpecialCtaPn.ts
+++ b/ts/features/pn/hooks/useSpecialCtaPn.ts
@@ -82,7 +82,7 @@ export const useSpecialCtaPn = (
     usePnActivation(serviceId);
 
   const { isLoadingServicePreferenceByChannel, servicePreferenceByChannel } =
-    useServicePreferenceByChannel("inbox");
+    useServicePreferenceByChannel("inbox", serviceId);
 
   const isLoading =
     isLoadingServicePreferenceByChannel || isLoadingPnActivation;

--- a/ts/features/services/details/components/ServiceDetailsPreferences.tsx
+++ b/ts/features/services/details/components/ServiceDetailsPreferences.tsx
@@ -20,7 +20,7 @@ import {
   isErrorServicePreferenceSelector,
   isLoadingServicePreferenceSelector,
   serviceMetadataInfoSelector,
-  servicePreferenceResponseSuccessSelector
+  servicePreferenceResponseSuccessByIdSelector
 } from "../store/reducers";
 
 type PreferenceSwitchListItem = {
@@ -38,16 +38,16 @@ export const ServiceDetailsPreferences = ({
 
   const dispatch = useIODispatch();
 
-  const servicePreferenceResponseSuccess = useIOSelector(
-    servicePreferenceResponseSuccessSelector
+  const servicePreferenceResponseSuccess = useIOSelector(state =>
+    servicePreferenceResponseSuccessByIdSelector(state)(serviceId)
   );
 
-  const isLoadingServicePreference = useIOSelector(
-    isLoadingServicePreferenceSelector
+  const isLoadingServicePreference = useIOSelector(state =>
+    isLoadingServicePreferenceSelector(state)(serviceId)
   );
 
-  const isErrorServicePreference = useIOSelector(
-    isErrorServicePreferenceSelector
+  const isErrorServicePreference = useIOSelector(state =>
+    isErrorServicePreferenceSelector(state)(serviceId)
   );
 
   const isPremiumMessagesOptInOutEnabled = useIOSelector(

--- a/ts/features/services/details/components/ServiceDetailsScreenCdc.tsx
+++ b/ts/features/services/details/components/ServiceDetailsScreenCdc.tsx
@@ -5,15 +5,15 @@ import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
 import { useSpecialCtaCdc } from "../../../bonus/cdc/hooks/useSpecialCtaCdc";
 import { ServiceDetailsScreenBase } from "../types";
 import { getServiceActionsProps } from "../utils";
+import { ServiceId } from "../../../../../definitions/backend/ServiceId";
 
-export type ServiceDetailsScreenCdcProps = ServiceDetailsScreenBase;
-// Will be useful when implementing the mixpanel tracking
-// & {
-// serviceId: ServiceId;
-// };
+export type ServiceDetailsScreenCdcProps = ServiceDetailsScreenBase & {
+  serviceId: ServiceId;
+};
 
 export const ServiceDetailsScreenCdc = ({
   children,
+  serviceId,
   ctas,
   onPressCta,
   title = ""
@@ -29,7 +29,7 @@ export const ServiceDetailsScreenCdc = ({
     title
   });
 
-  const specialActionProps = useSpecialCtaCdc();
+  const specialActionProps = useSpecialCtaCdc(serviceId);
 
   const actions = getServiceActionsProps(specialActionProps, ctas, onPressCta);
 

--- a/ts/features/services/details/components/__tests__/ServiceDetailsScreenCdc.test.tsx
+++ b/ts/features/services/details/components/__tests__/ServiceDetailsScreenCdc.test.tsx
@@ -9,13 +9,15 @@ import { baseRawBackendStatus as backendStatus } from "../../../../../store/redu
 import { GlobalState } from "../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
 import { ServiceDetailsScreenCdc } from "../ServiceDetailsScreenCdc";
+import { ServiceId } from "../../../../../../definitions/backend/ServiceId";
 
+const dummy_serviceId = "serviceCdc" as ServiceId;
 const renderComponent = (state: GlobalState) => {
   const store = createStore(appReducer, state as any);
 
   return renderScreenWithNavigationStoreContext(
     () => (
-      <ServiceDetailsScreenCdc>
+      <ServiceDetailsScreenCdc serviceId={dummy_serviceId}>
         <Body>DUMMY</Body>
       </ServiceDetailsScreenCdc>
     ),

--- a/ts/features/services/details/components/__tests__/ServiceDetailsScreenCgn.test.tsx
+++ b/ts/features/services/details/components/__tests__/ServiceDetailsScreenCgn.test.tsx
@@ -89,10 +89,12 @@ describe("ServiceDetailsScreenCgn", () => {
       features: {
         services: {
           details: {
-            byId: {
+            dataById: {
               [serviceId]: pot.some(service)
             },
-            servicePreference: pot.noneError(servicePreferenceError)
+            preferencesById: {
+              [serviceId]: pot.noneError(servicePreferenceError)
+            }
           }
         }
       },
@@ -116,10 +118,12 @@ describe("ServiceDetailsScreenCgn", () => {
       features: {
         services: {
           details: {
-            byId: {
+            dataById: {
               [serviceId]: pot.some(service)
             },
-            servicePreference: pot.some(servicePreferenceWihInboxDisabled)
+            preferencesById: {
+              [serviceId]: pot.some(servicePreferenceWihInboxDisabled)
+            }
           }
         }
       },
@@ -143,10 +147,12 @@ describe("ServiceDetailsScreenCgn", () => {
       features: {
         services: {
           details: {
-            byId: {
+            dataById: {
               [serviceId]: pot.some(service)
             },
-            servicePreference: pot.some(servicePreferenceWihInboxEnabled)
+            preferencesById: {
+              [serviceId]: pot.some(servicePreferenceWihInboxEnabled)
+            }
           }
         }
       },

--- a/ts/features/services/details/components/__tests__/ServiceDetailsScreenDefault.test.tsx
+++ b/ts/features/services/details/components/__tests__/ServiceDetailsScreenDefault.test.tsx
@@ -56,10 +56,12 @@ describe("ServiceDetailsScreenDefault", () => {
       features: {
         services: {
           details: {
-            byId: {
+            dataById: {
               [serviceId]: pot.some(service)
             },
-            servicePreference: pot.some(servicePreferenceWihInboxEnabled)
+            preferencesById: {
+              [serviceId]: pot.some(servicePreferenceWihInboxEnabled)
+            }
           }
         }
       }
@@ -74,10 +76,12 @@ describe("ServiceDetailsScreenDefault", () => {
       features: {
         services: {
           details: {
-            byId: {
+            dataById: {
               [serviceId]: pot.some(service)
             },
-            servicePreference: pot.some(servicePreferenceWihInboxEnabled)
+            preferencesById: {
+              [serviceId]: pot.some(servicePreferenceWihInboxEnabled)
+            }
           }
         }
       }
@@ -92,10 +96,12 @@ describe("ServiceDetailsScreenDefault", () => {
       features: {
         services: {
           details: {
-            byId: {
+            dataById: {
               [serviceId]: pot.some(service)
             },
-            servicePreference: pot.some(servicePreferenceWihInboxEnabled)
+            preferencesById: {
+              [serviceId]: pot.some(servicePreferenceWihInboxEnabled)
+            }
           }
         }
       }

--- a/ts/features/services/details/components/__tests__/ServiceDetailsScreenPn.test.tsx
+++ b/ts/features/services/details/components/__tests__/ServiceDetailsScreenPn.test.tsx
@@ -98,10 +98,12 @@ describe("ServiceDetailsScreenPn", () => {
       features: {
         services: {
           details: {
-            byId: {
+            dataById: {
               [serviceId]: pot.some(service)
             },
-            servicePreference: pot.noneError(servicePreferenceError)
+            preferencesById: {
+              [serviceId]: pot.noneError(servicePreferenceError)
+            }
           }
         }
       },
@@ -129,10 +131,12 @@ describe("ServiceDetailsScreenPn", () => {
       features: {
         services: {
           details: {
-            byId: {
+            dataById: {
               [serviceId]: pot.some(service)
             },
-            servicePreference: pot.some(servicePreferenceWihInboxDisabled)
+            preferencesById: {
+              [serviceId]: pot.some(servicePreferenceWihInboxDisabled)
+            }
           }
         }
       },
@@ -160,10 +164,12 @@ describe("ServiceDetailsScreenPn", () => {
       features: {
         services: {
           details: {
-            byId: {
+            dataById: {
               [serviceId]: pot.some(service)
             },
-            servicePreference: pot.some(servicePreferenceWihInboxDisabled)
+            preferencesById: {
+              [serviceId]: pot.some(servicePreferenceWihInboxDisabled)
+            }
           }
         }
       },
@@ -187,10 +193,12 @@ describe("ServiceDetailsScreenPn", () => {
       features: {
         services: {
           details: {
-            byId: {
+            dataById: {
               [serviceId]: pot.some(service)
             },
-            servicePreference: pot.some(servicePreferenceWihInboxEnabled)
+            preferencesById: {
+              [serviceId]: pot.some(servicePreferenceWihInboxEnabled)
+            }
           }
         }
       },

--- a/ts/features/services/details/hooks/useServicePreference.ts
+++ b/ts/features/services/details/hooks/useServicePreference.ts
@@ -2,15 +2,17 @@ import * as pot from "@pagopa/ts-commons/lib/pot";
 import { useIOSelector } from "../../../../store/hooks";
 import { servicePreferenceByChannelPotSelector } from "../store/reducers";
 import { EnabledChannels } from "../../../../utils/profile";
+import { ServiceId } from "../../../../../definitions/backend/ServiceId";
 
 /**
  * Hook to get the service preference by channel
  */
 export const useServicePreferenceByChannel = (
-  channel: keyof EnabledChannels
+  channel: keyof EnabledChannels,
+  serviceId: ServiceId | undefined
 ) => {
   const servicePreferenceByChannelPot = useIOSelector(state =>
-    servicePreferenceByChannelPotSelector(state, channel)
+    servicePreferenceByChannelPotSelector(state, channel)(serviceId)
   );
 
   const servicePreferenceByChannel = pot.toUndefined(

--- a/ts/features/services/details/saga/handleUpsertServicePreference.ts
+++ b/ts/features/services/details/saga/handleUpsertServicePreference.ts
@@ -14,8 +14,9 @@ import { withRefreshApiCall } from "../../../authentication/fastLogin/saga/utils
 import { trackPNPushSettings } from "../../../pn/analytics";
 import { upsertServicePreference } from "../store/actions/preference";
 import {
+  ServicePreferencePot,
   serviceMetadataInfoSelector,
-  servicePreferencePotSelector
+  servicePreferencePotByIdSelector
 } from "../store/reducers";
 import { isServicePreferenceResponseSuccess } from "../types/ServicePreferenceResponse";
 import { mapKinds } from "./handleGetServicePreference";
@@ -28,9 +29,7 @@ import { mapKinds } from "./handleGetServicePreference";
  * @param action
  */
 const calculateUpdatingPreference = (
-  currentServicePreferenceState: ReturnType<
-    typeof servicePreferencePotSelector
-  >,
+  currentServicePreferenceState: ServicePreferencePot,
   action: ActionType<typeof upsertServicePreference.request>
 ): ServicePreference => {
   if (
@@ -97,7 +96,9 @@ export function* handleUpsertServicePreference(
 ) {
   yield* call(trackPNPushNotificationSettings, action);
 
-  const servicePreferencePot = yield* select(servicePreferencePotSelector);
+  const servicePreferencePot = yield* select(state =>
+    servicePreferencePotByIdSelector(state)(action.payload.id)
+  );
 
   const updatingPreference = calculateUpdatingPreference(
     servicePreferencePot,

--- a/ts/features/services/details/store/reducers/__tests__/servicePreference.test.ts
+++ b/ts/features/services/details/store/reducers/__tests__/servicePreference.test.ts
@@ -1,9 +1,10 @@
 import * as pot from "@pagopa/ts-commons/lib/pot";
-import { Action, createStore } from "redux";
+import { createStore } from "redux";
 import {
   isErrorServicePreferenceSelector,
   isLoadingServicePreferenceSelector,
-  servicePreferenceResponseSuccessSelector
+  servicePreferencePotByIdSelector,
+  servicePreferenceResponseSuccessByIdSelector
 } from "..";
 import { ServiceId } from "../../../../../../../definitions/backend/ServiceId";
 import { applicationChangeState } from "../../../../../../store/actions/application";
@@ -21,74 +22,232 @@ import {
 } from "../../actions/preference";
 
 const serviceId = "serviceId" as ServiceId;
+const serviceId2 = "serviceId2" as ServiceId;
+const serviceId3 = "serviceId3" as ServiceId;
 
-const servicePreferenceResponseSuccess: ServicePreferenceResponse = {
-  id: serviceId,
-  kind: "success",
-  value: {
+const getServicePreferenceResponseSuccess = (id = serviceId) =>
+  ({
+    id,
+    kind: "success",
+    value: {
+      inbox: true,
+      push: true,
+      email: false,
+      can_access_message_read_status: false,
+      settings_version: 0
+    }
+  } as ServicePreferenceResponse);
+
+const getServicePreferenceResponseFailure = (id = serviceId) =>
+  ({
+    id,
+    kind: "notFound"
+  } as ServicePreferenceResponse);
+
+const getServicePreferenceError = (id = serviceId) =>
+  ({
+    id,
+    ...getNetworkError(new Error("GenericError"))
+  } as WithServiceID<NetworkError>);
+
+const getUpdatingResponse = (id = serviceId) =>
+  ({
+    id,
     inbox: true,
     push: true,
-    email: false,
-    can_access_message_read_status: false,
+    email: true,
+    can_access_message_read_status: true,
     settings_version: 0
-  }
-};
-
-const servicePreferenceResponseFailure: ServicePreferenceResponse = {
-  id: serviceId,
-  kind: "notFound"
-};
-
-const servicePreferenceError: WithServiceID<NetworkError> = {
-  id: serviceId,
-  ...getNetworkError(new Error("GenericError"))
-};
-
-const updatingResponse: WithServiceID<ServicePreference> = {
-  id: serviceId,
-  inbox: true,
-  push: true,
-  email: true,
-  can_access_message_read_status: true,
-  settings_version: 0
-};
+  } as WithServiceID<ServicePreference>);
 
 describe("servicePreference reducer", () => {
   it("should have initial state", () => {
     const state = appReducer(undefined, applicationChangeState("active"));
-
-    expect(state.features.services.details.servicePreference).toStrictEqual(
-      pot.none
-    );
+    expect(state.features.services.details.preferencesById).toStrictEqual({});
   });
 
-  it("should handle loadServicePreference action", () => {
+  it("should handle loadServicePreference action, both failure and success for a single service", () => {
     const state = appReducer(undefined, applicationChangeState("active"));
     const store = createStore(appReducer, state as any);
+
+    const preference = getServicePreferenceResponseSuccess();
 
     store.dispatch(loadServicePreference.request(serviceId));
 
     expect(
-      store.getState().features.services.details.servicePreference
-    ).toStrictEqual(pot.noneLoading);
+      store.getState().features.services.details.preferencesById
+    ).toStrictEqual({
+      [serviceId]: pot.noneLoading
+    });
 
-    store.dispatch(
-      loadServicePreference.success(servicePreferenceResponseSuccess)
-    );
+    store.dispatch(loadServicePreference.success(preference));
     expect(
-      store.getState().features.services.details.servicePreference
-    ).toStrictEqual(pot.some(servicePreferenceResponseSuccess));
+      store.getState().features.services.details.preferencesById
+    ).toStrictEqual({
+      [serviceId]: pot.some(preference)
+    });
 
-    store.dispatch(loadServicePreference.failure(servicePreferenceError));
+    store.dispatch(loadServicePreference.failure(getServicePreferenceError()));
     expect(
-      store.getState().features.services.details.servicePreference
-    ).toStrictEqual(
-      pot.someError(servicePreferenceResponseSuccess, servicePreferenceError)
-    );
+      store.getState().features.services.details.preferencesById
+    ).toStrictEqual({
+      [serviceId]: pot.someError(preference, getServicePreferenceError())
+    });
   });
 
-  it("should handle upsertServicePreference action", () => {
+  it("should handle loadServicePreference actions for multiple services", () => {
     const state = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, state as any);
+
+    // Load service 1
+    store.dispatch(loadServicePreference.request(serviceId));
+    expect(
+      store.getState().features.services.details.preferencesById
+    ).toStrictEqual({
+      [serviceId]: pot.noneLoading
+    });
+
+    // Load service 2
+    store.dispatch(loadServicePreference.request(serviceId2));
+    expect(
+      store.getState().features.services.details.preferencesById
+    ).toStrictEqual({
+      [serviceId]: pot.noneLoading,
+      [serviceId2]: pot.noneLoading
+    });
+
+    // Service 1 succeeds
+    const preference1 = getServicePreferenceResponseSuccess(serviceId);
+    store.dispatch(loadServicePreference.success(preference1));
+    expect(
+      store.getState().features.services.details.preferencesById
+    ).toStrictEqual({
+      [serviceId]: pot.some(preference1),
+      [serviceId2]: pot.noneLoading
+    });
+
+    // Service 2 fails
+    store.dispatch(
+      loadServicePreference.failure(getServicePreferenceError(serviceId2))
+    );
+    expect(
+      store.getState().features.services.details.preferencesById
+    ).toStrictEqual({
+      [serviceId]: pot.some(preference1),
+      [serviceId2]: pot.noneError(getServicePreferenceError(serviceId2))
+    });
+
+    // Service 2 is retried and succeeds
+    const preference2 = getServicePreferenceResponseSuccess(serviceId2);
+    store.dispatch(loadServicePreference.request(serviceId2));
+    store.dispatch(loadServicePreference.success(preference2));
+    expect(
+      store.getState().features.services.details.preferencesById
+    ).toStrictEqual({
+      [serviceId]: pot.some(preference1),
+      [serviceId2]: pot.some(preference2)
+    });
+  });
+
+  it("should handle mixed loadServicePreference and upsertServicePreference actions for multiple services", () => {
+    const state = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, state as any);
+
+    // Load both services
+    const preference1 = getServicePreferenceResponseSuccess(serviceId);
+    const preference2 = getServicePreferenceResponseSuccess(serviceId2);
+
+    store.dispatch(loadServicePreference.success(preference1));
+    store.dispatch(loadServicePreference.success(preference2));
+
+    expect(
+      store.getState().features.services.details.preferencesById
+    ).toStrictEqual({
+      [serviceId]: pot.some(preference1),
+      [serviceId2]: pot.some(preference2)
+    });
+
+    // Update service 1
+    const updatingResponse1 = getUpdatingResponse(serviceId);
+    store.dispatch(upsertServicePreference.request(updatingResponse1));
+
+    expect(
+      store.getState().features.services.details.preferencesById
+    ).toStrictEqual({
+      [serviceId]: pot.someUpdating(preference1, {
+        id: serviceId,
+        kind: "success",
+        value: {
+          inbox: true,
+          push: true,
+          email: true,
+          can_access_message_read_status: true,
+          settings_version: 0
+        }
+      }),
+      [serviceId2]: pot.some(preference2)
+    });
+
+    // Service 1 update fails
+    store.dispatch(
+      upsertServicePreference.failure(getServicePreferenceError(serviceId))
+    );
+
+    // Update service 2
+    const updatingResponse2 = getUpdatingResponse(serviceId2);
+    store.dispatch(upsertServicePreference.request(updatingResponse2));
+
+    expect(
+      store.getState().features.services.details.preferencesById
+    ).toStrictEqual({
+      [serviceId]: pot.someError(
+        preference1,
+        getServicePreferenceError(serviceId)
+      ),
+      [serviceId2]: pot.someUpdating(preference2, {
+        id: serviceId2,
+        kind: "success",
+        value: {
+          inbox: true,
+          push: true,
+          email: true,
+          can_access_message_read_status: true,
+          settings_version: 0
+        }
+      })
+    });
+
+    // Service 2 update succeeds
+    const updatedPreference2 = {
+      id: serviceId2,
+      kind: "success",
+      value: {
+        inbox: true,
+        push: true,
+        email: true,
+        can_access_message_read_status: true,
+        settings_version: 0
+      }
+    } as ServicePreferenceResponse;
+
+    store.dispatch(upsertServicePreference.success(updatedPreference2));
+
+    expect(
+      store.getState().features.services.details.preferencesById
+    ).toStrictEqual({
+      [serviceId]: pot.someError(
+        preference1,
+        getServicePreferenceError(serviceId)
+      ),
+      [serviceId2]: pot.some(updatedPreference2)
+    });
+  });
+
+  it("should handle a failing upsertServicePreference action", () => {
+    const state = appReducer(undefined, applicationChangeState("active"));
+
+    const preference = getServicePreferenceResponseSuccess();
+
     const finalState: GlobalState = {
       ...state,
       features: {
@@ -97,19 +256,21 @@ describe("servicePreference reducer", () => {
           ...state.features.services,
           details: {
             ...state.features.services.details,
-            servicePreference: pot.some(servicePreferenceResponseSuccess)
+            preferencesById: {
+              [serviceId]: pot.some(preference)
+            }
           }
         }
       }
     };
     const store = createStore(appReducer, finalState as any);
 
-    store.dispatch(upsertServicePreference.request(updatingResponse));
+    store.dispatch(upsertServicePreference.request(getUpdatingResponse()));
 
     expect(
-      store.getState().features.services.details.servicePreference
-    ).toStrictEqual(
-      pot.someUpdating(servicePreferenceResponseSuccess, {
+      store.getState().features.services.details.preferencesById
+    ).toStrictEqual({
+      [serviceId]: pot.someUpdating(preference, {
         id: serviceId,
         kind: "success",
         value: {
@@ -120,110 +281,251 @@ describe("servicePreference reducer", () => {
           settings_version: 0
         }
       })
-    );
+    });
 
-    store.dispatch(upsertServicePreference.failure(servicePreferenceError));
-    expect(
-      store.getState().features.services.details.servicePreference
-    ).toStrictEqual(
-      pot.someError(servicePreferenceResponseSuccess, servicePreferenceError)
+    store.dispatch(
+      upsertServicePreference.failure(getServicePreferenceError())
     );
+    expect(
+      store.getState().features.services.details.preferencesById
+    ).toStrictEqual({
+      [serviceId]: pot.someError(preference, getServicePreferenceError())
+    });
   });
 });
 
 describe("servicePreference selectors", () => {
-  describe("servicePreferenceResponseSuccessSelector", () => {
+  describe("servicePreferencePotByIdSelector", () => {
+    it("should return pot.none when service ID is undefined", () => {
+      const state = appReducer(undefined, applicationChangeState("active"));
+
+      const servicePreferencePot =
+        servicePreferencePotByIdSelector(state)(undefined);
+      expect(servicePreferencePot).toStrictEqual(pot.none);
+    });
+
+    it("should return the correct preference pot for a service ID", () => {
+      const state = appReducer(undefined, applicationChangeState("active"));
+      const store = createStore(appReducer, state as any);
+
+      // Initial state should be pot.none
+      expect(
+        servicePreferencePotByIdSelector(store.getState())(serviceId)
+      ).toStrictEqual(pot.none);
+
+      // After loading request
+      store.dispatch(loadServicePreference.request(serviceId));
+      expect(
+        servicePreferencePotByIdSelector(store.getState())(serviceId)
+      ).toStrictEqual(pot.noneLoading);
+
+      // After successful load
+      const preference = getServicePreferenceResponseSuccess();
+      store.dispatch(loadServicePreference.success(preference));
+      expect(
+        servicePreferencePotByIdSelector(store.getState())(serviceId)
+      ).toStrictEqual(pot.some(preference));
+    });
+  });
+
+  describe("servicePreferenceResponseSuccessByIdSelector", () => {
     it("should return servicePreferenceResponseSuccess when pot.some and the service preference is successfully loaded", () => {
-      const state = appReducer(
-        {} as GlobalState,
-        loadServicePreference.success(servicePreferenceResponseSuccess)
-      );
+      const state = appReducer(undefined, applicationChangeState("active"));
+      const store = createStore(appReducer, state as any);
+
+      const preference = getServicePreferenceResponseSuccess();
+      store.dispatch(loadServicePreference.success(preference));
+
       const servicePreferenceResponse =
-        servicePreferenceResponseSuccessSelector(state);
-      expect(servicePreferenceResponse).toStrictEqual(
-        servicePreferenceResponseSuccess
-      );
+        servicePreferenceResponseSuccessByIdSelector(store.getState())(
+          serviceId
+        );
+      expect(servicePreferenceResponse).toStrictEqual(preference);
     });
 
     it("should return undefined when pot.some and the service preference is NOT successfully loaded", () => {
-      const state = appReducer(
-        {} as GlobalState,
-        loadServicePreference.success(servicePreferenceResponseFailure)
-      );
+      const state = appReducer(undefined, applicationChangeState("active"));
+      const store = createStore(appReducer, state as any);
+
+      const failure = getServicePreferenceResponseFailure();
+      store.dispatch(loadServicePreference.success(failure));
+
       const servicePreferenceResponse =
-        servicePreferenceResponseSuccessSelector(state);
+        servicePreferenceResponseSuccessByIdSelector(store.getState())(
+          serviceId
+        );
       expect(servicePreferenceResponse).toBeUndefined();
+    });
+
+    it("should return the correct preference when multiple services are loaded", () => {
+      const state = appReducer(undefined, applicationChangeState("active"));
+      const store = createStore(appReducer, state as any);
+
+      // Load preferences for two different services
+      const preference1 = getServicePreferenceResponseSuccess(serviceId);
+      const preference2 = getServicePreferenceResponseSuccess(serviceId2);
+
+      store.dispatch(loadServicePreference.success(preference1));
+      store.dispatch(loadServicePreference.success(preference2));
+
+      // Check that correct preferences are returned for each service
+      const servicePreference1 = servicePreferenceResponseSuccessByIdSelector(
+        store.getState()
+      )(serviceId);
+      const servicePreference2 = servicePreferenceResponseSuccessByIdSelector(
+        store.getState()
+      )(serviceId2);
+
+      expect(servicePreference1).toStrictEqual(preference1);
+      expect(servicePreference2).toStrictEqual(preference2);
     });
   });
 
   describe("isLoadingServicePreferenceSelector", () => {
     it("should return true when pot.loading", () => {
-      const state = appReducer(
-        {} as GlobalState,
-        loadServicePreference.request(serviceId)
-      );
+      const state = appReducer(undefined, applicationChangeState("active"));
+      const store = createStore(appReducer, state as any);
 
-      const isLoadingServicePreference =
-        isLoadingServicePreferenceSelector(state);
+      store.dispatch(loadServicePreference.request(serviceId));
+
+      const isLoadingServicePreference = isLoadingServicePreferenceSelector(
+        store.getState()
+      )(serviceId);
       expect(isLoadingServicePreference).toStrictEqual(true);
     });
 
     it("should return true when pot.updating", () => {
-      const state = appReducer(
-        {} as GlobalState,
-        upsertServicePreference.request(updatingResponse)
-      );
+      const state = appReducer(undefined, applicationChangeState("active"));
+      const store = createStore(appReducer, state as any);
 
-      const isLoadingServicePreference =
-        isLoadingServicePreferenceSelector(state);
+      const preference = getServicePreferenceResponseSuccess();
+      store.dispatch(loadServicePreference.success(preference));
+      store.dispatch(upsertServicePreference.request(getUpdatingResponse()));
+
+      const isLoadingServicePreference = isLoadingServicePreferenceSelector(
+        store.getState()
+      )(serviceId);
       expect(isLoadingServicePreference).toStrictEqual(true);
     });
 
     it("should return false when not pot.some", () => {
-      expect(
-        isLoadingServicePreferenceSelector(appReducer(undefined, {} as Action))
-      ).toStrictEqual(false);
+      const state = appReducer(undefined, applicationChangeState("active"));
+      const store = createStore(appReducer, state as any);
 
       expect(
-        isLoadingServicePreferenceSelector(
-          appReducer(
-            {} as GlobalState,
-            loadServicePreference.failure(servicePreferenceError)
-          )
+        isLoadingServicePreferenceSelector(store.getState())(serviceId)
+      ).toStrictEqual(false);
+
+      store.dispatch(
+        loadServicePreference.failure(getServicePreferenceError())
+      );
+
+      expect(
+        isLoadingServicePreferenceSelector(store.getState())(serviceId)
+      ).toStrictEqual(false);
+    });
+
+    it("should correctly identify loading state for multiple services", () => {
+      const state = appReducer(undefined, applicationChangeState("active"));
+      const store = createStore(appReducer, state as any);
+
+      // Load service 1
+      store.dispatch(loadServicePreference.request(serviceId));
+
+      // Load and complete service 2
+      store.dispatch(loadServicePreference.request(serviceId2));
+      store.dispatch(
+        loadServicePreference.success(
+          getServicePreferenceResponseSuccess(serviceId2)
         )
+      );
+
+      // Check that service 1 is loading but service 2 is not
+      expect(
+        isLoadingServicePreferenceSelector(store.getState())(serviceId)
+      ).toStrictEqual(true);
+      expect(
+        isLoadingServicePreferenceSelector(store.getState())(serviceId2)
       ).toStrictEqual(false);
     });
   });
 
   describe("isErrorServicePreferenceSelector", () => {
     it("should return true when pot.error", () => {
-      const state = appReducer(
-        {} as GlobalState,
-        loadServicePreference.failure(servicePreferenceError)
+      const state = appReducer(undefined, applicationChangeState("active"));
+      const store = createStore(appReducer, state as any);
+
+      store.dispatch(
+        loadServicePreference.failure(getServicePreferenceError())
       );
 
-      const isErrorServicePreference = isErrorServicePreferenceSelector(state);
+      const isErrorServicePreference = isErrorServicePreferenceSelector(
+        store.getState()
+      )(serviceId);
       expect(isErrorServicePreference).toStrictEqual(true);
     });
 
     it("should return true when pot.some and service is not successfully loaded", () => {
-      const state = appReducer(
-        {} as GlobalState,
-        loadServicePreference.success(servicePreferenceResponseFailure)
+      const state = appReducer(undefined, applicationChangeState("active"));
+      const store = createStore(appReducer, state as any);
+
+      store.dispatch(
+        loadServicePreference.success(getServicePreferenceResponseFailure())
       );
 
-      const isErrorServicePreference = isErrorServicePreferenceSelector(state);
+      const isErrorServicePreference = isErrorServicePreferenceSelector(
+        store.getState()
+      )(serviceId);
       expect(isErrorServicePreference).toStrictEqual(true);
     });
 
     it("should return false when pot.some and service is successfully loaded", () => {
-      const state = appReducer(
-        {} as GlobalState,
-        loadServicePreference.success(servicePreferenceResponseSuccess)
+      const state = appReducer(undefined, applicationChangeState("active"));
+      const store = createStore(appReducer, state as any);
+
+      store.dispatch(
+        loadServicePreference.success(getServicePreferenceResponseSuccess())
       );
 
-      const isErrorServicePreference = isErrorServicePreferenceSelector(state);
+      const isErrorServicePreference = isErrorServicePreferenceSelector(
+        store.getState()
+      )(serviceId);
       expect(isErrorServicePreference).toStrictEqual(false);
+    });
+
+    it("should correctly identify error state for multiple services", () => {
+      const state = appReducer(undefined, applicationChangeState("active"));
+      const store = createStore(appReducer, state as any);
+
+      // Service 1 succeeds
+      store.dispatch(
+        loadServicePreference.success(
+          getServicePreferenceResponseSuccess(serviceId)
+        )
+      );
+
+      // Service 2 fails
+      store.dispatch(
+        loadServicePreference.failure(getServicePreferenceError(serviceId2))
+      );
+
+      // Service 3 has "notFound" kind
+      store.dispatch(
+        loadServicePreference.success(
+          getServicePreferenceResponseFailure(serviceId3)
+        )
+      );
+
+      // Check that service 1 is not error but services 2 and 3 are
+      expect(
+        isErrorServicePreferenceSelector(store.getState())(serviceId)
+      ).toStrictEqual(false);
+      expect(
+        isErrorServicePreferenceSelector(store.getState())(serviceId2)
+      ).toStrictEqual(true);
+      expect(
+        isErrorServicePreferenceSelector(store.getState())(serviceId3)
+      ).toStrictEqual(true);
     });
   });
 });

--- a/ts/features/services/details/store/reducers/__tests__/servicesById.test.ts
+++ b/ts/features/services/details/store/reducers/__tests__/servicesById.test.ts
@@ -41,7 +41,7 @@ describe("serviceById reducer", () => {
   it("should have initial state", () => {
     const state = appReducer(undefined, applicationChangeState("active"));
 
-    expect(state.features.services.details.byId).toStrictEqual({});
+    expect(state.features.services.details.dataById).toStrictEqual({});
   });
 
   it("should handle loadServiceDetail action", () => {
@@ -50,12 +50,12 @@ describe("serviceById reducer", () => {
 
     store.dispatch(loadServiceDetail.request(serviceId));
 
-    expect(store.getState().features.services.details.byId).toStrictEqual({
+    expect(store.getState().features.services.details.dataById).toStrictEqual({
       serviceId: pot.noneLoading
     });
 
     store.dispatch(loadServiceDetail.success(service));
-    expect(store.getState().features.services.details.byId).toStrictEqual({
+    expect(store.getState().features.services.details.dataById).toStrictEqual({
       serviceId: pot.some(service)
     });
 
@@ -65,7 +65,7 @@ describe("serviceById reducer", () => {
     };
 
     store.dispatch(loadServiceDetail.failure(tError));
-    expect(store.getState().features.services.details.byId).toStrictEqual({
+    expect(store.getState().features.services.details.dataById).toStrictEqual({
       serviceId: pot.someError(service, new Error("load failed"))
     });
   });
@@ -82,7 +82,7 @@ describe("serviceById reducer", () => {
       appReducer,
       sequenceOfActions
     );
-    expect(state.features.services.details.byId).toEqual({});
+    expect(state.features.services.details.dataById).toEqual({});
   });
 
   it("should handle sessionExpired action", () => {
@@ -97,7 +97,7 @@ describe("serviceById reducer", () => {
       appReducer,
       sequenceOfActions
     );
-    expect(state.features.services.details.byId).toEqual({});
+    expect(state.features.services.details.dataById).toEqual({});
   });
 });
 


### PR DESCRIPTION
## Short description
refactor of service preferences' reducer and selectors to handle multiple services simultaneously

## List of changes proposed in this pull request
- refactored reducer and selectors for the services' preferences
- updated impacted components
- updated tests

## How to test
When running the app and navigating between various services' preferences screens:
- using reactotron, check that the data of each service is correctly stored
- make sure all screens work as intended
Also, automatic tests should pass