### PR TITLE
fix: [IOPLT-000] Adjust `AppFeedbackProvider` bottom sheet spacing on Android

### DIFF
--- a/ts/features/appReviews/components/AppFeedbackProvider.tsx
+++ b/ts/features/appReviews/components/AppFeedbackProvider.tsx
@@ -79,7 +79,6 @@ export const AppFeedbackProvider = ({ children }: PropsWithChildren) => {
       />
     )
   });
-  present()
 
   useEffect(() => {
     if (topic === undefined || !canAskFeedback) {


### PR DESCRIPTION
## Short description
This pull request updates the `AppFeedbackProvider` component to improve its bottom sheet data visualization

## List of changes proposed in this pull request
- Conditionally rendered a `VSpacer` of size 32 below the description text in the bottom sheet modal when running on Android, providing better visual separation

## How to test
Ensure that text now is not overlapped by the CTA on Android

## Preview
| Master | IOPLT-000 |
|--------|--------|
| <img alt="image" src="https://github.com/user-attachments/assets/1e95eb3c-fe39-47d0-b94f-c1af0c313eb7" /> | <img alt="Screenshot 2025-11-11 at 10 18 44" src="https://github.com/user-attachments/assets/ddaa7e35-4ec4-42cc-a895-41c31418188c" /> | 


