### PR TITLE
fix(IT-Wallet): [SIW-3468] Fix limit reached screen source for mixpanel event

### DIFF
--- a/ts/features/itwallet/analytics/index.ts
+++ b/ts/features/itwallet/analytics/index.ts
@@ -272,7 +272,10 @@ type ItwCopyListItem = {
   item_copied: string;
 };
 
-export type ItwOfflineRicaricaAppIOSource = "bottom_sheet" | "banner";
+export type ItwOfflineRicaricaAppIOSource =
+  | "bottom_sheet"
+  | "banner"
+  | "access_expired_screen";
 
 type ItwCredentialInfoDetails = {
   credential: MixPanelCredential;

--- a/ts/features/itwallet/wallet/components/ItwOfflineAccessGate.tsx
+++ b/ts/features/itwallet/wallet/components/ItwOfflineAccessGate.tsx
@@ -59,8 +59,7 @@ const LimitWarningScreenContent = ({
 };
 
 const LimitReachedScreenContent = () => {
-  const handleAppRestart = useAppRestartAction("banner");
-
+  const handleAppRestart = useAppRestartAction("access_expired_screen");
   useFocusEffect(trackItwOfflineAccessExpired);
 
   return (


### PR DESCRIPTION
## Short description
Update source for mixpanel event `ITW_OFFLINE_RICARICA_APP_IO` from "banner" to "access_expired_screen".

## List of changes proposed in this pull request
- Update source parameter in `useAppRestartAction` to pass the requested value
- Extend `ItwOfflineRicaricaAppIOSource` types

## How to test
To test this PR:

1. Open the IO app while offline and trigger the **Limit Reach screen** by accessing it 5 times.
2. Reconnect to the network and tap "**Ricarica l'app**".
3. Verify via logs or Mixpanel that the event’s source field is now "access_expired_screen".