### PR TITLE
fix: [IOPLT-1311] Fixes link issue on markdown rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@babel/plugin-transform-react-jsx": "^7.25.9",
     "@babel/plugin-transform-regenerator": "^7.18.6",
     "@gorhom/bottom-sheet": "^5.1.2",
-    "@pagopa/io-app-design-system": "5.8.1",
+    "@pagopa/io-app-design-system": "5.9.0",
     "@pagopa/io-pagopa-commons": "^3.1.0",
     "@pagopa/io-react-native-cie": "^1.1.0",
     "@pagopa/io-react-native-cieid": "^0.3.5",

--- a/ts/components/IOMarkdown/renderRules.tsx
+++ b/ts/components/IOMarkdown/renderRules.tsx
@@ -496,7 +496,13 @@ export const linkNodeToReactNative = (
   onPress: () => void,
   render: Renderer
 ) => (
-  <Body weight="Semibold" asLink key={getTxtNodeKey(link)} onPress={onPress}>
+  <Body
+    weight="Semibold"
+    asLink
+    avoidPressable
+    key={getTxtNodeKey(link)}
+    onPress={onPress}
+  >
     {link.children.map(render)}
   </Body>
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3863,9 +3863,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagopa/io-app-design-system@npm:5.8.1":
-  version: 5.8.1
-  resolution: "@pagopa/io-app-design-system@npm:5.8.1"
+"@pagopa/io-app-design-system@npm:5.9.0":
+  version: 5.9.0
+  resolution: "@pagopa/io-app-design-system@npm:5.9.0"
   dependencies:
     auto-changelog: ^2.4.0
     lodash: ^4.17.21
@@ -3886,7 +3886,7 @@ __metadata:
     react-native-reanimated: "*"
     react-native-safe-area-context: "*"
     react-native-svg: "*"
-  checksum: 6f18b985562c86bc0f14ecdc179fbf75cb7f13159a028e728ee71de81bd7057b5f1393d3f0e7374c120c6dbbce83271d84bbe35877c1b7ae8cf9b506c3a6d286
+  checksum: 5442096cebb034c335006a65547ec4c47049512bdce457cd08c1f81047ac1599f48ef58a5fb9fd20181c8aecc9dc94df4ef50c4ed205b4188b106243fe0ac569
   languageName: node
   linkType: hard
 
@@ -12947,7 +12947,7 @@ __metadata:
     "@babel/runtime": ^7.25.0
     "@gorhom/bottom-sheet": ^5.1.2
     "@jambit/eslint-plugin-typed-redux-saga": ^0.4.0
-    "@pagopa/io-app-design-system": 5.8.1
+    "@pagopa/io-app-design-system": 5.9.0
     "@pagopa/io-pagopa-commons": ^3.1.0
     "@pagopa/io-react-native-cie": ^1.1.0
     "@pagopa/io-react-native-cieid": ^0.3.5


### PR DESCRIPTION
## Short description
This PR bumps ds version and fix compatibility issue on Markdown links

## List of changes proposed in this pull request
- Bumps DS
- adds `avoidPressable` prop to link renderer into markdown

## How to test
Check the rendering on markdown for small screens and increased font option
