### PR TITLE
feat(IT Wallet): [SIW-2376] Add FAQ link for devices that do not support NFC

### DIFF
--- a/ts/features/itwallet/discovery/components/ItwNfcNotSupportedComponent.tsx
+++ b/ts/features/itwallet/discovery/components/ItwNfcNotSupportedComponent.tsx
@@ -1,3 +1,4 @@
+import { IOToast } from "@pagopa/io-app-design-system";
 import { useCallback } from "react";
 import I18n from "../../../../i18n";
 import {
@@ -10,6 +11,10 @@ import { useIOSelector } from "../../../../store/hooks";
 import { itwLifecycleIsValidSelector } from "../../lifecycle/store/selectors";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { ITW_ROUTES } from "../../navigation/routes";
+import { openWebUrl } from "../../../../utils/url";
+
+const NFC_NOT_SUPPORTED_HELP_URL =
+  "https://assistenza.ioapp.it/hc/it/articles/35541811236113-Cosa-serve-per-usare-IT-Wallet";
 
 export const ItwNfcNotSupportedComponent = () => {
   const navigation = useIONavigation();
@@ -20,6 +25,11 @@ export const ItwNfcNotSupportedComponent = () => {
   useAvoidHardwareBackButton();
 
   const goBack = useCallback(() => navigation.goBack(), [navigation]);
+
+  const handleOpenFaq = () =>
+    openWebUrl(NFC_NOT_SUPPORTED_HELP_URL, () =>
+      IOToast.error(I18n.t("genericError"))
+    );
 
   const navigateToDiscoveryInfoScreen = useCallback(
     () =>
@@ -35,9 +45,7 @@ export const ItwNfcNotSupportedComponent = () => {
         label: I18n.t(
           "features.itWallet.discovery.nfcNotSupported.actions.l3.continue"
         ),
-        onPress: () => {
-          // TODO: [SIW-2376] Open FAQ for devices that do not support NFC
-        }
+        onPress: handleOpenFaq
       }
     : {
         label: I18n.t(

--- a/ts/features/itwallet/discovery/components/ItwNfcNotSupportedComponent.tsx
+++ b/ts/features/itwallet/discovery/components/ItwNfcNotSupportedComponent.tsx
@@ -13,7 +13,7 @@ import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { ITW_ROUTES } from "../../navigation/routes";
 import { openWebUrl } from "../../../../utils/url";
 
-const NFC_NOT_SUPPORTED_HELP_URL =
+const NFC_NOT_SUPPORTED_FAQ_URL =
   "https://assistenza.ioapp.it/hc/it/articles/35541811236113-Cosa-serve-per-usare-IT-Wallet";
 
 export const ItwNfcNotSupportedComponent = () => {
@@ -27,7 +27,7 @@ export const ItwNfcNotSupportedComponent = () => {
   const goBack = useCallback(() => navigation.goBack(), [navigation]);
 
   const handleOpenFaq = () =>
-    openWebUrl(NFC_NOT_SUPPORTED_HELP_URL, () =>
+    openWebUrl(NFC_NOT_SUPPORTED_FAQ_URL, () =>
       IOToast.error(I18n.t("genericError"))
     );
 


### PR DESCRIPTION
## Short description
This PR adds a link to the FAQ for devices that do not support NFC

## List of changes proposed in this pull request
- updated the primary action in `ItwNfcNotSupportedComponent` to open the FAQ link

## How to test
- ensure the wallet is active and the device does not support NFC
- go to Settings > Playground > Documenti su IO > enable L3
- go to the wallet screen > upgrade to IT-wallet > tap on the _Scopri di più_ button
- check that the FAQ link is opened in the browser