### PR TITLE
chore: [IEL-360] Accessibility label with value for SEND_AAR_ERROR screen

### DIFF
--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -2373,7 +2373,8 @@
                 "supportTitle": "Contatta l'assistenza",
                 "chat": "Chiedi aiuto in chat",
                 "additionalDataTitle": "Dati aggiuntivi",
-                "errorCode": "Codice errore"
+                "errorCode": "Codice errore",
+                "errorCodeAccessibility": "Codice errore: {{errorCode}}, copia"
               }
             },
             "cieValidation": {

--- a/ts/features/pn/aar/components/errors/__tests__/__snapshots__/sendAarErrorSupportBottomSheetComponent.test.tsx.snap
+++ b/ts/features/pn/aar/components/errors/__tests__/__snapshots__/sendAarErrorSupportBottomSheetComponent.test.tsx.snap
@@ -357,7 +357,7 @@ exports[`sendAarErrorSupportBottomSheetComponent should match the snapshot with 
     </View>
   </View>,
   <View
-    accessibilityLabel="features.pn.aar.flow.ko.GENERIC.detail.errorCode"
+    accessibilityLabel="features.pn.aar.flow.ko.GENERIC.detail.errorCodeAccessibility"
     accessibilityRole="button"
     accessibilityState={
       {

--- a/ts/features/pn/aar/components/errors/hooks/__tests__/__snapshots__/useAarGenericErrorBottomSheet.test.ts.snap
+++ b/ts/features/pn/aar/components/errors/hooks/__tests__/__snapshots__/useAarGenericErrorBottomSheet.test.ts.snap
@@ -357,7 +357,7 @@ exports[`useAarGenericErrorBottomSheet ZendeskSecondLevelTag: "io_problema_notif
     </View>
   </View>,
   <View
-    accessibilityLabel="features.pn.aar.flow.ko.GENERIC.detail.errorCode"
+    accessibilityLabel="features.pn.aar.flow.ko.GENERIC.detail.errorCodeAccessibility"
     accessibilityRole="button"
     accessibilityState={
       {
@@ -955,7 +955,7 @@ exports[`useAarGenericErrorBottomSheet ZendeskSecondLevelTag: "io_problema_notif
     </View>
   </View>,
   <View
-    accessibilityLabel="features.pn.aar.flow.ko.GENERIC.detail.errorCode"
+    accessibilityLabel="features.pn.aar.flow.ko.GENERIC.detail.errorCodeAccessibility"
     accessibilityRole="button"
     accessibilityState={
       {
@@ -1553,7 +1553,7 @@ exports[`useAarGenericErrorBottomSheet ZendeskSecondLevelTag: "io_problema_notif
     </View>
   </View>,
   <View
-    accessibilityLabel="features.pn.aar.flow.ko.GENERIC.detail.errorCode"
+    accessibilityLabel="features.pn.aar.flow.ko.GENERIC.detail.errorCodeAccessibility"
     accessibilityRole="button"
     accessibilityState={
       {
@@ -2455,7 +2455,7 @@ exports[`useAarGenericErrorBottomSheet ZendeskSecondLevelTag: "io_problema_notif
     </View>
   </View>,
   <View
-    accessibilityLabel="features.pn.aar.flow.ko.GENERIC.detail.errorCode"
+    accessibilityLabel="features.pn.aar.flow.ko.GENERIC.detail.errorCodeAccessibility"
     accessibilityRole="button"
     accessibilityState={
       {
@@ -3053,7 +3053,7 @@ exports[`useAarGenericErrorBottomSheet ZendeskSecondLevelTag: "io_problema_notif
     </View>
   </View>,
   <View
-    accessibilityLabel="features.pn.aar.flow.ko.GENERIC.detail.errorCode"
+    accessibilityLabel="features.pn.aar.flow.ko.GENERIC.detail.errorCodeAccessibility"
     accessibilityRole="button"
     accessibilityState={
       {
@@ -3651,7 +3651,7 @@ exports[`useAarGenericErrorBottomSheet ZendeskSecondLevelTag: "io_problema_notif
     </View>
   </View>,
   <View
-    accessibilityLabel="features.pn.aar.flow.ko.GENERIC.detail.errorCode"
+    accessibilityLabel="features.pn.aar.flow.ko.GENERIC.detail.errorCodeAccessibility"
     accessibilityRole="button"
     accessibilityState={
       {

--- a/ts/features/pn/aar/components/errors/sendAarErrorSupportBottomSheetComponent.tsx
+++ b/ts/features/pn/aar/components/errors/sendAarErrorSupportBottomSheetComponent.tsx
@@ -40,7 +40,8 @@ export const sendAarErrorSupportBottomSheetComponent = (
         <ListItemInfoCopy
           label={I18n.t("features.pn.aar.flow.ko.GENERIC.detail.errorCode")}
           accessibilityLabel={I18n.t(
-            "features.pn.aar.flow.ko.GENERIC.detail.errorCode"
+            "features.pn.aar.flow.ko.GENERIC.detail.errorCodeAccessibility",
+            { errorCode: assistanceErrorCode }
           )}
           icon="ladybug"
           value={assistanceErrorCode}


### PR DESCRIPTION
## Short description
Update accessibilityLabel for "more details" bottomsheet in `SEND_AAR_ERROR` screen

## List of changes proposed in this pull request
- added `errorCode` value
- updated snapshots

## How to test
On the dev server, with default configuration, generate the QR for `SEND-SEND-SEND-000000-A-0`, then scan it from the app, then in the app manually set a value for `errorName` for `useAarGenericErrorBottomSheet` ( as the dev server's `ProblemJson` doesnt have a `code` property which in app turns into the errorName param )

<table><tr><th>Before</th><th>After</th></tr><tr><td width="50%">


<img width="596" height="1306" alt="image" src="https://github.com/user-attachments/assets/cc61b9a1-77e0-4511-86dc-2a8b87b544d2" />

</td><td>

<img width="596" height="1306" alt="image" src="https://github.com/user-attachments/assets/0d09e810-1fa4-40c4-b21d-fd177f122cdb" />



</td></tr></table>
