### PR TITLE
chore: [IEL-442] Updated copy for send AAR nfc error

### DIFF
--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -2541,7 +2541,7 @@
               "body": "Controlla che il sistema operativo sia aggiornato oppure scopri cosa fare.",
               "featureInfoText": [
                 "Per leggere la CIE è necessario un dispositivo con chip NFC.",
-                "È richiesto un sistema operativo Android 6.0 o iOS 13 o superiori."
+                "È richiesto un sistema operativo Android 8 o iOS 15.1 o superiori."
               ],
               "cta": "Cosa posso fare?"
             },

--- a/ts/features/pn/aar/components/errors/__tests__/__snapshots__/SendAarNfcNotSupportedComponent.test.tsx.snap
+++ b/ts/features/pn/aar/components/errors/__tests__/__snapshots__/SendAarNfcNotSupportedComponent.test.tsx.snap
@@ -626,7 +626,7 @@ exports[`SendAarNfcNotSupportedComponent should match the snapshot 1`] = `
                                 }
                                 testID="infoScreenBody"
                               >
-                                È richiesto un sistema operativo Android 6.0 o iOS 13 o superiori.
+                                È richiesto un sistema operativo Android 8 o iOS 15.1 o superiori.
                               </Text>
                             </View>
                           </View>


### PR DESCRIPTION
## Short description
Updated Os's versions for `SEND_AAR_ERROR` screen when Nfc is not supported

## List of changes proposed in this pull request
- Updated labels

## How to test
Using the dev server with its default configuration, generate the qr code for 'SEND-SEND-SEND-000004-A-0' ( the last of SEND AAR QRCodes) and pass it to `BARCODE_SCAN` screen, this will start the SEND flow for a delegated citizen. On `SEND_AAR_CIE_CARD_READING_EDUCATIONAL` after clicking the "start CIE reading" button if you're on an unsupported device there will be the `SEND_AAR_ERROR` displaying the `SendAarNfcNotSupportedComponent`

<table><tr><th>Before</th><th>After</th></tr><tr><td>
<img width="418" height="885" alt="Screenshot 2026-04-16 alle 17 17 24" src="https://github.com/user-attachments/assets/acc1e584-2ba8-4df9-ae9a-80226bd84c8f" />
</td><td>
<img width="418" height="885" alt="Screenshot 2026-04-16 alle 17 20 48" src="https://github.com/user-attachments/assets/7dee21fe-a796-40d5-ac84-a29dfc30e93a" />
</td></tr></table>