### PR TITLE
chore: [IOBP-2162,IOBP-2116] add info bottom sheet to idpay on waiting list item

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -5629,7 +5629,12 @@
       "initiativeOnboardedStatus": {
         "header": "My requests",
         "ON_WAITING_LIST": {
-          "label": "On waiting list"
+          "label": "On waiting list",
+          "accessibilityInfoLabel": "Info button",
+          "bottomSheet": {
+            "title": "On waiting list",
+            "content": "Your request for {{initiativeName}} has been placed on **waiting list**, as there are currently no funds available.\n\n\n###### ***What happens now?***\n\nYou don’t need to do anything: your request remains valid. You will receive a message with the outcome as soon as new resources become available.\n\n\n###### ***Have you enabled notifications?***\n\nIf you haven’t already, enable push notifications to not miss any messages.\n[Read how to do it](https://assistenza.ioapp.it/hc/it/articles/39312288127377-Come-attivare-le-notifiche-push-su-IO)"
+          }
         },
         "ON_EVALUATION": {
           "label": "On evaluation"

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -5869,7 +5869,12 @@
       "initiativeOnboardedStatus": {
         "header": "Le mie richieste",
         "ON_WAITING_LIST": {
-          "label": "In lista d'attesa"
+          "label": "In lista d'attesa",
+          "accessibilityInfoLabel": "Pulsante informazioni",
+          "bottomSheet": {
+            "title": "Sei in lista d'attesa",
+            "content": "La tua richiesta per {{initiativeName}} è stata inserita **in lista d’attesa**, poiché al momento non ci sono fondi disponibili.\n\n\n###### ***Cosa succede ora?***\n\nNon devi fare nulla: la tua richiesta rimane valida. Riceverai un messaggio con l’esito se si renderanno disponibili nuove risorse.\n\n\n###### ***Hai attivato le notifiche?***\n\nSe non l’hai già fatto, attiva le notifiche push per non perderti i messaggi.\n[Leggi come fare](https://assistenza.ioapp.it/hc/it/articles/39312288127377-Come-attivare-le-notifiche-push-su-IO)"
+          }
         },
         "ON_EVALUATION": {
           "label": "Verifica in corso"

--- a/ts/features/idpay/wallet/analytics/index.ts
+++ b/ts/features/idpay/wallet/analytics/index.ts
@@ -1,0 +1,16 @@
+import { mixpanelTrack } from "../../../../mixpanel";
+import { buildEventProperties } from "../../../../utils/analytics";
+
+type DefaultEventProperties = {
+  initiativeName?: string;
+  initiativeId?: string;
+};
+
+export const trackIDPayOnWaitingListInfoButtonTap = (
+  props: DefaultEventProperties
+) => {
+  mixpanelTrack(
+    "IDPAY_BONUS_STATUS_TAP",
+    buildEventProperties("UX", "action", props)
+  );
+};


### PR DESCRIPTION
## Short description
This pull request adds a new "info" button to the waiting list items in the IDPay feature, allowing users to view more details about their waiting list status through a bottom sheet. It also introduces analytics tracking for user interactions with this button and updates localization files to support the new UI elements and accessibility labels.

## List of changes proposed in this pull request
* Added an "info" icon button to waiting list items in `IdPayInitiativeWaitingList.tsx`, which opens a bottom sheet with detailed information when tapped. The bottom sheet displays initiative-specific content and is accessible with a proper label. 
* Implemented `trackIDPayOnWaitingListInfoButtonTap` function to send analytics events when users tap the info button, capturing initiative details. (`ts/features/idpay/wallet/analytics/index.ts`)
* Updated English and Italian localization files to include new labels, accessibility info, and bottom sheet content for the waiting list status

## How to test
With the dev-server started, try to complete the onboarding of `Bonus Elettrodomestici` initiative in order to have the initiative status forced to `ON_WAITING_LIST` (that's for test purposes) and open the `Servizi` tab checking that there is visibile an info button that shows a bottom sheet that should be like [the designed one on figma](https://www.figma.com/design/oo4ehPaT3ONNI8FAs9aZH2/PARI---Bonus-Elettrodomestici?node-id=8238-53735&t=MHp1buou1T7ULXPa-4)

## Preview
https://github.com/user-attachments/assets/9f2495d3-00f4-4441-a60c-750917d7cf66

