### PR TITLE
feat(IT Wallet): [SIW-2924] Increase screen brightness when showing presentation QRCode

### DIFF
--- a/ts/features/itwallet/presentation/proximity/hooks/useItwPresentQRCode.tsx
+++ b/ts/features/itwallet/presentation/proximity/hooks/useItwPresentQRCode.tsx
@@ -13,6 +13,7 @@ import {
 import I18n from "../../../../../i18n";
 import { ItwRetryableQRCode } from "../../../common/components/ItwRetryableQRCode";
 import { trackItwProximityQrCodeLoadingRetry } from "../analytics";
+import { MaxBrightness } from "../../../../../utils/brightness";
 
 const QR_WIDTH =
   Dimensions.get("window").width - IOVisualCostants.appMarginDefault * 2;
@@ -40,6 +41,7 @@ export const useItwPresentQRCode = () => {
     ),
     component: (
       <VStack space={24}>
+        <MaxBrightness useSmoothTransition={true} />
         <Body>
           {I18n.t(
             "features.itWallet.presentation.proximity.mdl.bottomSheet.body"

--- a/ts/utils/brightness.ts
+++ b/ts/utils/brightness.ts
@@ -245,3 +245,30 @@ export function useMaxBrightness({
     };
   }, [getBrightness, restoreInitialBrightness, setMaxBrightness]);
 }
+
+/**
+ * Convenience component that applies maximum brightness behavior when rendered.
+ *
+ * This component uses the `useMaxBrightness` hook internally to manage screen brightness.
+ * When this component is mounted, it sets the screen brightness to maximum.
+ * When unmounted, it restores the original brightness level.
+ *
+ * It accepts the same configuration options as `useMaxBrightness` via props.
+ *
+ * @example
+ * ```tsx
+ * // Basic usage
+ * <MaxBrightness />
+ * // With smooth transition
+ * <MaxBrightness useSmoothTransition={true} transitionDuration={2000} />
+ * ```
+ *
+ * @param props - Configuration options for brightness management
+ * @returns React.ReactNode that applies max brightness behavior when rendered
+ */
+export const MaxBrightness = (
+  props: UseMaxBrightnessOptions = {}
+): React.ReactNode => {
+  useMaxBrightness(props);
+  return null;
+};


### PR DESCRIPTION
## Short description
This PR makes sure that the screen brightness is set to the maximum when the presentation QRCode is shown.

## List of changes proposed in this pull request
- Implemented `MaxBrightness` convenience component to brightness utilities
- Added `MaxBrightness` to the Proximity QRCode bottom sheet

## How to test
- Open the MDL (L3) details screen. 
- Open the presentation QRCode bottom sheet
- Verify that the screen brightness is set to the maximum 
- Close the bottom sheet 
- Verify that the screen brightness is set to its previous value
