### PR TITLE
refactor: CTA on CdC service screen

### DIFF
--- a/ts/features/bonus/cdc/hooks/useSpecialCtaCdc.tsx
+++ b/ts/features/bonus/cdc/hooks/useSpecialCtaCdc.tsx
@@ -4,13 +4,11 @@ import I18n from "../../../../i18n";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { useIODispatch, useIOSelector } from "../../../../store/hooks";
 import { isCdcAppVersionSupportedSelector } from "../../../../store/reducers/backendStatus/remoteConfig";
-import { useServicePreferenceByChannel } from "../../../services/details/hooks/useServicePreference";
 import { loadAvailableBonuses } from "../../common/store/actions/availableBonusesTypes";
 import { CDC_ROUTES } from "../navigation/routes";
-import { ServiceId } from "../../../../../definitions/backend/ServiceId";
 import * as analytics from "../analytics";
 /**
- * Hook to handle the CDC activation/deactivation
+ * Hook to handle the CDC flow request
  */
 const useCdcActivation = () => {
   const navigation = useIONavigation();
@@ -32,45 +30,25 @@ const useCdcActivation = () => {
 
 /**
  * This hook determines and returns the appropriate primary action prop
- * for activating and deactivating the CDC service.
+ * for activating the CDC service.
  */
-export const useSpecialCtaCdc = (
-  serviceId: ServiceId
-): IOScrollViewActions["primary"] | undefined => {
+export const useSpecialCtaCdc = ():
+  | IOScrollViewActions["primary"]
+  | undefined => {
   const isCdcEnabled = useIOSelector(isCdcAppVersionSupportedSelector);
 
   const { subscribeHandler } = useCdcActivation();
 
-  const { isLoadingServicePreferenceByChannel, servicePreferenceByChannel } =
-    useServicePreferenceByChannel("inbox", serviceId);
-
-  const loading = isLoadingServicePreferenceByChannel;
-
-  // If the inbox channel is enabled, then the special service is active
-  const isServiceActive = servicePreferenceByChannel ?? false;
-
   return useMemo(() => {
-    // if cdc is not enabled or the inbox channel is undefined
-    // then the special service is not available
-    if (!isCdcEnabled || servicePreferenceByChannel === undefined) {
+    // if cdc is not enabled then the CTA is not available
+    if (!isCdcEnabled) {
       return undefined;
     }
 
-    if (!isServiceActive) {
-      return {
-        label: I18n.t("bonus.cdc.request"),
-        loading,
-        onPress: subscribeHandler,
-        testID: "service-activate-bonus-button"
-      };
-    }
-
-    return undefined;
-  }, [
-    isCdcEnabled,
-    loading,
-    isServiceActive,
-    servicePreferenceByChannel,
-    subscribeHandler
-  ]);
+    return {
+      label: I18n.t("bonus.cdc.request"),
+      onPress: subscribeHandler,
+      testID: "service-activate-bonus-button"
+    };
+  }, [isCdcEnabled, subscribeHandler]);
 };

--- a/ts/features/services/details/components/ServiceDetailsScreenCdc.tsx
+++ b/ts/features/services/details/components/ServiceDetailsScreenCdc.tsx
@@ -5,19 +5,13 @@ import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
 import { useSpecialCtaCdc } from "../../../bonus/cdc/hooks/useSpecialCtaCdc";
 import { ServiceDetailsScreenBase } from "../types";
 import { getServiceActionsProps } from "../utils";
-import { ServiceId } from "../../../../../definitions/backend/ServiceId";
-
-export type ServiceDetailsScreenCdcProps = ServiceDetailsScreenBase & {
-  serviceId: ServiceId;
-};
 
 export const ServiceDetailsScreenCdc = ({
   children,
-  serviceId,
   ctas,
   onPressCta,
   title = ""
-}: ServiceDetailsScreenCdcProps) => {
+}: ServiceDetailsScreenBase) => {
   const theme = useIOTheme();
   const animatedScrollViewRef = useAnimatedRef<Animated.ScrollView>();
 
@@ -29,7 +23,7 @@ export const ServiceDetailsScreenCdc = ({
     title
   });
 
-  const specialActionProps = useSpecialCtaCdc(serviceId);
+  const specialActionProps = useSpecialCtaCdc();
 
   const actions = getServiceActionsProps(specialActionProps, ctas, onPressCta);
 

--- a/ts/features/services/details/components/__tests__/ServiceDetailsScreenCdc.test.tsx
+++ b/ts/features/services/details/components/__tests__/ServiceDetailsScreenCdc.test.tsx
@@ -9,15 +9,13 @@ import { baseRawBackendStatus as backendStatus } from "../../../../../store/redu
 import { GlobalState } from "../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
 import { ServiceDetailsScreenCdc } from "../ServiceDetailsScreenCdc";
-import { ServiceId } from "../../../../../../definitions/backend/ServiceId";
 
-const dummy_serviceId = "serviceCdc" as ServiceId;
 const renderComponent = (state: GlobalState) => {
   const store = createStore(appReducer, state as any);
 
   return renderScreenWithNavigationStoreContext(
     () => (
-      <ServiceDetailsScreenCdc serviceId={dummy_serviceId}>
+      <ServiceDetailsScreenCdc>
         <Body>DUMMY</Body>
       </ServiceDetailsScreenCdc>
     ),


### PR DESCRIPTION
## Short description
This PR refactors the CdC `useSpecialCtaCdc` hook reduce unnecessary complexity by eliminating unused parameters and redundant logic that this flow shouldn't provide.

## List of changes proposed in this pull request
* Removed the `serviceId` parameter and associated logic from the `useSpecialCtaCdc` hook, including the `useServicePreferenceByChannel` call and related state management to only check if CDC is enabled and return the appropriate action.

## How to test
- With the dev-server started, open the service "Carta della cultura" and check that there is a custom CTA that starts the CdC flow.

## Preview
https://github.com/user-attachments/assets/f35da1cd-c1e4-41a3-8e96-78a26a058aec

