### PR TITLE
chore: [IOBP-2183] Align IDPay badge variant color

### DIFF
--- a/ts/features/idpay/details/components/IdPayInitiativeStatusItem.tsx
+++ b/ts/features/idpay/details/components/IdPayInitiativeStatusItem.tsx
@@ -21,13 +21,13 @@ const getStatusBadgeVariant = (
     case StatusEnum.NOT_REFUNDABLE_ONLY_IBAN:
     case StatusEnum.NOT_REFUNDABLE_ONLY_INSTRUMENT:
     case VoucherStatusEnum.ACTIVE:
-    case VoucherStatusEnum.USED:
       return "success";
     case StatusEnum.UNSUBSCRIBED:
     case VoucherStatusEnum.EXPIRED:
       return "error";
     case VoucherStatusEnum.EXPIRING:
       return "warning";
+    case VoucherStatusEnum.USED:
     default:
       return "default";
   }


### PR DESCRIPTION
## Short description
This pull request makes a small change to the logic for determining the status badge variant for IDPay initiatives.
The update changes how the badge color for `USED` voucher status is handled.

## List of changes proposed in this pull request
- The `VoucherStatusEnum.USED` case was moved so that it now returns "default" instead of "success" when determining the badge variant in `getStatusBadgeVariant`

## How to test
Ensure that initiatives label colors are now aligned with design

## Preview

https://github.com/user-attachments/assets/c2c44b04-a4cd-459d-9bfe-880dbec0edd3

