### PR TITLE
chore: [IOPLT-1149] Normalise threshold used to hide elements on smaller screens

### DIFF
--- a/ts/components/BonusCard/BonusCardScreenComponent.tsx
+++ b/ts/components/BonusCard/BonusCardScreenComponent.tsx
@@ -4,15 +4,15 @@ import {
   useIOThemeContext
 } from "@pagopa/io-app-design-system";
 import { ReactNode } from "react";
-import { Dimensions } from "react-native";
 import Animated, { useAnimatedRef } from "react-native-reanimated";
+import { useDetectSmallScreen } from "../../hooks/useDetectSmallScreen";
 import { useHeaderSecondLevel } from "../../hooks/useHeaderSecondLevel";
 import { SupportRequestParams } from "../../hooks/useStartSupportRequest";
+import { useIOSelector } from "../../store/hooks";
+import { isScreenReaderEnabledSelector } from "../../store/reducers/preferences";
 import { isAndroid } from "../../utils/platform";
 import FocusAwareStatusBar from "../ui/FocusAwareStatusBar";
 import { IOScrollView, IOScrollViewActions } from "../ui/IOScrollView";
-import { isScreenReaderEnabledSelector } from "../../store/reducers/preferences";
-import { useIOSelector } from "../../store/hooks";
 import { BonusCard } from "./BonusCard";
 
 type BaseProps = {
@@ -26,14 +26,6 @@ export type BonusScreenComponentProps = BaseProps &
   SupportRequestParams &
   BonusCard;
 
-/*
-Let's reuse the variable names set in the PR#6088 to make the
-the eventual refactoring much easier.
-In this specific case, we set the threshold to show/hide
-the `BonusCard` logo
-*/
-export const MIN_HEIGHT_TO_SHOW_FULL_RENDER = 700;
-
 const BonusCardScreenComponent = ({
   title,
   headerAction,
@@ -45,9 +37,7 @@ const BonusCardScreenComponent = ({
   ...cardProps
 }: BonusScreenComponentProps) => {
   const animatedScrollViewRef = useAnimatedRef<Animated.ScrollView>();
-
-  const screenHeight = Dimensions.get("window").height;
-  const shouldHideLogo = screenHeight < MIN_HEIGHT_TO_SHOW_FULL_RENDER;
+  const { isDeviceScreenSmall } = useDetectSmallScreen();
 
   const screenReaderEnabled = useIOSelector(isScreenReaderEnabledSelector);
 
@@ -88,7 +78,7 @@ const BonusCardScreenComponent = ({
         actions={actions}
         includeContentMargins={false}
       >
-        <BonusCard hideLogo={shouldHideLogo} {...cardProps} />
+        <BonusCard hideLogo={isDeviceScreenSmall} {...cardProps} />
         {children}
       </IOScrollView>
     </>

--- a/ts/features/authentication/login/optIn/screens/OptInScreen.tsx
+++ b/ts/features/authentication/login/optIn/screens/OptInScreen.tsx
@@ -1,5 +1,5 @@
 import { useRef } from "react";
-import { Dimensions, View } from "react-native";
+import { View } from "react-native";
 import {
   Badge,
   ContentWrapper,
@@ -33,6 +33,7 @@ import { useHeaderSecondLevel } from "../../../../../hooks/useHeaderSecondLevel"
 import { CieIdLoginProps } from "../../cie/components/CieIdLoginWebView";
 import { AuthenticationParamsList } from "../../../common/navigation/params/AuthenticationParamsList";
 import { AUTHENTICATION_ROUTES } from "../../../common/navigation/routes";
+import { useDetectSmallScreen } from "../../../../../hooks/useDetectSmallScreen";
 
 export enum Identifier {
   SPID = "SPID",
@@ -53,8 +54,6 @@ export type ChosenIdentifier =
       identifier: Identifier.CIE_ID;
       params: CieIdLoginProps;
     };
-
-export const MIN_HEIGHT_TO_SHOW_FULL_RENDER = 820;
 
 const authScreensMap = {
   CIE: AUTHENTICATION_ROUTES.CIE_PIN_SCREEN,
@@ -80,6 +79,8 @@ const OptInScreen = () => {
     useRoute<Route<"AUTHENTICATION_OPT_IN", ChosenIdentifier>>();
   const navigation = useIONavigation();
   const store = useIOStore();
+
+  const { isDeviceScreenSmall } = useDetectSmallScreen();
 
   useOnFirstRender(() => {
     trackLoginSessionOptIn();
@@ -131,7 +132,7 @@ const OptInScreen = () => {
           if the device height is > 820 then the pictogram will be visible,
           otherwise it will not be visible
           */}
-        {Dimensions.get("screen").height > MIN_HEIGHT_TO_SHOW_FULL_RENDER && (
+        {!isDeviceScreenSmall && (
           <View style={{ alignSelf: "center" }} testID="pictogram-test">
             <Pictogram name="passcode" size={120} />
           </View>

--- a/ts/features/settings/security/shared/components/PinCreation.tsx
+++ b/ts/features/settings/security/shared/components/PinCreation.tsx
@@ -228,10 +228,6 @@ export const PinCreation = ({ isOnboarding = false }: Props) => {
   return (
     <View testID="pin-creation-screen" style={{ flex: 1 }}>
       <View style={{ flex: 1, justifyContent: "center" }}>
-        {/*
-          If the device height is less than MIN_HEIGHT_TO_SHOW_FULL_RENDER,
-          then the pictogram will not be visible.
-          */}
         {!isDeviceScreenSmall && (
           <View style={{ alignSelf: "center" }}>
             <Pictogram name="key" size={64} />

--- a/ts/hooks/useDetectSmallScreen.ts
+++ b/ts/hooks/useDetectSmallScreen.ts
@@ -1,6 +1,15 @@
 import { Dimensions } from "react-native";
 
-const MIN_HEIGHT_TO_SHOW_FULL_RENDER = 780;
+/*
+This threshold excludes all the iOS devices with home button
+(iPhone SE 2022, for example) or Android devices with a
+viewport height considered too small.
+
+VIEWPORT HEIGHTS considered too small:
+iPhone SE 2022: 667px
+Pixel 2: 732px
+*/
+const MIN_HEIGHT_TO_SHOW_FULL_RENDER = 800;
 
 export const useDetectSmallScreen = () => ({
   isDeviceScreenSmall:


### PR DESCRIPTION
## Short description
This PR normalises the threshold used to hide elements on smaller screens. This change is intended to prevent the proliferation of seemingly arbitrary _magic numbers_ (what devices were taken into account, and why these and not others, etc.). Only one threshold is left, under which some elements can be hidden to prevent content overflow on certain screens.

## List of changes proposed in this pull request
- Use the `useDetectSmallScreen` hook in all the files where a custom `MIN_HEIGHT_TO_SHOW_FULL_RENDER` constant was previously used

## How to test
Check the screens impacted by the change and test if everything is working as expected.