### PR TITLE
fix: [IOBP-2130] IDPay duplicated Mixpanel event

### DIFF
--- a/ts/features/idpay/onboarding/screens/IdPayFailureScreen.tsx
+++ b/ts/features/idpay/onboarding/screens/IdPayFailureScreen.tsx
@@ -274,7 +274,7 @@ const IdPayFailureScreen = () => {
   );
 
   useEffect(() => {
-    if (O.some(failureOption)) {
+    if (O.some(failureOption) && O.isSome(failureOption)) {
       trackIDPayOnboardingFailure({
         initiativeId,
         initiativeName,


### PR DESCRIPTION
## Short description
This PR is fixing a duplicated Mixpanel triggered event by adding a better guard condition

## List of changes proposed in this pull request
- Adjust conditional logic in the `useEffect` hook to ensure that the failure tracking event is only triggered when `failureOption` is present and valid

## How to test
- Trigger a `IDPAY_ONBOARDING_ERROR` error
- Ensure that now the event is not triggered twice
