### PR TITLE
fix(IT Wallet): [SIW-2926] Credentials upgrade badge not showing when offline

### DIFF
--- a/ts/features/itwallet/common/components/ItwCredentialCard/ItwCredentialCard.tsx
+++ b/ts/features/itwallet/common/components/ItwCredentialCard/ItwCredentialCard.tsx
@@ -13,7 +13,7 @@ import {
 } from "../../utils/itwCredentialUtils";
 import { getThemeColorByCredentialType } from "../../utils/itwStyleUtils";
 import { ItwCredentialStatus } from "../../utils/itwTypesUtils";
-import { itwShouldRenderNewItWalletSelector } from "../../store/selectors";
+import { itwLifecycleIsITWalletValidSelector } from "../../../lifecycle/store/selectors";
 import { CardBackground } from "./CardBackground";
 import { DigitalVersionBadge } from "./DigitalVersionBadge";
 import { CardColorScheme } from "./types";
@@ -50,8 +50,8 @@ export const ItwCredentialCard = ({
   isItwCredential
 }: ItwCredentialCard) => {
   const typefacePreference = useIOSelector(fontPreferenceSelector);
-  const isNewItwRenderable = useIOSelector(itwShouldRenderNewItWalletSelector);
-  const needsItwUpgrade = isNewItwRenderable && !isItwCredential;
+  const isItwPid = useIOSelector(itwLifecycleIsITWalletValidSelector);
+  const needsItwUpgrade = isItwPid && !isItwCredential;
 
   const borderColorMap = useBorderColorByStatus();
 

--- a/ts/features/itwallet/common/components/ItwCredentialCard/__tests__/ItwCredentialCard.test.tsx
+++ b/ts/features/itwallet/common/components/ItwCredentialCard/__tests__/ItwCredentialCard.test.tsx
@@ -6,7 +6,7 @@ import { appReducer } from "../../../../../../store/reducers";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import { ItwCredentialStatus } from "../../../utils/itwTypesUtils";
 import { ItwCredentialCard } from "../ItwCredentialCard";
-import * as selectors from "../../../store/selectors";
+import * as lifecycleSelectors from "../../../../lifecycle/store/selectors";
 
 describe("ItwCredentialCard", () => {
   it.each(["EuropeanHealthInsuranceCard", "EuropeanDisabilityCard", "mDL"])(
@@ -69,7 +69,7 @@ describe("ItwCredentialCard", () => {
     } as GlobalState);
 
     jest
-      .spyOn(selectors, "itwShouldRenderNewItWalletSelector")
+      .spyOn(lifecycleSelectors, "itwLifecycleIsITWalletValidSelector")
       .mockReturnValue(true);
 
     const component = render(

--- a/ts/features/itwallet/wallet/components/ItwCredentialWalletCard.tsx
+++ b/ts/features/itwallet/wallet/components/ItwCredentialWalletCard.tsx
@@ -1,10 +1,10 @@
-import { withWalletCardBaseComponent } from "../../../wallet/components/WalletCardBaseComponent";
-import { ItwCredentialCard } from "../../common/components/ItwCredentialCard";
-import { WalletCardPressableBase } from "../../../wallet/components/WalletCardPressableBase";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
-import { ITW_ROUTES } from "../../navigation/routes";
-import { itwShouldRenderNewItWalletSelector } from "../../common/store/selectors";
 import { useIOSelector } from "../../../../store/hooks";
+import { withWalletCardBaseComponent } from "../../../wallet/components/WalletCardBaseComponent";
+import { WalletCardPressableBase } from "../../../wallet/components/WalletCardPressableBase";
+import { ItwCredentialCard } from "../../common/components/ItwCredentialCard";
+import { itwLifecycleIsITWalletValidSelector } from "../../lifecycle/store/selectors";
+import { ITW_ROUTES } from "../../navigation/routes";
 
 export type ItwCredentialWalletCardProps = ItwCredentialCard & {
   isPreview?: false; // Cards in wallet cannot be in preview mode
@@ -13,8 +13,8 @@ export type ItwCredentialWalletCardProps = ItwCredentialCard & {
 const WrappedItwCredentialCard = (props: ItwCredentialWalletCardProps) => {
   const { isItwCredential, credentialType } = props;
   const navigation = useIONavigation();
-  const isNewItwRenderable = useIOSelector(itwShouldRenderNewItWalletSelector);
-  const needsItwUpgrade = isNewItwRenderable && !isItwCredential;
+  const isItwPid = useIOSelector(itwLifecycleIsITWalletValidSelector);
+  const needsItwUpgrade = isItwPid && !isItwCredential;
 
   const handleOnPress = () => {
     if (needsItwUpgrade) {


### PR DESCRIPTION
## Short description
This PR fixes a problem that causes the "Upgrade" badge on credentials card to not being displayed in the offline mini-app.

## List of changes proposed in this pull request
- Updated rendering logic for the badge

## How to test
> [!NOTE]
> In order to test this PR you must be able to mock data with a proxy (eg.: Proxyman)

- Obtain an L2 PID and at least one credential.
- Restart the app
- Upgrade the wallet to L3 and make sure the credential upgrade step fails by mocking the `/credential` endpoint with a Proxy.
- Go to the Wallet and verify that the credentials display the "Upgrade" badge.
- Restart the app in offline mode
- Go to the Wallet and verify that the credentials are still displaying the "Upgrade" badge.
