### PR TITLE
fix: [IOBP-1700] Payment webview alert flow closed

### DIFF
--- a/ts/features/payments/checkout/components/WalletPaymentWebView.tsx
+++ b/ts/features/payments/checkout/components/WalletPaymentWebView.tsx
@@ -39,7 +39,7 @@ const WalletPaymentWebView = ({
         if (event.url.startsWith(WALLET_WEBVIEW_OUTCOME_SCHEMA)) {
           onSuccess?.(event.url);
         }
-        if (event.url === "about:blank") {
+        if (event.url === "about:blank" && event.isTopFrame) {
           onCancel?.(WalletPaymentOutcomeEnum.IN_APP_BROWSER_CLOSED_BY_USER);
         }
         return !event.url.startsWith(WALLET_WEBVIEW_OUTCOME_SCHEMA);

--- a/ts/features/payments/checkout/components/__tests__/WalletPaymentWebView.test.tsx
+++ b/ts/features/payments/checkout/components/__tests__/WalletPaymentWebView.test.tsx
@@ -93,6 +93,7 @@ describe("WalletPaymentWebView", () => {
 
     const webView = getByTestId("webview");
     fireEvent(webView, "onShouldStartLoadWithRequest", {
+      isTopFrame: true,
       url: "about:blank"
     });
 


### PR DESCRIPTION
## Short description
This PR includes a change to the `WalletPaymentWebView` component in the `WalletPaymentWebView.tsx` file. The change ensures that the "about:blank" URL check also verifies that the event is from the top frame before triggering the `onCancel` callback.

## List of changes proposed in this pull request
-Updated the condition to include `event.isTopFrame` when checking for the "about:blank" URL, ensuring more accurate handling of user cancellations in the in-app browser.

## How to test
- Start the app IO in UAT env on iOS;
- Start a payment flow and choose `PayPal (anche in 3 rate)` as payment method and reach the webview page;
- Check that the alert to close the flow doesn't trigger;