### PR TITLE
fix: [IOBP-2134] IDPay add missing Android bottom inset to rules info modal component

### DIFF
--- a/ts/features/idpay/details/components/IdPayInitiativeRulesInfoBox.tsx
+++ b/ts/features/idpay/details/components/IdPayInitiativeRulesInfoBox.tsx
@@ -13,6 +13,7 @@ import { StyleSheet, View } from "react-native";
 import IOMarkdown from "../../../../components/IOMarkdown";
 import { useIOBottomSheetModal } from "../../../../utils/hooks/bottomSheet";
 import { markdownToPlainText } from "../../../../utils/markdown";
+import { isAndroid } from "../../../../utils/platform";
 
 type Props = {
   content: string;
@@ -23,7 +24,12 @@ const IdPayInitiativeRulesInfoBox = (props: Props) => {
   const { content } = props;
 
   const { bottomSheet, present } = useIOBottomSheetModal({
-    component: <IOMarkdown content={content} />,
+    component: (
+      <>
+        <IOMarkdown content={content} />
+        {isAndroid && <VSpacer size={24} />}
+      </>
+    ),
     title: I18n.t("idpay.initiative.beneficiaryDetails.infoModal.title")
   });
 


### PR DESCRIPTION
## Short description
This pull request is adjusting the `IdPayInitiativeRulesInfoBox` component bottom spaces to improve the user experience on Android device

## List of changes proposed in this pull request
- Added a conditional `VSpacer` to the bottom sheet modal content for Android devices to improve layout spacing

## How to test
Ensure that on Android now bottom sheet has more bottom spaces