### PR TITLE
fix(IT Wallet): [SIW-3105] Fix navigation to credentials' catalog after PID issuance

### DIFF
--- a/ts/features/itwallet/machine/eid/actions.ts
+++ b/ts/features/itwallet/machine/eid/actions.ts
@@ -147,22 +147,8 @@ export const createEidIssuanceActionsImplementation = (
   },
 
   navigateToCredentialCatalog: () => {
-    navigation.reset({
-      index: 1,
-      routes: [
-        {
-          name: ROUTES.MAIN,
-          params: {
-            screen: ROUTES.WALLET_HOME
-          }
-        },
-        {
-          name: ITW_ROUTES.MAIN,
-          params: {
-            screen: ITW_ROUTES.ONBOARDING
-          }
-        }
-      ]
+    navigation.replace(ITW_ROUTES.MAIN, {
+      screen: ITW_ROUTES.ONBOARDING
     });
   },
 


### PR DESCRIPTION
## Short description
This PR addresses an issue where navigating to the credentials catalog screen would incorrectly display the wallet screen behind it during the transition animation.

## List of changes proposed in this pull request
- Replaced the `reset` navigation action with `replace`.

## How to test
- Complete a PID issuance.
- When prompted, select the option to navigate to the credentials catalog.
- Confirm that the wallet screen is not visible behind the credentials catalog during the transition animation.

## Preview

| Before | After | 
| ---- | --- |
| <video src="https://github.com/user-attachments/assets/cb47c4d3-b0dc-4578-bd79-66caf429f248" /> | <video src="https://github.com/user-attachments/assets/fb2d2288-9e12-420b-9b62-dfdccff52ae5" /> |






