### PR TITLE
feat: [IOCOM-2465] Global mocks for `react-native-screenshot-prevent`

### DIFF
--- a/jestSetup.js
+++ b/jestSetup.js
@@ -22,6 +22,7 @@ const mockRNQRGenerator = {
 import "react-native-get-random-values";
 require("@shopify/flash-list/jestSetup");
 jest.mock("rn-qr-generator", () => mockRNQRGenerator);
+jest.mock("react-native-screenshot-prevent", () => ({}));
 
 jest.mock("react-native-i18n");
 jest.mock("@pagopa/io-react-native-zendesk", () => mockZendesk);

--- a/ts/features/messages/components/Home/__tests__/Toast.test.tsx
+++ b/ts/features/messages/components/Home/__tests__/Toast.test.tsx
@@ -10,9 +10,6 @@ import * as archivingReducer from "../../../store/reducers/archiving";
 import * as preferencesReducer from "../../../../../store/reducers/preferences";
 import * as allPaginatedReducer from "../../../store/reducers/allPaginated";
 
-jest.mock("rn-qr-generator", () => ({}));
-jest.mock("react-native-screenshot-prevent", () => ({}));
-
 const mockToastSuccess = jest.fn();
 const mockToastError = jest.fn();
 jest.mock("@pagopa/io-app-design-system", () => ({

--- a/ts/features/messages/components/Home/__tests__/WrappedListItemMessage.test.tsx
+++ b/ts/features/messages/components/Home/__tests__/WrappedListItemMessage.test.tsx
@@ -17,9 +17,6 @@ import { MessageCategory } from "../../../../../../definitions/backend/MessageCa
 import { toggleScheduledMessageArchivingAction } from "../../../store/actions/archiving";
 import * as homeUtils from "../homeUtils";
 
-jest.mock("rn-qr-generator", () => ({}));
-jest.mock("react-native-screenshot-prevent", () => ({}));
-
 const mockNavigate = jest.fn();
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual<typeof import("@react-navigation/native")>(

--- a/ts/features/messages/components/MessageDetail/__tests__/MessageDetailsBody.test.tsx
+++ b/ts/features/messages/components/MessageDetail/__tests__/MessageDetailsBody.test.tsx
@@ -14,9 +14,6 @@ import { applicationChangeState } from "../../../../../store/actions/application
 jest.mock("../MessageMarkdown");
 jest.mock("../../../../../components/IOMarkdown");
 
-jest.mock("rn-qr-generator", () => ({}));
-jest.mock("react-native-screenshot-prevent", () => ({}));
-
 jest.mock("react-native-device-info", () => ({
   getReadableVersion: () => "2.0.0.0",
   getVersion: () => "2.0.0.0",

--- a/ts/features/pn/components/__test__/MessageBottomMenu.test.tsx
+++ b/ts/features/pn/components/__test__/MessageBottomMenu.test.tsx
@@ -9,9 +9,6 @@ import { NotificationPaymentInfo } from "../../../../../definitions/pn/Notificat
 import { UIMessageId } from "../../../messages/types";
 import { NotificationStatusHistory } from "../../../../../definitions/pn/NotificationStatusHistory";
 
-jest.mock("rn-qr-generator", () => ({}));
-jest.mock("react-native-screenshot-prevent", () => ({}));
-
 jest.mock("../TimelineListItem");
 jest.mock("../../../messages/components/MessageDetail/ContactsListItem");
 jest.mock("../../../messages/components/MessageDetail/ShowMoreListItem");

--- a/ts/features/pn/components/__test__/MessageDetails.test.tsx
+++ b/ts/features/pn/components/__test__/MessageDetails.test.tsx
@@ -15,8 +15,6 @@ import { PNMessage } from "../../store/types/types";
 import { MessageDetails } from "../MessageDetails";
 
 jest.mock("../MessageBottomMenu");
-jest.mock("rn-qr-generator", () => ({}));
-jest.mock("react-native-screenshot-prevent", () => ({}));
 
 const pnMessage = pipe(thirdPartyMessage, toPNMessage, O.toUndefined)!;
 

--- a/ts/features/pn/components/__test__/MessagePaymentBottomSheet.test.tsx
+++ b/ts/features/pn/components/__test__/MessagePaymentBottomSheet.test.tsx
@@ -12,9 +12,6 @@ import { Detail_v2Enum } from "../../../../../definitions/backend/PaymentProblem
 import { ServiceId } from "../../../../../definitions/backend/ServiceId";
 import { toSpecificError } from "../../../messages/store/actions";
 
-jest.mock("rn-qr-generator", () => ({}));
-jest.mock("react-native-screenshot-prevent", () => ({}));
-
 describe("MessagePaymentBottomSheet", () => {
   it("should match snapshot, no payments", () => {
     const messageId = "01HTHS3N21AFMBMKHGWVRAMXQ6" as UIMessageId;

--- a/ts/features/pn/components/__test__/MessagePayments.test.tsx
+++ b/ts/features/pn/components/__test__/MessagePayments.test.tsx
@@ -13,9 +13,6 @@ import { Detail_v2Enum } from "../../../../../definitions/backend/PaymentProblem
 import { ServiceId } from "../../../../../definitions/backend/ServiceId";
 import { toSpecificError } from "../../../messages/store/actions";
 
-jest.mock("rn-qr-generator", () => ({}));
-jest.mock("react-native-screenshot-prevent", () => ({}));
-
 const globalMessageId = "01HTFFDYS8VQ779EA4M5WB9YWA" as UIMessageId;
 const globalMaxVisiblePaymentCount = 5;
 const globalDueDate = new Date(2099, 4, 2, 1, 1, 1);

--- a/ts/features/pn/components/__test__/Timeline.test.tsx
+++ b/ts/features/pn/components/__test__/Timeline.test.tsx
@@ -5,9 +5,6 @@ import { applicationChangeState } from "../../../../store/actions/application";
 import { renderScreenWithNavigationStoreContext } from "../../../../utils/testWrapper";
 import PN_ROUTES from "../../navigation/routes";
 
-jest.mock("rn-qr-generator", () => ({}));
-jest.mock("react-native-screenshot-prevent", () => ({}));
-
 const defaultProps: TimelineProps = {
   data: [
     {

--- a/ts/features/pn/components/__test__/TimelineListItem.test.tsx
+++ b/ts/features/pn/components/__test__/TimelineListItem.test.tsx
@@ -9,9 +9,6 @@ import { NotificationStatusHistory } from "../../../../../definitions/pn/Notific
 import { GlobalState } from "../../../../store/reducers/types";
 import { BackendStatus } from "../../../../../definitions/content/BackendStatus";
 
-jest.mock("rn-qr-generator", () => ({}));
-jest.mock("react-native-screenshot-prevent", () => ({}));
-
 jest.mock("../Timeline");
 
 describe("TimelineListItem", () => {

--- a/ts/features/pn/screens/__test__/MessageDetailsScreen.test.tsx
+++ b/ts/features/pn/screens/__test__/MessageDetailsScreen.test.tsx
@@ -22,9 +22,6 @@ import { UIMessageId } from "../../../messages/types";
 import { applicationChangeState } from "../../../../store/actions/application";
 import { thirdPartyMessage } from "../../__mocks__/pnMessage";
 
-jest.mock("rn-qr-generator", () => ({}));
-jest.mock("react-native-screenshot-prevent", () => ({}));
-
 jest.mock("../../components/MessageDetails");
 
 describe("MessageDetailsScreen", () => {


### PR DESCRIPTION
## Short description
This pr adds global mock for `react-native-screenshot-prevent` in order not to have warning messages during tests.

## List of changes proposed in this pull request
- Global mock for `react-native-screenshot-prevent`
- Removed unneccessary mocks

## How to test
CI should succeed.
