### PR TITLE
fix(IT Wallet): [SIW-3005] Fix offline wallet header for `session_expired` access reason

### DIFF
--- a/ts/hooks/__tests__/useStatusAlertProps.test.tsx
+++ b/ts/hooks/__tests__/useStatusAlertProps.test.tsx
@@ -1,0 +1,178 @@
+import { renderHook } from "@testing-library/react-native";
+import { useDerivedConnectivityState } from "../useStatusAlertProps";
+import * as navigationSelectors from "../../store/reducers/navigation";
+import * as connectivitySelectors from "../../features/connectivity/store/selectors";
+import * as ingressSelectors from "../../features/ingress/store/selectors";
+import * as startup from "../../store/reducers/startup";
+import { OfflineAccessReasonEnum } from "../../features/ingress/store/reducer";
+import { AUTHENTICATION_ROUTES } from "../../features/authentication/common/navigation/routes";
+
+jest.mock("../../store/hooks", () => ({
+  useIOSelector: (selector: any) => selector()
+}));
+
+describe("useDerivedConnectivityState", () => {
+  it("should return `initial`", () => {
+    jest
+      .spyOn(navigationSelectors, "currentRouteSelector")
+      .mockReturnValue("Home");
+
+    jest
+      .spyOn(connectivitySelectors, "isConnectedSelector")
+      .mockReturnValue(false);
+
+    jest
+      .spyOn(ingressSelectors, "offlineAccessReasonSelector")
+      .mockReturnValue(OfflineAccessReasonEnum.SESSION_EXPIRED);
+
+    jest
+      .spyOn(startup, "isStartupLoaded")
+      .mockReturnValue(startup.StartupStatusEnum.INITIAL);
+
+    const { result } = renderHook(useDerivedConnectivityState);
+
+    expect(result.current).toBe("initial");
+  });
+
+  it("should return `blacklisted`", () => {
+    jest
+      .spyOn(navigationSelectors, "currentRouteSelector")
+      .mockReturnValue(AUTHENTICATION_ROUTES.LANDING);
+
+    jest
+      .spyOn(connectivitySelectors, "isConnectedSelector")
+      .mockReturnValue(false);
+
+    jest
+      .spyOn(ingressSelectors, "offlineAccessReasonSelector")
+      .mockReturnValue(OfflineAccessReasonEnum.SESSION_EXPIRED);
+
+    jest
+      .spyOn(startup, "isStartupLoaded")
+      .mockReturnValue(startup.StartupStatusEnum.NOT_AUTHENTICATED);
+
+    const { result } = renderHook(useDerivedConnectivityState);
+
+    expect(result.current).toBe("blacklisted");
+  });
+
+  it("should return `mini_app_device_offline`", () => {
+    jest
+      .spyOn(navigationSelectors, "currentRouteSelector")
+      .mockReturnValue("Home");
+
+    jest
+      .spyOn(connectivitySelectors, "isConnectedSelector")
+      .mockReturnValue(false);
+
+    jest
+      .spyOn(ingressSelectors, "offlineAccessReasonSelector")
+      .mockReturnValue(OfflineAccessReasonEnum.DEVICE_OFFLINE);
+
+    jest
+      .spyOn(startup, "isStartupLoaded")
+      .mockReturnValue(startup.StartupStatusEnum.NOT_AUTHENTICATED);
+
+    const { result } = renderHook(useDerivedConnectivityState);
+
+    expect(result.current).toBe("mini_app_device_offline");
+  });
+
+  it("should return `mini_app_back_online`", () => {
+    jest
+      .spyOn(navigationSelectors, "currentRouteSelector")
+      .mockReturnValue("Home");
+
+    jest
+      .spyOn(connectivitySelectors, "isConnectedSelector")
+      .mockReturnValue(true);
+
+    jest
+      .spyOn(ingressSelectors, "offlineAccessReasonSelector")
+      .mockReturnValue(OfflineAccessReasonEnum.DEVICE_OFFLINE);
+
+    jest
+      .spyOn(startup, "isStartupLoaded")
+      .mockReturnValue(startup.StartupStatusEnum.NOT_AUTHENTICATED);
+
+    const { result } = renderHook(useDerivedConnectivityState);
+
+    expect(result.current).toBe("mini_app_back_online");
+  });
+
+  it.each([
+    OfflineAccessReasonEnum.SESSION_EXPIRED,
+    OfflineAccessReasonEnum.SESSION_REFRESH,
+    OfflineAccessReasonEnum.TIMEOUT
+  ])(`should return "mini_app_$reason"`, reason => {
+    jest
+      .spyOn(navigationSelectors, "currentRouteSelector")
+      .mockReturnValue("Home");
+
+    jest
+      .spyOn(connectivitySelectors, "isConnectedSelector")
+      .mockReturnValue(true);
+
+    jest
+      .spyOn(ingressSelectors, "offlineAccessReasonSelector")
+      .mockReturnValue(reason);
+
+    jest
+      .spyOn(startup, "isStartupLoaded")
+      .mockReturnValue(startup.StartupStatusEnum.NOT_AUTHENTICATED);
+
+    const { result } = renderHook(useDerivedConnectivityState);
+
+    expect(result.current).toBe(`mini_app_${reason}`);
+  });
+
+  it("should return `offline`", () => {
+    jest
+      .spyOn(navigationSelectors, "currentRouteSelector")
+      .mockReturnValue("Home");
+
+    jest
+      .spyOn(connectivitySelectors, "isConnectedSelector")
+      .mockReturnValue(false);
+
+    jest
+      .spyOn(ingressSelectors, "offlineAccessReasonSelector")
+      .mockReturnValue(undefined);
+
+    jest
+      .spyOn(startup, "isStartupLoaded")
+      .mockReturnValue(startup.StartupStatusEnum.NOT_AUTHENTICATED);
+
+    const { result } = renderHook(useDerivedConnectivityState);
+
+    expect(result.current).toBe("offline");
+  });
+
+  it("should return `back_online`", () => {
+    jest
+      .spyOn(navigationSelectors, "currentRouteSelector")
+      .mockReturnValue("Home");
+
+    const connectionSpy = jest
+      .spyOn(connectivitySelectors, "isConnectedSelector")
+      .mockReturnValue(false);
+
+    jest
+      .spyOn(ingressSelectors, "offlineAccessReasonSelector")
+      .mockReturnValue(undefined);
+
+    jest
+      .spyOn(startup, "isStartupLoaded")
+      .mockReturnValue(startup.StartupStatusEnum.NOT_AUTHENTICATED);
+
+    const { result, rerender } = renderHook(useDerivedConnectivityState);
+
+    expect(result.current).toBe("offline");
+
+    connectionSpy.mockReturnValue(true);
+
+    rerender(undefined);
+
+    expect(result.current).toBe("back_online");
+  });
+});

--- a/ts/hooks/useStatusAlertProps.tsx
+++ b/ts/hooks/useStatusAlertProps.tsx
@@ -227,12 +227,12 @@ export const useStatusAlertProps = (): AlertProps | undefined => {
         break;
 
       case "mini_app_timeout":
-        setBottomSheet(itwOfflineModal?.bottomSheet);
+        setBottomSheet(undefined);
         setConnectivityAlert({
           variant: "info",
           content: I18n.t(`features.itWallet.offline.timeout.alert.content`),
           action: I18n.t(`features.itWallet.offline.timeout.alert.action`),
-          onPress: openItwOfflineBottomSheet
+          onPress: handleAppRestart
         });
         setAlertVisible(true);
         break;

--- a/ts/hooks/useStatusAlertProps.tsx
+++ b/ts/hooks/useStatusAlertProps.tsx
@@ -58,7 +58,14 @@ type AlertProps = {
   bottomSheet?: JSX.Element;
 };
 
-const useDerivedConnectivityState = () => {
+/**
+ * Helper hook to derive the connectivity state based on the current connectivity status,
+ * the offline access reason, the current route and the startup status, which helps to reduce
+ * the complexity of the main hook.
+ *
+ * @returns the derived connectivity state based on the current connectivity status,
+ */
+export const useDerivedConnectivityState = () => {
   const currentRoute = useIOSelector(currentRouteSelector);
   const isConnected = useIOSelector(isConnectedSelector);
   const offlineAccessReason = useIOSelector(offlineAccessReasonSelector);
@@ -154,6 +161,9 @@ export const useStatusAlertProps = (): AlertProps | undefined => {
 
   const handleAppRestart = useAppRestartAction("banner");
 
+  /**
+   * Effect to handle the connectivity state changes and update the alert and bottom sheet accordingly.
+   */
   useEffect(() => {
     if (derivedConnectivityState === prevDerivedConnectivityState) {
       // Skip if no change on the derived state


### PR DESCRIPTION
## Short description
This PR fixes a glitch with the offline/no session alert in the offline mini app.

## List of changes proposed in this pull request
- Refactored `useStatusAlertProps` hook
- Added `useDerivedConnectivityState` helper hook
- Added tests
- 
## How to test

With a valid wallet with at least one credential, test the different scenarios as described below. 
Verify the alerts, bottom sheets and CTAs works as expected.

<details>
<summary>Full app, remove connection</summary>
<p>

https://github.com/user-attachments/assets/e5d66c59-6d0f-471f-bb86-b5f1b3650633

</p>
</details> 

<details>
<summary>Full app, restablish connection</summary>
<p>

https://github.com/user-attachments/assets/4ac7c723-7341-4aaa-8fec-176ef655b15e

</p>
</details> 

<details>
<summary>Mini app, start with no connection</summary>
<p>

https://github.com/user-attachments/assets/dc0fd218-da89-46b0-8cee-8d6d1f90137b

</p>
</details> 

<details>
<summary>Mini app, login failure</summary>
<p>

(`https://api-app.io.pagopa.it/api/auth/v1/fast-login` fails)

https://github.com/user-attachments/assets/14897b4d-7b89-44bc-938f-f24862708c3d

</p>
</details> 

<details>
<summary>Mini app, high latency</summary>
<p>

https://github.com/user-attachments/assets/fe03a3d1-255f-4cc7-b235-45234ae25fe8

</p>
</details> 



<details>
<summary>Mini app, no session</summary>
<p>

https://github.com/user-attachments/assets/9f28ff24-832c-4ef0-a293-d2b021847efd

</p>
</details> 





