### PR TITLE
fix(IT Wallet): [SIW-2463] Mixpanel credential status events

### DIFF
--- a/ts/features/itwallet/analytics/index.ts
+++ b/ts/features/itwallet/analytics/index.ts
@@ -140,20 +140,29 @@ export type ItwCed = "not_available" | "valid" | "not_valid" | "expiring";
 /**
  * This map is used to map the eid credential status to the MixPanel eid credential status
  * valid: valid
- * pending: not_valid
- * expired: not_valid
+ * invalid: not_valid
+ * expired: expired
  * expiring: expiring
+ * jwtExpired: verification_expired
+ * jwtExpiring: expiring_verification
+ * unknown: unknown
  */
 export const ID_STATUS_MAP: Record<
   ItwCredentialStatus,
-  "valid" | "not_valid" | "expiring" | "unknown"
+  | "valid"
+  | "not_valid"
+  | "expiring"
+  | "expired"
+  | "expiring_verification"
+  | "verification_expired"
+  | "unknown"
 > = {
   valid: "valid",
   invalid: "not_valid",
-  expired: "not_valid",
+  expired: "expired",
   expiring: "expiring",
-  jwtExpired: "not_valid",
-  jwtExpiring: "expiring",
+  jwtExpired: "verification_expired",
+  jwtExpiring: "expiring_verification",
   unknown: "unknown"
 };
 

--- a/ts/features/itwallet/common/components/ItwEidInfoBottomSheetContent.tsx
+++ b/ts/features/itwallet/common/components/ItwEidInfoBottomSheetContent.tsx
@@ -23,7 +23,7 @@ import { ITW_ROUTES } from "../../navigation/routes";
 import { StoredCredential } from "../utils/itwTypesUtils";
 import {
   CREDENTIALS_MAP,
-  ID_STATUS_MAP,
+  mapEidStatusToMixpanel,
   trackCredentialDetail,
   trackWalletStartDeactivation
 } from "../../analytics";
@@ -75,7 +75,7 @@ const ItwEidInfoBottomSheetContent = ({
       if (eidStatus) {
         trackCredentialDetail({
           credential: CREDENTIALS_MAP[credential.credentialType],
-          credential_status: ID_STATUS_MAP[eidStatus]
+          credential_status: mapEidStatusToMixpanel(eidStatus)
         });
       }
     }, [credential.credentialType]);

--- a/ts/features/itwallet/common/store/selectors/preferences.ts
+++ b/ts/features/itwallet/common/store/selectors/preferences.ts
@@ -95,10 +95,7 @@ export const itwIsFiscalCodeWhitelistedSelector = (state: GlobalState) =>
  * @param state - The global state of the application.
  * @returns A boolean indicating whether L3 is enabled and the fiscal code is whitelisted.
  */
-export const itwIsL3EnabledSelector = (state: GlobalState) =>
-  (state.features.itWallet.preferences.isL3Enabled ||
-    state.features.itWallet.preferences.isFiscalCodeWhitelisted) ??
-  false;
+export const itwIsL3EnabledSelector = (state: GlobalState) => false;
 
 /**
  * Returns whether offline banner is hidden. Defaults to false.

--- a/ts/features/itwallet/presentation/details/screens/ItwPresentationCredentialDetailScreen.tsx
+++ b/ts/features/itwallet/presentation/details/screens/ItwPresentationCredentialDetailScreen.tsx
@@ -11,6 +11,7 @@ import {
 import { useIODispatch, useIOSelector } from "../../../../../store/hooks.ts";
 import {
   CREDENTIALS_MAP,
+  ID_STATUS_MAP,
   trackCredentialDetail,
   trackWalletCredentialShowFAC_SIMILE,
   trackWalletCredentialShowTrustmark
@@ -111,8 +112,7 @@ const ItwPresentationCredentialDetail = ({
   useFocusEffect(() => {
     trackCredentialDetail({
       credential: CREDENTIALS_MAP[credential.credentialType],
-      credential_status:
-        credential.storedStatusAttestation?.credentialStatus || "not_valid"
+      credential_status: ID_STATUS_MAP[status]
     });
   });
 

--- a/ts/features/itwallet/presentation/details/screens/ItwPresentationCredentialDetailScreen.tsx
+++ b/ts/features/itwallet/presentation/details/screens/ItwPresentationCredentialDetailScreen.tsx
@@ -11,7 +11,7 @@ import {
 import { useIODispatch, useIOSelector } from "../../../../../store/hooks.ts";
 import {
   CREDENTIALS_MAP,
-  ID_STATUS_MAP,
+  CREDENTIALS_STATUS_MAP,
   trackCredentialDetail,
   trackWalletCredentialShowFAC_SIMILE,
   trackWalletCredentialShowTrustmark
@@ -112,7 +112,7 @@ const ItwPresentationCredentialDetail = ({
   useFocusEffect(() => {
     trackCredentialDetail({
       credential: CREDENTIALS_MAP[credential.credentialType],
-      credential_status: ID_STATUS_MAP[status]
+      credential_status: CREDENTIALS_STATUS_MAP[status]
     });
   });
 

--- a/ts/mixpanelConfig/profileProperties.ts
+++ b/ts/mixpanelConfig/profileProperties.ts
@@ -15,15 +15,17 @@ import { idpSelector } from "../features/authentication/common/store/selectors";
 import { tosVersionSelector } from "../features/settings/common/store/selectors/index.ts";
 import { checkNotificationPermissions } from "../features/pushNotifications/utils";
 import {
+  getCredentialMixpanelStatus,
   ItwCed,
   ItwId,
   ItwPg,
   ItwStatus,
-  ItwTs
+  ItwTs,
+  mapEidStatusToMixpanel
 } from "../features/itwallet/analytics";
 import {
   itwCredentialsByTypeSelector,
-  itwCredentialsSelector
+  itwCredentialsEidStatusSelector
 } from "../features/itwallet/credentials/store/selectors";
 import { TrackCgnStatus } from "../features/bonus/cgn/analytics";
 import { itwAuthLevelSelector } from "../features/itwallet/common/store/selectors/preferences.ts";
@@ -149,20 +151,22 @@ const walletStatusHandler = (state: GlobalState): ItwStatus => {
 };
 
 const idStatusHandler = (state: GlobalState): ItwId => {
-  const credentialsState = itwCredentialsSelector(state);
-  return O.isSome(credentialsState.eid) ? "valid" : "not_available";
+  const eidStatus = itwCredentialsEidStatusSelector(state);
+  return eidStatus !== undefined
+    ? mapEidStatusToMixpanel(eidStatus)
+    : "not_available";
 };
 const pgStatusHandler = (state: GlobalState): ItwPg => {
   const credentialsByType = itwCredentialsByTypeSelector(state);
-  return credentialsByType.MDL ? "valid" : "not_available";
+  return getCredentialMixpanelStatus(credentialsByType.MDL);
 };
 const tsStatusHandler = (state: GlobalState): ItwTs => {
   const credentialsByType = itwCredentialsByTypeSelector(state);
-  return credentialsByType.EuropeanHealthInsuranceCard
-    ? "valid"
-    : "not_available";
+  return getCredentialMixpanelStatus(
+    credentialsByType.EuropeanHealthInsuranceCard
+  );
 };
 const cedStatusHandler = (state: GlobalState): ItwCed => {
   const credentialsByType = itwCredentialsByTypeSelector(state);
-  return credentialsByType.EuropeanDisabilityCard ? "valid" : "not_available";
+  return getCredentialMixpanelStatus(credentialsByType.EuropeanDisabilityCard);
 };

--- a/ts/mixpanelConfig/superProperties.ts
+++ b/ts/mixpanelConfig/superProperties.ts
@@ -1,5 +1,4 @@
 import { Appearance, ColorSchemeName } from "react-native";
-import * as O from "fp-ts/Option";
 import {
   isMixpanelInstanceInitialized,
   registerSuperProperties
@@ -21,15 +20,17 @@ import { GlobalState } from "../store/reducers/types";
 import { LoginSessionDuration } from "../features/authentication/fastLogin/analytics/optinAnalytics";
 import { checkNotificationPermissions } from "../features/pushNotifications/utils";
 import {
+  getCredentialMixpanelStatus,
   ItwCed,
   ItwId,
   ItwPg,
   ItwStatus,
-  ItwTs
+  ItwTs,
+  mapEidStatusToMixpanel
 } from "../features/itwallet/analytics";
 import {
   itwCredentialsByTypeSelector,
-  itwCredentialsSelector
+  itwCredentialsEidStatusSelector
 } from "../features/itwallet/credentials/store/selectors";
 import { TrackCgnStatus } from "../features/bonus/cgn/analytics";
 import { itwAuthLevelSelector } from "../features/itwallet/common/store/selectors/preferences.ts";
@@ -148,22 +149,24 @@ const walletStatusHandler = (state: GlobalState): ItwStatus => {
 };
 
 const idStatusHandler = (state: GlobalState): ItwId => {
-  const credentialsState = itwCredentialsSelector(state);
-  return O.isSome(credentialsState.eid) ? "valid" : "not_available";
+  const eidStatus = itwCredentialsEidStatusSelector(state);
+  return eidStatus !== undefined
+    ? mapEidStatusToMixpanel(eidStatus)
+    : "not_available";
 };
 const pgStatusHandler = (state: GlobalState): ItwPg => {
   const credentialsByType = itwCredentialsByTypeSelector(state);
-  return credentialsByType.MDL ? "valid" : "not_available";
+  return getCredentialMixpanelStatus(credentialsByType.MDL);
 };
 const tsStatusHandler = (state: GlobalState): ItwTs => {
   const credentialsByType = itwCredentialsByTypeSelector(state);
-  return credentialsByType.EuropeanHealthInsuranceCard
-    ? "valid"
-    : "not_available";
+  return getCredentialMixpanelStatus(
+    credentialsByType.EuropeanHealthInsuranceCard
+  );
 };
 const cedStatusHandler = (state: GlobalState): ItwCed => {
   const credentialsByType = itwCredentialsByTypeSelector(state);
-  return credentialsByType.EuropeanDisabilityCard ? "valid" : "not_available";
+  return getCredentialMixpanelStatus(credentialsByType.EuropeanDisabilityCard);
 };
 const offlineStatusHandler = (state: GlobalState): ConnectivityStatus => {
   const isConnected = isConnectedSelector(state);


### PR DESCRIPTION
## Short description
This PR fixes how credential status is tracked in Mixpanel in three key areas:

1. When updating profile properties

1. When updating super properties

1. When dispatching the `ITW_CREDENTIAL_DETAIL` event

## List of changes proposed in this pull request
- Introduced the `getCredentialMixpanelStatus` utility to consistently map a credential (when present) to the correct Mixpanel status. This function is now used by handlers to compute the status of specific credentials (MDL, TS, CED) when updating profile and super properties.
- Added `mapEidStatusToMixpanel`, a function for mapping the eID credential status to the appropriate Mixpanel status
- Replaced the `ID_STATUS_MAP` with `CREDENTIALS_STATUS_MAP`, which provides a mapping of `getCredentialStatus` values to Mixpanel statuses ( this map is not used for the eID, since its status is handled separately via `mapEidStatusToMixpanel`)

## How to test

1. Mock the `getCredentialStatus` return value for each credential type
1. Trigger the logic that sends the `ITW_CREDENTIAL_DETAIL` event and verify that the correct credential status is sent to Mixpanel
1. Check that the Mixpanel profile properties are updated with the expected credential status values.

1. Check that the Mixpanel super properties are updated with the expected credential status values.
