### PR TITLE
fix: [IOPAE-1730] Add accessibility `header` role to `EmptyState`

### DIFF
--- a/ts/features/services/common/components/EmptyState.tsx
+++ b/ts/features/services/common/components/EmptyState.tsx
@@ -30,7 +30,9 @@ export const EmptyState = ({
   <View testID={testID}>
     <VStack style={{ alignItems: "center" }} space={24}>
       <Pictogram name={pictogram} size={120} />
-      <H6 style={styles.text}>{title}</H6>
+      <H6 accessibilityRole="header" style={styles.text}>
+        {title}
+      </H6>
     </VStack>
     {subtitle && (
       <>

--- a/ts/features/services/search/screens/SearchScreen.tsx
+++ b/ts/features/services/search/screens/SearchScreen.tsx
@@ -132,7 +132,7 @@ export const SearchScreen = () => {
     [data?.count, navigateToInstitution]
   );
 
-  const renderListFooterComponent = useCallback(() => {
+  const ListFooterComponent = useMemo(() => {
     if (isUpdating) {
       return <ServiceListSkeleton />;
     }
@@ -140,7 +140,7 @@ export const SearchScreen = () => {
     return <VSpacer size={16} />;
   }, [isUpdating]);
 
-  const renderListEmptyComponent = useCallback(() => {
+  const ListEmptyComponent = useMemo(() => {
     if (query.length < MIN_QUERY_LENGTH) {
       return (
         <EmptyState
@@ -167,7 +167,7 @@ export const SearchScreen = () => {
     return null;
   }, [isLoading, query, data?.institutions]);
 
-  const renderListHeaderComponent = useCallback(() => {
+  const ListHeaderComponent = useMemo(() => {
     if ((data?.count ?? 0) > 0) {
       return (
         <ListItemHeader
@@ -204,9 +204,9 @@ export const SearchScreen = () => {
       </ContentWrapper>
       <FlashList
         ItemSeparatorComponent={Divider}
-        ListEmptyComponent={renderListEmptyComponent}
-        ListFooterComponent={renderListFooterComponent}
-        ListHeaderComponent={renderListHeaderComponent}
+        ListEmptyComponent={ListEmptyComponent}
+        ListFooterComponent={ListFooterComponent}
+        ListHeaderComponent={ListHeaderComponent}
         contentContainerStyle={{
           paddingHorizontal: IOVisualCostants.appMarginDefault
         }}


### PR DESCRIPTION
## Short description
This PR adds the accessibility role `header` to the `EmptyState` component.

## List of changes proposed in this pull request
- Added `header` role to `EmptyState`
- Replaced `useCallback` with `useMemo` in `SearchScreen`

## How to test
Check that SR correctly interpret the `header` role in `EmptyState`
