### PR TITLE
chore: [IEG-2805] Add emilio-dimari as CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,9 @@
 # see https://help.github.com/en/articles/about-code-owners#example-of-a-codeowners-file
 
-* @pagopa/io-app @ChrisMattew @gispada @soixdev91
+* @pagopa/io-app @ChrisMattew @gispada @soixdev91 @emilio-dimari 
 
-/locales/ @pagopa/io-app @thisisjp @ChrisMattew @gispada @soixdev91
-/ios/IO/it.lproj/ @pagopa/io-app @thisisjp @ChrisMattew @gispada @soixdev91
-/ios/IO/en.lproj/ @pagopa/io-app @thisisjp @ChrisMattew @gispada @soixdev91
-/ts/features/design-system @pagopa/io-app @dmnplb @ChrisMattew @gispada @soixdev91
-/ts/components/ui @pagopa/io-app @dmnplb @ChrisMattew @gispada @soixdev91
+/locales/ @pagopa/io-app @thisisjp @ChrisMattew @gispada @soixdev91 @emilio-dimari
+/ios/IO/it.lproj/ @pagopa/io-app @thisisjp @ChrisMattew @gispada @soixdev91 @emilio-dimari
+/ios/IO/en.lproj/ @pagopa/io-app @thisisjp @ChrisMattew @gispada @soixdev91 @emilio-dimari
+/ts/features/design-system @pagopa/io-app @dmnplb @ChrisMattew @gispada @soixdev91 @emilio-dimari
+/ts/components/ui @pagopa/io-app @dmnplb @ChrisMattew @gispada @soixdev91 @emilio-dimari


### PR DESCRIPTION
> [!WARNING]
> This PR depends on https://github.com/pagopa/eng-github-authorization/pull/3375 

## Short description
This pull request updates the `CODEOWNERS` file to include `@emilio-dimari` as a code owner for the entire repository and several key directories. This ensures that `@emilio-dimari` will be automatically requested for review on relevant pull requests.

## List of changes proposed in this pull request
- Added `@emilio-dimari` as a code owner

## How to test
N/A