### PR TITLE
chore(IT Wallet): [SIW-2533] Add back online alert within offline wallet

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -4933,6 +4933,12 @@
             "footerAction": "Ricarica l'app IO"
           }
         },
+        "back_online": {
+          "alert": {
+            "content": "Sei di nuovo online. Per usare tutti i servizi ",
+            "action": "ricarica app IO"
+          }
+        },
         "action": "Ricarica l'app IO",
         "failure": "Nessuna connessione. Collegati a internet e riprova."
       },

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -4933,6 +4933,12 @@
             "footerAction": "Ricarica l'app IO"
           }
         },
+        "back_online": {
+          "alert": {
+            "content": "Sei di nuovo online. Per usare tutti i servizi ",
+            "action": "ricarica app IO"
+          }
+        },
         "action": "Ricarica l'app IO",
         "failure": "Nessuna connessione. Collegati a internet e riprova."
       },

--- a/ts/features/itwallet/analytics/index.ts
+++ b/ts/features/itwallet/analytics/index.ts
@@ -177,9 +177,7 @@ type ItwOfflineBanner = {
   use_case: "starting_app" | "foreground" | "background";
 };
 
-type ItwOfflineRicaricaAppIO = {
-  source: "bottom_sheet" | "banner";
-};
+export type ItwOfflineRicaricaAppIOSource = "bottom_sheet" | "banner";
 
 // #region SCREEN VIEW EVENTS
 export const trackWalletDataShare = (properties: ItwWalletDataShare) => {
@@ -558,9 +556,9 @@ export function trackCredentialCardModal(credential: MixPanelCredential) {
   );
 }
 
-export function trackItwOfflineRicaricaAppIO({
-  source
-}: ItwOfflineRicaricaAppIO) {
+export function trackItwOfflineRicaricaAppIO(
+  source: ItwOfflineRicaricaAppIOSource
+) {
   void mixpanelTrack(
     ITW_ACTIONS_EVENTS.ITW_OFFLINE_RICARICA_APP_IO,
     buildEventProperties("UX", "action", {

--- a/ts/features/itwallet/common/helpers/withOfflineAlert.tsx
+++ b/ts/features/itwallet/common/helpers/withOfflineAlert.tsx
@@ -7,9 +7,10 @@ import {
 } from "@pagopa/io-app-design-system";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
-import { useCallback } from "react";
+import { ComponentProps, useCallback, useMemo } from "react";
 import { StatusBar } from "react-native";
 import { useRoute } from "@react-navigation/native";
+import { AlertEdgeToEdge } from "@pagopa/io-app-design-system/lib/typescript/components/alert/AlertEdgeToEdge";
 import IOMarkdown from "../../../../components/IOMarkdown";
 import I18n from "../../../../i18n";
 import { startApplicationInitialization } from "../../../../store/actions/application";
@@ -23,6 +24,7 @@ import { OfflineAccessReasonEnum } from "../../../ingress/store/reducer";
 import { offlineAccessReasonSelector } from "../../../ingress/store/selectors";
 import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender.ts";
 import {
+  ItwOfflineRicaricaAppIOSource,
   trackItwOfflineBanner,
   trackItwOfflineBottomSheet,
   trackItwOfflineReloadFailure,
@@ -44,38 +46,17 @@ import {
  *
  * @param offlineAccessReason - The specific reason for the offline state, used to
  *                             determine the content and behavior of the modal
+ * @param handleAppRestart - The function to handle the app restart
  * @returns An object with the bottom sheet modal controller (present, dismiss) and the modal component
  */
 const useOfflineAlertDetailModal = (
   offlineAccessReason: OfflineAccessReasonEnum
 ) => {
-  const toast = useIOToast();
   const dispatch = useIODispatch();
-  const isConnected = useIOSelector(isConnectedSelector);
-
-  const handleAppRestart = useCallback(() => {
-    if (isConnected) {
-      trackItwOfflineRicaricaAppIO({
-        source: "bottom_sheet"
-      });
-      // Reset the offline access reason.
-      // Since this state is `undefined` when the user is online,
-      // the startup saga will proceed without blocking.
-      dispatch(resetOfflineAccessReason());
-      // Dispatch this action to mount the correct navigator.
-      dispatch(startupLoadSuccess(StartupStatusEnum.INITIAL));
-      // restart startup saga
-      dispatch(startApplicationInitialization());
-    } else {
-      toast.error(I18n.t("features.itWallet.offline.failure"));
-      trackItwOfflineReloadFailure();
-    }
-  }, [dispatch, isConnected, toast]);
+  const handleAppRestart = useAppRestartAction("bottom_sheet");
 
   const navigateOnAuthPage = useCallback(() => {
-    trackItwOfflineRicaricaAppIO({
-      source: "bottom_sheet"
-    });
+    trackItwOfflineRicaricaAppIO("bottom_sheet");
     // Reset the offline access reason.
     // Since this state is `undefined` when the user is online,
     // the startup saga will proceed without blocking.
@@ -140,8 +121,10 @@ const OfflineAlertWrapper = ({
   offlineAccessReason,
   children
 }: React.PropsWithChildren<OfflineAlertWrapperProps>) => {
-  const detailModal = useOfflineAlertDetailModal(offlineAccessReason);
   const { name } = useRoute();
+
+  const isConnected = useIOSelector(isConnectedSelector);
+  const handleAppRestart = useAppRestartAction("banner");
 
   useOnFirstRender(() => {
     trackItwOfflineBanner({
@@ -151,24 +134,40 @@ const OfflineAlertWrapper = ({
     });
   });
 
+  const detailModal = useOfflineAlertDetailModal(offlineAccessReason);
+
   const openBottomSheet = useCallback(() => {
     detailModal.present();
     trackItwOfflineBottomSheet();
   }, [detailModal]);
 
+  const alertProps: ComponentProps<typeof AlertEdgeToEdge> = useMemo(() => {
+    if (
+      offlineAccessReason === OfflineAccessReasonEnum.DEVICE_OFFLINE &&
+      isConnected
+    ) {
+      return {
+        content: I18n.t(`features.itWallet.offline.back_online.alert.content`),
+        action: I18n.t(`features.itWallet.offline.back_online.alert.action`),
+        variant: "success",
+        onPress: handleAppRestart
+      };
+    }
+
+    return {
+      content: I18n.t(
+        `features.itWallet.offline.${offlineAccessReason}.alert.content`
+      ),
+      action: I18n.t(
+        `features.itWallet.offline.${offlineAccessReason}.alert.action`
+      ),
+      variant: "info",
+      onPress: openBottomSheet
+    };
+  }, [offlineAccessReason, isConnected, openBottomSheet, handleAppRestart]);
+
   return (
-    <AlertEdgeToEdgeWrapper
-      alertProps={{
-        content: I18n.t(
-          `features.itWallet.offline.${offlineAccessReason}.alert.content`
-        ),
-        action: I18n.t(
-          `features.itWallet.offline.${offlineAccessReason}.alert.action`
-        ),
-        variant: "info",
-        onPress: openBottomSheet
-      }}
-    >
+    <AlertEdgeToEdgeWrapper alertProps={alertProps}>
       <StatusBar
         barStyle="dark-content"
         backgroundColor={IOColors["info-100"]}
@@ -177,6 +176,35 @@ const OfflineAlertWrapper = ({
       {detailModal.bottomSheet}
     </AlertEdgeToEdgeWrapper>
   );
+};
+
+/**
+ * Hook that creates and manages a function to restart the application.
+ *
+ * @param source - The source of the app restart action, for analytics purposes
+ * @returns A function to restart the application
+ */
+const useAppRestartAction = (source: ItwOfflineRicaricaAppIOSource) => {
+  const toast = useIOToast();
+  const dispatch = useIODispatch();
+  const isConnected = useIOSelector(isConnectedSelector);
+
+  return useCallback(() => {
+    if (isConnected) {
+      trackItwOfflineRicaricaAppIO(source);
+      // Reset the offline access reason.
+      // Since this state is `undefined` when the user is online,
+      // the startup saga will proceed without blocking.
+      dispatch(resetOfflineAccessReason());
+      // Dispatch this action to mount the correct navigator.
+      dispatch(startupLoadSuccess(StartupStatusEnum.INITIAL));
+      // restart startup saga
+      dispatch(startApplicationInitialization());
+    } else {
+      toast.error(I18n.t("features.itWallet.offline.failure"));
+      trackItwOfflineReloadFailure();
+    }
+  }, [dispatch, isConnected, toast, source]);
 };
 
 /**


### PR DESCRIPTION
## Short description
This PR adds an alert which informs the user that is back online and he can restart the app to get full access.

## List of changes proposed in this pull request
- Added success alert to offline mini-app if access reason is `DEVICE_OFFLINE` and connectivity is present

## How to test
1. Ensure to have a valid wallet with at least one credential
2. Restart the app without internet connection
3. Check that the offline alert is displayed
4. Re-eanble the internet connection, check that the green alert is displayed after some time
5. Check that the alert allows to restart the app by pressing it

## Demo

https://github.com/user-attachments/assets/ba875f23-0fc1-4baf-a960-518bbf4de154



