### PR TITLE
fix(IT Wallet): [SIW-2767] Copy regression in "Documenti su IO" ready banner

### DIFF
--- a/ts/features/itwallet/common/components/ItwWalletReadyBanner.tsx
+++ b/ts/features/itwallet/common/components/ItwWalletReadyBanner.tsx
@@ -24,7 +24,7 @@ export const ItwWalletReadyBanner = () => {
   };
 
   const bannerTitle = !isNewItwRenderable
-    ? I18n.t("features.itWallet.issuance.eidResult.success.title")
+    ? I18n.t("features.itWallet.issuance.eidResult.successL2.title")
     : undefined;
 
   return (
@@ -33,7 +33,7 @@ export const ItwWalletReadyBanner = () => {
       content={I18n.t(
         isNewItwRenderable
           ? "features.itWallet.issuance.emptyWallet.itwReadyBanner.content"
-          : "features.itWallet.issuance.eidResult.success.subtitle"
+          : "features.itWallet.issuance.eidResult.successL2.subtitle"
       )}
       action={I18n.t(
         "features.itWallet.issuance.eidResult.successL2.actions.continueAlt"


### PR DESCRIPTION
## Short description
This PR fixes a regression introduced by #7191, that displays copy related to IT-Wallet in Documenti su IO ready banner.

## List of changes proposed in this pull request
- Fix i18n keys

## How to test
Activate Documenti su IO (disable L3 flag): check that the ready banner mentions Documenti su IO

|Before|After|
|------|-----|
|<img width="320"  alt="before" src="https://github.com/user-attachments/assets/f1fd7df4-21fa-4c83-b14f-edad3cad3268" />|<img width="320" alt="after" src="https://github.com/user-attachments/assets/e9cd35b5-f967-447a-b1f6-8d030eb290e3" />|