### PR TITLE
chore: [IOPLT-1801] Replace `forwardRef` with just the `ref` prop

### DIFF
--- a/ts/components/Carousel.tsx
+++ b/ts/components/Carousel.tsx
@@ -3,7 +3,6 @@ import {
   JSXElementConstructor,
   ReactElement,
   Ref,
-  forwardRef,
   useCallback,
   useMemo
 } from "react";
@@ -54,26 +53,24 @@ type Props<T> = {
  * This component renders a carousel of elements from a given `data` entry and a `Component` of your choice.
  * It allows you to define how many items to display at a time, how many space between the rendered elements and other important features inherited from the `FlatList` component.
  */
-function CarouselComponent<T extends Record<string, unknown>>(
-  {
-    data,
-    snapToAlignment,
-    decelerationRate,
-    pagingEnabled,
-    viewabilityConfig,
-    contentContainerStyle,
-    initialScrollIndex,
-    itemsGap = 0,
-    itemsPerTime = 1,
-    scrollEnabled = true,
-    style,
-    testID,
-    Component,
-    onViewableItemsChanged,
-    keyExtractor
-  }: WithTestID<Props<T>>,
-  ref: Ref<FlatList<T>>
-) {
+export const Carousel = <T extends Record<string, unknown>>({
+  ref,
+  data,
+  snapToAlignment,
+  decelerationRate,
+  pagingEnabled,
+  viewabilityConfig,
+  contentContainerStyle,
+  initialScrollIndex,
+  itemsGap = 0,
+  itemsPerTime = 1,
+  scrollEnabled = true,
+  style,
+  testID,
+  Component,
+  onViewableItemsChanged,
+  keyExtractor
+}: WithTestID<Props<T>> & { ref?: Ref<FlatList<T>> }): ReactElement => {
   const snapToInterval = useMemo(
     () => WINDOW_WIDTH - itemsGap * itemsPerTime,
     [itemsGap, itemsPerTime]
@@ -127,12 +124,8 @@ function CarouselComponent<T extends Record<string, unknown>>(
       onViewableItemsChanged={onViewableItemsChanged}
     />
   );
-}
+};
 
 const styles = StyleSheet.create({
   box: { overflow: "visible" }
 });
-
-export const Carousel = forwardRef(CarouselComponent) as <T>(
-  p: WithTestID<Props<T>> & { ref?: Ref<FlatList<T>> }
-) => ReactElement;

--- a/ts/components/LandingCardComponent.tsx
+++ b/ts/components/LandingCardComponent.tsx
@@ -10,10 +10,11 @@ import {
   Pictogram,
   VStack
 } from "@pagopa/io-app-design-system";
-import { forwardRef } from "react";
+import { Ref } from "react";
 import { ScrollView, useWindowDimensions, View } from "react-native";
 
 type Props = {
+  ref?: Ref<View>;
   id: number;
   pictogramName: IOPictograms;
   title: string;
@@ -24,39 +25,38 @@ type Props = {
 
 const VERTICAL_SPACING = 16;
 
-export const LandingCardComponent = forwardRef<View, Props>(
-  (
-    { accessibilityLabel, accessibilityHint, pictogramName, title, content },
-    ref
-  ) => {
-    const { width: screenWidth } = useWindowDimensions();
+export const LandingCardComponent = ({
+  ref,
+  accessibilityLabel,
+  accessibilityHint,
+  pictogramName,
+  title,
+  content
+}: Props) => {
+  const { width: screenWidth } = useWindowDimensions();
 
-    return (
-      <ScrollView
-        accessible={false}
-        contentContainerStyle={{ flexGrow: 1, justifyContent: "center" }}
+  return (
+    <ScrollView
+      accessible={false}
+      contentContainerStyle={{ flexGrow: 1, justifyContent: "center" }}
+    >
+      <ContentWrapper
+        ref={ref}
+        style={{ width: screenWidth }}
+        accessible={true}
+        accessibilityLabel={accessibilityLabel}
+        accessibilityHint={accessibilityHint}
       >
-        <ContentWrapper
-          ref={ref}
-          style={{ width: screenWidth }}
-          accessible={true}
-          accessibilityLabel={accessibilityLabel}
-          accessibilityHint={accessibilityHint}
-        >
-          <VStack space={VERTICAL_SPACING} style={{ alignItems: "center" }}>
-            <Pictogram size={180} name={pictogramName} />
-            <H3 importantForAccessibility="no" style={{ textAlign: "center" }}>
-              {title}
-            </H3>
-            <Body
-              importantForAccessibility="no"
-              style={{ textAlign: "center" }}
-            >
-              {content}
-            </Body>
-          </VStack>
-        </ContentWrapper>
-      </ScrollView>
-    );
-  }
-);
+        <VStack space={VERTICAL_SPACING} style={{ alignItems: "center" }}>
+          <Pictogram size={180} name={pictogramName} />
+          <H3 importantForAccessibility="no" style={{ textAlign: "center" }}>
+            {title}
+          </H3>
+          <Body importantForAccessibility="no" style={{ textAlign: "center" }}>
+            {content}
+          </Body>
+        </VStack>
+      </ContentWrapper>
+    </ScrollView>
+  );
+};

--- a/ts/components/screens/OperationResultScreenContent.tsx
+++ b/ts/components/screens/OperationResultScreenContent.tsx
@@ -11,10 +11,10 @@ import {
 } from "@pagopa/io-app-design-system";
 import {
   cloneElement,
-  forwardRef,
   isValidElement,
   PropsWithChildren,
-  ReactNode
+  ReactNode,
+  Ref
 } from "react";
 import { Platform, ScrollView, StyleSheet, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -30,6 +30,7 @@ type ButtonProps = Pick<
 >;
 
 type OperationResultScreenContentProps = WithTestID<{
+  ref?: Ref<View>;
   pictogram: IOPictograms | IOAnimatedPictograms;
   title: string;
   subtitle?: string;
@@ -48,92 +49,85 @@ const hasAnimatedVersion = (
   pictogram: IOPictograms | IOAnimatedPictograms
 ): pictogram is IOAnimatedPictograms => pictogram in IOAnimatedPictogramsAssets;
 
-const OperationResultScreenContent = forwardRef<
-  View,
-  PropsWithChildren<OperationResultScreenContentProps>
->(
-  (
-    {
-      disableAnimatedPictogram = false,
-      pictogram,
-      title,
-      subtitle,
-      onSubtitleLinkPress,
-      action,
-      secondaryAction,
-      children,
-      testID,
-      isHeaderVisible,
-      topElement = undefined
-    },
-    ref
-  ) => {
-    const isAnimatedPictogram =
-      !disableAnimatedPictogram && hasAnimatedVersion(pictogram);
+const OperationResultScreenContent = ({
+  ref,
+  disableAnimatedPictogram = false,
+  pictogram,
+  title,
+  subtitle,
+  onSubtitleLinkPress,
+  action,
+  secondaryAction,
+  children,
+  testID,
+  isHeaderVisible,
+  topElement = undefined
+}: PropsWithChildren<OperationResultScreenContentProps>) => {
+  const isAnimatedPictogram =
+    !disableAnimatedPictogram && hasAnimatedVersion(pictogram);
 
-    return (
-      <SafeAreaView
-        edges={isHeaderVisible ? ["bottom"] : undefined}
-        style={{ flexGrow: 1 }}
-        testID={testID}
-        ref={ref}
+  return (
+    <SafeAreaView
+      edges={isHeaderVisible ? ["bottom"] : undefined}
+      style={{ flexGrow: 1 }}
+      testID={testID}
+      ref={ref}
+    >
+      <ScrollView
+        alwaysBounceVertical={false}
+        centerContent={true}
+        contentContainerStyle={[
+          styles.wrapper,
+          /* Android fallback because `centerContent` is only an iOS property */
+          Platform.OS === "android" && styles.wrapperAndroid
+        ]}
       >
-        <ScrollView
-          alwaysBounceVertical={false}
-          centerContent={true}
-          contentContainerStyle={[
-            styles.wrapper,
-            /* Android fallback because `centerContent` is only an iOS property */
-            Platform.OS === "android" && styles.wrapperAndroid
-          ]}
-        >
-          {pictogram && (
-            <View style={{ alignItems: "center" }}>
-              {isAnimatedPictogram ? (
-                <AnimatedPictogram name={pictogram} size={120} />
-              ) : (
-                <Pictogram name={pictogram as IOPictograms} size={120} />
-              )}
-              <VSpacer size={24} />
+        {pictogram && (
+          <View style={{ alignItems: "center" }}>
+            {isAnimatedPictogram ? (
+              <AnimatedPictogram name={pictogram} size={120} />
+            ) : (
+              <Pictogram name={pictogram as IOPictograms} size={120} />
+            )}
+            <VSpacer size={24} />
+          </View>
+        )}
+        {topElement}
+        <H3 accessibilityRole="header" style={{ textAlign: "center" }}>
+          {title}
+        </H3>
+        {subtitle && (
+          <>
+            <VSpacer size={8} />
+            <IOMarkdownLite
+              content={subtitle}
+              textAlign="center"
+              onLinkPress={onSubtitleLinkPress}
+            />
+          </>
+        )}
+        {action && (
+          <View style={{ alignItems: "center" }}>
+            <VSpacer size={24} />
+            <View>
+              <IOButton variant="solid" {...action} />
             </View>
-          )}
-          {topElement}
-          <H3 accessibilityRole="header" style={{ textAlign: "center" }}>
-            {title}
-          </H3>
-          {subtitle && (
-            <>
-              <VSpacer size={8} />
-              <IOMarkdownLite
-                content={subtitle}
-                textAlign="center"
-                onLinkPress={onSubtitleLinkPress}
-              />
-            </>
-          )}
-          {action && (
-            <View style={{ alignItems: "center" }}>
-              <VSpacer size={24} />
-              <View>
-                <IOButton variant="solid" {...action} />
-              </View>
+          </View>
+        )}
+        {secondaryAction && (
+          <View style={{ alignItems: "center" }}>
+            <VSpacer size={24} />
+            <View>
+              <IOButton variant="link" {...secondaryAction} />
             </View>
-          )}
-          {secondaryAction && (
-            <View style={{ alignItems: "center" }}>
-              <VSpacer size={24} />
-              <View>
-                <IOButton variant="link" {...secondaryAction} />
-              </View>
-            </View>
-          )}
+          </View>
+        )}
 
-          {isValidElement(children) && cloneElement(children)}
-        </ScrollView>
-      </SafeAreaView>
-    );
-  }
-);
+        {isValidElement(children) && cloneElement(children)}
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
 
 const styles = StyleSheet.create({
   wrapper: {

--- a/ts/components/screens/WhatsNewScreenContent.tsx
+++ b/ts/components/screens/WhatsNewScreenContent.tsx
@@ -10,7 +10,7 @@ import {
   WithTestID
 } from "@pagopa/io-app-design-system";
 import { View, ScrollView, StyleSheet } from "react-native";
-import { forwardRef, PropsWithChildren } from "react";
+import { PropsWithChildren, Ref } from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import {
   AnimatedPictogram,
@@ -24,6 +24,7 @@ type ButtonProps<ExtraProps extends keyof IOButtonProps | never = never> = Pick<
 
 export type WhatsNewScreenContentProps = WithTestID<
   {
+    ref?: Ref<View>;
     title: string;
     badge?: Badge;
     action?: ButtonProps<"fullWidth">;
@@ -43,71 +44,64 @@ type GraphicAssetProps =
       loop?: never;
     };
 
-export const WhatsNewScreenContent = forwardRef<
-  View,
-  PropsWithChildren<WhatsNewScreenContentProps>
->(
-  (
-    {
-      enableAnimatedPictogram,
-      badge,
-      pictogram,
-      loop,
-      title,
-      action,
-      secondaryAction,
-      children,
-      testID
-    },
-    ref
-  ) => (
-    <SafeAreaView style={{ flexGrow: 1 }} testID={testID} ref={ref}>
-      <ScrollView
-        alwaysBounceVertical={false}
-        centerContent={true}
-        contentContainerStyle={styles.container}
-      >
-        <VStack space={24} style={styles.mainStack}>
-          {pictogram && (
-            <View style={styles.centeredItems}>
-              {enableAnimatedPictogram ? (
-                <AnimatedPictogram name={pictogram} size={120} loop={loop} />
-              ) : (
-                <Pictogram name={pictogram} size={120} />
-              )}
-            </View>
-          )}
-          {(title || badge || children) && (
-            <VStack space={8}>
-              {badge && (
-                <View style={styles.centeredItems}>
-                  <Badge {...badge} />
-                </View>
-              )}
-              <H3 accessibilityRole="header" style={{ textAlign: "center" }}>
-                {title}
-              </H3>
-              {children}
-            </VStack>
-          )}
-          {(action || secondaryAction) && (
-            <VStack space={16}>
-              {action && (
-                <View style={styles.centeredItems}>
-                  <IOButton variant="solid" {...action} />
-                </View>
-              )}
-              {secondaryAction && (
-                <View style={{ alignSelf: "center" }}>
-                  <IOButton variant="link" {...secondaryAction} />
-                </View>
-              )}
-            </VStack>
-          )}
-        </VStack>
-      </ScrollView>
-    </SafeAreaView>
-  )
+export const WhatsNewScreenContent = ({
+  ref,
+  enableAnimatedPictogram,
+  badge,
+  pictogram,
+  loop,
+  title,
+  action,
+  secondaryAction,
+  children,
+  testID
+}: PropsWithChildren<WhatsNewScreenContentProps>) => (
+  <SafeAreaView style={{ flexGrow: 1 }} testID={testID} ref={ref}>
+    <ScrollView
+      alwaysBounceVertical={false}
+      centerContent={true}
+      contentContainerStyle={styles.container}
+    >
+      <VStack space={24} style={styles.mainStack}>
+        {pictogram && (
+          <View style={styles.centeredItems}>
+            {enableAnimatedPictogram ? (
+              <AnimatedPictogram name={pictogram} size={120} loop={loop} />
+            ) : (
+              <Pictogram name={pictogram} size={120} />
+            )}
+          </View>
+        )}
+        {(title || badge || children) && (
+          <VStack space={8}>
+            {badge && (
+              <View style={styles.centeredItems}>
+                <Badge {...badge} />
+              </View>
+            )}
+            <H3 accessibilityRole="header" style={{ textAlign: "center" }}>
+              {title}
+            </H3>
+            {children}
+          </VStack>
+        )}
+        {(action || secondaryAction) && (
+          <VStack space={16}>
+            {action && (
+              <View style={styles.centeredItems}>
+                <IOButton variant="solid" {...action} />
+              </View>
+            )}
+            {secondaryAction && (
+              <View style={{ alignSelf: "center" }}>
+                <IOButton variant="link" {...secondaryAction} />
+              </View>
+            )}
+          </VStack>
+        )}
+      </VStack>
+    </ScrollView>
+  </SafeAreaView>
 );
 
 const styles = StyleSheet.create({

--- a/ts/components/ui/IOListViewWithLargeHeader.tsx
+++ b/ts/components/ui/IOListViewWithLargeHeader.tsx
@@ -8,14 +8,7 @@ import {
   VSpacer
 } from "@pagopa/io-app-design-system";
 import { useFocusEffect, useNavigation } from "@react-navigation/native";
-import {
-  ComponentProps,
-  createRef,
-  forwardRef,
-  JSX,
-  useCallback,
-  useState
-} from "react";
+import { ComponentProps, createRef, JSX, useCallback, useState } from "react";
 
 import { LayoutChangeEvent, View } from "react-native";
 import I18n from "i18next";
@@ -34,131 +27,127 @@ type Props<T> = ComponentProps<typeof IOListView<T>> &
  * the user scrolls. It also handles the contextual help and the FAQ.
  * Use of LargeHeader naming is due to similar behavior offered by the native iOS API.
  */
-export const IOListViewWithLargeHeader = forwardRef(
-  <T,>(
-    {
-      renderItem,
-      data,
-      keyExtractor,
-      title,
-      description,
-      subtitle,
-      actions,
-      goBack,
-      canGoback = true,
-      contextualHelp,
-      contextualHelpMarkdown,
-      faqCategories,
-      ignoreSafeAreaMargin = false,
-      refreshControlProps,
-      includeContentMargins = true,
-      headerActionsProp = {},
-      excludeEndContentMargin,
-      skeleton,
-      ListHeaderComponent,
-      ListFooterComponent,
-      ListEmptyComponent,
-      testID,
-      ignoreAccessibilityCheck = false,
-      loading
-    }: Props<T>,
-    ref: React.Ref<View>
-  ) => {
-    const [titleHeight, setTitleHeight] = useState(0);
+export const IOListViewWithLargeHeader = <T,>({
+  ref,
+  renderItem,
+  data,
+  keyExtractor,
+  title,
+  description,
+  subtitle,
+  actions,
+  goBack,
+  canGoback = true,
+  contextualHelp,
+  contextualHelpMarkdown,
+  faqCategories,
+  ignoreSafeAreaMargin = false,
+  refreshControlProps,
+  includeContentMargins = true,
+  headerActionsProp = {},
+  excludeEndContentMargin,
+  skeleton,
+  ListHeaderComponent,
+  ListFooterComponent,
+  ListEmptyComponent,
+  testID,
+  ignoreAccessibilityCheck = false,
+  loading
+}: Props<T>): JSX.Element => {
+  const [titleHeight, setTitleHeight] = useState(0);
 
-    const navigation = useNavigation();
-    const theme = useIOTheme();
+  const navigation = useNavigation();
+  const theme = useIOTheme();
 
-    const getTitleHeight = (event: LayoutChangeEvent) => {
-      const { height } = event.nativeEvent.layout;
-      setTitleHeight(height);
-    };
+  const getTitleHeight = (event: LayoutChangeEvent) => {
+    const { height } = event.nativeEvent.layout;
+    setTitleHeight(height);
+  };
 
-    const headerPropsWithoutGoBack = {
-      title: title.label,
-      contextualHelp,
-      contextualHelpMarkdown,
-      faqCategories,
-      ...headerActionsProp
-    };
+  const headerPropsWithoutGoBack = {
+    title: title.label,
+    contextualHelp,
+    contextualHelpMarkdown,
+    faqCategories,
+    ...headerActionsProp
+  };
 
-    const headerProps: ComponentProps<typeof HeaderSecondLevel> = {
-      ignoreSafeAreaMargin,
-      ignoreAccessibilityCheck,
-      ...useHeaderProps(
-        canGoback
-          ? {
-              ...headerPropsWithoutGoBack,
-              backAccessibilityLabel: I18n.t("global.buttons.back"),
-              goBack: goBack ?? navigation.goBack
-            }
-          : headerPropsWithoutGoBack
-      )
-    };
+  const headerProps: ComponentProps<typeof HeaderSecondLevel> = {
+    ignoreSafeAreaMargin,
+    ignoreAccessibilityCheck,
+    ...useHeaderProps(
+      canGoback
+        ? {
+            ...headerPropsWithoutGoBack,
+            backAccessibilityLabel: I18n.t("global.buttons.back"),
+            goBack: goBack ?? navigation.goBack
+          }
+        : headerPropsWithoutGoBack
+    )
+  };
 
-    const titleRef = createRef<View>();
+  const titleRef = createRef<View>();
 
-    useFocusEffect(
-      useCallback(() => setAccessibilityFocus(titleRef), [titleRef])
-    );
+  useFocusEffect(
+    useCallback(() => setAccessibilityFocus(titleRef), [titleRef])
+  );
 
-    return (
-      <IOListView<T>
-        ListHeaderComponent={
-          <>
-            <View onLayout={getTitleHeight}>
-              {title.section && (
-                <BodySmall weight="Semibold" color={theme["textBody-tertiary"]}>
-                  {title.section}
-                </BodySmall>
-              )}
-              <H2
-                color={theme["textHeading-default"]}
-                testID={title?.testID}
-                ref={ref ?? titleRef}
-                accessibilityLabel={title.accessibilityLabel ?? title.label}
-                accessibilityRole="header"
-              >
-                {title.label}
-              </H2>
-            </View>
-
-            {description && (
-              <>
-                <VSpacer size={16} />
-                <IOMarkdownLite content={description} />
-              </>
+  return (
+    <IOListView<T>
+      ListHeaderComponent={
+        <>
+          <View onLayout={getTitleHeight}>
+            {title.section && (
+              <BodySmall weight="Semibold" color={theme["textBody-tertiary"]}>
+                {title.section}
+              </BodySmall>
             )}
-            {subtitle && (
-              <>
-                <VSpacer size={8} />
-                <IOMarkdownLite content={subtitle} />
-              </>
-            )}
-            {ListHeaderComponent && (
-              <>
-                <VSpacer size={16} />
-                {ListHeaderComponent}
-              </>
-            )}
-          </>
-        }
-        loading={loading}
-        skeleton={skeleton}
-        ListFooterComponent={ListFooterComponent}
-        ListEmptyComponent={ListEmptyComponent}
-        ItemSeparatorComponent={Divider}
-        refreshControlProps={refreshControlProps}
-        renderItem={renderItem}
-        data={data}
-        keyExtractor={keyExtractor}
-        actions={actions}
-        headerConfig={headerProps}
-        snapOffset={titleHeight}
-        includeContentMargins={includeContentMargins}
-        excludeEndContentMargin={excludeEndContentMargin}
-        testID={testID}
-      />
-    );
-  }
-) as <T>(props: Props<T> & { ref?: React.Ref<View> }) => JSX.Element;
+            <H2
+              color={theme["textHeading-default"]}
+              testID={title?.testID}
+              ref={ref ?? titleRef}
+              accessibilityLabel={title.accessibilityLabel ?? title.label}
+              accessibilityRole="header"
+            >
+              {title.label}
+            </H2>
+          </View>
+
+          {description && (
+            <>
+              <VSpacer size={16} />
+              <IOMarkdownLite content={description} />
+            </>
+          )}
+          {subtitle && (
+            <>
+              <VSpacer size={8} />
+              <IOMarkdownLite content={subtitle} />
+            </>
+          )}
+          {ListHeaderComponent && (
+            <>
+              <VSpacer size={16} />
+              {ListHeaderComponent}
+            </>
+          )}
+        </>
+      }
+      loading={loading}
+      skeleton={skeleton}
+      ListFooterComponent={ListFooterComponent}
+      ListEmptyComponent={ListEmptyComponent}
+      ItemSeparatorComponent={Divider}
+      refreshControlProps={refreshControlProps}
+      renderItem={renderItem}
+      data={data}
+      keyExtractor={keyExtractor}
+      actions={actions}
+      headerConfig={headerProps}
+      snapOffset={titleHeight}
+      includeContentMargins={includeContentMargins}
+      excludeEndContentMargin={excludeEndContentMargin}
+      testID={testID}
+    />
+  );
+};

--- a/ts/components/ui/IOScrollViewWithLargeHeader.tsx
+++ b/ts/components/ui/IOScrollViewWithLargeHeader.tsx
@@ -9,13 +9,7 @@ import {
   VStack
 } from "@pagopa/io-app-design-system";
 import { useNavigation } from "@react-navigation/native";
-import {
-  ComponentProps,
-  forwardRef,
-  ReactNode,
-  useMemo,
-  useState
-} from "react";
+import { ComponentProps, ReactNode, Ref, useMemo, useState } from "react";
 
 import { LayoutChangeEvent, View } from "react-native";
 import Animated, { AnimatedRef } from "react-native-reanimated";
@@ -39,6 +33,7 @@ export type LargeHeaderTitleProps = {
 
 type Props = WithTestID<
   {
+    ref?: Ref<View>;
     children?: ReactNode;
     actions?: ComponentProps<typeof IOScrollView>["actions"];
     title: LargeHeaderTitleProps;
@@ -66,123 +61,119 @@ type Props = WithTestID<
  * the user scrolls. It also handles the contextual help and the FAQ.
  * Use of LargeHeader naming is due to similar behavior offered by the native iOS API.
  */
-export const IOScrollViewWithLargeHeader = forwardRef<View, Props>(
-  (
-    {
-      children,
-      title,
-      description,
-      onDescriptionLinkPress,
-      actions,
-      goBack,
-      canGoback = true,
-      contextualHelp,
-      contextualHelpMarkdown,
-      faqCategories,
-      ignoreSafeAreaMargin = false,
-      includeContentMargins = false,
-      headerActionsProp = {},
-      excludeEndContentMargin,
-      testID,
-      ignoreAccessibilityCheck = false,
-      animatedRef,
-      topElement = undefined,
-      alwaysBounceVertical
-    },
-    ref
-  ) => {
-    const [titleHeight, setTitleHeight] = useState(0);
+export const IOScrollViewWithLargeHeader = ({
+  ref,
+  children,
+  title,
+  description,
+  onDescriptionLinkPress,
+  actions,
+  goBack,
+  canGoback = true,
+  contextualHelp,
+  contextualHelpMarkdown,
+  faqCategories,
+  ignoreSafeAreaMargin = false,
+  includeContentMargins = false,
+  headerActionsProp = {},
+  excludeEndContentMargin,
+  testID,
+  ignoreAccessibilityCheck = false,
+  animatedRef,
+  topElement = undefined,
+  alwaysBounceVertical
+}: Props) => {
+  const [titleHeight, setTitleHeight] = useState(0);
 
-    const { isAlertVisible } = useIOAlertVisible();
+  const { isAlertVisible } = useIOAlertVisible();
 
-    const navigation = useNavigation();
-    const theme = useIOTheme();
+  const navigation = useNavigation();
+  const theme = useIOTheme();
 
-    const getTitleHeight = (event: LayoutChangeEvent) => {
-      const { height } = event.nativeEvent.layout;
-      setTitleHeight(height);
-    };
+  const getTitleHeight = (event: LayoutChangeEvent) => {
+    const { height } = event.nativeEvent.layout;
+    setTitleHeight(height);
+  };
 
-    const headerPropsWithoutGoBack = {
-      title: title.label,
-      contextualHelp,
-      contextualHelpMarkdown,
-      faqCategories,
-      ...headerActionsProp
-    };
+  const headerPropsWithoutGoBack = {
+    title: title.label,
+    contextualHelp,
+    contextualHelpMarkdown,
+    faqCategories,
+    ...headerActionsProp
+  };
 
-    const computeIgnoreSafeAreaMargin = useMemo(() => {
-      if (isAlertVisible) {
-        return true;
-      }
-      return ignoreSafeAreaMargin;
-    }, [ignoreSafeAreaMargin, isAlertVisible]);
+  const computeIgnoreSafeAreaMargin = useMemo(() => {
+    if (isAlertVisible) {
+      return true;
+    }
+    return ignoreSafeAreaMargin;
+  }, [ignoreSafeAreaMargin, isAlertVisible]);
 
-    const headerProps: ComponentProps<typeof HeaderSecondLevel> = {
-      ignoreSafeAreaMargin: computeIgnoreSafeAreaMargin,
-      ignoreAccessibilityCheck,
-      ...useHeaderProps(
-        canGoback
-          ? {
-              ...headerPropsWithoutGoBack,
-              backAccessibilityLabel: I18n.t("global.buttons.back"),
-              goBack: goBack ?? navigation.goBack
-            }
-          : headerPropsWithoutGoBack
-      )
-    };
+  const headerProps: ComponentProps<typeof HeaderSecondLevel> = {
+    ignoreSafeAreaMargin: computeIgnoreSafeAreaMargin,
+    ignoreAccessibilityCheck,
+    ...useHeaderProps(
+      canGoback
+        ? {
+            ...headerPropsWithoutGoBack,
+            backAccessibilityLabel: I18n.t("global.buttons.back"),
+            goBack: goBack ?? navigation.goBack
+          }
+        : headerPropsWithoutGoBack
+    )
+  };
 
-    return (
-      <IOScrollView
-        actions={actions}
-        animatedRef={animatedRef}
-        headerConfig={headerProps}
-        snapOffset={titleHeight}
-        includeContentMargins={false}
-        excludeEndContentMargin={excludeEndContentMargin}
-        testID={testID}
-        topElement={topElement}
-        alwaysBounceVertical={alwaysBounceVertical}
-      >
-        <ContentWrapper onLayout={getTitleHeight}>
-          <VStack space={8}>
-            {title.section && (
-              <BodySmall weight="Semibold" color={theme["textBody-tertiary"]}>
-                {title.section}
-              </BodySmall>
-            )}
-            <H2
-              color={theme["textHeading-default"]}
-              testID={title?.testID}
-              ref={ref}
-              accessibilityLabel={title.accessibilityLabel ?? title.label}
-              accessibilityRole="header"
-            >
-              {title.label}
-            </H2>
-          </VStack>
+  return (
+    <IOScrollView
+      actions={actions}
+      animatedRef={animatedRef}
+      headerConfig={headerProps}
+      snapOffset={titleHeight}
+      includeContentMargins={false}
+      excludeEndContentMargin={excludeEndContentMargin}
+      testID={testID}
+      topElement={topElement}
+      alwaysBounceVertical={alwaysBounceVertical}
+    >
+      <ContentWrapper onLayout={getTitleHeight}>
+        <VStack space={8}>
+          {title.section && (
+            <BodySmall weight="Semibold" color={theme["textBody-tertiary"]}>
+              {title.section}
+            </BodySmall>
+          )}
+          <H2
+            color={theme["textHeading-default"]}
+            testID={title?.testID}
+            ref={ref}
+            accessibilityLabel={title.accessibilityLabel ?? title.label}
+            accessibilityRole="header"
+          >
+            {title.label}
+          </H2>
+        </VStack>
+      </ContentWrapper>
+
+      {description && (
+        <ContentWrapper>
+          <VSpacer size={16} />
+          <IOMarkdownLite
+            content={description}
+            onLinkPress={onDescriptionLinkPress}
+          />
         </ContentWrapper>
-
-        {description && (
-          <ContentWrapper>
-            <VSpacer size={16} />
-            <IOMarkdownLite
-              content={description}
-              onLinkPress={onDescriptionLinkPress}
-            />
-          </ContentWrapper>
-        )}
-        {children && (
-          <>
-            <VSpacer size={16} />
-            {includeContentMargins ? (
-              <ContentWrapper>{children}</ContentWrapper>
-            ) : (
-              children
-            )}
-          </>
-        )}
-      </IOScrollView>
-    );
-  }
-);
+      )}
+      {children && (
+        <>
+          <VSpacer size={16} />
+          {includeContentMargins ? (
+            <ContentWrapper>{children}</ContentWrapper>
+          ) : (
+            children
+          )}
+        </>
+      )}
+    </IOScrollView>
+  );
+};

--- a/ts/features/authentication/common/components/Carousel.tsx
+++ b/ts/features/authentication/common/components/Carousel.tsx
@@ -1,6 +1,6 @@
 import { IOColors, useIOTheme, VSpacer } from "@pagopa/io-app-design-system";
 
-import { ComponentProps, forwardRef, useCallback, useRef } from "react";
+import { ComponentProps, useCallback, useRef, Ref } from "react";
 import {
   Animated,
   GestureResponderEvent,
@@ -26,6 +26,7 @@ const styles = StyleSheet.create({
 });
 
 export type CarouselProps = {
+  ref?: Ref<View>;
   carouselCards: ReadonlyArray<ComponentProps<typeof LandingCardComponent>>;
   dotEasterEggCallback?: () => void;
 };
@@ -104,8 +105,11 @@ const CarouselDots = (props: CarouselDotsProps) => {
   );
 };
 
-export const Carousel = forwardRef<View, CarouselProps>((props, ref) => {
-  const { carouselCards, dotEasterEggCallback } = props;
+export const Carousel = ({
+  ref,
+  carouselCards,
+  dotEasterEggCallback
+}: CarouselProps) => {
   const screenDimension = useWindowDimensions();
   const windowWidth = screenDimension.width;
   const scrollX = useRef(new Animated.Value(0)).current;
@@ -164,4 +168,4 @@ export const Carousel = forwardRef<View, CarouselProps>((props, ref) => {
       <VSpacer size={24} />
     </>
   );
-});
+};

--- a/ts/features/authentication/login/landing/components/LandingSessionExpiredComponent.tsx
+++ b/ts/features/authentication/login/landing/components/LandingSessionExpiredComponent.tsx
@@ -12,10 +12,11 @@ import {
   Pictogram,
   VSpacer
 } from "@pagopa/io-app-design-system";
-import { forwardRef } from "react";
+import { Ref } from "react";
 import { ScrollView, useWindowDimensions, View } from "react-native";
 
 type Props = {
+  ref?: Ref<View>;
   pictogramName: IOPictograms;
   title: string;
   content: string;
@@ -37,38 +38,42 @@ const PICTOGRAM_VERTICAL_SPACING = 24;
 const CONTENT_VERTICAL_SPACING = 8;
 const BUTTON_VERTICAL_SPACING = 24;
 
-export const LandingSessionExpiredComponent = forwardRef<View, Props>(
-  ({ pictogramName, title, content, buttonLink }, ref) => {
-    const { width: screenWidth } = useWindowDimensions();
+export const LandingSessionExpiredComponent = ({
+  pictogramName,
+  title,
+  content,
+  buttonLink,
+  ref
+}: Props) => {
+  const { width: screenWidth } = useWindowDimensions();
 
-    return (
-      <ScrollView
-        accessible={false}
-        contentContainerStyle={{ flexGrow: 1, justifyContent: "center" }}
+  return (
+    <ScrollView
+      accessible={false}
+      contentContainerStyle={{ flexGrow: 1, justifyContent: "center" }}
+    >
+      <ContentWrapper
+        style={{
+          width: screenWidth,
+          alignItems: "center"
+        }}
       >
-        <ContentWrapper
-          style={{
-            width: screenWidth,
-            alignItems: "center"
-          }}
-        >
-          <Pictogram size={180} name={pictogramName} />
-          <VSpacer size={PICTOGRAM_VERTICAL_SPACING} />
-          <H3 accessible ref={ref} style={{ textAlign: "center" }}>
-            {title}
-          </H3>
-          <VSpacer size={CONTENT_VERTICAL_SPACING} />
-          <Body accessible style={{ textAlign: "center" }}>
-            {content}
-          </Body>
-          {buttonLink && (
-            <View style={{ alignSelf: "center" }}>
-              <VSpacer size={BUTTON_VERTICAL_SPACING} />
-              <IOButton variant="link" {...buttonLink} />
-            </View>
-          )}
-        </ContentWrapper>
-      </ScrollView>
-    );
-  }
-);
+        <Pictogram size={180} name={pictogramName} />
+        <VSpacer size={PICTOGRAM_VERTICAL_SPACING} />
+        <H3 accessible ref={ref} style={{ textAlign: "center" }}>
+          {title}
+        </H3>
+        <VSpacer size={CONTENT_VERTICAL_SPACING} />
+        <Body accessible style={{ textAlign: "center" }}>
+          {content}
+        </Body>
+        {buttonLink && (
+          <View style={{ alignSelf: "center" }}>
+            <VSpacer size={BUTTON_VERTICAL_SPACING} />
+            <IOButton variant="link" {...buttonLink} />
+          </View>
+        )}
+      </ContentWrapper>
+    </ScrollView>
+  );
+};

--- a/ts/features/bonus/common/components/BonusInformationComponent.tsx
+++ b/ts/features/bonus/common/components/BonusInformationComponent.tsx
@@ -9,12 +9,7 @@ import {
 import * as AR from "fp-ts/lib/Array";
 import { constNull, pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/lib/Option";
-import {
-  ComponentProps,
-  forwardRef,
-  useContext,
-  useImperativeHandle
-} from "react";
+import { ComponentProps, useContext, useImperativeHandle, Ref } from "react";
 import { Image, ImageStyle, StyleProp } from "react-native";
 import Animated, {
   useAnimatedRef,
@@ -36,6 +31,7 @@ import { getRemoteLocale } from "../../../messages/utils/ctas";
 import TosBonusComponent from "./TosBonusComponent";
 
 type OwnProps = {
+  ref?: Ref<BonusInformationComponentRef>;
   onBack?: () => void;
   bonus: BonusAvailable;
   onConfirm?: () => void;
@@ -110,7 +106,7 @@ const imageHeight: number = 270;
 /**
  * A screen to explain how the bonus activation works and how it will be assigned
  */
-const BonusInformationComponent = forwardRef((props: Props, ref) => {
+const BonusInformationComponent = ({ ref, ...props }: Props) => {
   const { showModal, hideModal } = useContext(LightModalContext);
   const bonusType = props.bonus;
   const { imageStyle: imageProps } = props;
@@ -235,6 +231,6 @@ const BonusInformationComponent = forwardRef((props: Props, ref) => {
       </ContentWrapper>
     </IOScrollView>
   );
-});
+};
 
 export default BonusInformationComponent;

--- a/ts/features/messages/components/Home/MessageList.tsx
+++ b/ts/features/messages/components/Home/MessageList.tsx
@@ -1,5 +1,5 @@
 import { Divider } from "@pagopa/io-app-design-system";
-import { forwardRef, useCallback, useMemo } from "react";
+import { useCallback, useMemo, Ref } from "react";
 import { FlatList, RefreshControl, StyleSheet } from "react-native";
 import {
   useSafeAreaFrame,
@@ -41,118 +41,111 @@ const styles = StyleSheet.create({
 });
 
 type MessageListProps = {
+  ref?: Ref<FlatList>;
   category: MessageListCategory;
 };
 
 const topBarHeight = 108;
 const bottomTabHeight = 54;
 
-export const MessageList = forwardRef<FlatList, MessageListProps>(
-  ({ category }: MessageListProps, ref) => {
-    const store = useIOStore();
-    const dispatch = useIODispatch();
-    const safeAreaFrame = useSafeAreaFrame();
-    const safeAreaInsets = useSafeAreaInsets();
+export const MessageList = ({ ref, category }: MessageListProps) => {
+  const store = useIOStore();
+  const dispatch = useIODispatch();
+  const safeAreaFrame = useSafeAreaFrame();
+  const safeAreaInsets = useSafeAreaInsets();
 
-    const messageList = useIOSelector(state =>
-      messageListForCategorySelector(state, category)
-    );
-    const isRefreshing = useIOSelector(state =>
-      shouldShowRefreshControllOnListSelector(state, category)
-    );
-    const loadingList = useMemo(() => {
-      const listHeight =
-        safeAreaFrame.height -
-        safeAreaInsets.top -
-        safeAreaInsets.bottom -
-        topBarHeight -
-        bottomTabHeight;
-      const count = Math.floor(listHeight / SkeletonHeight);
-      return [...Array(count).keys()];
-    }, [safeAreaFrame.height, safeAreaInsets.top, safeAreaInsets.bottom]);
+  const messageList = useIOSelector(state =>
+    messageListForCategorySelector(state, category)
+  );
+  const isRefreshing = useIOSelector(state =>
+    shouldShowRefreshControllOnListSelector(state, category)
+  );
+  const loadingList = useMemo(() => {
+    const listHeight =
+      safeAreaFrame.height -
+      safeAreaInsets.top -
+      safeAreaInsets.bottom -
+      topBarHeight -
+      bottomTabHeight;
+    const count = Math.floor(listHeight / SkeletonHeight);
+    return [...Array(count).keys()];
+  }, [safeAreaFrame.height, safeAreaInsets.top, safeAreaInsets.bottom]);
 
-    const layoutInfo: ReadonlyArray<LayoutInfo> = useMemo(
-      () =>
-        generateMessageListLayoutInfo(
-          loadingList,
-          messageList,
-          store.getState()
-        ),
-      [loadingList, messageList, store]
-    );
-    const getItemLayoutCallback = useCallback(
-      (_: ArrayLike<UIMessage | number> | null | undefined, index: number) =>
-        layoutInfo[index],
-      [layoutInfo]
-    );
+  const layoutInfo: ReadonlyArray<LayoutInfo> = useMemo(
+    () =>
+      generateMessageListLayoutInfo(loadingList, messageList, store.getState()),
+    [loadingList, messageList, store]
+  );
+  const getItemLayoutCallback = useCallback(
+    (_: ArrayLike<UIMessage | number> | null | undefined, index: number) =>
+      layoutInfo[index],
+    [layoutInfo]
+  );
 
-    const onRefreshCallback = useCallback(() => {
-      trackPullToRefresh(category);
-      const state = store.getState();
-      const reloadAllMessagesAction =
-        getReloadAllMessagesActionForRefreshIfAllowed(state, category);
-      if (reloadAllMessagesAction) {
-        dispatch(reloadAllMessagesAction);
+  const onRefreshCallback = useCallback(() => {
+    trackPullToRefresh(category);
+    const state = store.getState();
+    const reloadAllMessagesAction =
+      getReloadAllMessagesActionForRefreshIfAllowed(state, category);
+    if (reloadAllMessagesAction) {
+      dispatch(reloadAllMessagesAction);
+    }
+  }, [category, dispatch, store]);
+  const onEndReachedCallback = useCallback(() => {
+    const state = store.getState();
+    const loadNextPageMessages = getLoadNextPageMessagesActionIfAllowed(
+      state,
+      category,
+      new Date()
+    );
+    trackMessageListEndReachedIfAllowed(
+      category,
+      !!loadNextPageMessages,
+      state
+    );
+    if (loadNextPageMessages) {
+      dispatch(loadNextPageMessages);
+    }
+  }, [category, dispatch, store]);
+  return (
+    <FlatList
+      ref={ref}
+      contentContainerStyle={styles.contentContainer}
+      data={(messageList ?? loadingList) as Readonly<Array<number | UIMessage>>}
+      ListEmptyComponent={<EmptyList category={category} />}
+      ItemSeparatorComponent={messageList ? () => <Divider /> : undefined}
+      ListHeaderComponent={
+        category === "INBOX" ? <LandingScreenBannerPicker /> : undefined
       }
-    }, [category, dispatch, store]);
-    const onEndReachedCallback = useCallback(() => {
-      const state = store.getState();
-      const loadNextPageMessages = getLoadNextPageMessagesActionIfAllowed(
-        state,
-        category,
-        new Date()
-      );
-      trackMessageListEndReachedIfAllowed(
-        category,
-        !!loadNextPageMessages,
-        state
-      );
-      if (loadNextPageMessages) {
-        dispatch(loadNextPageMessages);
+      getItemLayout={getItemLayoutCallback}
+      renderItem={({ index, item }) => {
+        if (typeof item === "number") {
+          return (
+            <ListItemMessageSkeleton
+              accessibilityLabel={I18n.t("messages.loading")}
+            />
+          );
+        } else {
+          return (
+            <WrappedListItemMessage
+              index={index}
+              message={item}
+              source={category}
+            />
+          );
+        }
+      }}
+      ListFooterComponent={<Footer category={category} />}
+      refreshControl={
+        <RefreshControl
+          refreshing={isRefreshing}
+          onRefresh={onRefreshCallback}
+          testID={`custom_refresh_control_${category.toLowerCase()}`}
+        />
       }
-    }, [category, dispatch, store]);
-    return (
-      <FlatList
-        ref={ref}
-        contentContainerStyle={styles.contentContainer}
-        data={
-          (messageList ?? loadingList) as Readonly<Array<number | UIMessage>>
-        }
-        ListEmptyComponent={<EmptyList category={category} />}
-        ItemSeparatorComponent={messageList ? () => <Divider /> : undefined}
-        ListHeaderComponent={
-          category === "INBOX" ? <LandingScreenBannerPicker /> : undefined
-        }
-        getItemLayout={getItemLayoutCallback}
-        renderItem={({ index, item }) => {
-          if (typeof item === "number") {
-            return (
-              <ListItemMessageSkeleton
-                accessibilityLabel={I18n.t("messages.loading")}
-              />
-            );
-          } else {
-            return (
-              <WrappedListItemMessage
-                index={index}
-                message={item}
-                source={category}
-              />
-            );
-          }
-        }}
-        ListFooterComponent={<Footer category={category} />}
-        refreshControl={
-          <RefreshControl
-            refreshing={isRefreshing}
-            onRefresh={onRefreshCallback}
-            testID={`custom_refresh_control_${category.toLowerCase()}`}
-          />
-        }
-        onEndReached={onEndReachedCallback}
-        onEndReachedThreshold={0.1}
-        testID={`message_list_${category.toLowerCase()}`}
-      />
-    );
-  }
-);
+      onEndReached={onEndReachedCallback}
+      onEndReachedThreshold={0.1}
+      testID={`message_list_${category.toLowerCase()}`}
+    />
+  );
+};

--- a/ts/features/messages/components/Home/PagerViewContainer.tsx
+++ b/ts/features/messages/components/Home/PagerViewContainer.tsx
@@ -1,5 +1,5 @@
 import { pipe } from "fp-ts/lib/function";
-import { forwardRef, useCallback, useRef } from "react";
+import { useCallback, useRef, Ref } from "react";
 import { FlatList, NativeSyntheticEvent } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
 import PagerView from "react-native-pager-view";
@@ -26,7 +26,7 @@ import {
 } from "./homeUtils";
 import { ArchiveRestoreBar } from "./ArchiveRestoreBar";
 
-export const PagerViewContainer = forwardRef<PagerView>((_, ref) => {
+export const PagerViewContainer = ({ ref }: { ref?: Ref<PagerView> }) => {
   const dispatch = useIODispatch();
   const store = useIOStore();
   const archiveFlatListRef = useRef<FlatList>(null);
@@ -172,4 +172,4 @@ export const PagerViewContainer = forwardRef<PagerView>((_, ref) => {
       <ArchiveRestoreBar />
     </>
   );
-});
+};

--- a/ts/features/messages/components/Home/__mocks__/PagerViewContainer.tsx
+++ b/ts/features/messages/components/Home/__mocks__/PagerViewContainer.tsx
@@ -1,10 +1,10 @@
-import { forwardRef } from "react";
+import { Ref } from "react";
 import { View } from "react-native";
 import PagerView from "react-native-pager-view";
 
-export const PagerViewContainer = forwardRef<PagerView>((_, ref) => (
+export const PagerViewContainer = ({ ref }: { ref?: Ref<PagerView> }) => (
   <PagerView ref={ref} testID="mock_pager_view_container">
     <View>Mock Inbox</View>
     <View>Mock Archive</View>
   </PagerView>
-));
+);

--- a/ts/features/messages/components/Home/__mocks__/TabNavigationContainer.tsx
+++ b/ts/features/messages/components/Home/__mocks__/TabNavigationContainer.tsx
@@ -1,9 +1,13 @@
-import { forwardRef } from "react";
+import { Ref } from "react";
 import { View } from "react-native";
 import PagerView from "react-native-pager-view";
 
-export const TabNavigationContainer = forwardRef<PagerView>((_, _ref) => (
+export const TabNavigationContainer = ({
+  ref: _ref
+}: {
+  ref?: Ref<PagerView>;
+}) => (
   <View testID="mock_tab_navigation_container">
     This is a mock for TabNavigationContainer
   </View>
-));
+);


### PR DESCRIPTION
## Short description
Replace `forwardRef` with just the `ref` prop, by taking advantage of the new React version (`19.x`).

## List of changes proposed in this pull request
- Simplify the logic by removing `forwardRef`

## Related PR(s)
* https://github.com/pagopa/io-app-design-system/pull/561

## How to test
Check whether any of the affected components have any regressions.