### PR TITLE
fix: [IEL-29] state handling when navigating between FCI documents

### DIFF
--- a/ts/features/fci/screens/valid/FciDocumentsScreen.tsx
+++ b/ts/features/fci/screens/valid/FciDocumentsScreen.tsx
@@ -70,13 +70,6 @@ const FciDocumentsScreen = () => {
   const [focusEpoch, setFocusEpoch] = useState(0);
 
   useEffect(() => {
-    if (isFocused) {
-      // needed to re-trigger pdf load when opening the same document twice
-      setFocusEpoch(e => e + 1);
-    }
-  }, [isFocused]);
-
-  useEffect(() => {
     if (documents.length !== 0 && isFocused) {
       dispatch(fciDownloadPreview.request({ url: documents[currentDoc].url }));
     }
@@ -100,6 +93,9 @@ const FciDocumentsScreen = () => {
 
   useEffect(() => {
     if (isFocused) {
+      // needed to re-trigger pdf load when opening the same document twice
+      setFocusEpoch(e => e + 1);
+
       setTotalPages(0);
       setCurrentPage(1);
     }
@@ -262,8 +258,12 @@ const FciDocumentsScreen = () => {
           currentPage,
           totalPages
         })}
-        iconLeftDisabled={totalPages === 0 || currentPage === 1}
+        /**
+         * buttons have to be disabled when totalPages is not ready yet (zero value) OR
+         * when corresponding limit is reached
+         */
         iconRightDisabled={currentPage >= totalPages}
+        iconLeftDisabled={totalPages === 0 || currentPage === 1}
         onPrevious={onPrevious}
         onNext={onNext}
         disabled={false}


### PR DESCRIPTION
## Short description
Fixes FCI document navigation state by resetting pagination on focus/doc changes, guarding PDF callbacks when unfocused, and hiding the nav bar until pages are loaded.

## List of changes proposed in this pull request
- Reset `currentPage` and `totalPages` when the screen refocuses or the document/path changes; avoid stale state while navigating.
- disable the nav bar page counter until `totalPages` is available.

## How to test
On the dev server, increasing the number of served documents for the FCI flow up to 5 consistently causes the flow to get stuck on the 4th document. The UI (`FCI_DOCUMENTS`) incorrectly shows “1 of 3 pages” and the Continue button, even though the document has only one page. In this state, the user is effectively blocked and cannot proceed to the next screen (`FCI_SIGNATURE_FIELDS`).

<table><tr><th>Before</th><th>After</th></tr><tr><td>
<img width="642" height="1372" alt="image" src="https://github.com/user-attachments/assets/c8b6b8d4-0abf-4cb7-b723-dc117a5b5c39" />
</td><td>
<img width="643" height="1373" alt="image" src="https://github.com/user-attachments/assets/ca35136b-1482-4185-9c48-e6f843b70d2c" />
</td></tr></table>
