### PR TITLE
fix: [IOPLT-1829] Sanitize Markdown from Form Feed character in order to solve iOS display issues

### DIFF
--- a/apps/main-app/ts/components/IOMarkdown/__tests__/markdownRenderer.test.ts
+++ b/apps/main-app/ts/components/IOMarkdown/__tests__/markdownRenderer.test.ts
@@ -1,6 +1,66 @@
-import { insertNewLinesIfNeededOnMatch } from "../markdownRenderer";
+import {
+  insertNewLinesIfNeededOnMatch,
+  sanitizeMarkdownFromFormFeed
+} from "../markdownRenderer";
 
 describe("markdownRenderer", () => {
+  describe("sanitizeMarkdownFromFormFeed", () => {
+    it("should return an empty string unchanged", () => {
+      expect(sanitizeMarkdownFromFormFeed("")).toBe("");
+    });
+
+    it("should leave a string without form feed unchanged", () => {
+      expect(sanitizeMarkdownFromFormFeed("Hello world")).toBe("Hello world");
+    });
+
+    it("should replace a single form feed with a space", () => {
+      expect(sanitizeMarkdownFromFormFeed("Hello\fworld")).toBe("Hello world");
+    });
+
+    it("should replace multiple form feeds with spaces", () => {
+      expect(sanitizeMarkdownFromFormFeed("\fHello\f\fworld\f")).toBe(
+        " Hello  world "
+      );
+    });
+
+    it("should replace a string composed only of form feeds with spaces", () => {
+      expect(sanitizeMarkdownFromFormFeed("\f\f\f")).toBe("   ");
+    });
+
+    it("should replace form feed inside a URL (side effect: URL becomes invalid)", () => {
+      // The regex is global and does NOT skip URLs — \f inside a URL will be
+      // replaced with a space. This is intentional: iOS text parser causes a
+      // blank page when it encounters \f, so all occurrences must be removed
+      // regardless of context.
+      expect(
+        sanitizeMarkdownFromFormFeed("https://example.com/path\fwith\ffeed")
+      ).toBe("https://example.com/path with feed");
+    });
+
+    it("should replace form feed in a markdown link URL", () => {
+      expect(
+        sanitizeMarkdownFromFormFeed("[label](https://example.com/\fpath)")
+      ).toBe("[label](https://example.com/ path)");
+    });
+
+    it("should replace form feed in markdown link text", () => {
+      expect(
+        sanitizeMarkdownFromFormFeed("[label\ftext](https://example.com/)")
+      ).toBe("[label text](https://example.com/)");
+    });
+
+    it("should replace form feed in a markdown image alt text", () => {
+      expect(sanitizeMarkdownFromFormFeed("![alt\ftext](image.png)")).toBe(
+        "![alt text](image.png)"
+      );
+    });
+
+    it("should not alter other whitespace characters (\\n, \\t)", () => {
+      expect(sanitizeMarkdownFromFormFeed("line1\nline2\ttabbed")).toBe(
+        "line1\nline2\ttabbed"
+      );
+    });
+  });
   describe("insertNewLinesIfNeededOnMatch", () => {
     it("Given two new lines before and after, should do nothing", () => {
       const match = { index: 2, [0]: { length: 12 } } as RegExpExecArray;

--- a/apps/main-app/ts/components/IOMarkdown/index.tsx
+++ b/apps/main-app/ts/components/IOMarkdown/index.tsx
@@ -10,7 +10,8 @@ import {
   convertReferenceLinksToInline,
   getRenderMarkdown,
   parse,
-  sanitizeMarkdownForImages
+  sanitizeMarkdownForImages,
+  sanitizeMarkdownFromFormFeed
 } from "./markdownRenderer";
 import { DEFAULT_RULES } from "./renderRules";
 
@@ -36,7 +37,10 @@ export type IOMarkdownProps = {
 const UnsafeIOMarkdown = ({ content, rules }: UnsafeProps) => {
   const screenReaderEnabled = useIOSelector(isScreenReaderEnabledSelector);
 
-  const inlineLinkMarkdown = convertReferenceLinksToInline(content);
+  const sanitizedFormFeedContent = sanitizeMarkdownFromFormFeed(content);
+  const inlineLinkMarkdown = convertReferenceLinksToInline(
+    sanitizedFormFeedContent
+  );
   const sanitizedMarkdown = sanitizeMarkdownForImages(inlineLinkMarkdown);
   const parsedContent = parse(sanitizedMarkdown);
   const renderMarkdown = getRenderMarkdown(

--- a/apps/main-app/ts/components/IOMarkdown/markdownRenderer.ts
+++ b/apps/main-app/ts/components/IOMarkdown/markdownRenderer.ts
@@ -170,6 +170,12 @@ export const sanitizeMarkdownForImages = (
   );
 };
 
+// Even if markdown parser handle form feed characters (\f), iOS text parser causes a blank page after the character due to own parsing rules.
+// To prevent this, we replace all form feed characters with a space character before parsing the markdown.
+export const sanitizeMarkdownFromFormFeed = (
+  inputMarkdownContent: string
+): string => inputMarkdownContent.replace(/\f/g, " ");
+
 const anyWhitespaceCharacterButNewLineSet = new Set([
   " ",
   "\t",

--- a/apps/main-app/ts/components/IOMarkdown/markdownRenderer.ts
+++ b/apps/main-app/ts/components/IOMarkdown/markdownRenderer.ts
@@ -174,7 +174,7 @@ export const sanitizeMarkdownForImages = (
 // To prevent this, we replace all form feed characters with a space character before parsing the markdown.
 export const sanitizeMarkdownFromFormFeed = (
   inputMarkdownContent: string
-): string => inputMarkdownContent.replace(/\f/g, " ");
+): string => inputMarkdownContent.replaceAll(/\f/g, " ");
 
 const anyWhitespaceCharacterButNewLineSet = new Set([
   " ",


### PR DESCRIPTION
## Short description
This PR solves an issue on IOMarkdown component that prevents the rendering on iOS devices when markdown text contains a Form Feed interruption `\f`

## List of changes proposed in this pull request
- Adds new sanitize function on renderer rules
- Sanitize the content before rendering
- Adds new specific tests

## How to test
Check markdown component rendering specifically on iOS to check for it to correctly render.
