### PR TITLE
feat(IT-Wallet): [SIW-4151] Add tracking for ITW activation with CieID L3

### DIFF
--- a/ts/features/itwallet/analytics/index.ts
+++ b/ts/features/itwallet/analytics/index.ts
@@ -343,7 +343,7 @@ export const trackItwRequest = (method?: ItwIdMethod, itw_flow?: ItwFlow) => {
 };
 
 export const trackItwIdAuthenticationCompleted = (
-  ITW_ID_method: Exclude<ItwIdMethod, "ciePin">
+  ITW_ID_method: ItwIdMethod
 ) => {
   void mixpanelTrack(
     ITW_TECH_EVENTS.ITW_ID_AUTHENTICATION_COMPLETED,
@@ -351,9 +351,7 @@ export const trackItwIdAuthenticationCompleted = (
   );
 };
 
-export const trackItwIdVerifiedDocument = (
-  ITW_ID_method: Exclude<ItwIdMethod, "ciePin">
-) => {
+export const trackItwIdVerifiedDocument = (ITW_ID_method: ItwIdMethod) => {
   void mixpanelTrack(
     ITW_TECH_EVENTS.ITW_ID_VERIFIED_DOCUMENT,
     buildEventProperties("TECH", undefined, { ITW_ID_method })

--- a/ts/features/itwallet/analytics/utils/types.ts
+++ b/ts/features/itwallet/analytics/utils/types.ts
@@ -74,7 +74,21 @@ export type CredentialStatusAssertionFailure = {
   reason?: unknown;
 };
 
-export type ItwIdMethod = IdentificationContext["mode"];
+export type ItwIdMethod =
+  | IdentificationContext["mode"]
+  | "cieid_L2"
+  | "cieid_L3";
+
+/**
+ * Maps an IdentificationContext to the corresponding ItwIdMethod value,
+ * distinguishing between CieID L2 and CieID L3 authentication levels.
+ */
+export const toItwIdMethod = (ctx: IdentificationContext): ItwIdMethod => {
+  if (ctx.mode === "cieId") {
+    return ctx.level === "L3" ? "cieid_L3" : "cieid_L2";
+  }
+  return ctx.mode;
+};
 
 export type TrackItwBannerProperties = {
   banner_id: string;

--- a/ts/features/itwallet/issuance/screens/ItwIssuanceEidPreviewScreen.tsx
+++ b/ts/features/itwallet/issuance/screens/ItwIssuanceEidPreviewScreen.tsx
@@ -39,6 +39,7 @@ import {
   trackItwRequestSuccess,
   trackSaveCredentialToWallet
 } from "../analytics";
+import { toItwIdMethod } from "../../analytics/utils/types";
 import { ItwCredentialPreviewClaimsList } from "../components/ItwCredentialPreviewClaimsList";
 
 export const ItwIssuanceEidPreviewScreen = () => {
@@ -93,8 +94,8 @@ const ContentView = ({ eid }: ContentViewProps) => {
       });
       if (identification) {
         trackItwRequestSuccess(
-          identification?.mode,
-          identification?.level,
+          toItwIdMethod(identification),
+          identification.level,
           isL3 ? "L3" : "L2"
         );
       }

--- a/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
+++ b/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
@@ -657,6 +657,86 @@ describe("itwEidIssuanceMachine", () => {
     });
   });
 
+  describe("updateCieIdIdentificationLevel", () => {
+    const buildCieIdCompletingSnapshot = (level: "l2" | "l3") => {
+      const initialSnapshot: MachineSnapshot = createActor(
+        itwEidIssuanceMachine
+      ).getSnapshot();
+
+      return _.merge(undefined, initialSnapshot, {
+        value: { UserIdentification: { CieID: "CompletingCieIDAuthFlow" } },
+        context: {
+          level,
+          mode: "issuance",
+          integrityKeyTag: T_INTEGRITY_KEY,
+          walletInstanceAttestation: { jwt: T_WIA },
+          identification: { mode: "cieId", level: "L2" },
+          authenticationContext: {
+            authUrl: "https://auth.test.it",
+            clientId: "client",
+            codeVerifier: "verifier",
+            issuerConf: {},
+            credentialDefinition: {},
+            callbackUrl: "",
+            redirectUri: "https://wallet.test.it/cb"
+          }
+        }
+      } as MachineSnapshot);
+    };
+
+    it("Should update identification level to L3 when challenge_info is absent in L3 flow", () => {
+      const actor = createActor(mockedMachine, {
+        snapshot: buildCieIdCompletingSnapshot("l3")
+      });
+      actor.start();
+
+      actor.send({
+        type: "user-identification-completed",
+        authRedirectUrl: "https://wallet.test.it/cb?code=abc&state=xyz"
+      });
+
+      expect(actor.getSnapshot().context.identification).toMatchObject({
+        mode: "cieId",
+        level: "L3"
+      });
+    });
+
+    it("Should keep identification level at L2 when challenge_info is present in L3 flow", () => {
+      const actor = createActor(mockedMachine, {
+        snapshot: buildCieIdCompletingSnapshot("l3")
+      });
+      actor.start();
+
+      actor.send({
+        type: "user-identification-completed",
+        authRedirectUrl:
+          "https://wallet.test.it/cb?code=abc&challenge_info=mock_challenge"
+      });
+
+      expect(actor.getSnapshot().context.identification).toMatchObject({
+        mode: "cieId",
+        level: "L2"
+      });
+    });
+
+    it("Should keep identification level at L2 in L2 flow regardless of challenge_info", () => {
+      const actor = createActor(mockedMachine, {
+        snapshot: buildCieIdCompletingSnapshot("l2")
+      });
+      actor.start();
+
+      actor.send({
+        type: "user-identification-completed",
+        authRedirectUrl: "https://wallet.test.it/cb?code=abc&state=xyz"
+      });
+
+      expect(actor.getSnapshot().context.identification).toMatchObject({
+        mode: "cieId",
+        level: "L2"
+      });
+    });
+  });
+
   it("Should obtain an eID (Cie+PIN)", async () => {
     /** Initial part is the same as the previous test, we can start from the identification */
 

--- a/ts/features/itwallet/machine/eid/actions.ts
+++ b/ts/features/itwallet/machine/eid/actions.ts
@@ -15,6 +15,7 @@ import {
   trackItwIdVerifiedDocument,
   trackSaveCredentialSuccess
 } from "../../analytics";
+import { toItwIdMethod } from "../../analytics/utils/types";
 import { itwMixPanelCredentialDetailsSelector } from "../../analytics/store/selectors";
 import {
   itwClearSimplifiedActivationRequirements,
@@ -333,7 +334,9 @@ export const createEidIssuanceActionsImplementation = (
     context
   }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
     const identificationMethod =
-      context.identification?.mode ??
+      (context.identification
+        ? toItwIdMethod(context.identification)
+        : undefined) ??
       // Simplified PID activation skips identification but still requires ITW_ID_method for analytics.
       (context.level === "l3" ? "ciePin" : undefined);
 
@@ -374,7 +377,7 @@ export const createEidIssuanceActionsImplementation = (
       "identification mode can not be ciePin"
     );
 
-    trackItwIdAuthenticationCompleted(context.identification.mode);
+    trackItwIdAuthenticationCompleted(toItwIdMethod(context.identification));
   },
 
   // Track SPID+CIE final phase
@@ -387,6 +390,6 @@ export const createEidIssuanceActionsImplementation = (
       "identification mode can not be ciePin"
     );
 
-    trackItwIdVerifiedDocument(context.identification.mode);
+    trackItwIdVerifiedDocument(toItwIdMethod(context.identification));
   }
 });

--- a/ts/features/itwallet/machine/eid/actors.ts
+++ b/ts/features/itwallet/machine/eid/actors.ts
@@ -7,6 +7,7 @@ import { assert } from "../../../../utils/assert";
 import { sessionTokenSelector } from "../../../authentication/common/store/selectors";
 import * as cieUtils from "../../../authentication/login/cie/utils/cie";
 import { trackItwRequest } from "../../analytics";
+import { toItwIdMethod } from "../../analytics/utils/types";
 import { Env } from "../../common/utils/environment";
 import {
   getWalletInstanceAttestation,
@@ -363,7 +364,7 @@ export const createEidIssuanceActorsImplementation = (
         });
 
       trackItwRequest(
-        input.identification.mode,
+        toItwIdMethod(input.identification),
         input.level === "l3" ? "L3" : "L2"
       );
 

--- a/ts/features/itwallet/machine/eid/machine.ts
+++ b/ts/features/itwallet/machine/eid/machine.ts
@@ -113,6 +113,23 @@ export const itwEidIssuanceMachine = setup({
         level: "L2"
       } as const
     })),
+
+    /**
+     * Updates the CieID identification level to L3 when IPZS confirms native L3
+     * authentication (i.e. challenge_info is absent in the callback URL, meaning
+     * no MRTD PoP is required because the CieID app already authenticated at L3).
+     */
+    updateCieIdIdentificationLevel: assign(({ context, event }) => {
+      assertEvent(event, "user-identification-completed");
+      if (
+        context.identification?.mode !== "cieId" ||
+        context.level !== "l3" ||
+        isMrtdPoPChallengeRequired(event.authRedirectUrl)
+      ) {
+        return {};
+      }
+      return { identification: { mode: "cieId", level: "L3" } as const };
+    }),
     setFailure: assign(({ event }) => ({ failure: mapEventToFailure(event) })),
     /**
      * Save the final redirect url in the machine context for later reuse.
@@ -608,7 +625,11 @@ export const itwEidIssuanceMachine = setup({
               on: {
                 "user-identification-completed": {
                   target: "Completed",
-                  actions: ["completeUserIdentification", "storeAuthLevel"]
+                  actions: [
+                    "completeUserIdentification",
+                    "updateCieIdIdentificationLevel",
+                    "storeAuthLevel"
+                  ]
                 },
                 error: {
                   actions: "setFailure",


### PR DESCRIPTION
## Short description
This PR implements analytics tracking for CieID L3 authentication in the IT-Wallet activation flow. After primary authentication via the CieID app, the `itw_id_method` property is now correctly set to `cieid_L2` or `cieid_L3` depending on the actual authentication level used. Additionally, `ITW_STATUS` for users who activate IT-Wallet with CieID native L3 now correctly reports `L3 (cieid_pin)`.

## List of changes proposed in this pull request
- Added `updateCieIdIdentificationLevel` action in `machine.ts` that upgrades `identification.level` from `L2` to `L3` when the CieID app authenticates at native L3
- Extended `ItwIdMethod` type in `analytics/utils/types.ts` to include `"cieid_L2"` and `"cieid_L3"` values alongside the existing `"cieId"`, `"ciePin"` and `"spid"`
- Added `toItwIdMethod` helper in `analytics/utils/types.ts` that maps an `IdentificationContext` to the appropriate `ItwIdMethod`, distinguishing CieID L2 from CieID L3
- Updated `trackItwIdAuthenticationCompleted` and `trackItwIdVerifiedDocument` in `analytics/index.ts` to accept the full `ItwIdMethod` type
- Updated all five tracked events (`ITW_ID_AUTHENTICATION_COMPLETED`, `ITW_ID_VERIFIED_DOCUMENT`, `ITW_ID_REQUEST`, `ITW_ID_REQUEST_SUCCESS`, `ITW_UX_SUCCESS`) in `actions.ts`, `actors.ts` and `ItwIssuanceEidPreviewScreen.tsx` to use `toItwIdMethod` instead of passing `identification.mode` directly
- Added unit tests for `updateCieIdIdentificationLevel` covering: L3 flow with no `challenge_info` (level promoted to L3), L3 flow with `challenge_info` present (level stays L2), L2 flow (level stays L2 regardless)

## How to test

 > **Note:** full end-to-end verification requires the IPZS release that returns the authentication level in the CieID callback URL. In the meantime, this feature can be tested using ITW version **1.3.3** in the **PRE** environment with the **CieID Collaudo** app.
 
**Manual — CieID L3**

  1. Start an IT-Wallet L3 issuance flow and select CieID as the identification method
  2. Complete authentication in the CieID app;
  3. Open Mixpanel and verify:
    - `ITW_ID_AUTHENTICATION_COMPLETED` → ITW_ID_method: "cieid_L3"
    - `ITW_ID_REQUEST` → ITW_ID_method: "cieid_L3"
    - `ITW_ID_REQUEST_SUCCESS` → ITW_ID_method: "cieid_L3"
    - `ITW_UX_SUCCESS` → ITW_ID_method: "cieid_L3"
    - User property `ITW_STATUS` → "L3 (cieid_pin)"

**Manual — CieID L2 + CAN**

  1. Same flow
  2. Complete CAN reading and MRTD PoP
  3. Open Mixpanel and verify:
    - `ITW_ID_AUTHENTICATION_COMPLETED` → ITW_ID_method: "cieid_L2"
    - `ITW_ID_VERIFIED_DOCUMENT` → ITW_ID_method: "cieid_L2"
    - `ITW_ID_REQUEST` → ITW_ID_method: "cieid_L2"
    - `ITW_ID_REQUEST_SUCCESS` → ITW_ID_method: "cieid_L2"
    - `ITW_UX_SUCCESS` → ITW_ID_method: "cieid_L2"
    - User property `ITW_STATUS` → "L3 (cieid_can)"