### PR TITLE
ci: [IOPLT-0000] Canary release trigger only on manual dispatch

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -1,10 +1,8 @@
 name: Canary release
 on:
-  issue_comment:                                     
-    types: [created]
+  workflow_dispatch:
 jobs:
   run-static-checks:
-    if: contains(github.event.comment.html_url, '/pull/') && contains(github.event.comment.body, '/canary')
     uses: ./.github/workflows/staticcheck.yaml
   prepare-canary-release:
     needs: run-static-checks


### PR DESCRIPTION
## Short description
This PR changes the canary workflow to trigger only on manual dispatch.
