### PR TITLE
fix(IT Wallet): [SIW-3084] Update copy related to IT-Wallet ID

### DIFF
--- a/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialTrustIssuerScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialTrustIssuerScreen.tsx
@@ -173,7 +173,7 @@ const ContentView = ({ credentialType, eid }: ContentViewProps) => {
   });
   const requiredClaims = claims.map(claim => ({
     claim,
-    source: getCredentialNameFromType(eid.credentialType)
+    source: getCredentialNameFromType(eid.credentialType, "", isItwL3)
   }));
 
   const trackScrollToBottom = (crossed: boolean) => {

--- a/ts/features/itwallet/presentation/remote/components/ItwRemotePresentationDetails.tsx
+++ b/ts/features/itwallet/presentation/remote/components/ItwRemotePresentationDetails.tsx
@@ -49,6 +49,28 @@ const mapClaims = (
     };
   });
 
+const RequestedCredentialsBlock = ({
+  credentials
+}: {
+  credentials: EnrichedPresentationDetails;
+}) => (
+  <VStack space={24}>
+    {credentials
+      .filter(c => c.claimsToDisplay.length > 0)
+      .map(c => (
+        <ClaimsSelector
+          key={c.id}
+          title={pipe(c.vct, getCredentialTypeByVct, credentialType =>
+            getCredentialNameFromType(credentialType, "", true)
+          )}
+          items={mapClaims(c.claimsToDisplay)}
+          defaultExpanded
+          selectionEnabled={false}
+        />
+      ))}
+  </VStack>
+);
+
 const ItwRemotePresentationDetails = () => {
   const theme = useIOTheme();
 
@@ -73,26 +95,6 @@ const ItwRemotePresentationDetails = () => {
     });
   };
 
-  const renderCredentialsBlock = (credentials: EnrichedPresentationDetails) => (
-    <VStack space={24}>
-      {credentials
-        .filter(c => c.claimsToDisplay.length > 0)
-        .map(c => (
-          <ClaimsSelector
-            key={c.id}
-            title={pipe(
-              c.vct,
-              getCredentialTypeByVct,
-              getCredentialNameFromType
-            )}
-            items={mapClaims(c.claimsToDisplay)}
-            defaultExpanded
-            selectionEnabled={false}
-          />
-        ))}
-    </VStack>
-  );
-
   return (
     <VStack space={24}>
       {required.map(({ purpose, credentials }) => (
@@ -111,7 +113,7 @@ const ItwRemotePresentationDetails = () => {
                 : undefined
             }
           />
-          {renderCredentialsBlock(credentials)}
+          <RequestedCredentialsBlock credentials={credentials} />
         </View>
       ))}
 
@@ -131,7 +133,7 @@ const ItwRemotePresentationDetails = () => {
                 : undefined
             }
           />
-          {renderCredentialsBlock(credentials)}
+          <RequestedCredentialsBlock credentials={credentials} />
           <VSpacer size={16} />
           <Alert
             variant="info"


### PR DESCRIPTION
## Short description
This PR replaces "Identità Digitale" with "IT-Wallet ID" where appropriate.

## List of changes proposed in this pull request
- Correctly pass the `isItwCredential` parameter to `getCredentialNameFromType`

## How to test
Check the following screens.

| Remote presentation | Credential Trust Issuer PID L3 | Credential Trust Issuer PID L2 |
|---|---|---|
|<img height="480" alt="it_wallet_id_2" src="https://github.com/user-attachments/assets/fc8ff8a0-f890-4f2f-bfc8-9e44d0a89f47" />|<img height="480" alt="it_wallet_id_1" src="https://github.com/user-attachments/assets/18be18ec-3c78-4cd4-81af-e9aaa51cbcd2" />|<img height="480" alt="it_wallet_id_3" src="https://github.com/user-attachments/assets/83533c07-7c61-475a-8e20-2377f99f87af" />|
 
