### PR TITLE
fix: [IOBP-1897] Cheaper PSP selected check improved

### DIFF
--- a/ts/features/payments/checkout/utils/__tests__/index.test.ts
+++ b/ts/features/payments/checkout/utils/__tests__/index.test.ts
@@ -89,10 +89,18 @@ describe("getPspFlagType", () => {
     expect(result).toBe("none");
   });
 
-  it("should return 'customer' when psp.onUs is true", () => {
+  it("should return 'customer' when psp.onUs is true and pspList is not empty", () => {
+    const psp = { onUs: true, idBundle: "1" };
+    const result = getPspFlagType(psp, [
+      { onUs: true, taxPayerFee: 1, idBundle: "1" }
+    ]);
+    expect(result).toBe("customer");
+  });
+
+  it("should return 'none' when pspList is empty", () => {
     const psp = { onUs: true, idBundle: "1" };
     const result = getPspFlagType(psp, []);
-    expect(result).toBe("customer");
+    expect(result).toBe("none");
   });
 
   it("should return 'unique' when pspList has only one element", () => {

--- a/ts/features/payments/checkout/utils/index.ts
+++ b/ts/features/payments/checkout/utils/index.ts
@@ -35,7 +35,7 @@ export const getPspFlagType = (
   psp: Bundle,
   pspList?: ReadonlyArray<Bundle>
 ): PaymentAnalyticsSelectedPspFlag => {
-  if (!pspList) {
+  if (!pspList || pspList.length === 0) {
     return "none";
   }
   if (psp.onUs) {

--- a/ts/features/payments/checkout/utils/index.ts
+++ b/ts/features/payments/checkout/utils/index.ts
@@ -44,8 +44,11 @@ export const getPspFlagType = (
   if (pspList.length === 1) {
     return "unique";
   }
-  const cheaperPsp = _.orderBy(pspList, psp => psp.taxPayerFee)[0];
-  return cheaperPsp.idBundle === psp.idBundle ? "cheaper" : "none";
+  const fees = pspList
+    .map(p => p.taxPayerFee)
+    .filter((fee): fee is number => typeof fee === "number");
+  const minFee = Math.min(...fees);
+  return psp.taxPayerFee === minFee ? "cheaper" : "none";
 };
 
 export const getPaymentPhaseFromStep = (


### PR DESCRIPTION
## Short description
This PR updates the `getPspFlagType` function in `ts/features/payments/checkout/utils/index.ts` to improve the handling of PSP fee comparison logic. This change ensures that when a user selects a PSP with the lowest fee, it is correctly tracked as "cheaper."
Previously, if multiple PSPs had the same (lowest) fee, only the first one in the list was marked as "cheaper."

## List of changes proposed in this pull request
Refactored the fee comparison logic in `getPspFlagType` to use `Math.min` on filtered numeric fees.

## How to test
- Start a payment flow and select a credit card as payment method;
- Select the cheaper PSP in the list and verify that if multiple PSPs have the same fee, selecting any of them (e.g., the second in the list) still correctly marks it as "cheaper."
