### PR TITLE
feat(IT Wallet): [SIW-2309] Add link to offline FAQ on click of offline banner

### DIFF
--- a/ts/features/itwallet/common/components/ItwOfflineWalletBanner.tsx
+++ b/ts/features/itwallet/common/components/ItwOfflineWalletBanner.tsx
@@ -1,8 +1,11 @@
-import { Banner } from "@pagopa/io-app-design-system";
+import { Banner, IOToast } from "@pagopa/io-app-design-system";
 import I18n from "../../../../i18n";
 import { useIODispatch, useIOSelector } from "../../../../store/hooks";
 import { itwSetOfflineBannerHidden } from "../store/actions/preferences.ts";
 import { itwShouldRenderOfflineBannerSelector } from "../store/selectors";
+import { openWebUrl } from "../../../../utils/url.ts";
+
+const offlineDocumentsFAQ = "https://assistenza.ioapp.it/hc/it/articles/34805335324049-Posso-usare-i-documenti-digitali-senza-connessione";
 
 export const ItwOfflineWalletBanner = () => {
   const dispatch = useIODispatch();
@@ -14,7 +17,9 @@ export const ItwOfflineWalletBanner = () => {
   }
 
   const handlePress = () => {
-    // TODO: [SIW-2309] Implement action when the FAQ are ready
+    openWebUrl(offlineDocumentsFAQ, () =>
+      IOToast.error(I18n.t("genericError"))
+    );
   };
 
   const handleOnClose = () => {

--- a/ts/features/itwallet/common/components/ItwOfflineWalletBanner.tsx
+++ b/ts/features/itwallet/common/components/ItwOfflineWalletBanner.tsx
@@ -5,7 +5,8 @@ import { itwSetOfflineBannerHidden } from "../store/actions/preferences.ts";
 import { itwShouldRenderOfflineBannerSelector } from "../store/selectors";
 import { openWebUrl } from "../../../../utils/url.ts";
 
-const offlineDocumentsFAQ = "https://assistenza.ioapp.it/hc/it/articles/34805335324049-Posso-usare-i-documenti-digitali-senza-connessione";
+const offlineDocumentsFAQ =
+  "https://assistenza.ioapp.it/hc/it/articles/34805335324049-Posso-usare-i-documenti-digitali-senza-connessione";
 
 export const ItwOfflineWalletBanner = () => {
   const dispatch = useIODispatch();


### PR DESCRIPTION
## Short description
This PR adds the link to the offline FAQ on click of the offline banner.

## List of changes proposed in this pull request
- Updated the `handlePress` of  `ItwOfflineWalletBanner` 

## How to test
1. Navigate to the offline wallet banner in app.
2. Click on the offline banner.
3. Verify that the offline FAQ link opens in a new tab.
