### PR TITLE
chore: [IOBP-1969] Add Mixpanel events for help center CaC banner

### DIFF
--- a/ts/features/zendesk/analytics/index.ts
+++ b/ts/features/zendesk/analytics/index.ts
@@ -13,6 +13,7 @@ import {
   zendeskSupportStart
 } from "../store/actions";
 import { mixpanelTrack } from "../../../mixpanel";
+import { buildEventProperties } from "../../../utils/analytics";
 
 const trackZendesk = (action: Action): void => {
   switch (action.type) {
@@ -49,3 +50,33 @@ const trackZendesk = (action: Action): void => {
 const emptyTracking = (__: Action) => constVoid();
 
 export default zendeskEnabled ? trackZendesk : emptyTracking;
+
+export const trackZendeskCaCBannerShow = (cacUrl: string) =>
+  mixpanelTrack(
+    "BANNER",
+    buildEventProperties("UX", "screen_view", {
+      banner_id: "CONTEXTUAL_HELP",
+      banner_page: "CONTEXTUAL_HELP_CAC",
+      banner_landing: cacUrl
+    })
+  );
+
+export const trackZendeskCaCBannerTap = (cacUrl: string) => {
+  mixpanelTrack(
+    "TAP_BANNER",
+    buildEventProperties("UX", "action", {
+      banner_id: "CONTEXTUAL_HELP",
+      banner_page: "CONTEXTUAL_HELP_CAC",
+      banner_landing: cacUrl
+    })
+  );
+
+  mixpanelTrack(
+    "HC_CTA_TAPPED",
+    buildEventProperties("UX", "action", {
+      hc_source: "CONTEXTUAL_HELP",
+      hc_id: "CONTEXTUAL_HELP_CAC",
+      hc_landing_url: cacUrl
+    })
+  );
+};

--- a/ts/features/zendesk/screens/ZendeskSupportHelpCenter.tsx
+++ b/ts/features/zendesk/screens/ZendeskSupportHelpCenter.tsx
@@ -86,6 +86,11 @@ import {
   ZendeskTokenStatusEnum
 } from "../store/reducers";
 import { handleContactSupport } from "../utils";
+import {
+  trackZendeskCaCBannerShow,
+  trackZendeskCaCBannerTap
+} from "../analytics";
+import { useOnFirstRender } from "../../../utils/hooks/useOnFirstRender";
 
 type FaqManagerProps = Pick<
   ZendeskStartPayload,
@@ -173,11 +178,19 @@ const FaqManager = (props: FaqManagerProps) => {
   const locale = getFullLocale();
   const localeFallback = fallbackForLocalizedMessageKeys(locale);
 
+  useOnFirstRender(() => {
+    if (isCacBannerEnabled && bannerCaCConfig && bannerCaCConfig.action) {
+      trackZendeskCaCBannerShow(bannerCaCConfig.action.url?.[localeFallback]);
+    }
+  });
+
   const handleBannerPress = () => {
     if (!bannerCaCConfig?.action) {
       return;
     }
-    // TODO: IOBP-1969 add trackHelpCenterCtaTapped for tracking into Mixpanel
+
+    trackZendeskCaCBannerTap(bannerCaCConfig.action.url?.[localeFallback]);
+
     return openWebUrl(bannerCaCConfig.action.url?.[localeFallback], () =>
       IOToast.error(I18n.t("global.jserror.title"))
     );


### PR DESCRIPTION
## Short description
This pull request adds analytics tracking for the display and interaction of the Contextual Help CaC banner in the Zendesk Help Center feature

## List of changes proposed in this pull request
- Added `trackZendeskCaCBannerShow` and `trackZendeskCaCBannerTap` functions to send Mixpanel events for banner display and tap actions, including detailed event properties

## How to test
Ensure that new events are tracked while showing and tapping on CaC banner
