### PR TITLE
feat(IT Wallet): [SIW-2817] Add ITW revocation CTA

### DIFF
--- a/locales/de/index.json
+++ b/locales/de/index.json
@@ -3779,7 +3779,7 @@
           "action": "Bestätige und fortfahren"
         },
         "loadingScreen": {
-          "title": "Wir deaktivieren Dokumente in IO...",
+          "title": "Wir deaktivieren {{name}}...",
           "subtitle": "Warte ein paar Sekunden"
         },
         "failureScreen": {

--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -5201,9 +5201,18 @@
           }
         },
         "itWalletId": {
-          "detail": {
-            "description": "È il tuo pass digitale per dimostrare chi sei, accedere ai servizi online e ottenere nuovi documenti.",
-            "listItemHeader": "Dati del mio IT-Wallet ID"
+          "description": "È il tuo pass digitale per dimostrare chi sei, accedere ai servizi online e ottenere nuovi documenti.",
+          "listItemHeader": "Dati del mio IT-Wallet ID",
+          "cta": {
+            "revoke": "Disattiva IT-Wallet"
+          },
+          "dialog": {
+            "revoke": {
+              "title": "Vuoi davvero disattivare IT-Wallet?",
+              "message": "Eliminerai i documenti che hai aggiunto al Portafoglio.\nSe cambi idea, potrai riattivare IT-Wallet in futuro.",
+              "confirm": "Sì, disattiva",
+              "cancel": "No, torna indietro"
+            }
           }
         }
       },
@@ -5228,7 +5237,7 @@
           "action": "Conferma e continua"
         },
         "loadingScreen": {
-          "title": "Stiamo disattivando Documenti su IO...",
+          "title": "Stiamo disattivando {{name}}...",
           "subtitle": "Attendi qualche secondo"
         },
         "failureScreen": {

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -5201,9 +5201,18 @@
           }
         },
         "itWalletId": {
-          "detail": {
-            "description": "È il tuo pass digitale per dimostrare chi sei, accedere ai servizi online e ottenere nuovi documenti.",
-            "listItemHeader": "Dati del mio IT-Wallet ID"
+          "description": "È il tuo pass digitale per dimostrare chi sei, accedere ai servizi online e ottenere nuovi documenti.",
+          "listItemHeader": "Dati del mio IT-Wallet ID",
+          "cta": {
+            "revoke": "Disattiva IT-Wallet"
+          },
+          "dialog": {
+            "revoke": {
+              "title": "Vuoi davvero disattivare IT-Wallet?",
+              "message": "Eliminerai i documenti che hai aggiunto al Portafoglio.\nSe cambi idea, potrai riattivare IT-Wallet in futuro.",
+              "confirm": "Sì, disattiva",
+              "cancel": "No, torna indietro"
+            }
           }
         }
       },
@@ -5228,7 +5237,7 @@
           "action": "Conferma e continua"
         },
         "loadingScreen": {
-          "title": "Stiamo disattivando Documenti su IO...",
+          "title": "Stiamo disattivando {{name}}...",
           "subtitle": "Attendi qualche secondo"
         },
         "failureScreen": {

--- a/ts/features/itwallet/lifecycle/screens/ItwLifecycleWalletRevocationScreen.tsx
+++ b/ts/features/itwallet/lifecycle/screens/ItwLifecycleWalletRevocationScreen.tsx
@@ -7,15 +7,19 @@ import LoadingScreenContent from "../../../../components/screens/LoadingScreenCo
 import { useItwDisableGestureNavigation } from "../../common/hooks/useItwDisableGestureNavigation";
 import { useAvoidHardwareBackButton } from "../../../../utils/useAvoidHardwareBackButton";
 import { useOfflineToastGuard } from "../../../../hooks/useOfflineToastGuard.ts";
+import { useIOSelector } from "../../../../store/hooks.ts";
+import { itwLifecycleIsITWalletValidSelector } from "../store/selectors/index.ts";
 
 const RevocationLoadingScreen = () => {
+  const isItwL3 = useIOSelector(itwLifecycleIsITWalletValidSelector);
   useItwDisableGestureNavigation();
   useAvoidHardwareBackButton();
 
   return (
     <LoadingScreenContent
       contentTitle={I18n.t(
-        "features.itWallet.walletRevocation.loadingScreen.title"
+        "features.itWallet.walletRevocation.loadingScreen.title",
+        { name: isItwL3 ? "IT-Wallet" : "Documenti su IO" }
       )}
     >
       <ContentWrapper style={{ alignItems: "center" }}>

--- a/ts/features/itwallet/machine/eid/machine.ts
+++ b/ts/features/itwallet/machine/eid/machine.ts
@@ -266,6 +266,7 @@ export const itwEidIssuanceMachine = setup({
     },
     WalletInstanceRevocation: {
       tags: [ItwTags.Loading],
+      entry: "navigateToWalletRevocationScreen",
       invoke: {
         src: "revokeWalletInstance",
         onDone: {

--- a/ts/features/itwallet/presentation/details/components/ItwPresentationPidDetail.tsx
+++ b/ts/features/itwallet/presentation/details/components/ItwPresentationPidDetail.tsx
@@ -22,7 +22,7 @@ export const ItwPresentationPidDetail = ({ credential }: Props) => {
   const navigation = useIONavigation();
 
   const listItemHeaderLabel = I18n.t(
-    "features.itWallet.presentation.itWalletId.detail.listItemHeader"
+    "features.itWallet.presentation.itWalletId.listItemHeader"
   );
   const claims = useMemo(
     () =>

--- a/ts/features/itwallet/presentation/details/components/ItwPresentationPidDetailFooter.tsx
+++ b/ts/features/itwallet/presentation/details/components/ItwPresentationPidDetailFooter.tsx
@@ -1,10 +1,11 @@
-import { View } from "react-native";
+import { Alert, View } from "react-native";
 import { ListItemAction } from "@pagopa/io-app-design-system";
 import { constNull } from "fp-ts/lib/function";
 import { memo } from "react";
 import I18n from "../../../../../i18n";
 import { useItwStartCredentialSupportRequest } from "../hooks/useItwStartCredentialSupportRequest";
 import { StoredCredential } from "../../../common/utils/itwTypesUtils";
+import { ItwEidIssuanceMachineContext } from "../../../machine/eid/provider";
 
 const POWERED_BY_IT_WALLET = "Powered by IT-Wallet";
 
@@ -13,12 +14,35 @@ type Props = {
 };
 
 const ItwPresentationPidDetailFooter = ({ credential }: Props) => {
+  const machineRef = ItwEidIssuanceMachineContext.useActorRef();
   const startAndTrackSupportRequest =
     useItwStartCredentialSupportRequest(credential);
 
   const requestAssistanceLabel = I18n.t(
     "features.itWallet.presentation.credentialDetails.actions.requestAssistance"
   );
+
+  const handleRevokePress = () => {
+    Alert.alert(
+      I18n.t("features.itWallet.presentation.itWalletId.dialog.revoke.title"),
+      I18n.t("features.itWallet.presentation.itWalletId.dialog.revoke.message"),
+      [
+        {
+          text: I18n.t(
+            "features.itWallet.presentation.itWalletId.dialog.revoke.confirm"
+          ),
+          style: "destructive",
+          onPress: () => machineRef.send({ type: "revoke-wallet-instance" })
+        },
+        {
+          text: I18n.t(
+            "features.itWallet.presentation.itWalletId.dialog.revoke.cancel"
+          ),
+          style: "cancel"
+        }
+      ]
+    );
+  };
 
   return (
     <View>
@@ -36,7 +60,15 @@ const ItwPresentationPidDetailFooter = ({ credential }: Props) => {
         accessibilityLabel={POWERED_BY_IT_WALLET}
         onPress={constNull}
       />
-      {/* TODO: add "remove from wallet" item */}
+      <ListItemAction
+        variant="danger"
+        icon="trashcan"
+        label={I18n.t("features.itWallet.presentation.itWalletId.cta.revoke")}
+        accessibilityLabel={I18n.t(
+          "features.itWallet.presentation.itWalletId.cta.revoke"
+        )}
+        onPress={handleRevokePress}
+      />
     </View>
   );
 };

--- a/ts/features/itwallet/presentation/details/components/ItwPresentationPidScaffoldScreen.tsx
+++ b/ts/features/itwallet/presentation/details/components/ItwPresentationPidScaffoldScreen.tsx
@@ -41,9 +41,7 @@ const ScreenHeader = memo(() => (
       <VStack space={16}>
         <H2>{I18n.t("features.itWallet.credentialName.pid")}</H2>
         <Body color="black">
-          {I18n.t(
-            "features.itWallet.presentation.itWalletId.detail.description"
-          )}
+          {I18n.t("features.itWallet.presentation.itWalletId.description")}
         </Body>
       </VStack>
     </ContentWrapper>


### PR DESCRIPTION
## Short description
This PR adds the revocation CTA within the IT Wallet ID screen

## List of changes proposed in this pull request
- Updated locales
- Added revocation CTA in [ItwPresentationPidDetailFooter.tsx](https://github.com/pagopa/io-app/compare/SIW-2817-add-itw-revoke-cta?expand=1#diff-85e939ce71e71f460fe654ed57a9b92c028315169e4c7338340854568c123669)

## How to test
1. Navigate to the IT Wallet ID screen
2. Tap on the revocation CTA at the bottom
3. Ensure that the wallet is correctly revoked

## Demo

<video src="https://github.com/user-attachments/assets/60f12b90-a613-452f-addd-df2f7ac1d4d6" />



