### PR TITLE
refactor: [SIW-2897] Request `mdoc` credentials only for PID L3

### DIFF
--- a/ts/features/itwallet/common/utils/itwCredentialIssuanceUtils.ts
+++ b/ts/features/itwallet/common/utils/itwCredentialIssuanceUtils.ts
@@ -16,6 +16,7 @@ export type RequestCredentialParams = {
   credentialType: string;
   walletInstanceAttestation: string;
   isNewIssuanceFlowEnabled: boolean;
+  isPidL3: boolean;
 };
 
 /**

--- a/ts/features/itwallet/machine/credential/actors.ts
+++ b/ts/features/itwallet/machine/credential/actors.ts
@@ -11,6 +11,7 @@ import { StoredCredential } from "../../common/utils/itwTypesUtils";
 import { itwCredentialsEidSelector } from "../../credentials/store/selectors";
 import { itwIntegrityKeyTagSelector } from "../../issuance/store/selectors";
 import { Env } from "../../common/utils/environment";
+import { itwLifecycleIsITWalletValidSelector } from "../../lifecycle/store/selectors";
 import { type Context } from "./context";
 
 export type GetWalletAttestationActorInput = {
@@ -114,6 +115,7 @@ export const createCredentialIssuanceActorsImplementation = (
       walletInstanceAttestation,
       isNewIssuanceFlowEnabled
     } = input;
+    const isPidL3 = itwLifecycleIsITWalletValidSelector(store.getState());
 
     assert(credentialType, "credentialType is undefined");
     assert(walletInstanceAttestation, "walletInstanceAttestation is undefined");
@@ -122,7 +124,8 @@ export const createCredentialIssuanceActorsImplementation = (
       env,
       credentialType,
       walletInstanceAttestation,
-      isNewIssuanceFlowEnabled: !!isNewIssuanceFlowEnabled
+      isNewIssuanceFlowEnabled: !!isNewIssuanceFlowEnabled,
+      isPidL3
     });
   });
 


### PR DESCRIPTION
## Short description
This PR adds the PID level check during the credential request phase. The check ensures that formats other than `dc+sd-jwt` are excluded if the available PID does not meet the required security level (PID L3

## How to test
Using Reactotron or a proxy tool, ensure that the `mdl` in both formats is requested only if a `PID L3` is available.
If an `eID` is used (by requesting credentials through flow 1.0) or a `PID L2` is available, the `mdl` must only be requested in the `dc+sd-jwt` format
