### PR TITLE
fix: [IOBP-1750] Replace radio group id property in IBAN list item

### DIFF
--- a/ts/features/idpay/configuration/screens/IdPayIbanEnrollmentScreen.tsx
+++ b/ts/features/idpay/configuration/screens/IdPayIbanEnrollmentScreen.tsx
@@ -1,7 +1,6 @@
 import { FeatureInfo, RadioGroup, VSpacer } from "@pagopa/io-app-design-system";
 import { RouteProp, useFocusEffect, useRoute } from "@react-navigation/native";
 import { ComponentProps, useCallback, useEffect, useState } from "react";
-import { IbanDTO } from "../../../../../definitions/idpay/IbanDTO";
 import LoadingSpinnerOverlay from "../../../../components/LoadingSpinnerOverlay";
 import { IOScrollView } from "../../../../components/ui/IOScrollView";
 import { IOScrollViewWithLargeHeader } from "../../../../components/ui/IOScrollViewWithLargeHeader";
@@ -45,7 +44,7 @@ export const IdPayIbanEnrollmentScreen = () => {
   const enrolledIban =
     IdPayConfigurationMachineContext.useSelector(selectEnrolledIban);
 
-  const [selectedIban, setSelectedIban] = useState<IbanDTO | undefined>();
+  const [selectedIban, setSelectedIban] = useState<string | undefined>();
 
   useFocusEffect(
     useCallback(() => {
@@ -61,19 +60,22 @@ export const IdPayIbanEnrollmentScreen = () => {
 
   useEffect(() => {
     if (enrolledIban) {
-      setSelectedIban(enrolledIban);
+      setSelectedIban(enrolledIban.iban);
     }
   }, [enrolledIban]);
 
   const handleSelectIban = useCallback(
-    (iban: IbanDTO) => {
+    (iban: string) => {
       setSelectedIban(iban);
 
       if (isIbanOnly) {
-        machine.send({ type: "enroll-iban", iban });
+        const ibanObject = ibanList.find(el => el.iban === iban);
+        if (ibanObject) {
+          machine.send({ type: "enroll-iban", iban: ibanObject });
+        }
       }
     },
-    [isIbanOnly, machine]
+    [ibanList, isIbanOnly, machine]
   );
 
   const handleBackPress = () => {
@@ -82,7 +84,10 @@ export const IdPayIbanEnrollmentScreen = () => {
 
   const handleContinuePress = () => {
     if (selectedIban !== undefined) {
-      machine.send({ type: "enroll-iban", iban: selectedIban });
+      const selectedIbanObject = ibanList.find(el => el.iban === selectedIban);
+      if (selectedIbanObject) {
+        machine.send({ type: "enroll-iban", iban: selectedIbanObject });
+      }
     }
   };
 
@@ -142,12 +147,12 @@ export const IdPayIbanEnrollmentScreen = () => {
       description={I18n.t("idpay.configuration.iban.enrollment.subTitle")}
     >
       <LoadingSpinnerOverlay isLoading={isLoading} loadingOpacity={1}>
-        <RadioGroup<IbanDTO>
+        <RadioGroup<string>
           type="radioListItem"
           key="check_income"
           items={Array.from(ibanList, el => ({
             ...el,
-            id: el,
+            id: el.iban,
             value: el.iban,
             description: el.description
           }))}


### PR DESCRIPTION
## Short description
This pull request updates the `IdPayIbanEnrollmentScreen` resolving the error message `two children with same key`.
This is necessary since all rendered object had key `radio_item_obj` since passed properties were not string but object

## List of changes proposed in this pull request
- Modified the `handleSelectIban` and `handleContinuePress` functions to find the corresponding `IbanDTO` object from the `ibanList` before sending it to the machine. This ensures the correct object is passed while maintaining the simplified `string` type for `selectedIban`
- Updated the `RadioGroup` component to use `string` instead of `IbanDTO` for its items

## How to test
- Press on an IDPAY card
- Go to `Add new IBAN`
- Ensure that landing in the page is not throwing the error

## Preview

| Before | Now |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/8abaad7e-9300-4319-a04a-616695d358a4"/> | <video src="https://github.com/user-attachments/assets/75dd2ae2-0332-4c35-8a0c-20df515a5a1a"/> | 
