### PR TITLE
chore: [IOBP-1753] Enable `about:*` wildcard schema inside the payment webview whitelist

### DIFF
--- a/ts/features/payments/checkout/components/WalletPaymentWebView.tsx
+++ b/ts/features/payments/checkout/components/WalletPaymentWebView.tsx
@@ -9,6 +9,7 @@ import { PaymentStartWebViewPayload } from "../store/actions/orchestration";
 const originSchemasWhiteList = [
   "https://*",
   `${WALLET_WEBVIEW_OUTCOME_SCHEMA}://*`,
+  "about:*",
   ...(isDevEnv ? ["http://*"] : [])
 ];
 


### PR DESCRIPTION
This PR adds the `about:*` schema to the `originSchemasWhiteList` array to expand the list of allowed schemas. On iOS, during redirects within PSP webpages, it can occasionally redirect to about:*, which triggers the WebView's `onHttpError` and results in a `GENERIC_ERROR` outcome.

## How to test
This issue can only be tested through a payment performed in the production environment, as it has not been reproducible in UAT. Moreover, the redirect to `about:*` doesn't occur consistently, making it difficult to trigger the error on demand.
For this reason, the fix should be considered final only after a controlled release in production, monitoring the `GENERIC_ERROR` rate via Mixpanel to verify a significant reduction in occurrences.
