### PR TITLE
chore: [IEL-411] Updated copy for CIE scan screen on Android

### DIFF
--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -2480,7 +2480,8 @@
           },
           "cieScanning": {
             "idle": {
-              "title": "Poggia il retro del telefono sulla CIE",
+              "title": "Posiziona il retro del telefono sulla CIE",
+              "subtitle": "Fai scorrere il telefono sulla carta. Un suono o una vibrazione indicano che la carta è stata rilevata. Se la lettura non parte con il retro, prova con il lato anteriore del telefono.",
               "status": "Posiziona il telefono sulla CIE per iniziare la lettura."
             },
             "reading": {

--- a/ts/features/pn/aar/components/SendAarCieCardReadingComponent.tsx
+++ b/ts/features/pn/aar/components/SendAarCieCardReadingComponent.tsx
@@ -227,6 +227,7 @@ export const SendAarCieCardReadingComponent = ({
     return {
       [ReadStatus.IDLE]: {
         title: i18n.t("features.pn.aar.flow.cieScanning.idle.title"),
+        subtitle: i18n.t("features.pn.aar.flow.cieScanning.idle.subtitle"),
         pictogram: "nfcScanAndroid",
         secondaryAction: {
           testID: "idleCloseButton",

--- a/ts/features/pn/aar/components/__tests__/__snapshots__/SendAarCieCardReadingComponent.test.tsx.snap
+++ b/ts/features/pn/aar/components/__tests__/__snapshots__/SendAarCieCardReadingComponent.test.tsx.snap
@@ -4863,6 +4863,26 @@ exports[`SendAarCieCardReadingComponent should match the snapshot for readState:
                                     features.pn.aar.flow.cieScanning.idle.title
                                   </Text>
                                 </View>
+                                <Text
+                                  allowFontScaling={true}
+                                  dynamicTypeRamp="body"
+                                  maxFontSizeMultiplier={1.5}
+                                  style={
+                                    [
+                                      {},
+                                      {
+                                        "color": "#636B82",
+                                        "fontFamily": "Titillio",
+                                        "fontSize": 16,
+                                        "fontStyle": "normal",
+                                        "fontWeight": "400",
+                                        "lineHeight": 24,
+                                      },
+                                    ]
+                                  }
+                                >
+                                  features.pn.aar.flow.cieScanning.idle.subtitle
+                                </Text>
                               </View>
                               <RNSVGSvgView
                                 align="xMidYMid"


### PR DESCRIPTION
## Short description
Updated copy for CIE scan screen (`SendAarCieCardReadingComponent`) on Android

## List of changes proposed in this pull request
- Changed title for idle state
- Added subtitle for idle state
- Updated test

## How to test
Using the dev server with its default configuration, generate the qr code for 'SEND-SEND-SEND-000004-A-0' ( the last of SEND AAR QRCodes) and pass it to BARCODE_SCAN screen on Android, this will start the SEND flow for a delegated citizen. `SEND_AAR_CIE_CARD_READING` is the updated screen
<table>
<tr>
<th>Before</th><th>After</th>
</tr>
<tr>
<td>
<img width="613" height="1315" alt="Screenshot 2026-04-20 alle 15 31 35" src="https://github.com/user-attachments/assets/a0a1a081-af6c-46a3-8bbf-e0bda75099fe" />

</td>
<td>
<img width="613" height="1315" alt="Screenshot 2026-04-20 alle 15 29 33" src="https://github.com/user-attachments/assets/a917cb0a-96f4-4326-b5e1-3db45ad9f7e7" />

</td>
</tr>
</table>
