### PR TITLE
fix: [IOCOM-2666] Save `mandateId` upon AAR retrieval

### DIFF
--- a/ts/features/pn/aar/saga/__tests__/fetchQrCodeSaga.test.ts
+++ b/ts/features/pn/aar/saga/__tests__/fetchQrCodeSaga.test.ts
@@ -40,45 +40,49 @@ describe("fetchQrCodeSaga", () => {
   });
 
   sendUATEnvironment.forEach(isSendUATEnvironment => {
-    it(`should correctly update state on a 200 response with isTest='${isSendUATEnvironment}'`, () => {
-      const successState: AARFlowState = {
-        type: sendAARFlowStates.fetchingNotificationData,
-        iun: "123123",
-        fullNameDestinatario: "nomecognome"
-      };
-      const successResponse = E.right({
-        headers: {},
-        status: 200,
-        value: {
+    [undefined, "d27a353f-09a9-46c0-a63f-ab7a72cb1861"].forEach(mandateId => {
+      it(`should correctly update state on a 200 response with isTest='${isSendUATEnvironment}' and mandateId='${mandateId}'`, () => {
+        const successState: AARFlowState = {
+          type: sendAARFlowStates.fetchingNotificationData,
           iun: "123123",
-          recipientInfo: {
-            denomination: "nomecognome",
-            taxId: "taxID"
+          fullNameDestinatario: "nomecognome",
+          mandateId
+        };
+        const successResponse = E.right({
+          headers: {},
+          status: 200,
+          value: {
+            iun: "123123",
+            recipientInfo: {
+              denomination: "nomecognome",
+              taxId: "taxID"
+            },
+            mandateId
           }
-        }
-      });
-      const mockApiCall = jest
-        .fn()
-        .mockReturnValue(mockResolvedCall(successResponse));
+        });
+        const mockApiCall = jest
+          .fn()
+          .mockReturnValue(mockResolvedCall(successResponse));
 
-      testSaga(fetchAARQrCodeSaga, mockApiCall, sessionToken)
-        .next()
-        .select(currentAARFlowData)
-        .next(mockFetchingQrState)
-        .select(isPnTestEnabledSelector)
-        .next(isSendUATEnvironment)
-        .call(withRefreshApiCall, mockApiCall())
-        .next(successResponse)
-        .put(setAarFlowState(successState))
-        .next()
-        .isDone();
+        testSaga(fetchAARQrCodeSaga, mockApiCall, sessionToken)
+          .next()
+          .select(currentAARFlowData)
+          .next(mockFetchingQrState)
+          .select(isPnTestEnabledSelector)
+          .next(isSendUATEnvironment)
+          .call(withRefreshApiCall, mockApiCall())
+          .next(successResponse)
+          .put(setAarFlowState(successState))
+          .next()
+          .isDone();
 
-      expect(mockApiCall).toHaveBeenCalledWith({
-        Bearer: sessionTokenWithBearer,
-        body: {
-          aarQrCodeValue: aQRCode
-        },
-        isTest: isSendUATEnvironment
+        expect(mockApiCall).toHaveBeenCalledWith({
+          Bearer: sessionTokenWithBearer,
+          body: {
+            aarQrCodeValue: aQRCode
+          },
+          isTest: isSendUATEnvironment
+        });
       });
     });
 

--- a/ts/features/pn/aar/saga/fetchQrCodeSaga.ts
+++ b/ts/features/pn/aar/saga/fetchQrCodeSaga.ts
@@ -47,11 +47,12 @@ export function* fetchAARQrCodeSaga(
         data => {
           switch (data.status) {
             case 200:
-              const { iun, recipientInfo } = data.value;
+              const { iun, recipientInfo, mandateId } = data.value;
               const nextState: AARFlowState = {
                 type: sendAARFlowStates.fetchingNotificationData,
                 iun,
-                fullNameDestinatario: recipientInfo.denomination
+                fullNameDestinatario: recipientInfo.denomination,
+                mandateId
               };
               return setAarFlowState(nextState);
             case 403:


### PR DESCRIPTION
## Short description
This PR fixes a bug where the optional `mandateId` was not saved

## List of changes proposed in this pull request
- `mandateId` is now saved into the redux state when the AAR API call includes it

## How to test
Using the io-dev-api-server, follow an AAR link that points to SEND notification with ID 2 and one that points to SEND notification with ID 3. Both should work and open the notification's details
