### PR TITLE
style: [IOBP-1623] Update hide receipt button color

### DIFF
--- a/ts/features/payments/receipts/components/HideReceiptButton.tsx
+++ b/ts/features/payments/receipts/components/HideReceiptButton.tsx
@@ -82,7 +82,7 @@ const HideReceiptButton = (props: Props) => {
           "features.payments.transactions.receipt.hideFromList"
         )}
         icon="eyeHide"
-        variant="primary"
+        variant="danger"
       />
     </ContentWrapper>
   );


### PR DESCRIPTION
## Short description
This pull request includes a minor change to the `HideReceiptButton` modifying the `variant` property that has been updated from `"primary"` to `"danger"` to better reflect its purpose of hiding receipts

## List of changes proposed in this pull request
- Update `variant` property

## How to test
Ensure that the hide receipt button color now is red