### PR TITLE
fix: [IOPLT-000] Forced portrait mode for Android devices

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -126,7 +126,7 @@
     <activity android:name="zendesk.messaging.MessagingActivity" android:theme="@style/ZendeskTheme" />
     <!-- END Zendesk -->
 
-    <activity android:name=".MainActivity" android:launchMode="singleTop" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode" android:windowSoftInputMode="adjustResize" android:exported="true">
+    <activity android:name=".MainActivity" android:launchMode="singleTop" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode" android:windowSoftInputMode="adjustResize" android:exported="true" android:screenOrientation="portrait">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
## Short description
This pull request is avoiding the `landscape` mode on Android devices by updating Android manifest configuration to enforce `portrait` screen orientation

## List of changes proposed in this pull request
- Forced portrait mode with `android:screenOrientation="portrait"`, ensuring the app always launches in portrait mode

## How to test
Ensure that on Android now the App cannot be in `landscape` mode 

## Preview

https://github.com/user-attachments/assets/7aa83395-b82f-41bf-b06b-a1a6f39995de

