### PR TITLE
refactor: [IOBP-1866] Remove the IDPay unsubscribe CTA  and adapted the beneficiary details content screen

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -5510,7 +5510,7 @@
       "beneficiaryDetails": {
         "infobox": {
           "title": "Cosa ti permette di fare?",
-          "rulesButton": "Leggi le regole"
+          "rulesButton": "Read the rules"
         },
         "infoModal": {
           "title": "Regole dell'iniziativa",
@@ -5533,7 +5533,7 @@
         "protocolNumber": "Numero di protocollo",
         "lastUpdate": "Saldo aggiornato al {{dateString}}",
         "buttons": {
-          "privacy": "Preferenze & Privacy",
+          "privacy": "Preferenze e Privacy",
           "unsubscribe": "Rimuovi {{initiativeName}}",
           "requestHelp": "Chiedi aiuto"
         }

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -5510,7 +5510,7 @@
       "beneficiaryDetails": {
         "infobox": {
           "title": "Cosa ti permette di fare?",
-          "rulesButton": "Leggi le regole"
+          "rulesButton": "Leggi il regolamento"
         },
         "infoModal": {
           "title": "Regole dell'iniziativa",
@@ -5533,7 +5533,7 @@
         "protocolNumber": "Numero di protocollo",
         "lastUpdate": "Saldo aggiornato al {{dateString}}",
         "buttons": {
-          "privacy": "Preferenze & Privacy",
+          "privacy": "Preferenze e Privacy",
           "unsubscribe": "Rimuovi {{initiativeName}}",
           "requestHelp": "Chiedi aiuto"
         }

--- a/ts/features/idpay/details/components/IdPayBeneficiaryDetailsContent.tsx
+++ b/ts/features/idpay/details/components/IdPayBeneficiaryDetailsContent.tsx
@@ -139,7 +139,7 @@ const IdPayBeneficiaryDetailsContent = (props: BeneficiaryDetailsProps) => {
             // while the refunded amount is always 0
             label: I18n.t("idpay.initiative.beneficiaryDetails.spentUntilNow"),
             value:
-              initiativeDetails.accruedCents === undefined
+              initiativeDetails.accruedCents !== undefined
                 ? formatNumberCurrencyOrDefault(initiativeDetails.accruedCents)
                 : undefined,
             testID: "accruedTestID"

--- a/ts/features/idpay/details/components/IdPayBeneficiaryDetailsContent.tsx
+++ b/ts/features/idpay/details/components/IdPayBeneficiaryDetailsContent.tsx
@@ -1,6 +1,4 @@
 import {
-  Body,
-  BodySmall,
   Divider,
   IOSkeleton,
   ListItemAction,
@@ -12,7 +10,6 @@ import {
 } from "@pagopa/io-app-design-system";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { useNavigation } from "@react-navigation/native";
-import { sequenceS } from "fp-ts/lib/Apply";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
 import { ReactNode } from "react";
@@ -36,12 +33,12 @@ import { format } from "../../../../utils/dates";
 import { SERVICES_ROUTES } from "../../../services/common/navigation/routes";
 import { useIdPaySupportModal } from "../../common/hooks/useIdPaySupportModal";
 import { formatNumberCurrencyOrDefault } from "../../common/utils/strings";
-import { IdPayUnsubscriptionRoutes } from "../../unsubscription/navigation/routes";
 import { IDPayDetailsRoutes } from "../navigation";
 import {
   IdPayInitiativeRulesInfoBox,
   IdPayInitiativeRulesInfoBoxSkeleton
 } from "./IdPayInitiativeRulesInfoBox";
+import { IdPayinitiativeStatusItem } from "./IdPayInitiativeStatusItem";
 
 type TableRow = WithTestID<{
   label: string;
@@ -74,11 +71,7 @@ const IdPayBeneficiaryDetailsContent = (props: BeneficiaryDetailsProps) => {
     return <BeneficiaryDetailsContentSkeleton />;
   }
 
-  const {
-    initiativeId,
-    initiativeName,
-    initiativeRewardType: initiativeType
-  } = initiativeDetails;
+  const { initiativeRewardType: initiativeType } = initiativeDetails;
 
   const ruleInfoBox = pipe(
     beneficiaryDetails.ruleDescription,
@@ -89,19 +82,10 @@ const IdPayBeneficiaryDetailsContent = (props: BeneficiaryDetailsProps) => {
     )
   );
 
-  const statusString = pipe(
-    initiativeDetails.status,
-    O.fromNullable,
-    O.map(status =>
-      I18n.t(`idpay.initiative.details.initiativeCard.statusLabels.${status}`)
-    ),
-    O.getOrElse(() => "-")
-  );
-
   const endDateString = pipe(
     initiativeDetails.endDate,
     O.fromNullable,
-    O.map(formatDate("DD/MM/YYYY")),
+    O.map(formatDate("DD/MM/YYYY, HH:mm")),
     O.getOrElse(() => "-")
   );
 
@@ -109,14 +93,14 @@ const IdPayBeneficiaryDetailsContent = (props: BeneficiaryDetailsProps) => {
     beneficiaryDetails.fruitionStartDate,
     O.fromNullable,
     O.map(formatDate("DD MMM YYYY")),
-    O.getOrElse(() => "-")
+    O.getOrElseW(() => undefined)
   );
 
   const fruitionEndDateString = pipe(
     beneficiaryDetails.fruitionEndDate,
     O.fromNullable,
     O.map(formatDate("DD MMM YYYY")),
-    O.getOrElse(() => "-")
+    O.getOrElseW(() => undefined)
   );
 
   const rewardRuleRow = pipe(
@@ -139,16 +123,6 @@ const IdPayBeneficiaryDetailsContent = (props: BeneficiaryDetailsProps) => {
     O.getOrElse<TableRow>(() => ({ label: "-", value: "-" }))
   );
 
-  const lastUpdateString = pipe(
-    beneficiaryDetails.updateDate,
-    O.fromNullable,
-    O.map(formatDate("DD MMMM YYYY, HH:mm")),
-    O.map(dateString =>
-      I18n.t("idpay.initiative.beneficiaryDetails.lastUpdate", { dateString })
-    ),
-    O.toUndefined
-  );
-
   const onboardingDateString = pipe(
     onboardingStatus.onboardingOkDate,
     O.fromNullable,
@@ -164,9 +138,10 @@ const IdPayBeneficiaryDetailsContent = (props: BeneficiaryDetailsProps) => {
             // in DISCOUNT initiatives, the spent amount is held in the accrued field,
             // while the refunded amount is always 0
             label: I18n.t("idpay.initiative.beneficiaryDetails.spentUntilNow"),
-            value: formatNumberCurrencyOrDefault(
-              initiativeDetails.accruedCents
-            ),
+            value:
+              initiativeDetails.accruedCents === undefined
+                ? formatNumberCurrencyOrDefault(initiativeDetails.accruedCents)
+                : undefined,
             testID: "accruedTestID"
           }
         ];
@@ -208,34 +183,7 @@ const IdPayBeneficiaryDetailsContent = (props: BeneficiaryDetailsProps) => {
     startIdPaySupport(IDPayDetailsRoutes.IDPAY_DETAILS_BENEFICIARY);
   };
 
-  const handleUnsubscribePress = () => {
-    pipe(
-      sequenceS(O.Monad)({
-        initiativeName: O.fromNullable(initiativeName),
-        initiativeType: O.fromNullable(initiativeType)
-      }),
-      O.map(({ initiativeName, initiativeType }) => {
-        navigation.navigate(
-          IdPayUnsubscriptionRoutes.IDPAY_UNSUBSCRIPTION_MAIN,
-          {
-            screen: IdPayUnsubscriptionRoutes.IDPAY_UNSUBSCRIPTION_CONFIRMATION,
-            params: {
-              initiativeId,
-              initiativeName,
-              initiativeType
-            }
-          }
-        );
-      })
-    );
-  };
-
   const summaryData = [
-    {
-      label: I18n.t("idpay.initiative.beneficiaryDetails.status"),
-      value: statusString,
-      testID: "statusTestID"
-    },
     {
       label: I18n.t("idpay.initiative.beneficiaryDetails.endDate"),
       value: endDateString,
@@ -246,7 +194,7 @@ const IdPayBeneficiaryDetailsContent = (props: BeneficiaryDetailsProps) => {
       value: formatNumberCurrencyOrDefault(initiativeDetails.amountCents),
       testID: "amountTestID"
     },
-    ...getTypeDependantTableRows()
+    ...getTypeDependantTableRows().filter(row => row.value)
   ];
 
   const enrollmentData = [
@@ -254,11 +202,6 @@ const IdPayBeneficiaryDetailsContent = (props: BeneficiaryDetailsProps) => {
       label: I18n.t("idpay.initiative.beneficiaryDetails.enrollmentDate"),
       value: onboardingDateString,
       testID: "onboardingDateTestID"
-    },
-    {
-      label: I18n.t("idpay.initiative.beneficiaryDetails.protocolNumber"),
-      value: "-",
-      testID: "protocolTestID"
     }
   ];
 
@@ -276,19 +219,22 @@ const IdPayBeneficiaryDetailsContent = (props: BeneficiaryDetailsProps) => {
     rewardRuleRow
   ];
 
-  const renderTableRow = (data: Array<TableRow>) =>
-    data.map((row, i) => (
-      <View key={row.testID}>
-        <ListItemInfo
-          key={row.testID}
-          label={row.label}
-          value={row.value}
-          testID={row.testID}
-        />
-        {i !== data.length - 1 && <Divider />}
-      </View>
-    ));
+  const canShowRulesData = !!spendingRulesData.filter(rule => rule.value);
 
+  const renderTableRow = (data: Array<TableRow>) =>
+    data
+      .filter(el => el.value)
+      .map((row, i) => (
+        <View key={row.testID}>
+          <ListItemInfo
+            key={row.testID}
+            label={row.label}
+            value={row.value}
+            testID={row.testID}
+          />
+          {i !== data.length - 1 && <Divider />}
+        </View>
+      ));
   const renderBeneficiaryDetailsContent = () => {
     switch (initiativeType) {
       case InitiativeRewardTypeEnum.DISCOUNT:
@@ -298,16 +244,19 @@ const IdPayBeneficiaryDetailsContent = (props: BeneficiaryDetailsProps) => {
             <ListItemHeader
               label={I18n.t("idpay.initiative.beneficiaryDetails.summary")}
             />
+            <IdPayinitiativeStatusItem status={initiativeDetails.status} />
             {renderTableRow(summaryData)}
             <VSpacer size={8} />
-            <BodySmall weight="Regular">{lastUpdateString}</BodySmall>
-            <VSpacer size={8} />
-            <ListItemHeader
-              label={I18n.t(
-                "idpay.initiative.beneficiaryDetails.spendingRules"
-              )}
-            />
-            {renderTableRow(spendingRulesData)}
+            {canShowRulesData && (
+              <>
+                <ListItemHeader
+                  label={I18n.t(
+                    "idpay.initiative.beneficiaryDetails.spendingRules"
+                  )}
+                />
+                {renderTableRow(spendingRulesData)}
+              </>
+            )}
             <ListItemHeader
               label={I18n.t(
                 "idpay.initiative.beneficiaryDetails.enrollmentDetails"
@@ -315,18 +264,14 @@ const IdPayBeneficiaryDetailsContent = (props: BeneficiaryDetailsProps) => {
             />
             {renderTableRow(enrollmentData)}
             <VSpacer size={16} />
-            <Body weight="Semibold" asLink onPress={handlePrivacyLinkPress}>
-              {I18n.t("idpay.initiative.beneficiaryDetails.buttons.privacy")}
-            </Body>
-            <VSpacer size={16} />
-            <Body weight="Semibold" asLink onPress={handleUnsubscribePress}>
-              {I18n.t(
-                "idpay.initiative.beneficiaryDetails.buttons.unsubscribe",
-                {
-                  initiativeName
-                }
+            <ListItemAction
+              icon="security"
+              variant="primary"
+              label={I18n.t(
+                "idpay.initiative.beneficiaryDetails.buttons.privacy"
               )}
-            </Body>
+              onPress={handlePrivacyLinkPress}
+            />
           </>
         );
       default:

--- a/ts/features/idpay/details/components/IdPayInitiativeRulesInfoBox.tsx
+++ b/ts/features/idpay/details/components/IdPayInitiativeRulesInfoBox.tsx
@@ -1,14 +1,11 @@
 import {
   Body,
-  FooterActions,
   H6,
-  HSpacer,
+  IOButton,
   IOColors,
   IOSkeleton,
-  Icon,
   VSpacer,
-  VStack,
-  useIOTheme
+  VStack
 } from "@pagopa/io-app-design-system";
 import { StyleSheet, View } from "react-native";
 import IOMarkdown from "../../../../components/IOMarkdown";
@@ -21,24 +18,10 @@ type Props = {
 
 const IdPayInitiativeRulesInfoBox = (props: Props) => {
   const { content } = props;
-  const theme = useIOTheme();
 
-  const { bottomSheet, present, dismiss } = useIOBottomSheetModal({
+  const { bottomSheet, present } = useIOBottomSheetModal({
     component: <IOMarkdown content={content} />,
-    title: I18n.t("idpay.initiative.beneficiaryDetails.infoModal.title"),
-    footer: (
-      <FooterActions
-        actions={{
-          type: "SingleButton",
-          primary: {
-            label: I18n.t(
-              "idpay.initiative.beneficiaryDetails.infoModal.button"
-            ),
-            onPress: () => dismiss()
-          }
-        }}
-      />
-    )
+    title: I18n.t("idpay.initiative.beneficiaryDetails.infoModal.title")
   });
 
   return (
@@ -51,11 +34,15 @@ const IdPayInitiativeRulesInfoBox = (props: Props) => {
         </Body>
         <VSpacer size={16} />
         <View style={{ flexDirection: "row" }}>
-          <Icon name="categLearning" color={theme["interactiveElem-default"]} />
-          <HSpacer size={8} />
-          <Body weight="Semibold" asLink onPress={() => present()}>
-            {I18n.t("idpay.initiative.beneficiaryDetails.infobox.rulesButton")}
-          </Body>
+          <IOButton
+            iconPosition="end"
+            variant="link"
+            label={I18n.t(
+              "idpay.initiative.beneficiaryDetails.infobox.rulesButton"
+            )}
+            onPress={present}
+            icon="categLearning"
+          />
         </View>
       </View>
       <VSpacer size={16} />

--- a/ts/features/idpay/details/components/IdPayInitiativeStatusItem.tsx
+++ b/ts/features/idpay/details/components/IdPayInitiativeStatusItem.tsx
@@ -1,0 +1,54 @@
+import {
+  Badge,
+  Divider,
+  H6,
+  IOListItemStyles
+} from "@pagopa/io-app-design-system";
+import { ComponentProps } from "react";
+import { View } from "react-native";
+import { StatusEnum } from "../../../../../definitions/idpay/InitiativeDTO";
+import I18n from "../../../../i18n";
+
+const getStatusBadgeVariant = (
+  status: StatusEnum
+): ComponentProps<typeof Badge>["variant"] => {
+  switch (status) {
+    case StatusEnum.REFUNDABLE:
+    case StatusEnum.NOT_REFUNDABLE:
+    case StatusEnum.NOT_REFUNDABLE_ONLY_IBAN:
+    case StatusEnum.NOT_REFUNDABLE_ONLY_INSTRUMENT:
+      return "success";
+    case StatusEnum.UNSUBSCRIBED:
+      return "error";
+    default:
+      return "default";
+  }
+};
+
+type IdPayinitiativeStatusItemProps = {
+  status: StatusEnum;
+};
+
+export const IdPayinitiativeStatusItem = ({
+  status
+}: IdPayinitiativeStatusItemProps) => {
+  const statusString = I18n.t(
+    `idpay.initiative.details.initiativeCard.statusLabels.${status}`
+  );
+
+  return (
+    <View testID="statusTestID">
+      <View
+        style={{
+          ...IOListItemStyles.listItem,
+          justifyContent: "space-between",
+          flexDirection: "row"
+        }}
+      >
+        <H6>{I18n.t("idpay.initiative.beneficiaryDetails.status")}</H6>
+        <Badge text={statusString} variant={getStatusBadgeVariant(status)} />
+      </View>
+      <Divider />
+    </View>
+  );
+};

--- a/ts/features/idpay/details/components/__tests__/IdPayBeneficiaryDetailsContent.test.tsx
+++ b/ts/features/idpay/details/components/__tests__/IdPayBeneficiaryDetailsContent.test.tsx
@@ -32,8 +32,8 @@ jest.mock("@react-navigation/native", () => {
 });
 
 const T_INITIATIVE_ID = "ABC123";
-const T_END_DATE = new Date(2023, 0, 1);
-const T_END_DATE_TEXT = "01/01/2023";
+const T_END_DATE = new Date(2023, 0, 1, 10, 0);
+const T_END_DATE_TEXT = "01/01/2023, 10:00";
 const T_AMOUNT = 70;
 const T_AMOUNT_TEXT = "70,00 €";
 const T_ACCRUED = 20;

--- a/ts/features/idpay/details/screens/IdPayBeneficiaryDetailsScreen.tsx
+++ b/ts/features/idpay/details/screens/IdPayBeneficiaryDetailsScreen.tsx
@@ -1,10 +1,9 @@
-import { ContentWrapper, VSpacer } from "@pagopa/io-app-design-system";
+import { VSpacer } from "@pagopa/io-app-design-system";
 import * as pot from "@pagopa/ts-commons/lib/pot";
 import { RouteProp, useRoute } from "@react-navigation/native";
 import { sequenceS } from "fp-ts/lib/Apply";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
-import { ScrollView } from "react-native";
 import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
 import { useIODispatch, useIOSelector } from "../../../../store/hooks";
 import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
@@ -19,6 +18,7 @@ import {
   idPayBeneficiaryDetailsGet,
   idPayOnboardingStatusGet
 } from "../store/actions";
+import { IOScrollView } from "../../../../components/ui/IOScrollView";
 
 export type IdPayBeneficiaryDetailsScreenParams = {
   initiativeId: string;
@@ -67,13 +67,17 @@ const IdPayBeneficiaryDetailsScreen = () => {
     )
   );
 
-  useHeaderSecondLevel({ title: headerTitle || "" });
+  useHeaderSecondLevel({
+    title: headerTitle || "",
+    supportRequest: true,
+    enableDiscreteTransition: true
+  });
 
   return (
-    <ScrollView scrollIndicatorInsets={{ right: 1 }}>
+    <IOScrollView>
       <VSpacer size={16} />
-      <ContentWrapper>{content}</ContentWrapper>
-    </ScrollView>
+      {content}
+    </IOScrollView>
   );
 };
 

--- a/ts/features/idpay/details/screens/IdPayInitiativeDetailsScreen.tsx
+++ b/ts/features/idpay/details/screens/IdPayInitiativeDetailsScreen.tsx
@@ -43,7 +43,6 @@ import {
   IdPayInitiativeTimelineComponentSkeleton
 } from "../components/IdPayInitiativeTimelineComponent";
 import { IdPayMissingConfigurationAlert } from "../components/IdPayMissingConfigurationAlert";
-import IdPayRemoveFromWalletButton from "../components/IdPayRemoveFromWalletButton";
 import { useIdPayDiscountDetailsBottomSheet } from "../hooks/useIdPayDiscountDetailsBottomSheet";
 import { IDPayDetailsParamsList, IDPayDetailsRoutes } from "../navigation";
 import {
@@ -237,7 +236,6 @@ const IdPayInitiativeDetailsScreenComponent = () => {
                     <IdPayInitiativeDiscountSettingsComponent
                       initiative={initiative}
                     />
-                    <IdPayRemoveFromWalletButton {...initiative} />
                   </Animated.View>
                 </ContentWrapper>
               );


### PR DESCRIPTION
## Short description
This PR removes the IDPay unsubscribe CTA button as product requirement isn't needed anymore. This PR is used also to simplify beneficiary components, improving user interface elements with [the designed UI](https://www.figma.com/design/oo4ehPaT3ONNI8FAs9aZH2/PARI---Bonus-Elettrodomestici?node-id=2384-27360&t=2Gun57lciaoZgZQu-4).

## List of changes proposed in this pull request
* Added a new `IdPayinitiativeStatusItem` component to display initiative status with a badge for better visual distinction.
* Replaced `Body` and `BodySmall` components with `ListItemAction` and `IOButton` for better alignment with the design system.
* Replaced the `ScrollView` with the `IOScrollView` in `IdPayBeneficiaryDetailsScreen`.
* Refactored `IdPayInitiativeRulesInfoBox` to remove the footer as designed in the figma.
* Removed the `IdPayRemoveFromWalletButton` from `IdPayInitiativeDetailsScreen` as it is no longer required. 

## How to test
- With the dev-server started and the IDPay local feature flag enabled, open a discount initiative details and navigate to the beneficiary initiative detail page;
- Check that the provided UI matches the designed one;
- **!IMPORTANT NOTE!**: Every item in the provided value-label list is rendered conditionally. If the corresponding data is returned by the backend, it will be displayed; otherwise, it will be hidden. This means that on your dev server, you might see extra information (e.g., data not relevant to "Bonus Elettrodomestici") if it's returned. However, in production mode, the backend controls what should or shouldn't be shown, so only the appropriate data will be rendered.

## Preview
|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/ff1b94d9-514f-4b25-a4de-51fb35e9af7d" />|<video src="https://github.com/user-attachments/assets/fc21bdfd-d3e4-489b-b18d-cded5df7bd3b" />
