### PR TITLE
fix(IT-Wallet): [SIW-4278] Fix reactivation banner visibility

### DIFF
--- a/ts/features/itwallet/lifecycle/saga/__tests__/checkCurrentWalletInstanceStateSaga.test.ts
+++ b/ts/features/itwallet/lifecycle/saga/__tests__/checkCurrentWalletInstanceStateSaga.test.ts
@@ -5,7 +5,7 @@ import {
   getCurrentStatusWalletInstance
 } from "../checkCurrentWalletInstanceStateSaga.ts";
 import { itwSetWalletInstanceRemotelyActive } from "../../../walletInstance/store/actions";
-import { itwLifecycleIsOperationalSelector } from "../../store/selectors";
+import { itwLifecycleIsOperationalOrValid } from "../../store/selectors";
 
 describe("checkCurrentWalletInstanceStateSaga", () => {
   it("Sets the wallet instance as remotely active when remote is active, not revoked, and local is inactive", () => {
@@ -15,7 +15,7 @@ describe("checkCurrentWalletInstanceStateSaga", () => {
     return expectSaga(checkCurrentWalletInstanceStateSaga)
       .provide([
         [matchers.call(getCurrentStatusWalletInstance), remoteStatus],
-        [matchers.select(itwLifecycleIsOperationalSelector), localStatus]
+        [matchers.select(itwLifecycleIsOperationalOrValid), localStatus]
       ])
       .put(itwSetWalletInstanceRemotelyActive(true))
       .run(false);
@@ -28,7 +28,7 @@ describe("checkCurrentWalletInstanceStateSaga", () => {
     return expectSaga(checkCurrentWalletInstanceStateSaga)
       .provide([
         [matchers.call(getCurrentStatusWalletInstance), remoteStatus],
-        [matchers.select(itwLifecycleIsOperationalSelector), localStatus]
+        [matchers.select(itwLifecycleIsOperationalOrValid), localStatus]
       ])
       .put(itwSetWalletInstanceRemotelyActive(false))
       .run(false);
@@ -41,7 +41,7 @@ describe("checkCurrentWalletInstanceStateSaga", () => {
     return expectSaga(checkCurrentWalletInstanceStateSaga)
       .provide([
         [matchers.call(getCurrentStatusWalletInstance), remoteStatus],
-        [matchers.select(itwLifecycleIsOperationalSelector), localStatus]
+        [matchers.select(itwLifecycleIsOperationalOrValid), localStatus]
       ])
       .put(itwSetWalletInstanceRemotelyActive(false))
       .run(false);
@@ -54,7 +54,7 @@ describe("checkCurrentWalletInstanceStateSaga", () => {
     return expectSaga(checkCurrentWalletInstanceStateSaga)
       .provide([
         [matchers.call(getCurrentStatusWalletInstance), remoteStatus],
-        [matchers.select(itwLifecycleIsOperationalSelector), localStatus]
+        [matchers.select(itwLifecycleIsOperationalOrValid), localStatus]
       ])
       .put(itwSetWalletInstanceRemotelyActive(false))
       .run(false);

--- a/ts/features/itwallet/lifecycle/saga/checkCurrentWalletInstanceStateSaga.ts
+++ b/ts/features/itwallet/lifecycle/saga/checkCurrentWalletInstanceStateSaga.ts
@@ -9,10 +9,7 @@ import {
 } from "../../common/store/selectors/environment.ts";
 import { getEnv } from "../../common/utils/environment.ts";
 import { getCurrentWalletInstanceStatus } from "../../common/utils/itwAttestationUtils.ts";
-import {
-  itwLifecycleIsOperationalOrValid,
-  itwLifecycleIsValidSelector
-} from "../store/selectors";
+import { itwLifecycleIsOperationalOrValid } from "../store/selectors";
 
 export function* getCurrentStatusWalletInstance() {
   const sessionToken = yield* select(sessionTokenSelector);
@@ -45,7 +42,7 @@ export function* checkCurrentWalletInstanceStateSaga(): Generator<
   // An operational local wallet instance can exist even without a PID, for example
   // after a failed activation, and should not be treated as remotely active.
   const isItwOperationalOrValidLocally = yield* select(
-    itwLifecycleIsValidSelector
+    itwLifecycleIsOperationalOrValid
   );
 
   const itwCanBeReactivated = Boolean(

--- a/ts/features/itwallet/lifecycle/saga/checkCurrentWalletInstanceStateSaga.ts
+++ b/ts/features/itwallet/lifecycle/saga/checkCurrentWalletInstanceStateSaga.ts
@@ -9,7 +9,10 @@ import {
 } from "../../common/store/selectors/environment.ts";
 import { getEnv } from "../../common/utils/environment.ts";
 import { getCurrentWalletInstanceStatus } from "../../common/utils/itwAttestationUtils.ts";
-import { itwLifecycleIsOperationalSelector } from "../store/selectors";
+import {
+  itwLifecycleIsOperationalOrValid,
+  itwLifecycleIsValidSelector
+} from "../store/selectors";
 
 export function* getCurrentStatusWalletInstance() {
   const sessionToken = yield* select(sessionTokenSelector);
@@ -39,17 +42,16 @@ export function* checkCurrentWalletInstanceStateSaga(): Generator<
   const remoteWalletInstanceStatus = yield* call(
     getCurrentStatusWalletInstance
   );
-
   // An operational local wallet instance can exist even without a PID, for example
   // after a failed activation, and should not be treated as remotely active.
-  const isItwOperationalLocally = yield* select(
-    itwLifecycleIsOperationalSelector
+  const isItwOperationalOrValidLocally = yield* select(
+    itwLifecycleIsValidSelector
   );
 
   const itwCanBeReactivated = Boolean(
     remoteWalletInstanceStatus &&
     !remoteWalletInstanceStatus.is_revoked &&
-    !isItwOperationalLocally
+    !isItwOperationalOrValidLocally
   );
 
   yield* put(itwSetWalletInstanceRemotelyActive(itwCanBeReactivated));


### PR DESCRIPTION
## Short description
This PR fix a regression introduced in [this PR](https://github.com/pagopa/io-app/pull/8092), where reactivation banner was being showed in some unexpected cases
## List of changes proposed in this pull request
- Replace `itwLifecycleIsOperationalSelector` with `itwLifecycleIsOperationalOrValid`, so valid cases are still checked.

## How to test
Begin an IT Wallet activation
After the first step and landing to "Informativa privacy" screen, close the issuance flow. (This is where the Wallet instance is created)
Go back to "Portafoglio" section and verify that no reactivation banner appears.
Ensure no regression are introduced:

The user signs in on a device different from the one where they activated ITW.
The user signs in with another account on their device and then signs back in with their own account.
The user uninstalls IO from their device and later reinstalls it.
In all these cases, the reactivation banner should be displayed.
