### PR TITLE
refactor: [IOBP-000] Update initiative not started pictogram, fix empty list dark mode

### DIFF
--- a/ts/features/idpay/details/components/IdPayInitiativeTimelineComponent.tsx
+++ b/ts/features/idpay/details/components/IdPayInitiativeTimelineComponent.tsx
@@ -142,11 +142,7 @@ const TimelineComponentSkeleton = ({ size = 3 }: Pick<Props, "size">) => (
 );
 
 const EmptyTimelineComponent = () => (
-  <BodySmall
-    weight="Regular"
-    color="grey-850"
-    testID="IDPayEmptyTimelineTestID"
-  >
+  <BodySmall weight="Regular" testID="IDPayEmptyTimelineTestID">
     {I18n.t(
       "idpay.initiative.details.initiativeDetailsScreen.configured.yourOperationsSubtitle"
     )}

--- a/ts/features/idpay/onboarding/screens/IdPayFailureScreen.tsx
+++ b/ts/features/idpay/onboarding/screens/IdPayFailureScreen.tsx
@@ -163,7 +163,7 @@ const IdPayFailureScreen = () => {
         };
       case OnboardingFailureEnum.ONBOARDING_INITIATIVE_NOT_STARTED:
         return {
-          pictogram: "eventClose",
+          pictogram: "ended",
           title: I18n.t(
             "idpay.onboarding.failure.message.INITIATIVE_NOT_STARTED.title"
           ),


### PR DESCRIPTION
## Short description
This pull request makes a minor update to the `IdPayFailureScreen` component. The pictogram displayed for the `ONBOARDING_INITIATIVE_NOT_STARTED` failure case has been changed from `"eventClose"` to `"ended"` to better represent the failure state.
Fix IDPay dark mode empty list

## How to test
- Try to onboard a not started initiative
- Ensure that pictogram is aligned with design

## Preview

| Before | Now |
|--------|--------|
| <img width="440" height="934" alt="Screenshot 2025-10-03 at 09 34 29" src="https://github.com/user-attachments/assets/70dd3443-c38a-4fb9-9130-07a1f7783af7" /> | <img width="438" height="932" alt="Screenshot 2025-10-03 at 09 33 57" src="https://github.com/user-attachments/assets/3384d356-5541-4483-a88c-71f73c825635" /> | 


