### PR TITLE
chore: [IOBP-1723] Disable pagoPA UAT toggle if app is in local env

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -611,6 +611,7 @@
       "pagoPaEnvironment": {
         "pagoPaEnv": "pagoPA",
         "pagoPAEnvAlert": "This change requires app reboot",
+        "pagoPAEnvAlertLocal": "The pagoPA test environment cannot be enabled with the local app build",
         "alertConfirmTitle": "Do you want to use the pagoPA test environment?",
         "alertConfirmMessage": "If you enable the pagoPA test environment you will no longer see the history of your transactions and your saved payment methods, and you can only use payment methods expressly created for this purpose. If you don’t understand what it means not enable this feature.",
         "alertMessage": "The application must be restarted for the changes to take effect."

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -611,6 +611,7 @@
       "pagoPaEnvironment": {
         "pagoPaEnv": "pagoPA",
         "pagoPAEnvAlert": "La modifica richiede il riavvio dell'app",
+        "pagoPAEnvAlertLocal": "L'ambiente di UAT pagoPA non può essere abilitato con la build dell'app in locale",
         "alertConfirmTitle": "Vuoi usare l'ambiente di test pagoPA?",
         "alertConfirmMessage": "Se abiliti l'ambiente di test pagoPA non vedrai più lo storico delle tue transazioni e i tuoi metodi di pagamento salvati, e potrai usare solo metodi di pagamento espressamente creati per questo scopo. Se non ti è chiaro cosa questo significa non abilitare questa funzione.",
         "alertMessage": "È necessario il riavvio dell'applicazione affinché le modifiche abbiano effetto."

--- a/ts/features/settings/common/navigation/__test__/__snapshots__/SettingsNavigator.test.tsx.snap
+++ b/ts/features/settings/common/navigation/__test__/__snapshots__/SettingsNavigator.test.tsx.snap
@@ -2055,6 +2055,7 @@ exports[`SettingsNavigator renders all routes (snapshot) 1`] = `
                               [
                                 {
                                   "description": "This change requires app reboot",
+                                  "disabled": false,
                                   "label": "pagoPA",
                                   "onSwitchValueChange": [Function],
                                   "value": false,
@@ -2191,7 +2192,7 @@ exports[`SettingsNavigator renders all routes (snapshot) 1`] = `
                                     <View
                                       accessibilityState={
                                         {
-                                          "disabled": undefined,
+                                          "disabled": false,
                                         }
                                       }
                                       accessible={false}
@@ -2252,9 +2253,10 @@ exports[`SettingsNavigator renders all routes (snapshot) 1`] = `
                                         accessibilityState={
                                           {
                                             "checked": false,
-                                            "disabled": undefined,
+                                            "disabled": false,
                                           }
                                         }
+                                        disabled={false}
                                         onChange={[Function]}
                                         onResponderTerminationRequest={[Function]}
                                         onStartShouldSetResponder={[Function]}

--- a/ts/features/settings/devMode/components/DeveloperModeSection.tsx
+++ b/ts/features/settings/devMode/components/DeveloperModeSection.tsx
@@ -48,7 +48,7 @@ import {
 } from "../../../../store/reducers/persistedPreferences";
 import { clipboardSetStringWithFeedback } from "../../../../utils/clipboard";
 import { getDeviceId } from "../../../../utils/device";
-import { isDevEnv } from "../../../../utils/environment";
+import { isDevEnv, isLocalEnv } from "../../../../utils/environment";
 
 import { ITW_ROUTES } from "../../../itwallet/navigation/routes";
 import { useAppReviewRequest } from "../../../appReviews/hooks/useAppReviewRequest";
@@ -73,7 +73,12 @@ type DevDataCopyListItem = {
 
 type TestEnvironmentsListItem = Pick<
   ComponentProps<typeof ListItemSwitch>,
-  "label" | "value" | "description" | "testID" | "onSwitchValueChange"
+  | "label"
+  | "value"
+  | "description"
+  | "testID"
+  | "onSwitchValueChange"
+  | "disabled"
 >;
 
 type DevActionButton = {
@@ -498,9 +503,12 @@ const DeveloperTestEnvironmentSection = ({
   const testEnvironmentsListItems: ReadonlyArray<TestEnvironmentsListItem> = [
     {
       label: I18n.t("profile.main.pagoPaEnvironment.pagoPaEnv"),
-      description: I18n.t("profile.main.pagoPaEnvironment.pagoPAEnvAlert"),
+      description: isLocalEnv
+        ? I18n.t("profile.main.pagoPaEnvironment.pagoPAEnvAlertLocal")
+        : I18n.t("profile.main.pagoPaEnvironment.pagoPAEnvAlert"),
       value: isPagoPATestEnabled,
-      onSwitchValueChange: onPagoPAEnvironmentToggle
+      onSwitchValueChange: onPagoPAEnvironmentToggle,
+      disabled: isLocalEnv
     },
     {
       label: I18n.t("profile.main.pnEnvironment.pnEnv"),
@@ -536,6 +544,7 @@ const DeveloperTestEnvironmentSection = ({
           description={item.description}
           value={item.value}
           onSwitchValueChange={item.onSwitchValueChange}
+          disabled={item.disabled}
         />
       )}
       ItemSeparatorComponent={() => <Divider />}


### PR DESCRIPTION
## Short description
This PR introduces changes to improve the handling of the pagoPA test environment in the developer mode section of the settings. It supports detecting local app builds and disabling the pagoPA test environment in such cases, along with corresponding updates to localization files and UI components.

## List of changes proposed in this pull request
- Modified the `DeveloperTestEnvironmentSection` to use `isLocalEnv` to conditionally set the description and disable the toggle for the pagoPA test environment.

## How to test
Open the developer settings page with an app built with the .env.local variables and check that the `pagoPA` switch is disabled.

## Preview
The following preview shows both the case when the app is built with a local .env and another with the production .env

https://github.com/user-attachments/assets/64574470-2abc-4c72-9a63-5a975199d426


