### PR TITLE
fix(IT Wallet): [SIW-2764] Update CieID authUrlRegex to support L3 flow

### DIFF
--- a/ts/features/itwallet/identification/screens/cieId/ItwCieIdLoginScreen.tsx
+++ b/ts/features/itwallet/identification/screens/cieId/ItwCieIdLoginScreen.tsx
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
 });
 
 const isAuthenticationUrl = (url: string) => {
-  const authUrlRegex = /\/(livello1|livello2|nextUrl|openApp)(\/|\?|$)/;
+  const authUrlRegex = /\/(livello[123]|nextUrl|openApp|app)(\/|\?|$)/;
   return authUrlRegex.test(url);
 };
 


### PR DESCRIPTION
## Short description
This PR fixes support for the L3 auth request with CieID.

## List of changes proposed in this pull request
- Fixed the `authUrlRegex` by adding support for `livello3` (iOS) and `app` (Android)

## How to test
The test must be performed on both the old "Documenti su IO" flow and the new "IT-Wallet" flow.  
Steps:

- Start a wallet creation, accept the TOS, and when prompted, use CieID as the authentication method.
- "Documenti su IO" supports L2, so you just need a plain CieID account. "IT-Wallet" requires you to have L3 configured in the CieID app.
- If you reach the final screen and successfully obtain the eID/PID, the test is successful.

> [!NOTE]
> If you have not configured L3 in your CieID app, Android will show the correct K.O. screen. iOS, instead, will remain stuck on the loading screen due to a CieID app limitation that is beyond our control.