### PR TITLE
refactor: [IOBP-1740] Update CAC for card onboarding auth error

### DIFF
--- a/locales/de/index.json
+++ b/locales/de/index.json
@@ -1656,7 +1656,7 @@
           "title": "Autorisierung verweigert",
           "subtitle": "Vergewissere dich, dass du die Anweisungen deiner Bank oder Zahlungsapp korrekt befolgt hast.",
           "primaryAction": "Schließen",
-          "secondaryAction": "Mehr erfahren",
+          "secondaryAction": "Was kannst du tun?",
           "bottomSheet": {
             "title": "Was ist zu tun, wenn das Hinzufügen der Methode fehlschlägt?",
             "description": "**Kredit- oder Debitkarte** Bitte erkundige dich bei deiner Bank. Die häufigsten Fälle sind: \n- deine Karte ist nicht für Online-Einkäufe freigeschaltet.\n- du hast den 3DS-Dienst noch nicht aktiviert: Dies ist ein Sicherheitssystem für Online-Zahlungen.\n- deine Karte wurde gesperrt oder blockiert.\n- du hast deine Karte 'pausiert'.\n**Andere Methoden** Wende dich an den Support der Zahlungsmethode und frage nach dem Grund für die Ablehnung."

--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -1831,7 +1831,7 @@
           "title": "Autorizzazione negata",
           "subtitle": "Controlla di aver seguito correttamente le istruzioni della tua banca o app di pagamento.",
           "primaryAction": "Chiudi",
-          "secondaryAction": "Scopri di più",
+          "secondaryAction": "What can you do?",
           "bottomSheet": {
             "title": "Cosa fare se l’aggiunta del metodo non va a buon fine?",
             "description": "**Carta di credito o debito**\n\nTi invitiamo a verificare con la tua banca. I casi più frequenti sono:\n\n1. La tua carta non è abilitata agli acquisti online.\n2. Non hai ancora attivato il servizio 3DS: si tratta di un sistema di sicurezza legato ai pagamenti online.\n3. La tua carta è stata sospesa o bloccata.\n4. Hai messo 'in pausa' la tua carta.\n\n\n**Altri metodi**\n\nContatta l'assistenza del tuo metodo e chiedi il motivo del rifiuto."

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -1831,7 +1831,7 @@
           "title": "Autorizzazione negata",
           "subtitle": "Controlla di aver seguito correttamente le istruzioni della tua banca o app di pagamento.",
           "primaryAction": "Chiudi",
-          "secondaryAction": "Scopri di più",
+          "secondaryAction": "Cosa puoi fare?",
           "bottomSheet": {
             "title": "Cosa fare se l’aggiunta del metodo non va a buon fine?",
             "description": "**Carta di credito o debito**\n\nTi invitiamo a verificare con la tua banca. I casi più frequenti sono:\n\n1. La tua carta non è abilitata agli acquisti online.\n2. Non hai ancora attivato il servizio 3DS: si tratta di un sistema di sicurezza legato ai pagamenti online.\n3. La tua carta è stata sospesa o bloccata.\n4. Hai messo 'in pausa' la tua carta.\n\n\n**Altri metodi**\n\nContatta l'assistenza del tuo metodo e chiedi il motivo del rifiuto."

--- a/ts/features/payments/onboarding/screens/PaymentsOnboardingFeedbackScreen.tsx
+++ b/ts/features/payments/onboarding/screens/PaymentsOnboardingFeedbackScreen.tsx
@@ -23,6 +23,7 @@ import {
   useIOStore
 } from "../../../../store/hooks";
 import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
+import { openWebUrl } from "../../../../utils/url";
 import { useAvoidHardwareBackButton } from "../../../../utils/useAvoidHardwareBackButton";
 import { usePagoPaPayment } from "../../checkout/hooks/usePagoPaPayment";
 import { usePaymentFailureSupportModal } from "../../checkout/hooks/usePaymentFailureSupportModal";
@@ -30,7 +31,6 @@ import { PaymentsMethodDetailsRoutes } from "../../details/navigation/routes";
 import { paymentAnalyticsDataSelector } from "../../history/store/selectors";
 import { getPaymentsWalletUserMethods } from "../../wallet/store/actions";
 import * as analytics from "../analytics";
-import { usePaymentOnboardingAuthErrorBottomSheet } from "../components/PaymentsOnboardingAuthErrorBottomSheet";
 import { PaymentsOnboardingParamsList } from "../navigation/params";
 import { paymentsResetRptIdToResume } from "../store/actions";
 import {
@@ -69,6 +69,9 @@ export const pictogramByOutcome: Record<
   [WalletOnboardingOutcomeEnum.BE_KO]: "umbrella"
 };
 
+const ASSISTANCE_URL =
+  "https://assistenza.ioapp.it/hc/it/articles/35337442750225-Non-riesco-ad-aggiungere-un-metodo-di-pagamento";
+
 const PaymentsOnboardingFeedbackScreen = () => {
   const navigation = useNavigation<IOStackNavigationProp<AppParamsList>>();
   const route = useRoute<PaymentsOnboardingFeedbackScreenRouteProps>();
@@ -83,7 +86,7 @@ const PaymentsOnboardingFeedbackScreen = () => {
 
   const rptIdToResume = useIOSelector(selectPaymentOnboardingRptIdToResume);
   const { startPaymentFlow } = usePagoPaPayment();
-  const { bottomSheet, present } = usePaymentOnboardingAuthErrorBottomSheet();
+
   const supportModal = usePaymentFailureSupportModal({
     outcome,
     isOnboarding: true
@@ -183,7 +186,8 @@ const PaymentsOnboardingFeedbackScreen = () => {
           accessibilityLabel: I18n.t(
             `wallet.onboarding.outcome.AUTH_ERROR.secondaryAction`
           ),
-          onPress: present,
+          icon: "instruction" as const,
+          onPress: () => openWebUrl(ASSISTANCE_URL),
           testID: "wallet-onboarding-secondary-action-button"
         };
       case WalletOnboardingOutcomeEnum.BE_KO:
@@ -239,7 +243,6 @@ const PaymentsOnboardingFeedbackScreen = () => {
         }}
         secondaryAction={renderSecondaryAction()}
       />
-      {bottomSheet}
       {supportModal.bottomSheet}
     </View>
   );

--- a/ts/features/payments/onboarding/screens/PaymentsOnboardingFeedbackScreen.tsx
+++ b/ts/features/payments/onboarding/screens/PaymentsOnboardingFeedbackScreen.tsx
@@ -42,6 +42,7 @@ import {
   WalletOnboardingOutcome,
   WalletOnboardingOutcomeEnum
 } from "../types/OnboardingOutcomeEnum";
+import { trackHelpCenterCtaTapped } from "../../../../utils/analytics";
 
 export type PaymentsOnboardingFeedbackScreenParams = {
   outcome: WalletOnboardingOutcome;
@@ -68,6 +69,8 @@ export const pictogramByOutcome: Record<
   [WalletOnboardingOutcomeEnum.PSP_ERROR_ONBOARDING]: "attention",
   [WalletOnboardingOutcomeEnum.BE_KO]: "umbrella"
 };
+
+const PAYMENT_AUTHORIZATION_DENIED_ERROR = "PAYMENT_AUTHORIZATION_DENIED_ERROR";
 
 const ASSISTANCE_URL =
   "https://assistenza.ioapp.it/hc/it/articles/35337442750225-Non-riesco-ad-aggiungere-un-metodo-di-pagamento";
@@ -178,6 +181,17 @@ const PaymentsOnboardingFeedbackScreen = () => {
     supportModal.present();
   };
 
+  const { name: routeName } = useRoute();
+
+  const onPress = () => {
+    trackHelpCenterCtaTapped(
+      PAYMENT_AUTHORIZATION_DENIED_ERROR,
+      ASSISTANCE_URL,
+      routeName
+    );
+    openWebUrl(ASSISTANCE_URL);
+  };
+
   const renderSecondaryAction = () => {
     switch (outcome) {
       case WalletOnboardingOutcomeEnum.AUTH_ERROR:
@@ -187,7 +201,7 @@ const PaymentsOnboardingFeedbackScreen = () => {
             `wallet.onboarding.outcome.AUTH_ERROR.secondaryAction`
           ),
           icon: "instruction" as const,
-          onPress: () => openWebUrl(ASSISTANCE_URL),
+          onPress,
           testID: "wallet-onboarding-secondary-action-button"
         };
       case WalletOnboardingOutcomeEnum.BE_KO:


### PR DESCRIPTION
## Short description
This pull request is replacing the bottom sheet with a web link for card onboarding auth error

## List of changes proposed in this pull request
- Removed the `usePaymentOnboardingAuthErrorBottomSheet` hook and replaced the bottom sheet with a web link that opens the assistance URL when the secondary action button is pressed

## How to test
- Onboard a payment method
- Select `AUTH_ERROR` as outcome
- Ensure that second CTA is opening the browser instead a modal

## Preview

https://github.com/user-attachments/assets/ac798387-1b84-4281-b17c-d80cbd23ed5c

