### PR TITLE
fix: [IOPID-3930] FIMS history APIs split

### DIFF
--- a/scripts/generate-api-models.sh
+++ b/scripts/generate-api-models.sh
@@ -34,7 +34,7 @@ declare -a apis=(
   # Services APIs
   "./definitions/services https://raw.githubusercontent.com/pagopa/io-services-cms/io-services-app-backend@$IO_SERVICES_APP_BACKEND/apps/app-backend/api/external.yaml"
   # Fims APIs
-  "./definitions/fims_history https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/api_io_fims.yaml"
+  "./definitions/fims_history https://raw.githubusercontent.com/pagopa/io-backend/$IO_BACKEND_VERSION/openapi/generated/api_fims_platform.yaml"
   "./definitions/fims_sso https://raw.githubusercontent.com/pagopa/io-fims/a93f1a1abf5230f103d9f489b139902b87288061/apps/op-app/openapi.yaml"
   # CDN APIs
   "./definitions/content https://raw.githubusercontent.com/pagopa/io-services-metadata/$IO_SERVICES_METADATA_VERSION/definitions.yml"


### PR DESCRIPTION
## Short description
This PR updates the FIMS history's API to the new spec.

## List of changes proposed in this pull request
- Switched from old api_io_fims to the new api_fims_platform

## How to test
Using the prod environment, check that both accesses' list and related export operation work.
