### PR TITLE
fix: [IOBP-2155] IDPay omit toast message on failure as duplicated

### DIFF
--- a/ts/features/idpay/onboarding/screens/IdPayEnableMessageScreen.tsx
+++ b/ts/features/idpay/onboarding/screens/IdPayEnableMessageScreen.tsx
@@ -1,4 +1,3 @@
-import { IOToast } from "@pagopa/io-app-design-system";
 import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
 import I18n from "i18next";
@@ -85,7 +84,11 @@ const IdPayEnableMessageScreen = () => {
     }
     if (!isLoadingServicePreference) {
       if (isErrorServicePreference) {
-        IOToast.error(I18n.t("global.genericError"));
+        /*
+          Toast error intentionally omitted: error handling is managed within ServiceDetailsPreferences.
+          Uncomment below to enable toast notifications for debugging or testing purposes:
+          IOToast.error("I18n.t("global.genericError")");
+        */
         trackIDPayOnboardingNotificationError({ initiativeName, initiativeId });
       } else if (isSuccessServicePreference) {
         trackIDPayOnboardingNotificationOK({ initiativeName, initiativeId });


### PR DESCRIPTION
## Short description
This pull request makes a minor update to the error handling logic in the `IdPayEnableMessageScreen` component. The main change is the removal of the toast notification for service preference errors, with a comment added to clarify that error handling is now managed within `ServiceDetailsPreferences`.

## List of changes proposed in this pull request
- Commented out the toast error notification in the error handling block, with an explanatory note that error handling is now managed elsewhere, and left the code for potential debugging or testing use.

## How to test
- In UAT env open an IDPay initiative message
- Uncheck `Contattarti in app` toggle and press on the CTA `Richiedi il bonus`
- Scroll down and press on CTA `Richiedi il bonus`
- Disable internet connection and tap on the CTA `Ok, attiva`
- Now `Toast` component should appear only one time

## Preview

https://github.com/user-attachments/assets/c941337a-4714-473f-8288-38c2781f2b02

