### PR TITLE
feat: [IOCOM-2146,IOCOM-2149] Annonuce archive/restore

### DIFF
--- a/ts/features/messages/components/Home/Toasts.tsx
+++ b/ts/features/messages/components/Home/Toasts.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
+import { AccessibilityInfo } from "react-native";
 import { useIOToast } from "@pagopa/io-app-design-system";
-import { useIOSelector } from "../../../../store/hooks";
+import { useIOSelector, useIOStore } from "../../../../store/hooks";
 import {
   archiveMessagesErrorReasonSelector,
   inboxMessagesErrorReasonSelector
@@ -10,8 +11,10 @@ import {
   processingResultReasonSelector,
   processingResultTypeSelector
 } from "../../store/reducers/archiving";
+import { isScreenReaderEnabledSelector } from "../../../../store/reducers/preferences";
 
 export const Toasts = () => {
+  const store = useIOStore();
   const toast = useIOToast();
 
   // Handling of archiving/unarchiving operations result
@@ -26,12 +29,16 @@ export const Toasts = () => {
         case "success":
           toast.success(processingResultReason);
           break;
-        case "warning":
-          toast.warning(processingResultReason);
-          break;
+      }
+
+      const isScreenReaderEnabled = isScreenReaderEnabledSelector(
+        store.getState()
+      );
+      if (isScreenReaderEnabled) {
+        AccessibilityInfo.announceForAccessibility(processingResultReason);
       }
     }
-  }, [processingResultType, processingResultReason, toast]);
+  }, [processingResultType, processingResultReason, store, toast]);
 
   // Handling of inbox messages errors. Be aware that any error
   // that happens when the list is empty is not displayed with
@@ -43,7 +50,7 @@ export const Toasts = () => {
     }
   }, [inboxErrorMessage, toast]);
 
-  // Handling of archive messages errors. Be aware that any
+  // Handling of archived messages errors. Be aware that any
   // error that happens when the list is empty is not displayed
   // with a Toast but with the EmptyList component
   const archiveErrorMessage = useIOSelector(archiveMessagesErrorReasonSelector);

--- a/ts/features/messages/components/Home/__tests__/Toast.test.tsx
+++ b/ts/features/messages/components/Home/__tests__/Toast.test.tsx
@@ -1,0 +1,218 @@
+import { createStore } from "redux";
+import { AccessibilityInfo } from "react-native";
+import { GlobalState } from "../../../../../store/reducers/types";
+import { applicationChangeState } from "../../../../../store/actions/application";
+import { appReducer } from "../../../../../store/reducers";
+import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
+import { Toasts } from "../Toasts";
+import { MESSAGES_ROUTES } from "../../../navigation/routes";
+import * as archivingReducer from "../../../store/reducers/archiving";
+import * as preferencesReducer from "../../../../../store/reducers/preferences";
+import * as allPaginatedReducer from "../../../store/reducers/allPaginated";
+
+jest.mock("rn-qr-generator", () => ({}));
+jest.mock("react-native-screenshot-prevent", () => ({}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock("@pagopa/io-app-design-system", () => ({
+  ...jest.requireActual("@pagopa/io-app-design-system"),
+  useIOToast: () => ({
+    show: (_message: string, _options?: unknown) => jest.fn(),
+    error: mockToastError,
+    warning: (_message: string) => jest.fn(),
+    success: mockToastSuccess,
+    info: (_message: string) => jest.fn(),
+    hideAll: () => jest.fn(),
+    hide: (_id: number) => jest.fn()
+  })
+}));
+
+describe("Toast", () => {
+  const mockedAnnounceForAccessibility = jest
+    .spyOn(AccessibilityInfo, "announceForAccessibility")
+    .mockImplementation(jest.fn());
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  it("should match empty snapshot", () => {
+    const component = renderComponent();
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+  it("should display no toast when there are no data to show", () => {
+    mockSelectorOutput();
+
+    renderComponent();
+
+    expect(mockToastSuccess.mock.calls.length).toBe(0);
+    expect(mockToastError.mock.calls.length).toBe(0);
+    expect(mockedAnnounceForAccessibility.mock.calls.length).toBe(0);
+  });
+  it("should display a success toast when a message has been successfully archived or restored. No accessibility announcement if screen reader is disabled", () => {
+    const reason = "My reason of success";
+    mockSelectorOutput("success", reason, false);
+
+    renderComponent();
+
+    expect(mockToastSuccess.mock.calls.length).toBe(1);
+    expect(mockToastSuccess.mock.calls[0].length).toBe(1);
+    expect(mockToastSuccess.mock.calls[0][0]).toBe(reason);
+
+    expect(mockToastError.mock.calls.length).toBe(0);
+
+    expect(mockedAnnounceForAccessibility.mock.calls.length).toBe(0);
+  });
+  it("should display a success toast when a message has been successfully archived or restored. Accessibility was announced with screen reader enabled", () => {
+    const reason = "My reason of success";
+    mockSelectorOutput("success", reason, true);
+
+    renderComponent();
+
+    expect(mockToastSuccess.mock.calls.length).toBe(1);
+    expect(mockToastSuccess.mock.calls[0].length).toBe(1);
+    expect(mockToastSuccess.mock.calls[0][0]).toBe(reason);
+
+    expect(mockToastError.mock.calls.length).toBe(0);
+
+    expect(mockedAnnounceForAccessibility.mock.calls.length).toBe(1);
+    expect(mockedAnnounceForAccessibility.mock.calls[0].length).toBe(1);
+    expect(mockedAnnounceForAccessibility.mock.calls[0][0]).toBe(reason);
+  });
+  it("should display a failure toast when a message has been successfully archived or restored. No accessibility announcement if screen reader is disabled", () => {
+    const reason = "My reason of failure";
+    mockSelectorOutput("error", reason, false);
+
+    renderComponent();
+
+    expect(mockToastError.mock.calls.length).toBe(1);
+    expect(mockToastError.mock.calls[0].length).toBe(1);
+    expect(mockToastError.mock.calls[0][0]).toBe(reason);
+
+    expect(mockToastSuccess.mock.calls.length).toBe(0);
+
+    expect(mockedAnnounceForAccessibility.mock.calls.length).toBe(0);
+  });
+  it("should display a failure toast when a message has been successfully archived or restored. Accessibility was announced with screen reader enabled", () => {
+    const reason = "My reason of failure";
+    mockSelectorOutput("error", reason, true);
+
+    renderComponent();
+
+    expect(mockToastError.mock.calls.length).toBe(1);
+    expect(mockToastError.mock.calls[0].length).toBe(1);
+    expect(mockToastError.mock.calls[0][0]).toBe(reason);
+
+    expect(mockToastSuccess.mock.calls.length).toBe(0);
+
+    expect(mockedAnnounceForAccessibility.mock.calls.length).toBe(1);
+    expect(mockedAnnounceForAccessibility.mock.calls[0].length).toBe(1);
+    expect(mockedAnnounceForAccessibility.mock.calls[0][0]).toBe(reason);
+  });
+  it("should display a failure toast when there is an error in the Inbox", () => {
+    mockSelectorOutput(
+      undefined,
+      undefined,
+      false,
+      "Inbox error that is not displayed to the user"
+    );
+
+    renderComponent();
+
+    expect(mockToastError.mock.calls.length).toBe(1);
+    expect(mockToastError.mock.calls[0].length).toBe(1);
+    expect(mockToastError.mock.calls[0][0]).toBe(
+      "There is a temporary problem, please try again."
+    );
+
+    expect(mockToastSuccess.mock.calls.length).toBe(0);
+
+    expect(mockedAnnounceForAccessibility.mock.calls.length).toBe(0);
+  });
+  it("should display a failure toast when there is an error in the Archive", () => {
+    mockSelectorOutput(
+      undefined,
+      undefined,
+      false,
+      undefined,
+      "Archive error that is not displayed to the user"
+    );
+
+    renderComponent();
+
+    expect(mockToastError.mock.calls.length).toBe(1);
+    expect(mockToastError.mock.calls[0].length).toBe(1);
+    expect(mockToastError.mock.calls[0][0]).toBe(
+      "There is a temporary problem, please try again."
+    );
+
+    expect(mockToastSuccess.mock.calls.length).toBe(0);
+
+    expect(mockedAnnounceForAccessibility.mock.calls.length).toBe(0);
+  });
+  it("should display three toasts when there is a success in archiving/restoring, an error in Inbox and an error in Archive", () => {
+    const successReason = "My reason of success";
+    mockSelectorOutput(
+      "success",
+      successReason,
+      false,
+      "Inbox error that is not displayed to the user",
+      "Archive error that is not displayed to the user"
+    );
+
+    renderComponent();
+
+    expect(mockToastSuccess.mock.calls.length).toBe(1);
+    expect(mockToastSuccess.mock.calls[0].length).toBe(1);
+    expect(mockToastSuccess.mock.calls[0][0]).toBe(successReason);
+
+    expect(mockToastError.mock.calls.length).toBe(2);
+    expect(mockToastError.mock.calls[0].length).toBe(1);
+    expect(mockToastError.mock.calls[0][0]).toBe(
+      "There is a temporary problem, please try again."
+    );
+    expect(mockToastError.mock.calls[1][0]).toBe(
+      "There is a temporary problem, please try again."
+    );
+
+    expect(mockedAnnounceForAccessibility.mock.calls.length).toBe(0);
+  });
+});
+
+const mockSelectorOutput = (
+  processingResultType: "success" | "error" | undefined = undefined,
+  processingResultReason: string | undefined = undefined,
+  isScreenReaderEnabled: boolean = false,
+  inboxErrorReason: string | undefined = undefined,
+  archiveErrorReason: string | undefined = undefined
+) => {
+  jest
+    .spyOn(archivingReducer, "processingResultTypeSelector")
+    .mockImplementation((_state: GlobalState) => processingResultType);
+  jest
+    .spyOn(archivingReducer, "processingResultReasonSelector")
+    .mockImplementation((_state: GlobalState) => processingResultReason);
+  jest
+    .spyOn(preferencesReducer, "isScreenReaderEnabledSelector")
+    .mockImplementation((_state: GlobalState) => isScreenReaderEnabled);
+  jest
+    .spyOn(allPaginatedReducer, "inboxMessagesErrorReasonSelector")
+    .mockImplementation((_state: GlobalState) => inboxErrorReason);
+  jest
+    .spyOn(allPaginatedReducer, "archiveMessagesErrorReasonSelector")
+    .mockImplementation((_state: GlobalState) => archiveErrorReason);
+};
+
+const renderComponent = () => {
+  const initialState = appReducer(undefined, applicationChangeState("active"));
+  const store = createStore(appReducer, initialState as any);
+
+  return renderScreenWithNavigationStoreContext(
+    () => <Toasts />,
+    MESSAGES_ROUTES.MESSAGES_HOME,
+    {},
+    store
+  );
+};

--- a/ts/features/messages/components/Home/__tests__/__snapshots__/Toast.test.tsx.snap
+++ b/ts/features/messages/components/Home/__tests__/__snapshots__/Toast.test.tsx.snap
@@ -1,0 +1,347 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Toast should match empty snapshot 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <RNCSafeAreaProvider
+    onInsetsChange={[Function]}
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "#FFFFFF",
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          {
+            "zIndex": 1,
+          }
+        }
+      >
+        <View
+          accessibilityElementsHidden={false}
+          importantForAccessibility="auto"
+          onLayout={[Function]}
+          pointerEvents="box-none"
+          style={null}
+        >
+          <View
+            collapsable={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "zIndex": 0,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "borderBottomColor": "rgb(216, 216, 216)",
+                  "flex": 1,
+                  "shadowColor": "rgb(216, 216, 216)",
+                  "shadowOffset": {
+                    "height": 0.5,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.85,
+                  "shadowRadius": 0,
+                }
+              }
+            />
+          </View>
+          <View
+            collapsable={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "height": 44,
+                "maxHeight": undefined,
+                "minHeight": undefined,
+                "opacity": undefined,
+                "transform": undefined,
+              }
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                {
+                  "height": 0,
+                }
+              }
+            />
+            <View
+              pointerEvents="box-none"
+              style={
+                {
+                  "alignItems": "stretch",
+                  "flex": 1,
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginStart": 0,
+                    "opacity": 1,
+                  }
+                }
+              />
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "justifyContent": "center",
+                    "marginHorizontal": 16,
+                    "maxWidth": 718,
+                    "opacity": 1,
+                  }
+                }
+              >
+                <Text
+                  accessibilityRole="header"
+                  aria-level="1"
+                  collapsable={false}
+                  numberOfLines={1}
+                  onLayout={[Function]}
+                  style={
+                    {
+                      "color": "rgb(28, 28, 30)",
+                      "fontSize": 17,
+                      "fontWeight": "600",
+                    }
+                  }
+                >
+                  MESSAGES_HOME
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-end",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginEnd": 0,
+                    "opacity": 1,
+                  }
+                }
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+      <RNSScreenContainer
+        onLayout={[Function]}
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      >
+        <RNSScreen
+          activityState={2}
+          collapsable={false}
+          gestureResponseDistance={
+            {
+              "bottom": -1,
+              "end": -1,
+              "start": -1,
+              "top": -1,
+            }
+          }
+          onGestureCancel={[Function]}
+          pointerEvents="box-none"
+          sheetAllowedDetents="large"
+          sheetCornerRadius={-1}
+          sheetExpandsWhenScrolledToEdge={true}
+          sheetGrabberVisible={false}
+          sheetLargestUndimmedDetent="all"
+          style={
+            {
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+              "zIndex": undefined,
+            }
+          }
+        >
+          <View
+            collapsable={false}
+            style={
+              {
+                "opacity": 1,
+              }
+            }
+          />
+          <View
+            accessibilityElementsHidden={false}
+            closing={false}
+            collapsable={false}
+            gestureVelocityImpact={0.3}
+            importantForAccessibility="auto"
+            onClose={[Function]}
+            onGestureBegin={[Function]}
+            onGestureCanceled={[Function]}
+            onGestureEnd={[Function]}
+            onOpen={[Function]}
+            onTransition={[Function]}
+            pointerEvents="box-none"
+            style={
+              [
+                {
+                  "display": "flex",
+                  "overflow": undefined,
+                },
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+              ]
+            }
+            transitionSpec={
+              {
+                "close": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+                "open": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              pointerEvents="box-none"
+              style={
+                {
+                  "flex": 1,
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                enabled={false}
+                handlerTag={1}
+                handlerType="PanGestureHandler"
+                needsOffscreenAlphaCompositing={false}
+                onGestureHandlerEvent={[Function]}
+                onGestureHandlerStateChange={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "transform": [
+                      {
+                        "translateX": 0,
+                      },
+                      {
+                        "translateX": 0,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  pointerEvents="box-none"
+                  style={
+                    [
+                      {
+                        "flex": 1,
+                        "overflow": "hidden",
+                      },
+                      [
+                        {
+                          "backgroundColor": "#FFFFFF",
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "flex": 1,
+                        "flexDirection": "column-reverse",
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                        }
+                      }
+                    />
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RNSScreen>
+      </RNSScreenContainer>
+    </View>
+  </RNCSafeAreaProvider>
+</View>
+`;

--- a/ts/features/messages/store/reducers/archiving.ts
+++ b/ts/features/messages/store/reducers/archiving.ts
@@ -16,7 +16,7 @@ import { MessageListCategory } from "../../types/messageListCategory";
 export type ArchivingStatus = "disabled" | "enabled" | "processing";
 
 export type ProcessingResult = {
-  type: "success" | "warning" | "error";
+  type: "success" | "error";
   reason: string;
 };
 


### PR DESCRIPTION
## Short description
This PR adds accessibility announcement of the archiving/restoring message operation's result.

## List of changes proposed in this pull request
- When an archive/restore success/failure toast is displayed, the same content is also announced, if the screen reader is enabled

## How to test
Using the io-dev-api.server and a real device, test on both Android and iOS that the resulting operation's result is announced.
