### PR TITLE
feat: [IEL-452] add local FF to manage L3 login on FCI flow

### DIFF
--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -2067,6 +2067,12 @@
       "signatureFieldInfo": {
         "title": "What are restrictive clauses?",
         "subTitle": "These are clauses that highlight specific conditions to be aware of and that must be accepted. By law, they have to be easily identifiable to make sure the signer is aware of their contents before signing."
+      },
+      "requestL3": {
+        "localFlag": {
+          "title": "Enable L3 check for the signature flow",
+          "description": "By enabling this toggle, you activate the L3 check for the signature flow, which requires a new L3 login for users who do not have the L3 authentication level (CIE + PIN)"
+        }
       }
     },
     "wallet": {

--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -2872,6 +2872,12 @@
       "signatureFieldInfo": {
         "title": "Cosa sono le clausole vessatorie?",
         "subTitle": "Sono delle clausole che segnalano condizioni particolari a cui prestare attenzione e che devono essere accettate. Devono inoltre essere, per legge, facilmente identificabili per far sì che chi firma sia informato del loro contenuto prima di apporre la firma."
+      },
+      "requestL3": {
+        "localFlag": {
+          "title": "Attivazione check L3 per il flusso di firma",
+          "description": "Attivando questo toggle attivi il check L3 per il flusso di firma, che prevede una nuova login L3 per gli utenti che non possiedono il livello di autenticazione L3 (CIE + PIN)"
+        }
       }
     },
     "wallet": {

--- a/ts/features/common/store/reducers/__tests__/__snapshots__/index.test.ts.snap
+++ b/ts/features/common/store/reducers/__tests__/__snapshots__/index.test.ts.snap
@@ -45,6 +45,9 @@ exports[`featuresPersistor should match snapshot 1`] = `
     "qtspClauses": {
       "kind": "PotNone",
     },
+    "securityLevel": {
+      "localFeatureFlag": false,
+    },
     "signature": {
       "kind": "PotNone",
     },

--- a/ts/features/fci/store/actions/index.ts
+++ b/ts/features/fci/store/actions/index.ts
@@ -148,6 +148,12 @@ export const fciEnvironmentSet = createStandardAction("FCI_ENVIRONMENT_SET")<
   O.Option<EnvironmentEnum>
 >();
 
+/**
+ * Action used to set a local flag to test the L3 level active session login in the FCI flow.
+ */
+export const fciL3LocalFlag =
+  createStandardAction("FCI_L3_LOCAL_FLAG")<boolean>();
+
 export type FciActions =
   | ActionType<typeof fciSignatureRequestFromId>
   | ActionType<typeof fciSignatureRequestRetryFromId>
@@ -166,4 +172,5 @@ export type FciActions =
   | ActionType<typeof fciMetadataRequest>
   | ActionType<typeof fciSignaturesListRequest>
   | ActionType<typeof fciDocumentSignatureFields>
-  | ActionType<typeof fciEnvironmentSet>;
+  | ActionType<typeof fciEnvironmentSet>
+  | ActionType<typeof fciL3LocalFlag>;

--- a/ts/features/fci/store/reducers/__tests__/fciSecurityLevelReducer.test.ts
+++ b/ts/features/fci/store/reducers/__tests__/fciSecurityLevelReducer.test.ts
@@ -1,0 +1,52 @@
+import { createStore } from "redux";
+import { applicationChangeState } from "../../../../../store/actions/application";
+import { appReducer } from "../../../../../store/reducers";
+import { fciL3LocalFlag } from "../../actions";
+
+describe("FciSecurityLevelReducer", () => {
+  it("it should have an initialState with localFeatureFlag equal to false", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    expect(
+      globalState.features.fci.securityLevel.localFeatureFlag
+    ).toStrictEqual(false);
+  });
+  it("it should have localFeatureFlag equal to true if the fciL3LocalFlag is dispatched with true as payload", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+    store.dispatch(fciL3LocalFlag(true));
+    expect(
+      store.getState().features.fci.securityLevel.localFeatureFlag
+    ).toStrictEqual(true);
+  });
+  it("it should have localFeatureFlag equal to false if the fciL3LocalFlag is dispatched with false as payload", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+    store.dispatch(fciL3LocalFlag(false));
+    expect(
+      store.getState().features.fci.securityLevel.localFeatureFlag
+    ).toStrictEqual(false);
+  });
+  it("it should change localFeatureFlag from false to true if the initialState is false and fciL3LocalFlag is dispatched with true as payload", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+    expect(
+      store.getState().features.fci.securityLevel.localFeatureFlag
+    ).toStrictEqual(false);
+    store.dispatch(fciL3LocalFlag(true));
+    expect(
+      store.getState().features.fci.securityLevel.localFeatureFlag
+    ).toStrictEqual(true);
+  });
+  it("it should change localFeatureFlag from true to false if the initialState is true and fciL3LocalFlag is dispatched with false as payload", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+    store.dispatch(fciL3LocalFlag(true));
+    expect(
+      store.getState().features.fci.securityLevel.localFeatureFlag
+    ).toStrictEqual(true);
+    store.dispatch(fciL3LocalFlag(false));
+    expect(
+      store.getState().features.fci.securityLevel.localFeatureFlag
+    ).toStrictEqual(false);
+  });
+});

--- a/ts/features/fci/store/reducers/fciSecurityLevelReducer.ts
+++ b/ts/features/fci/store/reducers/fciSecurityLevelReducer.ts
@@ -1,0 +1,31 @@
+import { getType } from "typesafe-actions";
+import { Action } from "../../../../store/actions/types";
+import { fciL3LocalFlag } from "../actions";
+import { GlobalState } from "../../../../store/reducers/types";
+
+export type FciSecurityLevelStateType = {
+  localFeatureFlag: boolean;
+};
+
+const initialState: FciSecurityLevelStateType = {
+  localFeatureFlag: false
+};
+
+/**
+ * Store security level info for FCI flow
+ */
+export const fciSecurityLevelReducer = (
+  state: FciSecurityLevelStateType = initialState,
+  action: Action
+): FciSecurityLevelStateType => {
+  switch (action.type) {
+    case getType(fciL3LocalFlag):
+      return { ...state, localFeatureFlag: action.payload };
+  }
+  return state;
+};
+
+export const fciSecurityLevelLocalFeatureFlagSelector = (
+  state: GlobalState
+): FciSecurityLevelStateType["localFeatureFlag"] =>
+  state.features.fci.securityLevel.localFeatureFlag;

--- a/ts/features/fci/store/reducers/index.ts
+++ b/ts/features/fci/store/reducers/index.ts
@@ -25,6 +25,10 @@ import fciSignatureFieldDrawingReducer, {
   FciSignatureFieldDrawingState
 } from "./fciSignatureFieldDrawing";
 import fciEnvironmentReducer, { FciEnvironmentState } from "./fciEnvironment";
+import {
+  fciSecurityLevelReducer,
+  FciSecurityLevelStateType
+} from "./fciSecurityLevelReducer";
 
 export type FciState = {
   signatureRequest: FciSignatureRequestState;
@@ -38,6 +42,7 @@ export type FciState = {
   metadata: FciMetadataRequestState;
   signaturesList: FciSignaturesListRequestState;
   environment: FciEnvironmentState;
+  securityLevel: FciSecurityLevelStateType;
 };
 
 const fciReducer = combineReducers<FciState, Action>({
@@ -51,7 +56,8 @@ const fciReducer = combineReducers<FciState, Action>({
   pollFilledDocument: fciPollFilledDocumentReducer,
   metadata: fciMetadataReducer,
   signaturesList: fciSignaturesListRequestReducer,
-  environment: fciEnvironmentReducer
+  environment: fciEnvironmentReducer,
+  securityLevel: fciSecurityLevelReducer
 });
 
 export default fciReducer;

--- a/ts/features/settings/common/navigation/__test__/__snapshots__/SettingsNavigator.test.tsx.snap
+++ b/ts/features/settings/common/navigation/__test__/__snapshots__/SettingsNavigator.test.tsx.snap
@@ -2468,6 +2468,12 @@ exports[`SettingsNavigator renders all routes (snapshot) 1`] = `
                                   "onSwitchValueChange": [Function],
                                   "value": false,
                                 },
+                                {
+                                  "description": "Attivando questo toggle attivi il check L3 per il flusso di firma, che prevede una nuova login L3 per gli utenti che non possiedono il livello di autenticazione L3 (CIE + PIN)",
+                                  "label": "Attivazione check L3 per il flusso di firma",
+                                  "onSwitchValueChange": [Function],
+                                  "value": false,
+                                },
                               ]
                             }
                             getItem={[Function]}
@@ -3026,6 +3032,169 @@ exports[`SettingsNavigator renders all routes (snapshot) 1`] = `
                                     }
                                   >
                                     La modifica richiede il riavvio dell'app
+                                  </Text>
+                                </View>
+                                <View
+                                  style={
+                                    {
+                                      "backgroundColor": "#D2D6E3",
+                                      "height": 0.5,
+                                    }
+                                  }
+                                />
+                              </View>
+                              <View
+                                onFocusCapture={[Function]}
+                                onLayout={[Function]}
+                                style={null}
+                              >
+                                <View
+                                  accessible={false}
+                                  needsOffscreenAlphaCompositing={true}
+                                  pointerEvents="auto"
+                                  style={
+                                    [
+                                      {
+                                        "marginHorizontal": -24,
+                                        "paddingHorizontal": 24,
+                                        "paddingVertical": 12,
+                                      },
+                                      {
+                                        "opacity": 1,
+                                      },
+                                    ]
+                                  }
+                                  testID="ListItemSwitch"
+                                >
+                                  <View
+                                    accessible={false}
+                                    style={
+                                      [
+                                        {
+                                          "alignItems": "flex-start",
+                                          "flexDirection": "row",
+                                          "justifyContent": "space-between",
+                                        },
+                                        {
+                                          "alignItems": "center",
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    <View
+                                      accessibilityState={
+                                        {
+                                          "disabled": undefined,
+                                        }
+                                      }
+                                      accessible={false}
+                                      style={
+                                        {
+                                          "alignItems": "center",
+                                          "columnGap": 18,
+                                          "flex": 1,
+                                          "flexDirection": "row",
+                                        }
+                                      }
+                                    >
+                                      <Text
+                                        accessible={false}
+                                        allowFontScaling={true}
+                                        dynamicTypeRamp="headline"
+                                        importantForAccessibility="no-hide-descendants"
+                                        maxFontSizeMultiplier={1.5}
+                                        style={
+                                          [
+                                            {},
+                                            {
+                                              "color": "#0E0F13",
+                                              "fontFamily": "Titillio",
+                                              "fontSize": 16,
+                                              "fontStyle": "normal",
+                                              "fontWeight": "600",
+                                              "lineHeight": 24,
+                                            },
+                                            {
+                                              "flex": 1,
+                                            },
+                                          ]
+                                        }
+                                      >
+                                        Attivazione check L3 per il flusso di firma
+                                      </Text>
+                                    </View>
+                                    <View
+                                      style={
+                                        {
+                                          "width": 8,
+                                        }
+                                      }
+                                    />
+                                    <View
+                                      style={
+                                        {
+                                          "alignSelf": "flex-start",
+                                          "justifyContent": "center",
+                                          "minHeight": 32,
+                                        }
+                                      }
+                                    >
+                                      <RCTSwitch
+                                        accessibilityLabel="Attivazione check L3 per il flusso di firma"
+                                        accessibilityRole="switch"
+                                        accessibilityState={
+                                          {
+                                            "checked": false,
+                                            "disabled": undefined,
+                                          }
+                                        }
+                                        onChange={[Function]}
+                                        onResponderTerminationRequest={[Function]}
+                                        onStartShouldSetResponder={[Function]}
+                                        onTintColor="#0B3EE3"
+                                        style={
+                                          [
+                                            {
+                                              "alignSelf": "flex-start",
+                                            },
+                                            {
+                                              "backgroundColor": "#555C70",
+                                              "borderRadius": 16,
+                                            },
+                                          ]
+                                        }
+                                        thumbTintColor="#FFFFFF"
+                                        tintColor="#555C70"
+                                        value={false}
+                                      />
+                                    </View>
+                                  </View>
+                                  <View
+                                    style={
+                                      {
+                                        "height": 4,
+                                      }
+                                    }
+                                  />
+                                  <Text
+                                    allowFontScaling={true}
+                                    dynamicTypeRamp="footnote"
+                                    maxFontSizeMultiplier={1.5}
+                                    style={
+                                      [
+                                        {},
+                                        {
+                                          "color": "#555C70",
+                                          "fontFamily": "Titillio",
+                                          "fontSize": 14,
+                                          "fontStyle": "normal",
+                                          "fontWeight": "400",
+                                          "lineHeight": 21,
+                                        },
+                                      ]
+                                    }
+                                  >
+                                    Attivando questo toggle attivi il check L3 per il flusso di firma, che prevede una nuova login L3 per gli utenti che non possiedono il livello di autenticazione L3 (CIE + PIN)
                                   </Text>
                                 </View>
                               </View>

--- a/ts/features/settings/devMode/components/DeveloperModeSection.tsx
+++ b/ts/features/settings/devMode/components/DeveloperModeSection.tsx
@@ -579,9 +579,8 @@ const DeveloperTestEnvironmentSection = ({
       onSwitchValueChange: onActiveSessionLoginToggle
     },
     {
-      label: "activate FCI L3 test environment",
-      description:
-        "attivando questo flag durante una richiesta di firma, se non possiedi il livello di sicurezza L3 verrà attivato il flusso di login a sessione attiva",
+      label: I18n.t("features.fci.requestL3.localFlag.title"),
+      description: I18n.t("features.fci.requestL3.localFlag.description"),
       value: fciL3LocalFeatureFlag,
       onSwitchValueChange: onFciSecurityLevelLocalFlagToggleChange
     }

--- a/ts/features/settings/devMode/components/DeveloperModeSection.tsx
+++ b/ts/features/settings/devMode/components/DeveloperModeSection.tsx
@@ -55,6 +55,8 @@ import { notificationsInstallationSelector } from "../../../pushNotifications/st
 import { SETTINGS_ROUTES } from "../../common/navigation/routes";
 import { clearCache } from "../../common/store/actions";
 import { isPnRemoteEnabledSelector } from "../../../../store/reducers/backendStatus/remoteConfig.ts";
+import { fciL3LocalFlag } from "../../../fci/store/actions/index.ts";
+import { fciSecurityLevelLocalFeatureFlagSelector } from "../../../fci/store/reducers/fciSecurityLevelReducer.ts";
 import ExperimentalDesignEnableSwitch from "./ExperimentalDesignEnableSwitch";
 
 type PlaygroundsNavListItem = {
@@ -474,6 +476,9 @@ const DeveloperTestEnvironmentSection = ({
   const isActiveSessionLoginLocallyEnabled = useIOSelector(
     isActiveSessionLoginLocallyEnabledSelector
   );
+  const fciL3LocalFeatureFlag = useIOSelector(
+    fciSecurityLevelLocalFeatureFlagSelector
+  );
 
   const onPagoPAEnvironmentToggle = (enabled: boolean) => {
     if (enabled) {
@@ -543,6 +548,10 @@ const DeveloperTestEnvironmentSection = ({
     }
   };
 
+  const onFciSecurityLevelLocalFlagToggleChange = (enabled: boolean) => {
+    dispatch(fciL3LocalFlag(enabled));
+  };
+
   const testEnvironmentsListItems: ReadonlyArray<TestEnvironmentsListItem> = [
     {
       label: I18n.t("profile.main.pagoPaEnvironment.pagoPaEnv"),
@@ -568,6 +577,13 @@ const DeveloperTestEnvironmentSection = ({
       ),
       value: isActiveSessionLoginLocallyEnabled,
       onSwitchValueChange: onActiveSessionLoginToggle
+    },
+    {
+      label: "activate FCI L3 test environment",
+      description:
+        "attivando questo flag durante una richiesta di firma, se non possiedi il livello di sicurezza L3 verrà attivato il flusso di login a sessione attiva",
+      value: fciL3LocalFeatureFlag,
+      onSwitchValueChange: onFciSecurityLevelLocalFlagToggleChange
     }
   ];
 


### PR DESCRIPTION
## Short description
To test L3 access on the FCI flow in production, we need a local FF (a remote FF will also be added). 
This functionality will be added in an upcoming PR. 

## List of changes proposed in this pull request
In order to add the local FF to this PR, the following have been added:
- A custom reducer to manage the state of the local FF. The reducer’s state is NOT persisted
- Tests for the reducer
- An Action to handle state changes of the local FF
- A switch in the developers section to enable the local FF 


## Demo
https://github.com/user-attachments/assets/16a7dc7f-613d-4d86-934c-d5e3edc6f687



## How to test
Run the application and follow the video demo 