### PR TITLE
fix(IT Wallet): [SIW-3305] Missing `ITW_CREDENTIAL_DETAIL` tracking for credentials with `jwtExpired` status

### DIFF
--- a/ts/features/itwallet/presentation/details/screens/ItwPresentationCredentialDetailScreen.tsx
+++ b/ts/features/itwallet/presentation/details/screens/ItwPresentationCredentialDetailScreen.tsx
@@ -194,14 +194,12 @@ export const ItwPresentationCredentialDetail = ({
 
   useFocusEffect(
     useCallback(() => {
-      if (status !== "jwtExpired") {
-        const isMultilevel = isMultiLevelCredential(credential);
-        trackCredentialDetail({
-          credential: mixPanelCredential,
-          credential_status: CREDENTIAL_STATUS_MAP[status],
-          credential_type: isMultilevel ? "multiple" : "unique"
-        });
-      }
+      const isMultilevel = isMultiLevelCredential(credential);
+      trackCredentialDetail({
+        credential: mixPanelCredential,
+        credential_status: CREDENTIAL_STATUS_MAP[status],
+        credential_type: isMultilevel ? "multiple" : "unique"
+      });
     }, [status, credential, mixPanelCredential])
   );
 


### PR DESCRIPTION
## Short description
This PR fixes the sending of the `ITW_CREDENTIAL_DETAIL` event when accessing a credential with a `jwtExpired` status.

## List of changes proposed in this pull request
- Removed the restriction that blocked tracking from being sent for credentials with `jwtExpired` status.

## How to test
Verify that when accessing the credential detail for a credential with `jwtExpired` status, the `ITW_CREDENTIAL_DETAIL` event is sent correctly.
