### PR TITLE
refactor: [IOCOM-2541] DownloadAttachmentWorker and request

### DIFF
--- a/ts/features/messages/components/MessageDetail/MessageDetailsAttachmentItem.tsx
+++ b/ts/features/messages/components/MessageDetail/MessageDetailsAttachmentItem.tsx
@@ -11,7 +11,7 @@ type MessageDetailsAttachmentItemProps = {
   isPN?: boolean;
   messageId: string;
   onPreNavigate?: () => void;
-  serviceId?: ServiceId;
+  serviceId: ServiceId;
 };
 
 export const MessageDetailsAttachmentItem = ({

--- a/ts/features/messages/components/MessageDetail/MessageDetailsAttachments.tsx
+++ b/ts/features/messages/components/MessageDetail/MessageDetailsAttachments.tsx
@@ -1,9 +1,10 @@
-import { pipe } from "fp-ts/lib/function";
-import * as B from "fp-ts/lib/boolean";
 import { ListItemHeader } from "@pagopa/io-app-design-system";
+import * as B from "fp-ts/lib/boolean";
+import { pipe } from "fp-ts/lib/function";
+import { ServiceId } from "../../../../../definitions/backend/ServiceId";
+import I18n from "../../../../i18n";
 import { useIOSelector } from "../../../../store/hooks";
 import { thirdPartyMessageAttachments } from "../../store/reducers/thirdPartyById";
-import I18n from "../../../../i18n";
 import { ATTACHMENT_CATEGORY } from "../../types/attachmentCategory";
 import { MessageDetailsAttachmentItem } from "./MessageDetailsAttachmentItem";
 
@@ -11,12 +12,14 @@ export type MessageDetailsAttachmentsProps = {
   disabled?: boolean;
   isPN?: boolean;
   messageId: string;
+  serviceId: ServiceId;
 };
 
 export const MessageDetailsAttachments = ({
   disabled = false,
   isPN = false,
-  messageId
+  messageId,
+  serviceId
 }: MessageDetailsAttachmentsProps) => {
   const originalAttachments = useIOSelector(state =>
     thirdPartyMessageAttachments(state, messageId)
@@ -51,6 +54,7 @@ export const MessageDetailsAttachments = ({
           disabled={disabled}
           key={`MessageAttachment_${index}`}
           messageId={messageId}
+          serviceId={serviceId}
         />
       ))}
     </>

--- a/ts/features/messages/components/MessageDetail/__tests__/MessageDetailsAttachmentItem.test.tsx
+++ b/ts/features/messages/components/MessageDetail/__tests__/MessageDetailsAttachmentItem.test.tsx
@@ -10,6 +10,7 @@ import { ServiceId } from "../../../../../../definitions/backend/ServiceId";
 describe("MessageDetailsAttachmentItem", () => {
   it("Should match snapshot with required parameters", () => {
     const messageId = "01HNWXJG52YS359GWSYSRK2BWC";
+    const serviceId = "01HNWXKWAGWPHV7VGMQ21EZPSA" as ServiceId;
     const thirdPartyAttachment = {
       id: "1",
       url: "https://invalid.url",
@@ -18,7 +19,7 @@ describe("MessageDetailsAttachmentItem", () => {
       category: "DOCUMENT"
     } as ThirdPartyAttachment;
 
-    const component = renderScreen(thirdPartyAttachment, messageId);
+    const component = renderScreen(thirdPartyAttachment, messageId, serviceId);
     expect(component.toJSON()).toMatchSnapshot();
   });
   it("Should match snapshot with all parameters", () => {
@@ -44,6 +45,7 @@ describe("MessageDetailsAttachmentItem", () => {
   });
   it("Should match snapshot when the attachment has no name", () => {
     const messageId = "01HNWXJG52YS359GWSYSRK2BWC";
+    const serviceId = "01HNWXKWAGWPHV7VGMQ21EZPSA" as ServiceId;
     const thirdPartyAttachment = {
       id: "1",
       url: "https://invalid.url",
@@ -51,11 +53,12 @@ describe("MessageDetailsAttachmentItem", () => {
       category: "DOCUMENT"
     } as ThirdPartyAttachment;
 
-    const component = renderScreen(thirdPartyAttachment, messageId);
+    const component = renderScreen(thirdPartyAttachment, messageId, serviceId);
     expect(component.toJSON()).toMatchSnapshot();
   });
   it("Should match snapshot when is fetching the attachment", () => {
     const messageId = "01HNWXJG52YS359GWSYSRK2BWC";
+    const serviceId = "01HNWXKWAGWPHV7VGMQ21EZPSA" as ServiceId;
     const thirdPartyAttachment = {
       id: "1",
       url: "https://invalid.url",
@@ -66,7 +69,7 @@ describe("MessageDetailsAttachmentItem", () => {
     const component = renderScreen(
       thirdPartyAttachment,
       messageId,
-      undefined,
+      serviceId,
       undefined,
       true,
       false
@@ -78,7 +81,7 @@ describe("MessageDetailsAttachmentItem", () => {
 const renderScreen = (
   attachment: ThirdPartyAttachment,
   messageId: string,
-  serviceId?: ServiceId,
+  serviceId: ServiceId,
   bottomSpacer?: boolean,
   isFetching?: boolean,
   disabled?: boolean
@@ -90,7 +93,8 @@ const renderScreen = (
       ? downloadAttachment.request({
           attachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       : downloadAttachment.success({
           messageId,

--- a/ts/features/messages/components/MessageDetail/__tests__/MessageDetailsAttachments.test.tsx
+++ b/ts/features/messages/components/MessageDetail/__tests__/MessageDetailsAttachments.test.tsx
@@ -8,57 +8,52 @@ import { ThirdPartyMessage } from "../../../../../../definitions/backend/ThirdPa
 import { ThirdPartyMessageWithContent } from "../../../../../../definitions/backend/ThirdPartyMessageWithContent";
 import { ThirdPartyAttachment } from "../../../../../../definitions/backend/ThirdPartyAttachment";
 import { ATTACHMENT_CATEGORY } from "../../../types/attachmentCategory";
+import { ServiceId } from "../../../../../../definitions/backend/ServiceId";
 
 describe("MessageDetailsAttachments", () => {
+  const messageId = "01HNWYRT55GXGPXR16BW2MSBVY";
+  const serviceId = "01JKAGWVQRFE1P8QAHZS743M90" as ServiceId;
   it("Should match snapshot with no attachments", () => {
-    const messageId = "01HNWYRT55GXGPXR16BW2MSBVY";
-    const component = renderScreen(messageId);
+    const component = renderScreen(messageId, serviceId);
     expect(component.toJSON()).toMatchSnapshot();
   });
   it("Should match snapshot with no attachments and disabled UI", () => {
-    const messageId = "01HNWYRT55GXGPXR16BW2MSBVY";
-    const component = renderScreen(messageId, 0, true);
+    const component = renderScreen(messageId, serviceId, 0, true);
     expect(component.toJSON()).toMatchSnapshot();
   });
   it("Should match snapshot with no attachments, where F24 have been removed and disabled UI", () => {
-    const messageId = "01HNWYRT55GXGPXR16BW2MSBVY";
-    const component = renderScreen(messageId, 0, true, true);
+    const component = renderScreen(messageId, serviceId, 0, true, true);
     expect(component.toJSON()).toMatchSnapshot();
   });
   it("Should match snapshot with 1 attachment", () => {
-    const messageId = "01HNWYRT55GXGPXR16BW2MSBVY";
-    const component = renderScreen(messageId, 1);
+    const component = renderScreen(messageId, serviceId, 1);
     expect(component.toJSON()).toMatchSnapshot();
   });
   it("Should match snapshot with 1 attachment that is disabled", () => {
-    const messageId = "01HNWYRT55GXGPXR16BW2MSBVY";
-    const component = renderScreen(messageId, 1, true);
+    const component = renderScreen(messageId, serviceId, 1, true);
     expect(component.toJSON()).toMatchSnapshot();
   });
   it("Should match snapshot with 1 attachment that is disabled and F24 have been removed", () => {
-    const messageId = "01HNWYRT55GXGPXR16BW2MSBVY";
-    const component = renderScreen(messageId, 1, true, true);
+    const component = renderScreen(messageId, serviceId, 1, true, true);
     expect(component.toJSON()).toMatchSnapshot();
   });
   it("Should match snapshot with 10 attachments", () => {
-    const messageId = "01HNWYRT55GXGPXR16BW2MSBVY";
-    const component = renderScreen(messageId, 10);
+    const component = renderScreen(messageId, serviceId, 10);
     expect(component.toJSON()).toMatchSnapshot();
   });
   it("Should match snapshot with 10 attachments that are disabled", () => {
-    const messageId = "01HNWYRT55GXGPXR16BW2MSBVY";
-    const component = renderScreen(messageId, 10, true);
+    const component = renderScreen(messageId, serviceId, 10, true);
     expect(component.toJSON()).toMatchSnapshot();
   });
   it("Should match snapshot with 5 attachments that are disabled and F24 have been removed", () => {
-    const messageId = "01HNWYRT55GXGPXR16BW2MSBVY";
-    const component = renderScreen(messageId, 10, true, true);
+    const component = renderScreen(messageId, serviceId, 10, true, true);
     expect(component.toJSON()).toMatchSnapshot();
   });
 });
 
 const renderScreen = (
   messageId: string,
+  serviceId: ServiceId,
   attachmentCount: number = 0,
   disabled: boolean = false,
   isPN: boolean = false
@@ -90,6 +85,7 @@ const renderScreen = (
         messageId={messageId}
         disabled={disabled}
         isPN={isPN}
+        serviceId={serviceId}
       />
     ),
     "DUMMY",

--- a/ts/features/messages/hooks/useAttachmentDownload.tsx
+++ b/ts/features/messages/hooks/useAttachmentDownload.tsx
@@ -30,7 +30,7 @@ export const useAttachmentDownload = (
   messageId: string,
   attachment: ThirdPartyAttachment,
   isPN: boolean,
-  serviceId?: ServiceId,
+  serviceId: ServiceId,
   onPreNavigate?: () => void
 ) => {
   const attachmentId = attachment.id;
@@ -109,11 +109,21 @@ export const useAttachmentDownload = (
         downloadAttachment.request({
           attachment,
           messageId,
-          skipMixpanelTrackingOnFailure: isPN
+          skipMixpanelTrackingOnFailure: isPN,
+          serviceId
         })
       );
     }
-  }, [attachment, dispatch, download, doNavigate, isFetching, isPN, messageId]);
+  }, [
+    attachment,
+    dispatch,
+    download,
+    doNavigate,
+    isFetching,
+    isPN,
+    messageId,
+    serviceId
+  ]);
 
   useEffect(() => {
     const state = store.getState();

--- a/ts/features/messages/saga/__test__/handleDownloadAttachment.test.ts
+++ b/ts/features/messages/saga/__test__/handleDownloadAttachment.test.ts
@@ -27,10 +27,6 @@ const somePublicKey = O.some({
   y: "Tz0xNv++cOeLVapU/BhBS0FJydIcNcV25/ALb1HVu+s="
 });
 
-jest.mock("../../store/reducers/paginatedById", () => ({
-  getServiceByMessageId: jest.fn().mockReturnValue(serviceId)
-}));
-
 jest.mock("react-native-blob-util", () => ({
   config: jest.fn().mockImplementation(() => ({
     fetch: jest.fn()
@@ -54,7 +50,8 @@ describe("downloadAttachment given an attachment", () => {
         downloadAttachment.request({
           attachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       )
         .provide([
@@ -88,7 +85,8 @@ describe("downloadAttachment given an attachment", () => {
         downloadAttachment.request({
           attachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       )
         .provide([
@@ -123,7 +121,8 @@ describe("downloadAttachment given an attachment", () => {
         downloadAttachment.request({
           attachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       )
         .provide([

--- a/ts/features/messages/saga/handleDownloadAttachment.ts
+++ b/ts/features/messages/saga/handleDownloadAttachment.ts
@@ -6,7 +6,6 @@ import {
   delay,
   put,
   race,
-  select,
   take
 } from "typed-redux-saga/macro";
 import RNFS from "react-native-fs";
@@ -24,7 +23,6 @@ import {
   downloadAttachment
 } from "../store/actions";
 import { ServiceId } from "../../../../definitions/backend/ServiceId";
-import { getServiceByMessageId } from "../store/reducers/paginatedById";
 import {
   trackThirdPartyMessageAttachmentBadFormat,
   trackThirdPartyMessageAttachmentDownloadFailed,
@@ -88,9 +86,8 @@ export function* downloadAttachmentWorker(
   bearerToken: SessionToken,
   action: ActionType<typeof downloadAttachment.request>
 ): SagaIterator {
-  const { attachment, messageId, skipMixpanelTrackingOnFailure } =
+  const { attachment, messageId, skipMixpanelTrackingOnFailure, serviceId } =
     action.payload;
-  const serviceId = yield* select(getServiceByMessageId, messageId);
 
   const name = attachmentDisplayName(attachment);
 

--- a/ts/features/messages/screens/MessageDetailsScreen.tsx
+++ b/ts/features/messages/screens/MessageDetailsScreen.tsx
@@ -201,7 +201,10 @@ export const MessageDetailsScreen = (props: MessageDetailsScreenProps) => {
               serviceId={serviceId}
             />
             <VSpacer size={16} />
-            <MessageDetailsAttachments messageId={messageId} />
+            <MessageDetailsAttachments
+              messageId={messageId}
+              serviceId={serviceId}
+            />
             {hasRemoteContent && <RemoteContentBanner />}
           </ContentWrapper>
         </View>

--- a/ts/features/messages/store/actions/__tests__/index.test.ts
+++ b/ts/features/messages/store/actions/__tests__/index.test.ts
@@ -508,13 +508,15 @@ describe("index", () => {
         const action = downloadAttachment.request({
           attachment,
           messageId,
-          skipMixpanelTrackingOnFailure: skipTracking
+          skipMixpanelTrackingOnFailure: skipTracking,
+          serviceId
         });
         expect(action.type).toBe("DOWNLOAD_ATTACHMENT_REQUEST");
         expect(action.payload).toEqual({
           attachment,
           messageId,
-          skipMixpanelTrackingOnFailure: skipTracking
+          skipMixpanelTrackingOnFailure: skipTracking,
+          serviceId
         });
       });
     });

--- a/ts/features/messages/store/actions/index.ts
+++ b/ts/features/messages/store/actions/index.ts
@@ -195,6 +195,7 @@ export type DownloadAttachmentRequest = {
   attachment: ThirdPartyAttachment;
   messageId: string;
   skipMixpanelTrackingOnFailure: boolean;
+  serviceId: ServiceId;
 };
 
 export type DownloadAttachmentSuccess = {

--- a/ts/features/messages/store/reducers/__tests__/downloads.test.ts
+++ b/ts/features/messages/store/reducers/__tests__/downloads.test.ts
@@ -22,6 +22,7 @@ import { GlobalState } from "../../../../../store/reducers/types";
 import { appReducer } from "../../../../../store/reducers";
 import { applicationChangeState } from "../../../../../store/actions/application";
 import { ThirdPartyAttachment } from "../../../../../../definitions/backend/ThirdPartyAttachment";
+import { ServiceId } from "../../../../../../definitions/backend/ServiceId";
 
 const path = "/path/attachment.pdf";
 
@@ -237,6 +238,7 @@ describe("downloadedMessageAttachmentSelector", () => {
 
 describe("downloadsReducer", () => {
   const messageId = "01HP08KKPY65CBF4TRPHGJJ1GT";
+  const serviceId = "service0000001" as ServiceId;
 
   describe("given no download", () => {
     const initialState: Downloads = {
@@ -251,7 +253,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
 
@@ -350,7 +353,8 @@ describe("downloadsReducer", () => {
       downloadAttachment.request({
         attachment,
         messageId,
-        skipMixpanelTrackingOnFailure: false
+        skipMixpanelTrackingOnFailure: false,
+        serviceId
       })
     );
 
@@ -399,7 +403,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const isDownloadingMessage = isDownloadingMessageAttachmentSelector(
@@ -415,7 +420,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const isDownloadingMessage = isDownloadingMessageAttachmentSelector(
@@ -431,7 +437,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const isDownloadingMessage = isDownloadingMessageAttachmentSelector(
@@ -447,7 +454,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const successState = appReducer(
@@ -471,7 +479,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const failureState = appReducer(
@@ -495,7 +504,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const cancelledState = appReducer(
@@ -518,7 +528,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const clearedState = appReducer(
@@ -541,7 +552,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const isError = hasErrorOccourredOnRequestedDownloadSelector(
@@ -557,7 +569,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const failureState = appReducer(
@@ -581,7 +594,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const failureState = appReducer(
@@ -605,7 +619,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const failureState = appReducer(
@@ -629,7 +644,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const failureState = appReducer(
@@ -653,7 +669,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const failureState = appReducer(
@@ -676,7 +693,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const failureState = appReducer(
@@ -720,7 +738,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const isRequestedAttachmentDownload =
@@ -737,7 +756,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const isRequestedAttachmentDownload =
@@ -754,7 +774,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const isRequestedAttachmentDownload =
@@ -771,7 +792,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const successfulDownloadState = appReducer(
@@ -796,7 +818,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const failedDownloadState = appReducer(
@@ -821,7 +844,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const cancelledDownloadState = appReducer(
@@ -845,7 +869,8 @@ describe("downloadsReducer", () => {
         downloadAttachment.request({
           attachment: mockPdfAttachment,
           messageId,
-          skipMixpanelTrackingOnFailure: false
+          skipMixpanelTrackingOnFailure: false,
+          serviceId
         })
       );
       const clearRequestedDownloadState = appReducer(

--- a/ts/features/messages/store/reducers/paginatedById.ts
+++ b/ts/features/messages/store/reducers/paginatedById.ts
@@ -1,5 +1,4 @@
 import * as pot from "@pagopa/ts-commons/lib/pot";
-import { pipe } from "fp-ts/lib/function";
 import { getType } from "typesafe-actions";
 import {
   loadMessageById,
@@ -116,8 +115,3 @@ export const getPaginatedMessageById = (
   state: GlobalState,
   messageId: string
 ) => state.entities.messages.paginatedById[messageId] ?? pot.none;
-
-export const getServiceByMessageId = (state: GlobalState, messageId: string) =>
-  pipe(getPaginatedMessageById(state, messageId), message =>
-    pot.isSome(message) ? message.value.serviceId : undefined
-  );

--- a/ts/features/pn/components/F24ListBottomSheetLink.tsx
+++ b/ts/features/pn/components/F24ListBottomSheetLink.tsx
@@ -6,15 +6,18 @@ import { MessageDetailsAttachmentItem } from "../../messages/components/MessageD
 import { trackPNShowF24 } from "../analytics";
 import { useIODispatch } from "../../../store/hooks";
 import { cancelPreviousAttachmentDownload } from "../../messages/store/actions";
+import { ServiceId } from "../../../../definitions/backend/ServiceId";
 
 type F24ListBottomSheetLinkProps = {
   f24List: ReadonlyArray<ThirdPartyAttachment>;
   messageId: string;
+  serviceId: ServiceId;
 };
 
 export const F24ListBottomSheetLink = ({
   f24List,
-  messageId
+  messageId,
+  serviceId
 }: F24ListBottomSheetLinkProps) => {
   // The empty footer is needed in order for the internal scroll view to properly compute
   // its bottom space when the bottom sheet opens filling the entire view. Without it, the
@@ -33,6 +36,7 @@ export const F24ListBottomSheetLink = ({
             onPreNavigate={() => {
               dismiss();
             }}
+            serviceId={serviceId}
           />
         ))}
       </>

--- a/ts/features/pn/components/F24Section.tsx
+++ b/ts/features/pn/components/F24Section.tsx
@@ -46,7 +46,11 @@ export const F24Section = ({
         />
       )}
       {f24Count > 1 && (
-        <F24ListBottomSheetLink f24List={f24s} messageId={messageId} />
+        <F24ListBottomSheetLink
+          f24List={f24s}
+          messageId={messageId}
+          serviceId={serviceId}
+        />
       )}
       <VSpacer size={16} />
     </>

--- a/ts/features/pn/components/MessageDetails.tsx
+++ b/ts/features/pn/components/MessageDetails.tsx
@@ -106,6 +106,7 @@ export const MessageDetails = ({
             disabled={message.isCancelled}
             messageId={messageId}
             isPN
+            serviceId={serviceId}
           />
           <VSpacer size={16} />
           <MessagePayments

--- a/ts/features/pn/components/__test__/F24ListBottomSheetLink.test.tsx
+++ b/ts/features/pn/components/__test__/F24ListBottomSheetLink.test.tsx
@@ -4,6 +4,7 @@ import { appReducer } from "../../../../store/reducers";
 import { renderScreenWithNavigationStoreContext } from "../../../../utils/testWrapper";
 import { F24ListBottomSheetLink } from "../F24ListBottomSheetLink";
 import { ThirdPartyAttachment } from "../../../../../definitions/backend/ThirdPartyAttachment";
+import { ServiceId } from "../../../../../definitions/backend/ServiceId";
 
 const numberToThirdPartyAttachment = (index: number) =>
   ({
@@ -38,6 +39,7 @@ const renderComponent = (f24List: ReadonlyArray<ThirdPartyAttachment>) => {
       <F24ListBottomSheetLink
         f24List={f24List}
         messageId={"01HS94671EXDWDESDJB3NCBYPM"}
+        serviceId={"01JKAGWVQRFE1P8QAHZS743M90" as ServiceId}
       />
     ),
     "DUMMY",


### PR DESCRIPTION
## Short description
This pull request refactors downloadAttachmentWorker and downloadAttachment.request to improve structure and to allow downloadAttachment.request to accept a serviceId parameter instead of relying on the getServiceByMessageId selector.

## List of changes proposed in this pull request
- Modify downloadAttachment.request to accept serviceId as an input parameter
- Remove getServiceByMessageId selector usage

## How to test
Automated tests should pass