### PR TITLE
chore: [IOBP-2558] Add Mixpanel `reason` property at receipt PDF download error

### DIFF
--- a/ts/features/payments/receipts/analytics/index.ts
+++ b/ts/features/payments/receipts/analytics/index.ts
@@ -12,6 +12,7 @@ type PaymentReceiptAnalyticsProps = {
   user: PaymentsAnalyticsReceiptUser;
   organization_fiscal_code: string;
   trigger: HideReceiptTrigger;
+  reason?: string;
 };
 
 export const trackPaymentsReceiptListing = () => {

--- a/ts/features/payments/receipts/screens/ReceiptDetailsScreen.tsx
+++ b/ts/features/payments/receipts/screens/ReceiptDetailsScreen.tsx
@@ -34,6 +34,7 @@ import {
   walletReceiptDetailsPotSelector,
   walletReceiptPotSelector
 } from "../store/selectors";
+import { DownloadReceiptOutcomeErrorEnum } from "../types";
 
 export type ReceiptDetailsScreenParams = {
   transactionId: string;
@@ -103,7 +104,9 @@ const ReceiptDetailsScreen = () => {
       first_time_opening: paymentAnalyticsData?.receiptFirstTimeOpening,
       user: paymentAnalyticsData?.receiptUser,
       organization_fiscal_code:
-        paymentAnalyticsData?.receiptOrganizationFiscalCode
+        paymentAnalyticsData?.receiptOrganizationFiscalCode,
+      // This callback is only called when the generation fails due to a 404_002 error from the backend
+      reason: DownloadReceiptOutcomeErrorEnum.AT_404_002
     });
 
     toast.info(

--- a/ts/features/payments/receipts/screens/ReceiptDownloadErrorScreen.tsx
+++ b/ts/features/payments/receipts/screens/ReceiptDownloadErrorScreen.tsx
@@ -2,9 +2,13 @@ import * as pot from "@pagopa/ts-commons/lib/pot";
 import { OperationResultScreenContent } from "../../../../components/screens/OperationResultScreenContent";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { useIOSelector } from "../../../../store/hooks";
+import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
+import { paymentAnalyticsDataSelector } from "../../history/store/selectors";
+import * as analytics from "../analytics";
 import useReceiptFailureSupportModal from "../hooks/useReceiptFailureSupportModal";
 import { walletReceiptPotSelector } from "../store/selectors";
 import { mapDownloadReceiptErrorToOutcomeProps } from "../utils";
+import { getNetworkError } from "../../../../utils/errors";
 
 const ReceiptDownloadErrorScreen = () => {
   const transactionReceiptPot = useIOSelector(walletReceiptPotSelector);
@@ -16,17 +20,23 @@ const ReceiptDownloadErrorScreen = () => {
 
   const { bottomSheet, present } = useReceiptFailureSupportModal(receiptError);
 
-  // TODO add mixpanel tracking IOBP-2558
-  // useOnFirstRender(() =>
-  //   analytics.trackPaymentsDownloadReceiptError({
-  //     organization_name: paymentAnalyticsData?.receiptOrganizationName,
-  //     first_time_opening: paymentAnalyticsData?.receiptFirstTimeOpening,
-  //     user: paymentAnalyticsData?.receiptUser,
-  //     organization_fiscal_code:
-  //       paymentAnalyticsData?.receiptOrganizationFiscalCode
-  //     PARAM TO ADD HERE
-  //   })
-  // );
+  const paymentAnalyticsData = useIOSelector(paymentAnalyticsDataSelector);
+
+  const reason =
+    receiptError && "code" in receiptError
+      ? receiptError.code
+      : getNetworkError(receiptError).kind;
+
+  useOnFirstRender(() =>
+    analytics.trackPaymentsDownloadReceiptError({
+      organization_name: paymentAnalyticsData?.receiptOrganizationName,
+      first_time_opening: paymentAnalyticsData?.receiptFirstTimeOpening,
+      user: paymentAnalyticsData?.receiptUser,
+      organization_fiscal_code:
+        paymentAnalyticsData?.receiptOrganizationFiscalCode,
+      reason
+    })
+  );
 
   return (
     <>


### PR DESCRIPTION
## Short description
This pull request enhances analytics tracking for payment receipt downloads by adding a new `reason` field to capture the specific error encountered during receipt download failures

## List of changes proposed in this pull request
- Added an optional `reason` field to the `PaymentReceiptAnalyticsProps` type to record the error reason when tracking receipt download events.
- Apply `reason` to `ReceiptDetailsScreen` and `ReceiptDownloadErrorScreen`

## How to test
Make sure that during the download of a receipt, if an error occurs, it will be tracked inside `DOWNLOAD_RECEIPT_FAILURE` event with the `reason` property