### PR TITLE
chore: [IOAPPX-000] bump jailmonkey to `2.8.3`

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -57,7 +57,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - IOWalletProximity (1.2.2)
-  - jail-monkey (2.8.0):
+  - jail-monkey (2.8.3):
     - React-Core
   - JOSESwift (3.0.0)
   - lottie-ios (4.5.0)
@@ -2663,7 +2663,7 @@ SPEC CHECKSUMS:
   IoReactNativeCie: 54bdf08a12242b95af9caabfe7e045a06bec6f0c
   IoReactNativeProximity: 3efb5d2d87ea676bfd962fc710e81da1726f5dee
   IOWalletProximity: 55d5527de91a971dbcdbdda1838860c9860683ac
-  jail-monkey: 1846061ac12e861ac5a8ec7197b0daa775b83733
+  jail-monkey: 9298d04aa09f8c9cdcf04e7bf597ea423b52b5bf
   JOSESwift: 7784b1b844194d0f534eb6ac4fba5af683bccc79
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
   lottie-react-native: 35b7c1125a01f847fa5905d380e54951132d2450

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "hastscript": "^7.0.2",
     "hoist-non-react-statics": "^3.0.1",
     "io-ts": "^2.2.16",
-    "jail-monkey": "^2.8.0",
+    "jail-monkey": "^2.8.3",
     "jwk-thumbprint": "^0.1.4",
     "lodash": "^4.17.21",
     "lottie-react-native": "^7.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13080,7 +13080,7 @@ __metadata:
     hoist-non-react-statics: ^3.0.1
     husky: ^8.0.0
     io-ts: ^2.2.16
-    jail-monkey: ^2.8.0
+    jail-monkey: ^2.8.3
     jest: ^29.7.0
     js-yaml: ^3.13.1
     jwk-thumbprint: ^0.1.4
@@ -13217,10 +13217,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jail-monkey@npm:^2.8.0":
-  version: 2.8.0
-  resolution: "jail-monkey@npm:2.8.0"
-  checksum: 103956be764707954799924f9851255a0fc5d978621cee811547c26354411eba372dcf309ade406ab20d48fb36202274c6b4e8f698f8bf802a03b12d1a6dfb57
+"jail-monkey@npm:^2.8.3":
+  version: 2.8.3
+  resolution: "jail-monkey@npm:2.8.3"
+  checksum: d9cbc913c276819dcdbf5fabdf3d91e5871a296277230c9b73a10134931ce9f5a4a17e30fb807096e141f2dbccd686ec58e7d06a3c846c405643e54f9979b6e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Short description
This PR bumps jailmonkey to `2.8.3`

## List of changes proposed in this pull request
- [Changes](https://github.com/GantMan/jail-monkey/compare/v2.8.0...v2.8.3)
- Bump rootbeer to `0.1.1` that add support to android 16K 

## How to test
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
