### PR TITLE
fix(IT Wallet): [SIW-2492] Infinite loading when starting a presentation while another one is pending

### DIFF
--- a/ts/features/itwallet/presentation/remote/machine/__tests__/machine.test.ts
+++ b/ts/features/itwallet/presentation/remote/machine/__tests__/machine.test.ts
@@ -448,4 +448,23 @@ describe("itwRemoteMachine", () => {
     expect(actor.getSnapshot().value).toStrictEqual("Failure");
     expect(navigateToFailureScreen).toHaveBeenCalledTimes(1);
   });
+
+  it("should reset the machine", async () => {
+    const initialSnapshot = createActor(itwRemoteMachine).getSnapshot();
+    const actor = createActor(mockedMachine, {
+      snapshot: _.merge(undefined, initialSnapshot, {
+        value: "ClaimsDisclosure",
+        context: {
+          ...InitialContext,
+          payload: qrCodePayload,
+          rpSubject: "test_rp"
+        }
+      })
+    });
+    actor.start();
+    actor.send({ type: "reset" });
+
+    await waitFor(actor, snapshot => snapshot.matches("Idle"));
+    expect(actor.getSnapshot().context).toStrictEqual<Context>(InitialContext);
+  });
 });

--- a/ts/features/itwallet/presentation/remote/machine/events.ts
+++ b/ts/features/itwallet/presentation/remote/machine/events.ts
@@ -34,6 +34,10 @@ export type Consent = {
   type: "holder-consent";
 };
 
+export type Reset = {
+  type: "reset";
+};
+
 export type RemoteEvents =
   | Start
   | GoToWalletActivation
@@ -42,4 +46,5 @@ export type RemoteEvents =
   | Consent
   | ToggleCredential
   | Back
-  | Close;
+  | Close
+  | Reset;

--- a/ts/features/itwallet/presentation/remote/machine/machine.ts
+++ b/ts/features/itwallet/presentation/remote/machine/machine.ts
@@ -60,11 +60,18 @@ export const itwRemoteMachine = setup({
   id: "itwRemoteMachine",
   context: { ...InitialContext },
   initial: "Idle",
+  on: {
+    reset: {
+      target: ".Idle",
+      actions: assign({ ...InitialContext })
+    }
+  },
   states: {
     Idle: {
       description:
         "The machine is in idle, ready to start the remote presentation flow",
       on: {
+        reset: {}, // Do nothing if the machine is already idle
         start: {
           actions: assign(({ event }) => ({
             payload: event.payload

--- a/ts/features/itwallet/presentation/remote/screens/ItwRemoteRequestValidationScreen.tsx
+++ b/ts/features/itwallet/presentation/remote/screens/ItwRemoteRequestValidationScreen.tsx
@@ -61,10 +61,9 @@ const ContentView = ({ payload }: { payload: ItwRemoteRequestPayload }) => {
 
   useFocusEffect(
     useCallback(() => {
-      machineRef.send({
-        type: "start",
-        payload
-      });
+      // Reset the machine in case there is a pending presentation
+      machineRef.send({ type: "reset" });
+      machineRef.send({ type: "start", payload });
     }, [payload, machineRef])
   );
 

--- a/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteRequestValidation.test.tsx
+++ b/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteRequestValidation.test.tsx
@@ -26,11 +26,12 @@ describe("ItwRemoteRequestValidationScreen", () => {
   });
 
   it("should render the loading screen and start the machine if payload is valid", () => {
-    const validPayload = {
+    const validPayload: ItwRemoteRequestPayload = {
       client_id: "abc123xy",
       request_uri: "https://example.com/callback",
-      state: "hyqizm592"
-    } as ItwRemoteRequestPayload;
+      state: "hyqizm592",
+      request_uri_method: "get"
+    };
 
     const mockSend = jest.fn();
 
@@ -41,7 +42,11 @@ describe("ItwRemoteRequestValidationScreen", () => {
     const { getByTestId } = renderComponent(validPayload);
 
     act(() => {
-      expect(mockSend).toHaveBeenCalledTimes(1);
+      expect(mockSend).toHaveBeenCalledWith({ type: "reset" });
+      expect(mockSend).toHaveBeenCalledWith({
+        type: "start",
+        payload: validPayload
+      });
       expect(getByTestId("loader")).toBeTruthy();
     });
   });


### PR DESCRIPTION
## Short description
This PR fixes an issue that occurs when a new presentation is started while another one is pending. The wallet shows an infinite loading screen instead of restarting with the new presentation.

## List of changes proposed in this pull request
- Added a reset action to reset the presentation machine
- Updated tests

## How to test
1. Start a remote presentation and stop at the claims disclosure screen
2. Put the app in the background and start a new presentation with different claims (same-device)
3. Ensure the new presentation overrides the previous one and the new claims are displayed in the claims disclosure screen 

|Before (infinite loading)|After|
|------|------|
|<video width="320" src="https://github.com/user-attachments/assets/a0dd99bf-4dff-483d-bb43-768ece563753" />|<video width="320" src="https://github.com/user-attachments/assets/91a592bf-c900-4129-9eed-99de43b9ce37" />
