### PR TITLE
fix: [SIW-000] Fix crash on ItwEidLifecycleAlert rendered outside navigation context

### DIFF
--- a/ts/features/itwallet/common/components/ItwEidInfoBottomSheetContent.tsx
+++ b/ts/features/itwallet/common/components/ItwEidInfoBottomSheetContent.tsx
@@ -55,10 +55,12 @@ export const ItwEidInfoBottomSheetTitle = ({
 
 type ItwEidInfoBottomSheetContentProps = {
   navigation: ReturnType<typeof useIONavigation>;
+  currentScreenName?: string;
 };
 
 const ItwEidInfoBottomSheetContent = ({
-  navigation
+  navigation,
+  currentScreenName
 }: ItwEidInfoBottomSheetContentProps) => {
   const eidOption = useIOSelector(itwCredentialsEidSelector);
   const eidStatus = useIOSelector(itwCredentialsEidStatusSelector);
@@ -96,7 +98,11 @@ const ItwEidInfoBottomSheetContent = ({
             "features.itWallet.presentation.bottomSheets.eidInfo.contentTop"
           )}
         />
-        <ItwEidLifecycleAlert navigation={navigation} skipViewTracking={true} />
+        <ItwEidLifecycleAlert
+          navigation={navigation}
+          currentScreenName={currentScreenName}
+          skipViewTracking={true}
+        />
         <View>
           {claims.map((claim, index) => (
             <Fragment key={index}>

--- a/ts/features/itwallet/common/components/ItwEidLifecycleAlert.tsx
+++ b/ts/features/itwallet/common/components/ItwEidLifecycleAlert.tsx
@@ -6,7 +6,6 @@ import * as O from "fp-ts/lib/Option";
 import I18n from "i18next";
 import { ComponentProps, useMemo } from "react";
 import { View } from "react-native";
-import { useRoute } from "@react-navigation/native";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { useIOSelector } from "../../../../store/hooks";
 import { offlineAccessReasonSelector } from "../../../ingress/store/selectors";
@@ -18,8 +17,8 @@ import { itwLifecycleIsITWalletValidSelector } from "../../lifecycle/store/selec
 import { ITW_ROUTES } from "../../navigation/routes";
 import { useItwEidLifecycleAlertTracking } from "../hooks/useItwEidLifecycleAlertTracking";
 import {
-  ItwJwtCredentialStatus,
-  CredentialMetadata
+  CredentialMetadata,
+  ItwJwtCredentialStatus
 } from "../utils/itwTypesUtils";
 
 const defaultLifecycleStatus: Array<ItwJwtCredentialStatus> = [
@@ -34,6 +33,11 @@ type Props = {
    */
   lifecycleStatus?: Array<ItwJwtCredentialStatus>;
   navigation: ReturnType<typeof useIONavigation>;
+  /**
+   * The name of the current screen, used for analytics tracking
+   * and conditional rendering logic (e.g. PID detail screen).
+   */
+  currentScreenName?: string;
   skipViewTracking?: boolean;
 };
 
@@ -43,9 +47,9 @@ type Props = {
 export const ItwEidLifecycleAlert = ({
   lifecycleStatus = defaultLifecycleStatus,
   navigation,
+  currentScreenName,
   skipViewTracking
 }: Props) => {
-  const { name: currentScreenName } = useRoute();
   const eidOption = useIOSelector(itwCredentialsEidSelector);
   const isItw = useIOSelector(itwLifecycleIsITWalletValidSelector);
   const maybeEidStatus = useIOSelector(itwCredentialsEidStatusSelector);

--- a/ts/features/itwallet/common/components/__tests__/ItwEidLifecycleAlert.test.tsx
+++ b/ts/features/itwallet/common/components/__tests__/ItwEidLifecycleAlert.test.tsx
@@ -1,0 +1,138 @@
+import { render } from "@testing-library/react-native";
+import * as O from "fp-ts/lib/Option";
+import { createStore } from "redux";
+import { Provider } from "react-redux";
+import { applicationChangeState } from "../../../../../store/actions/application";
+import { appReducer } from "../../../../../store/reducers";
+import { ItwEidLifecycleAlert } from "../ItwEidLifecycleAlert";
+import * as credentialsSelectors from "../../../credentials/store/selectors";
+import * as lifecycleSelectors from "../../../lifecycle/store/selectors";
+import { ItwStoredCredentialsMocks } from "../../utils/itwMocksUtils";
+import * as alertTracking from "../../hooks/useItwEidLifecycleAlertTracking";
+
+const mockNavigation = {
+  navigate: jest.fn(),
+  addListener: jest.fn(() => jest.fn())
+} as any;
+
+jest.mock("../../../../../navigation/params/AppParamsList", () => ({
+  useIONavigation: () => mockNavigation
+}));
+
+describe("ItwEidLifecycleAlert", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should not crash when rendered outside a navigation context without currentScreenName", () => {
+    jest
+      .spyOn(credentialsSelectors, "itwCredentialsEidSelector")
+      .mockReturnValue(O.some(ItwStoredCredentialsMocks.eid));
+    jest
+      .spyOn(credentialsSelectors, "itwCredentialsEidStatusSelector")
+      .mockReturnValue("jwtExpiring");
+    jest
+      .spyOn(lifecycleSelectors, "itwLifecycleIsITWalletValidSelector")
+      .mockReturnValue(true);
+
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+
+    expect(() =>
+      render(
+        <Provider store={store}>
+          <ItwEidLifecycleAlert navigation={mockNavigation} />
+        </Provider>
+      )
+    ).not.toThrow();
+  });
+
+  it("should forward currentScreenName to the tracking hook", () => {
+    const expectedRoute = "ITW_PRESENTATION_EID_DETAIL";
+    const trackingSpy = jest.spyOn(
+      alertTracking,
+      "useItwEidLifecycleAlertTracking"
+    );
+
+    jest
+      .spyOn(credentialsSelectors, "itwCredentialsEidSelector")
+      .mockReturnValue(O.some(ItwStoredCredentialsMocks.eid));
+    jest
+      .spyOn(credentialsSelectors, "itwCredentialsEidStatusSelector")
+      .mockReturnValue("jwtExpiring");
+    jest
+      .spyOn(lifecycleSelectors, "itwLifecycleIsITWalletValidSelector")
+      .mockReturnValue(true);
+
+    renderComponent({ currentScreenName: expectedRoute });
+
+    expect(trackingSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentScreenName: expectedRoute
+      })
+    );
+  });
+
+  it("should render the alert when eID status is included in lifecycleStatus", () => {
+    jest
+      .spyOn(credentialsSelectors, "itwCredentialsEidSelector")
+      .mockReturnValue(O.some(ItwStoredCredentialsMocks.eid));
+    jest
+      .spyOn(credentialsSelectors, "itwCredentialsEidStatusSelector")
+      .mockReturnValue("jwtExpiring");
+    jest
+      .spyOn(lifecycleSelectors, "itwLifecycleIsITWalletValidSelector")
+      .mockReturnValue(true);
+
+    const { queryByTestId } = renderComponent();
+
+    expect(queryByTestId("itwEidLifecycleAlertTestID")).not.toBeNull();
+  });
+
+  it("should not render the alert when eID option is none", () => {
+    jest
+      .spyOn(credentialsSelectors, "itwCredentialsEidSelector")
+      .mockReturnValue(O.none);
+    jest
+      .spyOn(credentialsSelectors, "itwCredentialsEidStatusSelector")
+      .mockReturnValue(undefined);
+    jest
+      .spyOn(lifecycleSelectors, "itwLifecycleIsITWalletValidSelector")
+      .mockReturnValue(false);
+
+    const { queryByTestId } = renderComponent();
+
+    expect(queryByTestId("itwEidLifecycleAlertTestID")).toBeNull();
+  });
+
+  it("should not render the alert when eID status is not in lifecycleStatus", () => {
+    jest
+      .spyOn(credentialsSelectors, "itwCredentialsEidSelector")
+      .mockReturnValue(O.some(ItwStoredCredentialsMocks.eid));
+    jest
+      .spyOn(credentialsSelectors, "itwCredentialsEidStatusSelector")
+      .mockReturnValue("valid");
+    jest
+      .spyOn(lifecycleSelectors, "itwLifecycleIsITWalletValidSelector")
+      .mockReturnValue(true);
+
+    const { queryByTestId } = renderComponent({
+      lifecycleStatus: ["jwtExpiring"]
+    });
+
+    expect(queryByTestId("itwEidLifecycleAlertTestID")).toBeNull();
+  });
+});
+
+const renderComponent = (
+  props: Partial<React.ComponentProps<typeof ItwEidLifecycleAlert>> = {}
+) => {
+  const globalState = appReducer(undefined, applicationChangeState("active"));
+  const store = createStore(appReducer, globalState as any);
+
+  return render(
+    <Provider store={store}>
+      <ItwEidLifecycleAlert navigation={mockNavigation} {...props} />
+    </Provider>
+  );
+};

--- a/ts/features/itwallet/presentation/details/components/ItwPresentationCredentialStatusAlert.tsx
+++ b/ts/features/itwallet/presentation/details/components/ItwPresentationCredentialStatusAlert.tsx
@@ -4,6 +4,7 @@ import { pipe } from "fp-ts/lib/function";
 import I18n from "i18next";
 import { memo, useCallback } from "react";
 import { View } from "react-native";
+import { useRoute } from "@react-navigation/native";
 import IOMarkdown from "../../../../../components/IOMarkdown";
 import { useIOSelector } from "../../../../../store/hooks.ts";
 import { format } from "../../../../../utils/dates.ts";
@@ -161,6 +162,7 @@ export const deriveCredentialAlertType = (
  */
 const ItwPresentationCredentialStatusAlert = ({ credential }: Props) => {
   const navigation = useIONavigation();
+  const { name: currentScreenName } = useRoute();
   const eidStatus = useIOSelector(itwCredentialsEidStatusSelector);
   const { status, message } = useIOSelector(state =>
     itwCredentialStatusSelector(state, credential.credentialType)
@@ -209,7 +211,12 @@ const ItwPresentationCredentialStatusAlert = ({ credential }: Props) => {
 
   switch (alertType) {
     case CredentialAlertType.EID_LIFECYCLE:
-      return <ItwEidLifecycleAlert navigation={navigation} />;
+      return (
+        <ItwEidLifecycleAlert
+          navigation={navigation}
+          currentScreenName={currentScreenName}
+        />
+      );
     case CredentialAlertType.JWT_VERIFICATION:
       return (
         <JwtVerificationAlert

--- a/ts/features/itwallet/presentation/details/components/ItwPresentationPidDetail.tsx
+++ b/ts/features/itwallet/presentation/details/components/ItwPresentationPidDetail.tsx
@@ -3,6 +3,7 @@ import I18n from "i18next";
 import { useMemo, useState } from "react";
 import { View } from "react-native";
 import { Fragment } from "react/jsx-runtime";
+import { useRoute } from "@react-navigation/native";
 import { useIONavigation } from "../../../../../navigation/params/AppParamsList";
 import { ItwCredentialClaim } from "../../../common/components/ItwCredentialClaim";
 import { ItwEidLifecycleAlert } from "../../../common/components/ItwEidLifecycleAlert";
@@ -20,6 +21,7 @@ type Props = {
 export const ItwPresentationPidDetail = ({ credential }: Props) => {
   const [claimsHidden, setClaimsHidden] = useState(false);
   const navigation = useIONavigation();
+  const { name: currentScreenName } = useRoute();
 
   const listItemHeaderLabel = I18n.t(
     "features.itWallet.presentation.itWalletId.listItemHeader"
@@ -46,7 +48,11 @@ export const ItwPresentationPidDetail = ({ credential }: Props) => {
 
   return (
     <View>
-      <ItwEidLifecycleAlert navigation={navigation} skipViewTracking={false} />
+      <ItwEidLifecycleAlert
+        navigation={navigation}
+        currentScreenName={currentScreenName}
+        skipViewTracking={false}
+      />
       {claims.length > 0 && (
         <ListItemHeader label={listItemHeaderLabel} endElement={endElement} />
       )}

--- a/ts/features/itwallet/settings/screens/ItwSettingsScreen.tsx
+++ b/ts/features/itwallet/settings/screens/ItwSettingsScreen.tsx
@@ -1,5 +1,5 @@
 import { ContentWrapper, IOToast, VStack } from "@pagopa/io-app-design-system";
-import { useFocusEffect } from "@react-navigation/native";
+import { useFocusEffect, useRoute } from "@react-navigation/native";
 import { TxtLinkNode } from "@textlint/ast-node-types";
 import I18n from "i18next";
 import { useCallback, useMemo } from "react";
@@ -26,6 +26,7 @@ const MIXPANEL_SCREEN_NAME = ITW_SCREENVIEW_EVENTS.ITW_SETTINGS;
 
 const ItwSettingsScreen = () => {
   const navigation = useIONavigation();
+  const { name: currentScreenName } = useRoute();
   const machineRef = ItwEidIssuanceMachineContext.useActorRef();
   const isWalletValid = useIOSelector(itwLifecycleIsITWalletValidSelector);
 
@@ -91,7 +92,12 @@ const ItwSettingsScreen = () => {
       <ContentWrapper>
         <VStack space={8}>
           <View />
-          {isWalletValid && <ItwEidLifecycleAlert navigation={navigation} />}
+          {isWalletValid && (
+            <ItwEidLifecycleAlert
+              navigation={navigation}
+              currentScreenName={currentScreenName}
+            />
+          )}
           <IOMarkdown
             content={I18n.t("features.itWallet.settings.manage.content")}
             // TODO [SIW-2632] remove this rule and add IT Wallet url to I18n locales

--- a/ts/features/itwallet/wallet/components/ItwWalletCardsContainer.tsx
+++ b/ts/features/itwallet/wallet/components/ItwWalletCardsContainer.tsx
@@ -1,5 +1,5 @@
 import { ListItemHeader, VStack } from "@pagopa/io-app-design-system";
-import { useFocusEffect } from "@react-navigation/native";
+import { useFocusEffect, useRoute } from "@react-navigation/native";
 import I18n from "i18next";
 import { useCallback, useMemo } from "react";
 import { StyleSheet, View } from "react-native";
@@ -46,6 +46,7 @@ const LIFECYCLE_STATUS: Array<ItwJwtCredentialStatus> = [
 
 export const ItwWalletCardsContainer = withWalletCategoryFilter("itw", () => {
   const navigation = useIONavigation();
+  const { name: currentScreenName } = useRoute();
   const isNewItwRenderable = useIOSelector(itwShouldRenderNewItWalletSelector);
   const shouldHideEidAlert = useIOSelector(itwShouldHideEidLifecycleAlert);
   const shouldRenderUpgradeBanner = useIOSelector(
@@ -77,7 +78,12 @@ export const ItwWalletCardsContainer = withWalletCategoryFilter("itw", () => {
 
   const eidInfoBottomSheet = useIOBottomSheetModal({
     title: <ItwEidInfoBottomSheetTitle isExpired={isEidExpired} />,
-    component: <ItwEidInfoBottomSheetContent navigation={navigation} />
+    component: (
+      <ItwEidInfoBottomSheetContent
+        navigation={navigation}
+        currentScreenName={currentScreenName}
+      />
+    )
   });
 
   useFocusEffect(
@@ -131,6 +137,7 @@ export const ItwWalletCardsContainer = withWalletCategoryFilter("itw", () => {
           <ItwEidLifecycleAlert
             lifecycleStatus={LIFECYCLE_STATUS}
             navigation={navigation}
+            currentScreenName={currentScreenName}
           />
         )}
         {/* Dummy view to add space in case there is another component */}


### PR DESCRIPTION
## Short description
Fix a crash occurring when `ItwEidLifecycleAlert` is rendered outside a navigation route context (e.g., inside a bottom sheet). The component previously called `useRoute()` directly, which throws when no route is available. This change replaces it with an explicit `currentScreenName` optional prop passed from the parent.

## List of changes proposed in this pull request
- Removed `useRoute()` from `ItwEidLifecycleAlert`, replacing it with a `currentScreenName` optional prop
- Updated all call sites (`ItwWalletCardsContainer`, `ItwSettingsScreen`, `ItwPresentationPidDetail`, `ItwPresentationCredentialStatusAlert`, `ItwEidInfoBottomSheetContent`) to pass `currentScreenName` from parent context
- Added unit tests for `ItwEidLifecycleAlert` covering the fix and rendering behavior

## How to test
> [!IMPORTANT]
> An active _Documenti su IO_ wallet is required

1. Open the app and navigate to the wallet screen
2. Tap on "Cos'è" button near the "Documenti" title
3. Verify the app does **not** crash and the lifecycle alert renders correctly
4. Verify analytics tracking still reports the correct screen name