### PR TITLE
fix(IT Wallet): [SIW-2445] Infinite loading screen when starting presentation after full authentication

### DIFF
--- a/ts/features/itwallet/presentation/remote/screens/ItwRemoteRequestValidationScreen.tsx
+++ b/ts/features/itwallet/presentation/remote/screens/ItwRemoteRequestValidationScreen.tsx
@@ -34,7 +34,6 @@ const ItwRemoteRequestValidationScreen = ({ route }: ScreenProps) => {
    * so the app is started and the user goes through the identification or the full authentication process.
    * Here we wait for the startup status to be authenticated to avoid inconsistencies
    * between the machine and the navigation.
-   * This also applies when the token expires and the user needs to identify again.
    */
   if (statupStatus !== StartupStatusEnum.AUTHENTICATED) {
     return (

--- a/ts/features/itwallet/presentation/remote/screens/ItwRemoteRequestValidationScreen.tsx
+++ b/ts/features/itwallet/presentation/remote/screens/ItwRemoteRequestValidationScreen.tsx
@@ -11,7 +11,10 @@ import { ItwRemoteParamsList } from "../navigation/ItwRemoteParamsList.ts";
 import { ItwRemoteDeepLinkFailure } from "../components/ItwRemoteDeepLinkFailure.tsx";
 import { ItwRemoteLoadingScreen } from "../components/ItwRemoteLoadingScreen.tsx";
 import { useIOSelector } from "../../../../../store/hooks.ts";
-import { progressSelector } from "../../../../identification/store/selectors/index.ts";
+import {
+  StartupStatusEnum,
+  isStartupLoaded
+} from "../../../../../store/reducers/startup.ts";
 
 export type ItwRemoteRequestValidationScreenNavigationParams =
   Partial<ItwRemoteRequestPayload>;
@@ -24,16 +27,16 @@ type ScreenProps = IOStackNavigationRouteProps<
 const ItwRemoteRequestValidationScreen = ({ route }: ScreenProps) => {
   useItwDisableGestureNavigation();
 
-  const identificationProgress = useIOSelector(progressSelector);
+  const statupStatus = useIOSelector(isStartupLoaded);
 
   /**
-   * In case of same-device flow the app might not be running when the user opens the link,
-   * so the app is started and the user needs to complete the identification process.
-   * Here we wait for the identification to finish to avoid inconsistencies
+   * There may be scenarios where the app is not running when the user opens the link,
+   * so the app is started and the user goes through the identification or the full authentication process.
+   * Here we wait for the startup status to be authenticated to avoid inconsistencies
    * between the machine and the navigation.
    * This also applies when the token expires and the user needs to identify again.
    */
-  if (identificationProgress.kind !== "identified") {
+  if (statupStatus !== StartupStatusEnum.AUTHENTICATED) {
     return (
       <ItwRemoteLoadingScreen
         title={I18n.t(

--- a/ts/features/itwallet/presentation/remote/screens/ItwRemoteRequestValidationScreen.tsx
+++ b/ts/features/itwallet/presentation/remote/screens/ItwRemoteRequestValidationScreen.tsx
@@ -27,7 +27,7 @@ type ScreenProps = IOStackNavigationRouteProps<
 const ItwRemoteRequestValidationScreen = ({ route }: ScreenProps) => {
   useItwDisableGestureNavigation();
 
-  const statupStatus = useIOSelector(isStartupLoaded);
+  const startupStatus = useIOSelector(isStartupLoaded);
 
   /**
    * There may be scenarios where the app is not running when the user opens the link,
@@ -35,7 +35,7 @@ const ItwRemoteRequestValidationScreen = ({ route }: ScreenProps) => {
    * Here we wait for the startup status to be authenticated to avoid inconsistencies
    * between the machine and the navigation.
    */
-  if (statupStatus !== StartupStatusEnum.AUTHENTICATED) {
+  if (startupStatus !== StartupStatusEnum.AUTHENTICATED) {
     return (
       <ItwRemoteLoadingScreen
         title={I18n.t(

--- a/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteRequestValidation.test.tsx
+++ b/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteRequestValidation.test.tsx
@@ -1,5 +1,6 @@
-import { createStore } from "redux";
+import { createStore, Action } from "redux";
 import { fromPromise } from "xstate";
+import { act } from "@testing-library/react-native";
 import { ITW_REMOTE_ROUTES } from "../../navigation/routes.ts";
 import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper.tsx";
 import { GlobalState } from "../../../../../../store/reducers/types.ts";
@@ -12,6 +13,11 @@ import { IOStackNavigationProp } from "../../../../../../navigation/params/AppPa
 import { ItwRemoteParamsList } from "../../navigation/ItwRemoteParamsList.ts";
 import { itwRemoteMachine } from "../../machine/machine.ts";
 import { identificationSuccess } from "../../../../../identification/store/actions/index.ts";
+import { startupLoadSuccess } from "../../../../../../store/actions/startup.ts";
+import { StartupStatusEnum } from "../../../../../../store/reducers/startup.ts";
+import { reproduceSequence } from "../../../../../../utils/tests.ts";
+
+type ActorRef = ReturnType<typeof ItwRemoteMachineContext.useActorRef>;
 
 describe("ItwRemoteRequestValidationScreen", () => {
   it("it should render the screen correctly", () => {
@@ -19,16 +25,25 @@ describe("ItwRemoteRequestValidationScreen", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should render the loading screen if payload is valid", () => {
+  it("should render the loading screen and start the machine if payload is valid", async () => {
     const validPayload = {
       client_id: "abc123xy",
       request_uri: "https://example.com/callback",
       state: "hyqizm592"
     } as ItwRemoteRequestPayload;
 
+    const mockSend = jest.fn();
+
+    jest
+      .spyOn(ItwRemoteMachineContext, "useActorRef")
+      .mockReturnValue({ send: mockSend } as unknown as ActorRef);
+
     const { getByTestId } = renderComponent(validPayload);
 
-    expect(getByTestId("loader")).toBeTruthy();
+    await act(() => {
+      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(getByTestId("loader")).toBeTruthy();
+    });
   });
 
   it("should render failure screen if missing required fields", () => {
@@ -53,56 +68,90 @@ describe("ItwRemoteRequestValidationScreen", () => {
     expect(getByTestId("failure")).toBeTruthy();
   });
 
-  const renderComponent = (payload: Partial<ItwRemoteRequestPayload> = {}) => {
-    const globalState = appReducer(
-      appReducer(undefined, applicationChangeState("active")),
-      identificationSuccess({ isBiometric: true })
-    );
+  it("should render the loading screen and not start the machine if the user is not authenticated", async () => {
+    const validPayload = {
+      client_id: "abc123xy",
+      request_uri: "https://example.com/callback",
+      state: "hyqizm592"
+    } as ItwRemoteRequestPayload;
 
-    const mockNavigation = new Proxy(
-      {},
-      {
-        get: _ => jest.fn()
-      }
-    ) as unknown as IOStackNavigationProp<
-      ItwRemoteParamsList,
-      "ITW_REMOTE_REQUEST_VALIDATION"
-    >;
+    const mockSend = jest.fn();
+    jest
+      .spyOn(ItwRemoteMachineContext, "useActorRef")
+      .mockReturnValue({ send: mockSend } as unknown as ActorRef);
 
-    const route = {
-      key: "ITW_REMOTE_REQUEST_VALIDATION",
-      name: ITW_REMOTE_ROUTES.REQUEST_VALIDATION,
-      params: payload
-    };
+    const { getByTestId } = renderComponent(validPayload, false);
 
-    const logic = itwRemoteMachine.provide({
-      guards: {
-        isWalletActive: jest.fn().mockReturnValue(true),
-        isEidExpired: jest.fn().mockReturnValue(false),
-        isL3Enabled: jest.fn().mockReturnValue(true)
-      },
-      actions: {
-        navigateToClaimsDisclosureScreen: jest.fn()
-      },
-      actors: {
-        evaluateRelyingPartyTrust: fromPromise(jest.fn()),
-        getRequestObject: fromPromise(jest.fn()),
-        getPresentationDetails: fromPromise(jest.fn())
-      }
+    await act(() => {
+      expect(mockSend).not.toHaveBeenCalled();
+      expect(getByTestId("loader")).toBeTruthy();
     });
-
-    return renderScreenWithNavigationStoreContext<GlobalState>(
-      () => (
-        <ItwRemoteMachineContext.Provider logic={logic}>
-          <ItwRemoteRequestValidationScreen
-            navigation={mockNavigation}
-            route={route}
-          />
-        </ItwRemoteMachineContext.Provider>
-      ),
-      ITW_REMOTE_ROUTES.REQUEST_VALIDATION,
-      payload,
-      createStore(appReducer, globalState as any)
-    );
-  };
+  });
 });
+
+const renderComponent = (
+  payload: Partial<ItwRemoteRequestPayload> = {},
+  isAuthenticated = true
+) => {
+  const sequenceOfActions: ReadonlyArray<Action> = [
+    applicationChangeState("active"),
+    ...(isAuthenticated
+      ? [
+          startupLoadSuccess(StartupStatusEnum.AUTHENTICATED),
+          identificationSuccess({ isBiometric: true })
+        ]
+      : [])
+  ];
+
+  const globalState = reproduceSequence(
+    {} as GlobalState,
+    appReducer,
+    sequenceOfActions
+  );
+
+  const mockNavigation = new Proxy(
+    {},
+    {
+      get: _ => jest.fn()
+    }
+  ) as unknown as IOStackNavigationProp<
+    ItwRemoteParamsList,
+    "ITW_REMOTE_REQUEST_VALIDATION"
+  >;
+
+  const route = {
+    key: "ITW_REMOTE_REQUEST_VALIDATION",
+    name: ITW_REMOTE_ROUTES.REQUEST_VALIDATION,
+    params: payload
+  };
+
+  const logic = itwRemoteMachine.provide({
+    guards: {
+      isWalletActive: jest.fn().mockReturnValue(true),
+      isEidExpired: jest.fn().mockReturnValue(false),
+      isL3Enabled: jest.fn().mockReturnValue(true)
+    },
+    actions: {
+      navigateToClaimsDisclosureScreen: jest.fn()
+    },
+    actors: {
+      evaluateRelyingPartyTrust: fromPromise(jest.fn()),
+      getRequestObject: fromPromise(jest.fn()),
+      getPresentationDetails: fromPromise(jest.fn())
+    }
+  });
+
+  return renderScreenWithNavigationStoreContext<GlobalState>(
+    () => (
+      <ItwRemoteMachineContext.Provider logic={logic}>
+        <ItwRemoteRequestValidationScreen
+          navigation={mockNavigation}
+          route={route}
+        />
+      </ItwRemoteMachineContext.Provider>
+    ),
+    ITW_REMOTE_ROUTES.REQUEST_VALIDATION,
+    payload,
+    createStore(appReducer, globalState as any)
+  );
+};


### PR DESCRIPTION
## Short description
This PR fixes an issue that arises when the user completes a full authentication and immediately starts a remote presentation. The selector used to "pause" the machine was not correct, as identification is not triggered after the full authentication flow.

## List of changes proposed in this pull request
- Checked the startup status instead of the identification progress
- Added a test case

## How to test
Log out from app IO. Log in again and **without closing the app or putting it in the background** start a remote presentation: after the loading screen you should navigate to the claims disclosure screen.

> [!Important]
> Please check for regressions in the following scenarios:
> - Kill the app, start the same device flow
> - Put the app in the background, wait for some time, start the same device flow
