### PR TITLE
feat: Add IDPay user waiting list statuses inside the Services home screen

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -5564,6 +5564,14 @@
           "enrollment": "Errore nel collegamento dell'iniziativa, riprova.",
           "removal": "Errore nella rimozione dell'iniziativa, riprova."
         }
+      },
+      "initiativeOnboardedStatus": {
+        "ON_WAITING_LIST": {
+          "label": "On evaluation"
+        },
+        "ON_EVALUATION": {
+          "label": "On evaluation"
+        }
       }
     },
     "initiative": {

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -5573,6 +5573,14 @@
           "enrollment": "Errore nel collegamento dell'iniziativa, riprova.",
           "removal": "Errore nella rimozione dell'iniziativa, riprova."
         }
+      },
+      "initiativeOnboardedStatus": {
+        "ON_WAITING_LIST": {
+          "label": "Verifica in corso"
+        },
+        "ON_EVALUATION": {
+          "label": "Verifica in corso"
+        }
       }
     },
     "initiative": {

--- a/ts/features/idpay/wallet/components/IdPayInitiativeWaitingList.tsx
+++ b/ts/features/idpay/wallet/components/IdPayInitiativeWaitingList.tsx
@@ -1,0 +1,83 @@
+import { FlatList } from "react-native";
+import * as pot from "@pagopa/ts-commons/lib/pot";
+import {
+  Badge,
+  Divider,
+  ListItemHeader,
+  ListItemInfo,
+  ListItemNav,
+  VSpacer
+} from "@pagopa/io-app-design-system";
+import I18n from "i18next";
+import { constVoid } from "fp-ts/lib/function";
+import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
+import { useIODispatch, useIOSelector } from "../../../../store/hooks";
+import { isIdPayEnabledSelector } from "../../../../store/reducers/backendStatus/remoteConfig";
+import { idPayInitiativeWaitingListGet } from "../store/actions";
+import { idPayInitiativeWaitingListSelector } from "../store/reducers";
+import { StatusEnum as InitiativeOnboardingStatus } from "../../../../../definitions/idpay/UserOnboardingStatusDTO";
+
+export const IdPayInitiativeWaitingList = () => {
+  const dispatch = useIODispatch();
+  const isIdPayEnabled = useIOSelector(isIdPayEnabledSelector);
+
+  useOnFirstRender(
+    () => {
+      dispatch(idPayInitiativeWaitingListGet.request());
+    },
+    () => isIdPayEnabled
+  );
+
+  const initiativeWaitingListPot = useIOSelector(
+    idPayInitiativeWaitingListSelector
+  );
+  const initiativeWaitingList = pot.getOrElse(initiativeWaitingListPot, []);
+
+  const renderListHeaderComponent = () => (
+    <>
+      <VSpacer size={16} />
+      <ListItemHeader label="Le mie richieste" />
+    </>
+  );
+
+  if (!initiativeWaitingList || initiativeWaitingList.length === 0) {
+    return undefined;
+  }
+
+  return (
+    <FlatList
+      ListHeaderComponent={renderListHeaderComponent}
+      data={initiativeWaitingList}
+      ItemSeparatorComponent={() => <Divider />}
+      renderItem={({ item }) => (
+        <ListItemInfo
+          icon="hourglass"
+          topElement={{
+            type: "badge",
+            componentProps: getInitiativeStatusBadge(item.status)
+          }}
+          value={item.initiativeName}
+        />
+      )}
+    />
+  );
+};
+
+const getInitiativeStatusBadge = (
+  initiativeStatus: InitiativeOnboardingStatus
+): ComponentProps<typeof Badge> => {
+  switch (initiativeStatus) {
+    case InitiativeOnboardingStatus.ON_WAITING_LIST:
+    case InitiativeOnboardingStatus.ON_EVALUATION: {
+      return {
+        variant: "warning",
+        text: I18n.t(
+          "idpay.wallet.initiativeOnboardedStatus.ON_WAITING_LIST.label"
+        )
+      };
+    }
+    default: {
+      return undefined;
+    }
+  }
+};

--- a/ts/features/idpay/wallet/saga/handleGetInitiativeWaitingList.ts
+++ b/ts/features/idpay/wallet/saga/handleGetInitiativeWaitingList.ts
@@ -1,0 +1,62 @@
+import * as E from "fp-ts/lib/Either";
+
+import { pipe } from "fp-ts/lib/function";
+import { call, put } from "typed-redux-saga/macro";
+import { ActionType } from "typesafe-actions";
+import { PreferredLanguageEnum } from "../../../../../definitions/backend/PreferredLanguage";
+import { SagaCallReturnType } from "../../../../types/utils";
+import { getGenericError, getNetworkError } from "../../../../utils/errors";
+import { readablePrivacyReport } from "../../../../utils/reporters";
+import { IDPayClient } from "../../common/api/client";
+import { idPayInitiativeWaitingListGet } from "../store/actions";
+import { withRefreshApiCall } from "../../../authentication/fastLogin/saga/utils";
+
+export function* handleGetInitiativeWaitingList(
+  getOnboardingInitiativeWaitingList: IDPayClient["onboardingInitiativeUserStatus"],
+  bearerToken: string,
+  language: PreferredLanguageEnum,
+  action: ActionType<(typeof idPayInitiativeWaitingListGet)["request"]>
+) {
+  const getOnboardingInitiativeWaitingListRequest =
+    getOnboardingInitiativeWaitingList({
+      bearerAuth: bearerToken,
+      "Accept-Language": language
+    });
+
+  try {
+    const getOnboardingInitiativeWaitingListResult = (yield* call(
+      withRefreshApiCall,
+      getOnboardingInitiativeWaitingListRequest,
+      action
+    )) as unknown as SagaCallReturnType<
+      typeof getOnboardingInitiativeWaitingList
+    >;
+
+    yield* put(
+      pipe(
+        getOnboardingInitiativeWaitingListResult,
+        E.fold(
+          error =>
+            idPayInitiativeWaitingListGet.failure({
+              ...getGenericError(new Error(readablePrivacyReport(error)))
+            }),
+
+          res => {
+            if (res.status === 200) {
+              return idPayInitiativeWaitingListGet.success(res.value);
+            }
+            return idPayInitiativeWaitingListGet.failure({
+              ...getGenericError(new Error(`Error: ${res.status}`))
+            });
+          }
+        )
+      )
+    );
+  } catch (e) {
+    yield* put(
+      idPayInitiativeWaitingListGet.failure({
+        ...getNetworkError(e)
+      })
+    );
+  }
+}

--- a/ts/features/idpay/wallet/saga/index.ts
+++ b/ts/features/idpay/wallet/saga/index.ts
@@ -11,6 +11,7 @@ import { PreferredLanguageEnum } from "../../../../../definitions/backend/Prefer
 import { IDPayClient } from "../../common/api/client";
 import {
   IdPayInitiativesFromInstrumentPayloadType,
+  idPayInitiativeWaitingListGet,
   idPayInitiativesFromInstrumentGet,
   idPayInitiativesFromInstrumentRefreshStart,
   idPayInitiativesFromInstrumentRefreshStop,
@@ -25,6 +26,7 @@ import {
 import { handleGetIDPayWallet } from "./handleGetWallet";
 import { handleInitiativeInstrumentDelete } from "./handleInitiativeInstrumentDelete";
 import { handleInitiativeInstrumentEnrollment } from "./handleInitiativeInstrumentEnrollment";
+import { handleGetInitiativeWaitingList } from "./handleGetInitiativeWaitingList";
 
 /**
  * Handle the IDPay Wallet requests
@@ -63,6 +65,14 @@ export function* watchIDPayWalletSaga(
     idpayInitiativesInstrumentDelete.request,
     handleInitiativeInstrumentDelete,
     idPayClient.deleteInstrument,
+    bearerToken,
+    preferredLanguage
+  );
+
+  yield* takeEvery(
+    idPayInitiativeWaitingListGet.request,
+    handleGetInitiativeWaitingList,
+    idPayClient.onboardingInitiativeUserStatus,
     bearerToken,
     preferredLanguage
   );

--- a/ts/features/idpay/wallet/store/actions/index.ts
+++ b/ts/features/idpay/wallet/store/actions/index.ts
@@ -6,6 +6,7 @@ import {
 import { InitiativesWithInstrumentDTO } from "../../../../../../definitions/idpay/InitiativesWithInstrumentDTO";
 import { WalletDTO } from "../../../../../../definitions/idpay/WalletDTO";
 import { NetworkError } from "../../../../../utils/errors";
+import { ListUsersOnboardingStatusDTO } from "../../../../../../definitions/idpay/ListUsersOnboardingStatusDTO";
 
 export type IdPayInitiativesFromInstrumentPayloadType = {
   idWallet: string;
@@ -76,6 +77,12 @@ export const setIdPayOnboardingSucceeded = createStandardAction(
   "IDPAY_ONBOARDING_SUCCEEDED_SET"
 )<boolean>();
 
+export const idPayInitiativeWaitingListGet = createAsyncAction(
+  "IDPAY_INITIATIVE_WAITINGLIST_REQUEST",
+  "IDPAY_INITIATIVE_WAITINGLIST_SUCCESS",
+  "IDPAY_INITIATIVE_WAITINGLIST_FAILURE"
+)<void, ListUsersOnboardingStatusDTO, NetworkError>();
+
 export type IdPayWalletActions =
   | ActionType<typeof idPayWalletGet>
   | ActionType<typeof idPayInitiativesFromInstrumentGet>
@@ -83,4 +90,5 @@ export type IdPayWalletActions =
   | ActionType<typeof idpayInitiativesInstrumentDelete>
   | ActionType<typeof idPayInitiativesFromInstrumentRefreshStart>
   | ActionType<typeof idPayInitiativesFromInstrumentRefreshStop>
-  | ActionType<typeof setIdPayOnboardingSucceeded>;
+  | ActionType<typeof setIdPayOnboardingSucceeded>
+  | ActionType<typeof idPayInitiativeWaitingListGet>;

--- a/ts/features/idpay/wallet/store/reducers/index.ts
+++ b/ts/features/idpay/wallet/store/reducers/index.ts
@@ -11,12 +11,14 @@ import { isIdPayEnabledSelector } from "../../../../../store/reducers/backendSta
 import { GlobalState } from "../../../../../store/reducers/types";
 import { NetworkError } from "../../../../../utils/errors";
 import {
+  idPayInitiativeWaitingListGet,
   idPayInitiativesFromInstrumentGet,
   idPayWalletGet,
   idpayInitiativesInstrumentDelete,
   idpayInitiativesInstrumentEnroll,
   setIdPayOnboardingSucceeded
 } from "../actions";
+import { ListUsersOnboardingStatusDTO } from "../../../../../../definitions/idpay/ListUsersOnboardingStatusDTO";
 
 export type IdPayWalletState = {
   initiatives: pot.Pot<WalletDTO, NetworkError>;
@@ -29,13 +31,15 @@ export type IdPayWalletState = {
   // this will be populated on selection and reset when not loading and
   // we have a response from BE
   onboardingSucceeded: boolean;
+  initiativeWaitinglist: pot.Pot<ListUsersOnboardingStatusDTO, NetworkError>;
 };
 
 const INITIAL_STATE: IdPayWalletState = {
   initiatives: pot.none,
   initiativesWithInstrument: pot.none,
   initiativesAwaitingStatusUpdate: {},
-  onboardingSucceeded: false
+  onboardingSucceeded: false,
+  initiativeWaitinglist: pot.none
 };
 
 const reducer = (
@@ -132,6 +136,21 @@ const reducer = (
         ...state,
         onboardingSucceeded: action.payload
       };
+    case getType(idPayInitiativeWaitingListGet.request):
+      return {
+        ...state,
+        initiativeWaitinglist: pot.toLoading(state.initiativeWaitinglist)
+      };
+    case getType(idPayInitiativeWaitingListGet.success):
+      return { ...state, initiativeWaitinglist: pot.some(action.payload) };
+    case getType(idPayInitiativeWaitingListGet.failure):
+      return {
+        ...state,
+        initiativeWaitinglist: pot.toError(
+          state.initiativeWaitinglist,
+          action.payload
+        )
+      };
   }
   return state;
 };
@@ -216,6 +235,11 @@ export const idPayInitiativeFromInstrumentPotSelector = (
 export const isIdPayOnboardingSucceededSelector = createSelector(
   selectIdPayWallet,
   wallet => wallet.onboardingSucceeded
+);
+
+export const idPayInitiativeWaitingListSelector = createSelector(
+  selectIdPayWallet,
+  wallet => wallet.initiativeWaitinglist
 );
 
 export default reducer;

--- a/ts/features/services/home/screens/ServicesHomeScreen.tsx
+++ b/ts/features/services/home/screens/ServicesHomeScreen.tsx
@@ -36,6 +36,7 @@ import { featuredInstitutionsGet, featuredServicesGet } from "../store/actions";
 import { EmailNotificationBanner } from "../components/EmailNotificationBanner";
 import { getListItemAccessibilityLabelCount } from "../../../../utils/accessibility";
 import * as analytics from "../../common/analytics";
+import { IdPayInitiativeWaitingList } from "../../../idpay/wallet/components/IdPayInitiativeWaitingList";
 
 export const ServicesHomeScreen = () => {
   const dispatch = useIODispatch();
@@ -100,6 +101,7 @@ export const ServicesHomeScreen = () => {
         <EmailNotificationBanner />
         <Animated.View layout={LinearTransition.duration(300)}>
           <VStack space={16}>
+            <IdPayInitiativeWaitingList />
             <FeaturedServiceList />
             <FeaturedInstitutionList />
             <ListItemHeader


### PR DESCRIPTION
## Short description
This PR introduces a new feature that displays a user's IDPay initiative waiting list in the services home screen. It includes the necessary UI component, Redux state management, saga for API calls, and localization updates. The changes ensure that users can see the status of their IDPay initiative requests directly in the app.

## List of changes proposed in this pull request
* Added the `IdPayInitiativeWaitingList` component to show the user's pending IDPay initiatives, including status badges, and integrated it into the `ServicesHomeScreen`.
* Added Redux actions, reducer state, and selectors for fetching and storing the initiative waiting list.
* Added a saga (`handleGetInitiativeWaitingList`) to handle the async API call for retrieving the waiting list and wired it into the main wallet saga watcher.
* Updated the latest version of `io-app-design-system` that supports the `topElement` as property of the `ListItemInfo` component.

## How to test
0. Make sure you have installed the latest version of the `io-app-design-system` through `yarn install`.
1. Checkout the dev-server on this PR: https://github.com/pagopa/io-dev-api-server/pull/533
2. Complete an IDPay onboarding process 
3. Now that you've completed the initiative onboarding, check that inside the Services home screen, you can see the status of the onboarded IDPay initiative in an `On evaluation` status.

## Preview

https://github.com/user-attachments/assets/b8658561-3cd4-4497-814b-77ac60b25d51

