### PR TITLE
feat(IT Wallet): [SIW-2347] Enable attestation generation with fallback over TEE

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -106,7 +106,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - pagopa-io-react-native-integrity (0.3.1):
+  - pagopa-io-react-native-integrity (0.3.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2479,7 +2479,7 @@ SPEC CHECKSUMS:
   pagopa-io-react-native-cieid: 88d7f997157128a54426c261c5e1ddc9849a649d
   pagopa-io-react-native-crypto: c034b48871e47aefa569eda55cdb8432dab91aa5
   pagopa-io-react-native-http-client: d75b25d4375b795f173f396675cb3a12b888fe27
-  pagopa-io-react-native-integrity: 48c93d245cfea4bcbfeaab76ab5cda83e0e9c8c0
+  pagopa-io-react-native-integrity: 33729595fd6b8754b0f8027f9bbe8313bd7e9d76
   pagopa-io-react-native-jwt: 4f1c348d8260f0dc882412243531b3a516608e97
   pagopa-io-react-native-login-utils: 2e6ec74e7d03cfef7dc6e6eda0df6f1294ef64ac
   pagopa-io-react-native-secure-storage: 0297d41360d93f89e9f89c8412b99916e0dbf520

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@pagopa/io-react-native-cieid": "^0.3.5",
     "@pagopa/io-react-native-crypto": "^1.0.1",
     "@pagopa/io-react-native-http-client": "1.0.5",
-    "@pagopa/io-react-native-integrity": "^0.3.1",
+    "@pagopa/io-react-native-integrity": "^0.3.2",
     "@pagopa/io-react-native-jwt": "^2.1.0",
     "@pagopa/io-react-native-login-utils": "^1.0.8",
     "@pagopa/io-react-native-secure-storage": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3830,13 +3830,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagopa/io-react-native-integrity@npm:^0.3.1":
-  version: 0.3.1
-  resolution: "@pagopa/io-react-native-integrity@npm:0.3.1"
+"@pagopa/io-react-native-integrity@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "@pagopa/io-react-native-integrity@npm:0.3.2"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 74dc08b56af8b5b41015c2b4ef96fa6359eb0c0e1d7050e958adef26230fce694162c1546b1056562905941a9fbfba790ad179456c8832cfce55b800daff7e2b
+  checksum: 9adf99e81c119b07924a9b4edb58334d7891c958f7928199f69f49496aac4c133f668515141aa54b39c44b6f6a7088ee70d22ae7d48639605cf4d557de6c8f71
   languageName: node
   linkType: hard
 
@@ -13671,7 +13671,7 @@ __metadata:
     "@pagopa/io-react-native-cieid": ^0.3.5
     "@pagopa/io-react-native-crypto": ^1.0.1
     "@pagopa/io-react-native-http-client": 1.0.5
-    "@pagopa/io-react-native-integrity": ^0.3.1
+    "@pagopa/io-react-native-integrity": ^0.3.2
     "@pagopa/io-react-native-jwt": ^2.1.0
     "@pagopa/io-react-native-login-utils": ^1.0.8
     "@pagopa/io-react-native-secure-storage": ^0.2.0


### PR DESCRIPTION
## Short description
This PR adds a TEE fallback when the attestation generation with StrongBox enabled fails.

## List of changes proposed in this pull request
- Updated `io-react-native-integrity` to v0.3.2 to implement this feature

## How to test
With an Android device, try to activate ITW and check that no regressions are present. The preferred test would be to have a device that supports Strongbox but has issues with it, so although there is support for Strongbox, a fallback to TEE would be made. This case occurred on some Motorola and Xiaomi devices.

> [!NOTE]
> Testable from QA; however, as previously written, this test will be effective on devices with a Strongbox issue.