### PR TITLE
fix: [IOBP-2384] CGN card details header wrong focus

### DIFF
--- a/ts/features/bonus/cgn/components/CgnAnimatedBackground.tsx
+++ b/ts/features/bonus/cgn/components/CgnAnimatedBackground.tsx
@@ -1,5 +1,5 @@
 import WebView from "react-native-webview";
-import { View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import { Point, generateRandomSvgMovement } from "../utils/svgBackground";
 import { playSvg } from "./detail/CardSvgPayload";
 
@@ -10,10 +10,7 @@ export function CgnAnimatedBackground({ onLoadEnd }: { onLoadEnd?(): void }) {
       accessible={false}
       importantForAccessibility="no-hide-descendants"
       accessibilityElementsHidden={true}
-      style={{
-        height: "100%",
-        width: "100%"
-      }}
+      style={StyleSheet.absoluteFillObject}
     >
       <WebView
         androidCameraAccessDisabled={true}
@@ -24,8 +21,7 @@ export function CgnAnimatedBackground({ onLoadEnd }: { onLoadEnd?(): void }) {
           html: generatedSvg
         }}
         style={{
-          height: "100%",
-          width: "100%",
+          ...StyleSheet.absoluteFillObject,
           backgroundColor
         }}
         onLoadEnd={onLoadEnd}
@@ -33,6 +29,7 @@ export function CgnAnimatedBackground({ onLoadEnd }: { onLoadEnd?(): void }) {
     </View>
   );
 }
+
 const minPointA: Point = {
   x: 80,
   y: -100


### PR DESCRIPTION
## Short description
Wrapped CgnAnimatedBackground’s WebView with a non-accessible View to prevent it from receiving focus during 2-switch navigation.

## List of changes proposed in this pull request
- Wrapped the background WebView with a View using:
       importantForAccessibility="no-hide-descendants"
       accessible={false}
       accessibilityElementsHidden={true}
- Prevented the background animation from stealing accessibility focus during switch-based navigation

## How to test
Enable 2-switch navigation on device, from `CGN_DETAILS` verify that the animated background is skipped.

<table><tr><td>Previous</td><td>New</td></tr><tr><td>

https://github.com/user-attachments/assets/8605c029-1492-4d39-b846-2a9587979cc6

</td><td>

https://github.com/user-attachments/assets/74fe35df-8b4e-4806-a4ab-2e9cdb5c28b2

</td></tr></table>




