### PR TITLE
chore(CdC): [IOBP-1535] Add CdC FIMS with remote url and service configuration

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -2,7 +2,7 @@
 
 IO_BACKEND_VERSION=v16.12.1
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=1.0.68
+IO_SERVICES_METADATA_VERSION=IOBP-1727-add-cdc-fims-configurations
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.4.0
 # IO Wallet Backend version

--- a/ts/features/bonus/cdc/store/selectors/remoteConfig.ts
+++ b/ts/features/bonus/cdc/store/selectors/remoteConfig.ts
@@ -1,0 +1,23 @@
+import { pipe } from "fp-ts/lib/function";
+import { createSelector } from "reselect";
+import * as O from "fp-ts/lib/Option";
+import { GlobalState } from "../../../../../store/reducers/types";
+
+const cdcRemoteConfigSelector = (state: GlobalState) =>
+  pipe(
+    state.remoteConfig,
+    O.map(config => config.cdcV2)
+  );
+
+/**
+ * Return the remote config about CDC CTA inside the onboarding screen.
+ */
+export const cdcCtaConfigSelector = createSelector(
+  cdcRemoteConfigSelector,
+  cdcConfig =>
+    pipe(
+      cdcConfig,
+      O.map(cdc => cdc.cta_onboarding_config),
+      O.toUndefined
+    )
+);


### PR DESCRIPTION
## ⚠️ This PR depends on https://github.com/pagopa/io-services-metadata/pull/978

## Short description
This PR introduces support for the CDC onboarding flow via FIMS authentication, leveraging remote configurations. It also adds the ability to include the `deviceId` as a query parameter in the FIMS auth URL, controlled by a remote feature flag.

## List of changes proposed in this pull request
* [`ts/features/bonus/cdc/activation/screens/CdcBonusRequestInformationTos.tsx`](diffhunk://#diff-cfa4376631b208ff63ccc712193e710058b0643d98742d83dc64111ed7854ebcR11-R19): Added the `useFIMSRemoteServiceConfiguration` hook and implemented the `onStartCdcFlow` function to initiate the FIMS authentication flow. This includes handling device IDs and error scenarios using `IOToast`. Updated the button's `onPress` action to invoke `onStartCdcFlow`. [[1]](diffhunk://#diff-cfa4376631b208ff63ccc712193e710058b0643d98742d83dc64111ed7854ebcR11-R19) [[2]](diffhunk://#diff-cfa4376631b208ff63ccc712193e710058b0643d98742d83dc64111ed7854ebcR28-R40) [[3]](diffhunk://#diff-cfa4376631b208ff63ccc712193e710058b0643d98742d83dc64111ed7854ebcL43-R56)
* [`ts/features/bonus/cdc/store/selectors/remoteConfig.ts`](diffhunk://#diff-26cadf9600bdf09b95047a17d044bff33fd2cd638c7a958667bb5e60e02c6a68R1-R23): Added the `cdcCtaConfigSelector` to fetch CDC CTA onboarding configurations from the remote state.

## How to test
- Checkout this PR of the dev-server: https://github.com/pagopa/io-dev-api-server/pull/487
- Verify that the remote URL is correctly set when starting the CdC onboarding flow through the "Carta della Cultura" special service.
- Also check that, depending on whether the `includeDeviceId` feature flag is enabled or disabled, the user’s device ID is correctly appended (or not) as a query parameter to the URL.

**Note**: The URL provided on the dev server is not yet linked to a backend-side redirect. As a result, the CdC onboarding webpages cannot be accessed until the backend configuration is completed.
