### PR TITLE
feat: [IOPID-2649] Remove `cie_id` FF definition from the generated content definition file 

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -2,7 +2,7 @@
 
 IO_BACKEND_VERSION=v16.17.0
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=1.0.81
+IO_SERVICES_METADATA_VERSION=1.0.82
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.8.0
 # IO Wallet Backend version
@@ -32,7 +32,7 @@ declare -a apis=(
   "./definitions/fims_history https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_io_fims.yaml"
   "./definitions/fims_sso https://raw.githubusercontent.com/pagopa/io-fims/a93f1a1abf5230f103d9f489b139902b87288061/apps/op-app/openapi.yaml"
   # CDN APIs
-  "./definitions/content https://raw.githubusercontent.com/pagopa/io-services-metadata/refs/heads/IOPID-2649-remove-cieid-ff/definitions.yml"
+  "./definitions/content https://raw.githubusercontent.com/pagopa/io-services-metadata/$IO_SERVICES_METADATA_VERSION/definitions.yml"
   # Session Manager APIs
   "./definitions/session_manager https://raw.githubusercontent.com/pagopa/io-auth-n-identity-domain/refs/tags/io-session-manager@$IO_SESSION_MANAGER_VERSION/apps/io-session-manager/api/external.yaml"  
   # CGN APIs


### PR DESCRIPTION
> [!WARNING]
> Depends on https://github.com/pagopa/io-services-metadata/pull/1025 

## Short description
This PR upgrades the `IO_SESSION_MANAGER_VERSION` to remove the `cie_id` FF definition from the generated content definition file

## List of changes proposed in this pull request
- Upgraded `IO_SESSION_MANAGER_VERSION` to `1.0.82` 

## How to test
After running the `yarn generate` command, make sure that everything works correctly both in the production environment and in the local environment

