### PR TITLE
feat(IT-Wallet): [SIW-3911] skip MRTD PoP challenge when `challenge_info` is absent

### DIFF
--- a/ts/features/itwallet/common/utils/mrtd.ts
+++ b/ts/features/itwallet/common/utils/mrtd.ts
@@ -25,6 +25,18 @@ export type ValidateMrtdPoPChallengeParams = {
   ias: CredentialIssuance.MRTDPoP.IasPayload;
 };
 
+const getRedirectQuery = (url: string): URLSearchParams => {
+  const queryStart = url.indexOf("?");
+  return new URLSearchParams(queryStart >= 0 ? url.slice(queryStart + 1) : "");
+};
+
+/**
+ * Checks if the PID Provider requires the MRTD PoP step by looking for
+ * `challenge_info` in the post-auth redirect.
+ */
+export const isMrtdPoPChallengeRequired = (authRedirectUrl: string): boolean =>
+  getRedirectQuery(authRedirectUrl).has("challenge_info");
+
 export const initMrtdPoPChallenge = async ({
   itwVersion,
   authRedirectUrl,

--- a/ts/features/itwallet/common/utils/mrtd.ts
+++ b/ts/features/itwallet/common/utils/mrtd.ts
@@ -6,6 +6,7 @@ import {
 import { WIA_KEYTAG } from "./itwCryptoContextUtils";
 import { IssuerConfiguration } from "./itwTypesUtils";
 import { getIoWallet } from "./itwIoWallet";
+export { isMrtdPoPChallengeRequired } from "./mrtdUrl";
 
 export type InitMrtdPoPChallengeParams = {
   itwVersion: ItwVersion;
@@ -24,18 +25,6 @@ export type ValidateMrtdPoPChallengeParams = {
   mrtd: CredentialIssuance.MRTDPoP.MrtdPayload;
   ias: CredentialIssuance.MRTDPoP.IasPayload;
 };
-
-const getRedirectQuery = (url: string): URLSearchParams => {
-  const queryStart = url.indexOf("?");
-  return new URLSearchParams(queryStart >= 0 ? url.slice(queryStart + 1) : "");
-};
-
-/**
- * Checks if the PID Provider requires the MRTD PoP step by looking for
- * `challenge_info` in the post-auth redirect.
- */
-export const isMrtdPoPChallengeRequired = (authRedirectUrl: string): boolean =>
-  getRedirectQuery(authRedirectUrl).has("challenge_info");
 
 export const initMrtdPoPChallenge = async ({
   itwVersion,

--- a/ts/features/itwallet/common/utils/mrtdUrl.ts
+++ b/ts/features/itwallet/common/utils/mrtdUrl.ts
@@ -1,0 +1,13 @@
+const getRedirectQuery = (url: string): URLSearchParams => {
+  const queryStart = url.indexOf("?");
+  return new URLSearchParams(queryStart >= 0 ? url.slice(queryStart + 1) : "");
+};
+
+/**
+ * Checks if the PID Provider requires the MRTD PoP step by looking for
+ * `challenge_info` in the post-auth redirect URL.
+ * This is a pure URL-parsing utility with no native dependencies,
+ * safe to import from the XState machine definition.
+ */
+export const isMrtdPoPChallengeRequired = (authRedirectUrl: string): boolean =>
+  getRedirectQuery(authRedirectUrl).has("challenge_info");

--- a/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
+++ b/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
@@ -188,7 +188,7 @@ describe("itwEidIssuanceMachine", () => {
         StartAuthFlowActorParams
       >(startAuthFlow),
       initMrtdPoPChallenge: fromPromise<
-        MrtdPoPContext | null,
+        MrtdPoPContext,
         InitMrtdPoPChallengeActorParams
       >(initMrtdPoPChallenge),
       validateMrtdPoPChallenge: fromPromise<
@@ -2333,12 +2333,12 @@ describe("itwEidIssuanceMachine", () => {
 
     actor.send({
       type: "user-identification-completed",
-      authRedirectUrl: "http://spid.test.it"
+      authRedirectUrl: "http://spid.test.it?challenge_info=mock_challenge"
     });
 
     expect(actor.getSnapshot().context).toMatchObject({
       authenticationContext: {
-        callbackUrl: "http://spid.test.it"
+        callbackUrl: "http://spid.test.it?challenge_info=mock_challenge"
       }
     });
 
@@ -2499,7 +2499,7 @@ describe("itwEidIssuanceMachine", () => {
     );
   });
 
-  it("Should skip MRTD PoP and go straight to Issuance when challenge_info is absent (LoA High)", async () => {
+  it("Should skip MrtdPoP state entirely and go straight to Issuance when challenge_info is absent (LoA High)", async () => {
     const initialSnapshot: MachineSnapshot = createActor(
       itwEidIssuanceMachine
     ).getSnapshot();
@@ -2522,8 +2522,7 @@ describe("itwEidIssuanceMachine", () => {
 
     await waitFor(() => expect(startAuthFlow).toHaveBeenCalledTimes(1));
 
-    // No challenge_info → initMrtdPoPChallenge resolves to null → skip MRTD
-    initMrtdPoPChallenge.mockImplementation(() => Promise.resolve(null));
+    // No challenge_info → requiresMrtdVerification guard is false → MrtdPoP is skipped entirely
     requestAccessToken.mockImplementation(() =>
       Promise.resolve(T_ACCESS_TOKEN)
     );
@@ -2540,8 +2539,6 @@ describe("itwEidIssuanceMachine", () => {
       authRedirectUrl: "https://wallet.test.it/cb?code=abc&state=xyz"
     });
 
-    await waitFor(() => expect(initMrtdPoPChallenge).toHaveBeenCalledTimes(1));
-
     await waitForActor(actor, s =>
       s.matches({ Issuance: "DisplayingPreview" })
     );
@@ -2550,6 +2547,7 @@ describe("itwEidIssuanceMachine", () => {
     expect(actor.getSnapshot().context.authenticationContext).toMatchObject({
       callbackUrl: "https://wallet.test.it/cb?code=abc&state=xyz"
     });
+    expect(initMrtdPoPChallenge).not.toHaveBeenCalled();
     expect(validateMrtdPoPChallenge).not.toHaveBeenCalled();
   });
 

--- a/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
+++ b/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
@@ -188,7 +188,7 @@ describe("itwEidIssuanceMachine", () => {
         StartAuthFlowActorParams
       >(startAuthFlow),
       initMrtdPoPChallenge: fromPromise<
-        MrtdPoPContext,
+        MrtdPoPContext | null,
         InitMrtdPoPChallengeActorParams
       >(initMrtdPoPChallenge),
       validateMrtdPoPChallenge: fromPromise<
@@ -2497,6 +2497,60 @@ describe("itwEidIssuanceMachine", () => {
         Issuance: "DisplayingPreview"
       })
     );
+  });
+
+  it("Should skip MRTD PoP and go straight to Issuance when challenge_info is absent (LoA High)", async () => {
+    const initialSnapshot: MachineSnapshot = createActor(
+      itwEidIssuanceMachine
+    ).getSnapshot();
+
+    const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
+      value: { UserIdentification: "Identification" },
+      context: {
+        level: "l3",
+        mode: "issuance",
+        integrityKeyTag: T_INTEGRITY_KEY,
+        walletInstanceAttestation: { jwt: T_WIA }
+      }
+    } as MachineSnapshot);
+
+    const actor = createActor(mockedMachine, { snapshot });
+    actor.start();
+
+    startAuthFlow.mockImplementation(() => Promise.resolve({}));
+    actor.send({ type: "select-identification-mode", mode: "cieId" });
+
+    await waitFor(() => expect(startAuthFlow).toHaveBeenCalledTimes(1));
+
+    // No challenge_info → initMrtdPoPChallenge resolves to null → skip MRTD
+    initMrtdPoPChallenge.mockImplementation(() => Promise.resolve(null));
+    requestAccessToken.mockImplementation(() =>
+      Promise.resolve(T_ACCESS_TOKEN)
+    );
+    requestEid.mockImplementation(() =>
+      Promise.resolve({
+        credential: { credential: "", metadata: ItwStoredCredentialsMocks.eid },
+        walletUnitAttestations: T_WUA
+      })
+    );
+    issuedEidMatchesAuthenticatedUser.mockImplementation(() => true);
+
+    actor.send({
+      type: "user-identification-completed",
+      authRedirectUrl: "https://wallet.test.it/cb?code=abc&state=xyz"
+    });
+
+    await waitFor(() => expect(initMrtdPoPChallenge).toHaveBeenCalledTimes(1));
+
+    await waitForActor(actor, s =>
+      s.matches({ Issuance: "DisplayingPreview" })
+    );
+
+    expect(actor.getSnapshot().context.mrtdContext).toBeUndefined();
+    expect(actor.getSnapshot().context.authenticationContext).toMatchObject({
+      callbackUrl: "https://wallet.test.it/cb?code=abc&state=xyz"
+    });
+    expect(validateMrtdPoPChallenge).not.toHaveBeenCalled();
   });
 
   it("Should wait for session refresh then retry the eID request", async () => {

--- a/ts/features/itwallet/machine/eid/actors.ts
+++ b/ts/features/itwallet/machine/eid/actors.ts
@@ -270,7 +270,7 @@ export const createEidIssuanceActorsImplementation = (
   ),
 
   initMrtdPoPChallenge: fromPromise<
-    MrtdPoPContext | null,
+    MrtdPoPContext,
     InitMrtdPoPChallengeActorParams
   >(async ({ input }) => {
     assert(input.authenticationContext, "authenticationContext is undefined");
@@ -278,15 +278,6 @@ export const createEidIssuanceActorsImplementation = (
       input.walletInstanceAttestation,
       "walletInstanceAttestation is undefined"
     );
-
-    // Skip MRTD PoP when `challenge_info` is absent (LoA High authentication)
-    if (
-      !mrtdUtils.isMrtdPoPChallengeRequired(
-        input.authenticationContext.callbackUrl
-      )
-    ) {
-      return null;
-    }
 
     return mrtdUtils.initMrtdPoPChallenge({
       itwVersion,

--- a/ts/features/itwallet/machine/eid/actors.ts
+++ b/ts/features/itwallet/machine/eid/actors.ts
@@ -270,7 +270,7 @@ export const createEidIssuanceActorsImplementation = (
   ),
 
   initMrtdPoPChallenge: fromPromise<
-    MrtdPoPContext,
+    MrtdPoPContext | null,
     InitMrtdPoPChallengeActorParams
   >(async ({ input }) => {
     assert(input.authenticationContext, "authenticationContext is undefined");
@@ -278,6 +278,15 @@ export const createEidIssuanceActorsImplementation = (
       input.walletInstanceAttestation,
       "walletInstanceAttestation is undefined"
     );
+
+    // Skip MRTD PoP when `challenge_info` is absent (LoA High authentication)
+    if (
+      !mrtdUtils.isMrtdPoPChallengeRequired(
+        input.authenticationContext.callbackUrl
+      )
+    ) {
+      return null;
+    }
 
     return mrtdUtils.initMrtdPoPChallenge({
       itwVersion,

--- a/ts/features/itwallet/machine/eid/machine.ts
+++ b/ts/features/itwallet/machine/eid/machine.ts
@@ -175,7 +175,7 @@ export const itwEidIssuanceMachine = setup({
      */
 
     initMrtdPoPChallenge: fromPromise<
-      MrtdPoPContext,
+      MrtdPoPContext | null,
       InitMrtdPoPChallengeActorParams
     >(notImplemented),
     validateMrtdPoPChallenge: fromPromise<
@@ -910,7 +910,7 @@ export const itwEidIssuanceMachine = setup({
       states: {
         InitializingChallenge: {
           description:
-            "Initializes the MRTD PoP challenge with the callbackUrl obtained from the primary authentication (SPID/CieID)",
+            "Initializes the MRTD PoP challenge. Returns `null` when `challenge_info` is absent (LoA High), skipping directly to issuance.",
           tags: [ItwTags.Loading],
           invoke: {
             src: "initMrtdPoPChallenge",
@@ -918,12 +918,18 @@ export const itwEidIssuanceMachine = setup({
               authenticationContext: context.authenticationContext,
               walletInstanceAttestation: context.walletInstanceAttestation?.jwt
             }),
-            onDone: {
-              target: "DisplayingCanPreparationInstructions",
-              actions: assign(({ event }) => ({
-                mrtdContext: event.output
-              }))
-            },
+            onDone: [
+              {
+                guard: ({ event }) => event.output === null,
+                target: "#itwEidIssuanceMachine.Issuance"
+              },
+              {
+                target: "DisplayingCanPreparationInstructions",
+                actions: assign(({ event }) => ({
+                  mrtdContext: event.output ?? undefined
+                }))
+              }
+            ],
             onError: {
               actions: "setFailure",
               target: "#itwEidIssuanceMachine.Failure"

--- a/ts/features/itwallet/machine/eid/machine.ts
+++ b/ts/features/itwallet/machine/eid/machine.ts
@@ -18,6 +18,7 @@ import {
 } from "../../common/utils/itwTypesUtils";
 import { ItwTags } from "../tags";
 import { itwCredentialUpgradeMachine } from "../upgrade/machine.ts";
+import { isMrtdPoPChallengeRequired } from "../../common/utils/mrtdUrl";
 import {
   GetWalletAttestationActorParams,
   InitMrtdPoPChallengeActorParams,
@@ -175,7 +176,7 @@ export const itwEidIssuanceMachine = setup({
      */
 
     initMrtdPoPChallenge: fromPromise<
-      MrtdPoPContext | null,
+      MrtdPoPContext,
       InitMrtdPoPChallengeActorParams
     >(notImplemented),
     validateMrtdPoPChallenge: fromPromise<
@@ -220,9 +221,12 @@ export const itwEidIssuanceMachine = setup({
     isL3FeaturesEnabled: ({ context }) => context.level === "l3",
     isEligibleForItwSimplifiedActivation: notImplemented,
     requiresMrtdVerification: ({ context }) =>
-      // MRTD PoP verification is a step required for SPID and CieID identification modes
-      // when issuing an L3 PID
-      context.level === "l3" && context.identification?.mode !== "ciePin",
+      // MRTD PoP verification is required for SPID and CieID identification modes
+      // when issuing an L3 PID and the PID Provider signals a challenge via `challenge_info`.
+      context.level === "l3" &&
+      context.identification?.mode !== "ciePin" &&
+      context.authenticationContext !== undefined &&
+      isMrtdPoPChallengeRequired(context.authenticationContext.callbackUrl),
     isWalletValid: notImplemented
   }
 }).createMachine({
@@ -910,7 +914,7 @@ export const itwEidIssuanceMachine = setup({
       states: {
         InitializingChallenge: {
           description:
-            "Initializes the MRTD PoP challenge. Returns `null` when `challenge_info` is absent (LoA High), skipping directly to issuance.",
+            "Initializes the MRTD PoP challenge. The machine only enters this state when `challenge_info` is present in the callback URL.",
           tags: [ItwTags.Loading],
           invoke: {
             src: "initMrtdPoPChallenge",
@@ -918,18 +922,12 @@ export const itwEidIssuanceMachine = setup({
               authenticationContext: context.authenticationContext,
               walletInstanceAttestation: context.walletInstanceAttestation?.jwt
             }),
-            onDone: [
-              {
-                guard: ({ event }) => event.output === null,
-                target: "#itwEidIssuanceMachine.Issuance"
-              },
-              {
-                target: "DisplayingCanPreparationInstructions",
-                actions: assign(({ event }) => ({
-                  mrtdContext: event.output ?? undefined
-                }))
-              }
-            ],
+            onDone: {
+              target: "DisplayingCanPreparationInstructions",
+              actions: assign(({ event }) => ({
+                mrtdContext: event.output
+              }))
+            },
             onError: {
               actions: "setFailure",
               target: "#itwEidIssuanceMachine.Failure"


### PR DESCRIPTION
## Short description
Split the CieID flow based on the presence of `challenge_info` in the post-auth redirect, per IT-Wallet spec. The PID Provider decides at runtime whether MRTD PoP is needed; the app now respects that decision instead of always forcing the MRTD step.

 ## List of changes proposed in this pull request
 - Added `isMrtdPoPChallengeRequired` utility to check for `challenge_info` in the redirect URL
 - `initMrtdPoPChallenge` actor returns `null` when MRTD PoP is not required
 - eID issuance machine branches on `null` → skip to Issuance; otherwise proceed with MRTD PoP
 - Added test for the skip-MRTD path

 ## How to test
 1. Start an L3 eID issuance flow with CieID
 2. If the redirect has no `challenge_info` → app skips NFC/MRTD screens and goes to eID preview
 3. If the redirect has `challenge_info` → existing MRTD PoP flow works as before