### PR TITLE
fix: [IOBP-1726] Add missing key to Markdown Body element

### DIFF
--- a/ts/features/payments/checkout/screens/WalletPaymentConfirmScreen.tsx
+++ b/ts/features/payments/checkout/screens/WalletPaymentConfirmScreen.tsx
@@ -242,6 +242,7 @@ const WalletPaymentConfirmScreen = () => {
           Link: (param, renderer) => (
             <Body
               asLink
+              key={param.raw}
               weight="Semibold"
               onPress={() => onLinkPress(param.url)}
               accessibilityRole="link"


### PR DESCRIPTION
## Short description
This change will fix the console message `Warning Each child in a list should have a unique "key" prop` as addressed in this commit: 0f822032dd705c4bd49551dbc8685e17c5fe007a

## List of changes proposed in this pull request
- Add missing key to list object

## How to test
- Start a payment workflow till the checkout
- Ensure that the console error disappeared