### PR TITLE
fix: [IOCOM-2451] payment reminder alert empty focus

### DIFF
--- a/ts/features/messages/hooks/useMessageReminder.ts
+++ b/ts/features/messages/hooks/useMessageReminder.ts
@@ -55,8 +55,8 @@ export const useMessageReminder = (
     // prompt an alert to inform that his calendar permissions could have been turned off
     if (!permissionGranted) {
       Alert.alert(
-        "",
         I18n.t("messages.cta.calendarPermDenied.title"),
+        undefined,
         [
           {
             text: I18n.t("messages.cta.calendarPermDenied.cancel"),


### PR DESCRIPTION
## Short description
this PR targets an issue where, especially on Android, when using a screenReader, the a11y focus would fall on an empty title when opening the alert that requests calendar permissions in a payment message with reminder.

## List of changes proposed in this pull request
- swapped title and body in the affected Alert

## How to test
on both Android and iOS, using physical devices, make sure that the following case happens:
1) using a screen reader, and with calendar permissions disabled for the app, open a reminder message 
2) when receiving a system prompt for calendar access, dismiss it without enabling the permissions
3) when tapping on the "alert"(component) that prompts the addition of a reminder, a system alert should open and the screen reader focus should fall on the first paragraph -- **not on an empty invisible paragraph**. 

