### PR TITLE
chore: [IOPID-3472,IOPID-3478] Bump `IngressScreen` timeout from `10` to `25`

### DIFF
--- a/ts/features/ingress/__test__/IngressScreen.test.tsx
+++ b/ts/features/ingress/__test__/IngressScreen.test.tsx
@@ -90,7 +90,7 @@ describe(IngressScreen, () => {
       jest.clearAllTimers();
       jest.clearAllMocks();
     });
-    it("Should update LoadingScreenContent contentTitle after 5 sec and display the cdn unreachable blocking screen after 10", async () => {
+    it("Should update LoadingScreenContent contentTitle after 5 sec and display the cdn unreachable blocking screen after 20", async () => {
       const {
         getDeviceBlockingScreen,
         queryByText,
@@ -99,7 +99,7 @@ describe(IngressScreen, () => {
       } = await renderComponentWithSlowdowns();
 
       await act(() => {
-        jest.advanceTimersByTime(5000);
+        jest.advanceTimersByTime(20000);
       });
 
       expect(getDeviceBlockingScreen()).toBeTruthy();
@@ -112,7 +112,7 @@ describe(IngressScreen, () => {
       expect(getFirstText()).toBeNull();
       expect(getSecondText()).toBeNull();
     });
-    it("Should update LoadingScreenContent contentTitle after 5s and display the slowdowns blocking screen after 10s", async () => {
+    it("Should update LoadingScreenContent contentTitle after 5s and display the slowdowns blocking screen after 20s", async () => {
       jest
         .spyOn(backendStatusSelectors, "isBackendStatusLoadedSelector")
         .mockImplementation(() => true);
@@ -125,7 +125,7 @@ describe(IngressScreen, () => {
       } = await renderComponentWithSlowdowns();
 
       await act(() => {
-        jest.advanceTimersByTime(5000);
+        jest.advanceTimersByTime(20000);
       });
 
       expect(getDeviceBlockingScreen()).toBeTruthy();

--- a/ts/features/ingress/screens/IngressScreen.tsx
+++ b/ts/features/ingress/screens/IngressScreen.tsx
@@ -32,7 +32,7 @@ import { OfflineAccessReasonEnum } from "../store/reducer";
 import { itwOfflineAccessAvailableSelector } from "../../itwallet/common/store/selectors";
 
 const TIMEOUT_CHANGE_LABEL = (5 * 1000) as Millisecond;
-const TIMEOUT_BLOCKING_SCREEN = (10 * 1000) as Millisecond;
+const TIMEOUT_BLOCKING_SCREEN = (25 * 1000) as Millisecond;
 
 export const IngressScreen = () => {
   const isMixpanelInitialized = useIOSelector(isMixpanelInitializedSelector);

--- a/ts/features/ingress/screens/IngressScreen.tsx
+++ b/ts/features/ingress/screens/IngressScreen.tsx
@@ -30,6 +30,7 @@ import { isConnectedSelector } from "../../connectivity/store/selectors";
 import { identificationRequest } from "../../identification/store/actions";
 import { OfflineAccessReasonEnum } from "../store/reducer";
 import { itwOfflineAccessAvailableSelector } from "../../itwallet/common/store/selectors";
+import { useOnFirstRender } from "../../../utils/hooks/useOnFirstRender";
 
 const TIMEOUT_CHANGE_LABEL = (5 * 1000) as Millisecond;
 const TIMEOUT_BLOCKING_SCREEN = (25 * 1000) as Millisecond;
@@ -81,8 +82,8 @@ export const IngressScreen = () => {
 
     timeouts.push(
       setTimeout(() => {
-        setShowBlockingScreen(true);
         dispatch(setIsBlockingScreen());
+        setShowBlockingScreen(true);
         timeouts.shift();
       }, TIMEOUT_BLOCKING_SCREEN)
     );
@@ -164,6 +165,11 @@ export const IngressScreen = () => {
 const IngressScreenNoInternetConnection = memo(() => {
   const isMixpanelEnabled = useIOSelector(isMixpanelEnabledSelector);
   const isMixpanelInitialized = useIOSelector(isMixpanelInitializedSelector);
+  const dispatch = useIODispatch();
+
+  useOnFirstRender(() => {
+    dispatch(setIsBlockingScreen());
+  });
 
   useEffect(() => {
     if (isMixpanelInitialized && isMixpanelEnabled !== false) {

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -264,7 +264,8 @@ export function* initializeApplicationSaga(
   }
 
   // ingress screen
-  const isBlockingScreen = yield* select(isBlockingScreenSelector);
+  // eslint-disable-next-line functional/no-let
+  let isBlockingScreen = yield* select(isBlockingScreenSelector);
   if (isBlockingScreen) {
     return;
   }
@@ -453,6 +454,11 @@ export function* initializeApplicationSaga(
     return;
   }
   yield* put(startupTransientError(startupTransientErrorInitialState));
+
+  isBlockingScreen = yield* select(isBlockingScreenSelector);
+  if (isBlockingScreen) {
+    return;
+  }
 
   // eslint-disable-next-line functional/no-let
   let userProfile = maybeUserProfile.value;


### PR DESCRIPTION
## Short description
This pull request updates the timeout logic for displaying blocking screens in the ingress flow, ensuring up to 3 different API from backend to be delayed and updates related tests and sagas for consistency.

Bonus fix: It also refines the blocking screen trigger logic.

## List of changes proposed in this pull request

**Timeout and Blocking Screen Logic Updates**

* Increased the timeout for displaying the blocking screen from 10 seconds to 25 seconds in `IngressScreen.tsx`, ensuring up to 3 different API from backend to be delayed
* Updated the order of dispatching `setIsBlockingScreen()` and showing the blocking screen to ensure proper state management.
* Added a hook in `IngressScreenNoInternetConnection` to dispatch `setIsBlockingScreen()` on first render, ensuring the blocking screen state is set immediately for no internet scenarios too.

**Saga Consistency**

* Modified `initializeApplicationSaga` to re-check the blocking screen state after transient error handling, ensuring the app halts initialization if the blocking screen is active. [[1]](diffhunk://#diff-8a5b2f3967d681b976fe673762bd1061f5b430130c880c1195b76af06362cf31L267-R268) [[2]](diffhunk://#diff-8a5b2f3967d681b976fe673762bd1061f5b430130c880c1195b76af06362cf31R458-R462)

## How to test
Using Proxyman, test different delay combinations for the `/ping`, `/session`, and `/profile` API calls. Verify that when a blocking screen error occurs, the user can only close and reopen the app. Ensure that the blocking screen appears only after 25 seconds.
