### PR TITLE
fix(IT Wallet): [SIW-29911] Fix bottom margin in credential details screen

### DIFF
--- a/ts/features/itwallet/presentation/details/components/ItwPresentationDetailsScreenBase.tsx
+++ b/ts/features/itwallet/presentation/details/components/ItwPresentationDetailsScreenBase.tsx
@@ -90,7 +90,7 @@ const ItwPresentationDetailsScreenBase = ({
       <Animated.ScrollView
         ref={animatedScrollViewRef}
         contentContainerStyle={{
-          paddingBottom: footerActionsMeasurements.safeBottomAreaHeight
+          paddingBottom: footerActionsMeasurements.safeBottomAreaHeight || 24
         }}
         onScroll={scrollHandler}
         scrollEventThrottle={8}


### PR DESCRIPTION
## Short description
This PR fixes a small regression with the bottom margin in some credential details screen.

## List of changes proposed in this pull request
- Added `24` pt margin if `safeBottomAreaHeight` is `0`

## How to test
- Navigate to the MDL (L2) details page, verify that the screen has the correct bottom margin.
- Navigate to the TS details page, verify that the screen has the correct bottom margin
