### PR TITLE
chore: [IOBP-2025] Dark mode logo for bonus hero image

### DIFF
--- a/ts/features/bonus/common/components/BonusInformationComponent.tsx
+++ b/ts/features/bonus/common/components/BonusInformationComponent.tsx
@@ -3,6 +3,7 @@ import {
   ContentWrapper,
   H2,
   IOButtonBlockSpecificProps,
+  useIOThemeContext,
   VSpacer
 } from "@pagopa/io-app-design-system";
 import * as AR from "fp-ts/lib/Array";
@@ -152,8 +153,14 @@ const BonusInformationComponent = (props: Props) => {
     O.chain(urls => AR.lookup(0, [...urls]))
   );
 
+  const { themeType } = useIOThemeContext();
+  const isDark = themeType === "dark";
+
   const maybeBonusTos = maybeNotNullyString(bonusTypeLocalizedContent.tos_url);
-  const maybeHeroImage = maybeNotNullyString(bonusType.hero_image);
+  const maybeHeroImage =
+    isDark && bonusType.hero_image_dark
+      ? maybeNotNullyString(bonusType.hero_image_dark)
+      : maybeNotNullyString(bonusType.hero_image);
 
   const actions: IOScrollViewActions = props.secondaryAction
     ? {


### PR DESCRIPTION
## Short description
This pull request updates the `BonusInformationComponent` to support dark mode by displaying a different hero image when the app is in dark theme

## List of changes proposed in this pull request
- Updated hero image selection logic to use `bonusType.hero_image_dark` when the theme is dark, falling back to the default image otherwise

## How to test
Check that in dark mode the `hero_image` is now accessible for CdC
