### PR TITLE
chore(IT Wallet): [SIW-2906] Update credential upgrade badge display criteria

### DIFF
--- a/ts/features/itwallet/common/components/ItwCredentialCard/ItwCredentialCard.tsx
+++ b/ts/features/itwallet/common/components/ItwCredentialCard/ItwCredentialCard.tsx
@@ -5,7 +5,6 @@ import { StyleSheet, View } from "react-native";
 import I18n from "../../../../../i18n";
 import { useIOSelector } from "../../../../../store/hooks";
 import { fontPreferenceSelector } from "../../../../../store/reducers/persistedPreferences";
-import { itwShouldRenderNewItWalletSelector } from "../../store/selectors";
 import {
   getCredentialNameFromType,
   tagPropsByStatus,
@@ -14,6 +13,7 @@ import {
 } from "../../utils/itwCredentialUtils";
 import { getThemeColorByCredentialType } from "../../utils/itwStyleUtils";
 import { ItwCredentialStatus } from "../../utils/itwTypesUtils";
+import { itwShouldRenderNewItWalletSelector } from "../../store/selectors";
 import { CardBackground } from "./CardBackground";
 import { DigitalVersionBadge } from "./DigitalVersionBadge";
 import { CardColorScheme } from "./types";
@@ -32,8 +32,10 @@ export type ItwCredentialCard = {
   /**
    * Used to determine if the card should be displayed with a
    * badge for the upgrade pending status.
+   * If its false but the user has an L3 PID, the card will
+   * be displayed with a badge.
    */
-  isLegacyFormat?: boolean;
+  isItwCredential?: boolean;
 };
 
 type StyleProps = {
@@ -45,11 +47,11 @@ type StyleProps = {
 export const ItwCredentialCard = ({
   credentialType,
   credentialStatus = "valid",
-  isLegacyFormat = false
+  isItwCredential
 }: ItwCredentialCard) => {
   const typefacePreference = useIOSelector(fontPreferenceSelector);
   const isNewItwRenderable = useIOSelector(itwShouldRenderNewItWalletSelector);
-  const needsItwUpgrade = isNewItwRenderable && isLegacyFormat;
+  const needsItwUpgrade = isNewItwRenderable && !isItwCredential;
 
   const borderColorMap = useBorderColorByStatus();
 

--- a/ts/features/itwallet/common/components/ItwCredentialCard/__tests__/ItwCredentialCard.test.tsx
+++ b/ts/features/itwallet/common/components/ItwCredentialCard/__tests__/ItwCredentialCard.test.tsx
@@ -74,7 +74,7 @@ describe("ItwCredentialCard", () => {
 
     const component = render(
       <Provider store={store}>
-        <ItwCredentialCard credentialType="mDL" isLegacyFormat={true} />
+        <ItwCredentialCard credentialType="mDL" isItwCredential={false} />
       </Provider>
     );
     expect(component).toMatchSnapshot();

--- a/ts/features/itwallet/common/utils/itwCredentialUtils.ts
+++ b/ts/features/itwallet/common/utils/itwCredentialUtils.ts
@@ -97,9 +97,6 @@ export const validCredentialStatuses: Array<ItwCredentialStatus> = [
  * checks whether the `assurance_level` field is equal to `"high"`,
  * and returns `true` only in that case.
  *
- * This must be used **only for eID**, since credentials obtained
- * with the old eID always have `assurance_level` set to `"high"`.
- *
  * @param sdJwt - The SD-JWT string to check
  * @returns boolean indicating if the credential is an ITW credential (L3)
  */

--- a/ts/features/itwallet/credentials/saga/__tests__/handleWalletCredentialsRehydration.test.ts
+++ b/ts/features/itwallet/credentials/saga/__tests__/handleWalletCredentialsRehydration.test.ts
@@ -110,7 +110,7 @@ describe("ITW handleWalletCredentialsRehydration saga", () => {
             category: "itw",
             credentialType: CredentialType.DRIVING_LICENSE,
             credentialStatus: "valid",
-            isLegacyFormat: false
+            isItwCredential: false
           },
           {
             key: `ITW_${CredentialType.EUROPEAN_DISABILITY_CARD}`,
@@ -118,7 +118,7 @@ describe("ITW handleWalletCredentialsRehydration saga", () => {
             category: "itw",
             credentialType: CredentialType.EUROPEAN_DISABILITY_CARD,
             credentialStatus: "valid",
-            isLegacyFormat: false
+            isItwCredential: false
           }
         ])
       )

--- a/ts/features/itwallet/wallet/components/ItwCredentialWalletCard.tsx
+++ b/ts/features/itwallet/wallet/components/ItwCredentialWalletCard.tsx
@@ -11,10 +11,10 @@ export type ItwCredentialWalletCardProps = ItwCredentialCard & {
 };
 
 const WrappedItwCredentialCard = (props: ItwCredentialWalletCardProps) => {
-  const { isLegacyFormat, credentialType } = props;
+  const { isItwCredential, credentialType } = props;
   const navigation = useIONavigation();
   const isNewItwRenderable = useIOSelector(itwShouldRenderNewItWalletSelector);
-  const needsItwUpgrade = isNewItwRenderable && isLegacyFormat;
+  const needsItwUpgrade = isNewItwRenderable && !isItwCredential;
 
   const handleOnPress = () => {
     if (needsItwUpgrade) {

--- a/ts/features/itwallet/wallet/utils/index.ts
+++ b/ts/features/itwallet/wallet/utils/index.ts
@@ -1,9 +1,7 @@
 import { WalletCard } from "../../../wallet/types";
 import { getCredentialStatus } from "../../common/utils/itwCredentialStatusUtils";
-import {
-  CredentialFormat,
-  StoredCredential
-} from "../../common/utils/itwTypesUtils";
+import { isItwCredential } from "../../common/utils/itwCredentialUtils";
+import { StoredCredential } from "../../common/utils/itwTypesUtils";
 
 export const mapCredentialToWalletCard = (
   credential: StoredCredential
@@ -13,5 +11,5 @@ export const mapCredentialToWalletCard = (
   category: "itw",
   credentialType: credential.credentialType,
   credentialStatus: getCredentialStatus(credential),
-  isLegacyFormat: credential.format === CredentialFormat.LEGACY_SD_JWT
+  isItwCredential: isItwCredential(credential.credential)
 });


### PR DESCRIPTION
## Short description
This PR updates the "Upgrade" badge display criteria, making it visible only if the credential's `assurance_level` is not the same as the PID's.

## List of changes proposed in this pull request
- Updated `ItwCredentialCard` props: replaced `isLegacyFormat` with `isItwCredential`
- Updated "Upgrade" badge render logic: the badge is now displayed if the credential has `assurnace_level` !== `high` and the user has an IT Wallet L3 PID
- Updated `mapCredentialToWalletCard` utility function
 
## How to test
> [!NOTE]
> In order to test this PR you must be able to mock data with a proxy (eg.: Proxyman)

- With the L3 flag disabled, obtain the wallet and at least one credential.
- Restart the app
- With the L3 flag enabled, upgrade the wallet and make sure the credential upgrade step fails by mocking the `/credential` endpoint with a Proxy.
- Go to the Wallet and verify that the credentials display the "Upgrade" badge.
