### PR TITLE
Missing dot in offline banner

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -254,7 +254,7 @@
         "action": "Riprova"
       },
       "statusMessage": {
-        "message": "Nessuna connessione",
+        "message": "Nessuna connessione.",
         "action": "Cosa posso fare?"
       },
       "connectionRestored": "Connessione ripristinata.",

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -254,7 +254,7 @@
         "action": "Riprova"
       },
       "statusMessage": {
-        "message": "Nessuna connessione",
+        "message": "Nessuna connessione.",
         "action": "Cosa posso fare?"
       },
       "connectionRestored": "Connessione ripristinata.",


### PR DESCRIPTION
this PR solves an OCD issue (😆 ) so that the text shown in the offline banner is correctly rendered with the aside CTA

Before

> Nessuna connessione **Cosa posso fare?**

After

> Nessuna connessione. **Cosa posso fare?**