### PR TITLE
fix(localization): [IEL-000] Correct line breaks in payment outcome subtitles

### DIFF
--- a/locales/it/index.json
+++ b/locales/it/index.json
@@ -1499,7 +1499,7 @@
         },
         "TIMEOUT": {
           "title": "La sessione è scaduta",
-          "subtitle": "Non è stato addebitato alcun importo.\\nPer la tua sicurezza, hai a disposizione un tempo limitato per completare l’operazione."
+          "subtitle": "Non è stato addebitato alcun importo.\nPer la tua sicurezza, hai a disposizione un tempo limitato per completare l’operazione."
         },
         "CIRCUIT_ERROR": {
           "title": "Il circuito della carta non è supportato"
@@ -1517,7 +1517,7 @@
         },
         "EXCESSIVE_AMOUNT": {
           "title": "Autorizzazione negata",
-          "subtitle": "Non è stato addebitato alcun importo.\\nProbabilmente hai sforato i limiti di spesa previsti dalla tua banca."
+          "subtitle": "Non è stato addebitato alcun importo.\nProbabilmente hai sforato i limiti di spesa previsti dalla tua banca."
         },
         "INVALID_METHOD": {
           "title": "Il metodo di pagamento non è supportato"


### PR DESCRIPTION
## Short description
This pull request makes a small update to the Italian localization file, correcting the newline character in two subtitle strings.

## How to test
Navigate through the impacted screens and make sure the subtitles don't render the `/n` character.

<details><summary>Screens</summary>
<p>

| Before | After |
|--------|--------|
| <img width="1206" height="2622" alt="timeout-before" src="https://github.com/user-attachments/assets/310764e2-def8-4204-95de-0f0f21067ef5" /> | <img width="1206" height="2622" alt="timeout-after" src="https://github.com/user-attachments/assets/4ab28a74-beca-42c9-bd42-590e60613a4b" /> |
| <img width="1206" height="2622" alt="excessive-amount-before" src="https://github.com/user-attachments/assets/7d5e26a8-3fa1-4cf4-8082-ef84315bf22d" /> | <img width="1206" height="2622" alt="excessive-amount-after" src="https://github.com/user-attachments/assets/462b6924-1ad6-4b93-b57f-f86fdd75d1a3" /> | 

</p>
</details> 
