### PR TITLE
chore: [IOBP-1822] Add IdPay CIE code remote feature flag

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -2,7 +2,7 @@
 
 IO_BACKEND_VERSION=v16.17.0
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=1.0.73
+IO_SERVICES_METADATA_VERSION=IOBP-1820-add-idpay-cie-code-remote-feature-flag
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.4.0
 # IO Wallet Backend version

--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -2,7 +2,7 @@
 
 IO_BACKEND_VERSION=v16.17.0
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=IOBP-1820-add-idpay-cie-code-remote-feature-flag
+IO_SERVICES_METADATA_VERSION=1.0.74
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.4.0
 # IO Wallet Backend version

--- a/ts/features/idpay/code/components/IdPayCodeCieBanner.tsx
+++ b/ts/features/idpay/code/components/IdPayCodeCieBanner.tsx
@@ -11,6 +11,7 @@ import { IdPayCodeRoutes } from "../navigation/routes";
 import { IOStackNavigationProp } from "../../../../navigation/params/AppParamsList";
 import { isLoadingDiscountInitiativeInstrumentsSelector } from "../../configuration/store";
 import { idPayCodeCieBannerClose } from "../store/actions";
+import { isIdPayCiePaymentCodeEnabledSelector } from "../../../../store/reducers/backendStatus/remoteConfig";
 
 export type IdPayCodeCIEBannerParams = {
   initiativeId: string;
@@ -21,7 +22,11 @@ const IdPayCodeCieBanner = ({ initiativeId }: IdPayCodeCIEBannerParams) => {
   const navigation =
     useNavigation<IOStackNavigationProp<IdPayCodeParamsList>>();
   const dispatch = useIODispatch();
-  const showBanner = useIOSelector(showIdPayCodeBannerSelector);
+  const isIdPayCodeCieEnabled = useIOSelector(
+    isIdPayCiePaymentCodeEnabledSelector
+  );
+  const showBanner =
+    useIOSelector(showIdPayCodeBannerSelector) && isIdPayCodeCieEnabled;
   const isLoadingInitiativeInstruments = useIOSelector(
     isLoadingDiscountInitiativeInstrumentsSelector
   );

--- a/ts/features/idpay/details/components/IdPayInitiativeDiscountSettingsComponent.tsx
+++ b/ts/features/idpay/details/components/IdPayInitiativeDiscountSettingsComponent.tsx
@@ -12,6 +12,8 @@ import I18n from "../../../../i18n";
 import { IOStackNavigationProp } from "../../../../navigation/params/AppParamsList";
 import { IdPayConfigurationParamsList } from "../../configuration/navigation/params";
 import { IdPayConfigurationRoutes } from "../../configuration/navigation/routes";
+import { useIOSelector } from "../../../../store/hooks";
+import { isIdPayCiePaymentCodeEnabledSelector } from "../../../../store/reducers/backendStatus/remoteConfig";
 
 type Props = {
   initiative: InitiativeDTO;
@@ -22,6 +24,10 @@ const IdPayInitiativeDiscountSettingsComponent = (props: Props) => {
 
   const navigation =
     useNavigation<IOStackNavigationProp<IdPayConfigurationParamsList>>();
+
+  const isIdPayCodeCieEnabled = useIOSelector(
+    isIdPayCiePaymentCodeEnabledSelector
+  );
 
   const navigateToInstrumentsConfiguration = ({
     initiativeId,
@@ -85,6 +91,10 @@ const IdPayInitiativeDiscountSettingsComponent = (props: Props) => {
       }
     )
   );
+
+  if (!isIdPayCodeCieEnabled) {
+    return undefined;
+  }
 
   return (
     <View testID={"IDPayDetailsSettingsTestID"}>

--- a/ts/features/idpay/details/screens/__tests__/IdPayInitiativeDetailsScreen.test.tsx
+++ b/ts/features/idpay/details/screens/__tests__/IdPayInitiativeDetailsScreen.test.tsx
@@ -118,7 +118,7 @@ describe("Test IdPayInitiativeDetailsScreen screen", () => {
     ).not.toBeTruthy();
 
     expect(component.queryByTestId("IDPayTimelineSkeletonTestID")).toBeNull();
-    expect(component.queryByTestId("IDPayDetailsSettingsTestID")).toBeTruthy();
+    expect(component.queryByTestId("IDPayDetailsSettingsTestID")).toBeNull();
 
     expect(
       component.queryByText(

--- a/ts/features/settings/security/screens/SecurityScreen.tsx
+++ b/ts/features/settings/security/screens/SecurityScreen.tsx
@@ -17,10 +17,7 @@ import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { identificationRequest } from "../../../identification/store/actions";
 import { preferenceFingerprintIsEnabledSaveSuccess } from "../../../../store/actions/persistedPreferences";
 import { useIODispatch, useIOSelector } from "../../../../store/hooks";
-import {
-  isFingerprintEnabledSelector,
-  isIdPayLocallyEnabledSelector
-} from "../../../../store/reducers/persistedPreferences";
+import { isFingerprintEnabledSelector } from "../../../../store/reducers/persistedPreferences";
 import { getFlowType } from "../../../../utils/analytics";
 import {
   biometricAuthenticationRequest,
@@ -37,6 +34,7 @@ import { FAQsCategoriesType } from "../../../../utils/faq";
 import { fimsIsHistoryEnabledSelector } from "../../../fims/history/store/selectors";
 import { FIMS_ROUTES } from "../../../fims/common/navigation";
 import { SETTINGS_ROUTES } from "../../common/navigation/routes";
+import { isIdPayCiePaymentCodeEnabledSelector } from "../../../../store/reducers/backendStatus/remoteConfig";
 
 const contextualHelpMarkdown: ContextualHelpPropsMarkdown = {
   title: "profile.preferences.contextualHelpTitle",
@@ -53,7 +51,9 @@ const SecurityScreen = (): ReactElement => {
   const dispatch = useIODispatch();
   const isFingerprintEnabled = useIOSelector(isFingerprintEnabledSelector);
   const isIdPayCodeOnboarded = useIOSelector(isIdPayCodeOnboardedSelector);
-  const isIdPayEnabled = useIOSelector(isIdPayLocallyEnabledSelector);
+  const isIdPayCieCodeEnabled = useIOSelector(
+    isIdPayCiePaymentCodeEnabledSelector
+  );
   const isFimsHistoryEnabled = useIOSelector(fimsIsHistoryEnabledSelector);
   const navigation = useIONavigation();
   const [isBiometricDataAvailable, setIsBiometricDataAvailable] =
@@ -179,7 +179,7 @@ const SecurityScreen = (): ReactElement => {
           onPress={requestIdentificationAndResetPin}
           testID="reset-unlock-code"
         />
-        {isIdPayEnabled && (
+        {isIdPayCieCodeEnabled && (
           /* Reset IDPay code */
           <>
             <Divider />

--- a/ts/features/settings/security/screens/__tests__/SecurityScreen.test.tsx
+++ b/ts/features/settings/security/screens/__tests__/SecurityScreen.test.tsx
@@ -151,7 +151,7 @@ describe("Test SecurityScreen", () => {
           selector ===
           // eslint-disable-next-line @typescript-eslint/no-var-requires
           require("../../../../../store/reducers/persistedPreferences")
-            .isIdPayLocallyEnabledSelector
+            .isIdPayCiePaymentCodeEnabledSelector
         ) {
           return true;
         }

--- a/ts/features/settings/security/screens/__tests__/SecurityScreen.test.tsx
+++ b/ts/features/settings/security/screens/__tests__/SecurityScreen.test.tsx
@@ -150,7 +150,7 @@ describe("Test SecurityScreen", () => {
         if (
           selector ===
           // eslint-disable-next-line @typescript-eslint/no-var-requires
-          require("../../../../../store/reducers/persistedPreferences")
+          require("../../../../../store/reducers/backendStatus/remoteConfig")
             .isIdPayCiePaymentCodeEnabledSelector
         ) {
           return true;

--- a/ts/store/reducers/backendStatus/remoteConfig.ts
+++ b/ts/store/reducers/backendStatus/remoteConfig.ts
@@ -354,6 +354,17 @@ export const isIdPayEnabledSelector = createSelector(
     )
 );
 
+export const isIdPayCiePaymentCodeEnabledSelector = (state: GlobalState) =>
+  pipe(state, remoteConfigSelector, remoteConfig =>
+    isPropertyWithMinAppVersionEnabled({
+      remoteConfig,
+      mainLocalFlag: true,
+      configPropertyName: "idPay",
+      optionalLocalFlag: true,
+      optionalConfig: "cie_payments"
+    })
+  );
+
 export const idPayOnboardingRequiresAppUpdateSelector = (state: GlobalState) =>
   pipe(
     state,


### PR DESCRIPTION
## ⚠️ This PR depends on https://github.com/pagopa/io-services-metadata/pull/1003

## Short description
This PR introduces changes to enable and integrate a new remote feature flag for IDPay CIE payment codes. The updates include modifying selectors, conditional logic, and component behavior to support the new feature flag.

## List of changes proposed in this pull request
* Updated `IO_SERVICES_METADATA_VERSION` to reference the new feature flag version.
* Added a new selector `isIdPayCiePaymentCodeEnabledSelector` to check if the CIE payment code feature is enabled based on remote configuration.
* Updated the `showBanner` logic to include the new `isIdPayCiePaymentCodeEnabledSelector` for determining whether to display the banner.
* Added conditional rendering based on `isIdPayCiePaymentCodeEnabledSelector` to ensure the component is only displayed when the feature is enabled.

## How to test
- Checkout the dev-server from this PR: https://github.com/pagopa/io-dev-api-server/pull/499
- Check that the CIE-related features on discount initiatives aren't available if the version setted in the dev-server configuration is greater than the your current app version

## Preview
|IdPay CIE code enabled|IdPay CIE disabled|
|-|-|
|<video src="https://github.com/user-attachments/assets/3c775d5c-f63d-4f26-8014-f3622c5ca532" />|<video src="https://github.com/user-attachments/assets/9d6941ce-4f07-4f76-ac52-4ba0ffe367ec" />|
