### PR TITLE
perf: [IOPLT-1780] Improve the `codecov` setup

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: coverage-${{ matrix.shard }}
-          path: coverage/
+          path: coverage/lcov.info
           retention-days: 1
   codecov:
     name: Codecov

--- a/codecov.yml
+++ b/codecov.yml
@@ -27,6 +27,9 @@ comment:
   require_changes: false
 
 ignore:
+  - "ts/@types"
+  - "ts/__mocks__"
+  - "ts/theme"
   - "ts/features/design-system"
   - "ts/features/**/playgrounds"
   - "ts/features/settings/devMode"

--- a/codecov.yml
+++ b/codecov.yml
@@ -26,5 +26,10 @@ comment:
   behavior: default
   require_changes: false
 
+ignore:
+  - "ts/features/design-system"
+  - "ts/features/**/playgrounds"
+  - "ts/features/settings/devMode"
+
 github_checks:
   annotations: false

--- a/jest.config.js
+++ b/jest.config.js
@@ -19,5 +19,12 @@ module.exports = {
   setupFilesAfterEnv: ["./jestAfterEnvSetup.js"],
   collectCoverage: true,
   coverageReporters: ["lcov", "text"],
+  coveragePathIgnorePatterns: [
+    "<rootDir>/ts/@types/",
+    "<rootDir>/ts/theme/",
+    "<rootDir>/ts/features/design-system/",
+    "<rootDir>/ts/features/.*/playgrounds/",
+    "<rootDir>/ts/features/settings/devMode/"
+  ],
   testPathIgnorePatterns: [".*fiscal-code.test.ts$"]
 };


### PR DESCRIPTION
## Short description
Add the following two enhancements to the `codecov` setup, after the separate job added in this PR:
- https://github.com/pagopa/io-app/pull/8009

Firstly, the `upload-coverage` job only uploads the relevant files (a few KB), rather than the entire report (around 15/16 MB per shard). Retention set at one day was already minimising the impact, but we want to avoid wasting compute resources on useless material.

Secondly, we ignore all internal sections (DS, Playgrounds, etc.) as these were never covered by tests.

## Changes
- Update `*.yaml` and `*.yml` conf files to reflect the new setup

## How to test
Check the `codecov` job in the **Static checks** CI workflow