### PR TITLE
chore(IT Wallet): [SIW-3083] Rename "Residenza" to "Attestato di residenza"

### DIFF
--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -4324,7 +4324,7 @@
         "ts": "Tessera Sanitaria - Tessera europea di assicurazione malattia",
         "ed": "Titoli accademici",
         "ee": "Iscrizioni universitarie",
-        "res": "Residenza"
+        "res": "Attestato di residenza"
       },
       "wallet": {
         "active": "Attivo",

--- a/ts/features/itwallet/common/components/ItwCredentialCard/__tests__/__snapshots__/ItwCredentialCard.test.tsx.snap
+++ b/ts/features/itwallet/common/components/ItwCredentialCard/__tests__/__snapshots__/ItwCredentialCard.test.tsx.snap
@@ -1863,7 +1863,7 @@ exports[`ItwCredentialCard should match snapshot when credential type is "reside
           ]
         }
       >
-        RESIDENZA
+        ATTESTATO DI RESIDENZA
       </Text>
     </View>
   </View>


### PR DESCRIPTION
## Short description
This PR renames "Residenza" to "Attestato di residenza".

## List of changes proposed in this pull request
- Renamed residency credential
- Updated snapshots

## How to test
Ensure the residency credential is always displayed as "Attestato di residenza".

| Wallet | Detail |
|-|-|
|<img height="460" src="https://github.com/user-attachments/assets/e9071c1c-775a-4b56-8716-a9bd906acc1e" />|<img height="460" src="https://github.com/user-attachments/assets/9bbbca48-e9cc-49c2-90f6-e6d5986b9b92" />|


