### PR TITLE
feat(IT Wallet): [SIW-2805] Added in invalid mdl bottom sheet to remove credential

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -4823,7 +4823,10 @@
           "statusAction": "Cosa posso fare?",
           "mdl": {
             "content": "Puoi usare la tua Patente su IO solo in Italia esclusivamente per dimostrare l'abilitazione alla guida in caso di controlli delle Forze dell'ordine.",
-            "contentL3": "La tua Patente su IO ha lo stesso valore legale del documento fisico, solo sul territorio italiano."
+            "contentL3": "La tua Patente su IO ha lo stesso valore legale del documento fisico, solo sul territorio italiano.",
+            "invalid": {
+              "cta": "Rimuovi documento dal Portafoglio"
+            }
           },
           "ehc": {
             "content": "Puoi usare la tua Tessera Sanitaria - Tessera europea di assicurazione malattia su IO per accedere alle prestazioni fornite dal Servizio Sanitario Nazionale."

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -4823,7 +4823,10 @@
           "statusAction": "Cosa posso fare?",
           "mdl": {
             "content": "Puoi usare la tua Patente su IO solo in Italia esclusivamente per dimostrare l'abilitazione alla guida in caso di controlli delle Forze dell'ordine.",
-            "contentL3": "La tua Patente su IO ha lo stesso valore legale del documento fisico, solo sul territorio italiano."
+            "contentL3": "La tua Patente su IO ha lo stesso valore legale del documento fisico, solo sul territorio italiano.",
+            "invalid": {
+              "cta": "Rimuovi documento dal Portafoglio"
+            }
           },
           "ehc": {
             "content": "Puoi usare la tua Tessera Sanitaria - Tessera europea di assicurazione malattia su IO per accedere alle prestazioni fornite dal Servizio Sanitario Nazionale."

--- a/ts/features/itwallet/presentation/details/components/ItwPresentationCredentialStatusAlert.tsx
+++ b/ts/features/itwallet/presentation/details/components/ItwPresentationCredentialStatusAlert.tsx
@@ -147,16 +147,16 @@ const IssuerDynamicErrorAlert = ({
       <VStack space={24}>
         <IOMarkdown content={localizedMessage.description} />
         {showCta && (
-                  <View style={{ marginBottom: 16 }}>
-                  <IOButton
-                    variant="solid"
-                    fullWidth
-                    label={I18n.t(
-                      "features.itWallet.presentation.alerts.mdl.invalid.cta"
-                    )}
-                    onPress={confirmAndRemoveCredential}
-                  />
-                </View>
+          <View style={{ marginBottom: 16 }}>
+            <IOButton
+              variant="solid"
+              fullWidth
+              label={I18n.t(
+                "features.itWallet.presentation.alerts.mdl.invalid.cta"
+              )}
+              onPress={confirmAndRemoveCredential}
+            />
+          </View>
         )}
       </VStack>
     )

--- a/ts/features/itwallet/presentation/details/components/ItwPresentationDetailsFooter.tsx
+++ b/ts/features/itwallet/presentation/details/components/ItwPresentationDetailsFooter.tsx
@@ -1,25 +1,15 @@
-import { ListItemAction, useIOToast } from "@pagopa/io-app-design-system";
+import { ListItemAction } from "@pagopa/io-app-design-system";
 import { memo, ReactNode, useMemo } from "react";
-import { Alert, View } from "react-native";
+import { View } from "react-native";
 import I18n from "../../../../../i18n.ts";
-import { useIONavigation } from "../../../../../navigation/params/AppParamsList.ts";
-import {
-  useIODispatch,
-  useIOSelector,
-  useIOStore
-} from "../../../../../store/hooks.ts";
-import {
-  CREDENTIALS_MAP,
-  trackCredentialDeleteProperties,
-  trackItwCredentialDelete
-} from "../../../analytics";
+import { useIOSelector } from "../../../../../store/hooks.ts";
 import { itwIPatenteCtaConfigSelector } from "../../../common/store/selectors/remoteConfig.ts";
 import { StoredCredential } from "../../../common/utils/itwTypesUtils.ts";
-import { itwCredentialsRemoveByType } from "../../../credentials/store/actions";
 import { useFIMSRemoteServiceConfiguration } from "../../../../fims/common/hooks";
 import { getCredentialDocumentNumber } from "../../../trustmark/utils";
 import { useOfflineToastGuard } from "../../../../../hooks/useOfflineToastGuard.ts";
 import { useItwStartCredentialSupportRequest } from "../hooks/useItwStartCredentialSupportRequest.tsx";
+import { useItwRemoveCredentialWithConfirm } from "../hooks/useItwRemoveCredentialWithConfirm";
 
 type ItwPresentationDetailFooterProps = {
   credential: StoredCredential;
@@ -32,52 +22,10 @@ type IPatenteListItemActionProps = {
 const ItwPresentationDetailsFooter = ({
   credential
 }: ItwPresentationDetailFooterProps) => {
-  const dispatch = useIODispatch();
-  const store = useIOStore();
-
-  const navigation = useIONavigation();
-  const toast = useIOToast();
-
   const startAndTrackSupportRequest =
     useItwStartCredentialSupportRequest(credential);
-
-  const handleRemoveCredential = () => {
-    dispatch(itwCredentialsRemoveByType(credential.credentialType));
-    toast.success(
-      I18n.t("features.itWallet.presentation.credentialDetails.toast.removed")
-    );
-    void trackCredentialDeleteProperties(
-      CREDENTIALS_MAP[credential.credentialType],
-      store.getState()
-    );
-
-    navigation.pop();
-  };
-
-  const showRemoveCredentialDialog = () => {
-    trackItwCredentialDelete(CREDENTIALS_MAP[credential.credentialType]);
-    return Alert.alert(
-      I18n.t(
-        "features.itWallet.presentation.credentialDetails.dialogs.remove.title"
-      ),
-      I18n.t(
-        "features.itWallet.presentation.credentialDetails.dialogs.remove.content"
-      ),
-      [
-        {
-          text: I18n.t(
-            "features.itWallet.presentation.credentialDetails.dialogs.remove.confirm"
-          ),
-          style: "destructive",
-          onPress: handleRemoveCredential
-        },
-        {
-          text: I18n.t("global.buttons.cancel"),
-          style: "cancel"
-        }
-      ]
-    );
-  };
+  const { confirmAndRemoveCredential } =
+    useItwRemoveCredentialWithConfirm(credential);
 
   const credentialActions = useMemo(
     () => getCredentialActions(credential),
@@ -109,7 +57,7 @@ const ItwPresentationDetailsFooter = ({
         accessibilityLabel={I18n.t(
           "features.itWallet.presentation.credentialDetails.actions.removeFromWallet"
         )}
-        onPress={showRemoveCredentialDialog}
+        onPress={confirmAndRemoveCredential}
       />
     </View>
   );

--- a/ts/features/itwallet/presentation/details/hooks/useItwRemoveCredentialWithConfirm.tsx
+++ b/ts/features/itwallet/presentation/details/hooks/useItwRemoveCredentialWithConfirm.tsx
@@ -1,0 +1,66 @@
+import { useIOToast } from "@pagopa/io-app-design-system";
+import I18n from "i18n-js";
+import { Alert } from "react-native";
+import { useIONavigation } from "../../../../../navigation/params/AppParamsList";
+import { useIODispatch, useIOStore } from "../../../../../store/hooks";
+import {
+  trackCredentialDeleteProperties,
+  CREDENTIALS_MAP,
+  trackItwCredentialDelete
+} from "../../../analytics";
+import { StoredCredential } from "../../../common/utils/itwTypesUtils";
+import { itwCredentialsRemoveByType } from "../../../credentials/store/actions";
+
+/**
+ * Hook that shows a confirmation dialog and, if confirmed, removes a credential from the wallet
+ */
+export const useItwRemoveCredentialWithConfirm = (
+  credential: StoredCredential
+) => {
+  const dispatch = useIODispatch();
+  const store = useIOStore();
+  const toast = useIOToast();
+  const navigation = useIONavigation();
+
+  const handleRemoveCredential = () => {
+    dispatch(itwCredentialsRemoveByType(credential.credentialType));
+    toast.success(
+      I18n.t("features.itWallet.presentation.credentialDetails.toast.removed")
+    );
+    void trackCredentialDeleteProperties(
+      CREDENTIALS_MAP[credential.credentialType],
+      store.getState()
+    );
+
+    navigation.pop();
+  };
+
+  const confirmAndRemoveCredential = () => {
+    trackItwCredentialDelete(CREDENTIALS_MAP[credential.credentialType]);
+    return Alert.alert(
+      I18n.t(
+        "features.itWallet.presentation.credentialDetails.dialogs.remove.title"
+      ),
+      I18n.t(
+        "features.itWallet.presentation.credentialDetails.dialogs.remove.content"
+      ),
+      [
+        {
+          text: I18n.t(
+            "features.itWallet.presentation.credentialDetails.dialogs.remove.confirm"
+          ),
+          style: "destructive",
+          onPress: handleRemoveCredential
+        },
+        {
+          text: I18n.t("global.buttons.cancel"),
+          style: "cancel"
+        }
+      ]
+    );
+  };
+
+  return {
+    confirmAndRemoveCredential
+  };
+};


### PR DESCRIPTION
## Short description
This PR adds a remove credential cta inside the bottom sheet that appears when tapping on the status alert for an invalid MDL.

## List of changes proposed in this pull request
- Created the `useItwRemoveCredentialWithConfirm` hook to encapsulate the logic for confirming and removing a credential.
- The removal logic was previously used in `ItwPresentationDetailsFooter`; now it's reused in both the footer and the invalid MDL bottom sheet through the new hook

## How to test
1. Request the MDL.
2. Use the proxy to simulate an invalid credential status.
3. Tap on the alert banner related to the invalid MDL.
4. Verify that the CTA to remove the credential appears inside the bottom sheet.
5. Tap the CTA and confirm the removal.
6. Verify that the credential has been successfully removed from the wallet.


https://github.com/user-attachments/assets/a6606497-9793-4d21-adba-5c119f47bf9c


