### PR TITLE
fix: [IOPLT-0000] Disables ANR errors to Sentry from native layer config

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -70,6 +70,10 @@
 
     <!-- END Required by react-native-push-notification -->
 
+    <!-- Sentry -->
+
+    <meta-data android:name="io.sentry.anr.enable" android:value="false" />
+
     <!-- Mixpanel -->
 
     <meta-data android:name="com.mixpanel.android.MPConfig.UseIpAddressForGeolocation" android:value="false" />


### PR DESCRIPTION
## Short description
This PR disables Android ANRs error from native config to sentry

