### PR TITLE
feat: [IOBP-1943] IDPay assistance modal

### DIFF
--- a/locales/de/index.json
+++ b/locales/de/index.json
@@ -4135,6 +4135,15 @@
         "subtitle": "Attendi qualche secondo",
         "title": "Stiamo elaborando la tua richiesta"
       }
+    },
+    "support": {
+      "errorCode": "Fehlercode",
+      "serviceId": "Service ID",
+      "initiativeId": "ID Initiative",
+      "supportTitle": "Contatta l'assistenza",
+      "chat": "Chiedi aiuto in chat",
+      "additionalDataTitle": "Dati aggiuntivi",
+      "copyAll": "Copia tutti"
     }
   }
 }

--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -6091,6 +6091,15 @@
         "input": "Discount code",
         "button": "Continua"
       }
+    },
+    "support": {
+      "errorCode": "Error code",
+      "serviceId": "Service ID",
+      "initiativeId": "Initiative ID",
+      "supportTitle": "Contatta l'assistenza",
+      "chat": "Chiedi aiuto in chat",
+      "additionalDataTitle": "Additional data",
+      "copyAll": "Copy all"
     }
   },
   "barcodeScan": {

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -6091,6 +6091,15 @@
         "input": "Codice sconto",
         "button": "Continua"
       }
+    },
+    "support": {
+      "errorCode": "Codice errore",
+      "serviceId": "ID servizio",
+      "initiativeId": "ID iniziativa",
+      "supportTitle": "Contatta l'assistenza",
+      "chat": "Chiedi aiuto in chat",
+      "additionalDataTitle": "Dati aggiuntivi",
+      "copyAll": "Copia tutti"
     }
   },
   "barcodeScan": {

--- a/ts/features/idpay/common/hooks/useIDPayFailureSupportModal.tsx
+++ b/ts/features/idpay/common/hooks/useIDPayFailureSupportModal.tsx
@@ -1,0 +1,151 @@
+import {
+  ListItemAction,
+  ListItemHeader,
+  ListItemInfoCopy,
+  VSpacer
+} from "@pagopa/io-app-design-system";
+import {
+  addTicketCustomField,
+  appendLog,
+  resetCustomFields
+} from "@pagopa/io-react-native-zendesk";
+import { JSX, useState } from "react";
+import I18n from "../../../../i18n";
+import { useIODispatch } from "../../../../store/hooks";
+import { clipboardSetStringWithFeedback } from "../../../../utils/clipboard";
+import { useIOBottomSheetModal } from "../../../../utils/hooks/bottomSheet";
+import {
+  defaultZendeskIDPayCategory,
+  zendeskCategoryId,
+  zendeskIdPayCategoryId
+} from "../../../../utils/supportAssistance";
+import {
+  zendeskSelectedCategory,
+  zendeskSupportStart
+} from "../../../zendesk/store/actions";
+import { OnboardingFailureEnum } from "../../onboarding/types/OnboardingFailure";
+
+type IDPayFailureSupportModal = {
+  bottomSheet: JSX.Element;
+  present: (failure: OnboardingFailureEnum) => void;
+};
+
+const useIDPayFailureSupportModal = (
+  serviceId: string,
+  initiativeId?: string
+): IDPayFailureSupportModal => {
+  const dispatch = useIODispatch();
+
+  const [currentFaultCodeDetail, setCurrentFaultCodeDetail] =
+    useState<string>("");
+
+  const zendeskAssistanceLogAndStart = () => {
+    resetCustomFields();
+    // attach the main zendesk category to the ticket
+    addTicketCustomField(
+      zendeskIdPayCategoryId,
+      defaultZendeskIDPayCategory.value
+    );
+
+    addTicketCustomField(zendeskCategoryId, defaultZendeskIDPayCategory.value);
+
+    appendLog(
+      JSON.stringify({
+        serviceId,
+        initiativeId,
+        faultCode: currentFaultCodeDetail
+      })
+    );
+
+    dispatch(
+      zendeskSupportStart({
+        startingRoute: "n/a",
+        assistanceType: {
+          idPay: true
+        }
+      })
+    );
+    dispatch(zendeskSelectedCategory(defaultZendeskIDPayCategory));
+  };
+
+  const handleCopyAllToClipboard = () => {
+    const data = initiativeId
+      ? `${I18n.t("idpay.support.errorCode")}: ${currentFaultCodeDetail}
+    ${I18n.t("idpay.support.serviceId")}: ${serviceId}
+    ${I18n.t("idpay.support.initiativeId")}: ${initiativeId}`
+      : `${I18n.t("idpay.support.errorCode")}: ${currentFaultCodeDetail}
+    ${I18n.t("idpay.support.serviceId")}: ${serviceId}`;
+
+    clipboardSetStringWithFeedback(data);
+  };
+
+  const {
+    bottomSheet,
+    present: presentModal,
+    dismiss
+  } = useIOBottomSheetModal({
+    component: (
+      <>
+        <ListItemHeader label={I18n.t("idpay.support.supportTitle")} />
+        <ListItemAction
+          label={I18n.t("idpay.support.chat")}
+          accessibilityLabel={I18n.t("idpay.support.chat")}
+          onPress={() => {
+            dismiss();
+            zendeskAssistanceLogAndStart();
+          }}
+          variant="primary"
+          icon="chat"
+        />
+        <VSpacer size={24} />
+        <ListItemHeader
+          label={I18n.t("idpay.support.additionalDataTitle")}
+          endElement={{
+            type: "buttonLink",
+            componentProps: {
+              label: I18n.t("idpay.support.copyAll"),
+              onPress: handleCopyAllToClipboard
+            }
+          }}
+        />
+        <ListItemInfoCopy
+          label={I18n.t("idpay.support.errorCode")}
+          accessibilityLabel={I18n.t("idpay.support.errorCode")}
+          icon="ladybug"
+          value={currentFaultCodeDetail}
+          onPress={() => clipboardSetStringWithFeedback(currentFaultCodeDetail)}
+        />
+        <ListItemInfoCopy
+          label={I18n.t("idpay.support.serviceId")}
+          icon="pinOff"
+          value={serviceId}
+          onPress={() => clipboardSetStringWithFeedback(serviceId)}
+        />
+        {initiativeId && (
+          <ListItemInfoCopy
+            label={I18n.t("idpay.support.initiativeId")}
+            icon="bonus"
+            value={initiativeId}
+            onPress={() =>
+              initiativeId && clipboardSetStringWithFeedback(initiativeId)
+            }
+          />
+        )}
+        <VSpacer size={24} />
+      </>
+    ),
+    title: ""
+  });
+
+  const present = (failure: OnboardingFailureEnum) => {
+    setCurrentFaultCodeDetail(failure || OnboardingFailureEnum.GENERIC);
+    presentModal();
+  };
+
+  return {
+    bottomSheet,
+    present
+  };
+};
+
+export default useIDPayFailureSupportModal;

--- a/ts/features/idpay/onboarding/screens/IdPayFailureScreen.tsx
+++ b/ts/features/idpay/onboarding/screens/IdPayFailureScreen.tsx
@@ -1,14 +1,18 @@
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
-import { voidType } from "io-ts";
 import { useMemo } from "react";
 import {
   OperationResultScreenContent,
   OperationResultScreenContentProps
 } from "../../../../components/screens/OperationResultScreenContent";
 import I18n from "../../../../i18n";
+import useIDPayFailureSupportModal from "../../common/hooks/useIDPayFailureSupportModal";
 import { IdPayOnboardingMachineContext } from "../machine/provider";
-import { selectOnboardingFailure } from "../machine/selectors";
+import {
+  selectInitiative,
+  selectOnboardingFailure,
+  selectServiceId
+} from "../machine/selectors";
 import { OnboardingFailureEnum } from "../types/OnboardingFailure";
 
 const IdPayFailureScreen = () => {
@@ -16,6 +20,19 @@ const IdPayFailureScreen = () => {
   const machine = useActorRef();
 
   const failureOption = useSelector(selectOnboardingFailure);
+  const serviceId = useSelector(selectServiceId);
+  const initiative = useSelector(selectInitiative);
+
+  const initiativeId = pipe(
+    initiative,
+    O.map(i => i.initiativeId),
+    O.toUndefined
+  );
+
+  const { bottomSheet, present } = useIDPayFailureSupportModal(
+    serviceId,
+    initiativeId
+  );
 
   const defaultCloseAction = useMemo(
     () => ({
@@ -52,13 +69,12 @@ const IdPayFailureScreen = () => {
         accessibilityLabel: I18n.t(
           `wallet.onboarding.outcome.BE_KO.secondaryAction`
         ),
-        // TODO: implement this in IOBP-1943
-        onPress: () => voidType
+        onPress: () => present(OnboardingFailureEnum.GENERIC)
       },
       enableAnimatedPictogram: true,
       loop: true
     }),
-    [machine]
+    [machine, present]
   );
 
   const mapFailureToContentProps = (
@@ -190,7 +206,12 @@ const IdPayFailureScreen = () => {
     O.getOrElse(() => genericErrorProps)
   );
 
-  return <OperationResultScreenContent {...contentProps} />;
+  return (
+    <>
+      <OperationResultScreenContent {...contentProps} />
+      {bottomSheet}
+    </>
+  );
 };
 
 export default IdPayFailureScreen;

--- a/ts/utils/supportAssistance.ts
+++ b/ts/utils/supportAssistance.ts
@@ -161,6 +161,15 @@ export const defaultIdPayExpenseCategory: ZendeskCategory = {
   }
 };
 
+export const defaultZendeskIDPayCategory: ZendeskCategory = {
+  value: "idpay",
+  description: {
+    "it-IT": "IDPay",
+    "en-EN": "IDPay",
+    "de-DE": "IDPay"
+  }
+};
+
 export const resetAssistanceData = () => {
   resetCustomFields();
   resetLog();


### PR DESCRIPTION
## Short description
This pull request introduces a new user support feature for IDPay onboarding failures. It adds a reusable modal for contacting support and integrates the modal into the failure screen

## List of changes proposed in this pull request
- Added a new hook `useIDPayFailureSupportModal` that provides a bottom sheet modal for contacting support, copying error details, and starting a Zendesk chat, including logic to log and attach relevant data for assistance
- Integrated the support modal into the `IdPayFailureScreen`, enabling users to access support directly from the failure screen and pass relevant failure, service, and initiative data
- Update locales

## How to test
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
- From IDPay onboarding list, tap on generic error
- Ensure that the second cta is aligned with design and tap on it
- Ensure that support modal is opening with all needed data (note: if not present `initiativeId` will not be visible)

## Preview

https://github.com/user-attachments/assets/3b257a8c-a35c-4ced-a91d-2fc419283f81

