### PR TITLE
fix(IT-Wallet): [SIW-2891] IT-Wallet activation button

### DIFF
--- a/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteFailureScreen.test.tsx
+++ b/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteFailureScreen.test.tsx
@@ -2,6 +2,7 @@ import { createActor } from "xstate";
 import { createStore } from "redux";
 import { Credential, Errors } from "@pagopa/io-react-native-wallet";
 import { FederationError } from "@pagopa/io-react-native-wallet-v2/src/trust/errors";
+import { constTrue } from "fp-ts/lib/function";
 import { RemoteFailure, RemoteFailureType } from "../../machine/failure";
 import { itwRemoteMachine } from "../../machine/machine";
 import { ItwRemoteMachineContext } from "../../machine/provider";
@@ -11,6 +12,7 @@ import { GlobalState } from "../../../../../../store/reducers/types";
 import { ITW_REMOTE_ROUTES } from "../../navigation/routes";
 import { appReducer } from "../../../../../../store/reducers";
 import { applicationChangeState } from "../../../../../../store/actions/application";
+import * as preferencesSelectors from "../../../../common/store/selectors/preferences";
 
 describe("ItwRemoteFailureScreen", () => {
   test.each<RemoteFailure>([
@@ -50,6 +52,9 @@ describe("ItwRemoteFailureScreen", () => {
       reason: new Error() as FederationError
     }
   ])("should render failure screen for $type", failure => {
+    jest
+      .spyOn(preferencesSelectors, "itwIsL3EnabledSelector")
+      .mockImplementation(constTrue);
     expect(renderComponent(failure)).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Short description
This PR fixes the IT-Wallet activation button visualization.

## List of changes proposed in this pull request
- Show the button conditionally in the Wallet Inactive Screen.

## How to test
Ensure it is not possible to activate the Wallet when the L3 flag is disabled.