### PR TITLE
a11y: [IOCOM-2152] empty message search results should be announced

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -2733,7 +2733,10 @@
     },
     "search": {
       "emptyState": {
-        "title": "Enter at least three letters"
+        "title": "Enter at least three letters",
+        "a11y":{
+          "noneFound": "Nessun messaggio trovato"
+        }
       },
       "input": {
         "cancel": "Cancel",

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -2733,7 +2733,10 @@
     },
     "search": {
       "emptyState": {
-        "title": "Inserisci almeno tre caratteri"
+        "title": "Inserisci almeno tre caratteri",
+        "a11y":{
+          "noneFound": "Nessun messaggio trovato"
+        }
       },
       "input": {
         "cancel": "Annulla",

--- a/ts/features/messages/screens/MessagesSearchScreen.tsx
+++ b/ts/features/messages/screens/MessagesSearchScreen.tsx
@@ -6,25 +6,26 @@ import {
   SearchInputRef,
   VSpacer
 } from "@pagopa/io-app-design-system";
+import { useFocusEffect } from "@react-navigation/native";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   FlatList,
   ListRenderItemInfo,
   Platform,
+  View,
   ViewStyle
 } from "react-native";
-import { useFocusEffect } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import I18n from "../../../i18n";
-import { EmptyList } from "../components/Search/EmptyList";
 import { useIONavigation } from "../../../navigation/params/AppParamsList";
 import { useIOStore } from "../../../store/hooks";
-import { UIMessage } from "../types";
-import { WrappedListItemMessage } from "../components/Home/WrappedListItemMessage";
 import {
   trackMessageSearchClosing,
   trackMessageSearchPage
 } from "../analytics";
+import { WrappedListItemMessage } from "../components/Home/WrappedListItemMessage";
+import { EmptyList } from "../components/Search/EmptyList";
+import { UIMessage } from "../types";
 import { getMessageSearchResult } from "./searchUtils";
 
 const INPUT_PADDING: IOSpacingScale = 16;
@@ -68,7 +69,19 @@ export const MessagesSearchScreen = () => {
       );
     }
 
-    return <VSpacer size={16} />;
+    return (
+      <View
+        accessible={true}
+        accessibilityLabel={I18n.t("messages.search.emptyState.a11y.noneFound")}
+        importantForAccessibility="yes"
+        style={{
+          minHeight: "50%"
+        }}
+      >
+        {/* the spacer here is required to make the View accessible via external keyboard  */}
+        <VSpacer size={16} />
+      </View>
+    );
   };
 
   const handleCancel = useCallback(() => {


### PR DESCRIPTION
## Short description
this PR allows users to be notified by a screen reader when no messages match the search parameters provided in the search screen

## List of changes proposed in this pull request
- required a11y i18n keys
- addition of an accessibility focusable unstyled component in the empty message search screen, so that when navigating with an external keyboard, an user will be able to focus it and be notified of the (lack of) search results.

## How to test
automated tests should pass.
also check that, on both iOS and Android, when searching for messages with a query longer than 3 characters, when:
- tapping the top half of the empty list
OR
- with the software keyboard closed, swiping right until the new component is focused

the screen reader informs the user that no message was found.
