### PR TITLE
fix(IT Wallet): [SIW-2757] Add default space value to `VStack` components if not set

### DIFF
--- a/ts/features/itwallet/presentation/details/components/ItwPresentationPidScaffoldScreen.tsx
+++ b/ts/features/itwallet/presentation/details/components/ItwPresentationPidScaffoldScreen.tsx
@@ -38,7 +38,7 @@ const ScreenHeader = memo(() => (
   <View style={styles.header}>
     <BackgroundGradient />
     <ContentWrapper>
-      <VStack>
+      <VStack space={16}>
         <H2>{I18n.t("features.itWallet.credentialName.pid")}</H2>
         <Body color="black">
           {I18n.t(

--- a/ts/features/itwallet/wallet/components/ItwWalletCardsContainer.tsx
+++ b/ts/features/itwallet/wallet/components/ItwWalletCardsContainer.tsx
@@ -1,6 +1,6 @@
 import { ListItemHeader, Optional, VStack } from "@pagopa/io-app-design-system";
 import { useFocusEffect } from "@react-navigation/native";
-import { useCallback, useMemo } from "react";
+import { ReactNode, useCallback, useMemo } from "react";
 import { StyleSheet, View } from "react-native";
 import { useDebugInfo } from "../../../../hooks/useDebugInfo";
 import I18n from "../../../../i18n";
@@ -98,10 +98,12 @@ export const ItwWalletCardsContainer = withWalletCategoryFilter("itw", () => {
   // When the new Wallet UI is renderable and there are no
   // banners between the header and the cards, the vertical space
   // has to be removed.
-  const Container = useMemo(
-    () => (!hasActiveBannersAboveWallet && isNewItwRenderable ? View : VStack),
-    [hasActiveBannersAboveWallet, isNewItwRenderable]
-  );
+  const Container = ({ children }: { children: ReactNode }) => {
+    if (!hasActiveBannersAboveWallet && isNewItwRenderable) {
+      return <View>{children}</View>;
+    }
+    return <VStack space={16}>{children}</VStack>;
+  };
 
   return (
     <Container>
@@ -117,7 +119,7 @@ export const ItwWalletCardsContainer = withWalletCategoryFilter("itw", () => {
           />
         </View>
       )}
-      <VStack>
+      <VStack space={16}>
         <ItwOfflineWalletBanner />
         <WalletCardsCategoryContainer
           key={`cards_category_itw`}

--- a/ts/features/wallet/components/WalletCardsContainer.tsx
+++ b/ts/features/wallet/components/WalletCardsContainer.tsx
@@ -86,7 +86,7 @@ const WalletCardsContainer = () => {
  * Renders the banners that are displayed at the top of the wallet screen
  */
 const WalletBannersContainer = memo(() => (
-  <VStack>
+  <VStack space={16}>
     <ItwEnvironmentAlert />
     <ItwUpgradeBanner />
     <ItwWalletNotAvailableBanner />


### PR DESCRIPTION
## Short description
This PR adds a default space value to all `VStack` components when no spacing is set.

## List of changes proposed in this pull request
- Apply default space value to `VStack` components without an explicit space prop

## How to test
Go to the affected screens and check that there are no visual regressions.
