### PR TITLE
chore: [IEL-451] added remote FF and url for Fci Security check

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -2,7 +2,7 @@
 
 IO_BACKEND_VERSION=v17.5.2
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=1.0.98
+IO_SERVICES_METADATA_VERSION=1.0.100
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.23.1
 # IO Wallet user function version

--- a/ts/features/fci/store/selectors/__tests__/remoteConfig.test.ts
+++ b/ts/features/fci/store/selectors/__tests__/remoteConfig.test.ts
@@ -71,6 +71,20 @@ describe("isFciSecurityLevelCheckEnabledSelector", () => {
       )
     ).toBe(true);
   });
+
+  it("returns true when both min_app_version gates are satisfied (Security Level min version Equals App version)", () => {
+    mockAppVersion("2.0.0.0");
+    expect(
+      isFciSecurityLevelCheckEnabledSelector(
+        makeState({
+          min_app_version: { ios: "1.0.0.0", android: "1.0.0.0" },
+          security_level_check: {
+            min_app_version: { ios: "2.0.0.0", android: "2.0.0.0" }
+          }
+        })
+      )
+    ).toBe(true);
+  });
 });
 
 describe("fciSecurityLevelCheckHelpCenterUrlSelector", () => {

--- a/ts/features/fci/store/selectors/__tests__/remoteConfig.test.ts
+++ b/ts/features/fci/store/selectors/__tests__/remoteConfig.test.ts
@@ -1,0 +1,102 @@
+import * as O from "fp-ts/lib/Option";
+import * as appVersion from "../../../../../utils/appVersion";
+import {
+  fciSecurityLevelCheckHelpCenterUrlSelector,
+  isFciSecurityLevelCheckEnabledSelector
+} from "../remoteConfig";
+import { GlobalState } from "../../../../../store/reducers/types.ts";
+
+const noneState = { remoteConfig: O.none } as GlobalState;
+
+const makeState = (fci: object): GlobalState =>
+  ({ remoteConfig: O.some({ fci }) }) as GlobalState;
+
+const mockAppVersion = (v: string) =>
+  jest.spyOn(appVersion, "getAppVersion").mockReturnValue(v);
+
+describe("isFciSecurityLevelCheckEnabledSelector", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it("returns false when remoteConfig is none", () => {
+    expect(isFciSecurityLevelCheckEnabledSelector(noneState)).toBe(false);
+  });
+
+  it("returns false when fci min_app_version is not satisfied", () => {
+    mockAppVersion("1.0.0.0");
+    expect(
+      isFciSecurityLevelCheckEnabledSelector(
+        makeState({
+          min_app_version: { ios: "2.0.0.0", android: "2.0.0.0" },
+          security_level_check: {
+            min_app_version: { ios: "1.0.0.0", android: "1.0.0.0" }
+          }
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("returns false when security_level_check min_app_version is not satisfied", () => {
+    mockAppVersion("1.0.0.0");
+    expect(
+      isFciSecurityLevelCheckEnabledSelector(
+        makeState({
+          min_app_version: { ios: "1.0.0.0", android: "1.0.0.0" },
+          security_level_check: {
+            min_app_version: { ios: "2.0.0.0", android: "2.0.0.0" }
+          }
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("returns false when security_level_check is absent", () => {
+    mockAppVersion("2.0.0.0");
+    expect(
+      isFciSecurityLevelCheckEnabledSelector(
+        makeState({ min_app_version: { ios: "1.0.0.0", android: "1.0.0.0" } })
+      )
+    ).toBe(false);
+  });
+
+  it("returns true when both min_app_version gates are satisfied", () => {
+    mockAppVersion("3.0.0.0");
+    expect(
+      isFciSecurityLevelCheckEnabledSelector(
+        makeState({
+          min_app_version: { ios: "1.0.0.0", android: "1.0.0.0" },
+          security_level_check: {
+            min_app_version: { ios: "2.0.0.0", android: "2.0.0.0" }
+          }
+        })
+      )
+    ).toBe(true);
+  });
+});
+
+describe("fciSecurityLevelCheckHelpCenterUrlSelector", () => {
+  it("returns undefined when remoteConfig is none", () => {
+    expect(
+      fciSecurityLevelCheckHelpCenterUrlSelector(noneState)
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when helpCenter_url is absent", () => {
+    expect(
+      fciSecurityLevelCheckHelpCenterUrlSelector(
+        makeState({ min_app_version: { ios: "1.0.0.0", android: "1.0.0.0" } })
+      )
+    ).toBeUndefined();
+  });
+
+  it("returns the helpCenter_url when present", () => {
+    const url = "https://help.example.com/fci-security";
+    expect(
+      fciSecurityLevelCheckHelpCenterUrlSelector(
+        makeState({
+          min_app_version: { ios: "1.0.0.0", android: "1.0.0.0" },
+          security_level_check: { helpCenter_url: url }
+        })
+      )
+    ).toBe(url);
+  });
+});

--- a/ts/features/fci/store/selectors/remoteConfig.ts
+++ b/ts/features/fci/store/selectors/remoteConfig.ts
@@ -1,0 +1,42 @@
+import * as O from "fp-ts/lib/Option";
+import { pipe } from "fp-ts/lib/function";
+import { createSelector } from "reselect";
+import { GlobalState } from "../../../../store/reducers/types.ts";
+import { isMinAppVersionSupported } from "../../../../store/reducers/featureFlagWithMinAppVersionStatus.ts";
+
+const fciRemoteConfigSelector = (state: GlobalState) =>
+  pipe(
+    state.remoteConfig,
+    O.map(config => config.fci)
+  );
+
+/**
+ * Return the remote config about FCI's Security Level Check (if it requires L3 auth) enabled/disabled
+ * if there is no data or the local Feature Flag is disabled,
+ * false is the default value -> (FCI's Security Level Check disabled)
+ */
+export const isFciSecurityLevelCheckEnabledSelector = (state: GlobalState) =>
+  pipe(
+    state,
+    fciRemoteConfigSelector,
+    fciConfig =>
+      isMinAppVersionSupported(fciConfig) &&
+      pipe(
+        fciConfig,
+        O.chainNullableK(fci => fci.security_level_check),
+        isMinAppVersionSupported
+      )
+  );
+
+/**
+ * Return the remote config help center url for the FCI security level check.
+ */
+export const fciSecurityLevelCheckHelpCenterUrlSelector = createSelector(
+  fciRemoteConfigSelector,
+  fciConfig =>
+    pipe(
+      fciConfig,
+      O.map(fci => fci.security_level_check?.helpCenter_url),
+      O.toUndefined
+    )
+);


### PR DESCRIPTION
> [!NOTE]
> Depends on https://github.com/pagopa/io-services-metadata/pull/1182
## Short description
Adds remote feature flag support for the FCI Security Level Check feature.

## List of changes proposed in this pull request
- Added `isFciSecurityLevelCheckEnabledSelector` which reads `fci.security_level_check `from remote config and checks both the parent fci and the security_level_check minimum app version
- Added `fciSecurityLevelCheckHelpCenterUrlSelector` which reads `fci.security_level_check.helpCenter_url` from remote config

## How to test
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
