### PR TITLE
ci: [IOPLT-000] Adds slack message step when canary is available

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -243,16 +243,36 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   notify-new-version:
     runs-on: ubuntu-latest
+    environment: dev
     needs:
         - prepare-canary-release
         - release-android
         - release-ios
     steps:
-      - id: checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab #v3.5.2
-      - id: comment-process-end
-        if: github.event.issue.number
-        run: |
-          gh issue comment ${{ github.event.issue.number }} -b "Release correctly created, [${{ needs.prepare-canary-release.outputs.canaryVersion }}](https://github.com/pagopa/io-app/releases/tag/${{ needs.prepare-canary-release.outputs.canaryVersion }})"
+      - name: Send Slack Notification on Success
+        continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IO_APP_SLACK_HELPER_BOT_TOKEN: ${{ secrets.IO_APP_SLACK_HELPER_BOT_TOKEN }}
+          APP_VERSION_TAG: ${{ needs.prepare-canary-release.outputs.canaryVersion }}
+        run: |
+          echo "APP_VERSION_TAG=$APP_VERSION_TAG"
+          STATUS_ICON=":white_check_mark:"
+
+          # Use jq to safely construct the JSON payload for Slack          
+          slack_payload=$(jq -n \
+            --arg channel "io_app_core" \
+            --arg text ":gear: *L'ultima versione della canary è disponibile*
+            
+            - *App Version Tag:* \`$APP_VERSION_TAG\`
+            '{
+              "channel": $channel,
+              "text": $text,
+              "unfurl_links": false,
+              "unfurl_media": false
+            }')
+
+          # Post the message to Slack using curl
+          curl -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $IO_APP_SLACK_HELPER_BOT_TOKEN" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            -d "$slack_payload"


### PR DESCRIPTION
## Short description
This pull request updates the `notify-new-version` job in the `.github/workflows/release-canary.yml` workflow to improve post-release notifications. The previous step that commented on GitHub issues has been replaced with a new step that sends a Slack notification when a new canary release is available.

## List of changes proposed in this pull request
* Replaced the GitHub issue comment step with a new step that sends a Slack notification to the `io_app_core` channel, including the app version tag and a status icon. The Slack message is sent using a bot token and a JSON payload constructed with `jq`. (`.github/workflows/release-canary.yml`)
* Set the `environment` for the `notify-new-version` job to `dev` to clarify the deployment context. (`.github/workflows/release-canary.yml`)

## How to test
Run the workflow.
