### PR TITLE
feat(IT Wallet): [SIW-2444] Add `useOfflineToastGuard` when opening FIMS from MDL details

### DIFF
--- a/ts/features/itwallet/presentation/details/components/ItwPresentationDetailsFooter.tsx
+++ b/ts/features/itwallet/presentation/details/components/ItwPresentationDetailsFooter.tsx
@@ -147,6 +147,9 @@ const IPatenteListItemAction = ({ docNumber }: IPatenteListItemActionProps) => {
   const { startFIMSAuthenticationFlow } =
     useFIMSRemoteServiceConfiguration("iPatente");
   const ctaConfig = useIOSelector(itwIPatenteCtaConfigSelector);
+  const startFimsAuthenticationFlow = useOfflineToastGuard(() =>
+    startFIMSAuthenticationFlow(label, iPatenteUrl)
+  );
 
   if (!ctaConfig?.visibility) {
     return null;
@@ -166,7 +169,7 @@ const IPatenteListItemAction = ({ docNumber }: IPatenteListItemActionProps) => {
       variant="primary"
       icon="externalLink"
       label={label}
-      onPress={() => startFIMSAuthenticationFlow(label, iPatenteUrl)}
+      onPress={startFimsAuthenticationFlow}
     />
   );
 };


### PR DESCRIPTION
This PR adds the `useOfflineToastGuard` hook to protect the FIMS flow with the offline toast.

## Short description
Include a summary of the changes.

## List of changes proposed in this pull request
- Added `useOfflineToastGuard` hook to protect the FIMS flow with the offline toast.

## How to test
When using the full app in offline mode or the mini-app in offline mode, navigate to the MDL details screen and press the "Vai al saldo punti patente" CTA. The offline toast should pop up. 
