### PR TITLE
fix: [IOBP-1889] IDPay PDND criteria back navigation logic

### DIFF
--- a/ts/features/idpay/onboarding/machine/machine.ts
+++ b/ts/features/idpay/onboarding/machine/machine.ts
@@ -180,6 +180,10 @@ export const idPayOnboardingMachine = setup({
     },
 
     DisplayingInitiativeInfo: {
+      entry: "navigateToInitiativeDetailsScreen",
+      actions: assign(() => ({
+        currentStep: 1
+      })),
       on: {
         next: [
           {
@@ -286,9 +290,6 @@ export const idPayOnboardingMachine = setup({
           }
         ],
         back: {
-          actions: assign(({ context }) => ({
-            currentStep: context.currentStep - 1
-          })),
           target: "#idpay-onboarding.DisplayingInitiativeInfo"
         }
       }

--- a/ts/features/idpay/onboarding/machine/machine.ts
+++ b/ts/features/idpay/onboarding/machine/machine.ts
@@ -386,8 +386,10 @@ export const idPayOnboardingMachine = setup({
                     target:
                       "#idpay-onboarding.DisplayingSelfDeclarationList.DisplayingBooleanSelfDeclarationList",
                     actions: assign(({ context }) => ({
-                      selfDeclarationsMultiPage:
-                        +context.selfDeclarationsMultiPage - 1,
+                      selfDeclarationsMultiPage: Math.max(
+                        0,
+                        +context.selfDeclarationsMultiPage - 1
+                      ),
                       currentStep: context.currentStep - 1
                     }))
                   },
@@ -395,8 +397,10 @@ export const idPayOnboardingMachine = setup({
                     guard: and(["isFirstMultiConsentPage", "hasPdndCriteria"]),
                     target: "#idpay-onboarding.DisplayingPdndCriteria",
                     actions: assign(({ context }) => ({
-                      selfDeclarationsMultiPage:
-                        +context.selfDeclarationsMultiPage - 1,
+                      selfDeclarationsMultiPage: Math.max(
+                        0,
+                        +context.selfDeclarationsMultiPage - 1
+                      ),
                       currentStep: context.currentStep - 1
                     }))
                   },
@@ -404,8 +408,10 @@ export const idPayOnboardingMachine = setup({
                     guard: "isFirstMultiConsentPage",
                     target: "#idpay-onboarding.DisplayingInitiativeInfo",
                     actions: assign(({ context }) => ({
-                      selfDeclarationsMultiPage:
-                        +context.selfDeclarationsMultiPage - 1,
+                      selfDeclarationsMultiPage: Math.max(
+                        0,
+                        +context.selfDeclarationsMultiPage - 1
+                      ),
                       currentStep: context.currentStep - 1
                     }))
                   }


### PR DESCRIPTION
## Short description
This PR is focusing on improving the navigation and step management logic within the onboarding state machine fixing the no navigation back issue on the onboarding flow

## List of changes proposed in this pull request
- Introduced an `entry` action (`navigateToInitiativeDetailsScreen`) and updated the state to set `currentStep` to 1 when transitioning to the `DisplayingInitiativeInfo` state
- Removed the `actions` block for the `back` event, simplifying the transition logic to directly target the `DisplayingInitiativeInfo` state without modifying the `currentStep` as it will be filled every time on start onboarding

## How to test
Ensure that stepper and navigator is not missing `tap` on the onboarding flow

## Preview
| Before | Now |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/c0f0d83d-5905-4034-8c92-19f7c23d65dd"/> | <video src="https://github.com/user-attachments/assets/615c8e5c-761d-402f-9826-a7dff57a0a16"/>|


 


