### PR TITLE
refactor: [IOBP-1931] Update IDPay operation details modal

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -5665,8 +5665,8 @@
             "labels": {
               "business": "Esercente",
               "status": "Stato",
-              "totalAmount": "Importo totale",
-              "idpayAmount": "Importo transazione ID Pay",
+              "totalAmount": "Importo del bene",
+              "idpayAmount": "Sconto riconosciuto",
               "transactionID": "ID transazione"
             }
           }

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -5665,8 +5665,8 @@
             "labels": {
               "business": "Esercente",
               "status": "Stato",
-              "totalAmount": "Importo totale",
-              "idpayAmount": "Importo transazione ID Pay",
+              "totalAmount": "Importo del bene",
+              "idpayAmount": "Sconto riconosciuto",
               "transactionID": "ID transazione"
             }
           }

--- a/ts/features/idpay/timeline/components/IdPayTimelineDetailsBottomSheet.tsx
+++ b/ts/features/idpay/timeline/components/IdPayTimelineDetailsBottomSheet.tsx
@@ -1,6 +1,4 @@
 import {
-  IOButton,
-  ContentWrapper,
   H6,
   IOSkeleton,
   Pictogram,
@@ -13,7 +11,7 @@ import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
 import * as t from "io-ts";
 import { useState } from "react";
-import { StyleSheet, View } from "react-native";
+import { View } from "react-native";
 import { InitiativeDTO } from "../../../../../definitions/idpay/InitiativeDTO";
 import { OperationListDTO } from "../../../../../definitions/idpay/OperationListDTO";
 import { OperationTypeEnum as RefundOperationTypeEnum } from "../../../../../definitions/idpay/RefundOperationDTO";
@@ -115,24 +113,9 @@ const useIdPayTimelineDetailsBottomSheet = (
       O.toUndefined
     );
   };
-
-  const modalFooter = (
-    <ContentWrapper>
-      <View style={styles.footer}>
-        <IOButton
-          fullWidth
-          variant="outline"
-          label={I18n.t("global.buttons.close")}
-          onPress={() => modal.dismiss()}
-        />
-      </View>
-    </ContentWrapper>
-  );
-
   const modal = useIOBottomSheetModal({
     component: getModalContent(),
-    title: titleComponent,
-    footer: modalFooter
+    title: titleComponent
   });
 
   const present = (operation: OperationListDTO) =>
@@ -179,12 +162,6 @@ const ErrorComponent = () => (
     <H6>{I18n.t("idpay.initiative.operationDetails.errorBody")}</H6>
   </View>
 );
-
-const styles = StyleSheet.create({
-  footer: {
-    paddingVertical: 16
-  }
-});
 
 export { useIdPayTimelineDetailsBottomSheet };
 export type { IdPayTimelineDetailsBottomSheetModal };


### PR DESCRIPTION
## Short description
This pull request refactor the `IdPayTimelineDetailsBottomSheet` to align the operation details modal to design

## List of changes proposed in this pull request
- Update locales
- Removed the `modalFooter` constant, which included a footer with a close button, and its associated styles. The `useIOBottomSheetModal` function no longer includes a `footer` property

## How to test
- Navigate into a discount bonus
- Tap on an list element
- Ensure displayed modal information are aligned with design 

## Preview

https://github.com/user-attachments/assets/a8bf24b1-4e2a-4f18-982e-4e99c481633b

