### PR TITLE
fix: [IOPLT-000] codecov percentage reporting

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -67,12 +67,15 @@ jobs:
           else
             yarn test:ci --passWithNoTests --shard=${{ matrix.shard }}/10
           fi
+      - id: rename-coverage
+        if: needs.static-checks.outputs.should_test == 'true' && steps.run-test.outcome == 'success'
+        run: cp coverage/lcov.info coverage/lcov-${{ matrix.shard }}.info
       - id: upload-coverage
         if: needs.static-checks.outputs.should_test == 'true' && steps.run-test.outcome == 'success'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: coverage-artifact-${{ matrix.shard }}
-          path: coverage/lcov.info
+          path: coverage/lcov-${{ matrix.shard }}.info
           retention-days: 1
   unit-test-gate:
     name: Unit tests result


### PR DESCRIPTION
## Short description
The main change is to ensure that coverage reports from different test shards do not overwrite each other by renaming them before uploading.

## List of changes proposed in this pull request
- Added a step to rename the coverage report file (`lcov.info`) to include the shard number, preventing file overwrites when running tests in parallel shards.
- Updated the upload step to use the renamed coverage report file (`lcov-${{ matrix.shard }}.info`) for each shard.

## How to test
Codecov badge should restore the old percentage value