### PR TITLE
fix(IT-Wallet): [SIW-4237] Update credential reissuing tracking credential property value

### DIFF
--- a/ts/features/itwallet/machine/credential/actions.ts
+++ b/ts/features/itwallet/machine/credential/actions.ts
@@ -203,7 +203,7 @@ export const createCredentialIssuanceActionsImplementation = (
   >) => {
     assert(context.credentialType, "credentialType is undefined");
     trackStartCredentialUpgrade(
-      getMixPanelCredential(context.credentialType, true)
+      getMixPanelCredential(context.credentialType, context.isItWalletValid)
     );
   }
 });


### PR DESCRIPTION
## Short description
Replace hardcoded `true` for credential upgrade tracking using context property `isItWalletValid` in order to distinguish between L2 and L3.

## List of changes proposed in this pull request
- Replace `true` with `context.isItWalletValid` in `trackStartCredentialUpgrade`

## How to test
1. Start with eID L2/Documenti su IO and an already existing credential, such as a driving licence.
2. Start the eID reissuing process from the playground, then either intercept the POST /as/par request and force it to fail, or mock the `requestAccessToken` function so that it throws an error.
3. When the transparent reissuing of the credentials starts, the driving licence fails.
4. At the end of the flow, you should see the credential marked as to be "Da verifica".
5. Start the manual reissuing of the failed credential.
6. Check the `ITW_CREDENTIAL_START_REISSUING` event, it should have the correct `credential` value
