### PR TITLE
refactor: [IOBP-2339] IDPay update `UNSUBSCRIBED` icon and label

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -5701,7 +5701,7 @@
                 "SUSPENDED": "Sospensione",
                 "READMITTED": "Riattivazione",
                 "CIE": "Abilitazione carta d’identità elettronica",
-                "UNSUBSCRIBED": "Recesso dall’iniziativa"
+                "UNSUBSCRIBED": "Scadenza iniziativa"
               }
             }
           }

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -5995,7 +5995,7 @@
                 "SUSPENDED": "Sospensione",
                 "READMITTED": "Riattivazione",
                 "CIE": "Abilitazione carta d’identità elettronica",
-                "UNSUBSCRIBED": "Recesso dall’iniziativa"
+                "UNSUBSCRIBED": "Scadenza iniziativa"
               }
             }
           }

--- a/ts/features/idpay/details/components/IdPayTimelineOperationListItem.tsx
+++ b/ts/features/idpay/details/components/IdPayTimelineOperationListItem.tsx
@@ -374,7 +374,7 @@ const getUnsubscribedOperationProps = (
   operation: UnsubscribeOperationDTO
 ): ListItemTransaction => ({
   paymentLogoIcon: (
-    <Icon name={"logout"} color="grey-300" testID="creditCardLogoTestID" />
+    <Icon name={"closeSmall"} color="grey-300" testID="creditCardLogoTestID" />
   ),
   title: I18n.t(
     `idpay.initiative.details.initiativeDetailsScreen.configured.operationsList.operationDescriptions.UNSUBSCRIBED`


### PR DESCRIPTION
## Short description
This pull request updates the wording for the "UNSUBSCRIBED" status item files, and changes the icon used for this operation in the timeline component

## List of changes proposed in this pull request
- Changed the translation for `UNSUBSCRIBED` from "Recesso dall’iniziativa" to "Scadenza iniziativa"
- Updated the icon for the "UNSUBSCRIBED" operation from `logout` to `closeSmall` 

## How to test
Ensure that icon and label are aligned with design requirements