### PR TITLE
fix(IT Wallet): [SIW-2469] Disable gesture navigation in the final presentation screen

### DIFF
--- a/ts/features/itwallet/presentation/remote/screens/ItwRemoteAuthResponseScreen.tsx
+++ b/ts/features/itwallet/presentation/remote/screens/ItwRemoteAuthResponseScreen.tsx
@@ -1,6 +1,7 @@
 import { Linking } from "react-native";
 import { IOToast } from "@pagopa/io-app-design-system";
 import { OperationResultScreenContent } from "../../../../../components/screens/OperationResultScreenContent";
+import { useItwDisableGestureNavigation } from "../../../common/hooks/useItwDisableGestureNavigation";
 import I18n from "../../../../../i18n";
 import { ItwRemoteLoadingScreen } from "../components/ItwRemoteLoadingScreen";
 import { ItwRemoteMachineContext } from "../machine/provider";
@@ -12,6 +13,8 @@ import {
 } from "../machine/selectors";
 
 export const ItwRemoteAuthResponseScreen = () => {
+  useItwDisableGestureNavigation();
+
   const machineRef = ItwRemoteMachineContext.useActorRef();
   const isLoading = ItwRemoteMachineContext.useSelector(selectIsLoading);
   const isSuccess = ItwRemoteMachineContext.useSelector(selectIsSuccess);


### PR DESCRIPTION
## Short description
This PR disables gesture navigation in `ItwRemoteAuthResponseScreen`. Currently it is possible to swipe back to the claims disclosure screen, breaking the flow.

## List of changes proposed in this pull request
- Call `useItwDisableGestureNavigation` hook

## How to test
Complete the remote presentation (same-device and cross-device) on iOS. In the last screen (`ITW_REMOTE_AUTH_RESPONSE`) try to swipe back: it should not be possible to navigate to the previous screen.