### PR TITLE
chore: [IOCOM-3101] io-react-native-http-client version bump

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Alamofire (5.9.1)
+  - Alamofire (5.11.2)
   - boost (1.84.0)
   - BVLinearGradient (2.5.6):
     - React
@@ -113,8 +113,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - IoReactNativeHttpClient (1.1.1):
-    - Alamofire (~> 5.9.1)
+  - IoReactNativeHttpClient (1.2.0):
+    - Alamofire (~> 5.11)
     - boost
     - DoubleConversion
     - fast_float
@@ -4007,7 +4007,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  Alamofire: f36a35757af4587d8e4f4bfa223ad10be2422b8c
+  Alamofire: 400275dd1c6d87d95a041861d2a59da4b520a203
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   BVLinearGradient: 44fd36b87f318e7933c4c91a6991442a5e3f5bcf
   CieSDK: f0413f57294d3df9cf915bc5b20e44b8ba2cb3cc
@@ -4026,7 +4026,7 @@ SPEC CHECKSUMS:
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 9f4dfe93326146a1c99eb535b1cb0b857a3cd172
   IoReactNativeCie: 8c772d46d499acad8cfab4e5993c5f50d78cd9e9
-  IoReactNativeHttpClient: 8095efc7a0ef59631b5664b35711c3ab42056d52
+  IoReactNativeHttpClient: bc2f2838fe9f959375d4d7e0419b11ebf27af379
   IoReactNativeIso18013: 785e402750f29c9e2e316ae13e3fa5add5da9b17
   IOWalletCBOR: 92742ef1cbd1b627ba153d0c7c11b81ad22f45cc
   IOWalletProximity: 1d8fc9acc9d97d34364c42927af3ac682448977e

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@pagopa/io-react-native-cie": "1.3.5-rc.2",
     "@pagopa/io-react-native-cieid": "0.4.0",
     "@pagopa/io-react-native-crypto": "^1.2.3",
-    "@pagopa/io-react-native-http-client": "1.1.1",
+    "@pagopa/io-react-native-http-client": "1.2.0",
     "@pagopa/io-react-native-integrity": "^0.3.2",
     "@pagopa/io-react-native-iso18013": "^0.8.1",
     "@pagopa/io-react-native-jwt": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4449,13 +4449,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagopa/io-react-native-http-client@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@pagopa/io-react-native-http-client@npm:1.1.1"
+"@pagopa/io-react-native-http-client@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@pagopa/io-react-native-http-client@npm:1.2.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 3f857dd16c58d17d18699336e439611982650e2d71c69d12376038f415fb1becc2a780789e2def818c2661df8fa93ed378ca67573a68352937c3f7e2ee36570a
+  checksum: 1d2628c1e3e89845f1bf9b620eb2927cda2f8de62525535d3500c20c9ef61f6c4c41f3d24b779aa784907f3f75621b3edfc1d8e81fb5934d1636a89e5614c045
   languageName: node
   linkType: hard
 
@@ -13738,7 +13738,7 @@ __metadata:
     "@pagopa/io-react-native-cie": 1.3.5-rc.2
     "@pagopa/io-react-native-cieid": 0.4.0
     "@pagopa/io-react-native-crypto": ^1.2.3
-    "@pagopa/io-react-native-http-client": 1.1.1
+    "@pagopa/io-react-native-http-client": 1.2.0
     "@pagopa/io-react-native-integrity": ^0.3.2
     "@pagopa/io-react-native-iso18013": ^0.8.1
     "@pagopa/io-react-native-jwt": ^2.1.0


### PR DESCRIPTION
## Short description
this PR updates said package to 1.2.0

## List of changes proposed in this pull request
- updated package
- updated podfile dependencies linked to it

## How to test
automated tests should pass.
also, on both an android and an iOS physical device, the driving license score and  lombardy's welfare flows should not show any regressions
