### PR TITLE
refactor: [IOBP-1624] Add extra bottom padding to CGN merchants list

### DIFF
--- a/ts/features/bonus/cgn/screens/merchants/CgnMerchantsListByCategory.tsx
+++ b/ts/features/bonus/cgn/screens/merchants/CgnMerchantsListByCategory.tsx
@@ -4,6 +4,7 @@ import {
   H3,
   HSpacer,
   IOColors,
+  IOVisualCostants,
   Icon,
   hexToRgba
 } from "@pagopa/io-app-design-system";
@@ -47,9 +48,6 @@ export type CgnMerchantListByCategoryScreenNavigationParams = Readonly<{
 }>;
 
 const CgnMerchantsListByCategory = () => {
-  // const screenHeight = Dimensions.get("window").height;
-  // const translationY = useSharedValue(0);
-
   const animatedFlatListRef = useAnimatedRef<Animated.FlatList<any>>();
 
   const dispatch = useIODispatch();
@@ -240,7 +238,8 @@ const CgnMerchantsListByCategory = () => {
           scrollEventThrottle={8}
           snapToEnd={false}
           contentContainerStyle={{
-            flexGrow: 1
+            flexGrow: 1,
+            paddingBottom: IOVisualCostants.appMarginDefault
           }}
           refreshControl={refreshControl}
           data={merchantsAll}


### PR DESCRIPTION
## Short description
This pull request makes updates to the `CgnMerchantsListByCategory` file adding a new constant for consistent spacing

## List of changes proposed in this pull request
- Removed unused variables `screenHeight` and `translationY` from the component to clean up the code
-  Updated the `contentContainerStyle` of the `FlatList` to include `paddingBottom` using `IOVisualCostants.appMarginDefault`, ensuring consistent spacing across the app

## How to test
Ensure that in iOS the screen `CGN_MERCHANTS_LIST_BY_CATEGORY` has enough room for last element