### PR TITLE
chore: [IEL-324,IEL-332] Update endpoints for FCI and Send API

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -44,11 +44,10 @@ declare -a apis=(
   "./definitions/cgn https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION_CGN_CDC/openapi/generated/api_cgn_card_platform.yaml"
   "./definitions/cgn/merchants https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION_CGN_CDC/openapi/generated/api_cgn_search_platform.yaml"
   # PN APIs
-  "./definitions/pn https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_pn.yaml"
   "./definitions/pn/aar https://raw.githubusercontent.com/pagopa/io-messages/refs/tags/send-func@$SEND_FUNC_VERSION/apps/send-func/openapi/aar-notification.yaml"
   "./definitions/pn/lollipop-lambda https://raw.githubusercontent.com/pagopa/io-messages/refs/tags/send-func@$SEND_FUNC_VERSION/apps/send-func/openapi/lollipop-integration-check.yaml"
   # FCI APIs
-  "./definitions/fci https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_io_sign.yaml"
+  "./definitions/fci https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/openapi/generated/api_io_sign.yaml"
   # ITW APIs
   "./definitions/itw https://raw.githubusercontent.com/pagopa/io-wallet/io-wallet-user-func@$IO_WALLET_USER_FUNC_VERSION/apps/io-wallet-user-func/openapi-external/user_v1/swagger.yaml"
   # Connectivity APIs (used for connectivity checks)

--- a/ts/features/pn/api/client.ts
+++ b/ts/features/pn/api/client.ts
@@ -1,4 +1,4 @@
-import { createClient } from "../../../../definitions/pn/client";
+import { createClient } from "../../../../definitions/communication/client";
 import { fetchMaxRetries, fetchTimeout } from "../../../config";
 import { defaultRetryingFetch } from "../../../utils/fetch";
 

--- a/ts/features/pn/store/sagas/__tests__/watchPnSaga.test.ts
+++ b/ts/features/pn/store/sagas/__tests__/watchPnSaga.test.ts
@@ -24,7 +24,7 @@ const mockBearerToken = "mock-token";
 const mockServiceId = "service-id" as ServiceId;
 const mockUpsertPNActivation = jest.fn();
 const mockPnClient: Partial<CLIENT.PnClient> = {
-  upsertPNActivation: mockUpsertPNActivation
+  upsertSendActivation: mockUpsertPNActivation
 };
 
 // Extract functions from testable export
@@ -224,7 +224,7 @@ describe("watchPnSaga", () => {
         .takeLatest(
           pnActivationUpsert.request,
           handlePnActivation,
-          mockPnClient.upsertPNActivation
+          mockPnClient.upsertSendActivation
         )
         .next()
         .takeLatest(

--- a/ts/features/pn/store/sagas/watchPnSaga.ts
+++ b/ts/features/pn/store/sagas/watchPnSaga.ts
@@ -31,7 +31,7 @@ export function* tryLoadSENDPreferences() {
 const tooManyRequestsError = new Error("timeout -- too many requests");
 
 function* handlePnActivation(
-  upsertPnActivation: PnClient["upsertPNActivation"],
+  upsertSendActivation: PnClient["upsertSendActivation"],
   action: ActionType<typeof pnActivationUpsert.request>
 ) {
   const activation_status = action.payload.value;
@@ -47,7 +47,7 @@ function* handlePnActivation(
       },
       isTest
     };
-    const result = yield* call(upsertPnActivation, requestData);
+    const result = yield* call(upsertSendActivation, requestData);
 
     if (E.isRight(result)) {
       switch (result.right.status) {
@@ -114,7 +114,7 @@ export function* watchPnSaga(bearerToken: string): SagaIterator {
   yield* takeLatest(
     pnActivationUpsert.request,
     handlePnActivation,
-    pnClient.upsertPNActivation
+    pnClient.upsertSendActivation
   );
 
   yield* takeLatest(


### PR DESCRIPTION
## Short description
This pull request updates FCI API endpoint to use new base paths and removes the PN endpoint as now it is part of the communication API, reflecting recent backend route changes. 

## List of changes proposed in this pull request
- Updated FCI API endpoint
- Removed `definitions/pn/client` generation from `generate-api-models.sh` as the PN API is now included in `definitions/communication`
- Replaced `upsertPNActivation` method with `upsertSendActivation`

## How to test
Run the app and check everything works as expected in the FCI flow and Send service Activation/Deactivation