### PR TITLE
[IOPID-3214] Offline wallet: startup timeout scenario

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -352,6 +352,11 @@
     "contextualHelp": {
       "title": "Startup problems?"
     },
+    "offline_access_banner": {
+      "title": "Ti servono i documenti?",
+      "content": "Non attendere, sono sempre disponibili, anche se non hai connessione!",
+      "action": "Vai ai documenti"
+    },
     "connection_lost": {
       "title": "It looks like you don't have an active internet connection",
       "description": "Check your connection and restart the app."
@@ -5321,6 +5326,17 @@
             "title": "Servizi dell’app limitati",
             "content": "###### Cosa posso fare?\n\nQuando l’autenticazione non va a buon fine, oppure la connessione alla rete non è stabile, alcuni servizi dell’app potrebbero essere limitati.\n\nDocumenti su IO funziona **anche in questi casi** per un uso controllato, ma la validità dei tuoi documenti è aggiornata all’ultimo accesso in app con connessione a una rete.\n\nAttendi qualche minuto e ricarica l’app per continuare ad usare tutti i servizi di IO.",
             "footerAction": "Ricarica l'app IO"
+          }
+        },
+        "timeout": {
+          "alert": {
+            "content": " Hai bisogno di tornare alla versione completa di IO?",
+            "action": "Ricarica l’app IO"
+          },
+          "modal": {
+            "title": "Il tuo accesso all’app è scaduto",
+            "content": "###### Cosa posso fare?\n\nQuando la tua sessione di accesso all’app scade, alcuni servizi dell’app potrebbero essere limitati per motivi di sicurezza.\n\nAccedi di nuovo con SPID o CIE per continuare ad usare tutti i servizi di IO.",
+            "footerAction": "Log in again"
           }
         },
         "back_online": {

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -352,6 +352,11 @@
     "contextualHelp": {
       "title": "Problemi di inizializzazione?"
     },
+    "offline_access_banner": {
+      "title": "Ti servono i documenti?",
+      "content": "Non attendere, sono sempre disponibili, anche se non hai connessione!",
+      "action": "Vai ai documenti"
+    },
     "connection_lost": {
       "title": "Non hai una connessione a internet attiva",
       "description": "Controlla la tua connessione e riavvia l’app."
@@ -5321,6 +5326,17 @@
             "title": "Servizi dell’app limitati",
             "content": "###### Cosa posso fare?\n\nQuando l’autenticazione non va a buon fine, oppure la connessione alla rete non è stabile, alcuni servizi dell’app potrebbero essere limitati.\n\nDocumenti su IO funziona **anche in questi casi** per un uso controllato, ma la validità dei tuoi documenti è aggiornata all’ultimo accesso in app con connessione a una rete.\n\nAttendi qualche minuto e ricarica l’app per continuare ad usare tutti i servizi di IO.",
             "footerAction": "Ricarica l'app IO"
+          }
+        },
+        "timeout": {
+          "alert": {
+            "content": " Hai bisogno di tornare alla versione completa di IO?",
+            "action": "Ricarica l’app IO"
+          },
+          "modal": {
+            "title": "Il tuo accesso all’app è scaduto",
+            "content": "###### Cosa posso fare?\n\nQuando la tua sessione di accesso all’app scade, alcuni servizi dell’app potrebbero essere limitati per motivi di sicurezza.\n\nAccedi di nuovo con SPID o CIE per continuare ad usare tutti i servizi di IO.",
+            "footerAction": "Accedi di nuovo"
           }
         },
         "back_online": {

--- a/ts/components/screens/LoadingScreenContent.tsx
+++ b/ts/components/screens/LoadingScreenContent.tsx
@@ -2,6 +2,7 @@
  * An ingress screen to choose the real first screen the user must navigate to.
  */
 import {
+  Banner,
   ContentWrapper,
   H3,
   IOColors,
@@ -18,6 +19,7 @@ import {
   AnimatedPictogram,
   IOAnimatedPictograms
 } from "../ui/AnimatedPictogram";
+import I18n from "../../i18n";
 
 const styles = StyleSheet.create({
   container: {
@@ -33,6 +35,7 @@ type LoadingScreenContentProps = WithTestID<{
   children?: ReactNode;
   headerVisible?: boolean;
   animatedPictogramSource?: IOAnimatedPictograms;
+  banner: { showBanner?: boolean; onPress: () => void };
 }>;
 
 export const LoadingScreenContent = (props: LoadingScreenContentProps) => {
@@ -42,7 +45,8 @@ export const LoadingScreenContent = (props: LoadingScreenContentProps) => {
     children,
     headerVisible,
     testID,
-    animatedPictogramSource
+    animatedPictogramSource,
+    banner = { showBanner: false }
   } = props;
 
   useEffect(() => {
@@ -66,10 +70,10 @@ export const LoadingScreenContent = (props: LoadingScreenContentProps) => {
       edges={headerVisible ? ["bottom"] : undefined}
       testID={testID}
     >
-      <ContentWrapper>
+      <ContentWrapper style={{ flex: 1 }}>
         <VStack
           space={SPACE_BETWEEN_SPINNER_AND_TEXT}
-          style={{ alignItems: "center" }}
+          style={{ alignItems: "center", flex: 1, justifyContent: "center" }}
         >
           <View
             accessible={false}
@@ -93,9 +97,21 @@ export const LoadingScreenContent = (props: LoadingScreenContentProps) => {
           >
             {contentTitle}
           </H3>
+          {children}
         </VStack>
       </ContentWrapper>
-      {children}
+      <ContentWrapper style={{ marginBottom: 16 }}>
+        {banner.showBanner && (
+          <Banner
+            pictogramName="identityCheck"
+            color="neutral"
+            title={I18n.t("startup.offline_access_banner.title")}
+            content={I18n.t("startup.offline_access_banner.content")}
+            action={I18n.t("startup.offline_access_banner.action")}
+            onPress={banner.onPress}
+          />
+        )}
+      </ContentWrapper>
     </SafeAreaView>
   );
 };

--- a/ts/components/screens/__tests__/__snapshots__/LoadingScreenContent.test.tsx.snap
+++ b/ts/components/screens/__tests__/__snapshots__/LoadingScreenContent.test.tsx.snap
@@ -390,6 +390,7 @@ exports[`LoadingScreenContent should match the snapshot with title, a child, hea
                         <View
                           style={
                             {
+                              "flex": 1,
                               "paddingHorizontal": 24,
                             }
                           }
@@ -399,8 +400,10 @@ exports[`LoadingScreenContent should match the snapshot with title, a child, hea
                               {
                                 "alignItems": "center",
                                 "display": "flex",
+                                "flex": 1,
                                 "flexDirection": "column",
                                 "gap": 24,
+                                "justifyContent": "center",
                               }
                             }
                           >
@@ -612,11 +615,19 @@ exports[`LoadingScreenContent should match the snapshot with title, a child, hea
                             >
                               Test Content Title
                             </Text>
+                            <Text>
+                              My test child
+                            </Text>
                           </View>
                         </View>
-                        <Text>
-                          My test child
-                        </Text>
+                        <View
+                          style={
+                            {
+                              "marginBottom": 16,
+                              "paddingHorizontal": 24,
+                            }
+                          }
+                        />
                       </RNCSafeAreaView>
                     </View>
                   </View>
@@ -1021,6 +1032,7 @@ exports[`LoadingScreenContent should match the snapshot with title, a child, hea
                         <View
                           style={
                             {
+                              "flex": 1,
                               "paddingHorizontal": 24,
                             }
                           }
@@ -1030,8 +1042,10 @@ exports[`LoadingScreenContent should match the snapshot with title, a child, hea
                               {
                                 "alignItems": "center",
                                 "display": "flex",
+                                "flex": 1,
                                 "flexDirection": "column",
                                 "gap": 24,
+                                "justifyContent": "center",
                               }
                             }
                           >
@@ -1243,11 +1257,19 @@ exports[`LoadingScreenContent should match the snapshot with title, a child, hea
                             >
                               Test Content Title
                             </Text>
+                            <Text>
+                              My test child
+                            </Text>
                           </View>
                         </View>
-                        <Text>
-                          My test child
-                        </Text>
+                        <View
+                          style={
+                            {
+                              "marginBottom": 16,
+                              "paddingHorizontal": 24,
+                            }
+                          }
+                        />
                       </RNCSafeAreaView>
                     </View>
                   </View>
@@ -1652,6 +1674,7 @@ exports[`LoadingScreenContent should match the snapshot with title, no children,
                         <View
                           style={
                             {
+                              "flex": 1,
                               "paddingHorizontal": 24,
                             }
                           }
@@ -1661,8 +1684,10 @@ exports[`LoadingScreenContent should match the snapshot with title, no children,
                               {
                                 "alignItems": "center",
                                 "display": "flex",
+                                "flex": 1,
                                 "flexDirection": "column",
                                 "gap": 24,
+                                "justifyContent": "center",
                               }
                             }
                           >
@@ -1876,6 +1901,14 @@ exports[`LoadingScreenContent should match the snapshot with title, no children,
                             </Text>
                           </View>
                         </View>
+                        <View
+                          style={
+                            {
+                              "marginBottom": 16,
+                              "paddingHorizontal": 24,
+                            }
+                          }
+                        />
                       </RNCSafeAreaView>
                     </View>
                   </View>
@@ -2280,6 +2313,7 @@ exports[`LoadingScreenContent should match the snapshot with title, no children,
                         <View
                           style={
                             {
+                              "flex": 1,
                               "paddingHorizontal": 24,
                             }
                           }
@@ -2289,8 +2323,10 @@ exports[`LoadingScreenContent should match the snapshot with title, no children,
                               {
                                 "alignItems": "center",
                                 "display": "flex",
+                                "flex": 1,
                                 "flexDirection": "column",
                                 "gap": 24,
+                                "justifyContent": "center",
                               }
                             }
                           >
@@ -2504,6 +2540,14 @@ exports[`LoadingScreenContent should match the snapshot with title, no children,
                             </Text>
                           </View>
                         </View>
+                        <View
+                          style={
+                            {
+                              "marginBottom": 16,
+                              "paddingHorizontal": 24,
+                            }
+                          }
+                        />
                       </RNCSafeAreaView>
                     </View>
                   </View>

--- a/ts/features/ingress/__test__/__snapshots__/IngressScreen.test.tsx.snap
+++ b/ts/features/ingress/__test__/__snapshots__/IngressScreen.test.tsx.snap
@@ -391,6 +391,7 @@ exports[`IngressScreen Should match the snapshot 1`] = `
                         <View
                           style={
                             {
+                              "flex": 1,
                               "paddingHorizontal": 24,
                             }
                           }
@@ -400,8 +401,10 @@ exports[`IngressScreen Should match the snapshot 1`] = `
                               {
                                 "alignItems": "center",
                                 "display": "flex",
+                                "flex": 1,
                                 "flexDirection": "column",
                                 "gap": 24,
+                                "justifyContent": "center",
                               }
                             }
                           >
@@ -557,6 +560,14 @@ exports[`IngressScreen Should match the snapshot 1`] = `
                             </Text>
                           </View>
                         </View>
+                        <View
+                          style={
+                            {
+                              "marginBottom": 16,
+                              "paddingHorizontal": 24,
+                            }
+                          }
+                        />
                       </RNCSafeAreaView>
                     </View>
                   </View>

--- a/ts/features/ingress/store/reducer/index.ts
+++ b/ts/features/ingress/store/reducer/index.ts
@@ -9,7 +9,8 @@ import { Action } from "../../../../store/actions/types";
 export enum OfflineAccessReasonEnum {
   DEVICE_OFFLINE = "device_offline", // The device is offline when the app is started
   SESSION_REFRESH = "session_refresh", // Error on session refresh
-  SESSION_EXPIRED = "session_expired" // Session has expired or user has logged out
+  SESSION_EXPIRED = "session_expired", // Session has expired or user has logged out
+  TIMEOUT = "timeout" // The app has not been able to connect to the backend within a certain time
 }
 export type IngressScreenState = {
   isBlockingScreen: boolean;

--- a/ts/features/itwallet/wallet/components/ItwOfflineAlertWrapper.tsx
+++ b/ts/features/itwallet/wallet/components/ItwOfflineAlertWrapper.tsx
@@ -106,6 +106,15 @@ const AlertWrapper = ({
       };
     }
 
+    if (offlineAccessReason === OfflineAccessReasonEnum.TIMEOUT) {
+      return {
+        content: I18n.t(`features.itWallet.offline.timeout.alert.content`),
+        action: I18n.t(`features.itWallet.offline.timeout.alert.action`),
+        variant: "info",
+        onPress: handleAppRestart
+      };
+    }
+
     return {
       content: I18n.t(
         `features.itWallet.offline.${offlineAccessReason}.alert.content`

--- a/ts/features/messages/screens/__tests__/__snapshots__/MessageRouterScreen.test.tsx.snap
+++ b/ts/features/messages/screens/__tests__/__snapshots__/MessageRouterScreen.test.tsx.snap
@@ -231,6 +231,7 @@ exports[`MessageRouterScreen should match snapshot before starting to retrieve m
                         <View
                           style={
                             {
+                              "flex": 1,
                               "paddingHorizontal": 24,
                             }
                           }
@@ -240,8 +241,10 @@ exports[`MessageRouterScreen should match snapshot before starting to retrieve m
                               {
                                 "alignItems": "center",
                                 "display": "flex",
+                                "flex": 1,
                                 "flexDirection": "column",
                                 "gap": 24,
+                                "justifyContent": "center",
                               }
                             }
                           >
@@ -453,43 +456,51 @@ exports[`MessageRouterScreen should match snapshot before starting to retrieve m
                             >
                               Loading message details
                             </Text>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "height": 8,
+                                  }
+                                }
+                              />
+                              <Text
+                                allowFontScaling={true}
+                                dynamicTypeRamp="body"
+                                maxFontSizeMultiplier={1.5}
+                                style={
+                                  [
+                                    {},
+                                    {
+                                      "color": "#555C70",
+                                      "fontFamily": "Titillio",
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "400",
+                                      "lineHeight": 24,
+                                    },
+                                  ]
+                                }
+                              >
+                                Wait a few moments
+                              </Text>
+                            </View>
                           </View>
                         </View>
                         <View
                           style={
                             {
-                              "alignItems": "center",
+                              "marginBottom": 16,
+                              "paddingHorizontal": 24,
                             }
                           }
-                        >
-                          <View
-                            style={
-                              {
-                                "height": 8,
-                              }
-                            }
-                          />
-                          <Text
-                            allowFontScaling={true}
-                            dynamicTypeRamp="body"
-                            maxFontSizeMultiplier={1.5}
-                            style={
-                              [
-                                {},
-                                {
-                                  "color": "#555C70",
-                                  "fontFamily": "Titillio",
-                                  "fontSize": 16,
-                                  "fontStyle": "normal",
-                                  "fontWeight": "400",
-                                  "lineHeight": 24,
-                                },
-                              ]
-                            }
-                          >
-                            Wait a few moments
-                          </Text>
-                        </View>
+                        />
                       </RNCSafeAreaView>
                     </View>
                     <View
@@ -1085,6 +1096,7 @@ exports[`MessageRouterScreen should match snapshot if message data retrieval was
                         <View
                           style={
                             {
+                              "flex": 1,
                               "paddingHorizontal": 24,
                             }
                           }
@@ -1094,8 +1106,10 @@ exports[`MessageRouterScreen should match snapshot if message data retrieval was
                               {
                                 "alignItems": "center",
                                 "display": "flex",
+                                "flex": 1,
                                 "flexDirection": "column",
                                 "gap": 24,
+                                "justifyContent": "center",
                               }
                             }
                           >
@@ -1307,43 +1321,51 @@ exports[`MessageRouterScreen should match snapshot if message data retrieval was
                             >
                               Loading message details
                             </Text>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "height": 8,
+                                  }
+                                }
+                              />
+                              <Text
+                                allowFontScaling={true}
+                                dynamicTypeRamp="body"
+                                maxFontSizeMultiplier={1.5}
+                                style={
+                                  [
+                                    {},
+                                    {
+                                      "color": "#555C70",
+                                      "fontFamily": "Titillio",
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "400",
+                                      "lineHeight": 24,
+                                    },
+                                  ]
+                                }
+                              >
+                                Wait a few moments
+                              </Text>
+                            </View>
                           </View>
                         </View>
                         <View
                           style={
                             {
-                              "alignItems": "center",
+                              "marginBottom": 16,
+                              "paddingHorizontal": 24,
                             }
                           }
-                        >
-                          <View
-                            style={
-                              {
-                                "height": 8,
-                              }
-                            }
-                          />
-                          <Text
-                            allowFontScaling={true}
-                            dynamicTypeRamp="body"
-                            maxFontSizeMultiplier={1.5}
-                            style={
-                              [
-                                {},
-                                {
-                                  "color": "#555C70",
-                                  "fontFamily": "Titillio",
-                                  "fontSize": 16,
-                                  "fontStyle": "normal",
-                                  "fontWeight": "400",
-                                  "lineHeight": 24,
-                                },
-                              ]
-                            }
-                          >
-                            Wait a few moments
-                          </Text>
-                        </View>
+                        />
                       </RNCSafeAreaView>
                     </View>
                     <View
@@ -3034,6 +3056,7 @@ exports[`MessageRouterScreen should match snapshot on message data retrieval suc
                         <View
                           style={
                             {
+                              "flex": 1,
                               "paddingHorizontal": 24,
                             }
                           }
@@ -3043,8 +3066,10 @@ exports[`MessageRouterScreen should match snapshot on message data retrieval suc
                               {
                                 "alignItems": "center",
                                 "display": "flex",
+                                "flex": 1,
                                 "flexDirection": "column",
                                 "gap": 24,
+                                "justifyContent": "center",
                               }
                             }
                           >
@@ -3256,43 +3281,51 @@ exports[`MessageRouterScreen should match snapshot on message data retrieval suc
                             >
                               Loading message details
                             </Text>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "height": 8,
+                                  }
+                                }
+                              />
+                              <Text
+                                allowFontScaling={true}
+                                dynamicTypeRamp="body"
+                                maxFontSizeMultiplier={1.5}
+                                style={
+                                  [
+                                    {},
+                                    {
+                                      "color": "#555C70",
+                                      "fontFamily": "Titillio",
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "400",
+                                      "lineHeight": 24,
+                                    },
+                                  ]
+                                }
+                              >
+                                Wait a few moments
+                              </Text>
+                            </View>
                           </View>
                         </View>
                         <View
                           style={
                             {
-                              "alignItems": "center",
+                              "marginBottom": 16,
+                              "paddingHorizontal": 24,
                             }
                           }
-                        >
-                          <View
-                            style={
-                              {
-                                "height": 8,
-                              }
-                            }
-                          />
-                          <Text
-                            allowFontScaling={true}
-                            dynamicTypeRamp="body"
-                            maxFontSizeMultiplier={1.5}
-                            style={
-                              [
-                                {},
-                                {
-                                  "color": "#555C70",
-                                  "fontFamily": "Titillio",
-                                  "fontSize": 16,
-                                  "fontStyle": "normal",
-                                  "fontWeight": "400",
-                                  "lineHeight": 24,
-                                },
-                              ]
-                            }
-                          >
-                            Wait a few moments
-                          </Text>
-                        </View>
+                        />
                       </RNCSafeAreaView>
                     </View>
                     <View
@@ -3888,6 +3921,7 @@ exports[`MessageRouterScreen should match snapshot while retrieving message data
                         <View
                           style={
                             {
+                              "flex": 1,
                               "paddingHorizontal": 24,
                             }
                           }
@@ -3897,8 +3931,10 @@ exports[`MessageRouterScreen should match snapshot while retrieving message data
                               {
                                 "alignItems": "center",
                                 "display": "flex",
+                                "flex": 1,
                                 "flexDirection": "column",
                                 "gap": 24,
+                                "justifyContent": "center",
                               }
                             }
                           >
@@ -4110,43 +4146,51 @@ exports[`MessageRouterScreen should match snapshot while retrieving message data
                             >
                               Loading message details
                             </Text>
+                            <View
+                              style={
+                                {
+                                  "alignItems": "center",
+                                }
+                              }
+                            >
+                              <View
+                                style={
+                                  {
+                                    "height": 8,
+                                  }
+                                }
+                              />
+                              <Text
+                                allowFontScaling={true}
+                                dynamicTypeRamp="body"
+                                maxFontSizeMultiplier={1.5}
+                                style={
+                                  [
+                                    {},
+                                    {
+                                      "color": "#555C70",
+                                      "fontFamily": "Titillio",
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "400",
+                                      "lineHeight": 24,
+                                    },
+                                  ]
+                                }
+                              >
+                                Wait a few moments
+                              </Text>
+                            </View>
                           </View>
                         </View>
                         <View
                           style={
                             {
-                              "alignItems": "center",
+                              "marginBottom": 16,
+                              "paddingHorizontal": 24,
                             }
                           }
-                        >
-                          <View
-                            style={
-                              {
-                                "height": 8,
-                              }
-                            }
-                          />
-                          <Text
-                            allowFontScaling={true}
-                            dynamicTypeRamp="body"
-                            maxFontSizeMultiplier={1.5}
-                            style={
-                              [
-                                {},
-                                {
-                                  "color": "#555C70",
-                                  "fontFamily": "Titillio",
-                                  "fontSize": 16,
-                                  "fontStyle": "normal",
-                                  "fontWeight": "400",
-                                  "lineHeight": 24,
-                                },
-                              ]
-                            }
-                          >
-                            Wait a few moments
-                          </Text>
-                        </View>
+                        />
                       </RNCSafeAreaView>
                     </View>
                     <View

--- a/ts/sagas/__tests__/initializeApplicationSaga.test.ts
+++ b/ts/sagas/__tests__/initializeApplicationSaga.test.ts
@@ -41,7 +41,10 @@ import { watchLogoutSaga } from "../../features/authentication/common/saga/watch
 import { cancellAllLocalNotifications } from "../../features/pushNotifications/utils";
 import { handleApplicationStartupTransientError } from "../../features/startup/sagas";
 import { startupTransientErrorInitialState } from "../../store/reducers/startup";
-import { isBlockingScreenSelector } from "../../features/ingress/store/selectors";
+import {
+  isBlockingScreenSelector,
+  offlineAccessReasonSelector
+} from "../../features/ingress/store/selectors";
 import { notificationPermissionsListener } from "../../features/pushNotifications/sagas/notificationPermissionsListener";
 import { trackKeychainFailures } from "../../utils/analytics";
 import { checkSession } from "../../features/authentication/common/saga/watchCheckSessionSaga";
@@ -120,6 +123,8 @@ describe("initializeApplicationSaga", () => {
       .next()
       .call(isDeviceOfflineWithWalletSaga)
       .next()
+      .select(offlineAccessReasonSelector)
+      .next()
       .fork(watchSessionRefreshInOfflineSaga)
       .next()
       .select(remoteConfigSelector)
@@ -179,6 +184,8 @@ describe("initializeApplicationSaga", () => {
       .next()
       .call(isDeviceOfflineWithWalletSaga)
       .next()
+      .select(offlineAccessReasonSelector)
+      .next()
       .fork(watchSessionRefreshInOfflineSaga)
       .next()
       .select(remoteConfigSelector)
@@ -231,6 +238,8 @@ describe("initializeApplicationSaga", () => {
       .fork(watchItwOfflineSaga)
       .next()
       .call(isDeviceOfflineWithWalletSaga)
+      .next()
+      .select(offlineAccessReasonSelector)
       .next()
       .fork(watchSessionRefreshInOfflineSaga)
       .next()
@@ -289,6 +298,8 @@ describe("initializeApplicationSaga", () => {
       .fork(watchItwOfflineSaga)
       .next()
       .call(isDeviceOfflineWithWalletSaga)
+      .next()
+      .select(offlineAccessReasonSelector)
       .next()
       .fork(watchSessionRefreshInOfflineSaga)
       .next()
@@ -361,6 +372,8 @@ describe("initializeApplicationSaga", () => {
       .next()
       .call(isDeviceOfflineWithWalletSaga)
       .next()
+      .select(offlineAccessReasonSelector)
+      .next()
       .fork(watchSessionRefreshInOfflineSaga)
       .next()
       .select(remoteConfigSelector)
@@ -418,6 +431,8 @@ describe("initializeApplicationSaga", () => {
       .fork(watchItwOfflineSaga)
       .next()
       .call(isDeviceOfflineWithWalletSaga)
+      .next()
+      .select(offlineAccessReasonSelector)
       .next()
       .fork(watchSessionRefreshInOfflineSaga)
       .next()

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -51,7 +51,10 @@ import {
   isDeviceOfflineWithWalletSaga,
   watchSessionRefreshInOfflineSaga
 } from "../features/ingress/saga";
-import { isBlockingScreenSelector } from "../features/ingress/store/selectors";
+import {
+  isBlockingScreenSelector,
+  offlineAccessReasonSelector
+} from "../features/ingress/store/selectors";
 import {
   watchItwOfflineSaga,
   watchItwSaga
@@ -133,6 +136,7 @@ import { getPin } from "../utils/keychain";
 import { watchActiveSessionLoginSaga } from "../features/authentication/activeSessionLogin/saga";
 import ROUTES from "../navigation/routes";
 import { MESSAGES_ROUTES } from "../features/messages/navigation/routes";
+import { OfflineAccessReasonEnum } from "../features/ingress/store/reducer";
 import { previousInstallationDataDeleteSaga } from "./installation";
 import {
   askMixpanelOptIn,
@@ -251,6 +255,8 @@ export function* initializeApplicationSaga(
   }
   // #LOLLIPOP_CHECK_BLOCK1_END
 
+  // OFFLINE WALLET MINI-APP CHECKS
+
   // Start watching for ITW sagas that do not require internet connection or a valid session
   yield* fork(watchItwOfflineSaga);
 
@@ -265,6 +271,12 @@ export function* initializeApplicationSaga(
    */
   const isDeviceOfflineWithWallet = yield* call(isDeviceOfflineWithWalletSaga);
   if (isDeviceOfflineWithWallet) {
+    return;
+  }
+
+  const offlineAccessReason = yield* select(offlineAccessReasonSelector);
+
+  if (offlineAccessReason === OfflineAccessReasonEnum.TIMEOUT) {
     return;
   }
 


### PR DESCRIPTION
## Short description
This PR introduces the handling of the timeout case during the app startup loading.
When the app fails to connect within the expected time, the user is offered the option to access the Wallet in offline mode.
Unlike other offline reasons, this case only displays a banner with a refresh action and does not trigger a bottom sheet.

## List of changes proposed in this pull request
- Added specific handling for OfflineAccessReasonEnum.TIMEOUT.
- Displayed a banner with refresh action for the timeout scenario.
- Prevented the bottom sheet from being rendered when the reason is timeout.
- Updated translations for the new timeout alert messages.

## DEMO
Wip

## How to test
1. Start application 
2. Simulate a startup timeout (use proxyman or your internet connection)
3. Verify that: 
  - A banner is displayed with the correct timeout content and refresh action.
  - No bottom sheet is displayed.
  - The refresh action correctly restarts the app.
4. Verify that other offline reasons (device_offline, session_expired, session_refresh) still show the banner + bottom sheet as expected.