### PR TITLE
feat: [IOPLT-1291] Enable the theme switch on global app preferences

### DIFF
--- a/ts/RootContainer.tsx
+++ b/ts/RootContainer.tsx
@@ -28,6 +28,7 @@ import {
 } from "./store/reducers/persistedPreferences";
 import { GlobalState } from "./store/reducers/types";
 import { Store } from "./store/actions/types";
+import { useAppThemeConfiguration } from "./hooks/useAppThemeConfiguration";
 
 type Props = ReturnType<typeof mapStateToProps> &
   typeof mapDispatchToProps & { store: Store };
@@ -145,4 +146,15 @@ const mapDispatchToProps = {
   setScreenReaderEnabled
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(RootContainer);
+const RootContainerClass = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(RootContainer);
+
+const RootContainerFC = ({ store }: { store: Store }) => {
+  useAppThemeConfiguration();
+
+  return <RootContainerClass store={store} />;
+};
+
+export default RootContainerFC;

--- a/ts/hooks/useAppThemeConfiguration.tsx
+++ b/ts/hooks/useAppThemeConfiguration.tsx
@@ -1,0 +1,44 @@
+import { useIOThemeContext } from "@pagopa/io-app-design-system";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { Appearance, ColorSchemeName, useColorScheme } from "react-native";
+import { useEffect } from "react";
+import { constVoid } from "fp-ts/lib/function";
+import { useOnFirstRender } from "../utils/hooks/useOnFirstRender";
+
+export const THEME_PERSISTENCE_KEY = "selectedAppThemeConfiguration";
+export type ColorModeChoice = "system" | "dark" | "light";
+
+export const useAppThemeConfiguration = () => {
+  const { setTheme } = useIOThemeContext();
+  const systemColorScheme = useColorScheme();
+
+  useOnFirstRender(() => {
+    AsyncStorage.getItem(THEME_PERSISTENCE_KEY)
+      .then(value => {
+        if (value === undefined || value === null) {
+          Appearance.setColorScheme("light");
+          setTheme("light");
+        }
+        Appearance.setColorScheme(
+          value === "system" ? undefined : (value as ColorSchemeName)
+        );
+        setTheme(
+          value === "system" ? systemColorScheme : (value as ColorSchemeName)
+        );
+      })
+      .catch(() => {
+        Appearance.setColorScheme("light");
+        setTheme("light");
+      });
+  });
+
+  useEffect(() => {
+    AsyncStorage.getItem(THEME_PERSISTENCE_KEY)
+      .then(value => {
+        if (value === "system") {
+          setTheme(systemColorScheme);
+        }
+      })
+      .catch(constVoid);
+  }, [systemColorScheme, setTheme]);
+};


### PR DESCRIPTION
> [!note]
> This PR depends on pagopa/io-app-design-system#488

## Short description
This PR enables the in-app preference to pick the preferred color mode:
- `system` the app theme follows the system theme
- `light` app has the light theme
- `dark` app has the dark theme

## List of changes proposed in this pull request
- information is memorized in the AsyncStorage with specific key to load on any app start
- information affects the DS theme configuration
- an hook handles the app startup configuration and system theme updates
- Preferences screen overrides DS theme and AsyncStorage saving.

## How to test
Change theme preference on Settings > Appearance Preferences and switch between themes.