### PR TITLE
refactor: [IOPLT-000] Replace `InputAccessoryView` with `react-native-keyboard-controller` library

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2405,6 +2405,63 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - react-native-keyboard-controller (1.21.4):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - react-native-keyboard-controller/common (= 1.21.4)
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - react-native-keyboard-controller/common (1.21.4):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - react-native-netinfo (11.4.1):
     - React-Core
   - react-native-notifications-utils (0.3.0):
@@ -3885,6 +3942,7 @@ DEPENDENCIES:
   - react-native-fingerprint-scanner (from `../node_modules/react-native-fingerprint-scanner`)
   - react-native-get-random-values (from `../node_modules/react-native-get-random-values`)
   - react-native-image-picker (from `../node_modules/react-native-image-picker`)
+  - react-native-keyboard-controller (from `../node_modules/react-native-keyboard-controller`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-notifications-utils (from `../node_modules/react-native-notifications-utils`)
   - react-native-pager-view (from `../node_modules/react-native-pager-view`)
@@ -4130,6 +4188,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-get-random-values"
   react-native-image-picker:
     :path: "../node_modules/react-native-image-picker"
+  react-native-keyboard-controller:
+    :path: "../node_modules/react-native-keyboard-controller"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-notifications-utils:
@@ -4282,7 +4342,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 82d1d7996af4c5850242966eb81e73f9a6dfab1e
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: 679e6a22e75c512c1e01359e17888ceb5d18923f
+  hermes-engine: 164271b8ea721e2a09c8557be75de7e6cc98f7ea
   IoReactNativeCie: 8c772d46d499acad8cfab4e5993c5f50d78cd9e9
   IoReactNativeIso18013: 16937f3e6f9a1369af0892fbde445f44682cfc51
   IOWalletCBOR: 92742ef1cbd1b627ba153d0c7c11b81ad22f45cc
@@ -4345,6 +4405,7 @@ SPEC CHECKSUMS:
   react-native-fingerprint-scanner: 91bf6825709dd7bd3abc4588a4772eb097a2b2d8
   react-native-get-random-values: d16467cf726c618e9c7a8c3c39c31faa2244bbba
   react-native-image-picker: b16541b587b275e81a12f9b82f215c5e9b0ccbf3
+  react-native-keyboard-controller: dbffd215d98d5c9a682fad20696fef23cb2807bf
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
   react-native-notifications-utils: 3e4bfc85db8610c150945472a8976a036a8931a7
   react-native-pager-view: 5c3098839820aa73d75873e7b1a7eb9f119602b7

--- a/jestSetup.js
+++ b/jestSetup.js
@@ -208,7 +208,9 @@ jest.mock(
     };
   }
 );
-jest.spyOn(AppState, "addEventListener").mockImplementation(() => ({remove: jest.fn()}));
+jest
+  .spyOn(AppState, "addEventListener")
+  .mockImplementation(() => ({ remove: jest.fn() }));
 
 jest.mock("mixpanel-react-native", () => ({
   __esModule: true,
@@ -281,3 +283,7 @@ jest.mock("@pagopa/io-react-native-iso18013", () => ({
 jest.mock("@pagopa/io-react-native-cie", () => ({
   CieManager: jest.fn()
 }));
+
+jest.mock("react-native-keyboard-controller", () =>
+  require("react-native-keyboard-controller/jest")
+);

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "react-native-gesture-handler": "^2.28.0",
     "react-native-haptic-feedback": "^2.3.3",
     "react-native-image-picker": "7.2.3",
+    "react-native-keyboard-controller": "^1.21.4",
     "react-native-keychain": "^10.0.0",
     "react-native-linear-gradient": "^2.5.6",
     "react-native-notifications-utils": "^0.3.0",

--- a/ts/App.tsx
+++ b/ts/App.tsx
@@ -6,6 +6,7 @@ import {
   ToastProvider
 } from "@pagopa/io-app-design-system";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
@@ -155,33 +156,35 @@ export type AppDispatch = typeof store.dispatch;
  */
 const App = (): JSX.Element => (
   <GestureHandlerRootView style={{ flex: 1 }}>
-    <SafeAreaProvider>
-      <IODSExperimentalContextProvider>
-        <IONewTypefaceContextProvider>
-          <IOThemeContextProvider theme={"light"}>
-            <ToastProvider>
-              <Provider store={store}>
-                <PersistGate loading={undefined} persistor={persistor}>
-                  <TourProvider>
-                    <IOAlertVisibleContextProvider>
-                      <BottomSheetModalProvider>
-                        <LightModalProvider>
-                          <AppFeedbackProvider>
-                            <StatusMessages>
-                              <RootContainer store={store} />
-                            </StatusMessages>
-                          </AppFeedbackProvider>
-                        </LightModalProvider>
-                      </BottomSheetModalProvider>
-                    </IOAlertVisibleContextProvider>
-                  </TourProvider>
-                </PersistGate>
-              </Provider>
-            </ToastProvider>
-          </IOThemeContextProvider>
-        </IONewTypefaceContextProvider>
-      </IODSExperimentalContextProvider>
-    </SafeAreaProvider>
+    <KeyboardProvider>
+      <SafeAreaProvider>
+        <IODSExperimentalContextProvider>
+          <IONewTypefaceContextProvider>
+            <IOThemeContextProvider theme={"light"}>
+              <ToastProvider>
+                <Provider store={store}>
+                  <PersistGate loading={undefined} persistor={persistor}>
+                    <TourProvider>
+                      <IOAlertVisibleContextProvider>
+                        <BottomSheetModalProvider>
+                          <LightModalProvider>
+                            <AppFeedbackProvider>
+                              <StatusMessages>
+                                <RootContainer store={store} />
+                              </StatusMessages>
+                            </AppFeedbackProvider>
+                          </LightModalProvider>
+                        </BottomSheetModalProvider>
+                      </IOAlertVisibleContextProvider>
+                    </TourProvider>
+                  </PersistGate>
+                </Provider>
+              </ToastProvider>
+            </IOThemeContextProvider>
+          </IONewTypefaceContextProvider>
+        </IODSExperimentalContextProvider>
+      </SafeAreaProvider>
+    </KeyboardProvider>
   </GestureHandlerRootView>
 );
 

--- a/ts/features/payments/checkout/screens/WalletPaymentInputFiscalCodeScreen.tsx
+++ b/ts/features/payments/checkout/screens/WalletPaymentInputFiscalCodeScreen.tsx
@@ -1,4 +1,4 @@
-import { TextInputValidation } from "@pagopa/io-app-design-system";
+import { IOButton, TextInputValidation } from "@pagopa/io-app-design-system";
 import {
   PaymentNoticeNumberFromString,
   RptId
@@ -10,6 +10,7 @@ import * as O from "fp-ts/lib/Option";
 import { flow, pipe } from "fp-ts/lib/function";
 import { useEffect, useRef, useState } from "react";
 import { Keyboard, Platform, View } from "react-native";
+import { KeyboardStickyView } from "react-native-keyboard-controller";
 import I18n from "i18next";
 import { IOScrollViewWithLargeHeader } from "../../../../components/ui/IOScrollViewWithLargeHeader";
 import {
@@ -28,6 +29,7 @@ import { PaymentsCheckoutParamsList } from "../navigation/params";
 import { TextInputValidationRefProps } from "../types";
 import { useIOSelector } from "../../../../store/hooks";
 import { isScreenReaderEnabledSelector } from "../../../../store/reducers/preferences";
+import { useFooterActionsMargin } from "../../../../hooks/useFooterActionsMargin";
 
 export type WalletPaymentInputFiscalCodeScreenNavigationParams = {
   paymentNoticeNumber: O.Option<PaymentNoticeNumberFromString>;
@@ -107,6 +109,8 @@ const WalletPaymentInputFiscalCodeScreen = () => {
     analytics.trackPaymentOrganizationDataEntry();
   });
 
+  const { bottomMargin } = useFooterActionsMargin();
+
   return (
     <>
       <IOScrollViewWithLargeHeader
@@ -118,13 +122,6 @@ const WalletPaymentInputFiscalCodeScreen = () => {
         canGoback
         headerActionsProp={{ showHelp: true }}
         contextualHelp={emptyContextualHelp}
-        actions={{
-          type: "SingleButton",
-          primary: {
-            label: I18n.t("global.buttons.continue"),
-            onPress: handleContinueClick
-          }
-        }}
         ref={textInputWrapperRef}
         includeContentMargins
       >
@@ -156,29 +153,22 @@ const WalletPaymentInputFiscalCodeScreen = () => {
             textInputProps={{
               keyboardType: "number-pad",
               inputMode: "numeric",
-              returnKeyType: "done",
-              inputAccessoryViewID: "fiscalCodeInputAccessoryView"
+              inputAccessoryViewID: "keyboardStickyView"
             }}
             autoFocus
           />
         )}
       </IOScrollViewWithLargeHeader>
-      {
-        // TODO: We remove the InputAccessoryView for now cause of some issues experiencing with a no show of the component inside.
-        // ref: https://github.com/facebook/react-native/pull/52825
-        // Platform.OS === "ios" && (
-        //   <InputAccessoryView nativeID={"fiscalCodeInputAccessoryView"}>
-        //     <View style={{ padding: 20 }}>
-        //       <IOButton
-        //         fullWidth
-        //         variant="solid"
-        //         label={I18n.t("global.buttons.continue")}
-        //         onPress={handleContinueClick}
-        //       />
-        //     </View>
-        //   </InputAccessoryView>
-        // )
-      }
+      <KeyboardStickyView offset={{ closed: 0 }}>
+        <View style={{ paddingHorizontal: 20, marginBottom: bottomMargin }}>
+          <IOButton
+            fullWidth
+            variant="solid"
+            label={I18n.t("global.buttons.continue")}
+            onPress={handleContinueClick}
+          />
+        </View>
+      </KeyboardStickyView>
     </>
   );
 };

--- a/ts/features/payments/checkout/screens/WalletPaymentInputNoticeNumberScreen.tsx
+++ b/ts/features/payments/checkout/screens/WalletPaymentInputNoticeNumberScreen.tsx
@@ -1,12 +1,14 @@
-import { TextInputValidation } from "@pagopa/io-app-design-system";
+import { IOButton, TextInputValidation } from "@pagopa/io-app-design-system";
 import { PaymentNoticeNumberFromString } from "@pagopa/io-pagopa-commons/lib/pagopa";
 import { useNavigation } from "@react-navigation/native";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
+import I18n from "i18next";
 import { useRef, useState } from "react";
 import { Keyboard, View } from "react-native";
-import I18n from "i18next";
+import { KeyboardStickyView } from "react-native-keyboard-controller";
 import { IOScrollViewWithLargeHeader } from "../../../../components/ui/IOScrollViewWithLargeHeader";
+import { useFooterActionsMargin } from "../../../../hooks/useFooterActionsMargin";
 import {
   AppParamsList,
   IOStackNavigationProp
@@ -62,6 +64,8 @@ const WalletPaymentInputNoticeNumberScreen = () => {
 
   const textInputRef = useRef<TextInputValidationRefProps>(null);
 
+  const { bottomMargin } = useFooterActionsMargin();
+
   return (
     <>
       <IOScrollViewWithLargeHeader
@@ -73,13 +77,6 @@ const WalletPaymentInputNoticeNumberScreen = () => {
         canGoback={true}
         contextualHelp={emptyContextualHelp}
         headerActionsProp={{ showHelp: true }}
-        actions={{
-          type: "SingleButton",
-          primary: {
-            label: I18n.t("global.buttons.continue"),
-            onPress: handleContinueClick
-          }
-        }}
         includeContentMargins
         ref={textInputWrapperRef}
       >
@@ -119,28 +116,26 @@ const WalletPaymentInputNoticeNumberScreen = () => {
           textInputProps={{
             keyboardType: "number-pad",
             inputMode: "numeric",
-            returnKeyType: "done",
-            inputAccessoryViewID: "noticeNumberInputAccessoryView"
+            inputAccessoryViewID: "keyboardStickyView"
           }}
           autoFocus
         />
       </IOScrollViewWithLargeHeader>
-      {
-        // TODO: We remove the InputAccessoryView for now cause of some issues experiencing with a no show of the component inside.
-        // ref: https://github.com/facebook/react-native/pull/52825
-        // Platform.OS === "ios" && (
-        //   <InputAccessoryView nativeID="noticeNumberInputAccessoryView">
-        //     <View style={{ padding: 20 }}>
-        //       <IOButton
-        //         fullWidth
-        //         variant="solid"
-        //         label={I18n.t("global.buttons.continue")}
-        //         onPress={handleContinueClick}
-        //       />
-        //     </View>
-        //   </InputAccessoryView>
-        // )
-      }
+      <KeyboardStickyView offset={{ closed: 0 }}>
+        <View
+          style={{
+            paddingHorizontal: 20,
+            marginBottom: bottomMargin
+          }}
+        >
+          <IOButton
+            fullWidth
+            variant="solid"
+            label={I18n.t("global.buttons.continue")}
+            onPress={handleContinueClick}
+          />
+        </View>
+      </KeyboardStickyView>
     </>
   );
 };

--- a/ts/features/payments/checkout/screens/__tests__/__snapshots__/WalletPaymentInputFiscalCodeScreen.test.tsx.snap
+++ b/ts/features/payments/checkout/screens/__tests__/__snapshots__/WalletPaymentInputFiscalCodeScreen.test.tsx.snap
@@ -671,7 +671,7 @@ exports[`WalletPaymentInputFiscalCodeScreen should render the WalletPaymentInput
                                 disableFullscreenUI={true}
                                 editable={true}
                                 importantForAccessibility="yes"
-                                inputAccessoryViewID="fiscalCodeInputAccessoryView"
+                                inputAccessoryViewID="keyboardStickyView"
                                 inputMode="numeric"
                                 keyboardType="number-pad"
                                 maxFontSizeMultiplier={1.5}
@@ -679,7 +679,6 @@ exports[`WalletPaymentInputFiscalCodeScreen should render the WalletPaymentInput
                                 onBlur={[Function]}
                                 onChangeText={[Function]}
                                 onFocus={[Function]}
-                                returnKeyType="done"
                                 selectionColor="#0B3EE3"
                                 style={
                                   [
@@ -943,178 +942,17 @@ exports[`WalletPaymentInputFiscalCodeScreen should render the WalletPaymentInput
                         </View>
                       </RCTScrollView>
                       <View
-                        pointerEvents="box-none"
-                        style={
-                          [
-                            {
-                              "bottom": 0,
-                              "justifyContent": "flex-end",
-                              "position": "absolute",
-                              "width": "100%",
-                            },
-                            {
-                              "height": 120,
-                              "paddingBottom": 24,
-                            },
-                          ]
+                        offset={
+                          {
+                            "closed": 0,
+                          }
                         }
                       >
                         <View
-                          collapsable={false}
-                          jestAnimatedProps={
-                            {
-                              "value": {},
-                            }
-                          }
-                          jestAnimatedStyle={
-                            {
-                              "value": {},
-                            }
-                          }
-                          jestInlineStyle={
-                            [
-                              {
-                                "bottom": 0,
-                                "left": 0,
-                                "position": "absolute",
-                                "right": 0,
-                                "top": 0,
-                              },
-                              false,
-                            ]
-                          }
-                          pointerEvents="none"
-                          style={
-                            [
-                              {
-                                "bottom": 0,
-                                "left": 0,
-                                "position": "absolute",
-                                "right": 0,
-                                "top": 0,
-                              },
-                              false,
-                            ]
-                          }
-                        >
-                          <View
-                            collapsable={false}
-                            jestAnimatedProps={
-                              {
-                                "value": {},
-                              }
-                            }
-                            jestAnimatedStyle={
-                              {
-                                "value": {
-                                  "opacity": 1,
-                                },
-                              }
-                            }
-                            jestInlineStyle={
-                              [
-                                false,
-                              ]
-                            }
-                            style={
-                              [
-                                {
-                                  "opacity": 1,
-                                },
-                                false,
-                              ]
-                            }
-                          >
-                            <BVLinearGradient
-                              colors={
-                                [
-                                  16777215,
-                                  33554431,
-                                  83886079,
-                                  150994943,
-                                  268435455,
-                                  385875967,
-                                  520093695,
-                                  687865855,
-                                  855638015,
-                                  1056964607,
-                                  1258291199,
-                                  1476395007,
-                                  1711276031,
-                                  1946157055,
-                                  2214592511,
-                                  2466250751,
-                                  2751463423,
-                                  3036676095,
-                                  3338665983,
-                                  3640655871,
-                                  3959422975,
-                                  4294967295,
-                                ]
-                              }
-                              endPoint={
-                                {
-                                  "x": 0.5,
-                                  "y": 1,
-                                }
-                              }
-                              locations={
-                                [
-                                  0,
-                                  0.047619047619047616,
-                                  0.09523809523809523,
-                                  0.14285714285714285,
-                                  0.19047619047619047,
-                                  0.23809523809523808,
-                                  0.2857142857142857,
-                                  0.3333333333333333,
-                                  0.38095238095238093,
-                                  0.42857142857142855,
-                                  0.47619047619047616,
-                                  0.5238095238095237,
-                                  0.5714285714285714,
-                                  0.6190476190476191,
-                                  0.6666666666666666,
-                                  0.7142857142857142,
-                                  0.7619047619047619,
-                                  0.8095238095238095,
-                                  0.8571428571428571,
-                                  0.9047619047619047,
-                                  0.9523809523809523,
-                                  1,
-                                ]
-                              }
-                              startPoint={
-                                {
-                                  "x": 0.5,
-                                  "y": 0,
-                                }
-                              }
-                              style={
-                                {
-                                  "height": 99.6,
-                                }
-                              }
-                            />
-                          </View>
-                          <View
-                            style={
-                              {
-                                "backgroundColor": "#FFFFFF",
-                                "bottom": 0,
-                                "height": 20.4,
-                              }
-                            }
-                          />
-                        </View>
-                        <View
-                          onLayout={[Function]}
-                          pointerEvents="box-none"
                           style={
                             {
-                              "flexShrink": 0,
-                              "paddingHorizontal": 24,
-                              "width": "100%",
+                              "marginBottom": 24,
+                              "paddingHorizontal": 20,
                             }
                           }
                         >

--- a/ts/features/payments/checkout/screens/__tests__/__snapshots__/WalletPaymentInputNoticeNumberScreen.test.tsx.snap
+++ b/ts/features/payments/checkout/screens/__tests__/__snapshots__/WalletPaymentInputNoticeNumberScreen.test.tsx.snap
@@ -671,14 +671,13 @@ exports[`WalletPaymentInputNoticeNumberScreen should render the WalletPaymentInp
                                 disableFullscreenUI={true}
                                 editable={true}
                                 importantForAccessibility="yes"
-                                inputAccessoryViewID="noticeNumberInputAccessoryView"
+                                inputAccessoryViewID="keyboardStickyView"
                                 inputMode="numeric"
                                 keyboardType="number-pad"
                                 maxFontSizeMultiplier={1.5}
                                 onBlur={[Function]}
                                 onChangeText={[Function]}
                                 onFocus={[Function]}
-                                returnKeyType="done"
                                 selectionColor="#0B3EE3"
                                 style={
                                   [
@@ -903,178 +902,17 @@ exports[`WalletPaymentInputNoticeNumberScreen should render the WalletPaymentInp
                         </View>
                       </RCTScrollView>
                       <View
-                        pointerEvents="box-none"
-                        style={
-                          [
-                            {
-                              "bottom": 0,
-                              "justifyContent": "flex-end",
-                              "position": "absolute",
-                              "width": "100%",
-                            },
-                            {
-                              "height": 120,
-                              "paddingBottom": 24,
-                            },
-                          ]
+                        offset={
+                          {
+                            "closed": 0,
+                          }
                         }
                       >
                         <View
-                          collapsable={false}
-                          jestAnimatedProps={
-                            {
-                              "value": {},
-                            }
-                          }
-                          jestAnimatedStyle={
-                            {
-                              "value": {},
-                            }
-                          }
-                          jestInlineStyle={
-                            [
-                              {
-                                "bottom": 0,
-                                "left": 0,
-                                "position": "absolute",
-                                "right": 0,
-                                "top": 0,
-                              },
-                              false,
-                            ]
-                          }
-                          pointerEvents="none"
-                          style={
-                            [
-                              {
-                                "bottom": 0,
-                                "left": 0,
-                                "position": "absolute",
-                                "right": 0,
-                                "top": 0,
-                              },
-                              false,
-                            ]
-                          }
-                        >
-                          <View
-                            collapsable={false}
-                            jestAnimatedProps={
-                              {
-                                "value": {},
-                              }
-                            }
-                            jestAnimatedStyle={
-                              {
-                                "value": {
-                                  "opacity": 1,
-                                },
-                              }
-                            }
-                            jestInlineStyle={
-                              [
-                                false,
-                              ]
-                            }
-                            style={
-                              [
-                                {
-                                  "opacity": 1,
-                                },
-                                false,
-                              ]
-                            }
-                          >
-                            <BVLinearGradient
-                              colors={
-                                [
-                                  16777215,
-                                  33554431,
-                                  83886079,
-                                  150994943,
-                                  268435455,
-                                  385875967,
-                                  520093695,
-                                  687865855,
-                                  855638015,
-                                  1056964607,
-                                  1258291199,
-                                  1476395007,
-                                  1711276031,
-                                  1946157055,
-                                  2214592511,
-                                  2466250751,
-                                  2751463423,
-                                  3036676095,
-                                  3338665983,
-                                  3640655871,
-                                  3959422975,
-                                  4294967295,
-                                ]
-                              }
-                              endPoint={
-                                {
-                                  "x": 0.5,
-                                  "y": 1,
-                                }
-                              }
-                              locations={
-                                [
-                                  0,
-                                  0.047619047619047616,
-                                  0.09523809523809523,
-                                  0.14285714285714285,
-                                  0.19047619047619047,
-                                  0.23809523809523808,
-                                  0.2857142857142857,
-                                  0.3333333333333333,
-                                  0.38095238095238093,
-                                  0.42857142857142855,
-                                  0.47619047619047616,
-                                  0.5238095238095237,
-                                  0.5714285714285714,
-                                  0.6190476190476191,
-                                  0.6666666666666666,
-                                  0.7142857142857142,
-                                  0.7619047619047619,
-                                  0.8095238095238095,
-                                  0.8571428571428571,
-                                  0.9047619047619047,
-                                  0.9523809523809523,
-                                  1,
-                                ]
-                              }
-                              startPoint={
-                                {
-                                  "x": 0.5,
-                                  "y": 0,
-                                }
-                              }
-                              style={
-                                {
-                                  "height": 99.6,
-                                }
-                              }
-                            />
-                          </View>
-                          <View
-                            style={
-                              {
-                                "backgroundColor": "#FFFFFF",
-                                "bottom": 0,
-                                "height": 20.4,
-                              }
-                            }
-                          />
-                        </View>
-                        <View
-                          onLayout={[Function]}
-                          pointerEvents="box-none"
                           style={
                             {
-                              "flexShrink": 0,
-                              "paddingHorizontal": 24,
-                              "width": "100%",
+                              "marginBottom": 24,
+                              "paddingHorizontal": 20,
                             }
                           }
                         >

--- a/yarn.lock
+++ b/yarn.lock
@@ -13811,6 +13811,7 @@ __metadata:
     react-native-get-random-values: ^1.11.0
     react-native-haptic-feedback: ^2.3.3
     react-native-image-picker: 7.2.3
+    react-native-keyboard-controller: ^1.21.4
     react-native-keychain: ^10.0.0
     react-native-linear-gradient: ^2.5.6
     react-native-notifications-utils: ^0.3.0
@@ -19540,6 +19541,19 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 8fb6d8ab7b953c7d7cec8c987cef24f1c5348a293a85cb49c7c53b54ef110c0ca746736ae730e297603c8c76020df912e93915fb17518c4f2f91143757177aba
+  languageName: node
+  linkType: hard
+
+"react-native-keyboard-controller@npm:^1.21.4":
+  version: 1.21.4
+  resolution: "react-native-keyboard-controller@npm:1.21.4"
+  dependencies:
+    react-native-is-edge-to-edge: ^1.2.1
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+    react-native-reanimated: ">=3.0.0"
+  checksum: c5007632a4f7bb49f4852b41ffde87bb2ca5d91702dbdef054b2bf641f550d14b47a46db2b322b56e5c1d9a756c7951d90bccef152f26a563fc0284d034d7ed1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Short description
This pull request introduces the `react-native-keyboard-controller` library to improve keyboard handling and user experience on payment input screens. 
The main focus is on replacing the previous input accessory view logic with the new `KeyboardStickyView` component since in RN 0.83 there's an [issue](https://github.com/pagopa/io-app/pull/7951#pullrequestreview-4067133660) on showing the old component

> [!TIP]
> With this library, the behavior is now consistent on the Android side as well. 

## List of changes proposed in this pull request
- Added `react-native-keyboard-controller` as a dependency and wrapped the app with `KeyboardProvider` in `App.tsx` to enable global keyboard control features
- Replaced the previous (and commented-out) `InputAccessoryView` logic with the new `KeyboardStickyView` component for both `WalletPaymentInputFiscalCodeScreen.tsx` and `WalletPaymentInputNoticeNumberScreen.tsx`, ensuring the "Continue" button is always accessible above the keyboard
- Removed the `actions` prop from `IOScrollViewWithLargeHeader` in both payment input screens
- Utilized the `useFooterActionsMargin` hook to ensure proper spacing for the sticky button on both screens

## How to test
Ensure that the CTAs `Continua` in payment flow (notice number and fiscal code input form screens) are visible and working as before with no regression

## Preview

| iOS | Android |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/19681729-f6dd-4dfe-8d61-92bfc1b10f88"/> | <video src="https://github.com/user-attachments/assets/453e0347-272e-4c6a-b9fb-f84d604503dc"/> | 



