### PR TITLE
fix(IT Wallet): [SIW-2865] Claim labels not visible with dark theme on Android

### DIFF
--- a/ts/features/itwallet/common/components/ItwSkeumorphicCard/ClaimLabel.tsx
+++ b/ts/features/itwallet/common/components/ItwSkeumorphicCard/ClaimLabel.tsx
@@ -1,9 +1,10 @@
 import {
+  IOColors,
   IOFontWeight,
-  makeFontStyleObject
+  makeFontStyleObject,
+  useIOTheme
 } from "@pagopa/io-app-design-system";
 import { FunctionComponent, PropsWithChildren } from "react";
-
 import { Text, TextStyle, useWindowDimensions } from "react-native";
 import { HIDDEN_CLAIM_TEXT } from "../../utils/constants.ts";
 
@@ -26,6 +27,7 @@ export const ClaimLabel: FunctionComponent<
   hidden,
   ...props
 }) => {
+  const theme = useIOTheme();
   const { width } = useWindowDimensions();
 
   // 360 is the width of the screen in the smallest device
@@ -51,6 +53,9 @@ export const ClaimLabel: FunctionComponent<
           undefined,
           false
         ),
+        // Skeumorphic MUST NOT change appearance based on the current theme (both system and app theme)
+        // so it is safe to force the text color and make sure it is readable
+        color: IOColors["grey-900"],
         textTransform
       }}
     >

--- a/ts/features/itwallet/common/components/ItwSkeumorphicCard/ClaimLabel.tsx
+++ b/ts/features/itwallet/common/components/ItwSkeumorphicCard/ClaimLabel.tsx
@@ -1,8 +1,7 @@
 import {
   IOColors,
   IOFontWeight,
-  makeFontStyleObject,
-  useIOTheme
+  makeFontStyleObject
 } from "@pagopa/io-app-design-system";
 import { FunctionComponent, PropsWithChildren } from "react";
 import { Text, TextStyle, useWindowDimensions } from "react-native";
@@ -27,7 +26,6 @@ export const ClaimLabel: FunctionComponent<
   hidden,
   ...props
 }) => {
-  const theme = useIOTheme();
   const { width } = useWindowDimensions();
 
   // 360 is the width of the screen in the smallest device

--- a/ts/features/itwallet/common/components/ItwSkeumorphicCard/__tests__/__snapshots__/CardData.test.tsx.snap
+++ b/ts/features/itwallet/common/components/ItwSkeumorphicCard/__tests__/__snapshots__/CardData.test.tsx.snap
@@ -198,6 +198,7 @@ exports[`CardData should match snapshot for DC front data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 22.916666666666668,
           "fontStyle": "normal",
@@ -231,6 +232,7 @@ exports[`CardData should match snapshot for DC front data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 22.916666666666668,
           "fontStyle": "normal",
@@ -264,6 +266,7 @@ exports[`CardData should match snapshot for DC front data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 22.916666666666668,
           "fontStyle": "normal",
@@ -297,6 +300,7 @@ exports[`CardData should match snapshot for DC front data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 22.916666666666668,
           "fontStyle": "normal",
@@ -330,6 +334,7 @@ exports[`CardData should match snapshot for DC front data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 22.916666666666668,
           "fontStyle": "normal",
@@ -377,6 +382,7 @@ exports[`CardData should match snapshot for MDL back data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 18.75,
           "fontStyle": "normal",
@@ -410,6 +416,7 @@ exports[`CardData should match snapshot for MDL back data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 18.75,
           "fontStyle": "normal",
@@ -443,6 +450,7 @@ exports[`CardData should match snapshot for MDL back data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 18.75,
           "fontStyle": "normal",
@@ -476,6 +484,7 @@ exports[`CardData should match snapshot for MDL back data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 18.75,
           "fontStyle": "normal",
@@ -509,6 +518,7 @@ exports[`CardData should match snapshot for MDL back data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 18.75,
           "fontStyle": "normal",
@@ -542,6 +552,7 @@ exports[`CardData should match snapshot for MDL back data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 18.75,
           "fontStyle": "normal",
@@ -606,6 +617,7 @@ exports[`CardData should match snapshot for MDL front data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 22.916666666666668,
           "fontStyle": "normal",
@@ -639,6 +651,7 @@ exports[`CardData should match snapshot for MDL front data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 22.916666666666668,
           "fontStyle": "normal",
@@ -672,6 +685,7 @@ exports[`CardData should match snapshot for MDL front data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 22.916666666666668,
           "fontStyle": "normal",
@@ -705,6 +719,7 @@ exports[`CardData should match snapshot for MDL front data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 22.916666666666668,
           "fontStyle": "normal",
@@ -738,6 +753,7 @@ exports[`CardData should match snapshot for MDL front data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 22.916666666666668,
           "fontStyle": "normal",
@@ -771,6 +787,7 @@ exports[`CardData should match snapshot for MDL front data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 22.916666666666668,
           "fontStyle": "normal",
@@ -804,6 +821,7 @@ exports[`CardData should match snapshot for MDL front data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 22.916666666666668,
           "fontStyle": "normal",
@@ -837,6 +855,7 @@ exports[`CardData should match snapshot for MDL front data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 22.916666666666668,
           "fontStyle": "normal",
@@ -870,6 +889,7 @@ exports[`CardData should match snapshot for MDL front data 1`] = `
       numberOfLines={1}
       style={
         {
+          "color": "#1D1F26",
           "fontFamily": "Titillium Sans Pro",
           "fontSize": 22.916666666666668,
           "fontStyle": "normal",


### PR DESCRIPTION
## Short description
This PR resolves a rendering issue on Android where ClaimLabel text on skeumorphic cards would inherit the system's theme color. This resulted in low-contrast, illegible text when dark mode was enabled.

## List of changes proposed in this pull request
- Explicitly set high-contract color for `Text` within `ClaimLabel` component

## How to test

1. Run the application on an Android device.
2. Navigate to the screen displaying the MDL details.
3. Toggle the system theme between light and dark modes.
4. Confirm that the text labels on the skeumorphic card are legible and maintain sufficient contrast in both themes. 

## Preview

| Before | After |
| --- | --- |
|<img width="250" height="2280" alt="Screenshot_20250812_095651" src="https://github.com/user-attachments/assets/45c321d2-6e3e-478e-8d05-836d25edd72d" /> | <img width="250" height="2280" alt="Screenshot_20250812_095651" src="https://github.com/user-attachments/assets/0410970b-89e6-43b8-8506-b7387e110af6" />|
