### PR TITLE
feat: [IOCOM-2686] Remove UAL support for SEND dev env

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -159,7 +159,6 @@
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
         <data android:scheme="https" />
-        <data android:host="cittadini.dev.notifichedigitali.it" />
         <data android:host="cittadini.uat.notifichedigitali.it" />
         <data android:host="cittadini.notifichedigitali.it" />
         <data android:pathPrefix="/io" />

--- a/ios/ItaliaApp/ItaliaApp.entitlements
+++ b/ios/ItaliaApp/ItaliaApp.entitlements
@@ -7,7 +7,6 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:continua.io.pagopa.it</string>
-		<string>applinks:cittadini.dev.notifichedigitali.it</string>
 		<string>applinks:cittadini.uat.notifichedigitali.it</string>
 		<string>applinks:cittadini.notifichedigitali.it</string>
 	</array>


### PR DESCRIPTION
## Short description
This PR removes Universal (iOS) and App (Android) Link support for SEND dev environment

## List of changes proposed in this pull request
- Removed dev SEND env from android manifest
- Removed dev SEND env from iOS entitlements

## How to test
On iOS, run the application on the simulator (or on a real device), create a reminder (or a message) with the following linked url `https://cittadini.dev.notifichedigitali.it/io?aar=asd123` and check that, upon tapping the link, the IO App does **_NOT_** open.
In order to test this on Android, the build must be uploaded to the stores, so that the auto-verification process can happen with the proper signing certificate. As for this PR, check that the syntax is correct with respect to the linked documentation and the associated online files:
- [Asset Links - Android](https://cittadini.dev.notifichedigitali.it/.well-known/assetlinks.json)
- [App Site Associations - iOS](https://cittadini.dev.notifichedigitali.it/.well-known/apple-app-site-association)
