### PR TITLE
refactor: [IOPID3038,IOPID-3047] delete unused code from startup saga

### DIFF
--- a/ts/features/onboarding/store/__test__/index.test.ts
+++ b/ts/features/onboarding/store/__test__/index.test.ts
@@ -1,4 +1,4 @@
-import { fingerprintAcknowledged, clearOnboarding } from "../actions";
+import { fingerprintAcknowledged } from "../actions";
 import { sessionExpired } from "../../../authentication/common/store/actions";
 import { isFingerprintAcknowledgedSelector } from "../selectors";
 import reducer, { OnboardingState } from "../reducers";
@@ -19,12 +19,6 @@ describe("onboarding reducer", () => {
     expect(newState).toEqual({
       isFingerprintAcknowledged: true
     });
-  });
-
-  it("should reset state on clearOnboarding", () => {
-    const prevState: OnboardingState = { isFingerprintAcknowledged: true };
-    const newState = reducer(prevState, clearOnboarding());
-    expect(newState).toEqual(INITIAL_STATE);
   });
 
   it("should reset state on sessionExpired", () => {

--- a/ts/features/onboarding/store/actions/index.ts
+++ b/ts/features/onboarding/store/actions/index.ts
@@ -14,8 +14,6 @@ export const emailAcknowledged = createStandardAction("EMAIL_ACKNOWLEDGED")();
 
 export const abortOnboarding = createStandardAction("ABORT_ONBOARDING")();
 
-export const clearOnboarding = createStandardAction("CLEAR_ONBOARDING")();
-
 export const emailInsert = createStandardAction("EMAIL_INSERT")();
 
 export const servicesOptinCompleted = createStandardAction(
@@ -30,7 +28,6 @@ type OnboardingActionTypes =
   | typeof emailInsert
   | typeof emailAcknowledged
   | typeof abortOnboarding
-  | typeof clearOnboarding
   | typeof servicesOptinCompleted
   | typeof completeOnboarding;
 

--- a/ts/features/onboarding/store/reducers/index.ts
+++ b/ts/features/onboarding/store/reducers/index.ts
@@ -3,7 +3,7 @@
  * @flow
  */
 import { getType } from "typesafe-actions";
-import { clearOnboarding, fingerprintAcknowledged } from "../actions";
+import { fingerprintAcknowledged } from "../actions";
 import { Action } from "../../../../store/actions/types";
 import { sessionExpired } from "../../../authentication/common/store/actions";
 
@@ -26,7 +26,6 @@ const reducer = (
         isFingerprintAcknowledged: true
       };
     case getType(sessionExpired):
-    case getType(clearOnboarding):
       return INITIAL_STATE;
 
     default:

--- a/ts/features/settings/common/sagas/profile.ts
+++ b/ts/features/settings/common/sagas/profile.ts
@@ -27,6 +27,7 @@ import {
 } from "../../../../store/actions/crossSessions";
 import { navigateToRemoveAccountSuccess } from "../../../../store/actions/navigation";
 import {
+  clearCache,
   loadBonusBeforeRemoveAccount,
   profileLoadFailure,
   profileLoadRequest,
@@ -383,9 +384,7 @@ function* checkStoreHashedFiscalCode(
   ) {
     // delete current store pin
     yield* call(deletePin);
-    // Refactor: a similar check is also implemented inside the `startupSaga`.
-    // Consider aligning both flows or centralizing this logic to avoid duplicated behaviors.
-    // See related Jira task: https://pagopa.atlassian.net/browse/IOPID-3047
+    yield* put(clearCache());
     yield* put(
       differentProfileLoggedIn({
         isNewInstall: checkIsDifferentFiscalCode === undefined

--- a/ts/sagas/__tests__/initializeApplicationSaga.test.ts
+++ b/ts/sagas/__tests__/initializeApplicationSaga.test.ts
@@ -5,7 +5,6 @@ import { InitializedProfile } from "../../../definitions/backend/InitializedProf
 import mockedProfile from "../../__mocks__/initializedProfile";
 
 import { sessionExpired } from "../../features/authentication/common/store/actions";
-import { previousInstallationDataDeleteSuccess } from "../../store/actions/installation";
 import { resetProfileState } from "../../features/settings/common/store/actions";
 import {
   sessionInfoSelector,
@@ -104,8 +103,6 @@ describe("initializeApplicationSaga", () => {
       .next()
       .call(previousInstallationDataDeleteSaga)
       .next()
-      .put(previousInstallationDataDeleteSuccess())
-      .next()
       .next()
       .next()
       .fork(notificationPermissionsListener)
@@ -165,8 +162,6 @@ describe("initializeApplicationSaga", () => {
       .next()
       .call(previousInstallationDataDeleteSaga)
       .next()
-      .put(previousInstallationDataDeleteSuccess())
-      .next()
       .next()
       .next()
       .fork(notificationPermissionsListener)
@@ -219,8 +214,6 @@ describe("initializeApplicationSaga", () => {
       .call(cancellAllLocalNotifications)
       .next()
       .call(previousInstallationDataDeleteSaga)
-      .next()
-      .put(previousInstallationDataDeleteSuccess())
       .next()
       .next()
       .next()
@@ -279,8 +272,6 @@ describe("initializeApplicationSaga", () => {
       .call(cancellAllLocalNotifications)
       .next()
       .call(previousInstallationDataDeleteSaga)
-      .next()
-      .put(previousInstallationDataDeleteSuccess())
       .next()
       .next()
       .next()
@@ -353,8 +344,6 @@ describe("initializeApplicationSaga", () => {
       .next()
       .call(previousInstallationDataDeleteSaga)
       .next()
-      .put(previousInstallationDataDeleteSuccess())
-      .next()
       .next()
       .next()
       .fork(notificationPermissionsListener)
@@ -412,8 +401,6 @@ describe("initializeApplicationSaga", () => {
       .call(cancellAllLocalNotifications)
       .next()
       .call(previousInstallationDataDeleteSaga)
-      .next()
-      .put(previousInstallationDataDeleteSuccess())
       .next()
       .next()
       .next()

--- a/ts/sagas/installation.ts
+++ b/ts/sagas/installation.ts
@@ -5,6 +5,7 @@ import { put, select } from "typed-redux-saga/macro";
 import { isFirstRunAfterInstallSelector } from "../store/reducers/installation";
 import { ReduxSagaEffect } from "../types/utils";
 import { clearCurrentSession } from "../features/authentication/common/store/actions";
+import { previousInstallationDataDeleteSuccess } from "../store/actions/installation";
 
 /**
  * This generator function removes user data from previous application
@@ -23,4 +24,5 @@ export function* previousInstallationDataDeleteSaga(): Generator<
     // remove authentication data from the storage
     yield* put(clearCurrentSession());
   }
+  yield* put(previousInstallationDataDeleteSuccess());
 }


### PR DESCRIPTION
## Short description
In this PR, two changes were made to the startup saga aimed at decreasing technical debt (or business debt)

## List of changes proposed in this pull request
- IOPID-3038 move `previousInstallationDataDeleteSuccess` from startup saga to `previousInstallationDataDeleteSaga`
- IOPID-3047 code related to login of a different user has been removed because it was deprecated, and the logic still in place has been moved to where the check occurs if the logged-in user is different from the previous one.

## Demo
*WIP*

## How to test
*WIP*