### PR TITLE
fix: [IOBP-1940] Wrong banner and text layout alignment

### DIFF
--- a/ts/features/payments/home/screens/PaymentsHomeScreen.tsx
+++ b/ts/features/payments/home/screens/PaymentsHomeScreen.tsx
@@ -1,3 +1,4 @@
+import { ContentWrapper } from "@pagopa/io-app-design-system";
 import * as pot from "@pagopa/ts-commons/lib/pot";
 import { useFocusEffect } from "@react-navigation/native";
 import { useCallback, useState } from "react";
@@ -123,6 +124,7 @@ const PaymentsHomeScreen = () => {
   if (isTransactionsEmpty) {
     return (
       <IOScrollView
+        includeContentMargins={false}
         animatedRef={scrollViewContentRef}
         contentContainerStyle={{
           flexGrow: 1
@@ -190,7 +192,11 @@ const PaymentsHomeScreenContent = () => {
 
   return (
     <>
-      <PaymentsHomeUserMethodsList enforcedLoadingState={isLoadingFirstTime} />
+      <ContentWrapper>
+        <PaymentsHomeUserMethodsList
+          enforcedLoadingState={isLoadingFirstTime}
+        />
+      </ContentWrapper>
       <PaymentsHomeTransactionsList enforcedLoadingState={isLoadingFirstTime} />
     </>
   );


### PR DESCRIPTION
## Short description
This pull request fix a regression introduced in [this development](https://github.com/pagopa/io-app/pull/7228) (thanks @dmnplb )

## List of changes proposed in this pull request
- Restored the `ContentWrapper` component to wrap the `PaymentsHomeUserMethodsList`
- Updated the `IOScrollView` component to set `includeContentMargins` to `false`, allowing more control over content margins when list is empty

## How to test
**Test all cases with and without payment methods & transactions**
Ensure that spacing is now correct, carousel has no extra padding and text is aligned correctly

