### PR TITLE
fix(IT Wallet): [SIW-3989] Remove "Recommended" badge from CIE+PIN identification method

### DIFF
--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -4534,12 +4534,10 @@
             "description": "È un passaggio necessario per garantire la sicurezza dei tuoi dati.",
             "header": "Scegli come identificarti",
             "section": "",
-            "subtitle": "Scegli come identificarti",
             "reissuing": {
               "title": "Scegli come identificarti",
               "description": "È un passaggio necessario per continuare ad usare Documenti su IO.",
               "section": "Verifica di identità",
-              "subtitle": "",
               "method": {
                 "ciePin": {
                   "title": "Continua con CIE + PIN",

--- a/ts/features/itwallet/identification/common/screens/ItwL2IdentificationModeSelectionScreen.tsx
+++ b/ts/features/itwallet/identification/common/screens/ItwL2IdentificationModeSelectionScreen.tsx
@@ -1,6 +1,5 @@
 import {
   ContentWrapper,
-  ListItemHeader,
   ModuleNavigationAlt,
   VStack
 } from "@pagopa/io-app-design-system";
@@ -51,12 +50,11 @@ export const ItwL2IdentificationModeSelectionScreen = (
     [eidReissuing]
   );
 
-  const { title, description, section, subtitle } = useMemo(
+  const { title, description, section } = useMemo(
     () => ({
       title: I18n.t(`${baseTranslationPath}.title`),
       description: I18n.t(`${baseTranslationPath}.description`),
-      section: I18n.t(`${baseTranslationPath}.section`),
-      subtitle: I18n.t(`${baseTranslationPath}.subtitle`)
+      section: I18n.t(`${baseTranslationPath}.section`)
     }),
     [baseTranslationPath]
   );
@@ -129,7 +127,6 @@ export const ItwL2IdentificationModeSelectionScreen = (
       headerActionsProp={{ showHelp: true }}
     >
       <ContentWrapper>
-        <ListItemHeader label={subtitle} />
         <VStack space={8}>
           {isCieAuthenticationSupported &&
             !isCiePinDisabled &&

--- a/ts/features/itwallet/identification/common/screens/ItwL2IdentificationModeSelectionScreen.tsx
+++ b/ts/features/itwallet/identification/common/screens/ItwL2IdentificationModeSelectionScreen.tsx
@@ -144,13 +144,6 @@ export const ItwL2IdentificationModeSelectionScreen = (
                 testID="CiePin"
                 image={<CiePin width={28} height={32} />}
                 onPress={handleCiePinPress}
-                badge={{
-                  text: I18n.t(`${baseTranslationPath}.method.ciePin.badge`, {
-                    defaultValue: ""
-                  }),
-                  variant: "highlight",
-                  outline: false
-                }}
               />
             )}
           {!isSpidDisabled && (

--- a/ts/features/itwallet/identification/common/screens/ItwL2IdentificationModeSelectionScreen.tsx
+++ b/ts/features/itwallet/identification/common/screens/ItwL2IdentificationModeSelectionScreen.tsx
@@ -1,30 +1,30 @@
-import { useFocusEffect } from "@react-navigation/native";
-import { useCallback, useMemo } from "react";
 import {
   ContentWrapper,
-  VStack,
+  ListItemHeader,
   ModuleNavigationAlt,
-  ListItemHeader
+  VStack
 } from "@pagopa/io-app-design-system";
+import { useFocusEffect } from "@react-navigation/native";
 import I18n from "i18next";
-import { ItwEidIssuanceMachineContext } from "../../../machine/eid/provider";
+import { useCallback, useMemo } from "react";
+import CiePin from "../../../../../../img/features/itWallet/identification/cie_pin.svg";
+import SpidLogo from "../../../../../../img/features/itWallet/identification/spid_logo.svg";
+import LoadingScreenContent from "../../../../../components/screens/LoadingScreenContent";
+import { IOScrollViewWithLargeHeader } from "../../../../../components/ui/IOScrollViewWithLargeHeader";
+import { IOStackNavigationRouteProps } from "../../../../../navigation/params/AppParamsList";
+import { useIOSelector } from "../../../../../store/hooks";
 import {
   trackItWalletIDMethod,
   trackItWalletIDMethodSelected
 } from "../../../analytics";
-import { IOScrollViewWithLargeHeader } from "../../../../../components/ui/IOScrollViewWithLargeHeader";
-import { useIOSelector } from "../../../../../store/hooks";
 import { itwDisabledIdentificationMethodsSelector } from "../../../common/store/selectors/remoteConfig";
-import { IOStackNavigationRouteProps } from "../../../../../navigation/params/AppParamsList";
-import { ItwParamsList } from "../../../navigation/ItwParamsList";
+import { ItwEidIssuanceMachineContext } from "../../../machine/eid/provider";
 import {
   isCIEAuthenticationSupportedSelector,
   isL3FeaturesEnabledSelector,
   selectIsLoading
 } from "../../../machine/eid/selectors";
-import SpidLogo from "../../../../../../img/features/itWallet/identification/spid_logo.svg";
-import CiePin from "../../../../../../img/features/itWallet/identification/cie_pin.svg";
-import LoadingScreenContent from "../../../../../components/screens/LoadingScreenContent";
+import { ItwParamsList } from "../../../navigation/ItwParamsList";
 
 export type ItwL2IdentificationNavigationParams = {
   eidReissuing?: boolean;
@@ -144,6 +144,20 @@ export const ItwL2IdentificationModeSelectionScreen = (
                 testID="CiePin"
                 image={<CiePin width={28} height={32} />}
                 onPress={handleCiePinPress}
+                badge={
+                  eidReissuing
+                    ? {
+                        text: I18n.t(
+                          `${baseTranslationPath}.method.ciePin.badge`,
+                          {
+                            defaultValue: ""
+                          }
+                        ),
+                        variant: "highlight",
+                        outline: false
+                      }
+                    : undefined
+                }
               />
             )}
           {!isSpidDisabled && (

--- a/ts/features/itwallet/machine/eid/actions.ts
+++ b/ts/features/itwallet/machine/eid/actions.ts
@@ -80,10 +80,12 @@ export const createEidIssuanceActionsImplementation = (
     });
   },
 
-  navigateToL2IdentificationScreen: () => {
+  navigateToL2IdentificationScreen: ({
+    context
+  }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
     navigation.navigate(ITW_ROUTES.MAIN, {
       screen: ITW_ROUTES.IDENTIFICATION.MODE_SELECTION.L2,
-      params: { eidReissuing: false }
+      params: { eidReissuing: context.mode === "reissuance" }
     });
   },
 


### PR DESCRIPTION
## Short description
This PR removes the "Recommended" badge on the CIE+PIN identification method for the `Documenti su IO` issuance

## List of changes proposed in this pull request
- Removed `badge` from `ModuleNavigationAlt` component
- Added correct parameter to `navigateToL2IdentificationScreen` eid issuance action

## How to test
- Verify there isn't regression in the _Documenti su IO_ identification page
- Verify that the badge is displayed in the `Documenti su IO` identification page only for reissuing
