### PR TITLE
chore: [IOBP-2136] add mixpanel idpay feature disable screen tracking

### DIFF
--- a/ts/features/idpay/common/analytics/index.ts
+++ b/ts/features/idpay/common/analytics/index.ts
@@ -58,3 +58,7 @@ export const trackIDPayStaticCodeGenerationError = (
     buildEventProperties("KO", "screen_view", props)
   );
 };
+
+export const trackIDPayFeatureDisabledScreen = () => {
+  mixpanelTrack("IDPAY_FEATURE_DISABLED", buildEventProperties("UX", "error"));
+};

--- a/ts/features/idpay/common/screens/IdPayDisabledScreen.tsx
+++ b/ts/features/idpay/common/screens/IdPayDisabledScreen.tsx
@@ -3,6 +3,7 @@ import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
 import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
 import { OperationResultScreenContent } from "../../../../components/screens/OperationResultScreenContent";
+import { trackIDPayFeatureDisabledScreen } from "../analytics";
 
 /**
  * Screen displayed when the IDPay feature is disabled via feature flag.
@@ -13,8 +14,7 @@ export const IdPayDisabledScreen = () => {
   const navigation = useIONavigation();
 
   useOnFirstRender(() => {
-    // TODO: Add analytics tracking (https://pagopa.atlassian.net/browse/IOBP-2136)
-    // trackIDPayFeatureDisabledScreen();
+    trackIDPayFeatureDisabledScreen();
   });
 
   useHeaderSecondLevel({


### PR DESCRIPTION
## Short description
This pull request adds analytics tracking for when the entire IDPay feature is disabled, ensuring that this user experience event is properly logged.

## List of changes proposed in this pull request
* Added the `trackIDPayFeatureDisabledScreen` function to `index.ts` to log the "IDPAY_FEATURE_DISABLED" event when the disabled screen is shown.
* Imported and called `trackIDPayFeatureDisabledScreen` in `IdPayDisabledScreen.tsx` so that the event is tracked on the first render of the disabled screen.

## How to test
- On the dev-server, disable the entire `idPay` feature flag
- Check that whenever you try to start any IDPay-related flow, a blocking screen appears and the mixpanel event is fired correctly.
