### PR TITLE
refactor: [IOBP-1867,IOBP-1868] Update pictogram and outcome body text

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -5622,7 +5622,7 @@
         "message": {
           "GENERIC": {
             "title": "Si è verificato un errore imprevisto",
-            "subtitle": "Siamo già a lavoro per risolverlo: ti invitiamo a riprovare più tardi."
+            "subtitle": "Siamo già a lavoro per risolverlo. Prova più tardi ad accedere all’iniziativa."
           },
           "INITIATIVE_NOT_FOUND": {
             "title": "Non riusciamo a trovare quest’iniziativa",

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -5622,7 +5622,7 @@
         "message": {
           "GENERIC": {
             "title": "Si è verificato un errore imprevisto",
-            "subtitle": "Siamo già a lavoro per risolverlo: ti invitiamo a riprovare più tardi."
+            "subtitle": "Siamo già a lavoro per risolverlo. Prova più tardi ad accedere all’iniziativa."
           },
           "INITIATIVE_NOT_FOUND": {
             "title": "Non riusciamo a trovare quest’iniziativa",

--- a/ts/features/idpay/onboarding/screens/IdPayFailureScreen.tsx
+++ b/ts/features/idpay/onboarding/screens/IdPayFailureScreen.tsx
@@ -102,7 +102,7 @@ const IdPayFailureScreen = () => {
         };
       case OnboardingFailureEnum.INITIATIVE_ENDED:
         return {
-          pictogram: "ended",
+          pictogram: "time",
           title: I18n.t(
             "idpay.onboarding.failure.message.INITIATIVE_ENDED.title"
           ),


### PR DESCRIPTION
## Short description
This pull request includes updates to localization files and a minor UI adjustment in the `IdPayFailureScreen` component

## List of changes proposed in this pull request
- Updated the subtitle for the generic error message to clarify the suggested action for users.
- Changed the `pictogram` value for the `INITIATIVE_ENDED` failure state from `"ended"` to `"time"`

## How to test
Ensure that all screen are now aligned with design
