### PR TITLE
fix: [IOBP-1947] IDPay removed default color from barcode label

### DIFF
--- a/ts/features/idpay/barcode/components/IdPayBarcodeExpireProgressBar.tsx
+++ b/ts/features/idpay/barcode/components/IdPayBarcodeExpireProgressBar.tsx
@@ -42,12 +42,10 @@ export const IdPayBarcodeExpireProgressBar = ({
       <ProgressBar progressPercentage={seconds / secondsExpirationTotal} />
       <VSpacer size={8} />
       <View style={styles.centeredRow}>
-        <BodySmall weight="Regular" color="black">
+        <BodySmall weight="Regular">
           {I18n.t("idpay.barCode.resultScreen.success.expiresIn")}
         </BodySmall>
-        <BodySmall weight="Semibold" color="black">
-          {formattedSecondsToExpiration}
-        </BodySmall>
+        <BodySmall weight="Semibold">{formattedSecondsToExpiration}</BodySmall>
       </View>
     </View>
   );


### PR DESCRIPTION
## Short description
This pull request makes a minor UI update to the `IdPayBarcodeExpireProgressBar` component

## List of changes proposed in this pull request
- Removed explicit setting of the `color="black"` prop from two `BodySmall` allowing them to use selected theme color instead

## How to test
Generate an IDPay barcode with dark mode enabled and ensure that all labels are readable

## Preview

https://github.com/user-attachments/assets/d9e8199a-9710-42f0-b290-5429acb57fb6

