### PR TITLE
fix(IT-Wallet): [SIW-3284] IT-Wallet credentials not accessible with poor network

### DIFF
--- a/ts/features/itwallet/navigation/ItwStackNavigator.tsx
+++ b/ts/features/itwallet/navigation/ItwStackNavigator.tsx
@@ -2,12 +2,11 @@ import { createStackNavigator } from "@react-navigation/stack";
 import { ComponentType, memo } from "react";
 import { useIOSelector } from "../../../store/hooks";
 import { isGestureEnabled } from "../../../utils/navigation";
-import { isConnectedSelector } from "../../connectivity/store/selectors";
 import { ItwGenericErrorContent } from "../common/components/ItwGenericErrorContent";
 import { isItwEnabledSelector } from "../common/store/selectors/remoteConfig";
+import { ItwDiscoveryInfoComponent } from "../discovery/components/ItwDiscoveryInfoComponent.tsx";
 import { ItwAlreadyActiveScreen } from "../discovery/screens/ItwAlreadyActiveScreen";
 import { ItwDiscoveryInfoScreen } from "../discovery/screens/ItwDiscoveryInfoScreen";
-import { ItwDiscoveryInfoComponent } from "../discovery/components/ItwDiscoveryInfoComponent.tsx";
 import ItwIpzsPrivacyScreen from "../discovery/screens/ItwIpzsPrivacyScreen";
 import { ItwActivateNfcScreen } from "../identification/cie/screens/ItwActivateNfcScreen.tsx";
 import { ItwCieCanScreen } from "../identification/cie/screens/ItwCieCanScreen.tsx";
@@ -22,13 +21,13 @@ import ItwCieIdLoginScreen from "../identification/cieId/screens/ItwCieIdLoginSc
 import { ItwIdentificationModeSelectionScreen } from "../identification/common/screens/ItwIdentificationModeSelectionScreen.tsx";
 import { ItwIdentificationIdpSelectionScreen } from "../identification/spid/screens/ItwIdentificationIdpSelectionScreen.tsx";
 import ItwSpidIdpLoginScreen from "../identification/spid/screens/ItwSpidIdpLoginScreen.tsx";
-import { ItwIssuanceEidReissuanceLandingScreen } from "../issuance/screens/ItwIssuanceEidReissuanceLandingScreen";
 import { ItwIssuanceCredentialAsyncContinuationScreen } from "../issuance/screens/ItwIssuanceCredentialAsyncContinuationScreen";
 import { ItwIssuanceCredentialFailureScreen } from "../issuance/screens/ItwIssuanceCredentialFailureScreen";
 import { ItwIssuanceCredentialPreviewScreen } from "../issuance/screens/ItwIssuanceCredentialPreviewScreen";
 import { ItwIssuanceCredentialTrustIssuerScreen } from "../issuance/screens/ItwIssuanceCredentialTrustIssuerScreen";
 import { ItwIssuanceEidFailureScreen } from "../issuance/screens/ItwIssuanceEidFailureScreen";
 import { ItwIssuanceEidPreviewScreen } from "../issuance/screens/ItwIssuanceEidPreviewScreen";
+import { ItwIssuanceEidReissuanceLandingScreen } from "../issuance/screens/ItwIssuanceEidReissuanceLandingScreen";
 import { ItwIssuanceEidResultScreen } from "../issuance/screens/ItwIssuanceEidResultScreen";
 import { ItwIssuanceInactiveITWalletScreen } from "../issuance/screens/ItwIssuanceInactiveITWalletScreen.tsx";
 import { ItwIssuanceUpcomingCredentialScreen } from "../issuance/screens/ItwIssuanceUpcomingCredentialScreen";
@@ -233,7 +232,7 @@ const InnerNavigator = memo(() => {
       {/* CREDENTIAL PRESENTATION */}
       <Stack.Screen
         name={ITW_ROUTES.PRESENTATION.CREDENTIAL_DETAIL}
-        component={withItwEnabled(ItwPresentationCredentialDetailScreen)}
+        component={ItwPresentationCredentialDetailScreen}
         options={hiddenHeader}
       />
       <Stack.Screen
@@ -340,11 +339,5 @@ const withItwEnabled =
   <P extends Record<string, unknown>>(Screen: ComponentType<P>) =>
   (props: P) => {
     const isItwEnabled = useIOSelector(isItwEnabledSelector);
-    const isConnected = useIOSelector(isConnectedSelector);
-
-    // Show error content only if connected and IT Wallet is not enabled
-    if (isConnected && !isItwEnabled) {
-      return <ItwGenericErrorContent />;
-    }
-    return <Screen {...props} />;
+    return isItwEnabled ? <Screen {...props} /> : <ItwGenericErrorContent />;
   };


### PR DESCRIPTION
## Short description
This PR fixes a rare condition where the credential's details is not accessible if the connection status is ok but we are unable to check if the ITW remote flag is enabled

## List of changes proposed in this pull request
- Removed `ItwPresentationCredentialDetailScreen` from FF gate
- `ItwPresentationCredentialDetailScreen` hooks refactor 

## How to test
> [!WARNING]
> To test this PR you will need to mock the remote configuration endpoint with a Proxy tool.

Verify that the credentials details screen is correctly accessible when the app is online but the remote configuration is non available. 
Also verify that no regressions are introduced when the app is offline.
