### PR TITLE
fix(IT-Wallet): [SIW-4280] Possible race condition in eID upgrade flow triggered by adding a new credential

### DIFF
--- a/ts/features/itwallet/issuance/screens/ItwIssuanceEidResultScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceEidResultScreen.tsx
@@ -38,6 +38,8 @@ export const ItwIssuanceEidResultScreen = () => {
   const credentialType =
     ItwEidIssuanceMachineContext.useSelector(selectCredentialType);
   const isItwL3 = useIOSelector(itwLifecycleIsITWalletValidSelector);
+  const isEidMachineLoading =
+    ItwEidIssuanceMachineContext.useSelector(selectIsLoading);
 
   const itw_flow = isItwL3 ? "L3" : "reissuing_eID";
 
@@ -68,14 +70,16 @@ export const ItwIssuanceEidResultScreen = () => {
   const handleBackToWallet = () => machineRef.send({ type: "go-to-wallet" });
 
   useEffect(() => {
-    if (credentialType) {
+    // When the EID issuance was triggered by a credential request, the credential
+    // issuance must not start prematurely while the EID machine is still loading.
+    if (credentialType && !isEidMachineLoading) {
       credentialMachineRef.send({
         type: "select-credential",
         mode: "issuance",
         credentialType
       });
     }
-  }, [credentialType, credentialMachineRef]);
+  }, [credentialType, credentialMachineRef, isEidMachineLoading]);
 
   if (credentialType) {
     return <ItwIssuanceEidCredentialTriggerContent />;


### PR DESCRIPTION
## Short description
This PR fixes a possible race condition that arises when a credential is added and it triggers the issuance of a new eID + upgrade flow.

The new credential request might start while the upgrade machine is still running and requesting the other credentials: this leads to inconsistencies in the credentials store.

## List of changes proposed in this pull request
- Send the `select-credential` event only if the eID machine is not loading

## How to test
1. Activate "Documenti su IO" with CIE+PIN
2. Obtain a credential (MDL)
3. Restart the app and add a new credential (residency) **without upgrading first**: this should automatically start the upgrade flow
4. Ensure the MDL has been successfully upgraded and the residency is correct
5. Ensure the regular upgrade flow (not triggered by a specific credential) works as expected