### PR TITLE
fix: [IOBP-2173] track the correct event when app update requested

### DIFF
--- a/ts/features/idpay/onboarding/analytics/index.ts
+++ b/ts/features/idpay/onboarding/analytics/index.ts
@@ -242,7 +242,7 @@ export const trackIDPayOnboardingAppUpdateConfirm = (
   props: DefaultOnboardingEventProperties
 ) => {
   mixpanelTrack(
-    "APP_UPDATE_REQUESTED",
+    "APP_UPDATE_ACCEPTED",
     buildEventProperties("UX", "action", { ...props, flow: "idpay" })
   );
 };


### PR DESCRIPTION
## Short description
This pull request updates the tracked event name for the IDPay onboarding app update confirmation. Instead of tracking when an app update is requested, the code now tracks when the update is accepted.

## List of changes proposed in this pull request
* Changed the Mixpanel event name from `"APP_UPDATE_REQUESTED"` to `"APP_UPDATE_ACCEPTED"` in the `trackIDPayOnboardingAppUpdateConfirm` function in `ts/features/idpay/onboarding/analytics/index.ts`
