### PR TITLE
fix: [IOBP-1905] Adjust carousel spacing on empty transactions list

### DIFF
--- a/ts/features/payments/home/screens/PaymentsHomeScreen.tsx
+++ b/ts/features/payments/home/screens/PaymentsHomeScreen.tsx
@@ -1,11 +1,10 @@
-import { ContentWrapper } from "@pagopa/io-app-design-system";
 import * as pot from "@pagopa/ts-commons/lib/pot";
+import { useFocusEffect } from "@react-navigation/native";
 import { useCallback, useState } from "react";
 import Animated, {
   LinearTransition,
   useAnimatedRef
 } from "react-native-reanimated";
-import { useFocusEffect } from "@react-navigation/native";
 import {
   IOScrollView,
   IOScrollViewActions
@@ -191,11 +190,7 @@ const PaymentsHomeScreenContent = () => {
 
   return (
     <>
-      <ContentWrapper>
-        <PaymentsHomeUserMethodsList
-          enforcedLoadingState={isLoadingFirstTime}
-        />
-      </ContentWrapper>
+      <PaymentsHomeUserMethodsList enforcedLoadingState={isLoadingFirstTime} />
       <PaymentsHomeTransactionsList enforcedLoadingState={isLoadingFirstTime} />
     </>
   );


### PR DESCRIPTION
## Short description
This pull request fix the `PaymentsHomeScreen` card carousel by removing unnecessary `ContentWrapper` component that is adding extra horizontal spacing

## List of changes proposed in this pull request
-Removed `ContentWrapper` wrapper from `PaymentsHomeUserMethodsList` streamlining the layout

## How to test
- On dev-server change [that line simulating no remote transactions](https://github.com/pagopa/io-dev-api-server/blob/0ec7f23a4fa4b1d0d53714280e6323e870b9f3fd/src/config.ts#L191)
- Ensure that now with no transactions, carousel has no more horizontal padding 

## Preview

https://github.com/user-attachments/assets/b544d3be-0b73-4f63-b2db-097028fc8401

