### PR TITLE
refactor: [IEG-2771] Update basepath for CDC and CGN based on new proxy backend

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -36,8 +36,8 @@ declare -a apis=(
   # Session Manager APIs
   "./definitions/session_manager https://raw.githubusercontent.com/pagopa/io-auth-n-identity-domain/refs/tags/io-session-manager@$IO_SESSION_MANAGER_VERSION/apps/io-session-manager/api/external.yaml"  
   # CGN APIs
-  "./definitions/cgn https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_cgn.yaml"
-  "./definitions/cgn/merchants https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_cgn_operator_search.yaml"
+  "./definitions/cgn https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/openapi/generated/api_cgn_card_platform.yaml"
+  "./definitions/cgn/merchants https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/openapi/generated/api_cgn_search_platform.yaml"
   # PN APIs
   "./definitions/pn https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_pn.yaml"
   "./definitions/pn/aar https://raw.githubusercontent.com/pagopa/io-messages/refs/tags/send-func@$SEND_FUNC_VERSION/apps/send-func/openapi/aar-notification.yaml"
@@ -48,7 +48,7 @@ declare -a apis=(
   "./definitions/itw https://raw.githubusercontent.com/pagopa/io-wallet/io-wallet-user-func@$IO_WALLET_USER_FUNC_VERSION/apps/io-wallet-user-func/openapi-external/user_v1/swagger.yaml"
   # Connectivity APIs (used for connectivity checks)
   "./definitions/connectivity https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_public.yaml"
-  "./definitions/cdc https://raw.githubusercontent.com/pagopa/io-backend/refs/tags/$IO_BACKEND_VERSION/openapi/generated/api_cdc.yaml"
+  "./definitions/cdc https://raw.githubusercontent.com/pagopa/io-backend/refs/tags/$IO_BACKEND_VERSION/openapi/generated/api_cdc_support_platform.yaml"
 )
 
 for elem in "${apis[@]}"; do

--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IO_BACKEND_VERSION=v17.5.2
+IO_BACKEND_VERSION=v19.0.0
 # need to change after merge on io-services-metadata
 IO_SERVICES_METADATA_VERSION=1.0.98
 # Session manager version

--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IO_BACKEND_VERSION=v19.0.0
+IO_BACKEND_VERSION=v17.5.2
 # need to change after merge on io-services-metadata
 IO_SERVICES_METADATA_VERSION=1.0.98
 # Session manager version
@@ -9,6 +9,9 @@ IO_SESSION_MANAGER_VERSION=1.23.1
 IO_WALLET_USER_FUNC_VERSION=4.1.11
 # Send function version
 SEND_FUNC_VERSION=1.5.5
+# CGN and CDC APIs are generated with a different version of io-backend, so we need to specify it separately
+IO_BACKEND_VERSION_CGN_CDC=v19.0.0
+
 
 declare -a apis=(
   # Backend APIs
@@ -36,8 +39,8 @@ declare -a apis=(
   # Session Manager APIs
   "./definitions/session_manager https://raw.githubusercontent.com/pagopa/io-auth-n-identity-domain/refs/tags/io-session-manager@$IO_SESSION_MANAGER_VERSION/apps/io-session-manager/api/external.yaml"  
   # CGN APIs
-  "./definitions/cgn https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/openapi/generated/api_cgn_card_platform.yaml"
-  "./definitions/cgn/merchants https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/openapi/generated/api_cgn_search_platform.yaml"
+  "./definitions/cgn https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION_CGN_CDC/openapi/generated/api_cgn_card_platform.yaml"
+  "./definitions/cgn/merchants https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION_CGN_CDC/openapi/generated/api_cgn_search_platform.yaml"
   # PN APIs
   "./definitions/pn https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_pn.yaml"
   "./definitions/pn/aar https://raw.githubusercontent.com/pagopa/io-messages/refs/tags/send-func@$SEND_FUNC_VERSION/apps/send-func/openapi/aar-notification.yaml"
@@ -48,7 +51,8 @@ declare -a apis=(
   "./definitions/itw https://raw.githubusercontent.com/pagopa/io-wallet/io-wallet-user-func@$IO_WALLET_USER_FUNC_VERSION/apps/io-wallet-user-func/openapi-external/user_v1/swagger.yaml"
   # Connectivity APIs (used for connectivity checks)
   "./definitions/connectivity https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_public.yaml"
-  "./definitions/cdc https://raw.githubusercontent.com/pagopa/io-backend/refs/tags/$IO_BACKEND_VERSION/openapi/generated/api_cdc_support_platform.yaml"
+  # CDC APIs
+  "./definitions/cdc https://raw.githubusercontent.com/pagopa/io-backend/refs/tags/$IO_BACKEND_VERSION_CGN_CDC/openapi/generated/api_cdc_support_platform.yaml"
 )
 
 for elem in "${apis[@]}"; do

--- a/ts/features/bonus/cdc/common/api/client.ts
+++ b/ts/features/bonus/cdc/common/api/client.ts
@@ -4,7 +4,7 @@ import { defaultRetryingFetch } from "../../../../../utils/fetch";
 export const createCdcClient = (baseUrl: string, sessionToken: string) =>
   createClient<"Bearer">({
     baseUrl,
-    basePath: "/api/v1/cdc",
+    basePath: "/api/cdc-support/v1",
     fetchApi: defaultRetryingFetch(),
     withDefaults: op => params => {
       const paramsWithDefaults = {

--- a/ts/features/bonus/cgn/api/backendCgn.ts
+++ b/ts/features/bonus/cgn/api/backendCgn.ts
@@ -28,7 +28,7 @@ import { withBearerToken as withToken } from "../../../../utils/api";
 
 const tokenHeaderProducer = ParamAuthorizationBearerHeaderProducer();
 
-const BASE_URL = "/api/v1/cgn";
+const BASE_URL = "/api/cgn-card/v1";
 
 const startCgnActivation: StartCgnActivationT = {
   method: "post",

--- a/ts/features/bonus/cgn/api/backendCgnMerchants.ts
+++ b/ts/features/bonus/cgn/api/backendCgnMerchants.ts
@@ -22,7 +22,7 @@ import {
 import { tokenHeaderProducer, withBearerToken } from "../../../../utils/api";
 import { defaultRetryingFetch } from "../../../../utils/fetch";
 
-const BASE_URL = "/api/v1/cgn/operator-search";
+const BASE_URL = "/api/cgn-search/v1";
 
 const getMerchantsCount: CountT = {
   method: "get",

--- a/ts/features/bonus/cgn/screens/__test__/CgnMerchantSearchScreen.test.tsx
+++ b/ts/features/bonus/cgn/screens/__test__/CgnMerchantSearchScreen.test.tsx
@@ -10,12 +10,12 @@ import { applicationChangeState } from "../../../../../store/actions/application
 import { watchBonusCgnSaga } from "../../saga";
 
 const mockFetch: typeof fetch = async (url, options) => {
-  if (url === "/api/v1/cgn/operator-search/count") {
+  if (url === "/api/cgn-search/v1/count") {
     return new Response(JSON.stringify({ count: merchantList.length }), {
       status: 200
     });
   }
-  if (url === "/api/v1/cgn/operator-search/search") {
+  if (url === "/api/cgn-search/v1/search") {
     const body = JSON.parse(options?.body as string);
     if (body.token === "merchant") {
       return new Response(JSON.stringify({ items: merchantList }), {


### PR DESCRIPTION
## Short description
This pull request updates several API endpoints throughout the codebase to use new base paths, reflecting recent backend route changes. These updates ensure that all client and test code references the correct API URLs.

## List of changes proposed in this pull request
- Introduced a new variable `IO_BACKEND_VERSION_CGN_CDC` to allow CGN and CDC APIs to use a different backend version than the rest of the APIs
- Updated the API definitions for CGN and CDC in `scripts/generate-api-models.sh` to use the new OpenAPI YAML files and the new backend version variable, ensuring the correct API specs are used
-  Changed the base path for the CDC API client from `/api/v1/cdc` to `/api/cdc-support/v1` in `client.ts` to match the new backend API path
- Updated the CGN API client base path from `/api/v1/cgn` to `/api/cgn-card/v1` in `backendCgn.ts`
- Changed the CGN merchants API client base path from `/api/v1/cgn/operator-search` to `/api/cgn-search/v1` in `backendCgnMerchants.ts`

## How to test
Make sure everything continues to function as expected, even with the new base path in place