### PR TITLE
chore(IT Wallet): [SIW-2536] Decouple `credentials` reducer migrations from store structure types

### DIFF
--- a/ts/features/itwallet/credentials/store/reducers/__tests__/migrations.test.ts
+++ b/ts/features/itwallet/credentials/store/reducers/__tests__/migrations.test.ts
@@ -1,0 +1,95 @@
+import _ from "lodash";
+import * as O from "fp-ts/lib/Option";
+import { SdJwt } from "@pagopa/io-react-native-wallet";
+import { itwCredentialsStateMigrations } from "../migrations";
+
+jest.mock("@pagopa/io-react-native-wallet", () => ({
+  ...jest.requireActual("@pagopa/io-react-native-wallet"),
+  SdJwt: {
+    ...jest.requireActual("@pagopa/io-react-native-wallet").SdJwt,
+    decode: jest.fn()
+  }
+}));
+
+describe("ITW credentials reducer migrations", () => {
+  it("should migrate from 0 to 1", () => {
+    const basePersistedGlobalStateAt0 = {
+      eid: O.some({}),
+      credentials: [O.some({}), O.some({}), O.none],
+      _persist: {
+        version: 0,
+        rehydrated: false
+      }
+    };
+    const persistedStateAt1 = _.merge(undefined, basePersistedGlobalStateAt0, {
+      eid: O.some({ storedStatusAttestation: undefined }),
+      credentials: [
+        O.some({ storedStatusAttestation: undefined }),
+        O.some({ storedStatusAttestation: undefined }),
+        O.none
+      ]
+    });
+
+    const from0To1Migration = itwCredentialsStateMigrations[0];
+    expect(from0To1Migration).toBeDefined();
+    const nextState = from0To1Migration(basePersistedGlobalStateAt0);
+
+    expect(nextState).toStrictEqual(persistedStateAt1);
+  });
+
+  it("should migrate from 1 to 2", () => {
+    jest.spyOn(SdJwt, "decode").mockReturnValue({
+      disclosures: [{ decoded: ["", "iat", 1718132000] }],
+      sdJwt: {
+        payload: {
+          exp: 1718192000
+        }
+      }
+    } as any);
+
+    const basePersistedGlobalStateAt1 = {
+      eid: O.some({ storedStatusAttestation: undefined }),
+      credentials: [
+        O.some({ storedStatusAttestation: undefined }),
+        O.some({ storedStatusAttestation: undefined }),
+        O.none
+      ],
+      _persist: {
+        version: 0,
+        rehydrated: false
+      }
+    };
+    const persistedStateAt2 = _.merge(undefined, basePersistedGlobalStateAt1, {
+      eid: O.some({
+        storedStatusAttestation: undefined,
+        jwt: {
+          expiration: "2024-06-12T11:33:20.000Z",
+          issuedAt: "2024-06-11T18:53:20.000Z"
+        }
+      }),
+      credentials: [
+        O.some({
+          storedStatusAttestation: undefined,
+          jwt: {
+            expiration: "2024-06-12T11:33:20.000Z",
+            issuedAt: "2024-06-11T18:53:20.000Z"
+          }
+        }),
+        O.some({
+          storedStatusAttestation: undefined,
+          jwt: {
+            expiration: "2024-06-12T11:33:20.000Z",
+            issuedAt: "2024-06-11T18:53:20.000Z"
+          }
+        }),
+        O.none
+      ]
+    });
+
+    const from0To1Migration = itwCredentialsStateMigrations[1];
+    expect(from0To1Migration).toBeDefined();
+    const nextState = from0To1Migration(basePersistedGlobalStateAt1);
+
+    expect(nextState).toStrictEqual(persistedStateAt2);
+  });
+});

--- a/ts/features/itwallet/credentials/store/reducers/migrations.ts
+++ b/ts/features/itwallet/credentials/store/reducers/migrations.ts
@@ -1,38 +1,31 @@
 import { SdJwt } from "@pagopa/io-react-native-wallet";
 import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
-import { MigrationManifest, PersistPartial } from "redux-persist";
-import { StoredCredential } from "../../../common/utils/itwTypesUtils";
-import { ItwCredentialsState } from ".";
+import { MigrationManifest } from "redux-persist";
 
 export const CURRENT_REDUX_ITW_CREDENTIALS_STORE_VERSION = 1;
 
 export const itwCredentialsStateMigrations: MigrationManifest = {
-  "0": (state): ItwCredentialsState & PersistPartial => {
-    // Version 0
-    // Add optional `storedStatusAttestation` field
-    const addStoredStatusAttestation = (
-      credential: StoredCredential
-    ): StoredCredential => ({
+  // Version 0
+  // Add optional `storedStatusAttestation` field
+  "0": (state: any) => {
+    const addStoredStatusAttestation = (credential: any) => ({
       ...credential,
       storedStatusAttestation: undefined
     });
-    const prevState = state as ItwCredentialsState & PersistPartial;
     return {
-      ...prevState,
-      eid: pipe(prevState.eid, O.map(addStoredStatusAttestation)),
-      credentials: prevState.credentials.map(credential =>
+      ...state,
+      eid: pipe(state.eid, O.map(addStoredStatusAttestation)),
+      credentials: state.credentials.map((credential: any) =>
         pipe(credential, O.map(addStoredStatusAttestation))
       )
     };
   },
 
-  "1": (state): ItwCredentialsState & PersistPartial => {
-    // Version 1
-    // Add issuance and expiration dates to stored credentials
-    const addIatExpProperties = (
-      credential: StoredCredential
-    ): StoredCredential => {
+  // Version 1
+  // Add issuance and expiration dates to stored credentials
+  "1": (state: any) => {
+    const addIatExpProperties = (credential: any) => {
       const { disclosures, sdJwt } = SdJwt.decode(credential.credential);
       const iatDisclosure = disclosures.find(
         ({ decoded }) => decoded[1] === "iat"
@@ -51,11 +44,10 @@ export const itwCredentialsStateMigrations: MigrationManifest = {
         }
       };
     };
-    const prevState = state as ItwCredentialsState & PersistPartial;
     return {
-      ...prevState,
-      eid: pipe(prevState.eid, O.map(addIatExpProperties)),
-      credentials: prevState.credentials.map(credential =>
+      ...state,
+      eid: pipe(state.eid, O.map(addIatExpProperties)),
+      credentials: state.credentials.map((credential: any) =>
         pipe(credential, O.map(addIatExpProperties))
       )
     };


### PR DESCRIPTION
## Short description
This PR decouples the credentials reducer migrations from the store structure types. By removing direct references, we make the migrations more maintainable and resilient to future changes in the store shape. This helps ensure that migration logic remains stable even as the store evolves.

## List of changes proposed in this pull request
- Removed types from `credentials` reducer migrations

## How to test
Tests should pass
