### PR TITLE
feat(IT-Wallet): [SIW-3923] Make ANIST credentials available in prod

### DIFF
--- a/ts/features/itwallet/common/utils/itwCredentialUtils.ts
+++ b/ts/features/itwallet/common/utils/itwCredentialUtils.ts
@@ -25,7 +25,9 @@ export const l2Credentials = [
 export const newCredentials = [
   CredentialType.EDUCATION_DEGREE,
   CredentialType.EDUCATION_ENROLLMENT,
-  CredentialType.RESIDENCY
+  CredentialType.RESIDENCY,
+  CredentialType.EDUCATION_DIPLOMA,
+  CredentialType.EDUCATION_ATTENDANCE
 ] as const;
 
 export type NewCredential = (typeof newCredentials)[number];
@@ -33,11 +35,7 @@ export type NewCredential = (typeof newCredentials)[number];
 export type L2Credential = (typeof l2Credentials)[number];
 
 // Credentials that will be available in the future
-// TODO: [SIW-3923] remove once IPZS releases new credentials in PROD
-export const upcomingCredentials = [
-  CredentialType.EDUCATION_DIPLOMA,
-  CredentialType.EDUCATION_ATTENDANCE
-] as ReadonlyArray<string>;
+export const upcomingCredentials = [] as ReadonlyArray<string>;
 
 export const isUpcomingCredential = (type: string): boolean =>
   upcomingCredentials.includes(type);

--- a/ts/features/itwallet/presentation/details/components/ItwPresentationAdditionalInfoSection.tsx
+++ b/ts/features/itwallet/presentation/details/components/ItwPresentationAdditionalInfoSection.tsx
@@ -24,6 +24,8 @@ const ItwPresentationAdditionalInfoSection = ({ credential }: Props) => {
     case CredentialType.EDUCATION_DEGREE:
     case CredentialType.EDUCATION_ENROLLMENT:
     case CredentialType.RESIDENCY:
+    case CredentialType.EDUCATION_DIPLOMA:
+    case CredentialType.EDUCATION_ATTENDANCE:
       return (
         <ItwPresentationNewCredentialValidityAlert
           credentialType={credential.credentialType}


### PR DESCRIPTION
## Short description
This PR makes ANIST credentials (`education_diploma` and `education_attendance`) available in production.

## List of changes proposed in this pull request
- Moved credentials from `upcomingCredentials` to `newCredentials`

## How to test
1. Request the new credentials and verify they are correctly displayed in the wallet.