### PR TITLE
feat(IT-Wallet): [SIW-3681] Update of revocation alert copy

### DIFF
--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -5746,16 +5746,16 @@
           "closeButton": "Chiudi",
           "closeButtonAlt": "Ho capito",
           "revokedByWalletProvider": {
-            "title": "Documenti su IO è stata disattivata",
+            "title": "La funzionalità Documenti è stata disattivata",
             "content": "Per verificare i requisiti richiesti per continuare a usare la funzionalità sul tuo dispositivo, premi \"Scopri di più\"."
           },
           "newWalletInstanceCreated": {
-            "title": "Documenti su IO è stata disattivata su questo dispositivo",
-            "content": "Puoi usare i tuoi documenti su IO su un solo dispositivo alla volta per ragioni di sicurezza."
+            "title": "La funzionalità Documenti è stata disattivata su questo dispositivo",
+            "content": "Puoi usare i documenti digitali su un solo dispositivo alla volta per ragioni di sicurezza."
           },
           "revokedByUser": {
-            "title": "Hai disattivato Documenti su IO",
-            "content": "Se cambi idea, potrai riattivare Documenti su IO in futuro."
+            "title": "Hai rimosso i tuoi documenti digitali da IO",
+            "content": "Se cambi idea, potrai riattivare la funzionalità in futuro."
           }
         }
       },


### PR DESCRIPTION
## Short description
This PR updates the copy related to the revocation of ITWallet.

## List of changes proposed in this pull request
- Updated banner copy shown after a device change
- Updated banner copy shown after revocation via IO Web
- Updated banner copy shown after a technical revocation

## How to test
- Trigger a revocation due to a device change and verify the banner copy
- Trigger a revocation via IO Web and verify the banner copy
- Trigger a technical revocation and verify the banner copy

## Preview
| Scenario                    | Preview |
|-----------------------------|---------|
| Post device change          | <img width="340" height="738" alt="Screenshot 2026-01-27 alle 13 50 43" src="https://github.com/user-attachments/assets/08d963ee-6928-4617-8d76-f71ecf4620dc" /> |
| Post revocation via IO Web  | <img width="339" height="741" alt="Screenshot 2026-01-27 alle 13 48 49" src="https://github.com/user-attachments/assets/c78726f8-1cb8-42ac-aebf-8b6f4b577406" /> |
| Post technical revocation   | <img width="341" height="741" alt="Screenshot 2026-01-27 alle 13 49 57" src="https://github.com/user-attachments/assets/f6300fa0-b636-4e2a-b7e2-44750f1bfd5b" /> |


