### PR TITLE
fix: [IOBP-1752] Deeplink of CGN and payments infinite loading

### DIFF
--- a/ts/features/payments/common/saga/index.ts
+++ b/ts/features/payments/common/saga/index.ts
@@ -1,5 +1,5 @@
 import { SagaIterator } from "redux-saga";
-import { fork, select, takeLatest } from "typed-redux-saga/macro";
+import { fork, put, select, takeLatest } from "typed-redux-saga/macro";
 import { isPagoPATestEnabledSelector } from "../../../../store/reducers/persistedPreferences";
 import { walletApiBaseUrl, walletApiUatBaseUrl } from "../../../../config";
 import { watchPaymentsOnboardingSaga } from "../../onboarding/saga";
@@ -14,6 +14,7 @@ import {
   createTransactionClient,
   createWalletClient
 } from "../api/client";
+import { walletUpdate } from "../../../wallet/store/actions";
 import { handlePaymentsSessionToken } from "./handlePaymentsSessionToken";
 import { handleResumePaymentsPendingActions } from "./handleResumePaymentsPendingActions";
 import { cleanExpiredPaymentsOngoingFailed } from "./cleanExpiredPaymentsOngoingFailed";
@@ -47,4 +48,6 @@ export function* watchPaymentsSaga(walletToken: string): SagaIterator {
   yield* fork(watchPaymentsMethodDetailsSaga, walletClient);
   yield* fork(watchPaymentsReceiptSaga, transactionClient);
   yield* fork(watchPaymentsCheckoutSaga, paymentClient);
+
+  yield* put(walletUpdate());
 }

--- a/ts/navigation/AppStackNavigator.tsx
+++ b/ts/navigation/AppStackNavigator.tsx
@@ -29,7 +29,11 @@ import { startApplicationInitialization } from "../store/actions/application";
 import { setDebugCurrentRouteName } from "../store/actions/debug";
 import { useIODispatch, useIOSelector, useIOStore } from "../store/hooks";
 import { trackScreen } from "../store/middlewares/navigation";
-import { isCGNEnabledSelector } from "../store/reducers/backendStatus/remoteConfig";
+import {
+  isBackendStatusLoadedSelector,
+  isCGNEnabledAfterLoadSelector,
+  isCGNEnabledSelector
+} from "../store/reducers/backendStatus/remoteConfig";
 import { StartupStatusEnum, isStartupLoaded } from "../store/reducers/startup";
 import {
   IONavigationDarkTheme,
@@ -101,7 +105,7 @@ const InnerNavigationContainer = (props: InnerNavigationContainerProps) => {
   const dispatch = useIODispatch();
   const store = useIOStore();
 
-  const cgnEnabled = useIOSelector(isCGNEnabledSelector);
+  const cgnEnabled = useIOSelector(isCGNEnabledAfterLoadSelector);
 
   // Dark/Light Mode
   const { themeType } = useIOThemeContext();

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -408,6 +408,9 @@ export function* initializeApplicationSaga(
   // watch FCI saga
   yield* fork(watchFciSaga, sessionToken, keyInfo);
 
+  // Start watching for cgn actions
+  yield* fork(watchBonusCgnSaga, sessionToken);
+
   // whether we asked the user to login again
   const isSessionRefreshed = previousSessionToken !== sessionToken; // Needs further investigation
 
@@ -647,15 +650,11 @@ export function* initializeApplicationSaga(
   //
   // User is autenticated, session token is valid
   //
-
   // Start wathing new wallet sagas
   yield* fork(watchWalletSaga);
 
   // Here we can be sure that the session information is loaded and valid
   const bpdToken = maybeSessionInformation.value.bpdToken as string;
-
-  // Start watching for cgn actions
-  yield* fork(watchBonusCgnSaga, sessionToken);
 
   const pnEnabled: ReturnType<typeof isPnRemoteEnabledSelector> = yield* select(
     isPnRemoteEnabledSelector

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -408,9 +408,6 @@ export function* initializeApplicationSaga(
   // watch FCI saga
   yield* fork(watchFciSaga, sessionToken, keyInfo);
 
-  // Start watching for cgn actions
-  yield* fork(watchBonusCgnSaga, sessionToken);
-
   // whether we asked the user to login again
   const isSessionRefreshed = previousSessionToken !== sessionToken; // Needs further investigation
 
@@ -655,6 +652,9 @@ export function* initializeApplicationSaga(
 
   // Here we can be sure that the session information is loaded and valid
   const bpdToken = maybeSessionInformation.value.bpdToken as string;
+
+  // Start watching for cgn actions
+  yield* fork(watchBonusCgnSaga, sessionToken);
 
   const pnEnabled: ReturnType<typeof isPnRemoteEnabledSelector> = yield* select(
     isPnRemoteEnabledSelector

--- a/ts/store/reducers/backendStatus/remoteConfig.ts
+++ b/ts/store/reducers/backendStatus/remoteConfig.ts
@@ -113,6 +113,15 @@ export const isCGNEnabledSelector = (state: GlobalState) =>
     O.getOrElse(() => false)
   );
 
+/**
+ * Return true if CGN is enabled, but only after backend status is loaded.
+ * This prevents CGN from being disabled by default when backend status is not yet loaded.
+ */
+export const isCGNEnabledAfterLoadSelector = createSelector(
+  [isBackendStatusLoadedSelector, isCGNEnabledSelector],
+  (isLoaded, isEnabled) => (isLoaded ? isEnabled : true)
+);
+
 export const fimsRequiresAppUpdateSelector = (state: GlobalState) =>
   pipe(
     state,


### PR DESCRIPTION
## Short description
This PR fixes the payments and navigation sagas and improves the handling of CGN feature flags. With these fixes, now it's possible to open the wallet screen and CGN details screen with a deeplink without showing the infinite loading screen.

## List of changes proposed in this pull request
* Dispatched the `walletUpdate` action to ensure the wallet state is updated after initializing payment-related sagas. 
* Created a new selector, `isCGNEnabledAfterLoadSelector`, to ensure CGN is enabled only after backend status is fully loaded, preventing premature disabling.
* Updated the navigation logic to use `isCGNEnabledAfterLoadSelector` instead of `isCGNEnabledSelector`, improving reliability during app initialization. 

## How to test
- Open the browser on your simulator/emulator and navigate to these deeplink to test them in local:
   - `ioit://cgn-details/detail`-> Ensure that opening this link, you will see the CGN card details (of course,e only if you have it)
   - `ioit://main/wallet`-> Ensure that opening this link, you will see the wallet screen with the payment methods and other cards shown instead of infinite skeletons loading.

## Preview
### CGN
|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/8c6544eb-d2a7-444b-b111-4bc7dd422063" />|<video src="https://github.com/user-attachments/assets/b9ab8c0f-cc2b-4752-b59b-705fca79aca9" />|

### Wallet
|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/c698c23a-dd9b-48cd-9932-b2dc0a3791c8" />|<video src="https://github.com/user-attachments/assets/6bc578e5-0ed6-4cf9-b156-d8723440eb4c" />|