### PR TITLE
fix: [IOPID-2806] Add `maxFontSizeMultiplier` to `EmailInsertScreen`

### DIFF
--- a/ts/features/settings/userData/shared/screens/EmailInsertScreen.tsx
+++ b/ts/features/settings/userData/shared/screens/EmailInsertScreen.tsx
@@ -68,6 +68,12 @@ export type EmailInsertScreenNavigationParams = Readonly<{
 
 const EMPTY_EMAIL = "";
 
+/**
+ * Since we have some users with a very large font size, that can't enter or use
+ * this screen, we need to set a maximum font size multiplier.
+ */
+const MAX_FONT_SIZE_MULTIPLIER = 1.2;
+
 const contextualHelpMarkdown: ContextualHelpPropsMarkdown = {
   title: "email.insert.help.title",
   body: "email.insert.help.content"
@@ -432,20 +438,26 @@ const EmailInsertScreen = () => {
               accessibilityRole="header"
               ref={accessibilityFirstFocuseViewRef}
             >
-              <H1 testID="title-test">
+              <H1
+                testID="title-test"
+                maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+              >
                 {isFirstOnboarding
                   ? I18n.t("email.newinsert.title")
                   : I18n.t("email.edit.title")}
               </H1>
             </View>
             <VSpacer size={16} />
-            <Body>
+            <Body maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}>
               {isFirstOnboarding ? (
                 I18n.t("email.newinsert.subtitle")
               ) : (
                 <>
                   {I18n.t("email.edit.subtitle")}
-                  <Body weight="Semibold">
+                  <Body
+                    weight="Semibold"
+                    maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER}
+                  >
                     {` ${pipe(
                       optionEmail,
                       O.getOrElse(() => "")


### PR DESCRIPTION
## Short description
This PR sets a `maxFontSizeMultiplier` on all `Text` components within the `EmailInsertScreen` to prevent layout issues that may lead to unresponsiveness (React Navigation freeze) or screen elements becoming hidden (e.g., the input field and button).

<details><summary>Details</summary>
<p>

### Settings
| ❌ | ✅ | 
| - | - |
| <img src="https://github.com/user-attachments/assets/33573bb2-db2b-4d30-a637-435e6f097d59" widht="200" /> | <img src="https://github.com/user-attachments/assets/47b2ed36-c778-44ed-9e34-de5e28763d23" widht="200" /> | 

### Onboarding
| ❌ | ✅ | 
| - | - |
| <img src="https://github.com/user-attachments/assets/9daf1a82-2a8c-4d11-b5a2-7457fa1155e9" widht="200" /> | <img src="https://github.com/user-attachments/assets/2d64b40a-193f-46af-a7b8-c0ee66c33271" widht="200" /> |

</p>
</details> 

We’ve received reports from iOS users experiencing hangs when navigating to this screen. While we couldn't reproduce the freeze on development devices using a debug build, we did identify a secondary issue: if users were able to access the screen, some key UI components were rendered off-screen due to excessively large font sizes.

Since we can’t consistently reproduce the navigation issue, this fix focuses on improving layout stability by capping the maximum font scaling. We hope this also mitigates the freeze by avoiding layout overflows.

## List of changes proposed in this pull request
- Set `maxFontSizeMultiplier` to `1.2` for all `Text` components in `EmailInsertScreen`


## How to test

- On your iOS device, go to `Settings > Accessibility > Display & Text Size > Larger Text`
- Increase the font size using the slider (set it to the maximum value)
- In the app, go to `Settings > Your Data`
- Tap `Edit` on your email
- Ensure all components (input, text, button) are visible and usable
