### PR TITLE
chore: [IOCOM-2412] Remove Roboto

### DIFF
--- a/ios/ItaliaApp/Info.plist
+++ b/ios/ItaliaApp/Info.plist
@@ -98,12 +98,6 @@
     <string>The app needs NSSpeechRecognitionUsageDescription permission</string>
     <key>UIAppFonts</key>
     <array>
-      <string>RobotoMono-Bold.ttf</string>
-      <string>RobotoMono-BoldItalic.ttf</string>
-      <string>RobotoMono-Light.ttf</string>
-      <string>RobotoMono-LightItalic.ttf</string>
-      <string>RobotoMono-Regular.ttf</string>
-      <string>RobotoMono-RegularItalic.ttf</string>
       <string>DMMono-Medium.ttf</string>
       <string>TitilliumSansPro-Black.otf</string>
       <string>TitilliumSansPro-Bold.otf</string>


### PR DESCRIPTION
## Short description
This PR removes Roboto font references from Info.plist.

## List of changes proposed in this pull request
- Roboto was removed back in 2024 [here](https://github.com/pagopa/io-app/pull/6299)

## How to test
Check that the iOS project runs without warnings related to Roboto.
