### PR TITLE
fix(IT Wallet): [SIW-2663] TypeError: Cannot convert undefined value to object

### DIFF
--- a/ts/features/itwallet/credentials/saga/checkCredentialsStatusAttestation.ts
+++ b/ts/features/itwallet/credentials/saga/checkCredentialsStatusAttestation.ts
@@ -76,8 +76,6 @@ export function* updateCredentialStatusAttestationSaga(
  * This saga is responsible to check the status attestation for each credential in the wallet.
  */
 export function* checkCredentialsStatusAttestation() {
-  const state: GlobalState = yield* select();
-
   const isWalletValid = yield* select(itwLifecycleIsValidSelector);
 
   // Credentials can be requested only when the wallet is valid, i.e. the eID was issued
@@ -104,6 +102,7 @@ export function* checkCredentialsStatusAttestation() {
 
   yield* put(itwCredentialsStore(updatedCredentials));
 
+  const state: GlobalState = yield* select();
   void updateMixpanelProfileProperties(state);
   void updateMixpanelSuperProperties(state);
 }

--- a/ts/features/itwallet/lifecycle/saga/handleWalletInstanceResetSaga.ts
+++ b/ts/features/itwallet/lifecycle/saga/handleWalletInstanceResetSaga.ts
@@ -21,7 +21,6 @@ const getKeyTag = (credential: O.Option<StoredCredential>) =>
   );
 
 export function* handleWalletInstanceResetSaga() {
-  const state: GlobalState = yield* select();
   const integrityKeyTag = yield* select(itwIntegrityKeyTagSelector);
   const { eid, credentials } = yield* select(itwCredentialsSelector);
   try {
@@ -42,6 +41,7 @@ export function* handleWalletInstanceResetSaga() {
     );
     yield* all(itwKeyTags.map(deleteKey));
     // Update every mixpanel property related to the wallet instance and its credentials.
+    const state: GlobalState = yield* select();
     void updatePropertiesWalletRevoked(state);
   } catch (e) {
     Sentry.captureException(e);

--- a/ts/features/wallet/store/selectors/index.ts
+++ b/ts/features/wallet/store/selectors/index.ts
@@ -102,9 +102,13 @@ export const selectIsWalletLoading = (state: GlobalState) =>
 
 /**
  * Selects the placeholders from the wallet
+ *
+ * Note: We use a nullish coalescing default (?? {}) to prevent runtime errors if the state is malformed
+ * or not initialized properly (e.g., during tests, migrations, or hot reloads). This ensures Object.entries
+ * always receives an object, avoiding 'Cannot convert undefined value to object' errors.
  */
 export const selectWalletPlaceholderCards = createSelector(
-  (state: GlobalState) => state.features.wallet.placeholders.items,
+  (state: GlobalState) => state.features.wallet.placeholders?.items ?? {},
   placeholders =>
     Object.entries(placeholders).map(
       ([key, category]) =>


### PR DESCRIPTION
## Short description
This PR resolves the TypeError caused by the `selectWalletPlaceholderCards`, as seen on the Sentry dashboard.

## List of changes proposed in this pull request
- Added nullish coalescing
- Fixed state inconsistencies while updating Mixpanel properties, which was a possible cause of the error

## How to test
Check that no regressions were introduced by this change.
