### PR TITLE
feat: [IEL-537] Added check on the FF Fast Login opt-in on FCI L3 login

### DIFF
--- a/ts/features/fci/screens/__tests__/FciLoginL3Screen.test.tsx
+++ b/ts/features/fci/screens/__tests__/FciLoginL3Screen.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent } from "@testing-library/react-native";
 import { createStore } from "redux";
-import configureMockStore, { MockStoreEnhanced } from "redux-mock-store";
+import configureMockStore from "redux-mock-store";
 import * as pot from "@pagopa/ts-commons/lib/pot";
 import { applicationChangeState } from "../../../../store/actions/application";
 import { appReducer } from "../../../../store/reducers";
@@ -19,6 +19,9 @@ import {
   trackFciLoginRequest,
   trackFciLoginRequestContinue
 } from "../../analytics";
+import * as fastLoginSelectors from "../../../authentication/fastLogin/store/selectors";
+import { AUTHENTICATION_ROUTES } from "../../../authentication/common/navigation/routes";
+import { SETTINGS_ROUTES } from "../../../settings/common/navigation/routes";
 
 // Mock the NFC hook
 jest.mock("../../../pn/aar/hooks/useIsNfcFeatureAvailable");
@@ -26,6 +29,15 @@ jest.mock("../../analytics");
 
 const mockIsNfcAvailable =
   require("../../../pn/aar/hooks/useIsNfcFeatureAvailable").useIsNfcFeatureAvailable;
+
+const mockNavigate = jest.fn();
+
+jest.mock("../../../../navigation/params/AppParamsList", () => ({
+  useIONavigation: () => ({
+    navigate: mockNavigate,
+    setOptions: jest.fn()
+  })
+}));
 
 describe("FciLoginL3Screen", () => {
   beforeEach(() => {
@@ -67,8 +79,19 @@ describe("FciLoginL3Screen", () => {
 
   it("should dispatch active session login actions when continue button is pressed and NFC is available", () => {
     mockIsNfcAvailable.mockReturnValue(true);
+    const mockStore = configureMockStore<GlobalState>();
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = mockStore({
+      ...globalState,
+      profile: pot.some(mockedProfile)
+    });
 
-    const { component, store } = renderComponent({ useMockStore: true });
+    const component = renderScreenWithNavigationStoreContext<GlobalState>(
+      FciLoginL3Screen,
+      FCI_ROUTES.FCI_LOGIN_L3,
+      {},
+      store
+    );
 
     const continueButton = component.getByTestId("FciLoginL3ContinueButton");
 
@@ -82,6 +105,50 @@ describe("FciLoginL3Screen", () => {
     expect(actions).toContainEqual(setActiveSessionLoginFlow("FCI"));
   });
 
+  it("should navigate to LOGIN_OPTIN screen when continue button is pressed, NFC is available and fastLoginOptInFF is enabled", () => {
+    mockIsNfcAvailable.mockReturnValue(true);
+    jest
+      .spyOn(fastLoginSelectors, "fastLoginOptInFFEnabled")
+      .mockReturnValue(true);
+
+    const { component } = renderComponent();
+
+    const continueButton = component.getByTestId("FciLoginL3ContinueButton");
+
+    act(() => {
+      fireEvent.press(continueButton);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(FCI_ROUTES.MAIN, {
+      screen: FCI_ROUTES.LOGIN_OPTIN
+    });
+  });
+
+  it("should navigate to CIE_PIN_SCREEN when continue button is pressed, NFC is available and fastLoginOptInFF is disabled", () => {
+    mockIsNfcAvailable.mockReturnValue(true);
+    jest
+      .spyOn(fastLoginSelectors, "fastLoginOptInFFEnabled")
+      .mockReturnValue(false);
+
+    const { component } = renderComponent();
+
+    const continueButton = component.getByTestId("FciLoginL3ContinueButton");
+
+    act(() => {
+      fireEvent.press(continueButton);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      SETTINGS_ROUTES.PROFILE_NAVIGATOR,
+      {
+        screen: SETTINGS_ROUTES.AUTHENTICATION,
+        params: {
+          screen: AUTHENTICATION_ROUTES.CIE_PIN_SCREEN
+        }
+      }
+    );
+  });
+
   it("should navigate to NFC not available screen when continue button is pressed and NFC is not available", () => {
     mockIsNfcAvailable.mockReturnValue(false);
 
@@ -93,47 +160,25 @@ describe("FciLoginL3Screen", () => {
       fireEvent.press(continueButton);
     });
 
-    expect(continueButton).toBeDefined();
+    expect(mockNavigate).toHaveBeenCalledWith(FCI_ROUTES.MAIN, {
+      screen: FCI_ROUTES.NFC_NOT_AVAILABLE
+    });
   });
 });
 
-type RenderOptions = {
-  useMockStore?: boolean;
-};
-
-const renderComponent = (options?: RenderOptions) => {
+const renderComponent = () => {
   const globalState = appReducer(undefined, applicationChangeState("active"));
-
-  if (options?.useMockStore) {
-    const mockStore = configureMockStore<GlobalState>();
-    const store = mockStore({
-      ...globalState,
-      profile: pot.some(mockedProfile)
-    });
-
-    return {
-      component: renderScreenWithNavigationStoreContext<GlobalState>(
-        FciLoginL3Screen,
-        FCI_ROUTES.FCI_LOGIN_L3,
-        {},
-        store
-      ),
-      store
-    };
-  }
-
   const store = createStore(appReducer, {
     ...globalState,
     profile: pot.some(mockedProfile)
   } as any);
 
-  return {
-    component: renderScreenWithNavigationStoreContext<GlobalState>(
-      FciLoginL3Screen,
-      FCI_ROUTES.FCI_LOGIN_L3,
-      {},
-      store
-    ),
-    store: store as any as MockStoreEnhanced<GlobalState>
-  };
+  const component = renderScreenWithNavigationStoreContext<GlobalState>(
+    FciLoginL3Screen,
+    FCI_ROUTES.FCI_LOGIN_L3,
+    {},
+    store
+  );
+
+  return { component, store };
 };

--- a/ts/features/fci/screens/__tests__/__snapshots__/FciLoginL3Screen.test.tsx.snap
+++ b/ts/features/fci/screens/__tests__/__snapshots__/FciLoginL3Screen.test.tsx.snap
@@ -30,6 +30,147 @@ exports[`FciLoginL3Screen should match the snapshot 1`] = `
         ]
       }
     >
+      <View
+        collapsable={false}
+        pointerEvents="box-none"
+        style={
+          {
+            "zIndex": 1,
+          }
+        }
+      >
+        <View
+          accessibilityElementsHidden={false}
+          importantForAccessibility="auto"
+          onLayout={[Function]}
+          pointerEvents="box-none"
+          style={null}
+        >
+          <View
+            collapsable={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "bottom": 0,
+                "left": 0,
+                "opacity": 1,
+                "position": "absolute",
+                "right": 0,
+                "top": 0,
+                "zIndex": 0,
+              }
+            }
+          >
+            <View
+              collapsable={false}
+              style={
+                {
+                  "backgroundColor": "#FFFFFF",
+                  "borderBottomColor": "rgb(216, 216, 216)",
+                  "flex": 1,
+                  "shadowColor": "rgb(216, 216, 216)",
+                  "shadowOffset": {
+                    "height": 0.5,
+                    "width": 0,
+                  },
+                  "shadowOpacity": 0.85,
+                  "shadowRadius": 0,
+                }
+              }
+            />
+          </View>
+          <View
+            collapsable={false}
+            pointerEvents="box-none"
+            style={
+              {
+                "height": 44,
+                "maxHeight": undefined,
+                "minHeight": undefined,
+                "opacity": undefined,
+                "transform": undefined,
+              }
+            }
+          >
+            <View
+              pointerEvents="none"
+              style={
+                {
+                  "height": 0,
+                }
+              }
+            />
+            <View
+              pointerEvents="box-none"
+              style={
+                {
+                  "alignItems": "stretch",
+                  "flex": 1,
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-start",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginStart": 0,
+                    "opacity": 1,
+                  }
+                }
+              />
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "justifyContent": "center",
+                    "marginHorizontal": 16,
+                    "maxWidth": 718,
+                    "opacity": 1,
+                  }
+                }
+              >
+                <Text
+                  accessibilityRole="header"
+                  aria-level="1"
+                  collapsable={false}
+                  numberOfLines={1}
+                  onLayout={[Function]}
+                  style={
+                    {
+                      "color": "rgb(28, 28, 30)",
+                      "fontSize": 17,
+                      "fontWeight": "600",
+                    }
+                  }
+                >
+                  FCI_LOGIN_L3
+                </Text>
+              </View>
+              <View
+                collapsable={false}
+                pointerEvents="box-none"
+                style={
+                  {
+                    "alignItems": "flex-end",
+                    "flexBasis": 0,
+                    "flexGrow": 1,
+                    "justifyContent": "center",
+                    "marginEnd": 0,
+                    "opacity": 1,
+                  }
+                }
+              />
+            </View>
+          </View>
+        </View>
+      </View>
       <RNSScreenContainer
         onLayout={[Function]}
         style={
@@ -148,7 +289,7 @@ exports[`FciLoginL3Screen should match the snapshot 1`] = `
               <View
                 collapsable={false}
                 enabled={false}
-                handlerTag={1}
+                handlerTag={-1}
                 handlerType="PanGestureHandler"
                 needsOffscreenAlphaCompositing={false}
                 onGestureHandlerEvent={[Function]}
@@ -735,340 +876,6 @@ exports[`FciLoginL3Screen should match the snapshot 1`] = `
                         </RCTScrollView>
                       </RNCSafeAreaView>
                     </View>
-                    <View
-                      collapsable={false}
-                      pointerEvents="box-none"
-                    >
-                      <View
-                        accessibilityElementsHidden={false}
-                        importantForAccessibility="auto"
-                        onLayout={[Function]}
-                        pointerEvents="box-none"
-                        style={null}
-                      >
-                        <View
-                          accessibilityRole="header"
-                          collapsable={false}
-                          jestAnimatedProps={
-                            {
-                              "value": {},
-                            }
-                          }
-                          jestAnimatedStyle={
-                            {
-                              "value": {
-                                "backgroundColor": "#FFFFFF",
-                                "borderColor": "transparent",
-                              },
-                            }
-                          }
-                          jestInlineStyle={
-                            [
-                              {
-                                "borderBottomWidth": 1,
-                                "borderColor": "rgba(210,214,227,0)",
-                              },
-                              {},
-                            ]
-                          }
-                          style={
-                            [
-                              {
-                                "borderBottomWidth": 1,
-                                "borderColor": "rgba(210,214,227,0)",
-                              },
-                              {},
-                              {
-                                "backgroundColor": "#FFFFFF",
-                                "borderColor": "transparent",
-                              },
-                            ]
-                          }
-                        >
-                          <View
-                            collapsable={false}
-                            jestAnimatedProps={
-                              {
-                                "value": {},
-                              }
-                            }
-                            jestAnimatedStyle={
-                              {
-                                "value": {
-                                  "marginTop": 0,
-                                },
-                              }
-                            }
-                            jestInlineStyle={
-                              [
-                                {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                  "flexGrow": 1,
-                                  "height": 56,
-                                  "justifyContent": "space-between",
-                                  "paddingHorizontal": 24,
-                                },
-                              ]
-                            }
-                            style={
-                              [
-                                {
-                                  "marginTop": 0,
-                                },
-                                {
-                                  "alignItems": "center",
-                                  "flexDirection": "row",
-                                  "flexGrow": 1,
-                                  "height": 56,
-                                  "justifyContent": "space-between",
-                                  "paddingHorizontal": 24,
-                                },
-                              ]
-                            }
-                          >
-                            <View
-                              style={
-                                {
-                                  "width": 32,
-                                }
-                              }
-                            />
-                            <View
-                              accessibilityElementsHidden={true}
-                              accessibilityLabel=""
-                              accessibilityRole="header"
-                              accessible={false}
-                              importantForAccessibility="yes"
-                              style={
-                                {
-                                  "flexGrow": 1,
-                                  "flexShrink": 1,
-                                  "marginHorizontal": 16,
-                                }
-                              }
-                            >
-                              <Text
-                                accessible={false}
-                                allowFontScaling={true}
-                                collapsable={false}
-                                jestAnimatedProps={
-                                  {
-                                    "value": {},
-                                  }
-                                }
-                                jestAnimatedStyle={
-                                  {
-                                    "value": {
-                                      "opacity": 1,
-                                    },
-                                  }
-                                }
-                                jestInlineStyle={
-                                  [
-                                    {
-                                      "color": "#0E0F13",
-                                      "textAlign": "center",
-                                    },
-                                  ]
-                                }
-                                maxFontSizeMultiplier={1.5}
-                                numberOfLines={1}
-                                style={
-                                  [
-                                    {},
-                                    {
-                                      "color": undefined,
-                                      "fontFamily": "Titillio",
-                                      "fontSize": 14,
-                                      "fontStyle": "normal",
-                                      "fontWeight": "600",
-                                      "lineHeight": undefined,
-                                    },
-                                    [
-                                      {
-                                        "color": "#0E0F13",
-                                        "textAlign": "center",
-                                      },
-                                      {
-                                        "opacity": 1,
-                                      },
-                                    ],
-                                  ]
-                                }
-                              />
-                            </View>
-                            <View
-                              style={
-                                {
-                                  "display": "flex",
-                                  "flexDirection": "row",
-                                  "flexShrink": 0,
-                                  "gap": 24,
-                                }
-                              }
-                            >
-                              <View
-                                accessibilityLabel="Chiudi"
-                                accessibilityRole="button"
-                                accessibilityState={
-                                  {
-                                    "busy": undefined,
-                                    "checked": undefined,
-                                    "disabled": false,
-                                    "expanded": undefined,
-                                    "selected": undefined,
-                                  }
-                                }
-                                accessibilityValue={
-                                  {
-                                    "max": undefined,
-                                    "min": undefined,
-                                    "now": undefined,
-                                    "text": undefined,
-                                  }
-                                }
-                                accessible={true}
-                                collapsable={false}
-                                focusable={true}
-                                hitSlop={8}
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onResponderGrant={[Function]}
-                                onResponderMove={[Function]}
-                                onResponderRelease={[Function]}
-                                onResponderTerminate={[Function]}
-                                onResponderTerminationRequest={[Function]}
-                                onStartShouldSetResponder={[Function]}
-                              >
-                                <View
-                                  collapsable={false}
-                                  jestAnimatedProps={
-                                    {
-                                      "value": {},
-                                    }
-                                  }
-                                  jestAnimatedStyle={
-                                    {
-                                      "value": {
-                                        "transform": [
-                                          {
-                                            "scale": 1,
-                                          },
-                                        ],
-                                      },
-                                    }
-                                  }
-                                  jestInlineStyle={
-                                    [
-                                      {
-                                        "alignItems": "center",
-                                        "justifyContent": "center",
-                                      },
-                                      {
-                                        "height": 24,
-                                        "width": 24,
-                                      },
-                                    ]
-                                  }
-                                  style={
-                                    [
-                                      {
-                                        "alignItems": "center",
-                                        "justifyContent": "center",
-                                      },
-                                      {
-                                        "height": 24,
-                                        "width": 24,
-                                      },
-                                      {
-                                        "transform": [
-                                          {
-                                            "scale": 1,
-                                          },
-                                        ],
-                                      },
-                                    ]
-                                  }
-                                >
-                                  <RNSVGSvgView
-                                    accessibilityElementsHidden={true}
-                                    accessibilityLabel=""
-                                    accessible={false}
-                                    align="xMidYMid"
-                                    bbHeight={36}
-                                    bbWidth={36}
-                                    collapsable={false}
-                                    color="#0E0F13"
-                                    focusable={false}
-                                    height={36}
-                                    importantForAccessibility="no-hide-descendants"
-                                    jestAnimatedProps={
-                                      {
-                                        "value": {
-                                          "color": "rgba(14, 15, 19, 1)",
-                                        },
-                                      }
-                                    }
-                                    jestAnimatedStyle={
-                                      {
-                                        "value": {},
-                                      }
-                                    }
-                                    meetOrSlice={0}
-                                    minX={0}
-                                    minY={0}
-                                    style={
-                                      [
-                                        {
-                                          "backgroundColor": "transparent",
-                                          "borderWidth": 0,
-                                        },
-                                        {
-                                          "flex": 0,
-                                          "height": 36,
-                                          "width": 36,
-                                        },
-                                      ]
-                                    }
-                                    vbHeight={24}
-                                    vbWidth={24}
-                                    width={36}
-                                  >
-                                    <RNSVGGroup
-                                      fill={
-                                        {
-                                          "payload": 4278190080,
-                                          "type": 0,
-                                        }
-                                      }
-                                    >
-                                      <RNSVGPath
-                                        clipRule={0}
-                                        d="M19.7071 5.70711c.3905-.39053.3905-1.02369 0-1.41422-.3905-.39052-1.0237-.39052-1.4142 0L12 10.5858 5.70711 4.29289c-.39053-.39052-1.02369-.39052-1.41422 0-.39052.39053-.39052 1.02369 0 1.41422L10.5858 12l-6.29291 6.2929c-.39052.3905-.39052 1.0237 0 1.4142.39053.3905 1.02369.3905 1.41422 0L12 13.4142l6.2929 6.2929c.3905.3905 1.0237.3905 1.4142 0 .3905-.3905.3905-1.0237 0-1.4142L13.4142 12l6.2929-6.29289Z"
-                                        fill={
-                                          {
-                                            "type": 2,
-                                          }
-                                        }
-                                        fillRule={0}
-                                        propList={
-                                          [
-                                            "fill",
-                                            "fillRule",
-                                          ]
-                                        }
-                                      />
-                                    </RNSVGGroup>
-                                  </RNSVGSvgView>
-                                </View>
-                              </View>
-                            </View>
-                          </View>
-                        </View>
-                      </View>
-                    </View>
                   </View>
                 </View>
               </View>
@@ -1076,20 +883,6 @@ exports[`FciLoginL3Screen should match the snapshot 1`] = `
           </View>
         </RNSScreen>
       </RNSScreenContainer>
-      <View
-        collapsable={false}
-        pointerEvents="box-none"
-        style={
-          {
-            "height": 44,
-            "left": 0,
-            "position": "absolute",
-            "right": 0,
-            "top": 0,
-            "zIndex": 1,
-          }
-        }
-      />
     </View>
   </RNCSafeAreaProvider>
 </View>

--- a/ts/features/fci/screens/loginL3/FciLoginL3Screen.tsx
+++ b/ts/features/fci/screens/loginL3/FciLoginL3Screen.tsx
@@ -2,7 +2,7 @@ import i18n from "i18next";
 import { useEffect } from "react";
 import { Body, HeaderSecondLevel } from "@pagopa/io-app-design-system";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
-import { useIODispatch } from "../../../../store/hooks";
+import { useIODispatch, useIOSelector } from "../../../../store/hooks";
 import {
   setStartActiveSessionLogin,
   setIdpSelectedActiveSessionLogin,
@@ -20,12 +20,16 @@ import {
   trackFciLoginRequestClose,
   trackFciLoginRequestContinue
 } from "../../analytics";
+import { fastLoginOptInFFEnabled } from "../../../authentication/fastLogin/store/selectors/index.ts";
+import { AUTHENTICATION_ROUTES } from "../../../authentication/common/navigation/routes.ts";
+import { SETTINGS_ROUTES } from "../../../settings/common/navigation/routes.ts";
 
 export const FciLoginL3Screen = () => {
   const dispatch = useIODispatch();
   const navigation = useIONavigation();
   const isNfcAvailable = useIsNfcFeatureAvailable();
   const { setOptions } = useIONavigation();
+  const isFastLoginOptInFFEnabled = useIOSelector(fastLoginOptInFFEnabled);
 
   useOnFirstRender(() => {
     trackFciLoginRequest();
@@ -58,9 +62,18 @@ export const FciLoginL3Screen = () => {
       dispatch(setStartActiveSessionLogin());
       dispatch(setIdpSelectedActiveSessionLogin(IdpCIE));
       dispatch(setActiveSessionLoginFlow("FCI"));
-      navigation.navigate(FCI_ROUTES.MAIN, {
-        screen: FCI_ROUTES.LOGIN_OPTIN
-      });
+      if (isFastLoginOptInFFEnabled) {
+        navigation.navigate(FCI_ROUTES.MAIN, {
+          screen: FCI_ROUTES.LOGIN_OPTIN
+        });
+      } else {
+        navigation.navigate(SETTINGS_ROUTES.PROFILE_NAVIGATOR, {
+          screen: SETTINGS_ROUTES.AUTHENTICATION,
+          params: {
+            screen: AUTHENTICATION_ROUTES.CIE_PIN_SCREEN
+          }
+        });
+      }
     } else {
       navigation.navigate(FCI_ROUTES.MAIN, {
         screen: FCI_ROUTES.NFC_NOT_AVAILABLE


### PR DESCRIPTION
## Short description
In this PR, a check has been added to the remote FF for the fast login opt-in during the login process in the FCI flow for non-L3 users. If the FF is active, the user will be directed to the opt-in screen; otherwise, the user will be directed to the CIE PIN entry screen. 

## List of changes proposed in this pull request
- Add logic to manage navigation 
- Update tests
- Update snapshots

## Demo
<p>

| Opt-in FF active | Opt-in FF not active |
| - | - |
| <video src="https://github.com/user-attachments/assets/93635e56-8738-4171-98aa-07f58aa7d247" /> | <video src="https://github.com/user-attachments/assets/16be0ef0-44d0-43f7-b80b-4ba9811d9523" /> |

</p>

## How to test
1. Run the application using local environment 
2. Enable the FF for fast login and also the one for opt-in [here](https://github.com/pagopa/io-dev-api-server/blob/7a8702f0db816403887545529c13a621fa9e01cf/src/payloads/backend.ts#L328)
3. Activate FF to perform FCI L3 flow
4. Follow the video demo 

(You can also use the production environment, but you'll need to modify the data coming from io-services-metadata using Proxyman.)