### PR TITLE
fix: [SIW-000] fix IPZS privacy screen layout regression

### DIFF
--- a/apps/main-app/ts/components/ui/IOScrollViewWithLargeHeader.tsx
+++ b/apps/main-app/ts/components/ui/IOScrollViewWithLargeHeader.tsx
@@ -135,6 +135,7 @@ export const IOScrollViewWithLargeHeader = ({
       testID={testID}
       topElement={topElement}
       alwaysBounceVertical={alwaysBounceVertical}
+      contentContainerStyle={{ flexGrow: 1 }}
     >
       <ContentWrapper onLayout={getTitleHeight}>
         <VStack space={8}>

--- a/apps/main-app/ts/components/ui/IOScrollViewWithLargeHeader.tsx
+++ b/apps/main-app/ts/components/ui/IOScrollViewWithLargeHeader.tsx
@@ -53,6 +53,9 @@ type Props = WithTestID<
     animatedRef?: AnimatedRef<Animated.ScrollView>;
     topElement?: ReactNode;
     alwaysBounceVertical?: boolean;
+    contentContainerStyle?: ComponentProps<
+      typeof IOScrollView
+    >["contentContainerStyle"];
   } & SupportRequestParams
 >;
 
@@ -81,7 +84,8 @@ export const IOScrollViewWithLargeHeader = ({
   ignoreAccessibilityCheck = false,
   animatedRef,
   topElement = undefined,
-  alwaysBounceVertical
+  alwaysBounceVertical,
+  contentContainerStyle
 }: Props) => {
   const [titleHeight, setTitleHeight] = useState(0);
 
@@ -135,7 +139,7 @@ export const IOScrollViewWithLargeHeader = ({
       testID={testID}
       topElement={topElement}
       alwaysBounceVertical={alwaysBounceVertical}
-      contentContainerStyle={{ flexGrow: 1 }}
+      contentContainerStyle={contentContainerStyle}
     >
       <ContentWrapper onLayout={getTitleHeight}>
         <VStack space={8}>

--- a/apps/main-app/ts/features/itwallet/discovery/screens/ItwIpzsPrivacyScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/discovery/screens/ItwIpzsPrivacyScreen.tsx
@@ -55,6 +55,7 @@ const ItwIpzsPrivacyScreen = () => {
           )
         }}
         headerActionsProp={{ showHelp: true }}
+        contentContainerStyle={{ flexGrow: 1 }}
         actions={{
           type: "SingleButton",
           primary: {

--- a/apps/main-app/ts/features/itwallet/discovery/screens/__tests__/__snapshots__/ItwIpzsPrivacyScreen.test.tsx.snap
+++ b/apps/main-app/ts/features/itwallet/discovery/screens/__tests__/__snapshots__/ItwIpzsPrivacyScreen.test.tsx.snap
@@ -970,6 +970,7 @@ exports[`ItwIpzsPrivacyScreen should match the snapshot (L3 disabled) 1`] = `
                             contentContainerStyle={
                               [
                                 {
+                                  "flexGrow": 1,
                                   "paddingBottom": 56,
                                   "paddingHorizontal": 0,
                                 },
@@ -2509,6 +2510,7 @@ exports[`ItwIpzsPrivacyScreen should match the snapshot (L3 enabled) 1`] = `
                             contentContainerStyle={
                               [
                                 {
+                                  "flexGrow": 1,
                                   "paddingBottom": 56,
                                   "paddingHorizontal": 0,
                                 },


### PR DESCRIPTION
## Short description
This PR fix a regression introduced to Privacy screen where datas were not visualized
## List of changes proposed in this pull request
- Added `contentContainerStyle` to `IOScrollViewWithLargeHeader`
- Pass `flexGrow: 1` to scroll view in privacy screen

## How to test
1. Go to Privacy Screen and ensure the information are visualized correctly