### PR TITLE
chore: [IOBP-1948] Add `intent://` schema inside the payments origin webview whitelist schemas

### DIFF
--- a/ts/features/payments/checkout/components/WalletPaymentWebView.tsx
+++ b/ts/features/payments/checkout/components/WalletPaymentWebView.tsx
@@ -9,7 +9,7 @@ import { PaymentStartWebViewPayload } from "../store/actions/orchestration";
 const originSchemasWhiteList = [
   "https://*",
   `${WALLET_WEBVIEW_OUTCOME_SCHEMA}://*`,
-  "intent://",
+  "intent://*",
   "about:*",
   ...(isDevEnv ? ["http://*"] : [])
 ];

--- a/ts/features/payments/checkout/components/WalletPaymentWebView.tsx
+++ b/ts/features/payments/checkout/components/WalletPaymentWebView.tsx
@@ -9,6 +9,7 @@ import { PaymentStartWebViewPayload } from "../store/actions/orchestration";
 const originSchemasWhiteList = [
   "https://*",
   `${WALLET_WEBVIEW_OUTCOME_SCHEMA}://*`,
+  "intent://",
   "about:*",
   ...(isDevEnv ? ["http://*"] : [])
 ];


### PR DESCRIPTION
## Short description
This PR makes a small change to the `WalletPaymentWebView.tsx` file by adding support for the `intent://*` schema to the `originSchemasWhiteList` array. This update allows the webview to handle URLs with the `intent://*` schema, which is commonly used for deep linking in mobile applications on Android.

## List of changes proposed in this pull request
- Added `intent://*` schema to the whitelisted origin schemas;

## How to test
On the dev server, mock any page (e.g., the payment authorization page), add an Android intent link to an external app, and verify that tapping it launches the app successfully
