### PR TITLE
fix: [IOCOM-3147] Third party messages attachments url fix

### DIFF
--- a/ts/features/messages/saga/__test__/handleRequestInit.test.ts
+++ b/ts/features/messages/saga/__test__/handleRequestInit.test.ts
@@ -34,7 +34,7 @@ describe("handleDownloadAttachment", () => {
 
   it("handleRequestInit should follow the proper flow and return the enhanced lollipop headers", () => {
     const data = fetchParametersCommonInputData();
-    const attachmentFullUrl = `https://base.url/api/v1/third-party-messages/${data.messageId}/attachments/${data.attachmentFullUrl}`;
+    const attachmentFullUrl = `https://base.url/api/communication/v1/third-party-messages/${data.messageId}/attachments/${data.attachmentFullUrl}`;
     testSaga(
       handleRequestInit,
       {
@@ -64,7 +64,7 @@ describe("handleDownloadAttachment", () => {
 
   it("handleRequestInit should follow the proper flow and return standard headers when lollipopRequestInit fails", () => {
     const data = fetchParametersCommonInputData();
-    const attachmentFullUrl = `https://base.url/api/v1/third-party-messages/${data.messageId}/attachments/${data.attachmentFullUrl}`;
+    const attachmentFullUrl = `https://base.url/api/communication/v1/third-party-messages/${data.messageId}/attachments/${data.attachmentFullUrl}`;
     testSaga(
       handleRequestInit,
       {

--- a/ts/features/messages/utils/__tests__/attachments.test.ts
+++ b/ts/features/messages/utils/__tests__/attachments.test.ts
@@ -189,13 +189,13 @@ describe("attachments", () => {
   describe("attachmentDownloadUrl", () => {
     it("should construct the download URL correctly", () => {
       const attachment = { url: "some/path" } as ThirdPartyAttachment;
-      const expectedUrl = `/api/v1/third-party-messages/${messageId}/attachments/some/path`;
+      const expectedUrl = `/api/communication/v1/third-party-messages/${messageId}/attachments/some/path`;
       const url = attachmentDownloadUrl(messageId, attachment);
       expect(url).toBe(expectedUrl);
     });
     it("should strip leading slash from attachment url", () => {
       const attachment = { url: "/some/path" } as ThirdPartyAttachment;
-      const expectedUrl = `/api/v1/third-party-messages/${messageId}/attachments/some/path`;
+      const expectedUrl = `/api/communication/v1/third-party-messages/${messageId}/attachments/some/path`;
       const url = attachmentDownloadUrl(messageId, attachment);
       expect(url).toBe(expectedUrl);
     });

--- a/ts/features/messages/utils/attachments.ts
+++ b/ts/features/messages/utils/attachments.ts
@@ -37,8 +37,8 @@ export const attachmentDownloadUrl = (
   messageId: string,
   attachment: ThirdPartyAttachment
 ) =>
-  `${apiUrlPrefix}/api/v1/third-party-messages/${messageId}/attachments/${attachment.url.replace(
-    /^\//g, // note that attachmentUrl might contains a / at the beginning, so let's strip it
+  `${apiUrlPrefix}/api/communication/v1/third-party-messages/${messageId}/attachments/${attachment.url.replace(
+    /^\//g, // note that attachmentUrl might contain a / at the beginning, so let's strip it
     ""
   )}`;
 


### PR DESCRIPTION
## Short description
this PR updates the thirdpartymessage's attachment url to fit the new definitions

## List of changes proposed in this pull request
- updated URL
- updated tests

## How to test
automated tests should pass.
also, when running the dev-server at the latest revision, third party message attachments should load correctly and the server's log should display that the correct url was requested.