### PR TITLE
ci: [IOAPPX-511] Update download-artifact action

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -76,12 +76,12 @@ jobs:
       - id: install-packages
         run: yarn install --frozen-lockfile
       - id: download-locales
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: locales
           path: locales/
       - id: download-api-client
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: api-client
           path: definitions/
@@ -174,12 +174,12 @@ jobs:
       - id: install-packages
         run: yarn install --frozen-lockfile
       - id: download-locales
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: locales
           path: locales/
       - id: download-api-client
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: api-client
           path: definitions/

--- a/.github/workflows/release-new-cycle.yml
+++ b/.github/workflows/release-new-cycle.yml
@@ -93,12 +93,12 @@ jobs:
       - id: install-packages
         run: yarn install --frozen-lockfile
       - id: download-locales
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: locales
           path: locales/
       - id: download-api-client
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: api-client
           path: definitions/
@@ -191,12 +191,12 @@ jobs:
       - id: install-packages
         run: yarn install --frozen-lockfile
       - id: download-locales
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: locales
           path: locales/
       - id: download-api-client
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: api-client
           path: definitions/

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -127,12 +127,12 @@ jobs:
       - id: install-packages
         run: yarn install --frozen-lockfile
       - id: download-locales
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: locales
           path: locales/
       - id: download-api-client
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: api-client
           path: definitions/
@@ -225,12 +225,12 @@ jobs:
       - id: install-packages
         run: yarn install --frozen-lockfile
       - id: download-locales
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: locales
           path: locales/
       - id: download-api-client
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: api-client
           path: definitions/

--- a/.github/workflows/staticcheck.yaml
+++ b/.github/workflows/staticcheck.yaml
@@ -44,12 +44,12 @@ jobs:
       - id: install-packages
         run: yarn install --frozen-lockfile
       - id: download-locales
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: locales
           path: locales/
       - id: download-api-client
-        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: api-client
           path: definitions/


### PR DESCRIPTION
## Short description
This PR updates the `download-artifact` action for our workflows. The v5 introduces a breaking change on the `artifact-ids` which we don't use, the v6 doesn't introduce any breaking change.

## List of changes proposed in this pull request
N/A

## How to test
Static check should pass.