### PR TITLE
refactor: [IOBP-1961] Adjust IDPay progress bar dark mode colors

### DIFF
--- a/ts/components/BonusCard/BonusCardCounter.tsx
+++ b/ts/components/BonusCard/BonusCardCounter.tsx
@@ -63,7 +63,7 @@ const BonusCardCounter = (props: BonusCardCounter) => {
         {props.label}
       </LabelMini>
       <VSpacer size={4} />
-      <H3 color={isDark ? "blueIO-200" : "blueItalia-500"} style={styles.value}>
+      <H3 color={isDark ? "blueIO-300" : "blueItalia-500"} style={styles.value}>
         {props.value}
       </H3>
       {props.type === "ValueWithProgress" && (
@@ -81,7 +81,11 @@ type BonusProgressBarProps = {
 };
 
 const BonusProgressBar = ({ progress }: BonusProgressBarProps) => {
-  const progressBarColor: ColorValue = IOColors["blueItalia-500"];
+  const isDark = useIOThemeContext().themeType === "dark";
+
+  const progressBarColor: ColorValue = isDark
+    ? IOColors["blueIO-300"]
+    : IOColors["blueItalia-500"];
 
   const width = useSharedValue(100);
   useEffect(() => {

--- a/ts/features/bonus/common/components/ProgressBar.tsx
+++ b/ts/features/bonus/common/components/ProgressBar.tsx
@@ -1,4 +1,4 @@
-import { IOColors } from "@pagopa/io-app-design-system";
+import { IOColors, useIOThemeContext } from "@pagopa/io-app-design-system";
 import { FunctionComponent } from "react";
 
 import { View, StyleSheet, DimensionValue } from "react-native";
@@ -7,17 +7,6 @@ type Props = {
   // between 0 and 1
   progressPercentage: number;
 };
-
-const styles = StyleSheet.create({
-  progressBar: {
-    backgroundColor: IOColors["grey-100"],
-    height: 4
-  },
-  fillBar: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: IOColors["blueIO-500"]
-  }
-});
 
 /**
  * In order to fill the first amount of the bar, if there are 0 transactions,
@@ -37,16 +26,22 @@ const calculateStylePercentage = (
  * @param props
  * @constructor
  */
-export const ProgressBar: FunctionComponent<Props> = props => (
-  <View style={styles.progressBar}>
-    <View
-      testID={"progressBar"}
-      style={[
-        styles.fillBar,
-        {
+export const ProgressBar: FunctionComponent<Props> = props => {
+  const isDark = useIOThemeContext().themeType === "dark";
+  const backgroundColor = isDark
+    ? IOColors["blueIO-300"]
+    : IOColors["blueItalia-500"];
+
+  return (
+    <View style={{ backgroundColor: IOColors["grey-100"], height: 4 }}>
+      <View
+        testID={"progressBar"}
+        style={{
+          ...StyleSheet.absoluteFillObject,
+          backgroundColor,
           width: calculateStylePercentage(props.progressPercentage)
-        }
-      ]}
-    />
-  </View>
-);
+        }}
+      />
+    </View>
+  );
+};

--- a/ts/features/bonus/common/components/__tests__/ProgressBar.test.tsx
+++ b/ts/features/bonus/common/components/__tests__/ProgressBar.test.tsx
@@ -5,30 +5,30 @@ describe("ProgressBar", () => {
   it("should render correctly with 0% progress", () => {
     const { getByTestId } = render(<ProgressBar progressPercentage={0} />);
     const progressBar = getByTestId("progressBar");
-    expect(progressBar.props.style[1].width).toBe("1%");
+    expect(progressBar.props.style.width).toBe("1%");
   });
 
   it("should render correctly with 50% progress", () => {
     const { getByTestId } = render(<ProgressBar progressPercentage={0.5} />);
     const progressBar = getByTestId("progressBar");
-    expect(progressBar.props.style[1].width).toBe("50%");
+    expect(progressBar.props.style.width).toBe("50%");
   });
 
   it("should render correctly with 100% progress", () => {
     const { getByTestId } = render(<ProgressBar progressPercentage={1} />);
     const progressBar = getByTestId("progressBar");
-    expect(progressBar.props.style[1].width).toBe("100%");
+    expect(progressBar.props.style.width).toBe("100%");
   });
 
   it("should clamp percentage to a maximum of 100%", () => {
     const { getByTestId } = render(<ProgressBar progressPercentage={1.5} />);
     const progressBar = getByTestId("progressBar");
-    expect(progressBar.props.style[1].width).toBe("100%");
+    expect(progressBar.props.style.width).toBe("100%");
   });
 
   it("should clamp percentage to a minimum of 0%", () => {
     const { getByTestId } = render(<ProgressBar progressPercentage={-0.5} />);
     const progressBar = getByTestId("progressBar");
-    expect(progressBar.props.style[1].width).toBe("1%");
+    expect(progressBar.props.style.width).toBe("1%");
   });
 });

--- a/ts/features/idpay/wallet/components/IdPayCard.tsx
+++ b/ts/features/idpay/wallet/components/IdPayCard.tsx
@@ -50,7 +50,7 @@ export const IdPayCard = (props: IdPayCardProps) => {
     const available = isDarkMode ? ("white" as const) : ("blueIO-850" as const);
 
     const amountColor = isDarkMode
-      ? ("blueIO-200" as const)
+      ? ("blueIO-300" as const)
       : ("blueIO-500" as const);
 
     const validationColor = isDarkMode


### PR DESCRIPTION
## Short description
This pull request updates the color scheme for progress bars and value displays to better support dark mode 

## List of changes proposed in this pull request
- Apply `blueIO-300`(replacing the previous `blueIO-200`) in dark mode for `blueItalia-500` light mode color

## How to test
Ensure that IDPay progress bar colors are aligned with design