### PR TITLE
ci: [IOPLT-1781] Get last version code from play store on canary build

### DIFF
--- a/.github/workflows/publish-app-canary.yml
+++ b/.github/workflows/publish-app-canary.yml
@@ -8,6 +8,7 @@ jobs:
     name: Prepare canary release
     needs: run-static-checks
     runs-on: ubuntu-24.04
+    environment: canary
     outputs:
       canaryVersion: ${{ steps.github-release-creation.outputs.CANARY_VERSION }}
     steps:
@@ -29,9 +30,20 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
       - id: install-packages
         run: yarn install --frozen-lockfile
+      - id: setup-ruby
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
+        with:
+          bundler-cache: true
+      - id: resolve-canary-version-code
+        run: |
+          echo $ENCODED_IOAPP_JSON_KEY_FILE | base64 --decode > /tmp/json-key.json
+          cd android
+          bundle exec fastlane current_canary_version_code
+        env:
+          ENCODED_IOAPP_JSON_KEY_FILE: ${{ secrets.ENCODED_IOAPP_JSON_KEY_FILE }}
       - id: replace-version-with-canary
         run: |
-          UPDATED_BUILD_CODE=$(git rev-list HEAD --count)
+          UPDATED_BUILD_CODE=${{ steps.resolve-canary-version-code.outputs.CURRENT_CANARY_VERSION_CODE }}
           node scripts/canary/replaceCanaryVersion.js $UPDATED_BUILD_CODE
           mv ios/fastlane/Matchfile ios/fastlane/Matchfile_prod
           mv ios/fastlane/Matchfile_canary ios/fastlane/Matchfile

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -20,6 +20,24 @@ platform :android do
     # ENV["SLACK_URL"] = "https://hooks.slack.com/services/..."
   end
 
+  desc "Get current canary version code from Google Play"
+  lane :current_canary_version_code do
+    version_codes = google_play_track_version_codes(
+      package_name: "it.pagopa.io.app.canary",
+      track: "internal"
+    ) || []
+
+    current_code = (version_codes.map(&:to_i).max || 0)
+
+    if ENV["GITHUB_OUTPUT"]
+      File.open(ENV["GITHUB_OUTPUT"], "a") do |file|
+        file.puts("CURRENT_CANARY_VERSION_CODE=#{current_code}")
+      end
+    end
+
+    UI.message("CURRENT_CANARY_VERSION_CODE=#{current_code}")
+  end
+
   desc "Runs all the tests"
   lane :test do
     gradle(task: "test")

--- a/scripts/canary/replaceCanaryVersion.js
+++ b/scripts/canary/replaceCanaryVersion.js
@@ -21,11 +21,13 @@ const replaceCanaryVersion = () => {
 
   const versionSplit = package.version.split("-");
 
-  // replace the version, removing the rc part
-  package.version = `${versionSplit[0]}-canary.${parseInt(
-    process.argv[2],
+  const normalizedVersion = parseInt(
+    process.argv[2].slice(5),
     10
-  )}`;
+  );
+
+  // replace the version, removing the rc part
+  package.version = `${versionSplit[0]}-canary.${isNaN(normalizedVersion) ? 0 : normalizedVersion}`;
 
   const contents = fs.readFileSync(gradlePath).toString("utf8");
 
@@ -34,7 +36,7 @@ const replaceCanaryVersion = () => {
     (substr, ...args) =>
       replaceVersionCode(
         substr,
-        `20000${parseInt(process.argv[2], 10)}`,
+        `${parseInt(process.argv[2], 10)}`,
         ...args
       )
   );


### PR DESCRIPTION
## Short description
This pull request updates the canary release workflow to ensure the Android canary version code is accurately retrieved from Google Play and consistently applied throughout the build process. The main improvements involve introducing a Fastlane lane to fetch the current canary version code, integrating this into the GitHub Actions workflow, and updating the version replacement script for better reliability.

## List of changes proposed in this pull request
* Added a new Fastlane lane `current_canary_version_code` in `android/fastlane/Fastfile` to fetch the latest canary version code from the Google Play internal track, and output it for use in CI/CD pipelines.
* Updated `.github/workflows/publish-app-canary.yml` to run the new Fastlane lane and use its output as the build code, ensuring the canary version code is always in sync with Google Play.
* Set the `environment: canary` for the release job to improve workflow safety and environment targeting.
* Modified `scripts/canary/replaceCanaryVersion.js` to extract and normalize the version code from the argument, handle invalid values gracefully, and ensure the version string is correctly formatted.
* Updated the script to use the resolved canary version code directly, removing hardcoded prefixes and improving consistency.

## How to test
Run a canary build to check the changes perform as expected
