### PR TITLE
refactor: [IOCOM-2627] remove temporary isSendAARPhase2Enabled flag

### DIFF
--- a/ts/features/pn/aar/components/SendQRScanFlowHandlerComponent.tsx
+++ b/ts/features/pn/aar/components/SendQRScanFlowHandlerComponent.tsx
@@ -3,7 +3,7 @@ import I18n from "i18next";
 import { useCallback, useEffect } from "react";
 import { OperationResultScreenContent } from "../../../../components/screens/OperationResultScreenContent";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
-import { useIOStore } from "../../../../store/hooks";
+import { useIOSelector, useIOStore } from "../../../../store/hooks";
 import { openWebUrl } from "../../../../utils/url";
 import { MESSAGES_ROUTES } from "../../../messages/navigation/routes";
 import { areNotificationPermissionsEnabledSelector } from "../../../pushNotifications/store/reducers/environment";
@@ -15,7 +15,7 @@ import {
   trackSendQRCodeScanRedirectDismissed
 } from "../analytics";
 import { SendAARInitialFlowScreen } from "../screen/SendAARInitialFlowScreen";
-import { isSendAARPhase2Enabled } from "../utils/generic";
+import { isAAREnabled } from "../store/reducers";
 
 export type SendQRScanHandlerScreenProps = {
   aarUrl: string;
@@ -23,12 +23,15 @@ export type SendQRScanHandlerScreenProps = {
 
 export const SendQRScanFlowHandlerComponent = ({
   aarUrl
-}: SendQRScanHandlerScreenProps) =>
-  isSendAARPhase2Enabled() ? (
+}: SendQRScanHandlerScreenProps) => {
+  const aAREnabled = useIOSelector(isAAREnabled);
+
+  return aAREnabled ? (
     <SendAARInitialFlowScreen qrCode={aarUrl} />
   ) : (
     <SendQrScanRedirect aarUrl={aarUrl} />
   );
+};
 
 const SendQrScanRedirect = ({ aarUrl }: SendQRScanHandlerScreenProps) => {
   const store = useIOStore();

--- a/ts/features/pn/aar/components/__tests__/SendQRScanFlowHandlerComponent.test.tsx
+++ b/ts/features/pn/aar/components/__tests__/SendQRScanFlowHandlerComponent.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent } from "@testing-library/react-native";
 import * as O from "fp-ts/lib/Option";
 import { createStore } from "redux";
 import { ServiceId } from "../../../../../../definitions/backend/ServiceId";
+import * as HOOKS from "../../../../../store/hooks";
 import { applicationChangeState } from "../../../../../store/actions/application";
 import { appReducer } from "../../../../../store/reducers";
 import { GlobalState } from "../../../../../store/reducers/types";
@@ -12,7 +13,6 @@ import { MESSAGES_ROUTES } from "../../../../messages/navigation/routes";
 import PN_ROUTES from "../../../navigation/routes";
 import * as ANALYTICS from "../../analytics";
 import * as INITIAL_FLOW from "../../screen/SendAARInitialFlowScreen";
-import * as GENERIC_UTILS from "../../utils/generic";
 import { SendQRScanFlowHandlerComponent } from "../SendQRScanFlowHandlerComponent";
 
 const sendNotificationServiceId = "01G40DWQGKY5GRWSNM4303VNRP" as ServiceId;
@@ -32,9 +32,11 @@ jest.mock("@react-navigation/native", () => {
     })
   };
 });
-const phase2Spy = jest.spyOn(GENERIC_UTILS, "isSendAARPhase2Enabled");
-const enablePhase2 = () => phase2Spy.mockImplementation(() => true);
-const disablePhase2 = () => phase2Spy.mockImplementation(() => false);
+
+jest.mock("../../../../../store/hooks", () => ({
+  ...jest.requireActual("../../../../../store/hooks"),
+  useIOSelector: jest.fn()
+}));
 
 describe("SendQRScanFlowHandlerComponent", () => {
   const mockOpenWebUrl = jest.fn();
@@ -51,7 +53,7 @@ describe("SendQRScanFlowHandlerComponent", () => {
 
   beforeAll(() => {
     jest.spyOn(URLUTILS, "openWebUrl").mockImplementation(mockOpenWebUrl);
-    disablePhase2();
+    (HOOKS.useIOSelector as jest.Mock).mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -174,7 +176,7 @@ describe("SendQRScanFlowHandlerComponent", () => {
   });
 });
 
-describe("SendQRScanFlowHandlerComponent - AAR phase toggle", () => {
+describe("SendQRScanFlowHandlerComponent - AAR enabled", () => {
   const componentMock = jest.fn();
   const componentSpy = jest
     .spyOn(INITIAL_FLOW, "SendAARInitialFlowScreen")
@@ -183,11 +185,11 @@ describe("SendQRScanFlowHandlerComponent - AAR phase toggle", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     act(() => {
-      enablePhase2();
+      (HOOKS.useIOSelector as jest.Mock).mockReturnValue(true);
     });
   });
 
-  it("should render the initial flow screen if phase 2 is enabled", () => {
+  it("should render the initial flow screen if aAREnabled='true'", () => {
     expect(componentSpy).not.toHaveBeenCalled();
     renderComponent(true, true);
     expect(componentMock.mock.calls[0][0]).toEqual({

--- a/ts/features/pn/aar/utils/__tests__/generic.test.ts
+++ b/ts/features/pn/aar/utils/__tests__/generic.test.ts
@@ -1,8 +1,0 @@
-import { isSendAARPhase2Enabled } from "../generic";
-
-describe("generic AAR utils", () => {
-  it("sendAARPhase2Enabled should return false", () => {
-    const isEnabled = isSendAARPhase2Enabled();
-    expect(isEnabled).toBe(false);
-  });
-});

--- a/ts/features/pn/aar/utils/generic.ts
+++ b/ts/features/pn/aar/utils/generic.ts
@@ -1,6 +1,0 @@
-/**
- * this is purely a temporary addition in order
- * to differentiate between phase 1 and 2 of the AAR flow.
- * will be removed once we update to phase 2
- * */
-export const isSendAARPhase2Enabled = () => false;


### PR DESCRIPTION
## Short description
This PR removed the temporary isSendAARPhase2Enabled flag and replaced it with the isAAREnabled selector from the store to manage the AAR flow feature toggle.

## List of changes proposed in this pull request
- Removed the temporary isSendAARPhase2Enabled flag.
- Updated SendQRScanFlowHandlerComponent to use the isAAREnabled selector via useIOSelector for feature flag control.

## How to test
- Use the toggle available in the dev section to set AAR to true or false.
- All automated tests should pass.
