### PR TITLE
feat(IT-Wallet): [SIW-4244] Feature Flag with min app version for ITW

### DIFF
--- a/ts/features/itwallet/common/store/selectors/preferences.ts
+++ b/ts/features/itwallet/common/store/selectors/preferences.ts
@@ -1,4 +1,5 @@
 import { GlobalState } from "../../../../../store/reducers/types";
+import { isItwMinAppVersionSupportedSelector } from "./remoteConfig";
 
 export const itwPreferencesSelector = (state: GlobalState) =>
   state.features.itWallet.preferences;
@@ -26,7 +27,9 @@ export const itwIsClaimValueHiddenSelector = (state: GlobalState) =>
  * @param state the application global state
  */
 export const itwIsL3EnabledSelector = (state: GlobalState) =>
-  state.features.itWallet.preferences.isFiscalCodeWhitelisted ?? false;
+  (state.features.itWallet.preferences.isFiscalCodeWhitelisted ||
+    isItwMinAppVersionSupportedSelector(state)) ??
+  false;
 
 /**
  * Returns whether the user has the requirements for IT-Wallet simplified activation.

--- a/ts/features/itwallet/common/store/selectors/preferences.ts
+++ b/ts/features/itwallet/common/store/selectors/preferences.ts
@@ -1,5 +1,5 @@
 import { GlobalState } from "../../../../../store/reducers/types";
-import { isItwMinAppVersionSupportedSelector } from "./remoteConfig";
+import { isItwL3SupportedSelector } from "./remoteConfig";
 
 export const itwPreferencesSelector = (state: GlobalState) =>
   state.features.itWallet.preferences;
@@ -28,7 +28,7 @@ export const itwIsClaimValueHiddenSelector = (state: GlobalState) =>
  */
 export const itwIsL3EnabledSelector = (state: GlobalState) =>
   (state.features.itWallet.preferences.isFiscalCodeWhitelisted ||
-    isItwMinAppVersionSupportedSelector(state)) ??
+    isItwL3SupportedSelector(state)) ??
   false;
 
 /**

--- a/ts/features/itwallet/common/store/selectors/remoteConfig.ts
+++ b/ts/features/itwallet/common/store/selectors/remoteConfig.ts
@@ -17,7 +17,7 @@ const itwRemoteConfigSelector = (state: GlobalState) =>
   );
 
 /**
- * Returns the remote config for IT-WALLET
+ * Returns the remote config for Doc IO
  */
 export const isItwEnabledSelector = createSelector(
   itwRemoteConfigSelector,
@@ -128,5 +128,25 @@ export const itwIpzsPrivacyUrlSelector = createSelector(
       itwConfig,
       O.map(itw => itw.ipzs_privacy_url),
       O.toUndefined
+    )
+);
+
+/**
+ * Returns whether the current app version meets the minimum required to use IT Wallet.
+ */
+export const isItwMinAppVersionSupportedSelector = createSelector(
+  itwRemoteConfigSelector,
+  (itwConfig): boolean =>
+    pipe(
+      itwConfig,
+      O.map(itw =>
+        isVersionSupported(
+          Platform.OS === "ios"
+            ? itw.min_app_version.ios
+            : itw.min_app_version.android,
+          getAppVersion()
+        )
+      ),
+      O.getOrElse(() => false)
     )
 );

--- a/ts/features/itwallet/common/store/selectors/remoteConfig.ts
+++ b/ts/features/itwallet/common/store/selectors/remoteConfig.ts
@@ -134,7 +134,7 @@ export const itwIpzsPrivacyUrlSelector = createSelector(
 /**
  * Returns whether the current app version meets the minimum required to use IT Wallet.
  */
-export const isItwMinAppVersionSupportedSelector = createSelector(
+export const isItwL3SupportedSelector = createSelector(
   itwRemoteConfigSelector,
   (itwConfig): boolean =>
     pipe(

--- a/ts/features/itwallet/credentialsCatalogue/store/selectors/__tests__/index.test.ts
+++ b/ts/features/itwallet/credentialsCatalogue/store/selectors/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 import * as pot from "@pagopa/ts-commons/lib/pot";
+import * as O from "fp-ts/lib/Option";
 import { type GlobalState } from "../../../../../../store/reducers/types";
 import { DigitalCredentialsCatalogue } from "../../../../common/utils/itwCredentialsCatalogueUtils";
 import {
@@ -53,6 +54,7 @@ const buildState = (
         }
       }
     },
+    remoteConfig: O.none,
     persistedPreferences: {
       preferredLanguage:
         overrides.preferredLanguage !== undefined


### PR DESCRIPTION
## Short description
This PR adds a remote feature flag with minimum app version check to gate IT Wallet (L3) access. IT Wallet is now accessible to users whose fiscal code is whitelisted or whose app version meets the remotely configured minimum version.

## List of changes proposed in this pull request
- Added `isItwL3SupportedSelector` in `remoteConfig.ts` that checks whether the current app version meets the `min_app_version` configured remotely for IT Wallet
- Updated `itwIsL3EnabledSelector` in `preferences.ts` to return true if the fiscal code is whitelisted or the app version is supported
