### PR TITLE
fix: [IOPAE-2355] Fix SecureStorage import

### DIFF
--- a/ts/store/storages/secureStorage.ts
+++ b/ts/store/storages/secureStorage.ts
@@ -1,6 +1,5 @@
-import SecureStorage, {
-  SecureStorageError
-} from "@pagopa/io-react-native-secure-storage";
+import * as SecureStorage from "@pagopa/io-react-native-secure-storage";
+import { type SecureStorageError } from "@pagopa/io-react-native-secure-storage";
 import { type Storage } from "redux-persist";
 import * as Sentry from "@sentry/react-native";
 


### PR DESCRIPTION
## Short description
This PR fixes an issue caused by an incorrect import from `@pagopa/io-react-native-secure-storage`

## List of changes proposed in this pull request
- Changed import from default to namespace import

## How to test
Retrieve the documents and, upon the next login, verify that the data is still persisted
