### PR TITLE
fix(IT Wallet): [SIW-2813] Split attestation utils between v1 and v2

### DIFF
--- a/ts/features/itwallet/common/utils/itwAttestationUtils.ts
+++ b/ts/features/itwallet/common/utils/itwAttestationUtils.ts
@@ -1,19 +1,8 @@
-import {
-  createCryptoContextFor,
-  IntegrityContext,
-  WalletInstance,
-  WalletInstanceAttestation as WalletInstanceAttestationV1
-} from "@pagopa/io-react-native-wallet";
-import { WalletInstanceAttestation as WalletInstanceAttestationV2 } from "@pagopa/io-react-native-wallet-v2";
-import * as Sentry from "@sentry/react-native";
 import { SessionToken } from "../../../../types/SessionToken";
-import { createItWalletFetch } from "../../api/client";
-import { regenerateCryptoKey, WIA_KEYTAG } from "./itwCryptoContextUtils";
-import {
-  generateIntegrityHardwareKeyTag,
-  getIntegrityContext
-} from "./itwIntegrityUtils";
+import { generateIntegrityHardwareKeyTag } from "./itwIntegrityUtils";
 import { WalletInstanceAttestations } from "./itwTypesUtils.ts";
+import * as AttestationUtilsV1 from "./itwAttestationUtils.v1";
+import * as AttestationUtilsV2 from "./itwAttestationUtils.v2";
 import { Env } from "./environment.ts";
 
 /**
@@ -30,24 +19,22 @@ export const getIntegrityHardwareKeyTag = async (): Promise<string> =>
  * @param sessionToken - the session token to use for the API calls
  */
 export const registerWalletInstance = async (
-  { WALLET_PROVIDER_BASE_URL }: Env,
+  env: Env,
   hardwareKeyTag: string,
-  sessionToken: SessionToken
-) => {
-  const integrityContext = getIntegrityContext(hardwareKeyTag);
-  // Check if the wallet instance has been revoked
-  // This must be used only for API calls mediated through our backend which are related to the wallet instance only
-  const appFetch = createItWalletFetch(
-    sessionToken,
-    WALLET_PROVIDER_BASE_URL,
-    WALLET_PROVIDER_BASE_URL
-  );
-  await WalletInstance.createWalletInstance({
-    integrityContext,
-    walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
-    appFetch
-  });
-};
+  sessionToken: SessionToken,
+  newApiEnabled: boolean = false
+) =>
+  newApiEnabled
+    ? AttestationUtilsV2.registerWalletInstance(
+        env,
+        hardwareKeyTag,
+        sessionToken
+      )
+    : AttestationUtilsV1.registerWalletInstance(
+        env,
+        hardwareKeyTag,
+        sessionToken
+      );
 
 /**
  * Getter for the wallet attestation binded to the wallet instance created with the given hardwareKeyTag.
@@ -58,45 +45,14 @@ export const registerWalletInstance = async (
  * @return the wallet attestation in multiple formats
  */
 export const getAttestation = async (
-  { WALLET_PROVIDER_BASE_URL }: Env,
+  env: Env,
   hardwareKeyTag: string,
   sessionToken: SessionToken,
   newApiEnabled: boolean = false
-): Promise<WalletInstanceAttestations> => {
-  const WalletInstanceAttestation = newApiEnabled
-    ? WalletInstanceAttestationV2
-    : WalletInstanceAttestationV1;
-
-  const integrityContext = getIntegrityContext(hardwareKeyTag);
-
-  await regenerateCryptoKey(WIA_KEYTAG);
-  const wiaCryptoContext = createCryptoContextFor(WIA_KEYTAG);
-  const appFetch = createItWalletFetch(
-    sessionToken,
-    WALLET_PROVIDER_BASE_URL,
-    WALLET_PROVIDER_BASE_URL
-  );
-
-  const attestation = await WalletInstanceAttestation.getAttestation({
-    wiaCryptoContext,
-    integrityContext,
-    walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
-    appFetch
-  });
-
-  // Handle legacy attestation format
-  if (typeof attestation === "string") {
-    return { jwt: attestation };
-  }
-
-  return attestation.reduce(
-    (acc, { format, wallet_attestation }) => ({
-      ...acc,
-      [format]: wallet_attestation
-    }),
-    {} as WalletInstanceAttestations
-  );
-};
+): Promise<WalletInstanceAttestations> =>
+  newApiEnabled
+    ? AttestationUtilsV2.getAttestation(env, hardwareKeyTag, sessionToken)
+    : AttestationUtilsV1.getAttestation(env, hardwareKeyTag, sessionToken);
 
 /**
  * Checks if the Wallet Instance Attestation needs to be requested by
@@ -108,22 +64,10 @@ export const getAttestation = async (
 export const isWalletInstanceAttestationValid = (
   attestation: string,
   newApiEnabled: boolean = false
-): boolean => {
-  const WalletInstanceAttestation = newApiEnabled
-    ? WalletInstanceAttestationV2
-    : WalletInstanceAttestationV1;
-  // To keep things simple we store the old and new attestation under the same key,
-  // so we might end up with a valid old attestation for the new flow.
-  // We let decoding fail and catch the error to force the correct attestation to be fetched again.
-  try {
-    const { payload } = WalletInstanceAttestation.decode(attestation);
-    const expiryDate = new Date(payload.exp * 1000);
-    const now = new Date();
-    return now < expiryDate;
-  } catch {
-    return false;
-  }
-};
+): boolean =>
+  newApiEnabled
+    ? AttestationUtilsV2.isWalletInstanceAttestationValid(attestation)
+    : AttestationUtilsV1.isWalletInstanceAttestationValid(attestation);
 
 /**
  * Get the wallet instance status from the Wallet Provider.
@@ -133,20 +77,22 @@ export const isWalletInstanceAttestationValid = (
  * @param sessionToken The session token to use for the API calls
  */
 export const getWalletInstanceStatus = (
-  { WALLET_PROVIDER_BASE_URL }: Env,
+  env: Env,
   hardwareKeyTag: string,
-  sessionToken: SessionToken
+  sessionToken: SessionToken,
+  newApiEnabled: boolean = false
 ) =>
-  WalletInstance.getWalletInstanceStatus({
-    id: hardwareKeyTag,
-    walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
-    appFetch: createItWalletFetch(
-      sessionToken,
-      WALLET_PROVIDER_BASE_URL,
-      WALLET_PROVIDER_BASE_URL
-    )
-  });
-
+  newApiEnabled
+    ? AttestationUtilsV2.getWalletInstanceStatus(
+        env,
+        hardwareKeyTag,
+        sessionToken
+      )
+    : AttestationUtilsV1.getWalletInstanceStatus(
+        env,
+        hardwareKeyTag,
+        sessionToken
+      );
 /**
  * Get the current wallet instance status from the Wallet Provider.
  * This operation will check the wallet instance status based on the current fiscal code of the user.
@@ -154,24 +100,10 @@ export const getWalletInstanceStatus = (
  * @param sessionToken The session token to use for the API calls
  */
 export const getCurrentWalletInstanceStatus = (
-  { WALLET_PROVIDER_BASE_URL }: Env,
-  sessionToken: SessionToken
-) => {
-  try {
-    return WalletInstance.getCurrentWalletInstanceStatus({
-      walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
-      appFetch: createItWalletFetch(
-        sessionToken,
-        WALLET_PROVIDER_BASE_URL,
-        WALLET_PROVIDER_BASE_URL
-      )
-    });
-  } catch (e) {
-    Sentry.captureException(e, {
-      tags: {
-        isRequired: true
-      }
-    });
-    throw e;
-  }
-};
+  env: Env,
+  sessionToken: SessionToken,
+  newApiEnabled: boolean = false
+) =>
+  newApiEnabled
+    ? AttestationUtilsV2.getCurrentWalletInstanceStatus(env, sessionToken)
+    : AttestationUtilsV1.getCurrentWalletInstanceStatus(env, sessionToken);

--- a/ts/features/itwallet/common/utils/itwAttestationUtils.v1.ts
+++ b/ts/features/itwallet/common/utils/itwAttestationUtils.v1.ts
@@ -1,0 +1,143 @@
+import {
+  createCryptoContextFor,
+  WalletInstance,
+  WalletInstanceAttestation
+} from "@pagopa/io-react-native-wallet";
+import * as Sentry from "@sentry/react-native";
+import { SessionToken } from "../../../../types/SessionToken.ts";
+import { createItWalletFetch } from "../../api/client.ts";
+import { regenerateCryptoKey, WIA_KEYTAG } from "./itwCryptoContextUtils.ts";
+import { getIntegrityContext } from "./itwIntegrityUtils.ts";
+import { WalletInstanceAttestations } from "./itwTypesUtils.ts";
+import { Env } from "./environment.ts";
+
+/**
+ * Register a new wallet instance with hardwareKeyTag.
+ * @param env - The environment to use for the wallet provider base URL
+ * @param hardwareKeyTag - the hardware key tag of the integrity Context
+ * @param sessionToken - the session token to use for the API calls
+ */
+export const registerWalletInstance = async (
+  { WALLET_PROVIDER_BASE_URL }: Env,
+  hardwareKeyTag: string,
+  sessionToken: SessionToken
+) => {
+  const integrityContext = getIntegrityContext(hardwareKeyTag);
+  // Check if the wallet instance has been revoked
+  // This must be used only for API calls mediated through our backend which are related to the wallet instance only
+  const appFetch = createItWalletFetch(
+    sessionToken,
+    WALLET_PROVIDER_BASE_URL,
+    WALLET_PROVIDER_BASE_URL
+  );
+  await WalletInstance.createWalletInstance({
+    integrityContext,
+    walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
+    appFetch
+  });
+};
+
+/**
+ * Getter for the wallet attestation binded to the wallet instance created with the given hardwareKeyTag.
+ * @param env - The environment to use for the wallet provider base URL
+ * @param hardwareKeyTag - the hardware key tag of the wallet instance
+ * @param sessionToken - the session token to use for the API calls
+ * @return the wallet attestation in multiple formats
+ */
+export const getAttestation = async (
+  { WALLET_PROVIDER_BASE_URL }: Env,
+  hardwareKeyTag: string,
+  sessionToken: SessionToken
+): Promise<WalletInstanceAttestations> => {
+  const integrityContext = getIntegrityContext(hardwareKeyTag);
+
+  await regenerateCryptoKey(WIA_KEYTAG);
+  const wiaCryptoContext = createCryptoContextFor(WIA_KEYTAG);
+  const appFetch = createItWalletFetch(
+    sessionToken,
+    WALLET_PROVIDER_BASE_URL,
+    WALLET_PROVIDER_BASE_URL
+  );
+
+  const attestation = await WalletInstanceAttestation.getAttestation({
+    wiaCryptoContext,
+    integrityContext,
+    walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
+    appFetch
+  });
+
+  return { jwt: attestation };
+};
+
+/**
+ * Checks if the Wallet Instance Attestation needs to be requested by
+ * checking the expiry date
+ * @param attestation - the Wallet Instance Attestation to validate
+ * @returns true if the Wallet Instance Attestation is expired or not present
+ */
+export const isWalletInstanceAttestationValid = (
+  attestation: string
+): boolean => {
+  // To keep things simple we store the old and new attestation under the same key,
+  // so we might end up with a valid old attestation for the new flow.
+  // We let decoding fail and catch the error to force the correct attestation to be fetched again.
+  try {
+    const { payload } = WalletInstanceAttestation.decode(attestation);
+    const expiryDate = new Date(payload.exp * 1000);
+    const now = new Date();
+    return now < expiryDate;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Get the wallet instance status from the Wallet Provider.
+ * This operation is more lightweight than getting a new attestation to check the status.
+ * @param env - The environment to use for the wallet provider base URL
+ * @param hardwareKeyTag The hardware key tag used to create the wallet instance
+ * @param sessionToken The session token to use for the API calls
+ */
+export const getWalletInstanceStatus = (
+  { WALLET_PROVIDER_BASE_URL }: Env,
+  hardwareKeyTag: string,
+  sessionToken: SessionToken
+) =>
+  WalletInstance.getWalletInstanceStatus({
+    id: hardwareKeyTag,
+    walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
+    appFetch: createItWalletFetch(
+      sessionToken,
+      WALLET_PROVIDER_BASE_URL,
+      WALLET_PROVIDER_BASE_URL
+    )
+  });
+
+/**
+ * Get the current wallet instance status from the Wallet Provider.
+ * This operation will check the wallet instance status based on the current fiscal code of the user.
+ * @param env - The environment to use for the wallet provider base URL
+ * @param sessionToken The session token to use for the API calls
+ */
+export const getCurrentWalletInstanceStatus = (
+  { WALLET_PROVIDER_BASE_URL }: Env,
+  sessionToken: SessionToken
+) => {
+  try {
+    return WalletInstance.getCurrentWalletInstanceStatus({
+      walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
+      appFetch: createItWalletFetch(
+        sessionToken,
+        WALLET_PROVIDER_BASE_URL,
+        WALLET_PROVIDER_BASE_URL
+      )
+    });
+  } catch (e) {
+    Sentry.captureException(e, {
+      tags: {
+        isRequired: true
+      }
+    });
+    throw e;
+  }
+};

--- a/ts/features/itwallet/common/utils/itwAttestationUtils.v2.ts
+++ b/ts/features/itwallet/common/utils/itwAttestationUtils.v2.ts
@@ -1,0 +1,149 @@
+import {
+  WalletInstance,
+  WalletInstanceAttestation,
+  createCryptoContextFor
+} from "@pagopa/io-react-native-wallet-v2";
+import * as Sentry from "@sentry/react-native";
+import { SessionToken } from "../../../../types/SessionToken";
+import { createItWalletFetch } from "../../api/client";
+import { regenerateCryptoKey, WIA_KEYTAG } from "./itwCryptoContextUtils";
+import { getIntegrityContext } from "./itwIntegrityUtils";
+import { WalletInstanceAttestations } from "./itwTypesUtils.ts";
+import { Env } from "./environment.ts";
+
+/**
+ * Register a new wallet instance with hardwareKeyTag.
+ * @param env - The environment to use for the wallet provider base URL
+ * @param hardwareKeyTag - the hardware key tag of the integrity Context
+ * @param sessionToken - the session token to use for the API calls
+ */
+export const registerWalletInstance = async (
+  { WALLET_PROVIDER_BASE_URL }: Env,
+  hardwareKeyTag: string,
+  sessionToken: SessionToken
+) => {
+  const integrityContext = getIntegrityContext(hardwareKeyTag);
+  // Check if the wallet instance has been revoked
+  // This must be used only for API calls mediated through our backend which are related to the wallet instance only
+  const appFetch = createItWalletFetch(
+    sessionToken,
+    WALLET_PROVIDER_BASE_URL,
+    WALLET_PROVIDER_BASE_URL
+  );
+  await WalletInstance.createWalletInstance({
+    integrityContext,
+    walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
+    appFetch
+  });
+};
+
+/**
+ * Getter for the wallet attestation binded to the wallet instance created with the given hardwareKeyTag.
+ * @param env - The environment to use for the wallet provider base URL
+ * @param hardwareKeyTag - the hardware key tag of the wallet instance
+ * @param sessionToken - the session token to use for the API calls
+ * @return the wallet attestation in multiple formats
+ */
+export const getAttestation = async (
+  { WALLET_PROVIDER_BASE_URL }: Env,
+  hardwareKeyTag: string,
+  sessionToken: SessionToken
+): Promise<WalletInstanceAttestations> => {
+  const integrityContext = getIntegrityContext(hardwareKeyTag);
+
+  await regenerateCryptoKey(WIA_KEYTAG);
+  const wiaCryptoContext = createCryptoContextFor(WIA_KEYTAG);
+  const appFetch = createItWalletFetch(
+    sessionToken,
+    WALLET_PROVIDER_BASE_URL,
+    WALLET_PROVIDER_BASE_URL
+  );
+
+  const attestation = await WalletInstanceAttestation.getAttestation({
+    wiaCryptoContext,
+    integrityContext,
+    walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
+    appFetch
+  });
+
+  return attestation.reduce(
+    (acc, { format, wallet_attestation }) => ({
+      ...acc,
+      [format]: wallet_attestation
+    }),
+    {} as WalletInstanceAttestations
+  );
+};
+
+/**
+ * Checks if the Wallet Instance Attestation needs to be requested by
+ * checking the expiry date
+ * @param attestation - the Wallet Instance Attestation to validate
+ * @returns true if the Wallet Instance Attestation is expired or not present
+ */
+export const isWalletInstanceAttestationValid = (
+  attestation: string
+): boolean => {
+  // To keep things simple we store the old and new attestation under the same key,
+  // so we might end up with a valid old attestation for the new flow.
+  // We let decoding fail and catch the error to force the correct attestation to be fetched again.
+  try {
+    const { payload } = WalletInstanceAttestation.decode(attestation);
+    const expiryDate = new Date(payload.exp * 1000);
+    const now = new Date();
+    return now < expiryDate;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Get the wallet instance status from the Wallet Provider.
+ * This operation is more lightweight than getting a new attestation to check the status.
+ * @param env - The environment to use for the wallet provider base URL
+ * @param hardwareKeyTag The hardware key tag used to create the wallet instance
+ * @param sessionToken The session token to use for the API calls
+ */
+export const getWalletInstanceStatus = (
+  { WALLET_PROVIDER_BASE_URL }: Env,
+  hardwareKeyTag: string,
+  sessionToken: SessionToken
+) =>
+  WalletInstance.getWalletInstanceStatus({
+    id: hardwareKeyTag,
+    walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
+    appFetch: createItWalletFetch(
+      sessionToken,
+      WALLET_PROVIDER_BASE_URL,
+      WALLET_PROVIDER_BASE_URL
+    )
+  });
+
+/**
+ * Get the current wallet instance status from the Wallet Provider.
+ * This operation will check the wallet instance status based on the current fiscal code of the user.
+ * @param env - The environment to use for the wallet provider base URL
+ * @param sessionToken The session token to use for the API calls
+ */
+export const getCurrentWalletInstanceStatus = (
+  { WALLET_PROVIDER_BASE_URL }: Env,
+  sessionToken: SessionToken
+) => {
+  try {
+    return WalletInstance.getCurrentWalletInstanceStatus({
+      walletProviderBaseUrl: WALLET_PROVIDER_BASE_URL,
+      appFetch: createItWalletFetch(
+        sessionToken,
+        WALLET_PROVIDER_BASE_URL,
+        WALLET_PROVIDER_BASE_URL
+      )
+    });
+  } catch (e) {
+    Sentry.captureException(e, {
+      tags: {
+        isRequired: true
+      }
+    });
+    throw e;
+  }
+};

--- a/ts/features/itwallet/lifecycle/saga/__tests__/checkWalletInstanceStateSaga.test.ts
+++ b/ts/features/itwallet/lifecycle/saga/__tests__/checkWalletInstanceStateSaga.test.ts
@@ -55,7 +55,8 @@ describe("checkWalletInstanceStateSaga", () => {
           credentials: { credentials: {} },
           environment: {
             env: "prod"
-          }
+          },
+          preferences: {}
         }
       }
     };
@@ -84,7 +85,8 @@ describe("checkWalletInstanceStateSaga", () => {
           credentials: { credentials: {} },
           environment: {
             env: "prod"
-          }
+          },
+          preferences: {}
         }
       }
     };
@@ -114,7 +116,8 @@ describe("checkWalletInstanceStateSaga", () => {
           },
           environment: {
             env: "prod"
-          }
+          },
+          preferences: {}
         }
       }
     };
@@ -144,7 +147,8 @@ describe("checkWalletInstanceStateSaga", () => {
           },
           environment: {
             env: "prod"
-          }
+          },
+          preferences: {}
         }
       }
     };

--- a/ts/features/itwallet/lifecycle/saga/checkCurrentWalletInstanceStateSaga.ts
+++ b/ts/features/itwallet/lifecycle/saga/checkCurrentWalletInstanceStateSaga.ts
@@ -7,15 +7,22 @@ import { selectItwEnv } from "../../common/store/selectors/environment.ts";
 import { getEnv } from "../../common/utils/environment.ts";
 import { getCurrentWalletInstanceStatus } from "../../common/utils/itwAttestationUtils.ts";
 import { itwLifecycleIsValidSelector } from "../store/selectors";
+import { itwIsL3EnabledSelector } from "../../common/store/selectors/preferences.ts";
 
 export function* getCurrentStatusWalletInstance() {
   const sessionToken = yield* select(sessionTokenSelector);
+  const isWhiteListed = yield* select(itwIsL3EnabledSelector); // TODO: [SIW-2530] remove after full migration to API 1.0
   assert(sessionToken, "Missing session token");
 
   const env = getEnv(yield* select(selectItwEnv));
 
   try {
-    return yield* call(getCurrentWalletInstanceStatus, env, sessionToken);
+    return yield* call(
+      getCurrentWalletInstanceStatus,
+      env,
+      sessionToken,
+      isWhiteListed
+    );
   } catch (e) {
     return undefined;
   }

--- a/ts/features/itwallet/lifecycle/saga/checkWalletInstanceStateSaga.ts
+++ b/ts/features/itwallet/lifecycle/saga/checkWalletInstanceStateSaga.ts
@@ -15,12 +15,14 @@ import { getWalletInstanceStatus } from "../../common/utils/itwAttestationUtils"
 import { itwCredentialsEidSelector } from "../../credentials/store/selectors";
 import { itwIntegrityKeyTagSelector } from "../../issuance/store/selectors";
 import { itwUpdateWalletInstanceStatus } from "../../walletInstance/store/actions";
+import { itwIsL3EnabledSelector } from "../../common/store/selectors/preferences";
 import { itwLifecycleIsOperationalOrValid } from "../store/selectors";
 import { checkIntegrityServiceReadySaga } from "./checkIntegrityServiceReadySaga";
 import { handleWalletInstanceResetSaga } from "./handleWalletInstanceResetSaga";
 
 export function* getStatusOrResetWalletInstance(integrityKeyTag: string) {
   const sessionToken = yield* select(sessionTokenSelector);
+  const isWhiteListed = yield* select(itwIsL3EnabledSelector); // TODO: [SIW-2530] remove after full migration to API 1.0
   assert(sessionToken, "Missing session token");
 
   const env = getEnv(yield* select(selectItwEnv));
@@ -30,7 +32,8 @@ export function* getStatusOrResetWalletInstance(integrityKeyTag: string) {
       getWalletInstanceStatus,
       env,
       integrityKeyTag,
-      sessionToken
+      sessionToken,
+      isWhiteListed
     );
 
     if (walletInstanceStatus.is_revoked) {

--- a/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
+++ b/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../common/utils/itwTypesUtils";
 import { ItwTags } from "../../tags";
 import {
+  CreateWalletInstanceActorParams,
   GetWalletAttestationActorParams,
   RequestEidActorParams,
   StartAuthFlowActorParams,
@@ -118,7 +119,10 @@ describe("itwEidIssuanceMachine", () => {
       verifyTrustFederation: fromPromise<void, VerifyTrustFederationParams>(
         verifyTrustFederation
       ),
-      createWalletInstance: fromPromise<string>(createWalletInstance),
+      createWalletInstance: fromPromise<
+        string,
+        CreateWalletInstanceActorParams
+      >(createWalletInstance),
       revokeWalletInstance: fromPromise<void>(revokeWalletInstance),
       getWalletAttestation: fromPromise<
         WalletInstanceAttestations,

--- a/ts/features/itwallet/machine/eid/actors.ts
+++ b/ts/features/itwallet/machine/eid/actors.ts
@@ -31,6 +31,10 @@ import type {
   IdentificationContext
 } from "./context";
 
+export type CreateWalletInstanceActorParams = {
+  isL3IssuanceEnabled?: boolean;
+};
+
 export type RequestEidActorParams = {
   identification: IdentificationContext | undefined;
   walletInstanceAttestation: string | undefined;
@@ -97,34 +101,41 @@ export const createEidIssuanceActorsImplementation = (
     }
   ),
 
-  createWalletInstance: fromPromise<string>(async () => {
-    const sessionToken = sessionTokenSelector(store.getState());
-    assert(sessionToken, "sessionToken is undefined");
+  createWalletInstance: fromPromise<string, CreateWalletInstanceActorParams>(
+    async ({ input }) => {
+      const sessionToken = sessionTokenSelector(store.getState());
+      assert(sessionToken, "sessionToken is undefined");
 
-    // Reset the wallet store to prevent having dirty state before registering a new wallet instance
-    store.dispatch(itwLifecycleStoresReset());
+      // Reset the wallet store to prevent having dirty state before registering a new wallet instance
+      store.dispatch(itwLifecycleStoresReset());
 
-    // Await the integrity preparation before requesting the integrity key tag
-    const integrityServiceStatus = await pollForStoreValue({
-      getState: store.getState,
-      selector: itwIntegrityServiceStatusSelector,
-      condition: value => value !== undefined
-    }).catch(() => {
-      throw new Error("Integrity service status check timed out");
-    });
+      // Await the integrity preparation before requesting the integrity key tag
+      const integrityServiceStatus = await pollForStoreValue({
+        getState: store.getState,
+        selector: itwIntegrityServiceStatusSelector,
+        condition: value => value !== undefined
+      }).catch(() => {
+        throw new Error("Integrity service status check timed out");
+      });
 
-    // If the integrity service preparation is not ready (still undefined) or in an error state after 10 seconds the user will be prompted with an error,
-    // he will need to retry.
-    assert(
-      integrityServiceStatus === "ready",
-      `Integrity service status is ${integrityServiceStatus}`
-    );
+      // If the integrity service preparation is not ready (still undefined) or in an error state after 10 seconds the user will be prompted with an error,
+      // he will need to retry.
+      assert(
+        integrityServiceStatus === "ready",
+        `Integrity service status is ${integrityServiceStatus}`
+      );
 
-    const hardwareKeyTag = await getIntegrityHardwareKeyTag();
-    await registerWalletInstance(env, hardwareKeyTag, sessionToken);
+      const hardwareKeyTag = await getIntegrityHardwareKeyTag();
+      await registerWalletInstance(
+        env,
+        hardwareKeyTag,
+        sessionToken,
+        input.isL3IssuanceEnabled
+      );
 
-    return hardwareKeyTag;
-  }),
+      return hardwareKeyTag;
+    }
+  ),
 
   getWalletAttestation: fromPromise<
     WalletInstanceAttestations,

--- a/ts/features/itwallet/machine/eid/machine.ts
+++ b/ts/features/itwallet/machine/eid/machine.ts
@@ -11,7 +11,8 @@ import {
   GetWalletAttestationActorParams,
   type RequestEidActorParams,
   StartAuthFlowActorParams,
-  VerifyTrustFederationParams
+  VerifyTrustFederationParams,
+  CreateWalletInstanceActorParams
 } from "./actors";
 import {
   AuthenticationContext,
@@ -113,7 +114,9 @@ export const itwEidIssuanceMachine = setup({
       notImplemented
     ),
     getCieStatus: fromPromise<CieContext>(notImplemented),
-    createWalletInstance: fromPromise<string>(notImplemented),
+    createWalletInstance: fromPromise<string, CreateWalletInstanceActorParams>(
+      notImplemented
+    ),
     revokeWalletInstance: fromPromise<void>(notImplemented),
     getWalletAttestation: fromPromise<
       WalletInstanceAttestations,
@@ -242,6 +245,9 @@ export const itwEidIssuanceMachine = setup({
       tags: [ItwTags.Loading],
       invoke: {
         src: "createWalletInstance",
+        input: ({ context }) => ({
+          isL3IssuanceEnabled: context.isL3FeaturesEnabled
+        }),
         onDone: {
           actions: [
             assign(({ event }) => ({


### PR DESCRIPTION
## Short description
This PR splits `itwAttestationUtils.ts` into two files to avoid mixed imports of `io-react-native-wallet` v1 and v2.

Without this clear separation, `createCryptoContextFor` was imported only from v1, so the Wallet Attestation's `cnf.jwk` could be affected by the 33 bytes issue; later, when using the Wallet Attestation to request a IT-Wallet credential, the `createCryptoContextFor` from v2 was used and the two JWKs did not match.

> [!NOTE]
> The separation will be removed alongside the two versions `io-react-native-wallet`.

## List of changes proposed in this pull request
- Split `itwAttestationUtils.ts` into `itwAttestationUtils.v1.ts` and `itwAttestationUtils.v2.ts`
- Used the whitelisted status to choose between v1 and v2

## How to test
The problem is not easy to reproduce, as it only happens when a JWK with a coordinate of 33 bytes is generated. However, ensure the Wallet Attestation is fetched correctly when L3 flag is enabled and when it is disabled.
