### PR TITLE
chore(IT-Wallet): [SIW-3509] Adjust EID machine transition logic for L2+ issuance

### DIFF
--- a/ts/features/itwallet/common/utils/itwCredentialUtils.ts
+++ b/ts/features/itwallet/common/utils/itwCredentialUtils.ts
@@ -127,8 +127,12 @@ export const validCredentialStatuses: Array<ItwCredentialStatus> = [
 
 /**
  * Extracts the verification claim from the SD-JWT,
- * checks whether the `assurance_level` field is equal to `"high"`,
- * and returns `true` only in that case.
+ * checks whether the `assurance_level` field is equal to `"high"` or the
+ * `trust_framework` field is equal to `"it_l2+document_proof"`,
+ * and returns `true` only if one of these conditions is met.
+ *
+ * `"it_l2+document_proof"` indicates that the credential has been issued with
+ * a substantial authentication (SPID, CieID) plus an MRTD PoP verification,
  *
  * @param sdJwt - The SD-JWT string to check
  * @returns boolean indicating if the credential is an ITW credential (L3)

--- a/ts/features/itwallet/machine/eid/machine.ts
+++ b/ts/features/itwallet/machine/eid/machine.ts
@@ -967,6 +967,12 @@ export const itwEidIssuanceMachine = setup({
                   }
                 };
               })
+            },
+            close: {
+              target: "#itwEidIssuanceMachine.UserIdentification"
+            },
+            back: {
+              target: "DisplayingCieNfcPreparationInstructions"
             }
           }
         },


### PR DESCRIPTION
## Short description
This PR adjust the EID machine transition logic when closing/returning back.

## List of changes proposed in this pull request
* Added new transitions (`close` and `back`) to the eID issuance state machine in `machine.ts`, improving user navigation and allowing easier movement between identification and NFC preparation steps.

## How to test
Start an L2+ EID issuance. Once in the MRTD sign screen, try to close the flow and/or navigate back. The machine should work as expectes allowing to try again the sign.
