### PR TITLE
fix: [IOCOM-2486] Fix for images on IOMarkdown

### DIFF
--- a/ts/components/IOMarkdown/__tests__/markdownRenderer.test.ts
+++ b/ts/components/IOMarkdown/__tests__/markdownRenderer.test.ts
@@ -1,0 +1,83 @@
+import { insertNewLinesIfNeededOnMatch } from "../markdownRenderer";
+
+describe("markdownRenderer", () => {
+  describe("insertNewLinesIfNeededOnMatch", () => {
+    it("Given two new lines before and after, should do nothing", () => {
+      const match = { index: 2, [0]: { length: 12 } } as RegExpExecArray;
+      const output = insertNewLinesIfNeededOnMatch(
+        "\n\n![](anImage)\n\n",
+        match
+      );
+      expect(output).toBe("\n\n![](anImage)\n\n");
+    });
+    it("Given one new line before and two after, should add one new line before", () => {
+      const match = { index: 1, [0]: { length: 12 } } as RegExpExecArray;
+      const output = insertNewLinesIfNeededOnMatch("\n![](anImage)\n\n", match);
+      expect(output).toBe("\n\n![](anImage)\n\n");
+    });
+    it("Given no new line before and two after, should add two new lines before", () => {
+      const match = { index: 0, [0]: { length: 12 } } as RegExpExecArray;
+      const output = insertNewLinesIfNeededOnMatch("![](anImage)\n\n", match);
+      expect(output).toBe("\n\n![](anImage)\n\n");
+    });
+    it("Given two new lines before and one after, should add one new line after", () => {
+      const match = { index: 2, [0]: { length: 12 } } as RegExpExecArray;
+      const output = insertNewLinesIfNeededOnMatch("\n\n![](anImage)\n", match);
+      expect(output).toBe("\n\n![](anImage)\n\n");
+    });
+    it("Given two new lines before and no one after, should add two new lines after", () => {
+      const match = { index: 2, [0]: { length: 12 } } as RegExpExecArray;
+      const output = insertNewLinesIfNeededOnMatch("\n\n![](anImage)", match);
+      expect(output).toBe("\n\n![](anImage)\n\n");
+    });
+    it("Given no new line before nor after, should add two new lines before and after", () => {
+      const match = { index: 0, [0]: { length: 12 } } as RegExpExecArray;
+      const output = insertNewLinesIfNeededOnMatch("![](anImage)", match);
+      expect(output).toBe("\n\n![](anImage)\n\n");
+    });
+    it("Given one new line before and two after, with spaces, should add one new line before and one after", () => {
+      const match = { index: 2, [0]: { length: 12 } } as RegExpExecArray;
+      const output = insertNewLinesIfNeededOnMatch("\n ![](anImage) \n", match);
+      expect(output).toBe("\n \n![](anImage)\n \n");
+    });
+    it("Given two new lines before and two after, with spaces, should do nothing", () => {
+      const match = { index: 3, [0]: { length: 12 } } as RegExpExecArray;
+      const output = insertNewLinesIfNeededOnMatch(
+        "\n\n ![](anImage) \n\n",
+        match
+      );
+      expect(output).toBe("\n\n ![](anImage) \n\n");
+    });
+    it("Given two new lines before and one after, with spaces, should add one new line after", () => {
+      const match = { index: 3, [0]: { length: 12 } } as RegExpExecArray;
+      const output = insertNewLinesIfNeededOnMatch(
+        "\n\n ![](anImage) \n",
+        match
+      );
+      expect(output).toBe("\n\n ![](anImage)\n \n");
+    });
+    it("Given two new line before and no one after, with spaces, should add two new lines after", () => {
+      const match = { index: 3, [0]: { length: 12 } } as RegExpExecArray;
+      const output = insertNewLinesIfNeededOnMatch("\n\n ![](anImage) ", match);
+      expect(output).toBe("\n\n ![](anImage)\n\n ");
+    });
+    it("Given one new line before and two after, with spaces, should add one new line before", () => {
+      const match = { index: 2, [0]: { length: 12 } } as RegExpExecArray;
+      const output = insertNewLinesIfNeededOnMatch(
+        "\n ![](anImage) \n\n",
+        match
+      );
+      expect(output).toBe("\n \n![](anImage) \n\n");
+    });
+    it("Given no new line before and two after, with spaces, should add two new lines before", () => {
+      const match = { index: 1, [0]: { length: 12 } } as RegExpExecArray;
+      const output = insertNewLinesIfNeededOnMatch(" ![](anImage) \n\n", match);
+      expect(output).toBe(" \n\n![](anImage) \n\n");
+    });
+    it("Given no new line before nor after, with spaces, should add two new lines before and after", () => {
+      const match = { index: 1, [0]: { length: 12 } } as RegExpExecArray;
+      const output = insertNewLinesIfNeededOnMatch(" ![](anImage) ", match);
+      expect(output).toBe(" \n\n![](anImage)\n\n ");
+    });
+  });
+});

--- a/ts/components/IOMarkdown/markdownRenderer.ts
+++ b/ts/components/IOMarkdown/markdownRenderer.ts
@@ -176,34 +176,39 @@ export const insertNewLinesIfNeededOnMatch = (
 ): string => {
   const matchStartIndex = imageMatch.index;
   const matchEndIndex = matchStartIndex + imageMatch[0].length;
-  const sanitizedMarkdownContent = insertNewLineAtIndexIfNeeded(
-    markdownContent,
-    matchEndIndex
-  );
-  return insertNewLineAtIndexIfNeeded(
-    sanitizedMarkdownContent,
-    matchStartIndex - 1,
-    true
-  );
-};
 
-const insertNewLineAtIndexIfNeeded = (
-  markdownContent: string,
-  baseIndex: number,
-  insertAfterIndex: boolean = false
-) => {
-  if (baseIndex >= 0 && baseIndex < markdownContent.length) {
-    const character = markdownContent[baseIndex];
-    if (character !== "\n") {
-      const index = insertAfterIndex ? baseIndex + 1 : baseIndex;
-      return [
-        markdownContent.slice(0, index),
-        "\n\n",
-        markdownContent.slice(index)
-      ].join("");
-    }
+  // eslint-disable-next-line functional/no-let
+  let result = markdownContent;
+
+  // Check and add newlines before start index
+  const beforeSubstring = result.substring(0, matchStartIndex);
+  const newlinesBefore = (beforeSubstring.match(/\n/g) || []).length;
+
+  // eslint-disable-next-line functional/no-let
+  let endIndexAfterFirstInsertion = matchEndIndex;
+  if (newlinesBefore < 2) {
+    const newlinesToAdd = 2 - newlinesBefore;
+    const newlinesPrefix = "\n".repeat(newlinesToAdd);
+    result =
+      beforeSubstring + newlinesPrefix + result.substring(matchStartIndex);
+    // Update endIndex since we modified the string
+    endIndexAfterFirstInsertion += newlinesToAdd;
   }
-  return markdownContent;
+
+  // Check and add newlines after end index
+  const afterSubstring = result.substring(endIndexAfterFirstInsertion);
+  const newlinesAfter = (afterSubstring.match(/\n/g) || []).length;
+
+  if (newlinesAfter < 2) {
+    const newlinesToAdd = 2 - newlinesAfter;
+    const newlinesSuffix = "\n".repeat(newlinesToAdd);
+    result =
+      result.substring(0, endIndexAfterFirstInsertion) +
+      newlinesSuffix +
+      afterSubstring;
+  }
+
+  return result;
 };
 
 export const isTxtParentNode = (node: TxtNode): node is TxtParentNode =>


### PR DESCRIPTION
## Short description
This PR fixes an error when rendering IOMarkdown content with images

## List of changes proposed in this pull request
- better detection and sanitization of images in markdown content

## How to test
Using the io-dev-api-server, check that [all markdown examples listed here](https://github.com/pagopa/io-app/pull/6445) are still working properly.

Also check that the following markdowns renders properly (input them in the dev-server or hardcode them in the app):
`\n\n![](https://m.media-amazon.com/images/I/811FhSLBIcL._AC_SL1500_.jpg)\n\nA new line`
`\n\n![](https://m.media-amazon.com/images/I/811FhSLBIcL._AC_SL1500_.jpg)\nA new line`
`\n\n![](https://m.media-amazon.com/images/I/811FhSLBIcL._AC_SL1500_.jpg)A new line`
`\n![](https://m.media-amazon.com/images/I/811FhSLBIcL._AC_SL1500_.jpg)\n\nA new line`
`![](https://m.media-amazon.com/images/I/811FhSLBIcL._AC_SL1500_.jpg)\n\nA new line`
`![](https://m.media-amazon.com/images/I/811FhSLBIcL._AC_SL1500_.jpg)A new line`
`A start line\n\n![](https://m.media-amazon.com/images/I/811FhSLBIcL._AC_SL1500_.jpg)\n\nA new line`
`A start line\n\n![](https://m.media-amazon.com/images/I/811FhSLBIcL._AC_SL1500_.jpg)\nA new line`
`A start line\n\n![](https://m.media-amazon.com/images/I/811FhSLBIcL._AC_SL1500_.jpg)A new line`
`A start line\n![](https://m.media-amazon.com/images/I/811FhSLBIcL._AC_SL1500_.jpg)\n\nA new line`
`A start line![](https://m.media-amazon.com/images/I/811FhSLBIcL._AC_SL1500_.jpg)\n\nA new line`
`A start line![](https://m.media-amazon.com/images/I/811FhSLBIcL._AC_SL1500_.jpg)A new line`