### PR TITLE
feat: [IOBP-1899] IDPay initiative `USED` badge status

### DIFF
--- a/locales/de/index.json
+++ b/locales/de/index.json
@@ -3974,7 +3974,8 @@
     "expiring": "Verfällt am {{endDate}}",
     "expired": "Abgelaufen am {{endDate}}",
     "paused": "In Pause",
-    "removed": "Entfernt"
+    "removed": "Entfernt",
+    "used": "Utilizzato"
   },
   "transaction": {
     "details": {

--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -6143,7 +6143,8 @@
     "expiring": "Scade il {{endDate}}",
     "expired": "Scaduta il {{endDate}}",
     "paused": "In pausa",
-    "removed": "Rimossa"
+    "removed": "Rimossa",
+    "used": "Utilizzato"
   },
   "transaction": {
     "details": {

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -6143,7 +6143,8 @@
     "expiring": "Scade il {{endDate}}",
     "expired": "Scaduta il {{endDate}}",
     "paused": "In pausa",
-    "removed": "Rimossa"
+    "removed": "Rimossa",
+    "used": "Utilizzato"
   },
   "transaction": {
     "details": {

--- a/ts/components/BonusCard/type.ts
+++ b/ts/components/BonusCard/type.ts
@@ -3,4 +3,5 @@ export type BonusStatus =
   | "PAUSED"
   | "EXPIRING"
   | "EXPIRED"
-  | "REMOVED";
+  | "REMOVED"
+  | "USED";

--- a/ts/features/idpay/details/utils/index.tsx
+++ b/ts/features/idpay/details/utils/index.tsx
@@ -20,6 +20,11 @@ export const getInitiativeStatus = ({
     return "REMOVED";
   }
 
+  // TODO replace with initiative.status === "USED" when the API is updated
+  if (initiative.status === StatusEnum.SUSPENDED) {
+    return "USED";
+  }
+
   if (now > initiative.endDate) {
     return "EXPIRED";
   }
@@ -80,6 +85,14 @@ export function IdPayCardStatus({ now, initiative }: InitiativeProps) {
           testID="idpay-card-status-removed"
           variant="error"
           text={I18n.t("bonusCard.removed")}
+        />
+      );
+    case "USED":
+      return (
+        <Tag
+          testID="idpay-card-status-used"
+          variant="success"
+          text={I18n.t("bonusCard.used")}
         />
       );
   }


### PR DESCRIPTION
## Short description
This pull request introduces the new `USED` status for bonus cards across multiple files, ensuring consistent handling and localization

## List of changes proposed in this pull request
- Added `USED` as a new status in the `BonusStatus` type definition
- Added handling for the `USED` status in the `IdPayCardStatus` component, displaying a success tag with localized text

## How to test
Simulate a `USED` status for an IDPay initiative and ensure that rendered screen is aligned with design 

## Preview 
<img width="232" alt="Screenshot 2025-07-23 at 17 11 54" src="https://github.com/user-attachments/assets/2e6dbf04-fc34-4839-b1e9-2f9ba71d7e05" />

