### PR TITLE
fix(IT-Wallet): [SIW-4040] Fix simplified activation tracking

### DIFF
--- a/ts/features/itwallet/analytics/properties/__tests__/basePropertyBuilder.test.ts
+++ b/ts/features/itwallet/analytics/properties/__tests__/basePropertyBuilder.test.ts
@@ -5,6 +5,7 @@ import {
 import { applicationChangeState } from "../../../../../store/actions/application";
 import { appReducer } from "../../../../../store/reducers";
 import * as lifecycleSelectors from "../../../lifecycle/store/selectors";
+import * as credentialsSelectors from "../../../credentials/store/selectors";
 
 describe("buildItwBaseProperties", () => {
   afterEach(() => {
@@ -41,6 +42,40 @@ describe("buildItwBaseProperties", () => {
         "ITW_CED_V2"
       ])
     );
+  });
+
+  it("maps simplified activation from an existing L3 PID to CIE PIN IT-Wallet status", () => {
+    jest
+      .spyOn(lifecycleSelectors, "itwLifecycleIsITWalletValidSelector")
+      .mockReturnValue(true);
+    jest
+      .spyOn(credentialsSelectors, "itwCredentialsEidStatusSelector")
+      .mockReturnValue("valid");
+
+    const initialState = appReducer(
+      undefined,
+      applicationChangeState("active")
+    );
+    const state = {
+      ...initialState,
+      features: {
+        ...initialState.features,
+        itWallet: {
+          ...initialState.features.itWallet,
+          preferences: {
+            ...initialState.features.itWallet.preferences,
+            authLevel: "L3" as const,
+            identificationMode: "ciePin" as const
+          }
+        }
+      }
+    };
+
+    const result = buildItwBaseProperties(state);
+
+    expect(result.ITW_STATUS_V2).toBe("L3 (cie_pin)");
+    expect(result.ITW_PID).toBe("valid");
+    expect(result).not.toHaveProperty("ITW_ID_V2");
   });
 });
 

--- a/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
+++ b/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
@@ -89,8 +89,10 @@ const trackWalletInstanceCreation = jest.fn();
 const trackWalletInstanceRevocation = jest.fn();
 const trackIdentificationMethodSelected = jest.fn();
 const storeAuthLevel = jest.fn();
+const storeSimplifiedActivationAuthLevel = jest.fn();
 const freezeSimplifiedActivationRequirements = jest.fn();
 const clearSimplifiedActivationRequirements = jest.fn();
+const syncItwStatusAndPIDProperties = jest.fn();
 const navigateToCieCanScreen = jest.fn();
 const navigateToCieInternalAuthAndMrtdScreen = jest.fn();
 const trackItwIdAuthenticationCompleted = jest.fn();
@@ -159,8 +161,10 @@ describe("itwEidIssuanceMachine", () => {
       trackWalletInstanceRevocation,
       trackIdentificationMethodSelected,
       storeAuthLevel,
+      storeSimplifiedActivationAuthLevel,
       freezeSimplifiedActivationRequirements,
       clearSimplifiedActivationRequirements,
+      syncItwStatusAndPIDProperties,
       trackItwIdAuthenticationCompleted,
       trackItwIdVerifiedDocument
     },
@@ -2191,6 +2195,17 @@ describe("itwEidIssuanceMachine", () => {
     actor.send({ type: "accept-ipzs-privacy" });
     expect(actor.getSnapshot().value).toStrictEqual("Success");
     expect(clearSimplifiedActivationRequirements).toHaveBeenCalledTimes(1);
+    expect(storeSimplifiedActivationAuthLevel).toHaveBeenCalledTimes(1);
+    expect(syncItwStatusAndPIDProperties).toHaveBeenCalledTimes(1);
+    expect(
+      clearSimplifiedActivationRequirements.mock.invocationCallOrder[0]
+    ).toBeLessThan(syncItwStatusAndPIDProperties.mock.invocationCallOrder[0]);
+    expect(
+      storeSimplifiedActivationAuthLevel.mock.invocationCallOrder[0]
+    ).toBeLessThan(syncItwStatusAndPIDProperties.mock.invocationCallOrder[0]);
+    expect(
+      syncItwStatusAndPIDProperties.mock.invocationCallOrder[0]
+    ).toBeLessThan(trackWalletInstanceCreation.mock.invocationCallOrder[0]);
   });
 
   it("Should start the simplified activation flow with credentials upgrade only", async () => {
@@ -2225,6 +2240,17 @@ describe("itwEidIssuanceMachine", () => {
     );
 
     expect(clearSimplifiedActivationRequirements).toHaveBeenCalledTimes(1);
+    expect(storeSimplifiedActivationAuthLevel).toHaveBeenCalledTimes(1);
+    expect(syncItwStatusAndPIDProperties).toHaveBeenCalledTimes(1);
+    expect(
+      clearSimplifiedActivationRequirements.mock.invocationCallOrder[0]
+    ).toBeLessThan(syncItwStatusAndPIDProperties.mock.invocationCallOrder[0]);
+    expect(
+      storeSimplifiedActivationAuthLevel.mock.invocationCallOrder[0]
+    ).toBeLessThan(syncItwStatusAndPIDProperties.mock.invocationCallOrder[0]);
+    expect(
+      syncItwStatusAndPIDProperties.mock.invocationCallOrder[0]
+    ).toBeLessThan(trackWalletInstanceCreation.mock.invocationCallOrder[0]);
     expect(navigateToUpgradeCredentialsScreen).toHaveBeenCalledTimes(1);
   });
 

--- a/ts/features/itwallet/machine/eid/actions.ts
+++ b/ts/features/itwallet/machine/eid/actions.ts
@@ -15,6 +15,7 @@ import {
   trackItwIdVerifiedDocument,
   trackSaveCredentialSuccess
 } from "../../analytics";
+import { updateItwStatusAndPIDProperties } from "../../analytics/properties/propertyUpdaters";
 import { itwMixPanelCredentialDetailsSelector } from "../../analytics/store/selectors";
 import {
   itwClearSimplifiedActivationRequirements,
@@ -314,6 +315,15 @@ export const createEidIssuanceActionsImplementation = (
 
   clearSimplifiedActivationRequirements: () => {
     store.dispatch(itwClearSimplifiedActivationRequirements());
+  },
+
+  storeSimplifiedActivationAuthLevel: () => {
+    store.dispatch(itwSetAuthLevel("L3"));
+    store.dispatch(itwSetIdentificationMode("ciePin"));
+  },
+
+  syncItwStatusAndPIDProperties: () => {
+    updateItwStatusAndPIDProperties(store.getState());
   },
 
   storeCredentialUpgradeFailures: ({

--- a/ts/features/itwallet/machine/eid/machine.ts
+++ b/ts/features/itwallet/machine/eid/machine.ts
@@ -92,6 +92,7 @@ export const itwEidIssuanceMachine = setup({
     resetWalletInstance: notImplemented,
     freezeSimplifiedActivationRequirements: notImplemented,
     clearSimplifiedActivationRequirements: notImplemented,
+    storeSimplifiedActivationAuthLevel: notImplemented,
 
     /**
      * Analytics
@@ -100,6 +101,7 @@ export const itwEidIssuanceMachine = setup({
     trackWalletInstanceCreation: notImplemented,
     trackWalletInstanceRevocation: notImplemented,
     trackIdentificationMethodSelected: notImplemented,
+    syncItwStatusAndPIDProperties: notImplemented,
     trackItwIdAuthenticationCompleted: notImplemented,
     trackItwIdVerifiedDocument: notImplemented,
     /**
@@ -495,6 +497,8 @@ export const itwEidIssuanceMachine = setup({
       description: "State that manages the wallet's simplified activation flow",
       entry: [
         "clearSimplifiedActivationRequirements",
+        "storeSimplifiedActivationAuthLevel",
+        "syncItwStatusAndPIDProperties",
         "trackWalletInstanceCreation"
       ],
       always: [


### PR DESCRIPTION
## Short description
Fixes ITW_STATUS_V2 tracking for users activating IT-Wallet through the simplified flow after already having Documenti su IO active with an L3 PID.

## List of changes proposed in this pull request
- Persist the implied CIE PIN identification mode during simplified activation
- Sync IT-Wallet analytics properties so ITW_STATUS_V2 is tracked as `L3 (cie_pin)`
- Add regression coverage for the simplified activation case introduced after #8023

## How to test
- Run the IT-Wallet machine regression tests
- Run IT-Wallet analytics property tests
- Verify that a simplified activation from an existing L3 PID tracks `ITW_STATUS_V2 = L3 (cie_pin)`