### PR TITLE
fix(IT Wallet): [SIW-2843] Add optional `operationType` in `obtainCredential` utility function

### DIFF
--- a/ts/features/itwallet/common/utils/itwCredentialIssuanceUtils.ts
+++ b/ts/features/itwallet/common/utils/itwCredentialIssuanceUtils.ts
@@ -41,6 +41,7 @@ export type ObtainCredentialParams = {
   credentialDefinition?: AuthorizationDetail;
   issuerConf: IssuerConfiguration;
   isNewIssuanceFlowEnabled: boolean;
+  operationType?: "reissuing";
 };
 
 /**
@@ -54,6 +55,7 @@ export type ObtainCredentialParams = {
  * @param codeVerifier - The code verifier
  * @param credentialDefinition - The credential definition
  * @param issuerConf - The issuer configuration
+ * @param operationType - The operation type, e.g., "reissuing"
  * @returns The obtained credential
  */
 export const obtainCredential = async (params: ObtainCredentialParams) =>

--- a/ts/features/itwallet/common/utils/itwCredentialIssuanceUtils.v2.ts
+++ b/ts/features/itwallet/common/utils/itwCredentialIssuanceUtils.v2.ts
@@ -87,6 +87,7 @@ export type ObtainCredentialParams = {
   clientId: string;
   codeVerifier: string;
   issuerConf: IssuerConf;
+  operationType?: "reissuing";
 };
 
 // TODO: [SIW-2530] Update JSDoc accordingly
@@ -101,6 +102,7 @@ export type ObtainCredentialParams = {
  * @param codeVerifier - The code verifier
  * @param credentialDefinition - The credential definition
  * @param issuerConf - The issuer configuration
+ * @param operationType - The operation type, e.g., "reissuing"
  * @returns The obtained credential
  */
 export const obtainCredential = async ({
@@ -112,7 +114,8 @@ export const obtainCredential = async ({
   walletInstanceAttestation,
   clientId,
   codeVerifier,
-  issuerConf
+  issuerConf,
+  operationType
 }: ObtainCredentialParams) => {
   // Get WIA crypto context
   const wiaCryptoContext = createCryptoContextFor(WIA_KEYTAG);
@@ -167,7 +170,7 @@ export const obtainCredential = async ({
               dPopCryptoContext,
               credentialCryptoContext
             },
-            "reissuing"
+            operationType
           ).catch(enrichIssuerResponseError(credential_configuration_id));
 
         // Parse and verify the credential. The ignoreMissingAttributes flag must be set to false or omitted in production.

--- a/ts/features/itwallet/machine/credential/actors.ts
+++ b/ts/features/itwallet/machine/credential/actors.ts
@@ -138,7 +138,8 @@ export const createCredentialIssuanceActorsImplementation = (
       clientId,
       codeVerifier,
       credentialDefinition,
-      isNewIssuanceFlowEnabled
+      isNewIssuanceFlowEnabled,
+      operationType
     } = input;
 
     const eid = itwCredentialsEidSelector(store.getState());
@@ -166,7 +167,8 @@ export const createCredentialIssuanceActorsImplementation = (
       codeVerifier,
       credentialDefinition,
       pid: eid.value,
-      isNewIssuanceFlowEnabled: !!isNewIssuanceFlowEnabled
+      isNewIssuanceFlowEnabled: !!isNewIssuanceFlowEnabled,
+      operationType
     });
   });
 

--- a/ts/features/itwallet/machine/credential/machine.ts
+++ b/ts/features/itwallet/machine/credential/machine.ts
@@ -235,7 +235,10 @@ export const itwCredentialIssuanceMachine = setup({
               credentialDefinition: context.credentialDefinition,
               requestedCredential: context.requestedCredential,
               issuerConf: context.issuerConf,
-              isNewIssuanceFlowEnabled: context.isWhiteListed
+              isNewIssuanceFlowEnabled: context.isWhiteListed,
+              // if the user has access to the L3 features we need to pass the operationType
+              // header with the value "reissuing"
+              operationType: context.isWhiteListed ? "reissuing" : undefined
             }),
             onDone: [
               {


### PR DESCRIPTION
## Short description
This PR introduces a change to `obtainCredential` utility function, allowing `operationType` to be passed as a parameter.

## List of changes proposed in this pull request
- Refactored the code to allow `operationType` to be passed as a parameter to the `obtainCredential` utility function

## How to test
Ensure that `operationType` is provided only when the `L3` flag is enabled, and omitted otherwise.
