### PR TITLE
refactor: [IOBP-1751] apply IOListViewWithLargeHeader

### DIFF
--- a/ts/features/idpay/details/screens/IdPayOperationsListScreen.tsx
+++ b/ts/features/idpay/details/screens/IdPayOperationsListScreen.tsx
@@ -1,20 +1,18 @@
 import {
   Body,
-  ContentWrapper,
   Divider,
   HSpacer,
   IOSkeleton,
-  IOToast,
-  VSpacer
+  IOToast
 } from "@pagopa/io-app-design-system";
 import { useRoute } from "@react-navigation/core";
 import { RouteProp } from "@react-navigation/native";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
 import { useRef } from "react";
-import { ActivityIndicator, FlatList, StyleSheet } from "react-native";
+import { ActivityIndicator } from "react-native";
 import { OperationListDTO } from "../../../../../definitions/idpay/OperationListDTO";
-import { IOScrollViewWithLargeHeader } from "../../../../components/ui/IOScrollViewWithLargeHeader";
+import { IOListViewWithLargeHeader } from "../../../../components/ui/IOListViewWithLargeHeader";
 import I18n from "../../../../i18n";
 import customVariables from "../../../../theme/variables";
 import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
@@ -35,7 +33,7 @@ const TimelineLoader = () => (
   <ActivityIndicator
     animating={true}
     size={"large"}
-    style={styles.activityIndicator}
+    style={{ padding: 12 }}
     color={customVariables.brandPrimary}
     accessible={true}
     accessibilityHint={I18n.t("global.accessibility.activityIndicator.hint")}
@@ -97,19 +95,11 @@ export const IdPayOperationsListScreen = () => {
     )
   );
 
-  const operationList = isFirstLoading ? (
-    <FlatList
-      contentContainerStyle={styles.listContainer}
-      data={Array.from({ length: 10 })}
-      keyExtractor={(_, index) => `placeholder${index}`}
-      renderItem={() => <IdPayTimelineOperationListItem isLoading={true} />}
-      onRefresh={refresh}
-      refreshing={isRefreshing}
-    />
-  ) : (
-    <FlatList
-      contentContainerStyle={styles.listContainer}
+  return (
+    <IOListViewWithLargeHeader
+      skeleton={<IdPayTimelineOperationListItem isLoading />}
       data={timeline}
+      loading={isFirstLoading}
       keyExtractor={item => item.operationId}
       renderItem={({ item }) => (
         <IdPayTimelineOperationListItem
@@ -117,25 +107,7 @@ export const IdPayOperationsListScreen = () => {
           onPress={() => showOperationDetailsBottomSheet(item)}
         />
       )}
-      ItemSeparatorComponent={() => <Divider />}
-      onEndReached={fetchNextPage}
-      onEndReachedThreshold={0.5}
-      onRefresh={refresh}
-      refreshing={isRefreshing}
-      ListFooterComponent={isUpdating ? <TimelineLoader /> : null}
-    />
-  );
-
-  return (
-    <IOScrollViewWithLargeHeader
-      title={{
-        label: I18n.t(
-          "idpay.initiative.details.initiativeDetailsScreen.configured.operationsList.title"
-        )
-      }}
-    >
-      <ContentWrapper>
-        <VSpacer size={8} />
+      ListHeaderComponent={
         <Body>
           {I18n.t(
             "idpay.initiative.details.initiativeDetailsScreen.configured.operationsList.lastUpdated"
@@ -143,20 +115,24 @@ export const IdPayOperationsListScreen = () => {
           <HSpacer size={4} />
           {lastUpdateComponent}
         </Body>
-      </ContentWrapper>
-      <VSpacer size={16} />
-      {operationList}
+      }
+      contentContainerStyle={{
+        paddingBottom: 120,
+        paddingHorizontal: customVariables.contentPadding
+      }}
+      ItemSeparatorComponent={() => <Divider />}
+      onEndReached={fetchNextPage}
+      onEndReachedThreshold={0.5}
+      onRefresh={refresh}
+      refreshing={isRefreshing}
+      ListFooterComponent={isUpdating ? <TimelineLoader /> : null}
+      title={{
+        label: I18n.t(
+          "idpay.initiative.details.initiativeDetailsScreen.configured.operationsList.title"
+        )
+      }}
+    >
       {detailsBottomSheet.bottomSheet}
-    </IOScrollViewWithLargeHeader>
+    </IOListViewWithLargeHeader>
   );
 };
-
-const styles = StyleSheet.create({
-  activityIndicator: {
-    padding: 12
-  },
-  listContainer: {
-    paddingBottom: 120,
-    paddingHorizontal: customVariables.contentPadding
-  }
-});


### PR DESCRIPTION
## Short description
This pull request is replacing `FlatList` and `IOScrollViewWithLargeHeader` with `IOListViewWithLargeHeader` solving the issue `VirtualizedLists should never be nested inside plain ScrollViews` for IDPay `IDPAY_DETAILS_TIMELINE` screen

## List of changes proposed in this pull request
- Replaced `FlatList` and `IOScrollViewWithLargeHeader` with `IOListViewWithLargeHeader` to consolidate functionality and simplify the component structure.

## How to test
Ensure that opening the `IDPAY_DETAILS_TIMELINE` screen no error are displaying in console

## Preview
| Master | Current branch |
|--------|--------|
| <img width="413" alt="Screenshot 2025-06-16 at 11 15 12" src="https://github.com/user-attachments/assets/56d1231f-a99a-4feb-95f0-fdb296a2aa09" /> | <img width="439" alt="Screenshot 2025-06-16 at 11 16 59" src="https://github.com/user-attachments/assets/777031c7-9382-48b7-87a6-fa3c8af2efed" />|



