### PR TITLE
chore: [IOCOM-2364] add `reason` to `PN_SERVICE_STATUS_CHANGE_ERROR`

### DIFF
--- a/ts/features/pn/analytics/index.ts
+++ b/ts/features/pn/analytics/index.ts
@@ -70,11 +70,15 @@ export const trackPNServiceStatusChangeSuccess = (activated?: boolean) =>
     })
   );
 
-export const trackPNServiceStatusChangeError = (currentStatus?: boolean) =>
+export const trackPNServiceStatusChangeError = (
+  currentStatus: boolean,
+  reason: string
+) =>
   void mixpanelTrack(
     "PN_SERVICE_STATUS_CHANGE_ERROR",
     buildEventProperties("KO", undefined, {
-      CURRENT_STATUS: pnServiceActivationStatusBoolToString(currentStatus)
+      CURRENT_STATUS: pnServiceActivationStatusBoolToString(currentStatus),
+      reason
     })
   );
 

--- a/ts/features/pn/store/sagas/__tests__/watchPnSaga.test.ts
+++ b/ts/features/pn/store/sagas/__tests__/watchPnSaga.test.ts
@@ -112,7 +112,8 @@ describe("watchPnSaga", () => {
           .provide([
             [select(isPnTestEnabledSelector), false],
             [select(pnMessagingServiceIdSelector), mockServiceId],
-            [call(reportPNServiceStatusOnFailure, false), undefined]
+            [select(servicePreferencePotByIdSelector, mockServiceId), pot.none],
+            [call(reportPNServiceStatusOnFailure, false, "A reason"), undefined]
           ])
           .put(pnActivationUpsert.failure())
           .call(loadPreferenceIfValidId, mockServiceId)
@@ -136,7 +137,8 @@ describe("watchPnSaga", () => {
         .provide([
           [select(isPnTestEnabledSelector), false],
           [select(pnMessagingServiceIdSelector), mockServiceId],
-          [call(reportPNServiceStatusOnFailure, false), undefined]
+          [select(servicePreferencePotByIdSelector, mockServiceId), pot.none],
+          [call(reportPNServiceStatusOnFailure, false, "A reason"), undefined]
         ])
         .put(pnActivationUpsert.failure())
         .call(loadPreferenceIfValidId, mockServiceId)
@@ -150,14 +152,17 @@ describe("watchPnSaga", () => {
 
   describe("reportPNServiceStatusOnFailure", () => {
     it("should use predictedValue when service preferences are not available", () => {
-      testSaga(reportPNServiceStatusOnFailure, true)
+      testSaga(reportPNServiceStatusOnFailure, true, "A reason")
         .next()
         .select(pnMessagingServiceIdSelector)
         .next(mockServiceId)
         .select(servicePreferencePotByIdSelector, mockServiceId)
         .next(pot.none)
         .isDone();
-      expect(trackPNServiceStatusChangeError).toHaveBeenCalledWith(true);
+      expect(trackPNServiceStatusChangeError).toHaveBeenCalledWith(
+        true,
+        "A reason"
+      );
     });
 
     it("should use inbox value from service preferences when available", () => {
@@ -166,7 +171,7 @@ describe("watchPnSaga", () => {
         value: { inbox: true }
       };
 
-      testSaga(reportPNServiceStatusOnFailure, false)
+      testSaga(reportPNServiceStatusOnFailure, false, "A reason")
         .next()
         .select(pnMessagingServiceIdSelector)
         .next(mockServiceId)
@@ -174,7 +179,10 @@ describe("watchPnSaga", () => {
         .next(pot.some(servicePreferences))
         .isDone();
 
-      expect(trackPNServiceStatusChangeError).toHaveBeenCalledWith(true);
+      expect(trackPNServiceStatusChangeError).toHaveBeenCalledWith(
+        true,
+        "A reason"
+      );
     });
   });
 

--- a/ts/features/pn/store/sagas/watchPnSaga.ts
+++ b/ts/features/pn/store/sagas/watchPnSaga.ts
@@ -1,4 +1,5 @@
 import * as pot from "@pagopa/ts-commons/lib/pot";
+import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import * as E from "fp-ts/lib/Either";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
@@ -39,12 +40,13 @@ function* handlePnActivation(
       isPnTestEnabledSelector
     );
 
-    const result = yield* call(upsertPnActivation, {
+    const requestData = {
       body: {
         activation_status
       },
       isTest
-    });
+    };
+    const result = yield* call(upsertPnActivation, requestData);
 
     if (E.isRight(result) && result.right.status === 204) {
       yield* all([
@@ -53,12 +55,18 @@ function* handlePnActivation(
         call(loadPreferenceIfValidId, pnServiceId)
       ]);
       action.payload.onSuccess?.();
+    } else if (E.isLeft(result)) {
+      throw Error(readableReport(result.left));
     } else {
-      throw new Error();
+      throw Error(
+        `Status code: ${result.right.status} Request data: ${JSON.stringify(
+          requestData
+        )}`
+      );
     }
   } catch (e) {
     yield* all([
-      call(reportPNServiceStatusOnFailure, !activation_status),
+      call(reportPNServiceStatusOnFailure, !activation_status, `${e}`),
       put(pnActivationUpsert.failure()),
       call(loadPreferenceIfValidId, pnServiceId)
     ]);
@@ -66,7 +74,10 @@ function* handlePnActivation(
   }
 }
 
-function* reportPNServiceStatusOnFailure(predictedValue: boolean) {
+function* reportPNServiceStatusOnFailure(
+  predictedValue: boolean,
+  reason: string
+) {
   const pnServiceId = yield* select(pnMessagingServiceIdSelector);
   const pnServicePreferencesPot = yield* select(
     servicePreferencePotByIdSelector,
@@ -82,7 +93,7 @@ function* reportPNServiceStatusOnFailure(predictedValue: boolean) {
     ),
     O.getOrElse(() => predictedValue)
   );
-  trackPNServiceStatusChangeError(isServiceActive);
+  trackPNServiceStatusChangeError(isServiceActive, reason);
 }
 
 export function* watchPnSaga(bearerToken: SessionToken): SagaIterator {


### PR DESCRIPTION
## Short description
This PR adds the `reason` property to the mixpanel event `PN_SERVICE_STATUS_CHANGE_ERROR`

## List of changes proposed in this pull request
- `reason` property to the mixpanel event `PN_SERVICE_STATUS_CHANGE_ERROR`

## How to test
Using io-dev-api-server, simulate a left either, a 500 failure status code and a generic throw inside the pn activation saga and check that is properly reported.
