### PR TITLE
fix(IT Wallet): [SIW-2317] Discovery banner not displayed when leaving eID issuance flow

### DIFF
--- a/ts/features/itwallet/common/store/reducers/__tests__/preferences.test.ts
+++ b/ts/features/itwallet/common/store/reducers/__tests__/preferences.test.ts
@@ -140,7 +140,8 @@ describe("IT Wallet preferences reducer", () => {
     expect(newState).toEqual({
       ...itwPreferencesInitialState,
       claimValuesHidden: true,
-      isL3Enabled: true
+      isL3Enabled: true,
+      isWalletInstanceRemotelyActive: true
     });
   });
 });

--- a/ts/features/itwallet/common/store/reducers/preferences.ts
+++ b/ts/features/itwallet/common/store/reducers/preferences.ts
@@ -123,11 +123,15 @@ const reducer = (
       // When the wallet is being reset, we need to persist only the preferences:
       // - claimValuesHidden
       // - isL3Enabled
-      const { claimValuesHidden, isL3Enabled } = state;
+      // - isWalletInstanceRemotelyActive ->
+      //  (the correct value will be set in the saga related to the wallet deactivation, but we should avoid to have this value undefined)
+      const { claimValuesHidden, isL3Enabled, isWalletInstanceRemotelyActive } =
+        state;
       return {
         ...itwPreferencesInitialState,
         claimValuesHidden,
-        isL3Enabled
+        isL3Enabled,
+        isWalletInstanceRemotelyActive
       };
 
     default:

--- a/ts/features/itwallet/lifecycle/saga/__tests__/checkCurrentWalletInstanceStateSaga.test.ts
+++ b/ts/features/itwallet/lifecycle/saga/__tests__/checkCurrentWalletInstanceStateSaga.test.ts
@@ -5,7 +5,7 @@ import {
   getCurrentStatusWalletInstance
 } from "../checkCurrentWalletInstanceStateSaga.ts";
 import { itwSetWalletInstanceRemotelyActive } from "../../../common/store/actions/preferences.ts";
-import { itwLifecycleIsOperationalOrValid } from "../../store/selectors";
+import { itwLifecycleIsValidSelector } from "../../store/selectors";
 
 describe("checkCurrentWalletInstanceStateSaga", () => {
   it("Sets the wallet instance as remotely active when remote is active, not revoked, and local is inactive", () => {
@@ -15,7 +15,7 @@ describe("checkCurrentWalletInstanceStateSaga", () => {
     return expectSaga(checkCurrentWalletInstanceStateSaga)
       .provide([
         [matchers.call(getCurrentStatusWalletInstance), remoteStatus],
-        [matchers.select(itwLifecycleIsOperationalOrValid), localStatus]
+        [matchers.select(itwLifecycleIsValidSelector), localStatus]
       ])
       .put(itwSetWalletInstanceRemotelyActive(true))
       .run();
@@ -28,7 +28,7 @@ describe("checkCurrentWalletInstanceStateSaga", () => {
     return expectSaga(checkCurrentWalletInstanceStateSaga)
       .provide([
         [matchers.call(getCurrentStatusWalletInstance), remoteStatus],
-        [matchers.select(itwLifecycleIsOperationalOrValid), localStatus]
+        [matchers.select(itwLifecycleIsValidSelector), localStatus]
       ])
       .put(itwSetWalletInstanceRemotelyActive(false))
       .run();
@@ -41,7 +41,7 @@ describe("checkCurrentWalletInstanceStateSaga", () => {
     return expectSaga(checkCurrentWalletInstanceStateSaga)
       .provide([
         [matchers.call(getCurrentStatusWalletInstance), remoteStatus],
-        [matchers.select(itwLifecycleIsOperationalOrValid), localStatus]
+        [matchers.select(itwLifecycleIsValidSelector), localStatus]
       ])
       .put(itwSetWalletInstanceRemotelyActive(false))
       .run();
@@ -54,7 +54,7 @@ describe("checkCurrentWalletInstanceStateSaga", () => {
     return expectSaga(checkCurrentWalletInstanceStateSaga)
       .provide([
         [matchers.call(getCurrentStatusWalletInstance), remoteStatus],
-        [matchers.select(itwLifecycleIsOperationalOrValid), localStatus]
+        [matchers.select(itwLifecycleIsValidSelector), localStatus]
       ])
       .put(itwSetWalletInstanceRemotelyActive(false))
       .run();

--- a/ts/features/itwallet/lifecycle/saga/checkCurrentWalletInstanceStateSaga.ts
+++ b/ts/features/itwallet/lifecycle/saga/checkCurrentWalletInstanceStateSaga.ts
@@ -4,7 +4,7 @@ import { ReduxSagaEffect } from "../../../../types/utils";
 import { assert } from "../../../../utils/assert";
 import { getCurrentWalletInstanceStatus } from "../../common/utils/itwAttestationUtils.ts";
 import { itwSetWalletInstanceRemotelyActive } from "../../common/store/actions/preferences.ts";
-import { itwLifecycleIsOperationalOrValid } from "../store/selectors";
+import { itwLifecycleIsValidSelector } from "../store/selectors";
 
 export function* getCurrentStatusWalletInstance() {
   const sessionToken = yield* select(sessionTokenSelector);
@@ -26,14 +26,13 @@ export function* checkCurrentWalletInstanceStateSaga(): Generator<
   const remoteWalletInstanceStatus = yield* call(
     getCurrentStatusWalletInstance
   );
-  const isItwOperationalOrValid = yield* select(
-    itwLifecycleIsOperationalOrValid
-  );
+
+  const isItwValidLocally = yield* select(itwLifecycleIsValidSelector);
 
   const itwCanBeReactivated = Boolean(
     remoteWalletInstanceStatus &&
       !remoteWalletInstanceStatus.is_revoked &&
-      !isItwOperationalOrValid
+      !isItwValidLocally
   );
 
   yield* put(itwSetWalletInstanceRemotelyActive(itwCanBeReactivated));


### PR DESCRIPTION
## Short description
This PR fixed some issues with the IT Wallet Discovery banner

## List of changes proposed in this pull request
- Fixed an issue with `isWalletInstanceRemotelyActive` that was undefined when interrupting the eID issuance flow
- Replaced the selector to understand if the user has a local active wallet, now it is `itwLifecycleIsValidSelector` that checks if there is a valid `integrityKeyTag` and a valid `eid`. This was causing issues since we were checking only for the `integrityKeyTag` and not for the `eid`.

## How to test
1) Activate ITW from a clean installation and check if everything works as expected
2) Try to activate ITW and interrupt the flow before the identification screen; the previous banner should be displayed without issues.
3) Activate ITW, uninstall the app, or change device and re-activate ITW; the reactivation banner should be displayed
4) Activate ITW and revoke it; everything should be working, and the standard banner should be visible
