### PR TITLE
refactor: [IOBP-1988,IOBP-1989] Update IDPay `PAYMENT_GENERIC_ERROR` cases, add `IDPAY_` prefix

### DIFF
--- a/ts/features/idpay/common/hooks/useIDPayFailureSupportModal.tsx
+++ b/ts/features/idpay/common/hooks/useIDPayFailureSupportModal.tsx
@@ -36,7 +36,7 @@ const useIDPayFailureSupportModal = (
   initiativeId?: string
 ): IDPayFailureSupportModal => {
   const dispatch = useIODispatch();
-
+  const prefix = "IDPAY_";
   const [currentFaultCodeDetail, setCurrentFaultCodeDetail] =
     useState<string>("");
 
@@ -140,7 +140,8 @@ const useIDPayFailureSupportModal = (
 
   const present = (failure: OnboardingFailureEnum | PaymentFailureEnum) => {
     setCurrentFaultCodeDetail(
-      failure || OnboardingFailureEnum.ONBOARDING_GENERIC_ERROR
+      `${prefix}${failure}` ||
+        `${prefix}${OnboardingFailureEnum.ONBOARDING_GENERIC_ERROR}`
     );
     presentModal();
   };

--- a/ts/features/idpay/payment/machine/actors.ts
+++ b/ts/features/idpay/payment/machine/actors.ts
@@ -174,6 +174,9 @@ export const mapErrorCodeToFailure = (
       return PaymentFailureEnum.PAYMENT_ALREADY_ASSIGNED;
     case TransactionErrorCodeEnum.PAYMENT_INITIATIVE_INVALID_DATE:
       return PaymentFailureEnum.PAYMENT_INITIATIVE_INVALID_DATE;
+    case TransactionErrorCodeEnum.PAYMENT_GENERIC_ERROR:
+    case TransactionErrorCodeEnum.PAYMENT_MERCHANT_NOT_ONBOARDED:
+    case TransactionErrorCodeEnum.PAYMENT_NOT_ALLOWED_FOR_TRX_STATUS:
     default:
       return PaymentFailureEnum.PAYMENT_GENERIC_ERROR;
   }


### PR DESCRIPTION
## Short description
This pull request introduces improvements to error handling and code consistency in the IDPay feature

## List of changes proposed in this pull request
- Added a `prefix` variable (`IDPAY_`) to standardize the formatting of failure codes when presenting error details in the `useIDPayFailureSupportModal` hook
- Updated the `mapErrorCodeToFailure` function to explicitly handle additional transaction error codes (`PAYMENT_GENERIC_ERROR`, `PAYMENT_MERCHANT_NOT_ONBOARDED`, `PAYMENT_NOT_ALLOWED_FOR_TRX_STATUS`)

## How to test
Ensure that all IDPay errors now are sending the same error with `IDPAY_` prefix