### PR TITLE
fix(IT Wallet): [SIW-3505] Make Android CIE read screen scrollable

### DIFF
--- a/ts/features/common/components/cie/CieCardReadContent.tsx
+++ b/ts/features/common/components/cie/CieCardReadContent.tsx
@@ -17,13 +17,14 @@ import {
 import { Millisecond } from "@pagopa/ts-commons/lib/units";
 import { useFocusEffect } from "@react-navigation/native";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Platform, ScrollView, View } from "react-native";
+import { Platform, View } from "react-native";
 import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withSpring
 } from "react-native-reanimated";
 import { CircularProgress } from "../../../../components/ui/CircularProgress";
+import { IOScrollView } from "../../../../components/ui/IOScrollView";
 import { setAccessibilityFocus } from "../../../../utils/accessibility";
 import { isDevEnv } from "../../../../utils/environment";
 import { platformSelect } from "../../utils";
@@ -205,7 +206,7 @@ const ContentIos = (props: CieCardReadContentProps) => (
 );
 
 const ContentAndroid = (props: CieCardReadContentProps) => (
-  <ScrollView contentContainerStyle={{ flexGrow: 1, justifyContent: "center" }}>
+  <IOScrollView centerContent>
     <ContentWrapper>
       <VStack space={24}>
         <CircularProgress
@@ -228,7 +229,7 @@ const ContentAndroid = (props: CieCardReadContentProps) => (
         />
       </VStack>
     </ContentWrapper>
-  </ScrollView>
+  </IOScrollView>
 );
 
 /**


### PR DESCRIPTION
## Short description
This PR makes `ITW_IDENTIFICATION_CIE_AUTH_SCREEN` scrollable on Android. On devices with smaller screens and the font size set to 200% it was not possible to see all the content.

## List of changes proposed in this pull request
- Switched `View` with `ScrollView`

## How to test
Use an Android device with a small screen and set the system font to 200%. If not possible, edit the code to use a long placeholder text.

Ensure the CIE auth screen has not been modified with the default font size.

https://github.com/user-attachments/assets/35a44c75-0ea1-4dd2-9609-d0784f9edb4e



