### PR TITLE
fix: [IOBP-2054] Countdown progressbar barcode IDPay on Android devices

### DIFF
--- a/ts/features/idpay/barcode/components/IdPayBarcodeExpireProgressBar.tsx
+++ b/ts/features/idpay/barcode/components/IdPayBarcodeExpireProgressBar.tsx
@@ -4,23 +4,28 @@ import { useState, useEffect } from "react";
 import { StyleSheet, View } from "react-native";
 import I18n from "i18next";
 import { ProgressBar } from "../../../bonus/common/components/ProgressBar";
+import { calculateIdPayBarcodeSecondsToExpire } from "../utils";
+import { TransactionBarCodeResponse } from "../../../../../definitions/idpay/TransactionBarCodeResponse";
 
 type Props = {
-  secondsToExpiration: number;
+  barcode: TransactionBarCodeResponse;
   secondsExpirationTotal: number;
   setIsExpired: (isExpired: boolean) => void;
 };
 
 export const IdPayBarcodeExpireProgressBar = ({
-  secondsToExpiration,
+  barcode,
   secondsExpirationTotal,
   setIsExpired
 }: Props) => {
-  const [seconds, setSeconds] = useState(secondsToExpiration);
+  const [seconds, setSeconds] = useState(
+    calculateIdPayBarcodeSecondsToExpire(barcode)
+  );
   const isCodeExpired = seconds === 0;
   useEffect(() => {
     const timer = setInterval(() => {
       setSeconds(currentSecs => currentSecs - 1);
+      setSeconds(calculateIdPayBarcodeSecondsToExpire(barcode));
     }, 1000);
     if (seconds <= 0) {
       setSeconds(0);

--- a/ts/features/idpay/barcode/screens/IdPayBarcodeResultScreen.tsx
+++ b/ts/features/idpay/barcode/screens/IdPayBarcodeResultScreen.tsx
@@ -9,7 +9,7 @@ import * as pot from "@pagopa/ts-commons/lib/pot";
 import { RouteProp, useRoute } from "@react-navigation/native";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import { SafeAreaView, StyleSheet, View } from "react-native";
 import Barcode from "react-native-barcode-builder";
 import I18n from "i18next";
@@ -24,7 +24,6 @@ import { IdPayBarcodeExpireProgressBar } from "../components/IdPayBarcodeExpireP
 import { IdPayBarcodeParamsList } from "../navigation/params";
 import { idPayBarcodeByInitiativeIdSelector } from "../store";
 import { idPayGenerateBarcode } from "../store/actions";
-import { calculateIdPayBarcodeSecondsToExpire } from "../utils";
 import { clipboardSetStringWithFeedback } from "../../../../utils/clipboard";
 import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
 import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
@@ -150,13 +149,6 @@ const SuccessContent = ({
   });
 
   const [isBarcodeExpired, setIsBarcodeExpired] = useState(false);
-  // expire check is handled by the progress bar
-  // to avoid unnecessary rerenders, which could also be on the
-  // heavier side due to barcode generation
-  const secondsTillExpire = useMemo(
-    () => calculateIdPayBarcodeSecondsToExpire(barcode),
-    [barcode]
-  );
 
   if (isBarcodeExpired) {
     return <BarcodeExpiredContent initiativeId={barcode.initiativeId} />;
@@ -195,8 +187,8 @@ const SuccessContent = ({
         <H3 style={{ alignSelf: "center" }}>{trx}</H3>
         <VSpacer size={32} />
         <IdPayBarcodeExpireProgressBar
+          barcode={barcode}
           secondsExpirationTotal={barcode.trxExpirationSeconds}
-          secondsToExpiration={secondsTillExpire}
           setIsExpired={setIsBarcodeExpired}
         />
       </View>


### PR DESCRIPTION
## Short description
This pull request fixes the expiration logic of the IDPay barcode progress bar to ensure that, on Android devices, the countdown does not freeze when the app is sent to the background. 

## List of changes proposed in this pull request
* The `IdPayBarcodeExpireProgressBar` component now receives the full `barcode` object instead of a precomputed `secondsToExpiration` value, and internally calculates the seconds to expiration using the `calculateIdPayBarcodeSecondsToExpire` utility. This ensures the progress bar always displays the correct remaining time. 

## How to test
- On an android device or emulator, generate a barcode from the IDPay details screen.
- Verify that if you put the app in the background and resume it after a few seconds, the countdown correctly decrements according to the barcode’s validity and does not freeze.

## Preview
|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/1540f380-125c-4bd5-8458-7d480656cd11" />|<video src="https://github.com/user-attachments/assets/31bf7e22-c152-48e8-8446-e04bd469aac5" />