### PR TITLE
chore: [IOBP-1734] Add CdC mixpanel tracking events

### DIFF
--- a/ts/features/bonus/cdc/activation/screens/CdcBonusRequestInformationTos.tsx
+++ b/ts/features/bonus/cdc/activation/screens/CdcBonusRequestInformationTos.tsx
@@ -11,12 +11,18 @@ import { ID_CDC_TYPE } from "../../../common/utils";
 import { useFIMSRemoteServiceConfiguration } from "../../../../fims/common/hooks";
 import { cdcCtaConfigSelector } from "../../store/selectors/remoteConfig";
 import { getDeviceId } from "../../../../../utils/device";
+import { useOnFirstRender } from "../../../../../utils/hooks/useOnFirstRender";
+import * as analytics from "../../analytics";
 
 const CdcBonusRequestInformationTos = () => {
   const cdcInfo = useIOSelector(availableBonusTypesSelectorFromId(ID_CDC_TYPE));
   const { startFIMSAuthenticationFlow } =
     useFIMSRemoteServiceConfiguration("cdc-onboarding");
   const ctaConfig = useIOSelector(cdcCtaConfigSelector);
+
+  useOnFirstRender(() => {
+    analytics.trackCdcRequestIntro();
+  });
 
   if (cdcInfo === undefined) {
     return null;
@@ -30,11 +36,11 @@ const CdcBonusRequestInformationTos = () => {
       IOToast.error(I18n.t("global.genericError"));
       return;
     }
-
     const url = new URL(ctaConfig.url);
     if (ctaConfig.includeDeviceId) {
       url.searchParams.set("device", getDeviceId());
     }
+    analytics.trackCdcRequestIntroContinue();
     startFIMSAuthenticationFlow(I18n.t("bonus.cdc.request"), url.toString());
   };
 

--- a/ts/features/bonus/cdc/analytics/index.ts
+++ b/ts/features/bonus/cdc/analytics/index.ts
@@ -1,0 +1,14 @@
+import { mixpanelTrack } from "../../../../mixpanel";
+import { buildEventProperties } from "../../../../utils/analytics";
+
+export const trackCdcRequestStart = () =>
+  mixpanelTrack("CDC_REQUEST_START", buildEventProperties("UX", "action"));
+
+export const trackCdcRequestIntro = () =>
+  mixpanelTrack("CDC_REQUEST_INTRO", buildEventProperties("UX", "screen_view"));
+
+export const trackCdcRequestIntroContinue = () =>
+  mixpanelTrack(
+    "CDC_REQUEST_INTRO_CONTINUE",
+    buildEventProperties("UX", "action")
+  );

--- a/ts/features/bonus/cdc/hooks/useSpecialCtaCdc.tsx
+++ b/ts/features/bonus/cdc/hooks/useSpecialCtaCdc.tsx
@@ -8,6 +8,7 @@ import { useServicePreferenceByChannel } from "../../../services/details/hooks/u
 import { loadAvailableBonuses } from "../../common/store/actions/availableBonusesTypes";
 import { CDC_ROUTES } from "../navigation/routes";
 import { ServiceId } from "../../../../../definitions/backend/ServiceId";
+import * as analytics from "../analytics";
 /**
  * Hook to handle the CDC activation/deactivation
  */
@@ -18,6 +19,7 @@ const useCdcActivation = () => {
 
   const subscribeHandler = useCallback(() => {
     dispatch(loadAvailableBonuses.request());
+    analytics.trackCdcRequestStart();
     navigation.navigate(CDC_ROUTES.CDC_MAIN, {
       screen: CDC_ROUTES.CDC_INFORMATION_TOS
     });
@@ -54,7 +56,7 @@ export const useSpecialCtaCdc = (
       return undefined;
     }
 
-    if (!isServiceActive) {
+    if (isServiceActive) {
       return {
         label: I18n.t("bonus.cdc.request"),
         loading,

--- a/ts/features/bonus/cdc/hooks/useSpecialCtaCdc.tsx
+++ b/ts/features/bonus/cdc/hooks/useSpecialCtaCdc.tsx
@@ -56,7 +56,7 @@ export const useSpecialCtaCdc = (
       return undefined;
     }
 
-    if (isServiceActive) {
+    if (!isServiceActive) {
       return {
         label: I18n.t("bonus.cdc.request"),
         loading,


### PR DESCRIPTION
## Short description
This PR adds analytics tracking for user interactions on mixpanel. It adds new tracking events and integrates these events into existing components.

## List of changes proposed in this pull request
* Added `trackCdcRequestStart`, `trackCdcRequestIntro`, and `trackCdcRequestIntroContinue` functions to track user actions and screen views during the CDC activation flow. 
* Added `trackCdcRequestStart` into the `subscribeHandler` callback in the `useSpecialCtaCdc` hook to track the start of the CDC activation process.
* Added `trackCdcRequestIntro` and `trackCdcRequestIntroContinue` calls in the `CdcBonusRequestInformationTos` component to track screen views and user actions.

## How to test
- Start a new CdC onboarding request with the dev-server started trough the service "Carta della Cultura"
- Check that the mixpanel event are dispatched when are indicated in [the airtable definition](https://airtable.com/appfuAAW2S44jfutx/tbl95mgJHrJvJazCC/viwSkurftLXOxiuir/recLO6cGbQmO0qyV5?blocks=hide).
