### PR TITLE
fix: [IEL-55]: Add missing title to sign clauses screen

### DIFF
--- a/ts/features/fci/navigation/FciStackNavigator.tsx
+++ b/ts/features/fci/navigation/FciStackNavigator.tsx
@@ -46,13 +46,7 @@ export const FciStackNavigator = () => (
       name={FCI_ROUTES.USER_DATA_SHARE}
       component={FciDataSharingScreen}
     />
-    <Stack.Screen
-      name={FCI_ROUTES.QTSP_TOS}
-      component={FciQtspClausesScreen}
-      options={{
-        headerShown: false
-      }}
-    />
+    <Stack.Screen name={FCI_ROUTES.QTSP_TOS} component={FciQtspClausesScreen} />
     <Stack.Screen
       name={FCI_ROUTES.TYP}
       component={FciThankyouScreen}

--- a/ts/features/fci/screens/valid/FciQtspClausesScreen.tsx
+++ b/ts/features/fci/screens/valid/FciQtspClausesScreen.tsx
@@ -36,6 +36,7 @@ import {
   fciQtspPrivacyTextSelector,
   fciQtspPrivacyUrlSelector
 } from "../../store/reducers/fciQtspClauses";
+import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
 
 const FciQtspClausesScreen = () => {
   const dispatch = useIODispatch();
@@ -83,6 +84,13 @@ const FciQtspClausesScreen = () => {
       }
     });
   };
+
+  useHeaderSecondLevel({
+    title: "",
+    supportRequest: true,
+    contextualHelp: emptyContextualHelp,
+    headerShown: isPollFilledDocumentReady && !fciPollFilledDocumentError
+  });
 
   if (fciPollFilledDocumentError && !isPollFilledDocumentReady) {
     return (


### PR DESCRIPTION
## Short description
There was no screen title set on orror on clauses screen

## List of changes proposed in this pull request
- add second level header

## How to test

- Changes these files before running:

```patch
diff --git a/src/config.ts b/src/config.ts
index 5c6110b1..039b5f06 100644
--- a/src/config.ts
+++ b/src/config.ts
@@ -93,7 +93,7 @@ const defaultConfig: IoDevServerConfig = {
     paymentWithValidDueDateCount: 0,
     paymentWithExpiredDueDateCount: 0,
     fci: {
-      waitForSignatureCount: 0,
+      waitForSignatureCount: 1,
       rejectedCount: 0,
       expiredCount: 0,
       expired90Count: 0,
```
```patch
diff --git a/src/payloads/features/fci/qtsp-filled-document.ts b/src/payloads/features/fci/qtsp-filled-document.ts
index 0936c287..a7a9528a 100644
--- a/src/payloads/features/fci/qtsp-filled-document.ts
+++ b/src/payloads/features/fci/qtsp-filled-document.ts
@@ -9,5 +9,5 @@ export const createFilledDocumentBody: CreateFilledDocument = {
 };
 
 export const qtspFilledDocument: FilledDocumentDetailView = {
-  filled_document_url: templateUrl
+  filled_document_url: templateUrl + "kkk"
 };
```
- Run the app with dev server
- Follow the video
- Pay attention to the top of the screen

<table>
  <tr>
    <td>
      <video src="https://github.com/user-attachments/assets/cb4101b8-1a9a-4041-9e20-13c559e6a16d" controls width="300"></video>
    </td>
    <td>
      <video src="https://github.com/user-attachments/assets/d53fb23b-fee5-4c7c-8726-314cd87c2ec5" controls width="300"></video>
    </td>
  </tr>
</table>
