### PR TITLE
refactor: [IOBP-1743] Change text of help center CTA from PAYMENT_CANCELED error

### DIFF
--- a/locales/de/index.json
+++ b/locales/de/index.json
@@ -2241,7 +2241,7 @@
         "PAYMENT_CANCELED": {
           "title": "Die ausstellende Körperschaft hat diese Zahlungsmitteilung zurückgezogen",
           "subtitle": "Wende dich für weitere Informationen an die Körperschaft.",
-          "action": "Scopri di più"
+          "action": "Mehr erfahren"
         },
         "PAYMENT_DUPLICATED": {
           "title": "Diese Zahlungsmitteilung wurde bereits bezahlt!"

--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -2447,9 +2447,9 @@
           "subtitle": "Contatta l’Ente per maggiori informazioni."
         },
         "PAYMENT_CANCELED": {
-          "title": "L’Ente Creditore ha revocato questo avviso",
-          "subtitle": "Contatta l’Ente per maggiori informazioni.",
-          "action": "Scopri di più"
+          "title": "The Creditor Entity has revoked this notice",
+          "subtitle": "Please contact the Entity for more information.",
+          "action": "What can you do?"
         },
         "PAYMENT_DUPLICATED": {
           "title": "Questo avviso è stato già pagato!"

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -2449,7 +2449,7 @@
         "PAYMENT_CANCELED": {
           "title": "L’Ente Creditore ha revocato questo avviso",
           "subtitle": "Contatta l’Ente per maggiori informazioni.",
-          "action": "Scopri di più"
+          "action": "Cosa puoi fare?"
         },
         "PAYMENT_DUPLICATED": {
           "title": "Questo avviso è stato già pagato!"

--- a/ts/features/payments/checkout/components/WalletPaymentFailureDetail.tsx
+++ b/ts/features/payments/checkout/components/WalletPaymentFailureDetail.tsx
@@ -252,11 +252,13 @@ const WalletPaymentFailureDetail = ({ failure }: Props) => {
         };
       case "PAYMENT_CANCELED":
         return {
-          pictogram: "stopSecurity",
+          pictogram: "error",
           title: I18n.t("wallet.payment.failure.PAYMENT_CANCELED.title"),
           subtitle: I18n.t("wallet.payment.failure.PAYMENT_CANCELED.subtitle"),
           action: closeAction,
-          secondaryAction: discoverMoreAction
+          secondaryAction: discoverMoreAction,
+          enableAnimatedPictogram: true,
+          loop: false
         };
       case "PAYMENT_DUPLICATED":
         return {


### PR DESCRIPTION
## Short description
This PR includes updates to localization files for multiple languages and enhancements to the `WalletPaymentFailureDetail` component. The most significant changes involve updating translations for the "PAYMENT_CANCELED" action and improving the user interface for that error showing an animated pictogram.

## List of changes proposed in this pull request
  - Added support for animated pictograms for the `PAYMENT_CANCELED` error.
  
## How to test
- Checkout locally the dev-server to [this branch](https://github.com/pagopa/io-dev-api-server/tree/mock-verify-payment-canceled-error) to simulate a `PAYMENT_CANCELED` error during the verification request
- Check that there is a valid text and UI following [this design](https://www.figma.com/design/KY9BpP4LaSSd18fuYMwxYK/Paga-un-avviso-pagoPA?node-id=2750-12850&t=ogJEOirb8yDdzkoq-4)

## Preview
https://github.com/user-attachments/assets/f51874e3-ffd7-40aa-8f66-2365d1fcbd2f

