### PR TITLE
refactor: [IOPID-3142] remove GradientScrollView and delete unused copy 

### DIFF
--- a/locales/de/index.json
+++ b/locales/de/index.json
@@ -692,15 +692,6 @@
           "hint": "Karussell mit einer einführenden Anleitung zur IO-Funktionalität. Wähle, um den Inhalt kennenzulernen."
         }
       },
-      "cie_unsupported": {
-        "title": "Du kannst dich nicht mit CIE anmelden",
-        "body": "Das von dir verwendete Gerät unterstützt den Zugang mit einer elektronischen Identitätskarte (CIE) nicht.",
-        "button": "Verstanden",
-        "nfc_problem": "Zum Lesen der CIE ist ein Gerät mit NFC-Chip erforderlich.",
-        "os_problem": "Ein Betriebssystem mit Android 6.0 oder iOS 13 oder höher ist erforderlich.",
-        "nfc_alert": "Dein Gerät verfügt nicht über NFC.",
-        "os_alert": "Das Betriebssystem des Geräts ist nicht auf dem neuesten Stand."
-      },
       "cie_bottom_sheet": {
         "title": "Wie willst du dich anmelden?",
         "module_cie_pin": {

--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -837,15 +837,6 @@
         "body": "We need to check your identity from time to time for security reasons",
         "linkButtonLabel": "Read more"
       },
-      "cie_unsupported": {
-        "title": "You cannot use CIE",
-        "body": "The device you are using does not support access with Electronic ID Card (CIE).",
-        "button": "I get it",
-        "nfc_problem": "To read the CIE, a device with NFC chip is required.",
-        "os_problem": "An Android 6.0 or iOS 13 or higher operating system is required.",
-        "nfc_alert": "Your device does not have NFC.",
-        "os_alert": "The device's operating system is not up-to-date."
-      },
       "cie_bottom_sheet": {
         "title": "How do you want to login?",
         "module_cie_pin": {

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -837,15 +837,6 @@
         "body": "Per la tua sicurezza, di tanto in tanto dobbiamo verificare la tua identità",
         "linkButtonLabel": "Leggi come fare"
       },
-      "cie_unsupported": {
-        "title": "Non puoi entrare con CIE",
-        "body": "Il dispositivo che stai utilizzando non supporta l’accesso con Carta d’Identità Elettronica (CIE).",
-        "button": "Ho capito",
-        "nfc_problem": "Per leggere la CIE è necessario un dispositivo con chip NFC.",
-        "os_problem": "È richiesto un sistema operativo Android 6.0 o iOS 13 o superiori.",
-        "nfc_alert": "Il tuo dispositivo non ha l'NFC.",
-        "os_alert": "Il sistema operativo del dispositivo non è aggiornato."
-      },
       "cie_bottom_sheet": {
         "title": "Come vuoi entrare?",
         "module_cie_pin": {

--- a/ts/features/authentication/login/optIn/screens/OptInScreen.tsx
+++ b/ts/features/authentication/login/optIn/screens/OptInScreen.tsx
@@ -34,6 +34,7 @@ import { CieIdLoginProps } from "../../cie/components/CieIdLoginWebView";
 import { AuthenticationParamsList } from "../../../common/navigation/params/AuthenticationParamsList";
 import { AUTHENTICATION_ROUTES } from "../../../common/navigation/routes";
 import { useDetectSmallScreen } from "../../../../../hooks/useDetectSmallScreen";
+import { IOScrollView } from "../../../../../components/ui/IOScrollView";
 
 export enum Identifier {
   SPID = "SPID",
@@ -111,20 +112,22 @@ const OptInScreen = () => {
   };
 
   return (
-    <GradientScrollView
+    <IOScrollView
       testID="container-test"
-      primaryActionProps={{
-        label: I18n.t("authentication.opt_in.button_accept_lv"),
-        accessibilityLabel: I18n.t("authentication.opt_in.button_accept_lv"),
-        onPress: () => navigateToIdpPage(true),
-        testID: "accept-button-test"
-      }}
-      secondaryActionProps={{
-        label: I18n.t("authentication.opt_in.button_decline_lv"),
-        accessibilityLabel: I18n.t("authentication.opt_in.button_decline_lv"),
-        onPress: () => navigateToIdpPage(false),
-        testID: "decline-button-test",
-        variant: "link"
+      actions={{
+        type: "TwoButtons",
+        primary: {
+          label: I18n.t("authentication.opt_in.button_accept_lv"),
+          accessibilityLabel: I18n.t("authentication.opt_in.button_accept_lv"),
+          onPress: () => navigateToIdpPage(true),
+          testID: "accept-button-test"
+        },
+        secondary: {
+          label: I18n.t("authentication.opt_in.button_decline_lv"),
+          accessibilityLabel: I18n.t("authentication.opt_in.button_decline_lv"),
+          onPress: () => navigateToIdpPage(false),
+          testID: "decline-button-test"
+        }
       }}
     >
       <ContentWrapper>
@@ -186,7 +189,7 @@ const OptInScreen = () => {
         />
       </ContentWrapper>
       {securitySuggestionBottomSheet}
-    </GradientScrollView>
+    </IOScrollView>
   );
 };
 


### PR DESCRIPTION
## Short description
This PR removes unused texts that were left over from a screen deleted in [this PR](https://github.com/pagopa/io-app/pull/6653) and replaces the deprecated GradientScrollView component with IOScrollView

> [!Note]
> There is nothing to show, the screen remains the same.

## How to test
1. Run the application
2. Choose identification method 
3. Check if opt-in screen works properly 