### PR TITLE
fix: [IOCOM-2439] Message's eCommerce API

### DIFF
--- a/ts/api/backend.ts
+++ b/ts/api/backend.ts
@@ -293,12 +293,9 @@ export function BackendClient(
 
   const getPaymentInfoV2T: GetPaymentInfoV2T = {
     method: "get",
-    url: ({ ["rptId"]: rptId }) => `/api/v1/payment-info/${rptId}`,
-    headers: ({ ["Bearer"]: Bearer }) => ({
-      Authorization: Bearer,
-      "Content-Type": "application/json"
-    }),
-    query: ({ ["test"]: test }) => withoutUndefinedValues({ ["test"]: test }),
+    url: ({ rptId, test }) => `/api/v1/payment-info/${rptId}?test=${test}`,
+    headers: tokenHeaderProducer,
+    query: _q16 => ({}),
     response_decoder: getPaymentInfoV2DefaultDecoder()
   };
 

--- a/ts/api/backend.ts
+++ b/ts/api/backend.ts
@@ -293,9 +293,9 @@ export function BackendClient(
 
   const getPaymentInfoV2T: GetPaymentInfoV2T = {
     method: "get",
-    url: ({ rptId, test }) => `/api/v1/payment-info/${rptId}?test=${test}`,
+    url: ({ ["rptId"]: rptId }) => `/api/v1/payment-info/${rptId}`,
     headers: tokenHeaderProducer,
-    query: _q16 => ({}),
+    query: ({ ["test"]: test }) => withoutUndefinedValues({ ["test"]: test }),
     response_decoder: getPaymentInfoV2DefaultDecoder()
   };
 

--- a/ts/features/messages/analytics/__test__/index.test.ts
+++ b/ts/features/messages/analytics/__test__/index.test.ts
@@ -2,6 +2,7 @@ import {
   trackCTAFrontMatterDecodingError,
   trackMessageNotificationParsingFailure,
   trackMessageNotificationTap,
+  trackMessagePaymentFailure,
   trackOpenMessage
 } from "..";
 import { ServiceId } from "../../../../../definitions/backend/ServiceId";
@@ -245,6 +246,29 @@ describe("index", () => {
 
       expect(spiedOnMixpanelTrack.mock.calls.length).toBe(0);
       expect(spiedOnEnqueueMixpanelEvent.mock.calls.length).toBe(0);
+    });
+  });
+
+  describe("trackMessagePaymentFailure", () => {
+    it("should call 'mixpanelTrack' with proper parameters", () => {
+      const reason = "A reason";
+      const spyOnMixpanelTrack = jest
+        .spyOn(MIXPANEL, "mixpanelTrack")
+        .mockImplementation((_event, _properties) => undefined);
+
+      trackMessagePaymentFailure(reason);
+
+      expect(spyOnMixpanelTrack.mock.calls.length).toBe(1);
+      expect(spyOnMixpanelTrack.mock.calls[0].length).toBe(2);
+      expect(spyOnMixpanelTrack.mock.calls[0][0]).toBe(
+        "MESSAGE_PAYMENT_FAILURE"
+      );
+      expect(spyOnMixpanelTrack.mock.calls[0][1]).toEqual({
+        event_category: "KO",
+        event_type: undefined,
+        flow: undefined,
+        reason
+      });
     });
   });
 });

--- a/ts/features/messages/analytics/index.ts
+++ b/ts/features/messages/analytics/index.ts
@@ -528,3 +528,9 @@ export const trackCTAPressed = (
   });
   void mixpanelTrack(eventName, props);
 };
+
+export const trackMessagePaymentFailure = (reason: string) => {
+  const eventName = "MESSAGE_PAYMENT_FAILURE";
+  const props = buildEventProperties("KO", undefined, { reason });
+  void mixpanelTrack(eventName, props);
+};

--- a/ts/features/messages/saga/__test__/handlePaymentUpdateRequests.test.ts
+++ b/ts/features/messages/saga/__test__/handlePaymentUpdateRequests.test.ts
@@ -23,8 +23,12 @@ import {
   isPagoPATestEnabledSelector
 } from "../../../../store/reducers/persistedPreferences";
 import { withRefreshApiCall } from "../../../authentication/fastLogin/saga/utils";
+import * as MIXPANEL from "../../../../mixpanel";
 
 describe("handlePaymentUpdateRequests", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
   const messageId = "01JWXM7Q90CX4S57P855JZ63PC" as UIMessageId;
   const paymentId = "0123456789012345678901234567890";
   const serviceId = "01JWXM8C2NJT15SC930ZKGCRDB" as ServiceId;
@@ -169,6 +173,9 @@ describe("handlePaymentUpdateRequests", () => {
         serviceId
       });
       const error = Error(Detail_v2Enum.PAA_PAGAMENTO_DUPLICATO);
+      const paymentError = toSpecificError(
+        Detail_v2Enum.PAA_PAGAMENTO_DUPLICATO
+      );
 
       testSaga(
         testable!.paymentUpdateRequestWorker,
@@ -194,7 +201,9 @@ describe("handlePaymentUpdateRequests", () => {
         })
         .throw(error)
         .call(testable!.unknownErrorToPaymentError, error)
-        .next(toSpecificError(Detail_v2Enum.PAA_PAGAMENTO_DUPLICATO))
+        .next()
+        .call(testable!.trackPaymentErrorIfNeeded, paymentError)
+        .next()
         .put(
           updatePaymentForMessage.failure({
             messageId,
@@ -663,6 +672,48 @@ describe("handlePaymentUpdateRequests", () => {
     it("should return Error's message for Error value", () => {
       const output = testable!.unknownErrorToString(Error("This is a test"));
       expect(output).toEqual("This is a test");
+    });
+  });
+
+  describe("trackPaymentErrorIfNeeded", () => {
+    it("should track an anlytics event for a generic error", () => {
+      const spyOnMixpanelTrack = jest
+        .spyOn(MIXPANEL, "mixpanelTrack")
+        .mockImplementation((_event, _properties) => undefined);
+
+      testable!.trackPaymentErrorIfNeeded(toGenericError("An error"));
+
+      expect(spyOnMixpanelTrack.mock.calls.length).toBe(1);
+      expect(spyOnMixpanelTrack.mock.calls[0].length).toBe(2);
+      expect(spyOnMixpanelTrack.mock.calls[0][0]).toBe(
+        "MESSAGE_PAYMENT_FAILURE"
+      );
+      expect(spyOnMixpanelTrack.mock.calls[0][1]).toEqual({
+        event_category: "KO",
+        event_type: undefined,
+        flow: undefined,
+        reason: "An error"
+      });
+    });
+    it("should not track an anlytics event for a specific error", () => {
+      const spyOnMixpanelTrack = jest
+        .spyOn(MIXPANEL, "mixpanelTrack")
+        .mockImplementation((_event, _properties) => undefined);
+
+      testable!.trackPaymentErrorIfNeeded(
+        toSpecificError(Detail_v2Enum.PPT_PAGAMENTO_DUPLICATO)
+      );
+
+      expect(spyOnMixpanelTrack.mock.calls.length).toBe(0);
+    });
+    it("should not track an anlytics event for a timeout error", () => {
+      const spyOnMixpanelTrack = jest
+        .spyOn(MIXPANEL, "mixpanelTrack")
+        .mockImplementation((_event, _properties) => undefined);
+
+      testable!.trackPaymentErrorIfNeeded(toTimeoutError());
+
+      expect(spyOnMixpanelTrack.mock.calls.length).toBe(0);
     });
   });
 });

--- a/ts/features/messages/saga/__test__/handlePaymentUpdateRequests.test.ts
+++ b/ts/features/messages/saga/__test__/handlePaymentUpdateRequests.test.ts
@@ -201,14 +201,14 @@ describe("handlePaymentUpdateRequests", () => {
         })
         .throw(error)
         .call(testable!.unknownErrorToPaymentError, error)
-        .next()
+        .next(paymentError)
         .call(testable!.trackPaymentErrorIfNeeded, paymentError)
         .next()
         .put(
           updatePaymentForMessage.failure({
             messageId,
             paymentId,
-            reason: toSpecificError(Detail_v2Enum.PAA_PAGAMENTO_DUPLICATO),
+            reason: paymentError,
             serviceId
           })
         )

--- a/ts/features/messages/saga/handlePaymentUpdateRequests.ts
+++ b/ts/features/messages/saga/handlePaymentUpdateRequests.ts
@@ -15,9 +15,9 @@ import { ActionType } from "typesafe-actions";
 import { BackendClient } from "../../../api/backend";
 import {
   cancelQueuedPaymentUpdates,
+  isGenericError,
   PaymentError,
   toGenericError,
-  toReasonString,
   toSpecificError,
   toTimeoutError,
   updatePaymentForMessage
@@ -32,8 +32,7 @@ import { readablePrivacyReport } from "../../../utils/reporters";
 import { PaymentInfoResponse } from "../../../../definitions/backend/PaymentInfoResponse";
 import { Detail_v2Enum } from "../../../../definitions/backend/PaymentProblemJson";
 import { isTestEnv } from "../../../utils/environment";
-import { mixpanelTrack } from "../../../mixpanel";
-import { buildEventProperties } from "../../../utils/analytics";
+import { trackMessagePaymentFailure } from "../analytics";
 
 const PaymentUpdateWorkerCount = 5;
 
@@ -104,12 +103,7 @@ function* paymentUpdateRequestWorker(
       });
     } catch (e) {
       const reason = yield* call(unknownErrorToPaymentError, e);
-      void mixpanelTrack(
-        "MESSAGE_PAYMENT_FAILURE",
-        buildEventProperties("TECH", undefined, {
-          reason: toReasonString(reason)
-        })
-      );
+      yield* call(trackPaymentErrorIfNeeded, reason);
       const failureAction = updatePaymentForMessage.failure({
         messageId,
         paymentId,
@@ -260,10 +254,17 @@ const unknownErrorToString = (e: unknown): string => {
   return "Unknown error with no data";
 };
 
+const trackPaymentErrorIfNeeded = (error: PaymentError) => {
+  if (isGenericError(error)) {
+    trackMessagePaymentFailure(error.message);
+  }
+};
+
 export const testable = isTestEnv
   ? {
       legacyGetVerificaRpt,
       paymentUpdateRequestWorker,
+      trackPaymentErrorIfNeeded,
       unknownErrorToPaymentError,
       unknownErrorToString,
       updatePaymentInfo

--- a/ts/features/messages/store/actions/index.ts
+++ b/ts/features/messages/store/actions/index.ts
@@ -279,18 +279,6 @@ export const toSpecificError = (details: Detail_v2Enum): PaymentError => ({
 });
 export const toTimeoutError = (): PaymentError => ({ type: "timeout" });
 
-export const toReasonString = (error: PaymentError) => {
-  switch (error.type) {
-    case "generic":
-      return error.message;
-    case "specific":
-      return `${error.details}`;
-    case "timeout":
-      return "timeout";
-  }
-  return "error type unknown";
-};
-
 export type UpdatePaymentForMessageFailure = {
   messageId: UIMessageId;
   paymentId: string;

--- a/ts/features/messages/store/actions/index.ts
+++ b/ts/features/messages/store/actions/index.ts
@@ -279,6 +279,18 @@ export const toSpecificError = (details: Detail_v2Enum): PaymentError => ({
 });
 export const toTimeoutError = (): PaymentError => ({ type: "timeout" });
 
+export const toReasonString = (error: PaymentError) => {
+  switch (error.type) {
+    case "generic":
+      return error.message;
+    case "specific":
+      return `${error.details}`;
+    case "timeout":
+      return "timeout";
+  }
+  return "error type unknown";
+};
+
 export type UpdatePaymentForMessageFailure = {
   messageId: UIMessageId;
   paymentId: string;


### PR DESCRIPTION
## Short description
This pull request fixes the Authorization header being malformed on the new eCommerce API (for messages' payments)

## List of changes proposed in this pull request
- Proper Authorization header composition
- Tracking of generic errors on payment's failures

## How to test
Using the io-dev-api server, check that the new eCommerce API works properly
