### PR TITLE
fix: [IOBP-2214] trigger the mixpanel event of the email notification banner only if banner shows

### DIFF
--- a/ts/features/services/home/components/EmailNotificationBanner.tsx
+++ b/ts/features/services/home/components/EmailNotificationBanner.tsx
@@ -58,15 +58,18 @@ export const EmailNotificationBanner = () => {
     );
   };
 
-  useOnFirstRender(() => {
-    mixpanelTrack(
-      "BANNER",
-      buildEventProperties("UX", "screen_view", {
-        banner_id: "IDPAY_EMAIL_ACTIVATION",
-        banner_page: SERVICES_ROUTES.SERVICES_HOME
-      })
-    );
-  });
+  useOnFirstRender(
+    () => {
+      mixpanelTrack(
+        "BANNER",
+        buildEventProperties("UX", "screen_view", {
+          banner_id: "IDPAY_EMAIL_ACTIVATION",
+          banner_page: SERVICES_ROUTES.SERVICES_HOME
+        })
+      );
+    },
+    () => canShowBanner
+  );
 
   useEffect(() => {
     if (prevProfile && pot.isUpdating(prevProfile)) {


### PR DESCRIPTION
## Short description
This pull request introduces a small change to the `EmailNotificationBanner` component to improve its tracking logic. The change ensures that the Mixpanel tracking event is only triggered when the banner is eligible to be shown.

## List of changes proposed in this pull request
* The `useOnFirstRender` hook now takes a predicate function (`canShowBanner`) as its second argument, so the Mixpanel tracking event is only fired if the banner should be displayed.
