### PR TITLE
fix: [IOAPPX-500] IOScrollView interpolated opacity check of NaN values

### DIFF
--- a/ts/components/ui/IOScrollView.tsx
+++ b/ts/components/ui/IOScrollView.tsx
@@ -234,14 +234,17 @@ export const IOScrollView = ({
     }
   );
 
-  const opacityTransition = useAnimatedStyle(() => ({
-    opacity: interpolate(
+  const opacityTransition = useAnimatedStyle(() => {
+    const interpolatedOpacity = interpolate(
       scrollPositionPercentage.value,
       [0, gradientOpacityScrollTrigger, 1],
       [1, 1, 0],
       Extrapolation.CLAMP
-    )
-  }));
+    );
+    return {
+      opacity: Number.isNaN(interpolatedOpacity) ? 0 : interpolatedOpacity
+    };
+  });
 
   const ignoreSafeAreaMargin = useMemo(() => {
     if (alertProps !== undefined) {


### PR DESCRIPTION
## Short description
This PR refactors the `opacityTransition` logic in the `IOScrollView` component to improve robustness and handle edge cases where the interpolated opacity could result in `NaN`. (Thanks @shadowsheep1)
Without this fix, opening the IO app via the `ioit://main/wallet` deeplink can cause a crash.

## List of changes proposed in this pull request
* Updated the `opacityTransition` to explicitly check if `interpolatedOpacity` is `NaN` and default to `0` in such cases, ensuring the opacity value is always valid.

## How to test
Ensure that opening the app via the `ioit://main/wallet` deeplink does not cause the app to crash.

## Preview
|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/0077ad95-0356-4906-acec-05e70718a98a" />|<video src="https://github.com/user-attachments/assets/107c01b4-0b50-463b-a622-2359f2a27417" />
