### PR TITLE
Siw 2220 itwallet activation success

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -4647,6 +4647,13 @@
               "continueAlt": "Aggiungi documento",
               "close": "Continua più tardi"
             }
+          },
+          "successL3": {
+            "title": "Il tuo IT-Wallet è pronto!",
+            "subtitle": "Ora hai accesso ai vantaggi del nuovo portafoglio digitale di Stato.",
+            "actions": {
+              "continue": "Esplora IT-Wallet"
+            }
           }
         },
         "emptyWallet": {

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -55,7 +55,10 @@
       "nov",
       "dic"
     ],
-    "meridian": ["am", "pm"],
+    "meridian": [
+      "am",
+      "pm"
+    ],
     "time": {
       "minutes": {
         "zero": "0 minuti",
@@ -4646,6 +4649,13 @@
               "continue": "Aggiungi primo documento",
               "continueAlt": "Aggiungi documento",
               "close": "Continua più tardi"
+            }
+          },
+          "successL3": {
+            "title": "Il tuo IT-Wallet è pronto!",
+            "subtitle": "Ora hai accesso ai vantaggi del nuovo portafoglio digitale di Stato.",
+            "actions": {
+              "continue": "Esplora IT-Wallet"
             }
           }
         },

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -55,10 +55,7 @@
       "nov",
       "dic"
     ],
-    "meridian": [
-      "am",
-      "pm"
-    ],
+    "meridian": ["am", "pm"],
     "time": {
       "minutes": {
         "zero": "0 minuti",

--- a/ts/features/itwallet/issuance/screens/ItwIssuanceEidResultScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceEidResultScreen.tsx
@@ -5,10 +5,13 @@ import { ItwEidIssuanceMachineContext } from "../../machine/provider";
 import { useItwDisableGestureNavigation } from "../../common/hooks/useItwDisableGestureNavigation";
 import { useAvoidHardwareBackButton } from "../../../../utils/useAvoidHardwareBackButton";
 import { trackAddFirstCredential, trackBackToWallet } from "../../analytics";
+import { useIOSelector } from "../../../../store/hooks";
+import { itwLifecycleIsITWalletValidSelector } from "../../lifecycle/store/selectors";
 
 export const ItwIssuanceEidResultScreen = () => {
   const route = useRoute();
 
+  const isItWalletValid = useIOSelector(itwLifecycleIsITWalletValidSelector);
   const machineRef = ItwEidIssuanceMachineContext.useActorRef();
 
   useItwDisableGestureNavigation();
@@ -19,11 +22,28 @@ export const ItwIssuanceEidResultScreen = () => {
     trackAddFirstCredential();
   };
 
-  const handleClose = async () => {
-    machineRef.send({ type: "go-to-wallet" });
-    trackBackToWallet({ exit_page: route.name, credential: "ITW_ID_V2" });
-  };
+  const handleBackToWallet = () => machineRef.send({ type: "go-to-wallet" });
 
+  // The user successfully activated IT-Wallet
+  if (isItWalletValid) {
+    return (
+      <OperationResultScreenContent
+        pictogram="success"
+        title={I18n.t("features.itWallet.issuance.eidResult.successL3.title")}
+        subtitle={I18n.t(
+          "features.itWallet.issuance.eidResult.successL3.subtitle"
+        )}
+        action={{
+          label: I18n.t(
+            "features.itWallet.issuance.eidResult.successL3.actions.continue"
+          ),
+          onPress: handleBackToWallet
+        }}
+      />
+    );
+  }
+
+  // The user successfully activated Documenti su IO
   return (
     <OperationResultScreenContent
       pictogram="success"
@@ -39,7 +59,10 @@ export const ItwIssuanceEidResultScreen = () => {
         label: I18n.t(
           "features.itWallet.issuance.eidResult.success.actions.close"
         ),
-        onPress: handleClose
+        onPress: () => {
+          handleBackToWallet();
+          trackBackToWallet({ exit_page: route.name, credential: "ITW_ID_V2" });
+        }
       }}
     />
   );


### PR DESCRIPTION
## Short description
This PR modifies the Wallet activation screen to show that IT-Wallet was activated. The fallback to "Documenti su IO" remains.

## List of changes proposed in this pull request
- Updated `ItwIssuanceEidResultScreen`

## How to test
Activate IT-Wallet and Documenti su IO and ensure the success screens are coherent.

|Documenti su IO|IT-Wallet|
|-|-|
|<img width="260" alt="doc_io" src="https://github.com/user-attachments/assets/8f68eda6-90b8-45e9-9f2a-ecc96ffad254" />|<img width="260" alt="itwallet" src="https://github.com/user-attachments/assets/de016f49-b76b-46b6-a715-ebcbe33fbc53" />|