### PR TITLE
refactor: [IEG-2882] Replace EYCA url with remote data

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -2,7 +2,7 @@
 
 IO_BACKEND_VERSION=v17.5.2
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=IEG-2882-eyca-definitions
+IO_SERVICES_METADATA_VERSION=1.0.101
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.23.1
 # IO Wallet user function version

--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -2,7 +2,7 @@
 
 IO_BACKEND_VERSION=v17.5.2
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=1.0.100
+IO_SERVICES_METADATA_VERSION=IEG-2882-eyca-definitions
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.23.1
 # IO Wallet user function version

--- a/ts/features/bonus/cgn/components/detail/eyca/EycaInformationComponent.tsx
+++ b/ts/features/bonus/cgn/components/detail/eyca/EycaInformationComponent.tsx
@@ -7,32 +7,36 @@ import {
 import I18n from "i18next";
 import { useIOBottomSheetModal } from "../../../../../../utils/hooks/bottomSheet";
 import { openWebUrl } from "../../../../../../utils/url";
-import { EYCA_WEBSITE_BASE_URL } from "../../../utils/constants";
+import { useIOSelector } from "../../../../../../store/hooks";
+import { getEYCABaseUrl } from "../../../../../../store/reducers/backendStatus/remoteConfig";
 
 /**
  * this component shows information about EYCA card. It is included within a bottom sheet
  * @constructor
  */
-const EycaInformationComponent: React.FunctionComponent = () => (
-  <>
-    <IOMarkdownLite
-      content={I18n.t("bonus.cgn.detail.status.eycaDescription")}
-    />
-    <VSpacer size={16} />
-    <IOButton
-      variant="outline"
-      fullWidth
-      label={I18n.t("bonus.cgn.detail.cta.eyca.bottomSheet")}
-      onPress={() =>
-        openWebUrl(EYCA_WEBSITE_BASE_URL, () =>
-          IOToast.error(I18n.t("bonus.cgn.generic.linkError"))
-        )
-      }
-    />
+const EycaInformationComponent: React.FunctionComponent = () => {
+  const eycaBaseUrl = useIOSelector(getEYCABaseUrl);
+  return (
+    <>
+      <IOMarkdownLite
+        content={I18n.t("bonus.cgn.detail.status.eycaDescription")}
+      />
+      <VSpacer size={16} />
+      <IOButton
+        variant="outline"
+        fullWidth
+        label={I18n.t("bonus.cgn.detail.cta.eyca.bottomSheet")}
+        onPress={() =>
+          openWebUrl(eycaBaseUrl, () =>
+            IOToast.error(I18n.t("bonus.cgn.generic.linkError"))
+          )
+        }
+      />
 
-    <VSpacer size={16} />
-  </>
-);
+      <VSpacer size={16} />
+    </>
+  );
+};
 
 export const useEycaInformationBottomSheet = () =>
   useIOBottomSheetModal({

--- a/ts/features/bonus/cgn/screens/CgnDetailScreen.tsx
+++ b/ts/features/bonus/cgn/screens/CgnDetailScreen.tsx
@@ -34,7 +34,10 @@ import { IOScrollViewActions } from "../../../../components/ui/IOScrollView";
 import { useHardwareBackButton } from "../../../../hooks/useHardwareBackButton";
 import { IOStackNavigationProp } from "../../../../navigation/params/AppParamsList";
 import { useIODispatch, useIOSelector } from "../../../../store/hooks";
-import { isCGNEnabledSelector } from "../../../../store/reducers/backendStatus/remoteConfig";
+import {
+  getEYCADiscountUrl,
+  isCGNEnabledSelector
+} from "../../../../store/reducers/backendStatus/remoteConfig";
 import { formatDateAsShortFormat } from "../../../../utils/dates";
 import { useActionOnFocus } from "../../../../utils/hooks/useOnFocus";
 import { capitalizeTextName } from "../../../../utils/strings";
@@ -63,7 +66,6 @@ import {
   EycaDetailsState
 } from "../store/reducers/eyca/details";
 import { cgnUnsubscribeSelector } from "../store/reducers/unsubscribe";
-import { EYCA_WEBSITE_DISCOUNTS_PAGE_URL } from "../utils/constants";
 import { canEycaCardBeShown } from "../utils/eyca";
 
 function getLogoUris(card: Card | undefined, eycaDetails: EycaDetailsState) {
@@ -130,6 +132,7 @@ const CgnDetailScreen = (): ReactElement => {
   const logoUris = getLogoUris(cgnDetails, eycaDetails);
 
   const theme = useIOTheme();
+  const eycaDiscountPage = useIOSelector(getEYCADiscountUrl);
 
   const startCgnActivation = () => {
     dispatch(loadAvailableBonuses.request());
@@ -182,7 +185,7 @@ const CgnDetailScreen = (): ReactElement => {
           "bonus.cgn.detail.cta.eyca.showEycaDiscounts"
         ),
         onPress: () =>
-          openWebUrl(EYCA_WEBSITE_DISCOUNTS_PAGE_URL, () =>
+          openWebUrl(eycaDiscountPage, () =>
             IOToast.error(I18n.t("bonus.cgn.generic.linkError"))
           )
       };

--- a/ts/features/bonus/cgn/utils/constants.ts
+++ b/ts/features/bonus/cgn/utils/constants.ts
@@ -1,3 +1,0 @@
-export const EYCA_WEBSITE_BASE_URL = "https://eyca.org";
-
-export const EYCA_WEBSITE_DISCOUNTS_PAGE_URL = `${EYCA_WEBSITE_BASE_URL}/discounts/it`;

--- a/ts/store/reducers/backendStatus/remoteConfig.ts
+++ b/ts/store/reducers/backendStatus/remoteConfig.ts
@@ -106,6 +106,26 @@ export const engagementCGNDiscoveryBannerSelector = createSelector(
     )
 );
 
+export const getEYCABaseUrl = createSelector(
+  remoteConfigSelector,
+  (remoteConfig): string =>
+    pipe(
+      remoteConfig,
+      O.map(config => config.cgn.eyca_base_url),
+      O.getOrElse(() => "")
+    )
+);
+
+export const getEYCADiscountUrl = createSelector(
+  remoteConfigSelector,
+  (remoteConfig): string =>
+    pipe(
+      remoteConfig,
+      O.map(config => config.cgn.eyca_discount_url),
+      O.getOrElse(() => "")
+    )
+);
+
 export const assistanceToolConfigSelector = createSelector(
   remoteConfigSelector,
   (remoteConfig): ToolEnum | undefined =>

--- a/ts/store/reducers/backendStatus/remoteConfig.ts
+++ b/ts/store/reducers/backendStatus/remoteConfig.ts
@@ -111,7 +111,7 @@ export const getEYCABaseUrl = createSelector(
   (remoteConfig): string =>
     pipe(
       remoteConfig,
-      O.map(config => config.cgn.eyca_base_url),
+      O.chain(config => O.fromNullable(config.cgn.eyca_base_url)),
       O.getOrElse(() => "")
     )
 );
@@ -121,7 +121,7 @@ export const getEYCADiscountUrl = createSelector(
   (remoteConfig): string =>
     pipe(
       remoteConfig,
-      O.map(config => config.cgn.eyca_discount_url),
+      O.chain(config => O.fromNullable(config.cgn.eyca_discount_url)),
       O.getOrElse(() => "")
     )
 );


### PR DESCRIPTION
> [!NOTE]
> This PR depends on https://github.com/pagopa/io-services-metadata/pull/1185

## Short description
This pull request refactors how EYCA-related URLs are handled in the CGN feature. Instead of using hardcoded constants, the URLs are now retrieved from the application's remote configuration state, making them easier to update and maintain.

## List of changes proposed in this pull request
- Replaced the use of hardcoded `EYCA_WEBSITE_BASE_URL` and `EYCA_WEBSITE_DISCOUNTS_PAGE_URL` constants with selectors (`getEYCABaseUrl`, `getEYCADiscountUrl`) that retrieve the URLs from the remote configuration state in both `EycaInformationComponent` and `CgnDetailScreen`

## How to test
- Edit the dev server value [here](https://github.com/pagopa/io-services-metadata/pull/1185/changes#diff-611dc7e62a843f0611cd30d01edf45007ffa08f50c621481897bd1c4b402ddbaR63-R64)
- Ensure that links are reachable tapping on related CTAs