### PR TITLE
fix: [IOCOM-2450] SEND banner optimistic render fix

### DIFF
--- a/ts/features/pn/reminderBanner/components/PNActivationReminderBanner.tsx
+++ b/ts/features/pn/reminderBanner/components/PNActivationReminderBanner.tsx
@@ -1,14 +1,14 @@
 import { Banner, IOVisualCostants } from "@pagopa/io-app-design-system";
-import { useCallback } from "react";
+import { useFocusEffect } from "@react-navigation/native";
+import { useCallback, useRef } from "react";
 import { StyleSheet, View } from "react-native";
 import I18n from "../../../../i18n";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { useIODispatch } from "../../../../store/hooks";
 import { MESSAGES_ROUTES } from "../../../messages/navigation/routes";
+import { sendBannerMixpanelEvents } from "../../analytics/activationReminderBanner";
 import PN_ROUTES from "../../navigation/routes";
 import { dismissPnActivationReminderBanner } from "../../store/actions";
-import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
-import { sendBannerMixpanelEvents } from "../../analytics/activationReminderBanner";
 
 type Props = {
   handleOnClose: () => void;
@@ -17,10 +17,17 @@ type Props = {
 export const PNActivationReminderBanner = ({ handleOnClose }: Props) => {
   const navigation = useIONavigation();
   const dispatch = useIODispatch();
+  const isFirstRender = useRef<boolean>(true);
 
-  useOnFirstRender(() => {
-    sendBannerMixpanelEvents.bannerShown();
-  });
+  const maybeDispatchBannerShown = useCallback(() => {
+    if (isFirstRender.current) {
+      sendBannerMixpanelEvents.bannerShown();
+      // eslint-disable-next-line functional/immutable-data
+      isFirstRender.current = false;
+    }
+  }, [isFirstRender]);
+
+  useFocusEffect(maybeDispatchBannerShown);
 
   const closeHandler = useCallback(() => {
     sendBannerMixpanelEvents.bannerClose();

--- a/ts/features/pn/reminderBanner/reducer/__test__/bannerDismiss.test.ts
+++ b/ts/features/pn/reminderBanner/reducer/__test__/bannerDismiss.test.ts
@@ -333,7 +333,8 @@ describe("isPnActivationReminderBannerRenderableSelector", () => {
     }
   );
 
-  it("should handle an error state for isPnInboxEnabled, treating it as 'false' ", () => {
+  it("should handle an error state for isPnInboxEnabled, treating it as 'true' ", () => {
+    // this is to avoid "uncertain" renders
     const state = {
       features: {
         pn: {
@@ -362,6 +363,6 @@ describe("isPnActivationReminderBannerRenderableSelector", () => {
 
     expect(
       bannerDismiss.isPnActivationReminderBannerRenderableSelector(state)
-    ).toBe(true);
+    ).toBe(false);
   });
 });

--- a/ts/features/pn/reminderBanner/reducer/bannerDismiss.ts
+++ b/ts/features/pn/reminderBanner/reducer/bannerDismiss.ts
@@ -76,7 +76,7 @@ export const isPnActivationReminderBannerRenderableSelector = (
   const hasBannerBeenDismissed =
     state.features.pn.bannerDismiss.dismissed === true;
   const isPnRemoteEnabled = isPnRemoteEnabledSelector(state);
-  const isPnInboxEnabled = isPnServiceEnabled(state) ?? false;
+  const isPnInboxEnabled = isPnServiceEnabled(state) ?? true;
 
   return isPnRemoteEnabled && !hasBannerBeenDismissed && !isPnInboxEnabled;
 };


### PR DESCRIPTION
## Short description
This PR fixes a bug that made the SEND banner render and dispatch mixpanel events when the app was not certain about SEND's activation status

## List of changes proposed in this pull request
- rendering logic fix
- updated the BANNER_SHOWN event dispatching logic
- updated tests

## How to test
using the dev-server, add an `Alert` in  the banner's mixpanel dispatching logic (`maybeDispatchBannerShown`) , and make sure that
- it only runs if the banner is visible
- it does not rerun when switching screens
- it runs again when activating and deactivating the SEND preferences
- it does not run if you are in a screen different than MESSAGES_HOME
