### PR TITLE
fix: [IOBP-2480] Set unique transaction receipt list item key value

### DIFF
--- a/ts/features/payments/home/components/PaymentsHomeTransactionsList.tsx
+++ b/ts/features/payments/home/components/PaymentsHomeTransactionsList.tsx
@@ -103,9 +103,9 @@ const PaymentsHomeTransactionsList = ({ enforcedLoadingState }: Props) => {
       return (
         <View testID="PaymentsHomeTransactionsListTestID">
           {latestTransactionsPot.value.map((latestTransaction, index) => (
-            <Fragment key={`transaction_${latestTransaction.eventId}`}>
+            <Fragment key={`transaction_${latestTransaction.eventId}${index}`}>
               <ReceiptListItemTransaction
-                key={`transaction_${latestTransaction.eventId}`}
+                key={`transaction_${latestTransaction.eventId}${index}`}
                 onPress={() =>
                   handleNavigateToTransactionDetails(latestTransaction)
                 }

--- a/ts/features/payments/receipts/components/ReceiptCartList.tsx
+++ b/ts/features/payments/receipts/components/ReceiptCartList.tsx
@@ -30,7 +30,7 @@ export const ReceiptCartList = ({ carts, loading, onPress }: Props) => {
     <>
       {carts.map((cartItem, index) => (
         <ListItemTransaction
-          key={cartItem.refNumberValue ?? index.toString()}
+          key={`${cartItem.refNumberValue}${index}`}
           title={cartItem.subject ?? ""}
           subtitle={cartItem.payee?.name ?? ""}
           transaction={{

--- a/ts/features/payments/receipts/screens/ReceiptListScreen.tsx
+++ b/ts/features/payments/receipts/screens/ReceiptListScreen.tsx
@@ -222,7 +222,7 @@ const ReceiptListScreen = () => {
       )}
       ListEmptyComponent={EmptyStateList}
       ListFooterComponent={renderLoadingFooter}
-      keyExtractor={item => `transaction_${item.eventId}`}
+      keyExtractor={(item, index) => `transaction_${item.eventId}${index}`}
       renderItem={({ item }) => (
         <ReceiptFadeInOutAnimationView>
           <ReceiptListItemTransaction


### PR DESCRIPTION
## Short description
This pull request fixes the double rendering of list items caused by duplicated IDs across several payment-related components.

## List of changes proposed in this pull request
- Set unique key for`PaymentsHomeTransactionsList`, `ReceiptCartList` and `ReceiptListScreen` list item components.

## How to test
- Mock some transaction with `eventId`
- Ensure that refreshing or opening the list is not duplicate them

## Preview
| Master | IOBP-2480 |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/51f2c29b-36a7-41eb-9419-1b90d14824b6"/> | <video src="https://github.com/user-attachments/assets/731da9de-62da-4e42-8d8e-b6b4777f58d1"/> | 