### PR TITLE
fix: [IOCOM-2852] Proper SEND specs

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -40,7 +40,7 @@ declare -a apis=(
   "./definitions/cgn/merchants https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_cgn_operator_search.yaml"
   # PN APIs
   "./definitions/pn https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_pn.yaml"
-  "./definitions/pn/aar https://raw.githubusercontent.com/pagopa/io-messages/refs/heads/main/apps/send-func/openapi/aar-notification.yaml"
+  "./definitions/pn/aar https://raw.githubusercontent.com/pagopa/io-messages/refs/tags/send-func@1.4.3/apps/send-func/openapi/aar-notification.yaml"
   # FCI APIs
   "./definitions/fci https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_io_sign.yaml"
   # ITW APIs

--- a/ts/features/pn/aar/saga/__tests__/watchAARFlowSaga.test.ts
+++ b/ts/features/pn/aar/saga/__tests__/watchAARFlowSaga.test.ts
@@ -30,7 +30,7 @@ const mockSendAARClient: SendAARClient = {
   aarQRCodeCheck: jest.fn(),
   getAARNotification: jest.fn(),
   getNotificationAttachment: jest.fn(),
-  acceptIOMandate: jest.fn(),
+  acceptAARMandate: jest.fn(),
   createAARMandate: jest.fn()
 };
 

--- a/ts/features/pn/aar/saga/testSendNisMrtdSaga.ts
+++ b/ts/features/pn/aar/saga/testSendNisMrtdSaga.ts
@@ -69,7 +69,7 @@ export function* testAarAcceptMandateSaga(
     if (mandateId == null) {
       throw Error(`Accept mandate: nullish mandateid (${mandateId})`);
     }
-    const acceptAarMandateRequest = sendAARClient.acceptIOMandate({
+    const acceptAarMandateRequest = sendAARClient.acceptAARMandate({
       Bearer: `Bearer ${sessionToken}`,
       mandateId,
       body: {
@@ -90,7 +90,7 @@ export function* testAarAcceptMandateSaga(
     const result = (yield* call(
       withRefreshApiCall,
       acceptAarMandateRequest
-    )) as unknown as SagaCallReturnType<typeof sendAARClient.acceptIOMandate>;
+    )) as unknown as SagaCallReturnType<typeof sendAARClient.acceptAARMandate>;
 
     if (E.isLeft(result)) {
       const reason = `Accept mandate decoding failure (${readableReportSimplified(


### PR DESCRIPTION
## Short description
This PR aligns the SEND specs to send-func@1.4.3.

## List of changes proposed in this pull request
- SEND specs pinned to specific version instead of the main branch

## How to test
Statis checks should succeed.
