### PR TITLE
fix: [IEG-2587] Adjust Mixpanel event trigger on contextual onboarding

### DIFF
--- a/ts/features/payments/onboarding/hooks/useWalletOnboardingWebView.tsx
+++ b/ts/features/payments/onboarding/hooks/useWalletOnboardingWebView.tsx
@@ -77,7 +77,7 @@ export const useWalletOnboardingWebView = ({
   );
 
   const handleOnboardingResult = useCallback(
-    (resultUrl: string) => {
+    (resultUrl: string, isContextual: boolean = false) => {
       const url = new URLParse(resultUrl, true);
 
       const outcome = pipe(
@@ -92,10 +92,12 @@ export const useWalletOnboardingWebView = ({
       const is_onboarded = !!url.query.transactionId;
 
       dispatch(storePaymentIsOnboardedAction(is_onboarded));
-
-      analytics.trackPaymentOnboardingContextualCard({
-        is_onboarded
-      });
+      if (isContextual) {
+        // Tech analytics event for contextual onboarding flow
+        analytics.trackPaymentOnboardingContextualCard({
+          is_onboarded
+        });
+      }
 
       onOnboardingOutcome({
         outcome,
@@ -108,7 +110,7 @@ export const useWalletOnboardingWebView = ({
   );
 
   const openBrowserSessionOnboarding = useCallback(
-    async (url: string) => {
+    async (url: string, isContextual: boolean = false) => {
       try {
         const result =
           Platform.OS === "ios"
@@ -117,7 +119,7 @@ export const useWalletOnboardingWebView = ({
                 ONBOARDING_CALLBACK_URL_SCHEMA
               )
             : await startWebviewContextualOnboardingSession(url);
-        handleOnboardingResult(result);
+        handleOnboardingResult(result, isContextual);
       } catch {
         onOnboardingOutcome({
           outcome: WalletOnboardingOutcomeEnum.CANCELED_BY_USER
@@ -161,7 +163,7 @@ export const useWalletOnboardingWebView = ({
 
   const startContextualOnboarding = async (url: string) => {
     setIsPendingOnboarding(false);
-    await openBrowserSessionOnboarding(url);
+    await openBrowserSessionOnboarding(url, true);
   };
 
   return {


### PR DESCRIPTION
## Short description
This pull request fixes an issue where the `PAYMENT_METHOD_ONBOARDED` event was incorrectly triggered whenever a card was onboarded. The event should only be emitted after completing the contextual card onboarding flow, not during standard onboarding.

## List of changes proposed in this pull request
- The `handleOnboardingResult` function now accepts an `isContextual` flag, and triggers a contextual analytics event when appropriate
- The `openBrowserSessionOnboarding` function now accepts an `isContextual` flag and passes it to `handleOnboardingResult`
- The `startContextualOnboarding` function now calls `openBrowserSessionOnboarding` with the contextual flag set to `true`.

## How to test
- Onboard a card through contextual onboarding and verify that the `PAYMENT_METHOD_ONBOARDED` tech event is triggered
- Onboard a card through non-contextual flows and verify that the event is not triggered.