### PR TITLE
feat(IT Wallet): [SIW-2595] Add timeout error screen and progressive loading states for proximity flow

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -5008,6 +5008,20 @@
             "title": "In attesa di connessione per la verifica...",
             "subtitle": "Attendi qualche secondo..."
           },
+          "loadingStepScreen": {
+            "initial": {
+              "title": "Stiamo comunicando i tuoi dati per la verifica",
+              "subtitle": "Attendi qualche secondo..."
+            },
+            "reminder": {
+              "title": "Ancora un po' di pazienza...",
+              "subtitle": "Stiamo aspettando una risposta dai sistemi dell’ente che richiede i dati."
+            },
+            "final": {
+              "title": "Sembra che le cose vadano un po' a rilento",
+              "subtitle": "Ancora un po' di pazienza..."
+            }
+          },
           "selectiveDisclosure": {
             "title": "Dati richiesti",
             "subtitle": "Saranno mostrati a **{{relyingParty}}** per completare la verifica dei documenti richiesti.",
@@ -5025,6 +5039,11 @@
           "relyingParty": {
             "genericError": {
               "title": "Verifica interrotta",
+              "subtitle": "Un problema ha impedito la comunicazione con chi ha richiesto la verifica dei dati. Prova di nuovo.",
+              "primaryAction": "Chiudi"
+            },
+            "timeout": {
+              "title": "L’app di chi verifica non risponde",
               "subtitle": "Un problema ha impedito la comunicazione con chi ha richiesto la verifica dei dati. Prova di nuovo.",
               "primaryAction": "Chiudi"
             }

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -5008,6 +5008,20 @@
             "title": "In attesa di connessione per la verifica...",
             "subtitle": "Attendi qualche secondo..."
           },
+          "loadingStepScreen": {
+            "initial": {
+              "title": "Stiamo comunicando i tuoi dati per la verifica",
+              "subtitle": "Attendi qualche secondo..."
+            },
+            "reminder": {
+              "title": "Ancora un po' di pazienza...",
+              "subtitle": "Stiamo aspettando una risposta dai sistemi dell’ente che richiede i dati."
+            },
+            "final": {
+              "title": "Sembra che le cose vadano un po' a rilento",
+              "subtitle": "Ancora un po' di pazienza..."
+            }
+          },
           "selectiveDisclosure": {
             "title": "Dati richiesti",
             "subtitle": "Saranno mostrati a **{{relyingParty}}** per completare la verifica dei documenti richiesti.",
@@ -5025,6 +5039,11 @@
           "relyingParty": {
             "genericError": {
               "title": "Verifica interrotta",
+              "subtitle": "Un problema ha impedito la comunicazione con chi ha richiesto la verifica dei dati. Prova di nuovo.",
+              "primaryAction": "Chiudi"
+            },
+            "timeout": {
+              "title": "L’app di chi verifica non risponde",
               "subtitle": "Un problema ha impedito la comunicazione con chi ha richiesto la verifica dei dati. Prova di nuovo.",
               "primaryAction": "Chiudi"
             }

--- a/ts/features/itwallet/presentation/proximity/components/ItwProximityLoadingStepScreen.tsx
+++ b/ts/features/itwallet/presentation/proximity/components/ItwProximityLoadingStepScreen.tsx
@@ -1,0 +1,51 @@
+import { Body, ContentWrapper } from "@pagopa/io-app-design-system";
+import LoadingScreenContent from "../../../../../components/screens/LoadingScreenContent";
+import I18n from "../../../../../i18n";
+import { ItwProximityMachineContext } from "../machine/provider";
+import {
+  isInitialLoadingSelector,
+  isReminderLoadingSelector
+} from "../machine/selectors";
+
+export const ItwProximityLoadingStepScreen = () => {
+  const isInitialLoading = ItwProximityMachineContext.useSelector(
+    isInitialLoadingSelector
+  );
+
+  const isReminderLoading = ItwProximityMachineContext.useSelector(
+    isReminderLoadingSelector
+  );
+
+  const i18nNs = "features.itWallet.presentation.proximity"; // Common i18n namespace
+
+  const getLoadingScreenContentProps = () => {
+    if (isInitialLoading) {
+      return {
+        title: I18n.t(`${i18nNs}.loadingStepScreen.initial.title`),
+        subtitle: I18n.t(`${i18nNs}.loadingStepScreen.initial.subtitle`)
+      };
+    }
+
+    if (isReminderLoading) {
+      return {
+        title: I18n.t(`${i18nNs}.loadingStepScreen.reminder.title`),
+        subtitle: I18n.t(`${i18nNs}.loadingStepScreen.reminder.subtitle`)
+      };
+    }
+
+    return {
+      title: I18n.t(`${i18nNs}.loadingStepScreen.final.title`),
+      subtitle: I18n.t(`${i18nNs}.loadingStepScreen.final.subtitle`)
+    };
+  };
+
+  const { subtitle, title } = getLoadingScreenContentProps();
+
+  return (
+    <LoadingScreenContent testID="loader" contentTitle={title}>
+      <ContentWrapper style={{ alignItems: "center" }}>
+        <Body style={{ textAlign: "center" }}>{subtitle}</Body>
+      </ContentWrapper>
+    </LoadingScreenContent>
+  );
+};

--- a/ts/features/itwallet/presentation/proximity/machine/failure.ts
+++ b/ts/features/itwallet/presentation/proximity/machine/failure.ts
@@ -1,18 +1,13 @@
+import {
+  InvalidRequestedDocumentsError,
+  TimeoutError
+} from "../utils/itwProximityErrors.tsx";
 import { ProximityEvents } from "./events.ts";
-
-/**
- * Thrown when requested documents are not valid
- */
-export class InvalidRequestedDocumentsError extends Error {
-  constructor(message?: string) {
-    super(message);
-    this.name = this.constructor.name;
-  }
-}
 
 export enum ProximityFailureType {
   INVALID_REQUESTED_DOCUMENTS = "INVALID_REQUESTED_DOCUMENTS",
   RELYING_PARTY_GENERIC = "RELYING_PARTY_GENERIC",
+  TIMEOUT = "TIMEOUT",
   UNEXPECTED = "UNEXPECTED"
 }
 
@@ -22,6 +17,7 @@ export enum ProximityFailureType {
 export type ReasonTypeByFailure = {
   [ProximityFailureType.INVALID_REQUESTED_DOCUMENTS]: InvalidRequestedDocumentsError;
   [ProximityFailureType.RELYING_PARTY_GENERIC]: Error;
+  [ProximityFailureType.TIMEOUT]: TimeoutError;
   [ProximityFailureType.UNEXPECTED]: unknown;
 };
 
@@ -54,6 +50,13 @@ export const mapEventToFailure = (event: ProximityEvents): ProximityFailure => {
   if (error instanceof InvalidRequestedDocumentsError) {
     return {
       type: ProximityFailureType.INVALID_REQUESTED_DOCUMENTS,
+      reason: error
+    };
+  }
+
+  if (error instanceof TimeoutError) {
+    return {
+      type: ProximityFailureType.TIMEOUT,
       reason: error
     };
   }

--- a/ts/features/itwallet/presentation/proximity/machine/machine.ts
+++ b/ts/features/itwallet/presentation/proximity/machine/machine.ts
@@ -347,8 +347,7 @@ export const itwProximityMachine = setup({
           }
         },
         SendingDocuments: {
-          tags: [ItwPresentationTags.Loading],
-          entry: "navigateToSendDocumentsResponseScreen",
+          initial: "Initial",
           description: "Sends the required documents to the verifier app",
           invoke: {
             id: "sendDocuments",
@@ -363,6 +362,30 @@ export const itwProximityMachine = setup({
             onError: {
               actions: "setFailure",
               target: "#itwProximityMachine.Failure"
+            }
+          },
+          states: {
+            Initial: {
+              entry: "navigateToSendDocumentsResponseScreen",
+              description: "Initial loading state",
+              after: {
+                5000: {
+                  target:
+                    "#itwProximityMachine.DeviceCommunication.SendingDocuments.Reminder"
+                }
+              }
+            },
+            Reminder: {
+              description: "Loading state when the process is taking too long",
+              after: {
+                10000: {
+                  target:
+                    "#itwProximityMachine.DeviceCommunication.SendingDocuments.Final"
+                }
+              }
+            },
+            Final: {
+              description: "Final loading state"
             }
           }
         },

--- a/ts/features/itwallet/presentation/proximity/machine/selectors.ts
+++ b/ts/features/itwallet/presentation/proximity/machine/selectors.ts
@@ -32,3 +32,9 @@ export const selectFailureOption = (snapshot: MachineSnapshot) =>
 
 export const selectProximityDetails = (snapshot: MachineSnapshot) =>
   snapshot.context.proximityDetails;
+
+export const isInitialLoadingSelector = (snapshot: MachineSnapshot) =>
+  snapshot.matches({ DeviceCommunication: { SendingDocuments: "Initial" } });
+
+export const isReminderLoadingSelector = (snapshot: MachineSnapshot) =>
+  snapshot.matches({ DeviceCommunication: { SendingDocuments: "Reminder" } });

--- a/ts/features/itwallet/presentation/proximity/screens/ItwProximityFailureScreen.tsx
+++ b/ts/features/itwallet/presentation/proximity/screens/ItwProximityFailureScreen.tsx
@@ -52,6 +52,16 @@ const ContentView = ({ failure }: ContentViewProps) => {
               onPress: () => machineRef.send({ type: "close" })
             }
           };
+        case ProximityFailureType.TIMEOUT:
+          return {
+            title: I18n.t(`${i18nNs}.relyingParty.timeout.title`),
+            subtitle: I18n.t(`${i18nNs}.relyingParty.timeout.subtitle`),
+            pictogram: "umbrella",
+            action: {
+              label: I18n.t(`${i18nNs}.relyingParty.timeout.primaryAction`),
+              onPress: () => machineRef.send({ type: "close" })
+            }
+          };
         case ProximityFailureType.UNEXPECTED:
           return {
             title: I18n.t("features.itWallet.generic.error.title"),

--- a/ts/features/itwallet/presentation/proximity/screens/ItwProximitySendDocumentsResponseScreen.tsx
+++ b/ts/features/itwallet/presentation/proximity/screens/ItwProximitySendDocumentsResponseScreen.tsx
@@ -1,6 +1,5 @@
-import { Body, ContentWrapper } from "@pagopa/io-app-design-system";
 import { OperationResultScreenContent } from "../../../../../components/screens/OperationResultScreenContent";
-import LoadingScreenContent from "../../../../../components/screens/LoadingScreenContent.tsx";
+import { ItwProximityLoadingStepScreen } from "../components/ItwProximityLoadingStepScreen.tsx";
 import { useItwDisableGestureNavigation } from "../../../common/hooks/useItwDisableGestureNavigation";
 import { useAvoidHardwareBackButton } from "../../../../../utils/useAvoidHardwareBackButton.ts";
 import { ItwProximityMachineContext } from "../machine/provider.tsx";
@@ -19,21 +18,7 @@ export const ItwProximitySendDocumentsResponseScreen = () => {
   // We need to ensure that the current state is not `Success` to prevent a visual glitch
   // that occurs when any failure causes the machine to transition to the `Failure` state
   if (!isSuccess) {
-    return (
-      <LoadingScreenContent
-        contentTitle={I18n.t(
-          "features.itWallet.presentation.proximity.loadingScreen.title"
-        )}
-      >
-        <ContentWrapper style={{ alignItems: "center" }}>
-          <Body>
-            {I18n.t(
-              "features.itWallet.presentation.proximity.loadingScreen.subtitle"
-            )}
-          </Body>
-        </ContentWrapper>
-      </LoadingScreenContent>
-    );
+    return <ItwProximityLoadingStepScreen />;
   }
 
   return (

--- a/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityFailureScreen.test.tsx
+++ b/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityFailureScreen.test.tsx
@@ -1,10 +1,6 @@
 import { createActor } from "xstate";
 import { createStore } from "redux";
-import {
-  InvalidRequestedDocumentsError,
-  ProximityFailure,
-  ProximityFailureType
-} from "../../machine/failure";
+import { ProximityFailure, ProximityFailureType } from "../../machine/failure";
 import { itwProximityMachine } from "../../machine/machine";
 import { ItwProximityMachineContext } from "../../machine/provider";
 import { ItwProximityFailureScreen } from "../ItwProximityFailureScreen";
@@ -13,6 +9,10 @@ import { GlobalState } from "../../../../../../store/reducers/types";
 import { ITW_ROUTES } from "../../../../navigation/routes";
 import { appReducer } from "../../../../../../store/reducers";
 import { applicationChangeState } from "../../../../../../store/actions/application";
+import {
+  InvalidRequestedDocumentsError,
+  TimeoutError
+} from "../../utils/itwProximityErrors";
 
 describe("ItwProximityFailureScreen", () => {
   test.each<ProximityFailure>([
@@ -23,6 +23,10 @@ describe("ItwProximityFailureScreen", () => {
     {
       type: ProximityFailureType.RELYING_PARTY_GENERIC,
       reason: new Error("RP generic error")
+    },
+    {
+      type: ProximityFailureType.TIMEOUT,
+      reason: new TimeoutError("Request timed out")
     }
   ])("should render failure screen for $type", failure => {
     expect(renderComponent(failure)).toMatchSnapshot();

--- a/ts/features/itwallet/presentation/proximity/screens/__tests__/__snapshots__/ItwProximityFailureScreen.test.tsx.snap
+++ b/ts/features/itwallet/presentation/proximity/screens/__tests__/__snapshots__/ItwProximityFailureScreen.test.tsx.snap
@@ -1581,3 +1581,794 @@ exports[`ItwProximityFailureScreen should render failure screen for RELYING_PART
   </RNCSafeAreaProvider>
 </View>
 `;
+
+exports[`ItwProximityFailureScreen should render failure screen for TIMEOUT 1`] = `
+<View
+  style={
+    {
+      "flex": 1,
+    }
+  }
+>
+  <RNCSafeAreaProvider
+    onInsetsChange={[Function]}
+    style={
+      [
+        {
+          "flex": 1,
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        [
+          {
+            "backgroundColor": "#FFFFFF",
+            "flex": 1,
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          [
+            {
+              "zIndex": 1,
+            },
+            false,
+          ]
+        }
+      >
+        <View
+          accessibilityElementsHidden={false}
+          importantForAccessibility="auto"
+          onLayout={[Function]}
+          pointerEvents="box-none"
+          style={null}
+        >
+          <View
+            collapsable={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "zIndex": 0,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                [
+                  {
+                    "flex": 1,
+                    "shadowOffset": {
+                      "height": 0.5,
+                      "width": 0,
+                    },
+                    "shadowOpacity": 0.85,
+                    "shadowRadius": 0,
+                  },
+                  {
+                    "backgroundColor": "#FFFFFF",
+                    "borderBottomColor": "rgb(216, 216, 216)",
+                    "shadowColor": "rgb(216, 216, 216)",
+                  },
+                  [
+                    {},
+                    false,
+                  ],
+                ]
+              }
+            />
+          </View>
+          <View
+            collapsable={false}
+            pointerEvents="box-none"
+            style={
+              [
+                {
+                  "height": 44,
+                  "maxHeight": undefined,
+                  "minHeight": undefined,
+                  "opacity": undefined,
+                  "transform": undefined,
+                },
+              ]
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                {
+                  "height": 0,
+                }
+              }
+            />
+            <View
+              pointerEvents="box-none"
+              style={
+                {
+                  "alignItems": "stretch",
+                  "flex": 1,
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginStart": 0,
+                    "opacity": 1,
+                  }
+                }
+              />
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "justifyContent": "center",
+                    "marginHorizontal": 16,
+                    "maxWidth": 718,
+                    "opacity": 1,
+                  }
+                }
+              >
+                <Text
+                  accessibilityRole="header"
+                  aria-level="1"
+                  collapsable={false}
+                  numberOfLines={1}
+                  onLayout={[Function]}
+                  style={
+                    [
+                      {
+                        "fontSize": 17,
+                        "fontWeight": "600",
+                      },
+                      {
+                        "color": "rgb(28, 28, 30)",
+                      },
+                      undefined,
+                    ]
+                  }
+                >
+                  ITW_PROXIMITY_FAILURE
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-end",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginEnd": 0,
+                    "opacity": 1,
+                  }
+                }
+              />
+            </View>
+          </View>
+        </View>
+      </View>
+      <RNSScreenContainer
+        onLayout={[Function]}
+        style={
+          {
+            "flex": 1,
+          }
+        }
+      >
+        <RNSScreen
+          activityState={2}
+          collapsable={false}
+          gestureResponseDistance={
+            {
+              "bottom": -1,
+              "end": -1,
+              "start": -1,
+              "top": -1,
+            }
+          }
+          onGestureCancel={[Function]}
+          pointerEvents="box-none"
+          sheetAllowedDetents={
+            [
+              1,
+            ]
+          }
+          sheetCornerRadius={-1}
+          sheetElevation={24}
+          sheetExpandsWhenScrolledToEdge={true}
+          sheetGrabberVisible={false}
+          sheetInitialDetent={0}
+          sheetLargestUndimmedDetent={-1}
+          style={
+            [
+              {
+                "bottom": 0,
+                "left": 0,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+              },
+              {
+                "zIndex": undefined,
+              },
+            ]
+          }
+        >
+          <View
+            collapsable={false}
+            style={
+              {
+                "opacity": 1,
+              }
+            }
+          />
+          <View
+            accessibilityElementsHidden={false}
+            closing={false}
+            collapsable={false}
+            gestureVelocityImpact={0.3}
+            importantForAccessibility="auto"
+            onClose={[Function]}
+            onGestureBegin={[Function]}
+            onGestureCanceled={[Function]}
+            onGestureEnd={[Function]}
+            onOpen={[Function]}
+            onTransition={[Function]}
+            pointerEvents="box-none"
+            style={
+              [
+                {
+                  "display": "flex",
+                  "overflow": undefined,
+                },
+                {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+              ]
+            }
+            transitionSpec={
+              {
+                "close": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+                "open": {
+                  "animation": "spring",
+                  "config": {
+                    "damping": 500,
+                    "mass": 3,
+                    "overshootClamping": true,
+                    "restDisplacementThreshold": 10,
+                    "restSpeedThreshold": 10,
+                    "stiffness": 1000,
+                  },
+                },
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              pointerEvents="box-none"
+              style={
+                [
+                  {
+                    "flex": 1,
+                  },
+                  undefined,
+                  null,
+                ]
+              }
+            >
+              <View
+                collapsable={false}
+                enabled={false}
+                handlerTag={3}
+                handlerType="PanGestureHandler"
+                needsOffscreenAlphaCompositing={false}
+                onGestureHandlerEvent={[Function]}
+                onGestureHandlerStateChange={[Function]}
+                style={
+                  {
+                    "flex": 1,
+                    "transform": [
+                      {
+                        "translateX": 0,
+                      },
+                      {
+                        "translateX": 0,
+                      },
+                    ],
+                  }
+                }
+              >
+                <View
+                  pointerEvents="box-none"
+                  style={
+                    [
+                      {
+                        "flex": 1,
+                        "overflow": "hidden",
+                      },
+                      [
+                        {
+                          "backgroundColor": "#FFFFFF",
+                        },
+                        undefined,
+                      ],
+                    ]
+                  }
+                >
+                  <View
+                    style={
+                      {
+                        "flex": 1,
+                        "flexDirection": "column-reverse",
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        {
+                          "flex": 1,
+                        }
+                      }
+                    >
+                      <RNCSafeAreaView
+                        edges={
+                          {
+                            "bottom": "additive",
+                            "left": "additive",
+                            "right": "additive",
+                            "top": "additive",
+                          }
+                        }
+                        style={
+                          {
+                            "flexGrow": 1,
+                          }
+                        }
+                      >
+                        <RCTScrollView
+                          alwaysBounceVertical={false}
+                          centerContent={true}
+                          contentContainerStyle={
+                            [
+                              {
+                                "alignContent": "center",
+                                "alignItems": "stretch",
+                                "flexGrow": 1,
+                                "justifyContent": "center",
+                                "padding": 24,
+                              },
+                              false,
+                            ]
+                          }
+                        >
+                          <View>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <RNSVGSvgView
+                                align="xMidYMid"
+                                bbHeight={120}
+                                bbWidth={120}
+                                focusable={false}
+                                height={120}
+                                meetOrSlice={0}
+                                minX={0}
+                                minY={0}
+                                style={
+                                  [
+                                    {
+                                      "backgroundColor": "transparent",
+                                      "borderWidth": 0,
+                                    },
+                                    {
+                                      "flex": 0,
+                                      "height": 120,
+                                      "width": 120,
+                                    },
+                                  ]
+                                }
+                                vbHeight={240}
+                                vbWidth={240}
+                                width={120}
+                              >
+                                <RNSVGGroup
+                                  fill={
+                                    {
+                                      "payload": 4278190080,
+                                      "type": 0,
+                                    }
+                                  }
+                                >
+                                  <RNSVGPath
+                                    d="M107.085-.00176c8.154 4.82452 16.613 7.64993 26.423 5.57086.846 1.7059 1.647 3.27854 2.412 4.8689 4.086 8.5651 9.458 16.0907 17.405 21.6793 6.048 4.2559 12.878 6.2728 20.51 7.339 1.008 3.6517 1.818 7.3922 3.078 10.9817 5.993 17.0858 17.144 29.2581 34.774 35.1577.855.2844 1.656.7197 2.835 1.2439-.702 18.9514 6.857 33.6914 23.786 43.3314-2.637 8.77-2.979 17.193 1.701 25.438-4.617 2.275-9.333 1.342-13.779 1.253-24.344-.462-47.364-6.095-68.225-18.792-25.352-15.424-44.395-36.455-55.222-64.0336-9.3681-23.8471-8.1172-47.641 2.457-70.95509.432-.95957 1.089-1.82141 1.863-3.10084l-.018.01777Z"
+                                    fill={
+                                      {
+                                        "payload": 4289392367,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    clipRule={0}
+                                    d="M109.854 11.4438c.308-.7527 1.174-1.1168 1.936-.8134 5.193 2.0678 10.161 3.0476 15.22 3.0476.402 0 .773-.0003 1.13-.0163.594-.0266 1.147.2986 1.406.8271 5.076 10.3451 11.441 18.072 19.412 23.6721 5.074 3.5598 10.843 6.0292 17.921 7.5916.544.12.974.5301 1.115 1.0626.528 1.9974 1.092 4.0131 1.81 6.0443l.001.0035c6.628 18.908 18.825 31.837 36.306 38.6155.542.2103.91.7141.942 1.2888.921 16.9038 8.391 30.6088 21.912 40.2658.666.475.815 1.394.334 2.051-.482.658-1.412.806-2.077.33-14.018-10.012-21.89-24.212-23.082-41.5496-17.882-7.2088-30.368-20.7035-37.146-40.0383-.65-1.8408-1.176-3.6538-1.649-5.407-7.018-1.6462-12.891-4.2005-18.11-7.8623l-.001-.0006c-8.22-5.7753-14.755-13.644-19.945-23.9397-.09.0003-.178.0003-.264.0003h-.015c-5.47 0-10.815-1.0638-16.332-3.2608-.762-.3034-1.131-1.1596-.824-1.9122Z"
+                                    fill={
+                                      {
+                                        "payload": 4278240714,
+                                        "type": 0,
+                                      }
+                                    }
+                                    fillRule={0}
+                                    propList={
+                                      [
+                                        "fill",
+                                        "fillRule",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M30.7695 235.468c-6.1197-6.042-6.1197-15.869 0-21.911l17.2971-17.077 3.8158 3.768-17.2971 17.077c-4.0138 3.962-4.0138 10.413 0 14.375 4.0138 3.963 10.5474 3.963 14.5612 0l3.8158 3.768c-6.1196 6.041-16.0731 6.041-22.1928 0ZM128.876 111.262l-32.2061 31.797 3.8181 3.769 32.207-31.796-3.819-3.77Z"
+                                    fill={
+                                      {
+                                        "payload": 4289392367,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M3.29384 203.162 0 200.523c7.29864-8.876 71.8704-86.54 93.2353-79.565 5.8317 1.901 9.3057 4.949 10.3407 9.045 2.232 8.894-8.2168 19.636-13.2385 24.798l-.9.924-3.0778-2.888.9089-.942c4.1488-4.264 13.8504-14.242 12.1764-20.888-.6569-2.612-3.1948-4.656-7.5506-6.068-7.7126-2.515-37.6721 16.232-88.60056 78.223Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M92.4699 174.411c-9.5755 2.506-18.6921-2.95-22.8319-7.881-3.3478-3.989-2.8888-9.889 1.062-13.434 4.5627-4.096 12.5813-5.091 21.4009 4.389l-3.1228 2.835c-5.7057-6.131-11.4565-7.677-15.4163-4.123-2.2589 2.035-2.5468 5.393-.6479 7.659 4.0588 4.833 13.9133 10.324 23.1378 4.442 2.7899-1.777 4.3733-4.016 4.8413-6.85 1.251-7.623-6.0472-16.721-6.1192-16.81l3.3028-2.63c.351.426 8.5584 10.617 7.0104 20.089-.657 4.016-2.916 7.285-6.7314 9.72-1.9439 1.244-3.9148 2.079-5.8677 2.594h-.018Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M79.0336 194.02c-5.1568 1.351-10.0885.48-14.4803-2.612-4.3558-3.065-6.5517-6.726-6.5337-10.884.036-9.125 11.1415-16.935 11.6185-17.254l2.4388 3.429c-2.7178 1.893-9.7915 8.077-9.8095 13.852 0 2.754 1.548 5.189 4.7518 7.445 4.4638 3.137 9.5305 3.252 15.0742.329 8.7116-4.602 15.0563-15.06 14.9123-19.591l4.2383-.134c.207 6.531-7.2442 18.179-17.1527 23.412-1.7009.898-3.3928 1.564-5.0667 2.008h.009Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="M67.0458 207.463c-8.3696 2.185-15.1102-.391-19.169-7.437-3.1769-5.517-3.7979-10.422-1.827-14.571 3.4469-7.268 13.5624-9.125 13.9853-9.205l.747 4.123c-.072.008-8.3876 1.563-10.8894 6.868-1.35 2.843-.783 6.45 1.6739 10.715 3.5278 6.122 9.0985 7.632 17.0181 4.611 6.0477-2.301 11.3664-6.655 15.3892-12.581l3.6359-5.357 3.5278 2.327-3.6358 5.367c-4.5088 6.646-10.5205 11.541-17.3872 14.154-1.0439.399-2.0699.728-3.0688.986Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    d="m53.3313 224.754-3.0598-2.905c22.9668-23.501 15.4252-17.495 15.6232-17.832l3.6808 2.079c-.189.337 7.0917-5.225-16.2442 18.658Z"
+                                    fill={
+                                      {
+                                        "payload": 4278927075,
+                                        "type": 0,
+                                      }
+                                    }
+                                    propList={
+                                      [
+                                        "fill",
+                                      ]
+                                    }
+                                  />
+                                  <RNSVGPath
+                                    clipRule={0}
+                                    d="M93.3641 80.6211c.542.6099.4808 1.5383-.1366 2.0737L59.0022 112.37c-.6174.536-1.5573.475-2.0993-.134-.542-.61-.4809-1.539.1365-2.074l34.2253-29.6758c.6175-.5353 1.5574-.4749 2.0994.1349ZM145.714 157.555c.542.61.481 1.538-.137 2.073l-34.225 29.676c-.618.535-1.558.475-2.1-.135s-.48-1.538.137-2.073l34.225-29.676c.618-.536 1.558-.475 2.1.135Z"
+                                    fill={
+                                      {
+                                        "payload": 4278240714,
+                                        "type": 0,
+                                      }
+                                    }
+                                    fillRule={0}
+                                    propList={
+                                      [
+                                        "fill",
+                                        "fillRule",
+                                      ]
+                                    }
+                                  />
+                                </RNSVGGroup>
+                              </RNSVGSvgView>
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                            </View>
+                            <Text
+                              accessibilityRole="header"
+                              allowFontScaling={true}
+                              dynamicTypeRamp="title2"
+                              maxFontSizeMultiplier={1.5}
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "color": "#0E0F13",
+                                    "fontFamily": "Titillio",
+                                    "fontSize": 22,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "600",
+                                    "lineHeight": 33,
+                                  },
+                                  {
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                            >
+                              L’app di chi verifica non risponde
+                            </Text>
+                            <View
+                              style={
+                                {
+                                  "height": 8,
+                                }
+                              }
+                            />
+                            <Text
+                              allowFontScaling={true}
+                              dynamicTypeRamp="body"
+                              maxFontSizeMultiplier={1.5}
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "color": "#555C70",
+                                    "fontFamily": "Titillio",
+                                    "fontSize": 16,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "400",
+                                    "lineHeight": 24,
+                                  },
+                                  {
+                                    "textAlign": "center",
+                                  },
+                                ]
+                              }
+                              textBreakStrategy="simple"
+                            >
+                              Un problema ha impedito la comunicazione con chi ha richiesto la verifica dei dati. Prova di nuovo.
+                            </Text>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "height": 24,
+                                  }
+                                }
+                              />
+                              <View>
+                                <View
+                                  accessibilityLabel="Chiudi"
+                                  accessibilityRole="button"
+                                  accessibilityState={
+                                    {
+                                      "busy": false,
+                                      "checked": undefined,
+                                      "disabled": false,
+                                      "expanded": undefined,
+                                      "selected": undefined,
+                                    }
+                                  }
+                                  accessibilityValue={
+                                    {
+                                      "max": undefined,
+                                      "min": undefined,
+                                      "now": undefined,
+                                      "text": undefined,
+                                    }
+                                  }
+                                  accessible={true}
+                                  collapsable={false}
+                                  focusable={true}
+                                  onBlur={[Function]}
+                                  onClick={[Function]}
+                                  onFocus={[Function]}
+                                  onResponderGrant={[Function]}
+                                  onResponderMove={[Function]}
+                                  onResponderRelease={[Function]}
+                                  onResponderTerminate={[Function]}
+                                  onResponderTerminationRequest={[Function]}
+                                  onStartShouldSetResponder={[Function]}
+                                  style={
+                                    {
+                                      "alignSelf": "auto",
+                                      "flexShrink": 1,
+                                    }
+                                  }
+                                >
+                                  <View
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "center",
+                                          "borderCurve": "continuous",
+                                          "elevation": 0,
+                                          "flexDirection": "row",
+                                          "justifyContent": "center",
+                                          "overflow": "hidden",
+                                          "textAlignVertical": "center",
+                                        },
+                                        false,
+                                        {
+                                          "backgroundColor": undefined,
+                                        },
+                                        {
+                                          "paddingHorizontal": 24,
+                                        },
+                                        {
+                                          "backgroundColor": "#0B3EE3",
+                                          "borderColor": "#FFFFFF",
+                                          "borderRadius": 8,
+                                          "borderWidth": 0,
+                                          "height": 48,
+                                        },
+                                        {},
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      style={
+                                        [
+                                          {
+                                            "alignItems": "center",
+                                            "flexDirection": "row",
+                                            "justifyContent": "center",
+                                          },
+                                          {
+                                            "columnGap": 8,
+                                          },
+                                          false,
+                                        ]
+                                      }
+                                    >
+                                      <Text
+                                        accessibilityElementsHidden={true}
+                                        accessible={false}
+                                        allowFontScaling={true}
+                                        ellipsizeMode="tail"
+                                        importantForAccessibility="no-hide-descendants"
+                                        maxFontSizeMultiplier={1.5}
+                                        numberOfLines={1}
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#0E0F13",
+                                              "fontFamily": "Titillio",
+                                              "fontSize": 16,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "600",
+                                              "lineHeight": undefined,
+                                            },
+                                            [
+                                              {
+                                                "textAlign": "auto",
+                                              },
+                                              {
+                                                "color": "#FFFFFF",
+                                              },
+                                              {
+                                                "color": undefined,
+                                              },
+                                            ],
+                                          ]
+                                        }
+                                      >
+                                        Chiudi
+                                      </Text>
+                                    </View>
+                                  </View>
+                                </View>
+                              </View>
+                            </View>
+                          </View>
+                        </RCTScrollView>
+                      </RNCSafeAreaView>
+                    </View>
+                  </View>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RNSScreen>
+      </RNSScreenContainer>
+    </View>
+  </RNCSafeAreaProvider>
+</View>
+`;

--- a/ts/features/itwallet/presentation/proximity/utils/itwProximityErrors.tsx
+++ b/ts/features/itwallet/presentation/proximity/utils/itwProximityErrors.tsx
@@ -1,0 +1,21 @@
+/* eslint-disable max-classes-per-file */
+
+/**
+ * Thrown when requested documents are not valid
+ */
+export class InvalidRequestedDocumentsError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+/**
+ * Thrown when an operation times out
+ */
+export class TimeoutError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}

--- a/ts/features/itwallet/presentation/proximity/utils/itwProximityPresentationUtils.ts
+++ b/ts/features/itwallet/presentation/proximity/utils/itwProximityPresentationUtils.ts
@@ -10,6 +10,20 @@ import {
 import { parseClaims } from "../../../common/utils/itwClaimsUtils";
 import { assert } from "../../../../../utils/assert";
 import { ProximityDetails } from "./itwProximityTypeUtils";
+import { TimeoutError } from "./itwProximityErrors";
+
+export const promiseWithTimeout = <T>(
+  promise: Promise<T>,
+  timeoutMs: number
+) => {
+  const timeout = new Promise<never>((_, reject) => {
+    setTimeout(() => {
+      reject(new TimeoutError("Request timed out"));
+    }, timeoutMs);
+  });
+
+  return Promise.race<T>([promise, timeout]);
+};
 
 export const getProximityDetails = (
   request: VerifierRequest["request"],


### PR DESCRIPTION
This PR depends on https://github.com/pagopa/io-app/pull/7101

## Short description
This PR introduces a timeout error screen for the proximity flow. During the loading phase, a dynamic loading screen is shown with multiple steps to inform the user about the ongoing process.

## List of changes proposed in this pull request
- Added the `ItwProximityLoadingStepScreen` component to display contextual messages during the loading process
- Updated the state machine by introducing new states to handle progressive loading steps
- Updated the `sendDocuments` actor to raise a timeout error when the response exceeds a given duration

## Demo

<details open><summary>Proximity</summary>
<p>

| Loading OK | Loading KO Timeout |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/f113a44e-4d10-4fa8-a5bb-c03b060192eb"></video> | <video src="https://github.com/user-attachments/assets/f27cdf27-dcbc-4d76-a249-7010c0e2352a"></video> |

</p>
</details>

## How to test
> [!NOTE]  
> This PR cannot be tested at the moment because we currently don't have an available mDL credential.
> However, if you want to try the flow, after mocking both the value returned from [isItwCredential](https://github.com/pagopa/io-app/blob/master/ts/features/itwallet/common/utils/itwCredentialUtils.ts#L101)  and the mDL credential, follow the steps below:

- navigate to the credential details
- tap the "Mostra QR di verifica" button
- scan the QR code using the verifier app
- proceed with the proximity flow
- after authorizing the data presentation via PIN/biometric authentication, wait for the data transmission.If it exceeds the 20s, the timeout error screen should be displayed