### PR TITLE
fix: [IOPAE-1760] Add accessibility label for website in service details metadata

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -3004,6 +3004,9 @@
         "messageReadStatus": "Receive read receipts"
       },
       "metadata": {
+        "a11y": {
+          "website": "Browse the institution's website"
+        },
         "title": "Contacts and info",
         "website": "Browse Website",
         "downloadApp": "Download app",

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -3004,6 +3004,9 @@
         "messageReadStatus": "Ricevere conferme di lettura"
       },
       "metadata": {
+        "a11y": {
+          "website": "Visita il sito dell'ente"
+        },
         "title": "Contatti ed informazioni",
         "website": "Visita il sito",
         "downloadApp": "Scarica l'app",

--- a/ts/features/services/details/components/ServiceDetailsMetadata.tsx
+++ b/ts/features/services/details/components/ServiceDetailsMetadata.tsx
@@ -77,6 +77,7 @@ export const ServiceDetailsMetadata = ({
   const metadataListItems: ReadonlyArray<MetadataListItem> = [
     {
       kind: "ListItemAction",
+      accessibilityLabel: I18n.t("services.details.metadata.a11y.website"),
       condition: !!web_url,
       icon: "website",
       label: I18n.t("services.details.metadata.website"),


### PR DESCRIPTION
## Short description
This PR introduces an accessibility improvement to the `ServiceDetailsMetadata` component.

## List of changes proposed in this pull request
- Added `accessibilityLabel` to the website metadata item.

## How to test
Navigate to the service details screen, enable the screen reader, and verify that the website item is announced correctly.
