### PR TITLE
refactor: [IOBP-1950] Handle IDPay `PAYMENT_GENERIC_ERROR`

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -5823,6 +5823,10 @@
           "ON_EVALUATION": {
             "title": "L’ente sta valutando la tua domanda d’adesione",
             "subtitle": "Quando pronto, riceverai l’esito tramite un messaggio in app."
+          },
+          "PAYMENT_GENERIC_ERROR": {
+            "title": "Non siamo riusciti a completare l’operazione",
+            "subtitle": "Siamo già a lavoro per risolvere.  Riprova tra un po’."
           }
         }
       },

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -5823,6 +5823,10 @@
           "ON_EVALUATION": {
             "title": "L’ente sta valutando la tua domanda d’adesione",
             "subtitle": "Quando pronto, riceverai l’esito tramite un messaggio in app."
+          },
+          "PAYMENT_GENERIC_ERROR": {
+            "title": "Non siamo riusciti a completare l’operazione",
+            "subtitle": "Siamo già a lavoro per risolvere.  Riprova tra un po’."
           }
         }
       },

--- a/ts/features/idpay/common/hooks/useIDPayFailureSupportModal.tsx
+++ b/ts/features/idpay/common/hooks/useIDPayFailureSupportModal.tsx
@@ -24,10 +24,11 @@ import {
   zendeskSupportStart
 } from "../../../zendesk/store/actions";
 import { OnboardingFailureEnum } from "../../onboarding/types/OnboardingFailure";
+import { PaymentFailureEnum } from "../../payment/types/PaymentFailure";
 
 type IDPayFailureSupportModal = {
   bottomSheet: JSX.Element;
-  present: (failure: OnboardingFailureEnum) => void;
+  present: (failure: OnboardingFailureEnum | PaymentFailureEnum) => void;
 };
 
 const useIDPayFailureSupportModal = (
@@ -137,7 +138,7 @@ const useIDPayFailureSupportModal = (
     title: ""
   });
 
-  const present = (failure: OnboardingFailureEnum) => {
+  const present = (failure: OnboardingFailureEnum | PaymentFailureEnum) => {
     setCurrentFaultCodeDetail(failure || OnboardingFailureEnum.GENERIC);
     presentModal();
   };

--- a/ts/features/idpay/payment/machine/actors.ts
+++ b/ts/features/idpay/payment/machine/actors.ts
@@ -54,7 +54,9 @@ export const createActorsImplementation = (
                   return Promise.reject(mapErrorCodeToFailure(value.code));
               }
             }),
-            E.getOrElse(() => Promise.reject(PaymentFailureEnum.GENERIC))
+            E.getOrElse(() =>
+              Promise.reject(PaymentFailureEnum.PAYMENT_GENERIC_ERROR)
+            )
           )
         )
       );
@@ -92,7 +94,9 @@ export const createActorsImplementation = (
                   return Promise.reject(mapErrorCodeToFailure(value.code));
               }
             }),
-            E.getOrElse(() => Promise.reject(PaymentFailureEnum.GENERIC))
+            E.getOrElse(() =>
+              Promise.reject(PaymentFailureEnum.PAYMENT_GENERIC_ERROR)
+            )
           )
         )
       );
@@ -129,7 +133,9 @@ export const createActorsImplementation = (
                 return Promise.reject(mapErrorCodeToFailure(value.code));
             }
           }),
-          E.getOrElse(() => Promise.reject(PaymentFailureEnum.GENERIC))
+          E.getOrElse(() =>
+            Promise.reject(PaymentFailureEnum.PAYMENT_GENERIC_ERROR)
+          )
         )
       )
     );
@@ -153,23 +159,23 @@ export const mapErrorCodeToFailure = (
   switch (code) {
     case TransactionErrorCodeEnum.PAYMENT_TRANSACTION_EXPIRED:
     case TransactionErrorCodeEnum.PAYMENT_NOT_FOUND_OR_EXPIRED:
-      return PaymentFailureEnum.TRANSACTION_EXPIRED;
+      return PaymentFailureEnum.PAYMENT_TRANSACTION_EXPIRED;
     case TransactionErrorCodeEnum.PAYMENT_USER_SUSPENDED:
-      return PaymentFailureEnum.USER_SUSPENDED;
+      return PaymentFailureEnum.PAYMENT_USER_SUSPENDED;
     case TransactionErrorCodeEnum.PAYMENT_USER_NOT_ONBOARDED:
-      return PaymentFailureEnum.USER_NOT_ONBOARDED;
+      return PaymentFailureEnum.PAYMENT_USER_NOT_ONBOARDED;
     case TransactionErrorCodeEnum.PAYMENT_USER_UNSUBSCRIBED:
-      return PaymentFailureEnum.USER_UNSUBSCRIBED;
+      return PaymentFailureEnum.PAYMENT_USER_UNSUBSCRIBED;
     case TransactionErrorCodeEnum.PAYMENT_ALREADY_AUTHORIZED:
-      return PaymentFailureEnum.ALREADY_AUTHORIZED;
+      return PaymentFailureEnum.PAYMENT_ALREADY_AUTHORIZED;
     case TransactionErrorCodeEnum.PAYMENT_BUDGET_EXHAUSTED:
-      return PaymentFailureEnum.BUDGET_EXHAUSTED;
+      return PaymentFailureEnum.PAYMENT_BUDGET_EXHAUSTED;
     case TransactionErrorCodeEnum.PAYMENT_ALREADY_ASSIGNED:
-      return PaymentFailureEnum.ALREADY_ASSIGNED;
+      return PaymentFailureEnum.PAYMENT_ALREADY_ASSIGNED;
     case TransactionErrorCodeEnum.PAYMENT_INITIATIVE_INVALID_DATE:
-      return PaymentFailureEnum.INVALID_DATE;
+      return PaymentFailureEnum.PAYMENT_INITIATIVE_INVALID_DATE;
     default:
-      return PaymentFailureEnum.GENERIC;
+      return PaymentFailureEnum.PAYMENT_GENERIC_ERROR;
   }
 };
 
@@ -179,7 +185,7 @@ export const mapErrorCodeToFailure = (
  */
 const mapFetchError = (error: unknown): PaymentFailure => {
   if (error === "max-retries") {
-    return PaymentFailureEnum.TOO_MANY_REQUESTS;
+    return PaymentFailureEnum.PAYMENT_TOO_MANY_REQUESTS;
   }
-  return PaymentFailureEnum.GENERIC;
+  return PaymentFailureEnum.PAYMENT_GENERIC_ERROR;
 };

--- a/ts/features/idpay/payment/machine/machine.ts
+++ b/ts/features/idpay/payment/machine/machine.ts
@@ -186,6 +186,6 @@ const decodeFailure = flow(PaymentFailure.decode, O.fromEither);
 
 const isBlockingFalure = flow(
   decodeFailure,
-  O.map(failure => failure !== PaymentFailureEnum.TOO_MANY_REQUESTS),
+  O.map(failure => failure !== PaymentFailureEnum.PAYMENT_TOO_MANY_REQUESTS),
   O.getOrElse(() => false)
 );

--- a/ts/features/idpay/payment/screens/IDPayPaymentResultScreen.tsx
+++ b/ts/features/idpay/payment/screens/IDPayPaymentResultScreen.tsx
@@ -69,7 +69,7 @@ const mapFailureToContentProps = (
   failure: PaymentFailureEnum
 ): OperationResultScreenContentProps => {
   switch (failure) {
-    case PaymentFailureEnum.TRANSACTION_EXPIRED:
+    case PaymentFailureEnum.PAYMENT_TRANSACTION_EXPIRED:
       return {
         pictogram: "timing",
         title: I18n.t("idpay.payment.result.failure.TRANSACTION_EXPIRED.title"),
@@ -77,13 +77,13 @@ const mapFailureToContentProps = (
           "idpay.payment.result.failure.TRANSACTION_EXPIRED.subtitle"
         )
       };
-    case PaymentFailureEnum.USER_SUSPENDED:
+    case PaymentFailureEnum.PAYMENT_USER_SUSPENDED:
       return {
         pictogram: "attention",
         title: I18n.t("idpay.payment.result.failure.USER_SUSPENDED.title"),
         subtitle: I18n.t("idpay.payment.result.failure.USER_SUSPENDED.subtitle")
       };
-    case PaymentFailureEnum.USER_NOT_ONBOARDED:
+    case PaymentFailureEnum.PAYMENT_USER_NOT_ONBOARDED:
       return {
         pictogram: "error",
         title: I18n.t("idpay.payment.result.failure.USER_NOT_ONBOARDED.title"),
@@ -93,7 +93,7 @@ const mapFailureToContentProps = (
         enableAnimatedPictogram: true,
         loop: false
       };
-    case PaymentFailureEnum.USER_UNSUBSCRIBED:
+    case PaymentFailureEnum.PAYMENT_USER_UNSUBSCRIBED:
       return {
         pictogram: "error",
         title: I18n.t("idpay.payment.result.failure.USER_UNSUBSCRIBED.title"),
@@ -103,14 +103,14 @@ const mapFailureToContentProps = (
         enableAnimatedPictogram: true,
         loop: false
       };
-    case PaymentFailureEnum.ALREADY_AUTHORIZED:
+    case PaymentFailureEnum.PAYMENT_ALREADY_AUTHORIZED:
       return {
         pictogram: "success",
         title: I18n.t("idpay.payment.result.failure.ALREADY_AUTHORIZED.title"),
         enableAnimatedPictogram: true,
         loop: false
       };
-    case PaymentFailureEnum.BUDGET_EXHAUSTED:
+    case PaymentFailureEnum.PAYMENT_BUDGET_EXHAUSTED:
       return {
         pictogram: "fatalError",
         title: I18n.t("idpay.payment.result.failure.BUDGET_EXHAUSTED.title"),
@@ -120,7 +120,7 @@ const mapFailureToContentProps = (
         enableAnimatedPictogram: true,
         loop: false
       };
-    case PaymentFailureEnum.ALREADY_ASSIGNED:
+    case PaymentFailureEnum.PAYMENT_ALREADY_ASSIGNED:
       return {
         pictogram: "fatalError",
         title: I18n.t("idpay.payment.result.failure.ALREADY_ASSIGNED.title"),
@@ -130,7 +130,7 @@ const mapFailureToContentProps = (
         enableAnimatedPictogram: true,
         loop: false
       };
-    case PaymentFailureEnum.INVALID_DATE:
+    case PaymentFailureEnum.PAYMENT_INITIATIVE_INVALID_DATE:
       return {
         pictogram: "time",
         title: I18n.t("idpay.payment.result.failure.INVALID_DATE.title"),

--- a/ts/features/idpay/payment/types/PaymentFailure.ts
+++ b/ts/features/idpay/payment/types/PaymentFailure.ts
@@ -1,19 +1,16 @@
 import { enumType } from "@pagopa/ts-commons/lib/types";
 import * as t from "io-ts";
+import { CodeEnum } from "../../../../../definitions/idpay/TransactionErrorDTO";
 
-export enum PaymentFailureEnum {
-  GENERIC = "GENERIC",
-  TOO_MANY_REQUESTS = "TOO_MANY_REQUESTS",
-  TRANSACTION_EXPIRED = "TRANSACTION_EXPIRED",
-  USER_SUSPENDED = "USER_SUSPENDED",
-  USER_NOT_ONBOARDED = "USER_NOT_ONBOARDED",
-  USER_UNSUBSCRIBED = "USER_UNSUBSCRIBED",
-  ALREADY_AUTHORIZED = "ALREADY_AUTHORIZED",
-  BUDGET_EXHAUSTED = "BUDGET_EXHAUSTED",
-  ALREADY_ASSIGNED = "ALREADY_ASSIGNED",
-  INVALID_DATE = "INVALID_DATE",
+enum SessionExpiredEnum {
   SESSION_EXPIRED = "SESSION_EXPIRED"
 }
+
+export type PaymentFailureEnum = SessionExpiredEnum | CodeEnum;
+export const PaymentFailureEnum = {
+  ...SessionExpiredEnum,
+  ...CodeEnum
+};
 
 export type PaymentFailure = t.TypeOf<typeof PaymentFailure>;
 export const PaymentFailure = enumType<PaymentFailureEnum>(


### PR DESCRIPTION
## Short description
This pull request refactors the handling of payment failure errors in the IDPay payment flow, standardizing error codes, improving error messaging, and enhancing user support for generic payment errors

## List of changes proposed in this pull request
- Refactored `PaymentFailureEnum` to use a union of a new `SessionExpiredEnum` and backend-driven `CodeEnum` values, allowing for more granular and standardized error handling throughout the payment flow
- Updated the `useIDPayFailureSupportModal` hook to support both onboarding and payment failure enums, allowing the support modal to be presented for payment-specific errors
- Improved the `IDPayPaymentResultScreen` to recognize and handle the new `PAYMENT_GENERIC_ERROR`, including showing a specific pictogram, title, and subtitle, and providing a secondary action for user support via a modal

## How to test
- Enter a code with all 7 in `IDPAY_PAYMENT_CODE_INPUT`
- Tap on `Continua`
- Check that error screen is aligned with design

## Preview
https://github.com/user-attachments/assets/5b8d78a6-2abc-4794-9d2c-430bf119791f



