### PR TITLE
fix: [IOPLT-1900] Restore limits in the `jest` config to avoid memory saturation

### DIFF
--- a/apps/main-app/jest.config.js
+++ b/apps/main-app/jest.config.js
@@ -1,5 +1,9 @@
 module.exports = {
   preset: "react-native",
+  // Cap concurrency and recycle workers to keep RAM bounded.
+  maxWorkers: "50%",
+  // Above the per-worker baseline so only bloated workers recycle.
+  workerIdleMemoryLimit: "2.5GB",
   transform: {
     "\\.[jt]sx?$": "babel-jest",
     "\\.mjs$": "babel-jest"

--- a/apps/main-app/jest.config.no.timezone.js
+++ b/apps/main-app/jest.config.no.timezone.js
@@ -1,5 +1,9 @@
 module.exports = {
   preset: "react-native",
+  // Cap concurrency and recycle workers to keep RAM bounded.
+  maxWorkers: "50%",
+  // Above the per-worker baseline so only bloated workers recycle.
+  workerIdleMemoryLimit: "2.5GB",
   transformIgnorePatterns: [
     "node_modules/(?!(jest-)?@react-native|react-native|react-navigation|@react-navigation|react-navigation-redux-helpers|react-native-device-info|jsbarcode|@pagopa/react-native-cie|react-native-share|jail-monkey|@react-native-community/art|@shopify/react-native-skia|lottie-react-native|@codler|remark|unified|bail|is-plain-obj|trough|vfile|unist-util-stringify-position|mdast-util-from-markdown|mdast-util-to-string|micromark|parse-entities|character-entities|mdast-util-to-markdown|zwitch|longest-streak|@pagopa/io-react-native-zendesk|rn-qr-generator|mixpanel-react-native|@pagopa/io-app-design-system|uuid|@pagopa/io-react-native-cie)"
   ],


### PR DESCRIPTION
## Short description
Restore limits in the `jest` config to avoid memory saturation.

## List of changes proposed in this pull request
- Set `maxWorkers` and `workerIdleMemoryLimit` values in the `jest.config`

## How to test
Check whether the test suite in the local environment maintains reasonable RAM consumption.