### PR TITLE
fix: [IOAPPX-498] Document picker not opening

### DIFF
--- a/ts/features/barcode/hooks/useIOBarcodeFileReader.tsx
+++ b/ts/features/barcode/hooks/useIOBarcodeFileReader.tsx
@@ -7,17 +7,18 @@ import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
 import { useState } from "react";
 import { Alert, Linking, View } from "react-native";
-import DocumentPicker, {
-  DocumentPickerOptions,
-  DocumentPickerResponse,
-  NonEmptyArray,
-  types
-} from "@react-native-documents/picker";
 import {
   launchImageLibrary,
   ImagePickerResponse,
   ImageLibraryOptions
 } from "react-native-image-picker";
+import {
+  DocumentPickerOptions,
+  DocumentPickerResponse,
+  NonEmptyArray,
+  pick,
+  types
+} from "@react-native-documents/picker";
 import I18n from "../../../i18n";
 import { useIOBottomSheetModal } from "../../../utils/hooks/bottomSheet";
 import {
@@ -221,10 +222,13 @@ const useIOBarcodeFileReader = ({
   /**
    * Shows the document picker that lets the user select a PDF document from the library
    */
+  /**
+   * Shows the document picker that lets the user select a PDF document from the library
+   */
   const showDocumentPicker = async () => {
     setIsLoading(true);
     await pipe(
-      TE.tryCatch(() => DocumentPicker.pick(documentPickerOptions), E.toError),
+      TE.tryCatch(() => pick(documentPickerOptions), E.toError),
       TE.map(onDocumentSelected),
       TE.mapLeft(() => setIsLoading(false))
     )();

--- a/ts/features/barcode/hooks/useIOBarcodeFileReader.tsx
+++ b/ts/features/barcode/hooks/useIOBarcodeFileReader.tsx
@@ -222,9 +222,6 @@ const useIOBarcodeFileReader = ({
   /**
    * Shows the document picker that lets the user select a PDF document from the library
    */
-  /**
-   * Shows the document picker that lets the user select a PDF document from the library
-   */
   const showDocumentPicker = async () => {
     setIsLoading(true);
     await pipe(


### PR DESCRIPTION
## Short description
This PR fixes an issue that prevents the document picker from opening.

## List of changes proposed in this pull request
- Directly import the `pick` method.

## How to test
Start the app and try to upload a file from the "Scan" navigation tab on both Android and iOS. You should be able to load a file.
