### PR TITLE
fix: [IOBP-2017] CGN wrong header display

### DIFF
--- a/ts/hooks/useScrollHeaderAnimation.tsx
+++ b/ts/hooks/useScrollHeaderAnimation.tsx
@@ -17,8 +17,8 @@ import {
   useAnimatedStyle,
   useSharedValue
 } from "react-native-reanimated";
-import { IOScrollView } from "../components/ui/IOScrollView";
 import { useIOAlertVisible } from "../components/StatusMessages/IOAlertVisibleContext";
+import { IOListView } from "../components/ui/IOListView";
 
 const GRADIENT_OPACITY_SCROLL_TRIGGER = 0.85;
 const EXTRA_COLOR_STOPS = 20;
@@ -28,7 +28,7 @@ type IOViewHeaderScrollValues = ComponentProps<
 >["scrollValues"];
 
 export type ScrollAnimationHookProps = {
-  headerConfig?: ComponentProps<typeof IOScrollView>["headerConfig"];
+  headerConfig?: ComponentProps<typeof IOListView>["headerConfig"];
   snapOffset?: number;
 };
 
@@ -79,7 +79,7 @@ export const useScrollHeaderAnimation = ({
   );
 
   const ignoreSafeAreaMargin = useMemo(() => {
-    if (isAlertVisible !== undefined) {
+    if (isAlertVisible) {
       return true;
     }
     return headerConfig?.ignoreSafeAreaMargin;


### PR DESCRIPTION
## Short description
This pull request fixes the incorrect header display in the `IOListView` component used on the CGN screen.
It updates the `useScrollHeaderAnimation` hook to ensure proper rendering and alignment of the header in this context

## List of changes proposed in this pull request
- `ignoreSafeAreaMargin` by directly checking if `isAlertVisible` is truly, rather than allowing it to be `undefined`

## How to test
Ensure that now all `IOListView` component are rendering the header correctly

## Preview

https://github.com/user-attachments/assets/0255dcab-d97f-4529-b362-139d4f628628

