### PR TITLE
chore: [SIW-000] Bump `io-react-native-iso18013` to version `0.8.1`

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -142,7 +142,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - IoReactNativeIso18013 (0.8.0):
+  - IoReactNativeIso18013 (0.8.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3996,7 +3996,7 @@ SPEC CHECKSUMS:
   hermes-engine: 9f4dfe93326146a1c99eb535b1cb0b857a3cd172
   IoReactNativeCie: 8c772d46d499acad8cfab4e5993c5f50d78cd9e9
   IoReactNativeHttpClient: 8095efc7a0ef59631b5664b35711c3ab42056d52
-  IoReactNativeIso18013: efc3a6623463970575f986b6dc9b75fe9ba8b940
+  IoReactNativeIso18013: 785e402750f29c9e2e316ae13e3fa5add5da9b17
   IOWalletCBOR: 92742ef1cbd1b627ba153d0c7c11b81ad22f45cc
   IOWalletProximity: 1d8fc9acc9d97d34364c42927af3ac682448977e
   jail-monkey: 9298d04aa09f8c9cdcf04e7bf597ea423b52b5bf

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@pagopa/io-react-native-crypto": "^1.2.3",
     "@pagopa/io-react-native-http-client": "1.1.1",
     "@pagopa/io-react-native-integrity": "^0.3.2",
-    "@pagopa/io-react-native-iso18013": "^0.8.0",
+    "@pagopa/io-react-native-iso18013": "^0.8.1",
     "@pagopa/io-react-native-jwt": "^2.1.0",
     "@pagopa/io-react-native-login-utils": "1.2.0",
     "@pagopa/io-react-native-secure-storage": "^0.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4311,15 +4311,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagopa/io-react-native-iso18013@npm:^0.8.0":
-  version: 0.8.0
-  resolution: "@pagopa/io-react-native-iso18013@npm:0.8.0"
+"@pagopa/io-react-native-iso18013@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "@pagopa/io-react-native-iso18013@npm:0.8.1"
   dependencies:
     zod: ^3.25.67
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 15b35f6d0294ad95bef58c5f76a3ed357d77a3948fb42b63bbe5e33055d90b91cd190dee41646d2eec344d81d814ace19ea4ca521229723338b5bd59dec145fd
+  checksum: 0a3c558cfef0289aabef8cdd034d6e0f80b8f160205fbeadf30729639f4b42afc81564518bb7cafe09158cf171c5c40316c886baa9a11c63553bf45c32682b0f
   languageName: node
   linkType: hard
 
@@ -13365,7 +13365,7 @@ __metadata:
     "@pagopa/io-react-native-crypto": ^1.2.3
     "@pagopa/io-react-native-http-client": 1.1.1
     "@pagopa/io-react-native-integrity": ^0.3.2
-    "@pagopa/io-react-native-iso18013": ^0.8.0
+    "@pagopa/io-react-native-iso18013": ^0.8.1
     "@pagopa/io-react-native-jwt": ^2.1.0
     "@pagopa/io-react-native-login-utils": 1.2.0
     "@pagopa/io-react-native-secure-storage": ^0.2.1


### PR DESCRIPTION
## Short description
This PR resolves Android build failures by upgrading `io-react-native-iso18013` to version `0.8.1`

## List of changes proposed in this pull request
- Upgrade `io-react-native-iso18013` to version `0.8.1`

## How to test
Verify that the app build on bot iOS and Android
