### PR TITLE
fix(IT-Wallet): [SIW-4296] Persist `isRemotelyActive` after wallet reset

### DIFF
--- a/ts/features/itwallet/walletInstance/store/reducers/index.ts
+++ b/ts/features/itwallet/walletInstance/store/reducers/index.ts
@@ -165,9 +165,9 @@ const reducer = (
 
     case getType(itwLifecycleStoresReset):
       return {
+        ...itwWalletInstanceInitialState,
         // Should be persisted on wallet resets
-        isRemotelyActive: state.isRemotelyActive,
-        ...itwWalletInstanceInitialState
+        isRemotelyActive: state.isRemotelyActive
       };
 
     default:

--- a/ts/features/itwallet/walletInstance/store/reducers/index.ts
+++ b/ts/features/itwallet/walletInstance/store/reducers/index.ts
@@ -164,7 +164,11 @@ const reducer = (
     }
 
     case getType(itwLifecycleStoresReset):
-      return { ...itwWalletInstanceInitialState };
+      return {
+        // Should be persisted on wallet resets
+        isRemotelyActive: state.isRemotelyActive,
+        ...itwWalletInstanceInitialState
+      };
 
     default:
       return state;


### PR DESCRIPTION
## Short description
Fixes a bug with the wallet discovery banner.

### Steps to reproduce
1. Activate the wallet.
2. Simulate an error during PID issuance (for example, on the /credential endpoint).
3. Navigate back to the wallet home.
4. Observe that the discovery banner is missing, and a skeleton loader is displayed instead.

## List of changes proposed in this pull request

* Modified the reducer in `index.ts` to retain the `isRemotelyActive` property when handling the `itwLifecycleStoresReset` action, ensuring this value is not lost during wallet resets.

## How to test
1. Activate the wallet.
2. Simulate an error during PID issuance (for example, on the /credential endpoint).
3. Navigate back to the wallet home.
4. Observe that the discovery banner is now visible