### PR TITLE
chore: [IOBP-1818] Hide IDPay timeline "show all" CTA when available only few operations

### DIFF
--- a/ts/features/idpay/details/components/IdPayInitiativeTimelineComponent.tsx
+++ b/ts/features/idpay/details/components/IdPayInitiativeTimelineComponent.tsx
@@ -8,7 +8,7 @@ import {
 } from "@pagopa/io-app-design-system";
 import * as pot from "@pagopa/ts-commons/lib/pot";
 import { useNavigation } from "@react-navigation/native";
-import { Fragment } from "react";
+import { ComponentProps, Fragment } from "react";
 import { View } from "react-native";
 import I18n from "../../../../i18n";
 import {
@@ -82,13 +82,9 @@ const IdPayInitiativeTimelineComponent = ({
     );
   };
 
-  return (
-    <View testID="IDPayTimelineTestID">
-      <ListItemHeader
-        label={I18n.t(
-          "idpay.initiative.details.initiativeDetailsScreen.configured.yourOperations"
-        )}
-        endElement={{
+  const showAllCta: ComponentProps<typeof ListItemHeader>["endElement"] =
+    timeline.length >= size
+      ? {
           type: "buttonLink",
           componentProps: {
             label: I18n.t(
@@ -96,7 +92,16 @@ const IdPayInitiativeTimelineComponent = ({
             ),
             onPress: navigateToOperationsList
           }
-        }}
+        }
+      : undefined;
+
+  return (
+    <View testID="IDPayTimelineTestID">
+      <ListItemHeader
+        label={I18n.t(
+          "idpay.initiative.details.initiativeDetailsScreen.configured.yourOperations"
+        )}
+        endElement={showAllCta}
       />
       {renderTimelineContent()}
       {detailsBottomSheet.bottomSheet}


### PR DESCRIPTION
## Short description
This PR updates the `IdPayInitiativeTimelineComponent` refactoring the logic for conditional rendering of the "Show More" button, showing it only if the number of transactions is greater than or equal to the max size of the "latest transactions".

## List of changes proposed in this pull request
* Refactored the conditional rendering of the "Show More" button by introducing a `showAllCta` constant with a typed structure. This replaces inline logic and improves readability and maintainability.

## How to test
- Check that the "Show all" CTA is only visible when the list of operations is more than or equal to 5.
- Simulate with the dev-server a list of only 2 operations in the list by editing the size inside the dev-server file (`src/persistence/idpay.ts` from line `566`)
