### PR TITLE
chore: [IOBP-1646] Track MyBank PSP banner on mixpanel

### DIFF
--- a/ts/features/payments/checkout/analytics/index.ts
+++ b/ts/features/payments/checkout/analytics/index.ts
@@ -33,6 +33,8 @@ export type PaymentAnalyticsProps = {
   browser_type: PaymentAnalyticsBrowserType;
 };
 
+export const MYBANK_PSP_BANNER_ID = "mybank_psp_selection";
+
 // eslint-disable-next-line complexity
 export const getPaymentAnalyticsEventFromFailureOutcome = (
   outcome: WalletPaymentOutcomeEnum
@@ -437,3 +439,21 @@ export const trackPaymentUserCancellationContinue = (
     buildEventProperties("UX", "action", props)
   );
 };
+
+export const trackPaymentMyBankPspBanner = () =>
+  mixpanelTrack(
+    "BANNER",
+    buildEventProperties("UX", "screen_view", {
+      banner_id: MYBANK_PSP_BANNER_ID,
+      banner_page: "PAYMENT_PICK_PSP_SCREEN"
+    })
+  );
+
+export const trackPaymentMyBankPspBannerClose = () =>
+  mixpanelTrack(
+    "CLOSE_BANNER",
+    buildEventProperties("UX", "action", {
+      banner_id: MYBANK_PSP_BANNER_ID,
+      banner_page: "PAYMENT_PICK_PSP_SCREEN"
+    })
+  );

--- a/ts/features/payments/checkout/components/WalletPaymentPspBanner.tsx
+++ b/ts/features/payments/checkout/components/WalletPaymentPspBanner.tsx
@@ -26,6 +26,8 @@ import {
   walletPaymentSelectedPaymentMethodOptionSelector
 } from "../store/selectors/paymentMethods";
 import { paymentMethodPspBannerClose } from "../store/actions/orchestration";
+import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
+import * as analytics from "../analytics";
 
 const WalletPaymentPspBanner = () => {
   const dispatch = useIODispatch();
@@ -58,8 +60,11 @@ const WalletPaymentPspBanner = () => {
   };
 
   const handleBannerClose = () => {
+    analytics.trackPaymentMyBankPspBannerClose();
     dispatch(paymentMethodPspBannerClose(selectedPaymentMethodName));
   };
+
+  useOnFirstRender(() => analytics.trackPaymentMyBankPspBanner());
 
   if (!isBannerEnabled || !bannerConfig || isBannerClosed) {
     return null;


### PR DESCRIPTION
## Short description
This PR tracks on mixpanel the mybank psp banner inside the PSP selection screen.

## List of changes proposed in this pull request
- Added two tracking events `trackPaymentMyBankPspBanner` and `trackPaymentMyBankPspBannerClose`

## How to test
- Start a new payment;
- Select "MyBank" as payment method;
- When you reach the PSP selection screen and a PSP banner is displayed, verify that the events are correctly tracked in Mixpanel
