### PR TITLE
fix: [IOPLT-1779] Fix `codecov` setup

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -60,6 +60,8 @@ jobs:
     needs: unit-test
     if: always()
     steps:
+      - id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: download-coverage
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -60,8 +60,6 @@ jobs:
     needs: unit-test
     if: always()
     steps:
-      - id: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: download-coverage
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,5 +18,6 @@ module.exports = {
   globalSetup: "./jestGlobalSetup.js",
   setupFilesAfterEnv: ["./jestAfterEnvSetup.js"],
   collectCoverage: true,
+  coverageReporters: ["lcov", "text"],
   testPathIgnorePatterns: [".*fiscal-code.test.ts$"]
 };


### PR DESCRIPTION
## Short description
Fix the `codecov` setup, because it has been disrupted after the merge of this PR:
* https://github.com/pagopa/io-app/pull/8009
## List of changes proposed in this pull request
- Add `checkout` step
- Configure `jestSetup` to generate only the files required by the `codecov` job to reduce the overall footprint
