### PR TITLE
fix: [IOBP-2087] Map onboarding error code to failure screen

### DIFF
--- a/ts/features/idpay/onboarding/machine/actors.ts
+++ b/ts/features/idpay/onboarding/machine/actors.ts
@@ -177,16 +177,14 @@ export const createActorsImplementation = (
         response,
         E.fold(
           _ => Promise.reject(OnboardingFailureEnum.ONBOARDING_GENERIC_ERROR),
-          ({ status }) => {
+          ({ status, value }) => {
             switch (status) {
               case 202:
                 return Promise.resolve(undefined);
               case 401:
                 return Promise.reject(OnboardingFailureEnum.SESSION_EXPIRED);
               default:
-                return Promise.reject(
-                  OnboardingFailureEnum.ONBOARDING_GENERIC_ERROR
-                );
+                return Promise.reject(mapErrorCodeToFailure(value.code));
             }
           }
         )


### PR DESCRIPTION
## Short description
This pull request updates the error handling logic in the onboarding actors implementation to provide more specific error mapping based on backend error codes, rather than always returning a generic error. The main change is to use the `mapErrorCodeToFailure` function to map backend error codes to specific failure types.

## List of changes proposed in this pull request
* In `actors.ts`, the default error case in the onboarding response handler now uses `mapErrorCodeToFailure(value.code)` to map backend error codes to specific `OnboardingFailureEnum` values, instead of always returning a generic error.

## How to test
- Check that when you reach the end of an onboarding and you receive an error from the backend, it shows the correct failure screen
