### PR TITLE
fix(IT-Wallet): [SIW-3880] force tab bar style refresh on focus to fix iOS 26 misalignment

### DIFF
--- a/ts/features/wallet/screens/WalletHomeScreen.tsx
+++ b/ts/features/wallet/screens/WalletHomeScreen.tsx
@@ -8,8 +8,10 @@ import { useHeaderFirstLevel } from "../../../hooks/useHeaderFirstLevel";
 import { useTabItemPressWhenScreenActive } from "../../../hooks/useTabItemPressWhenScreenActive";
 import {
   IOStackNavigationRouteProps,
-  useIONavigation
+  useIONavigation,
+  useIOTabNavigation
 } from "../../../navigation/params/AppParamsList";
+import { useBottomTabNavigatorStyle } from "../../../hooks/useBottomTabNavigatorStyle";
 import { MainTabParamsList } from "../../../navigation/params/MainTabParamsList";
 import ROUTES from "../../../navigation/routes";
 import { useIODispatch, useIOSelector } from "../../../store/hooks";
@@ -146,6 +148,15 @@ const WalletHomeScreen = ({ route }: ScreenProps) => {
       itwFeedbackBottomSheet,
       route.name
     ])
+  );
+
+  const tabNavigation = useIOTabNavigation();
+  const tabBarStyle = useBottomTabNavigatorStyle();
+
+  useFocusEffect(
+    useCallback(() => {
+      tabNavigation.setOptions({ tabBarStyle });
+    }, [tabBarStyle, tabNavigation])
   );
 
   const handleRefreshWallet = useCallback(() => {


### PR DESCRIPTION
## Short description
On iPhone, `safeAreaInsets` may be recalculated during JS-based stack transitions. When the IT-Wallet credential detail stack is popped, `WalletHomeScreen` regains focus but the tab bar keeps a stale style computed from incorrect insets, causing icons to appear misaligned/partially off-screen. This fix forces the tab bar to recompute its style each time the screen gains focus.

## List of changes proposed in this pull request
- Add `useFocusEffect` in `WalletHomeScreen` that calls `tabNavigation.setOptions({ tabBarStyle })` on focus, following the same pattern used in `ArchiveRestoreBar.tsx`

## How to test
1. On an **iPhone**, open the Wallet tab
2. Tap a credential (driving license or health card)
3. Navigate back to the Wallet tab
4. Verify the tab bar icons are correctly aligned (not misaligned or partially off-screen)
5. Regression: repeat on a non-Dynamic Island device and verify no visual changes