### PR TITLE
chore: [IOAPPX-000] Add QA iOS beta group

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -205,7 +205,7 @@ platform :ios do
       distribute_external: true,
       notify_external_testers: true,
       app_platform: "ios",
-      groups: ["pagopa_beta_ios", "send_beta_ios", "ioproduct_beta_ios", "iomixpanel_beta_ios"],
+      groups: ["pagopa_beta_ios", "send_beta_ios", "ioproduct_beta_ios", "iomixpanel_beta_ios", "qa_beta_ios"],
       # max wait for App Store Connect processing (30 min)
       wait_processing_timeout_duration: 1800
     )


### PR DESCRIPTION
## Short description
This PR adds `qa_beta_ios` group for automatic beta distributions on iOS.

## List of changes proposed in this pull request
N/A

## How to test
N/A