### PR TITLE
feat: [IOCOM-2343] SEND banner i18n update

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -3782,7 +3782,7 @@
       "reminderBanner": {
         "title": "Ricevi le tue comunicazioni a valore legale su IO!",
         "body": "Con IO è più semplice, ti basta attivare il servizio SEND.",
-        "cta": "Attiva SEND su IO",
+        "cta": "Scopri SEND su IO",
         "activationFlow": {
           "FAILURE_DETAILS_FETCH": {
             "title": "Non riusciamo ad attivare il servizio SEND",

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -3782,7 +3782,7 @@
       "reminderBanner": {
         "title": "Ricevi le tue comunicazioni a valore legale su IO!",
         "body": "Con IO è più semplice, ti basta attivare il servizio SEND.",
-        "cta": "Attiva SEND su IO",
+        "cta": "Scopri SEND su IO",
         "activationFlow": {
           "FAILURE_DETAILS_FETCH": {
             "title": "Non riusciamo ad attivare il servizio SEND",

--- a/ts/features/pn/reminderBanner/components/__test__/__snapshots__/PNActivationReminderBanner.test.tsx.snap
+++ b/ts/features/pn/reminderBanner/components/__test__/__snapshots__/PNActivationReminderBanner.test.tsx.snap
@@ -399,7 +399,7 @@ exports[`pnActivationBanner should match snapshot 1`] = `
                             }
                           >
                             <View
-                              accessibilityLabel="Ricevi le tue comunicazioni a valore legale su IO! Con IO è più semplice, ti basta attivare il servizio SEND. Attiva SEND su IO"
+                              accessibilityLabel="Ricevi le tue comunicazioni a valore legale su IO! Con IO è più semplice, ti basta attivare il servizio SEND. Scopri SEND su IO"
                               accessibilityRole="button"
                               accessible={true}
                               style={
@@ -452,7 +452,7 @@ exports[`pnActivationBanner should match snapshot 1`] = `
                               </Text>
                               <View
                                 accessibilityElementsHidden={true}
-                                accessibilityLabel="Attiva SEND su IO"
+                                accessibilityLabel="Scopri SEND su IO"
                                 accessibilityRole="button"
                                 accessibilityState={
                                   {
@@ -515,7 +515,7 @@ exports[`pnActivationBanner should match snapshot 1`] = `
                                     ]
                                   }
                                 >
-                                  Attiva SEND su IO
+                                  Scopri SEND su IO
                                 </Text>
                               </View>
                             </View>


### PR DESCRIPTION
## Short description
updated i18n keys for said banner's CTA

## List of changes proposed in this pull request
- updated i18n keys
- updated snapshots where necessary

## How to test
tests should pass, also the SEND banner's CTA in the landing screen should match the new design.
