### PR TITLE
fix: [IOBP-1695] PAYMENT_HOME mixpanel event dispatched too many times

### DIFF
--- a/ts/features/payments/home/screens/PaymentsHomeScreen.tsx
+++ b/ts/features/payments/home/screens/PaymentsHomeScreen.tsx
@@ -5,6 +5,7 @@ import Animated, {
   LinearTransition,
   useAnimatedRef
 } from "react-native-reanimated";
+import { useFocusEffect } from "@react-navigation/native";
 import {
   IOScrollView,
   IOScrollViewActions
@@ -82,16 +83,22 @@ const PaymentsHomeScreen = () => {
 
   /* CODE RELATED TO THE HEADER -- END */
 
-  useEffect(() => {
-    if (!isLoading) {
-      setIsRefreshing(false);
-      analytics.trackPaymentsHome({
-        saved_payment_method:
-          paymentAnalyticsData?.savedPaymentMethods?.length ?? 0,
-        payments_home_status: paymentAnalyticsData?.paymentsHomeStatus
-      });
-    }
-  }, [isLoading, paymentAnalyticsData]);
+  useFocusEffect(
+    useCallback(() => {
+      if (!isLoading) {
+        setIsRefreshing(false);
+        analytics.trackPaymentsHome({
+          saved_payment_method:
+            paymentAnalyticsData?.savedPaymentMethods?.length ?? 0,
+          payments_home_status: paymentAnalyticsData?.paymentsHomeStatus
+        });
+      }
+    }, [
+      isLoading,
+      paymentAnalyticsData?.paymentsHomeStatus,
+      paymentAnalyticsData?.savedPaymentMethods?.length
+    ])
+  );
 
   const handleRefreshPaymentsHome = () => {
     if (isRefreshing || isLoading || cannotRefresh) {

--- a/ts/features/payments/home/screens/PaymentsHomeScreen.tsx
+++ b/ts/features/payments/home/screens/PaymentsHomeScreen.tsx
@@ -1,6 +1,6 @@
 import { ContentWrapper } from "@pagopa/io-app-design-system";
 import * as pot from "@pagopa/ts-commons/lib/pot";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import Animated, {
   LinearTransition,
   useAnimatedRef


### PR DESCRIPTION
## Short description
This PR fixes the `PaymentsHomeScreen`, ensuring analytics tracking is triggered correctly when the screen gains focus and not every time that the paymentAnalyticsData changes.

## List of changes proposed in this pull request
* Replaced `useEffect` with `useFocusEffect` in `PaymentsHomeScreen` to ensure the analytics tracking logic runs whenever the screen gains focus, aligning with navigation lifecycle events.
* Updated the dependency array of the callback in `useFocusEffect` to include `paymentAnalyticsData?.paymentsHomeStatus` and `paymentAnalyticsData?.savedPaymentMethods?.length`, ensuring the effect re-runs when these values change. 

## How to test
Ensure that the `PAYMENT_HOME` mixpanel event is tracked only when the payment home gains focus, and it doesn't dispatch the event during the payment flow.