### PR TITLE
fix: [IOPLT-1331] Remove extra thick border from `PaymentCard` expired state

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,12 +586,6 @@ We're committed to providing a faster and more satisfying experience for our cit
 
 The perception of slowness is mainly due to the navigation architecture, which is actually handled by the `react-navigation` library. Our internal testing has shown that there's a pretty obvious difference between the default `Stack` navigation and the `NativeStack`, which uses native APIs underneath. The latter is currently only enabled in the **Design System** section, which isn't accessible to everyone because it's only visible when developer mode is enabled.
 
-#### Why is there no dark mode?
-
-We're actively developing a dark mode for the app that will be available in the coming months. The initial release will be a beta version to allow users to explore and provide feedback.
-
-You can follow the related activities by [filtering the PRs with the `Dark Mode` label](https://github.com/pagopa/io-app/pulls?q=is%3Apr+label%3A%22Dark+mode+%F0%9F%8C%9D%22)
-
 ---
 
 If you want to improve the `io-app-design-system` library, feel free to contribute by opening an issue with your suggestions or by directly opening a PR. Criticism is welcome and appreciated.

--- a/ts/features/payments/common/components/PaymentCard.tsx
+++ b/ts/features/payments/common/components/PaymentCard.tsx
@@ -183,9 +183,7 @@ const PaymentCard = (props: PaymentCardComponentProps) => {
         styles.card,
         { backgroundColor, borderColor },
         props.isExpired && {
-          borderColor: errorBorderColor,
-          borderLeftWidth: 9,
-          paddingLeft: 7
+          borderColor: errorBorderColor
         }
       ]}
     >


### PR DESCRIPTION
## Short description
This PR updates the `PaymentCard` expired state, by using the established pattern for IT Wallet cards.

## List of changes proposed in this pull request
- Remove extra thick border from the expired state
- **[extra]** Remove the dark mode reference from README before the beta launch

### Preview
| Before | After |
|--------|--------|
| <img width="1206" height="1022" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-10 at 15 36 15" src="https://github.com/user-attachments/assets/ea2f9393-abd7-4877-945b-7b32bf36e6e2" /> | <img width="1206" height="1030" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-10 at 15 34 54" src="https://github.com/user-attachments/assets/5aea238c-6e46-4319-bc16-556849eb4ccd" /> | 

## How to test
Go to the **Design System** → **Cards** (Components) → scroll horizontally to view other states