### PR TITLE
feat(IT Wallet): [SIW-3471] Modify TYP copy in cases where the EID has already been renewed

### DIFF
--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -5099,8 +5099,8 @@
       },
       "reissuanceLandingScreen": {
         "notNecessary": {
-          "title": "Questo passaggio non è più necessario",
-          "subtitle": "È tutto pronto. Puoi gestire i tuoi documenti digitali nel Portafoglio.",
+          "title": "Hai già confermato la tua identità",
+          "subtitle": "Puoi gestire i tuoi documenti digitali nel Portafoglio.",
           "primaryAction": "Vai al Portafoglio"
         },
         "itWalletActivation": {

--- a/ts/features/itwallet/issuance/screens/__tests__/__snapshots__/ItwIssuanceEidReissuanceLandingScreen.test.tsx.snap
+++ b/ts/features/itwallet/issuance/screens/__tests__/__snapshots__/ItwIssuanceEidReissuanceLandingScreen.test.tsx.snap
@@ -2835,7 +2835,7 @@ exports[`ItwIssuanceEidReissuanceLandingScreen match snapshot for isAnyWalletVal
                                 ]
                               }
                             >
-                              Questo passaggio non è più necessario
+                              Hai già confermato la tua identità
                             </Text>
                             <View
                               style={
@@ -2865,7 +2865,7 @@ exports[`ItwIssuanceEidReissuanceLandingScreen match snapshot for isAnyWalletVal
                                 ]
                               }
                             >
-                              È tutto pronto. Puoi gestire i tuoi documenti digitali nel Portafoglio.
+                              Puoi gestire i tuoi documenti digitali nel Portafoglio.
                             </Text>
                             <View
                               style={
@@ -4099,7 +4099,7 @@ exports[`ItwIssuanceEidReissuanceLandingScreen match snapshot for isAnyWalletVal
                                 ]
                               }
                             >
-                              Questo passaggio non è più necessario
+                              Hai già confermato la tua identità
                             </Text>
                             <View
                               style={
@@ -4129,7 +4129,7 @@ exports[`ItwIssuanceEidReissuanceLandingScreen match snapshot for isAnyWalletVal
                                 ]
                               }
                             >
-                              È tutto pronto. Puoi gestire i tuoi documenti digitali nel Portafoglio.
+                              Puoi gestire i tuoi documenti digitali nel Portafoglio.
                             </Text>
                             <View
                               style={


### PR DESCRIPTION
## Short description
This PR introduce an edit to the TY page copy showed when the EID has already been renewed

## List of changes proposed in this pull request
- changed copy in translation file

## How to test
Go on IPZS message to confirm your identity, press on "Inizia": if you have already renewed your EID, a TY page will show:

<img width="340" height="740" alt="Screenshot 2025-12-02 alle 15 45 23" src="https://github.com/user-attachments/assets/97b4bac0-f336-4a97-a552-af0f3bcb2dfe" />

