### PR TITLE
fix(IT Wallt): [SIW-2314] Presentation claims optimization for UI display

### DIFF
--- a/ts/features/itwallet/presentation/remote/components/ItwRemotePresentationDetails.tsx
+++ b/ts/features/itwallet/presentation/remote/components/ItwRemotePresentationDetails.tsx
@@ -13,7 +13,8 @@ import I18n from "../../../../../i18n";
 import { getCredentialNameFromType } from "../../../common/utils/itwCredentialUtils";
 import {
   ClaimDisplayFormat,
-  getClaimDisplayValue
+  getClaimDisplayValue,
+  getSafeText
 } from "../../../common/utils/itwClaimsUtils";
 import { selectPresentationDetails } from "../machine/selectors";
 import { ItwRemoteMachineContext } from "../machine/provider";
@@ -26,8 +27,8 @@ const mapClaims = (claims: Array<ClaimDisplayFormat>) =>
     return {
       id: c.id,
       title: Array.isArray(displayValue)
-        ? displayValue.join(", ")
-        : displayValue,
+        ? displayValue.map(getSafeText).join(", ")
+        : getSafeText(displayValue),
       description: c.label
     };
   });

--- a/ts/features/itwallet/presentation/remote/utils/itwRemotePresentationUtils.ts
+++ b/ts/features/itwallet/presentation/remote/utils/itwRemotePresentationUtils.ts
@@ -47,7 +47,8 @@ export const enrichPresentationDetails = (
       ...c,
       claimsToDisplay: c.requiredDisclosures.map<ClaimDisplayFormat>(
         ([, claimName, claimValue]) => {
-          const claimDisplayName = credential?.parsedCredential[claimName].name;
+          const claimDisplayName =
+            credential?.parsedCredential[claimName]?.name;
           return {
             id: claimName,
             label:


### PR DESCRIPTION
## Short description
This PR fixes a rare exception that occurs when a claim requested for presentation cannot be localized because it is not found in the `parsedCredential` object.

The PR also uses the `getSafeText` utility to truncate long claim values that might impact performances.

## List of changes proposed in this pull request
- `getSafeText` when displaying claim values
- Handle missing claim localization 

## How to test
Use the following custom query in the test RP. Even though `EuropeanHealthInsuranceCard` is not a proper credential (as it just contains a PDF in Base64) it can be used to test edge cases and ensure the presentation flow is solid.

```json
{
  "credentials": [
    {
      "id": "TesseraTEAM",
      "format": "vc+sd-jwt",
      "meta": {
        "vct_values": ["EuropeanHealthInsuranceCard"]
      }
    }
  ]
}
```
