### PR TITLE
chore: [IOBP-1634] Mixpanel events for hide receipt swipe action

### DIFF
--- a/ts/features/payments/receipts/analytics/index.ts
+++ b/ts/features/payments/receipts/analytics/index.ts
@@ -9,6 +9,7 @@ export type PaymentReceiptAnalyticsProps = {
   first_time_opening: boolean;
   user: PaymentsAnalyticsReceiptUser;
   organization_fiscal_code: string;
+  trigger: "tap" | "swipe";
 };
 
 export const trackPaymentsReceiptListing = () => {

--- a/ts/features/payments/receipts/analytics/index.ts
+++ b/ts/features/payments/receipts/analytics/index.ts
@@ -3,17 +3,19 @@ import { buildEventProperties } from "../../../../utils/analytics";
 import { PaymentsAnalyticsReceiptUser } from "../../common/types/PaymentAnalytics";
 import { ReceiptsCategoryFilter } from "../types";
 
+export type HideReceiptTrigger = "tap" | "swipe";
+
 export type PaymentReceiptAnalyticsProps = {
   organization_name: string;
   payment_status: string;
   first_time_opening: boolean;
   user: PaymentsAnalyticsReceiptUser;
   organization_fiscal_code: string;
-  trigger: "tap" | "swipe";
+  trigger: HideReceiptTrigger;
 };
 
 export const trackPaymentsReceiptListing = () => {
-  void mixpanelTrack(
+  mixpanelTrack(
     "PAYMENTS_RECEIPT_LISTING",
     buildEventProperties("UX", "screen_view")
   );
@@ -22,7 +24,7 @@ export const trackPaymentsReceiptListing = () => {
 export const trackPaymentsOpenOldReceiptListing = (
   entryPoint: "payments_receipt_listing"
 ) => {
-  void mixpanelTrack(
+  mixpanelTrack(
     "OPEN_RECEIPT_OLD_LISTING",
     buildEventProperties("UX", "action", {
       entry_point: entryPoint
@@ -33,7 +35,7 @@ export const trackPaymentsOpenOldReceiptListing = (
 export const trackPaymentsOpenReceipt = (
   props: Partial<PaymentReceiptAnalyticsProps>
 ) => {
-  void mixpanelTrack(
+  mixpanelTrack(
     "OPEN_RECEIPT",
     buildEventProperties("UX", "screen_view", {
       ...props,
@@ -45,7 +47,7 @@ export const trackPaymentsOpenReceipt = (
 export const trackPaymentsDownloadReceiptAction = (
   props: Partial<PaymentReceiptAnalyticsProps>
 ) => {
-  void mixpanelTrack(
+  mixpanelTrack(
     "DOWNLOAD_RECEIPT",
     buildEventProperties("UX", "action", {
       ...props
@@ -54,16 +56,13 @@ export const trackPaymentsDownloadReceiptAction = (
 };
 
 export const trackPaymentsOpenSubReceipt = () => {
-  void mixpanelTrack(
-    "OPEN_SUB_RECEIPT",
-    buildEventProperties("UX", "screen_view")
-  );
+  mixpanelTrack("OPEN_SUB_RECEIPT", buildEventProperties("UX", "screen_view"));
 };
 
 export const trackPaymentsSaveAndShareReceipt = (
   props: Partial<PaymentReceiptAnalyticsProps>
 ) => {
-  void mixpanelTrack(
+  mixpanelTrack(
     "SAVE_AND_SHARE_RECEIPT",
     buildEventProperties("UX", "action", {
       ...props,
@@ -74,7 +73,7 @@ export const trackPaymentsSaveAndShareReceipt = (
 export const trackPaymentsDownloadReceiptSuccess = (
   props: Partial<PaymentReceiptAnalyticsProps>
 ) => {
-  void mixpanelTrack(
+  mixpanelTrack(
     "DOWNLOAD_RECEIPT_SUCCESS",
     buildEventProperties("UX", "screen_view", {
       ...props
@@ -85,7 +84,7 @@ export const trackPaymentsDownloadReceiptSuccess = (
 export const trackPaymentsDownloadReceiptError = (
   props: Partial<PaymentReceiptAnalyticsProps>
 ) => {
-  void mixpanelTrack(
+  mixpanelTrack(
     "DOWNLOAD_RECEIPT_FAILURE",
     buildEventProperties("KO", undefined, {
       ...props
@@ -96,16 +95,13 @@ export const trackPaymentsDownloadReceiptError = (
 export const trackHideReceipt = (
   props: Partial<PaymentReceiptAnalyticsProps>
 ) => {
-  void mixpanelTrack(
-    "HIDE_RECEIPT",
-    buildEventProperties("UX", "action", props)
-  );
+  mixpanelTrack("HIDE_RECEIPT", buildEventProperties("UX", "action", props));
 };
 
 export const trackHideReceiptConfirm = (
   props: Partial<PaymentReceiptAnalyticsProps>
 ) => {
-  void mixpanelTrack(
+  mixpanelTrack(
     "HIDE_RECEIPT_CONFIRM",
     buildEventProperties("UX", "action", props)
   );
@@ -114,7 +110,7 @@ export const trackHideReceiptConfirm = (
 export const trackHideReceiptSuccess = (
   props: Partial<PaymentReceiptAnalyticsProps>
 ) => {
-  void mixpanelTrack(
+  mixpanelTrack(
     "HIDE_RECEIPT_SUCCESS",
     buildEventProperties("UX", "screen_view", props)
   );
@@ -123,7 +119,7 @@ export const trackHideReceiptSuccess = (
 export const trackHideReceiptFailure = (
   props: Partial<PaymentReceiptAnalyticsProps>
 ) => {
-  void mixpanelTrack(
+  mixpanelTrack(
     "HIDE_RECEIPT_FAILURE",
     buildEventProperties("KO", undefined, props)
   );
@@ -132,7 +128,7 @@ export const trackHideReceiptFailure = (
 export const trackReceiptFilterUsage = (
   filter: Partial<ReceiptsCategoryFilter>
 ) => {
-  void mixpanelTrack(
+  mixpanelTrack(
     "PAYMENTS_RECEIPT_LISTING_FILTER",
     buildEventProperties("UX", "action", { filter })
   );

--- a/ts/features/payments/receipts/analytics/utils.ts
+++ b/ts/features/payments/receipts/analytics/utils.ts
@@ -1,0 +1,28 @@
+import { PaymentAnalyticsData } from "../../common/types/PaymentAnalytics";
+import * as analytics from "../analytics";
+
+export const analyticsHideReceiptAction = (
+  paymentAnalyticsData?: PaymentAnalyticsData,
+  trigger?: analytics.HideReceiptTrigger
+) =>
+  analytics.trackHideReceipt({
+    organization_name: paymentAnalyticsData?.receiptOrganizationName,
+    first_time_opening: paymentAnalyticsData?.receiptFirstTimeOpening,
+    user: paymentAnalyticsData?.receiptUser,
+    organization_fiscal_code:
+      paymentAnalyticsData?.receiptOrganizationFiscalCode,
+    trigger
+  });
+
+export const analyticsHideReceiptConfirmAction = (
+  paymentAnalyticsData?: PaymentAnalyticsData,
+  trigger?: analytics.HideReceiptTrigger
+) =>
+  analytics.trackHideReceiptConfirm({
+    organization_name: paymentAnalyticsData?.receiptOrganizationName,
+    first_time_opening: paymentAnalyticsData?.receiptFirstTimeOpening,
+    user: paymentAnalyticsData?.receiptUser,
+    organization_fiscal_code:
+      paymentAnalyticsData?.receiptOrganizationFiscalCode,
+    trigger
+  });

--- a/ts/features/payments/receipts/components/HideReceiptButton.tsx
+++ b/ts/features/payments/receipts/components/HideReceiptButton.tsx
@@ -5,53 +5,39 @@ import I18n from "../../../../i18n";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { useIOSelector } from "../../../../store/hooks";
 import { paymentAnalyticsDataSelector } from "../../history/store/selectors";
-import * as analytics from "../analytics";
+import {
+  analyticsHideReceiptAction,
+  analyticsHideReceiptConfirmAction
+} from "../analytics/utils";
 import { hidePaymentsReceiptAction } from "../store/actions";
+import { HideReceiptTrigger } from "../analytics";
 
 type Props = {
   transactionId: string;
+  trigger?: HideReceiptTrigger;
 };
 
 const HideReceiptButton = (props: Props) => {
-  const { transactionId } = props;
+  const { transactionId, trigger = "tap" } = props;
   const dispatch = useDispatch();
   const navigation = useIONavigation();
   const paymentAnalyticsData = useIOSelector(paymentAnalyticsDataSelector);
 
-  const analyticsHideReceiptAction = () => {
-    analytics.trackHideReceipt({
-      organization_name: paymentAnalyticsData?.receiptOrganizationName,
-      first_time_opening: paymentAnalyticsData?.receiptFirstTimeOpening,
-      user: paymentAnalyticsData?.receiptUser,
-      organization_fiscal_code:
-        paymentAnalyticsData?.receiptOrganizationFiscalCode
-    });
-  };
-
-  const analyticsHideReceiptConfirmAction = () => {
-    analytics.trackHideReceiptConfirm({
-      organization_name: paymentAnalyticsData?.receiptOrganizationName,
-      first_time_opening: paymentAnalyticsData?.receiptFirstTimeOpening,
-      user: paymentAnalyticsData?.receiptUser,
-      organization_fiscal_code:
-        paymentAnalyticsData?.receiptOrganizationFiscalCode
-    });
-  };
-
   const hideReceipt = () => {
     navigation.goBack();
 
-    analyticsHideReceiptConfirmAction();
+    analyticsHideReceiptConfirmAction(paymentAnalyticsData);
 
     dispatch(
       hidePaymentsReceiptAction.request({
-        transactionId
+        transactionId,
+        trigger
       })
     );
   };
 
   const handleHideFromList = () => {
-    analyticsHideReceiptAction();
+    analyticsHideReceiptAction(paymentAnalyticsData);
 
     Alert.alert(
       I18n.t("features.payments.transactions.receipt.hideBanner.title"),

--- a/ts/features/payments/receipts/components/ReceiptListItemTransaction.tsx
+++ b/ts/features/payments/receipts/components/ReceiptListItemTransaction.tsx
@@ -12,19 +12,17 @@ import ListItemSwipeAction, {
   SwipeControls
 } from "../../../../components/ListItemSwipeAction";
 import I18n from "../../../../i18n";
-import { useIODispatch, useIOSelector } from "../../../../store/hooks";
+import { useIODispatch } from "../../../../store/hooks";
 import { getAccessibleAmountText } from "../../../../utils/accessibility";
 import { format } from "../../../../utils/dates";
+import { PaymentAnalyticsData } from "../../common/types/PaymentAnalytics";
 import { getTransactionLogo } from "../../common/utils";
-import { hidePaymentsReceiptAction } from "../store/actions";
-import { formatAmountText } from "../utils";
 import {
   analyticsHideReceiptAction,
   analyticsHideReceiptConfirmAction
 } from "../analytics/utils";
-import { paymentAnalyticsDataSelector } from "../../history/store/selectors";
-import { paymentsGetPaymentDetailsAction } from "../../checkout/store/actions/networking";
-import { RptId } from "../../../../../definitions/pagopa/ecommerce/RptId";
+import { hidePaymentsReceiptAction } from "../store/actions";
+import { formatAmountText } from "../utils";
 
 type Props = {
   transaction: NoticeListItem;
@@ -74,7 +72,11 @@ const ReceiptListItemTransaction = memo(
 
     const dispatch = useIODispatch();
 
-    const paymentAnalyticsData = useIOSelector(paymentAnalyticsDataSelector);
+    const paymentAnalyticsData: PaymentAnalyticsData = {
+      receiptOrganizationName: transaction.payeeName,
+      receiptOrganizationFiscalCode: transaction.payeeTaxCode,
+      receiptUser: transaction.isPayer ? "payer" : "payee"
+    };
 
     const swipeActionProps = {
       icon: "eyeHide" as IOIcons,
@@ -85,10 +87,6 @@ const ReceiptListItemTransaction = memo(
         resetSwipePosition,
         triggerSwipeAction
       }: SwipeControls) => {
-        dispatch(
-          paymentsGetPaymentDetailsAction.request(transaction.eventId as RptId)
-        );
-
         analyticsHideReceiptAction(paymentAnalyticsData, "swipe");
 
         Alert.alert(

--- a/ts/features/payments/receipts/components/___tests___/ReceiptListItemTransaction.test.tsx
+++ b/ts/features/payments/receipts/components/___tests___/ReceiptListItemTransaction.test.tsx
@@ -4,12 +4,10 @@ import { NoticeListItem } from "../../../../../../definitions/pagopa/biz-events/
 import I18n from "../../../../../i18n";
 import { ReceiptListItemTransaction } from "../ReceiptListItemTransaction";
 
-const mockDispatch = jest.fn();
-
 jest.mock("../../../../../store/hooks", () => ({
   useIODispatch: jest.fn(),
   useIOStore: jest.fn(),
-  useIOSelector: mockDispatch
+  useIOSelector: jest.fn()
 }));
 
 const mockTransaction: NoticeListItem = {

--- a/ts/features/payments/receipts/saga/handleDisableReceipt.ts
+++ b/ts/features/payments/receipts/saga/handleDisableReceipt.ts
@@ -28,7 +28,8 @@ export function* handleDisableReceipt(
     analytics.trackHideReceiptFailure({
       organization_name: paymentsAnalyticsData?.receiptOrganizationName,
       first_time_opening: paymentsAnalyticsData?.receiptFirstTimeOpening,
-      user: paymentsAnalyticsData?.receiptUser
+      user: paymentsAnalyticsData?.receiptUser,
+      trigger: action.payload.trigger
     });
   };
 
@@ -41,7 +42,8 @@ export function* handleDisableReceipt(
       first_time_opening: paymentsAnalyticsData?.receiptFirstTimeOpening,
       user: paymentsAnalyticsData?.receiptUser,
       organization_fiscal_code:
-        paymentsAnalyticsData?.receiptOrganizationFiscalCode
+        paymentsAnalyticsData?.receiptOrganizationFiscalCode,
+      trigger: action.payload.trigger
     });
   };
 

--- a/ts/features/payments/receipts/store/actions/index.ts
+++ b/ts/features/payments/receipts/store/actions/index.ts
@@ -3,6 +3,7 @@ import { NetworkError } from "../../../../../utils/errors";
 import { NoticeListWrapResponse } from "../../../../../../definitions/pagopa/biz-events/NoticeListWrapResponse";
 import { NoticeDetailResponse } from "../../../../../../definitions/pagopa/biz-events/NoticeDetailResponse";
 import { ReceiptsCategoryFilter } from "../../types";
+import { HideReceiptTrigger } from "../../analytics";
 
 export type PaymentsReceiptPayload = {
   firstLoad?: boolean;
@@ -76,6 +77,7 @@ export const getPaymentsReceiptDownloadAction = createAsyncAction(
 
 type PaymentsTransactionReceiptDeletePayload = {
   transactionId: string;
+  trigger: HideReceiptTrigger;
 };
 
 export const hidePaymentsReceiptAction = createAsyncAction(


### PR DESCRIPTION
## Short description
This pull request refactors the analytics tracking logic. It introduces support for tracking user interaction trigger types by updating the relevant functions to include a `trigger` type parameter. Common tracking logic has been extracted into utility functions to reduce duplication and enhance maintainability. 

## List of changes proposed in this pull request
- Updated the hide payments receipt Mixpanel actions payload to include the `trigger` property 
- Removed the `void` keyword from `mixpanelTrack` calls as unnecessary
- Move common function in `utils` 

## How to test
Ensure that the same data sent to Mixpanel when the "Nascondi dalla lista" button is clicked is also sent when a receipt is hidden via swipe