### PR TITLE
chore: [IOPAE-2346] Add copy-to-clipboard support for service id in service details

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -3033,7 +3033,7 @@
       "metadata": {
         "a11y": {
           "website": "Browse the institution's website",
-          "copyIntoClipboard": "Copy to clipboard"
+          "copyToClipboard": "Copy to clipboard"
         },
         "title": "Contacts and info",
         "website": "Browse Website",

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -3033,7 +3033,7 @@
       "metadata": {
         "a11y": {
           "website": "Visita il sito dell'ente",
-          "copyIntoClipboard": "Copia negli appunti"
+          "copyToClipboard": "Copia negli appunti"
         },
         "title": "Contatti ed informazioni",
         "website": "Visita il sito",

--- a/ts/features/services/details/components/ServiceDetailsMetadata.tsx
+++ b/ts/features/services/details/components/ServiceDetailsMetadata.tsx
@@ -135,7 +135,7 @@ export const ServiceDetailsMetadata = ({
     {
       kind: "ListItemInfoCopy",
       accessibilityHint: I18n.t(
-        "services.details.metadata.a11y.copyIntoClipboard"
+        "services.details.metadata.a11y.copyToClipboard"
       ),
       icon: "entityCode",
       label: I18n.t("services.details.metadata.fiscalCode"),
@@ -154,7 +154,7 @@ export const ServiceDetailsMetadata = ({
     {
       kind: "ListItemInfoCopy",
       accessibilityHint: I18n.t(
-        "services.details.metadata.a11y.copyIntoClipboard"
+        "services.details.metadata.a11y.copyToClipboard"
       ),
       icon: "pinOff",
       label: I18n.t("services.details.metadata.serviceId"),


### PR DESCRIPTION
## Short description
This pull request adds clipboard functionality to the service id in the service details screen.

<details open><summary>Details</summary>
<p>

| service id |
| - |
| <img src="https://github.com/user-attachments/assets/2d1a6cf2-365b-4e1f-8d82-1e1c8ec8979f" width="300"/> |

</p>
</details> 

## List of changes proposed in this pull request
- Replace `ListItemInfo` component with `ListItemInfoCopy`.

## How to test
Navigate to the service details screen and check that the service id is copyable.