### PR TITLE
fix: [IOBP-1722] CGN Barcode width scale

### DIFF
--- a/ts/features/bonus/cgn/screens/discount/CgnDiscountCodeScreen.tsx
+++ b/ts/features/bonus/cgn/screens/discount/CgnDiscountCodeScreen.tsx
@@ -128,7 +128,12 @@ const CgnDiscountCodeScreen = () => {
               <Icon name="tag" color={theme["icon-decorative"]} />
             </View>
             <VSpacer size={4} />
-            <Barcode format="CODE128" value={discountCode} height={70} />
+            <Barcode
+              format="CODE128"
+              value={discountCode}
+              height={70}
+              width={1.15}
+            />
             <VSpacer size={4} />
             <H4 textStyle={StyleSheet.flatten([styles.labelCode])}>
               {discountCode}


### PR DESCRIPTION
## Short description
This PR fixes the appearance of the CGN barcode by adding a new `width` property for better visual customization that scales the barcode with the right fit for barcodes that are too long.

## List of changes proposed in this pull request
- Enhanced the `Barcode` component in `CgnDiscountCodeScreen` to include a `width` property set to `1.15`, improving the barcode's visual scaling.

## How to test
- Open the CGN card flow;
- Select a merchant that has a discount code with a barcode and check that if the barcode is too long (max length is 20 chars), the barcode doesn't go outside the screen


## Preview
|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/791ce531-2477-4e89-953f-d731cf539311" width="350px" />|<img src="https://github.com/user-attachments/assets/b8839cce-074d-469c-9fac-3e642b77a889" width="350px" />
