### PR TITLE
fix:  [IOPLT-1380] Remove hardcoded colors from `RefreshControl` in the `MessageList`

### DIFF
--- a/ts/features/messages/components/Home/MessageList.tsx
+++ b/ts/features/messages/components/Home/MessageList.tsx
@@ -1,4 +1,4 @@
-import { Divider, IOColors } from "@pagopa/io-app-design-system";
+import { Divider } from "@pagopa/io-app-design-system";
 import { forwardRef, useCallback, useMemo } from "react";
 import { FlatList, RefreshControl, StyleSheet } from "react-native";
 import {
@@ -146,8 +146,6 @@ export const MessageList = forwardRef<FlatList, MessageListProps>(
           <RefreshControl
             refreshing={isRefreshing}
             onRefresh={onRefreshCallback}
-            tintColor={IOColors["blueIO-500"]}
-            colors={[IOColors["blueIO-500"]]}
             testID={`custom_refresh_control_${category.toLowerCase()}`}
           />
         }


### PR DESCRIPTION
## Short description
This PR removes hardcoded colors from `RefreshControl` in the `MessageList` to fix an annoying visual bug that occurs when dark mode is enabled.

## List of changes proposed in this pull request
- Remove hardcoded color values from `MessageList`

### Preview

https://github.com/user-attachments/assets/3168821f-189b-4d9a-aed6-64b39fd35a14
