### PR TITLE
feat: [IOCOM-2550] Send AAR attachment download

### DIFF
--- a/ts/features/messages/components/MessageAttachment/MessageAttachment.tsx
+++ b/ts/features/messages/components/MessageAttachment/MessageAttachment.tsx
@@ -28,7 +28,7 @@ import { downloadedMessageAttachmentSelector } from "../../store/reducers/downlo
 import {
   attachmentContentType,
   attachmentDisplayName
-} from "../../store/reducers/transformers";
+} from "../../utils/attachments";
 import { PdfViewer } from "./PdfViewer";
 
 type MessageAttachmentFooterProps = {

--- a/ts/features/messages/hooks/useAttachmentDownload.tsx
+++ b/ts/features/messages/hooks/useAttachmentDownload.tsx
@@ -17,7 +17,7 @@ import {
 import { MESSAGES_ROUTES } from "../navigation/routes";
 import { ServiceId } from "../../../../definitions/backend/ServiceId";
 import { ThirdPartyAttachment } from "../../../../definitions/backend/ThirdPartyAttachment";
-import { attachmentDisplayName } from "../store/reducers/transformers";
+import { attachmentDisplayName } from "../utils/attachments";
 import {
   trackPNAttachmentDownloadFailure,
   trackPNAttachmentOpening

--- a/ts/features/messages/saga/__test__/handleDownloadAttachment.test.ts
+++ b/ts/features/messages/saga/__test__/handleDownloadAttachment.test.ts
@@ -1,12 +1,10 @@
+import { PublicKey } from "@pagopa/io-react-native-crypto";
 import ReactNativeBlobUtil from "react-native-blob-util";
 import { expectSaga } from "redux-saga-test-plan";
 import * as matchers from "redux-saga-test-plan/matchers";
 import * as O from "fp-ts/lib/Option";
 import I18n from "i18next";
-import {
-  downloadAttachmentWorker,
-  pdfSavePath
-} from "../handleDownloadAttachment";
+import { downloadAttachmentWorker } from "../handleDownloadAttachment";
 import { SessionToken } from "../../../../types/SessionToken";
 import { downloadAttachment } from "../../store/actions";
 import { mockPdfAttachment } from "../../__mocks__/attachment";
@@ -15,17 +13,26 @@ import {
   lollipopKeyTagSelector,
   lollipopPublicKeySelector
 } from "../../../lollipop/store/reducers/lollipop";
+import { KeyInfo } from "../../../lollipop/utils/crypto";
+import { pdfSavePath } from "../../utils/attachments";
 
 const messageId = "01JTT75QYSHWBTNTFM3CZZ17SH";
 const savePath = "/tmp/attachment.pdf";
 const serviceId = "service0000001" as ServiceId;
-const someKeyTag = O.some("a12e9221-c056-4bbc-8623-ca92df29361e");
-const somePublicKey = O.some({
+const keyTag = "a12e9221-c056-4bbc-8623-ca92df29361e";
+const someKeyTag = O.some(keyTag);
+const publicKey: PublicKey = {
   crv: "P-256",
   x: "dyLTwacs5ej/nnXIvCMexUBkmdh6ArJ4GPKjHob61mE=",
   kty: "EC",
   y: "Tz0xNv++cOeLVapU/BhBS0FJydIcNcV25/ALb1HVu+s="
-});
+};
+const somePublicKey = O.some(publicKey);
+const keyInfo: KeyInfo = {
+  keyTag,
+  publicKey,
+  publicKeyThumbprint: "w24n4sygj6zH-wLh0kGoQSl6QzA_LSQNRuKLUuJMYdo"
+};
 
 jest.mock("react-native-blob-util", () => ({
   config: jest.fn().mockImplementation(() => ({
@@ -47,6 +54,7 @@ describe("downloadAttachment given an attachment", () => {
       expectSaga(
         downloadAttachmentWorker,
         "token" as SessionToken,
+        keyInfo,
         downloadAttachment.request({
           attachment,
           messageId,
@@ -82,6 +90,7 @@ describe("downloadAttachment given an attachment", () => {
       expectSaga(
         downloadAttachmentWorker,
         "token" as SessionToken,
+        keyInfo,
         downloadAttachment.request({
           attachment,
           messageId,
@@ -118,6 +127,7 @@ describe("downloadAttachment given an attachment", () => {
       expectSaga(
         downloadAttachmentWorker,
         "token" as SessionToken,
+        keyInfo,
         downloadAttachment.request({
           attachment,
           messageId,

--- a/ts/features/messages/saga/__test__/handleRequestInit.test.ts
+++ b/ts/features/messages/saga/__test__/handleRequestInit.test.ts
@@ -1,18 +1,17 @@
+import { PublicKey } from "@pagopa/io-react-native-crypto";
 import * as O from "fp-ts/lib/Option";
-import { v4 as uuid } from "uuid";
 import { testSaga } from "redux-saga-test-plan";
 import {
   handleRequestInit,
   testableHandleRequestInitFactory
 } from "../handleRequestInit";
-import {
-  lollipopKeyTagSelector,
-  lollipopPublicKeySelector
-} from "../../../lollipop/store/reducers/lollipop";
-import { generateKeyInfo } from "../../../lollipop/saga";
 import { lollipopRequestInit } from "../../../lollipop/utils/fetch";
 import { ThirdPartyAttachment } from "../../../../../definitions/backend/ThirdPartyAttachment";
 import { messageId_1 } from "../../__mocks__/messages";
+import { KeyInfo } from "../../../lollipop/utils/crypto";
+
+const mockUUID = "1896a22a-978b-49e9-856b-1cd74f2de3d8";
+jest.mock("uuid", () => ({ v4: () => mockUUID }));
 
 const handleRequestInitFactory = testableHandleRequestInitFactory!;
 
@@ -40,15 +39,9 @@ describe("handleDownloadAttachment", () => {
       } as ThirdPartyAttachment,
       data.messageId,
       data.bearerToken,
-      data.nonce
+      data.keyInfo
     )
       .next()
-      .select(lollipopKeyTagSelector)
-      .next(data.keyTagOption)
-      .select(lollipopPublicKeySelector)
-      .next(data.publicKeyOption)
-      .call(generateKeyInfo, data.keyTagOption, data.publicKeyOption)
-      .next(data.keyInfo)
       .call(
         lollipopRequestInit,
         { nonce: data.nonce },
@@ -76,15 +69,9 @@ describe("handleDownloadAttachment", () => {
       } as ThirdPartyAttachment,
       data.messageId,
       data.bearerToken,
-      data.nonce
+      data.keyInfo
     )
       .next()
-      .select(lollipopKeyTagSelector)
-      .next(data.keyTagOption)
-      .select(lollipopPublicKeySelector)
-      .next(data.publicKeyOption)
-      .call(generateKeyInfo, data.keyTagOption, data.publicKeyOption)
-      .next(data.keyInfo)
       .call(
         lollipopRequestInit,
         { nonce: data.nonce },
@@ -103,26 +90,27 @@ describe("handleDownloadAttachment", () => {
 
 const fetchParametersCommonInputData = () => {
   const keyTag = "keyTag";
-  const publicKey = {
+  const publicKey: PublicKey = {
     kty: "EC",
     crv: "crv",
     x: "x",
     y: "y"
   };
+  const keyInfo: KeyInfo = {
+    keyTag,
+    publicKey,
+    publicKeyThumbprint: "hUjLQnu7ElEk1tx0vs9ziWHcJBTVGWTeHVyq3ZBhKBg"
+  };
   const bearerToken = "123asd";
   const headers = { Authorization: `Bearer ${bearerToken}` };
   return {
     bearerToken,
-    nonce: uuid(),
+    nonce: mockUUID,
     keyTag,
     keyTagOption: O.some(keyTag),
     publicKey,
     publicKeyOption: O.some(publicKey),
-    keyInfo: {
-      keyTag,
-      publicKey,
-      publicKeyThumbprint: "thumbprint"
-    },
+    keyInfo,
     messageId: messageId_1,
     attachmentId: "1",
     attachmentName: "1.pdf",

--- a/ts/features/messages/saga/handleClearAttachments.ts
+++ b/ts/features/messages/saga/handleClearAttachments.ts
@@ -2,7 +2,7 @@ import { ActionType } from "typesafe-actions";
 import { call } from "typed-redux-saga/macro";
 import RNFS from "react-native-fs";
 import { removeCachedAttachment } from "../store/actions";
-import { AttachmentsDirectoryPath } from "./handleDownloadAttachment";
+import { AttachmentsDirectoryPath } from "../utils/attachments";
 
 /**
  * Clears cached file for the attachment

--- a/ts/features/messages/saga/handleRequestInit.ts
+++ b/ts/features/messages/saga/handleRequestInit.ts
@@ -4,7 +4,7 @@ import { LollipopConfig } from "../../lollipop";
 import { lollipopRequestInit } from "../../lollipop/utils/fetch";
 import { isTestEnv } from "../../../utils/environment";
 import { ThirdPartyAttachment } from "../../../../definitions/backend/ThirdPartyAttachment";
-import { attachmentDownloadUrl } from "../store/reducers/transformers";
+import { attachmentDownloadUrl } from "../utils/attachments";
 import { KeyInfo } from "../../lollipop/utils/crypto";
 
 type HeaderType = Record<string, string>;

--- a/ts/features/messages/saga/handleRequestInit.ts
+++ b/ts/features/messages/saga/handleRequestInit.ts
@@ -1,14 +1,11 @@
-import { call, select } from "typed-redux-saga/macro";
-import {
-  lollipopKeyTagSelector,
-  lollipopPublicKeySelector
-} from "../../lollipop/store/reducers/lollipop";
-import { generateKeyInfo } from "../../lollipop/saga";
+import { v4 as uuid } from "uuid";
+import { call } from "typed-redux-saga/macro";
 import { LollipopConfig } from "../../lollipop";
 import { lollipopRequestInit } from "../../lollipop/utils/fetch";
 import { isTestEnv } from "../../../utils/environment";
 import { ThirdPartyAttachment } from "../../../../definitions/backend/ThirdPartyAttachment";
 import { attachmentDownloadUrl } from "../store/reducers/transformers";
+import { KeyInfo } from "../../lollipop/utils/crypto";
 
 type HeaderType = Record<string, string>;
 
@@ -16,15 +13,11 @@ export function* handleRequestInit(
   attachment: ThirdPartyAttachment,
   messageId: string,
   bearerToken: string,
-  nonce: string
+  keyInfo: KeyInfo
 ) {
   const lollopopConfig: LollipopConfig = {
-    nonce
+    nonce: uuid()
   };
-
-  const keyTag = yield* select(lollipopKeyTagSelector);
-  const publicKey = yield* select(lollipopPublicKeySelector);
-  const keyInfo = yield* call(generateKeyInfo, keyTag, publicKey);
 
   const attachmentFullUrl = attachmentDownloadUrl(messageId, attachment);
 

--- a/ts/features/messages/saga/index.ts
+++ b/ts/features/messages/saga/index.ts
@@ -22,6 +22,7 @@ import {
   startPaymentStatusTracking,
   upsertMessageStatusAttributes
 } from "../store/actions";
+import { KeyInfo } from "../../lollipop/utils/crypto";
 import { retryDataAfterFastLoginSessionExpirationSelector } from "../store/reducers/messageGetStatus";
 import { BackendClient } from "../../../api/backend";
 import { retrievingDataPreconditionStatusAction } from "../store/actions/preconditions";
@@ -53,7 +54,8 @@ import { handlePaymentUpdateRequests } from "./handlePaymentUpdateRequests";
  */
 export function* watchMessagesSaga(
   backendClient: BackendClient,
-  bearerToken: SessionToken
+  bearerToken: SessionToken,
+  keyInfo: KeyInfo
 ): SagaIterator {
   yield* takeLatest(
     loadNextPageMessages.request,
@@ -113,7 +115,8 @@ export function* watchMessagesSaga(
   yield* takeLatest(
     downloadAttachment.request,
     handleDownloadAttachment,
-    bearerToken
+    bearerToken,
+    keyInfo
   );
 
   // handle the request for updating a message's payment

--- a/ts/features/messages/store/reducers/__tests__/transformers.test.ts
+++ b/ts/features/messages/store/reducers/__tests__/transformers.test.ts
@@ -1,8 +1,8 @@
 import { CreatedMessageWithContentAndAttachments } from "../../../../../../definitions/backend/CreatedMessageWithContentAndAttachments";
 import { ThirdPartyAttachment } from "../../../../../../definitions/backend/ThirdPartyAttachment";
 import { message_1 } from "../../../__mocks__/message";
-
-import { attachmentDisplayName, toUIMessageDetails } from "../transformers";
+import { attachmentDisplayName } from "../../../utils/attachments";
+import { toUIMessageDetails } from "../transformers";
 
 const inputWithoutDueDate: CreatedMessageWithContentAndAttachments = {
   ...message_1,

--- a/ts/features/messages/store/reducers/thirdPartyById.ts
+++ b/ts/features/messages/store/reducers/thirdPartyById.ts
@@ -35,6 +35,23 @@ type EphemeralAARThirdPartyMessage = {
   mandateId?: string;
 } & ThirdPartyMessageWithContent;
 
+export const isEphemeralAARThirdPartyMessage = (
+  message: ThirdPartyMessageUnion
+): message is EphemeralAARThirdPartyMessage =>
+  message.kind === thirdPartyKind.AAR;
+
+export const isThirdParyMessageAarSelector = (
+  state: GlobalState,
+  ioMessageId: string
+) => {
+  const thirdPartyMessagePot = thirdPartyFromIdSelector(state, ioMessageId);
+  const thirdPartyMessage = pot.getOrElse(thirdPartyMessagePot, undefined);
+  return (
+    thirdPartyMessage != null &&
+    isEphemeralAARThirdPartyMessage(thirdPartyMessage)
+  );
+};
+
 export type ThirdPartyMessageUnion =
   | StandardThirdPartyMessage
   | EphemeralAARThirdPartyMessage;
@@ -71,6 +88,14 @@ export const thirdPartyFromIdSelector = (
   state: GlobalState,
   ioMessageId: string
 ) => state.entities.messages.thirdPartyById[ioMessageId] ?? pot.none;
+
+export const thirdPartyMessageSelector = (
+  state: GlobalState,
+  ioMessageId: string
+) => {
+  const thirdPartyMessagePot = thirdPartyFromIdSelector(state, ioMessageId);
+  return pot.toUndefined(thirdPartyMessagePot);
+};
 
 export const messageTitleSelector = (state: GlobalState, ioMessageId: string) =>
   messageContentSelector(

--- a/ts/features/messages/store/reducers/transformers.ts
+++ b/ts/features/messages/store/reducers/transformers.ts
@@ -4,8 +4,7 @@ import { MessageCategory } from "../../../../../definitions/backend/MessageCateg
 import { TagEnum } from "../../../../../definitions/backend/MessageCategoryBase";
 import { MessageStatusAttributes } from "../../../../../definitions/backend/MessageStatusAttributes";
 import { PublicMessage } from "../../../../../definitions/backend/PublicMessage";
-import { ThirdPartyAttachment } from "../../../../../definitions/backend/ThirdPartyAttachment";
-import { apiUrlPrefix } from "../../../../config";
+
 import {
   EUCovidCertificate,
   PaymentData,
@@ -97,16 +96,3 @@ export const toUIMessageDetails = (
     hasRemoteContent: !!content.third_party_data?.has_remote_content
   };
 };
-
-export const attachmentDisplayName = (attachment: ThirdPartyAttachment) =>
-  attachment.name ?? attachment.id;
-export const attachmentContentType = (attachment: ThirdPartyAttachment) =>
-  attachment.content_type ?? "application/octet-stream";
-export const attachmentDownloadUrl = (
-  messageId: string,
-  attachment: ThirdPartyAttachment
-) =>
-  `${apiUrlPrefix}/api/v1/third-party-messages/${messageId}/attachments/${attachment.url.replace(
-    /^\//g, // note that attachmentUrl might contains a / at the beginning, so let's strip it
-    ""
-  )}`;

--- a/ts/features/messages/utils/attachments.ts
+++ b/ts/features/messages/utils/attachments.ts
@@ -1,0 +1,40 @@
+import RNFS from "react-native-fs";
+import { ThirdPartyAttachment } from "../../../../definitions/backend/ThirdPartyAttachment";
+import { apiUrlPrefix } from "../../../config";
+
+export const AttachmentsDirectoryPath =
+  RNFS.CachesDirectoryPath + "/attachments";
+
+/**
+ * Builds the save path for the given attachment
+ * @param attachment
+ */
+export const pdfSavePath = (
+  messageId: string,
+  attachmentId: string,
+  name: string
+) => {
+  // Trim leading/trailing whitespace
+  // Basic sanitization: remove characters not allowed in filenames (common for most OS)
+  // Characters removed: / \ : * ? " < > |
+  const sanitizedFileName = name.trim().replace(/[/\\:*?"<>|]/g, "");
+  const sanitizedFileNameWithExtension = !sanitizedFileName
+    .toLowerCase()
+    .endsWith(".pdf")
+    ? `${sanitizedFileName}.pdf`
+    : sanitizedFileName;
+  return `${AttachmentsDirectoryPath}/${messageId}/${attachmentId}/${sanitizedFileNameWithExtension}`;
+};
+
+export const attachmentDisplayName = (attachment: ThirdPartyAttachment) =>
+  attachment.name ?? attachment.id;
+export const attachmentContentType = (attachment: ThirdPartyAttachment) =>
+  attachment.content_type ?? "application/octet-stream";
+export const attachmentDownloadUrl = (
+  messageId: string,
+  attachment: ThirdPartyAttachment
+) =>
+  `${apiUrlPrefix}/api/v1/third-party-messages/${messageId}/attachments/${attachment.url.replace(
+    /^\//g, // note that attachmentUrl might contains a / at the beginning, so let's strip it
+    ""
+  )}`;

--- a/ts/features/pn/aar/analytics/index.ts
+++ b/ts/features/pn/aar/analytics/index.ts
@@ -36,3 +36,11 @@ export const trackSendActivationModalDialogActivationDismissed = () => {
   const properties = buildEventProperties("UX", "action");
   mixpanelTrack(eventName, properties);
 };
+
+export const trackSendAARAttachmentDownloadFailure = (reason: string) => {
+  const eventName = "SEND_AAR_ATTACHMENT_DOWNLOAD_FAILED";
+  const props = buildEventProperties("KO", undefined, {
+    reason
+  });
+  void mixpanelTrack(eventName, props);
+};

--- a/ts/features/pn/aar/saga/downloadAARAttachmentSaga.ts
+++ b/ts/features/pn/aar/saga/downloadAARAttachmentSaga.ts
@@ -1,0 +1,183 @@
+import { isLeft } from "fp-ts/lib/Either";
+import { readableReportSimplified } from "@pagopa/ts-commons/lib/reporters";
+import { call, cancelled, delay, put, select } from "typed-redux-saga/macro";
+import { ActionType } from "typesafe-actions";
+import ReactNativeBlobUtil from "react-native-blob-util";
+import { SessionToken } from "../../../../types/SessionToken";
+import { KeyInfo } from "../../../lollipop/utils/crypto";
+import { createSendAARClientWithLollipop } from "../api/client";
+import { apiUrlPrefix, fetchTimeout } from "../../../../config";
+import { downloadAttachment } from "../../../messages/store/actions";
+import { withRefreshApiCall } from "../../../authentication/fastLogin/saga/utils";
+import { ReduxSagaEffect, SagaCallReturnType } from "../../../../types/utils";
+import { unknownToReason } from "../../../messages/utils";
+import { isPnTestEnabledSelector } from "../../../../store/reducers/persistedPreferences";
+import {
+  attachmentDisplayName,
+  pdfSavePath
+} from "../../../messages/utils/attachments";
+import { ThirdPartyAttachment } from "../../../../../definitions/backend/ThirdPartyAttachment";
+
+export function* downloadAARAttachmentSaga(
+  bearerToken: SessionToken,
+  keyInfo: KeyInfo,
+  mandateId: string | undefined,
+  action: ActionType<typeof downloadAttachment.request>
+) {
+  const { attachment, messageId } = action.payload;
+
+  const useSendUATEnvironment = yield* select(isPnTestEnabledSelector);
+
+  try {
+    const attachmentPrevalidatedUrl = yield* call(
+      getAttachmentPrevalidatedUrl,
+      bearerToken,
+      keyInfo,
+      attachment.url,
+      useSendUATEnvironment,
+      mandateId
+    );
+
+    const attachmentDownloadPath = yield* call(
+      downloadAttachmentFromPrevalidatedUrl,
+      attachment,
+      messageId,
+      attachmentPrevalidatedUrl
+    );
+
+    yield* put(
+      downloadAttachment.success({
+        attachment,
+        messageId,
+        path: attachmentDownloadPath
+      })
+    );
+  } catch (e) {
+    const reason = unknownToReason(e);
+    // TODO mixpanel
+    yield* put(
+      downloadAttachment.failure({
+        attachment,
+        messageId,
+        error: Error(reason)
+      })
+    );
+  } finally {
+    // In this way, the download pot's status
+    // in the reducer will be properly updated.
+    if (yield* cancelled()) {
+      yield* put(downloadAttachment.cancel({ attachment, messageId }));
+    }
+  }
+}
+
+function* getAttachmentPrevalidatedUrl(
+  bearerToken: SessionToken,
+  keyInfo: KeyInfo,
+  attachmentUrl: string,
+  useUATEnvironment: boolean,
+  mandateId: string | undefined
+): Generator<ReduxSagaEffect, string> {
+  while (true) {
+    const attachmentMetadataRetryAfterOrUrl = yield* call(
+      getAttachmentMetadata,
+      bearerToken,
+      keyInfo,
+      attachmentUrl,
+      useUATEnvironment,
+      mandateId
+    );
+    if (typeof attachmentMetadataRetryAfterOrUrl === "string") {
+      return attachmentMetadataRetryAfterOrUrl;
+    }
+    const retryAfterMilliseconds =
+      attachmentMetadataRetryAfterOrUrl >= 1000
+        ? attachmentMetadataRetryAfterOrUrl
+        : 1000 * attachmentMetadataRetryAfterOrUrl;
+    yield* delay(retryAfterMilliseconds);
+  }
+}
+
+function* getAttachmentMetadata(
+  bearerToken: SessionToken,
+  keyInfo: KeyInfo,
+  attachmentUrl: string,
+  useUATEnvironment: boolean,
+  mandateId?: string
+): Generator<ReduxSagaEffect, string | number> {
+  const sendAARClient = createSendAARClientWithLollipop(apiUrlPrefix, keyInfo);
+  const getAttachmentMetadataFactory = sendAARClient.getNotificationAttachment;
+
+  const urlEncodedBase64AttachmentUrl = encodeAttachmentUrl(attachmentUrl);
+
+  const request = getAttachmentMetadataFactory({
+    Bearer: `Bearer ${bearerToken}`,
+    urlEncodedBase64AttachmentUrl,
+    "x-pagopa-pn-io-src": "QRCODE",
+    mandateId,
+    isTest: useUATEnvironment
+  });
+
+  const responseEither = (yield* call(
+    withRefreshApiCall,
+    request
+  )) as SagaCallReturnType<typeof getAttachmentMetadataFactory>;
+
+  if (isLeft(responseEither)) {
+    const reason = readableReportSimplified(responseEither.left);
+    throw Error(reason);
+  }
+
+  const response = responseEither.right;
+  if (response.status !== 200) {
+    const problemJson = response.value;
+    throw Error(
+      `${response.status} ${problemJson.status} ${problemJson.title} ${problemJson.detail}`
+    );
+  }
+
+  const { retryAfter, url } = response.value;
+  if (url != null && url.trim().length > 0) {
+    return url;
+  } else if (retryAfter != null) {
+    return retryAfter;
+  }
+  throw Error(
+    `Both 'retryAfter' and 'url' fields are invalid (${retryAfter}) (${url})`
+  );
+}
+
+const encodeAttachmentUrl = (inputAttachmentUrl: string): string => {
+  const initialSlashRemovedInputAttachmentUrl = inputAttachmentUrl.startsWith(
+    "/"
+  )
+    ? inputAttachmentUrl.substring(1)
+    : inputAttachmentUrl;
+  const initialSlashRemovedInputAttachmentUrlBuffer = Buffer.from(
+    initialSlashRemovedInputAttachmentUrl,
+    "utf8"
+  );
+  const initialSlashRemovedInputAttachmentUrlBase64 =
+    initialSlashRemovedInputAttachmentUrlBuffer.toString("base64");
+  return encodeURIComponent(initialSlashRemovedInputAttachmentUrlBase64);
+};
+
+function* downloadAttachmentFromPrevalidatedUrl(
+  attachment: ThirdPartyAttachment,
+  messageId: string,
+  prevalidatedAttachmentUrl: string
+): Generator<ReduxSagaEffect, string> {
+  const attachmentId = attachment.id;
+  const attachmentName = attachmentDisplayName(attachment);
+  const config = yield* call(ReactNativeBlobUtil.config, {
+    path: pdfSavePath(messageId, attachmentId, attachmentName),
+    timeout: fetchTimeout
+  });
+  const result = yield* call(config.fetch, "get", prevalidatedAttachmentUrl);
+
+  const { status } = result.info();
+  if (status === 200) {
+    return result.path();
+  }
+  throw Error(`${status}`); // TODO more data
+}

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -376,7 +376,7 @@ export function* initializeApplicationSaga(
   yield* fork(watchServicesSaga, backendClient, sessionToken);
 
   // Start watching for Messages actions
-  yield* fork(watchMessagesSaga, backendClient, sessionToken);
+  yield* fork(watchMessagesSaga, backendClient, sessionToken, keyInfo);
 
   // start watching for FIMS actions
   yield* fork(watchFimsSaga, sessionToken);


### PR DESCRIPTION
## Short description
This PR add downloading of SEND AAR's attachments.

## List of changes proposed in this pull request
- New saga that retrieves the download metadata and then download the file
- Such saga is run based on the third party message type from which the attachment is requested
- Lollipop keyinfo data has been refactored, in order to be shared from the startup saga

## How to test
Using the io-dev-api-server, change the following files and lines:
- `ts/features/messages/hooks/useAttachmentDownload.tsx` row 109
```
downloadAttachment.request({
  attachment: {
    ...attachment,
    url: "REPLACEME" as NonEmptyString
  },
  messageId: "00000000000000000000000006",
  skipMixpanelTrackingOnFailure: isPN,
  serviceId
})
```
- `ts/features/messages/saga/handleDownloadAttachment.ts` row 197
```
  ephemeralAARThirdPartyMessage: true,
```

and replace `REPLACEME` with the url of an attachment that belongs to the send notification with ID `SEND-SEND-SEND-000002-A-0` (you can retrieve it by calling `http://localhost:3000/api/v1/send/aar/notifications/SEND-SEND-SEND-000002-A-0?isTest=false` with cUrl/Bruno/Postman/...).

Select the SEND message with title `Nuovo avviso di ingiunzione` and try to download one of it's attachments