### PR TITLE
chore: [IOBP-000] IDPay add `technicalMessage` for Mixpanel error static code

### DIFF
--- a/ts/features/idpay/common/analytics/index.ts
+++ b/ts/features/idpay/common/analytics/index.ts
@@ -51,6 +51,7 @@ export const trackIDPayStaticCodeGenerationCopy = (
 export const trackIDPayStaticCodeGenerationError = (
   props: StaticCodeEventProperties & {
     reason?: string;
+    technicalMessage?: string;
   }
 ) => {
   mixpanelTrack(

--- a/ts/features/idpay/common/hooks/useIDPayStaticCodeModal.tsx
+++ b/ts/features/idpay/common/hooks/useIDPayStaticCodeModal.tsx
@@ -149,10 +149,20 @@ export const useIDPayStaticCodeModal = (
                 failure => failure.code
               )
             );
+
+            const technicalMessage = pipe(
+              decodeFailure(barcodePot.error),
+              O.fold(
+                () => undefined,
+                failure => failure.message
+              )
+            );
+
             trackIDPayStaticCodeGenerationError({
               initiativeId,
               initiativeName,
-              reason
+              reason,
+              technicalMessage
             });
           }
           bottomSheet.dismiss();


### PR DESCRIPTION
## Short description
This pull request introduces an enhancement to error tracking for static code generation in the IDPay feature by adding a `technicalMessage` field to the error tracking event

## List of changes proposed in this pull request
- Updated `useIDPayStaticCodeModal.tsx` to extract and pass a technical error message to the analytics event, improving visibility into failure reasons during static code generation

## How to test
Ensure that `technicalMessage` is now tracked