### PR TITLE
chore: [IEL-357] Improve timeline items accessibility

### DIFF
--- a/ts/features/pn/components/Timeline.tsx
+++ b/ts/features/pn/components/Timeline.tsx
@@ -24,6 +24,7 @@ export type TimelineItemProps = {
   month: string;
   time: string;
   status: TimelineStatus;
+  accessibilityLabel: string;
 };
 
 export type TimelineProps = {
@@ -143,9 +144,14 @@ const TimelineItem = ({
   description,
   month,
   time,
+  accessibilityLabel,
   ...rest
 }: TimelineItemProps & Position) => (
-  <View accessible={true} style={styles.item}>
+  <View
+    accessible={true}
+    style={styles.item}
+    accessibilityLabel={accessibilityLabel}
+  >
     <TimelineOppositeContent day={day} month={month} />
     <TimelineSeparator {...rest}>
       <TimelineDot {...rest} />

--- a/ts/features/pn/components/TimelineListItem.tsx
+++ b/ts/features/pn/components/TimelineListItem.tsx
@@ -10,6 +10,7 @@ import { useIOBottomSheetModal } from "../../../utils/hooks/bottomSheet";
 import { NotificationStatusHistory } from "../../../../definitions/pn/NotificationStatusHistory";
 import { formatDateAsDay, formatDateAsMonth } from "../../../utils/dates";
 import {
+  getNotificationStatusAccessibilityLabel,
   getNotificationStatusInfo,
   notificationStatusToTimelineStatus
 } from "../utils";
@@ -49,7 +50,8 @@ const generateTimelineData = (
       minute: "2-digit"
     }).format(historyItem.activeFrom),
     description: getNotificationStatusInfo(historyItem.status),
-    status: notificationStatusToTimelineStatus(historyItem.status)
+    status: notificationStatusToTimelineStatus(historyItem.status),
+    accessibilityLabel: getNotificationStatusAccessibilityLabel(historyItem)
   }));
 
 export const TimelineListItem = ({

--- a/ts/features/pn/components/__test__/Timeline.test.tsx
+++ b/ts/features/pn/components/__test__/Timeline.test.tsx
@@ -4,6 +4,7 @@ import { appReducer } from "../../../../store/reducers";
 import { applicationChangeState } from "../../../../store/actions/application";
 import { renderScreenWithNavigationStoreContext } from "../../../../utils/testWrapper";
 import PN_ROUTES from "../../navigation/routes";
+import { getNotificationStatusAccessibilityLabel } from "../../utils";
 
 const defaultProps: TimelineProps = {
   data: [
@@ -91,7 +92,19 @@ const defaultProps: TimelineProps = {
       time: "23:00",
       status: "cancelled"
     }
-  ],
+  ].map(
+    x =>
+      ({
+        accessibilityLabel: getNotificationStatusAccessibilityLabel({
+          status: x.status,
+          activeFrom: new Date(
+            `2024-${x.month}-${x.day.padStart(2, "0")}T${x.time}:00.000Z`
+          ),
+          relatedTimelineElements: []
+        }),
+        ...x
+      }) as TimelineItemProps
+  ),
   footerHeight: 116
 };
 

--- a/ts/features/pn/components/__test__/__snapshots__/Timeline.test.tsx.snap
+++ b/ts/features/pn/components/__test__/__snapshots__/Timeline.test.tsx.snap
@@ -349,6 +349,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                         }
                       >
                         <View
+                          accessibilityLabel="1 gennaio, 01:00, viewed"
                           accessible={true}
                           style={
                             {
@@ -526,6 +527,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                           </View>
                         </View>
                         <View
+                          accessibilityLabel="3 febbraio, 03:00, cancelled"
                           accessible={true}
                           style={
                             {
@@ -701,6 +703,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                           </View>
                         </View>
                         <View
+                          accessibilityLabel="6 marzo, 05:00, default"
                           accessible={true}
                           style={
                             {
@@ -876,6 +879,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                           </View>
                         </View>
                         <View
+                          accessibilityLabel="9 aprile, 07:00, default"
                           accessible={true}
                           style={
                             {
@@ -1051,6 +1055,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                           </View>
                         </View>
                         <View
+                          accessibilityLabel="11 maggio, 09:00, effective"
                           accessible={true}
                           style={
                             {
@@ -1226,6 +1231,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                           </View>
                         </View>
                         <View
+                          accessibilityLabel="14 giugno, 11:00, unreachable"
                           accessible={true}
                           style={
                             {
@@ -1401,6 +1407,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                           </View>
                         </View>
                         <View
+                          accessibilityLabel="15 luglio, 13:00, viewed"
                           accessible={true}
                           style={
                             {
@@ -1576,6 +1583,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                           </View>
                         </View>
                         <View
+                          accessibilityLabel="18 agosto, 15:00, default"
                           accessible={true}
                           style={
                             {
@@ -1751,6 +1759,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                           </View>
                         </View>
                         <View
+                          accessibilityLabel="21 settembre, 17:00, default"
                           accessible={true}
                           style={
                             {
@@ -1926,6 +1935,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                           </View>
                         </View>
                         <View
+                          accessibilityLabel="24 ottobre, 19:00, default"
                           accessible={true}
                           style={
                             {
@@ -2101,6 +2111,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                           </View>
                         </View>
                         <View
+                          accessibilityLabel="27 novembre, 21:00, default"
                           accessible={true}
                           style={
                             {
@@ -2276,6 +2287,7 @@ exports[`Timeline component should match the snapshot, default data 1`] = `
                           </View>
                         </View>
                         <View
+                          accessibilityLabel="30 dicembre, 23:00, cancelled"
                           accessible={true}
                           style={
                             {

--- a/ts/features/pn/utils/index.ts
+++ b/ts/features/pn/utils/index.ts
@@ -24,7 +24,7 @@ export const getNotificationStatusInfo = (status: NotificationStatus) =>
 export const getNotificationStatusAccessibilityLabel = (
   historyItem: NotificationStatusHistoryElement
 ) =>
-  `${format(historyItem.activeFrom, "DD MMMM, HH:mm")}, ${getNotificationStatusInfo(historyItem.status)}`;
+  `${format(historyItem.activeFrom, "D MMMM, HH:mm")}, ${getNotificationStatusInfo(historyItem.status)}`;
 
 export const notificationStatusToTimelineStatus = (
   status: NotificationStatus

--- a/ts/features/pn/utils/index.ts
+++ b/ts/features/pn/utils/index.ts
@@ -11,6 +11,8 @@ import { ATTACHMENT_CATEGORY } from "../../messages/types/attachmentCategory";
 import { ServiceId } from "../../../../definitions/backend/ServiceId";
 import { TimelineStatus } from "../components/Timeline";
 import { SendOpeningSource } from "../../pushNotifications/analytics";
+import { NotificationStatusHistoryElement } from "../../../../definitions/pn/NotificationStatusHistoryElement.ts";
+import { format } from "../../../utils/dates.ts";
 
 export const maxVisiblePaymentCount = 5;
 
@@ -18,6 +20,11 @@ export const getNotificationStatusInfo = (status: NotificationStatus) =>
   I18n.t(`features.pn.details.timeline.status.${status}`, {
     defaultValue: status
   });
+
+export const getNotificationStatusAccessibilityLabel = (
+  historyItem: NotificationStatusHistoryElement
+) =>
+  `${format(historyItem.activeFrom, "DD MMMM, HH:mm")}, ${getNotificationStatusInfo(historyItem.status)}`;
 
 export const notificationStatusToTimelineStatus = (
   status: NotificationStatus


### PR DESCRIPTION
## Short description
Update accessibilityLabel for timeline items in a more human-readable format ( time + status )

## List of changes proposed in this pull request
- Built accessibilityLabel using `NotificationStatusHistoryElement` props

## How to test
Open any SEND notification and from its notification status check what screen reader reads on timeline items.
<table><tr><th>Before</th><th>After</th></tr><tr><td>
<img width="610" height="1313" alt="Screenshot 2026-04-13 alle 15 36 37" src="https://github.com/user-attachments/assets/a536eb58-a123-418e-a9c1-3fb06e1ad069" />

</td><td>
<img width="615" height="1316" alt="image" src="https://github.com/user-attachments/assets/df1471ee-4f28-48c0-90f4-f3389251d87f" />

</td></tr></table>
