### PR TITLE
chore(IT-Wallet): [SIW-3680] Updates `io-react-native-cie` to `v1.3.2`

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - boost (1.84.0)
   - BVLinearGradient (2.5.6):
     - React
-  - CieSDK (0.1.15)
+  - CieSDK (0.1.17)
   - DoubleConversion (1.1.6)
   - fast_float (8.0.0)
   - FBLazyVector (0.81.5)
@@ -12,9 +12,9 @@ PODS:
   - hermes-engine (0.81.5):
     - hermes-engine/Pre-built (= 0.81.5)
   - hermes-engine/Pre-built (0.81.5)
-  - IoReactNativeCie (1.3.0):
+  - IoReactNativeCie (1.3.2):
     - boost
-    - CieSDK (~> 0.1.15)
+    - CieSDK (~> 0.1.17)
     - DoubleConversion
     - fast_float
     - fmt
@@ -3596,14 +3596,14 @@ SPEC CHECKSUMS:
   Alamofire: f36a35757af4587d8e4f4bfa223ad10be2422b8c
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   BVLinearGradient: 44fd36b87f318e7933c4c91a6991442a5e3f5bcf
-  CieSDK: 0891f74b7fca198d1eebbe811c5ac929084b4fed
+  CieSDK: 35739b36e34e184a59e1550d03cac91700208115
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 5beb8028d5a2e75dd9634917f23e23d3a061d2aa
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 9f4dfe93326146a1c99eb535b1cb0b857a3cd172
-  IoReactNativeCie: d3d59823a78a54e45898eb6017bd218f3702abab
+  IoReactNativeCie: 7ef167d66b9bab4401fc92986c99fa6803681ad0
   IoReactNativeIso18013: 52cb5a7a0b32954cfadcc35ce09ad022c637daf2
   IOWalletCBOR: 92742ef1cbd1b627ba153d0c7c11b81ad22f45cc
   IOWalletProximity: 1836d6b5df0a64a97e09f355d15d5155f086f830

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@gorhom/bottom-sheet": "^5.1.2",
     "@pagopa/io-app-design-system": "5.11.18",
     "@pagopa/io-pagopa-commons": "^3.1.0",
-    "@pagopa/io-react-native-cie": "1.3.0",
+    "@pagopa/io-react-native-cie": "1.3.2",
     "@pagopa/io-react-native-cieid": "0.4.0",
     "@pagopa/io-react-native-crypto": "^1.2.3",
     "@pagopa/io-react-native-http-client": "1.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3205,15 +3205,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagopa/io-react-native-cie@npm:1.3.0":
-  version: 1.3.0
-  resolution: "@pagopa/io-react-native-cie@npm:1.3.0"
+"@pagopa/io-react-native-cie@npm:1.3.2":
+  version: 1.3.2
+  resolution: "@pagopa/io-react-native-cie@npm:1.3.2"
   dependencies:
     zod: ^3.24.4
   peerDependencies:
     react: ">=19.1"
     react-native: ">=0.81"
-  checksum: 82fc01aa8c16fe12e79b8934412fde0b3e7be0333a13284e36f2a51c217b4378bc2f82cde2c3aefb0614b8fea65c99715b3ce5b9c8089bb404d483850a306e15
+  checksum: 243a65211b2419cf5b3be44a659ebf81b0d0d5834ce1cd171bb7c24f5a0ffc89b53ade6a117a7227eee4c2283bad2f8e60a9114f8e48d9245033340de3714250
   languageName: node
   linkType: hard
 
@@ -11304,7 +11304,7 @@ __metadata:
     "@jambit/eslint-plugin-typed-redux-saga": ^0.4.0
     "@pagopa/io-app-design-system": 5.11.18
     "@pagopa/io-pagopa-commons": ^3.1.0
-    "@pagopa/io-react-native-cie": 1.3.0
+    "@pagopa/io-react-native-cie": 1.3.2
     "@pagopa/io-react-native-cieid": 0.4.0
     "@pagopa/io-react-native-crypto": ^1.2.3
     "@pagopa/io-react-native-http-client": 1.0.5


### PR DESCRIPTION
## Short description
This PR bumps the `@pagopa/io-react-native-cie` version to `1.3.2` and introduces the following SDK fixes:
- https://github.com/pagopa/io-react-native-cie/pull/18
- https://github.com/pagopa/io-react-native-cie/pull/19

## List of changes proposed in this pull request

* Upgraded `@pagopa/io-react-native-cie` from version `1.3.0` to `1.3.2` in `package.json` to incorporate recent improvements and bug fixes.

## How to test
On Android and iOS:
- Verify that no regressions are introduced in the CIE+PIN and L2+ activation flows.
- On the CIE read screen, change the system font scale without terminating the app, then bring the app back to the foreground. Verify that no errors occur and the app works correctly.