### PR TITLE
fix: [IOBP-2035] Receipts banner error padding

### DIFF
--- a/ts/features/payments/home/components/PaymentsHomeTransactionsList.tsx
+++ b/ts/features/payments/home/components/PaymentsHomeTransactionsList.tsx
@@ -121,15 +121,17 @@ const PaymentsHomeTransactionsList = ({ enforcedLoadingState }: Props) => {
 
     if (pot.isError(latestTransactionsPot)) {
       return (
-        <BannerErrorState
-          testID="PaymentsHomeTransactionsListTestID-error"
-          label="Il caricamento delle ricevute è fallito."
-          icon="warningFilled"
-          actionText={I18n.t(
-            "features.payments.transactions.error.banner.retryButton"
-          )}
-          onPress={handleOnRetry}
-        />
+        <ContentWrapper>
+          <BannerErrorState
+            testID="PaymentsHomeTransactionsListTestID-error"
+            label="Il caricamento delle ricevute è fallito."
+            icon="warningFilled"
+            actionText={I18n.t(
+              "features.payments.transactions.error.banner.retryButton"
+            )}
+            onPress={handleOnRetry}
+          />
+        </ContentWrapper>
       );
     }
 


### PR DESCRIPTION
## Short description
This pull request makes a small UI improvement to the `PaymentsHomeTransactionsList` component by wrapping the error state banner in a `ContentWrapper`.

## List of changes proposed in this pull request
  * Wrapped the `BannerErrorState` component in a `ContentWrapper` to ensure consistent layout when displaying errors in `PaymentsHomeTransactionsList.tsx`.

## How to test
- Check that whenever there is an error inside the payments home screen, check that there is an horizontal padding to the error banner

## Preview

|Before|After|
|-|-|
|<img src="https://github.com/user-attachments/assets/1c0fd9bc-af2f-437f-8e7c-b2d2cfa9d4ef" width="300px" />|<img src="https://github.com/user-attachments/assets/9a683c68-2e2a-4bd7-b4bc-1f5001fb4ff2" width="300px" />
