### PR TITLE
chore: [IOBP-1800] Update wallet card categories order

### DIFF
--- a/ts/features/wallet/types/index.ts
+++ b/ts/features/wallet/types/index.ts
@@ -5,7 +5,7 @@ import { ItwCredentialCard } from "../../itwallet/common/components/ItwCredentia
 import { PaymentWalletCardProps } from "../../payments/wallet/components/PaymentWalletCard";
 
 // Used to group the cards in the wallet. **DO NOT CHANGE THE ITEMS ORDER**
-export const walletCardCategories = ["itw", "cgn", "bonus", "payment"] as const;
+export const walletCardCategories = ["itw", "bonus", "cgn", "payment"] as const;
 export type WalletCardCategory = (typeof walletCardCategories)[number];
 
 // Used for the filtering logic in the wallet screen


### PR DESCRIPTION
## Short description
This PR is updating wallet card categories order to display IDPay bonus at top

## List of changes proposed in this pull request
- Update `walletCardCategories` dependency array

## How to test
Ensure that wallet card follow this order:
- IDPay
- CGN
- Payment cards

## Preview

<img width="426" alt="Screenshot 2025-06-30 at 16 06 14" src="https://github.com/user-attachments/assets/d3a5a0e4-30e2-4bac-b282-5b1d52688417" />
