### PR TITLE
chore(IT Wallet): [SIW-2218] IT-Wallet preview screen

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -4614,6 +4614,7 @@
         "eidPreview": {
           "title": "Identità verificata",
           "subtitle": "Stai attivando **Documenti su IO** come:",
+          "subtitleL3": "Ci siamo quasi! Stai per ottenere **IT-Wallet** come:",
           "actions": {
             "primary": "Continua",
             "secondary": "Annulla"

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -4614,6 +4614,7 @@
         "eidPreview": {
           "title": "Identità verificata",
           "subtitle": "Stai attivando **Documenti su IO** come:",
+          "subtitleL3": "Ci siamo quasi! Stai per ottenere **IT-Wallet** come:",
           "actions": {
             "primary": "Continua",
             "secondary": "Annulla"

--- a/ts/features/itwallet/issuance/screens/ItwIssuanceEidPreviewScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceEidPreviewScreen.tsx
@@ -36,6 +36,7 @@ import {
 } from "../../machine/eid/selectors";
 import { ItwEidIssuanceMachineContext } from "../../machine/provider";
 import { ItwCredentialPreviewClaimsList } from "../components/ItwCredentialPreviewClaimsList";
+import { isItwCredential } from "../../common/utils/itwCredentialUtils";
 
 export const ItwIssuanceEidPreviewScreen = () => {
   const eidOption = ItwEidIssuanceMachineContext.useSelector(selectEidOption);
@@ -72,6 +73,8 @@ const ContentView = ({ eid }: ContentViewProps) => {
   const dispatch = useIODispatch();
   const navigation = useIONavigation();
   const route = useRoute();
+
+  const isL3 = isItwCredential(eid.credential);
 
   const mixPanelCredential = useMemo(
     () => CREDENTIALS_MAP[eid.credentialType],
@@ -163,7 +166,11 @@ const ContentView = ({ eid }: ContentViewProps) => {
             <H2>{I18n.t("features.itWallet.issuance.eidPreview.title")}</H2>
           </HStack>
           <IOMarkdown
-            content={I18n.t("features.itWallet.issuance.eidPreview.subtitle")}
+            content={I18n.t(
+              `features.itWallet.issuance.eidPreview.${
+                isL3 ? "subtitleL3" : "subtitle"
+              }`
+            )}
           />
           <ItwCredentialPreviewClaimsList data={eid} releaserVisible={false} />
         </VStack>


### PR DESCRIPTION
## Short description
This PR slightly changes the copy in the PID preview screen to display the IT-Wallet activation message.

## List of changes proposed in this pull request
- Updated copy

## How to test
Activate IT-Wallet with L3: you should see the following screen.

<img width="260" alt="screen" src="https://github.com/user-attachments/assets/11a2f8b8-7cd4-42cb-a180-d7f6520e0d0f" />


Activate Documenti su IO (either with the fallback or by disabling the L3 feature flag): you should see the message "Stai attivando **Documenti su IO** come:"
