### PR TITLE
fix: [IOBP-2271] Adjust `PAYMENT_NOTICE_SUMMARY` text visualization 

### DIFF
--- a/ts/features/payments/checkout/screens/WalletPaymentDetailScreen.tsx
+++ b/ts/features/payments/checkout/screens/WalletPaymentDetailScreen.tsx
@@ -341,6 +341,7 @@ const WalletPaymentDetailContent = ({
         icon={"notes"}
         label={I18n.t("wallet.firstTransactionSummary.object")}
         value={description}
+        numberOfLines={0}
       />
       <Divider />
       <ListItemInfo


### PR DESCRIPTION
## Short description
This pull request introduces a minor change to the `PAYMENT_NOTICE_SUMMARY` screen to improve the rendering of the transaction description field.

## List of changes proposed in this pull request
- Set `numberOfLines={0}` to `ListItemInfo`  allowing the text to display without line restrictions 

## How to test
Ensure that payment summary obj is not truncated anymore

## Preview

<img width="1581" height="1073" alt="Screenshot 2025-11-25 at 14 37 02" src="https://github.com/user-attachments/assets/90dc62b9-f2d9-4b42-b99e-ce87e9514c4a" />

