### PR TITLE
fix(IT Wallet): [SIW-2349] Fix double header glitch in offline wallet screen

### DIFF
--- a/ts/features/onboarding/screens/__tests__/OnboardingShareDataScreen.test.tsx
+++ b/ts/features/onboarding/screens/__tests__/OnboardingShareDataScreen.test.tsx
@@ -7,11 +7,14 @@ import { appReducer } from "../../../../store/reducers";
 import { applicationChangeState } from "../../../../store/actions/application";
 import { trackMixPanelTrackingInfo } from "../../../settings/common/analytics/mixpanel/mixpanelAnalytics";
 
-jest.mock("../../../../store/hooks", () => ({
-  useIODispatch: () => jest.fn(),
-  useIOSelector: jest.fn(() => true),
-  useIOStore: () => ({ getState: jest.fn() })
-}));
+jest.mock("../../../../store/hooks", () => {
+  const original = jest.requireActual("../../../../store/hooks");
+
+  return {
+    ...original,
+    useIODispatch: () => jest.fn()
+  };
+});
 
 jest.mock("../../../../utils/analytics", () => ({
   getFlowType: () => "test-flow"

--- a/ts/features/onboarding/screens/biometric&securityChecks/__test__/FingerprintScreen.test.tsx
+++ b/ts/features/onboarding/screens/biometric&securityChecks/__test__/FingerprintScreen.test.tsx
@@ -11,11 +11,14 @@ import { appReducer } from "../../../../../store/reducers";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
 import I18n from "../../../../../i18n";
 
-jest.mock("../../../../../store/hooks", () => ({
-  useIODispatch: jest.fn(),
-  useIOSelector: jest.fn(() => true),
-  useIOStore: jest.fn()
-}));
+jest.mock("../../../../../store/hooks", () => {
+  const original = jest.requireActual("../../../../../store/hooks");
+
+  return {
+    ...original,
+    useIODispatch: jest.fn()
+  };
+});
 
 jest.mock("../../../../../utils/analytics", () => ({
   getFlowType: jest.fn(() => "test-flow"),

--- a/ts/features/onboarding/screens/biometric&securityChecks/__test__/MissingDeviceBiometricScreen.test.tsx
+++ b/ts/features/onboarding/screens/biometric&securityChecks/__test__/MissingDeviceBiometricScreen.test.tsx
@@ -6,11 +6,14 @@ import { renderScreenWithNavigationStoreContext } from "../../../../../utils/tes
 import I18n from "../../../../../i18n";
 import ROUTES from "../../../../../navigation/routes";
 
-jest.mock("../../../../../store/hooks", () => ({
-  useIODispatch: () => jest.fn(),
-  useIOSelector: jest.fn(() => true),
-  useIOStore: jest.fn()
-}));
+jest.mock("../../../../../store/hooks", () => {
+  const original = jest.requireActual("../../../../../store/hooks");
+
+  return {
+    ...original,
+    useIODispatch: jest.fn()
+  };
+});
 
 jest.mock("../../../../../utils/analytics", () => ({
   getFlowType: jest.fn(() => "test-flow"),

--- a/ts/features/onboarding/screens/biometric&securityChecks/__test__/MissingDevicePinScreen.test.tsx
+++ b/ts/features/onboarding/screens/biometric&securityChecks/__test__/MissingDevicePinScreen.test.tsx
@@ -6,11 +6,14 @@ import { renderScreenWithNavigationStoreContext } from "../../../../../utils/tes
 import I18n from "../../../../../i18n";
 import ROUTES from "../../../../../navigation/routes";
 
-jest.mock("../../../../../store/hooks", () => ({
-  useIODispatch: () => jest.fn(),
-  useIOSelector: jest.fn(() => true),
-  useIOStore: jest.fn()
-}));
+jest.mock("../../../../../store/hooks", () => {
+  const original = jest.requireActual("../../../../../store/hooks");
+
+  return {
+    ...original,
+    useIODispatch: jest.fn()
+  };
+});
 
 jest.mock("../../../../../utils/analytics", () => ({
   getFlowType: jest.fn(() => "test-flow"),

--- a/ts/hooks/useStatusAlertProps.tsx
+++ b/ts/hooks/useStatusAlertProps.tsx
@@ -77,8 +77,14 @@ export const useStatusAlertProps = (
   const localeFallback = fallbackForLocalizedMessageKeys(locale);
 
   useEffect(() => {
-    // If the user is offline and the current route is not in the blacklist, show the alert
-    if (blackListOfflineAlertRoutes.has(currentRoute)) {
+    if (
+      blackListOfflineAlertRoutes.has(currentRoute) ||
+      offlineAccessReason !== undefined
+    ) {
+      /**
+       * In case we are in the mini-app for offline usage or the current route is in the blacklist,
+       * we don't need to show the alert.
+       */
       setConnectivityAlert(undefined);
       return;
     }
@@ -131,13 +137,6 @@ export const useStatusAlertProps = (
   ]);
 
   return useMemo(() => {
-    if (offlineAccessReason) {
-      /**
-       * In case we are in the mini-app for offline usage, we don't need to show the alert.
-       * The mini-app manages the alert by itself.
-       */
-      return undefined;
-    }
     if (isConnected === false && connectivityAlert) {
       return {
         alertProps: connectivityAlert,
@@ -174,7 +173,6 @@ export const useStatusAlertProps = (
     localeFallback,
     isConnected,
     bottomSheet,
-    connectivityAlert,
-    offlineAccessReason
+    connectivityAlert
   ]);
 };


### PR DESCRIPTION
## Short description
> [!IMPORTANT]  
> I was unable to reproduce this bug on my Android device, so I cannot confirm whether the issue is fully resolved. The fix is based on assumptions and should be thoroughly tested across a variety of devices.

This PR is another attemp to address a visual glitch that causes a duplicate header to appear on the home screen of the offline mini-app, only on production build

## List of changes proposed in this pull request
- Moved `offlineAccessReason` check to `useEffect`

## How to test
The issue was reported on certain Android devices.  
To verify the fix:
1. Launch the app on an affected Android device (if available).
2. Navigate to the offline mini-app.
3. Confirm that the double header glitch no longer appears.
