### PR TITLE
fix(IT-Wallet): [SIW-0000] Catch error when canceling user authentication for eID issuance

### DIFF
--- a/apps/main-app/ts/features/itwallet/machine/eid/machine.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/machine.ts
@@ -1138,6 +1138,10 @@ export const itwEidIssuanceMachine = setup({
             onDone: {
               target: "RequestingEid",
               actions: assign(({ event }) => ({ accessToken: event.output }))
+            },
+            onError: {
+              actions: "setFailure",
+              target: "#itwEidIssuanceMachine.Failure"
             }
           }
         },


### PR DESCRIPTION
## Short description
This PR fixes a crash that occurs when the user does not give consent to proceed and presses "Cancel" on the eID auth webview.

## How to test
Activate the Wallet with CIE+PIN and press "Annulla" on the following screen:
<img width="240" src="https://github.com/user-attachments/assets/7b960dc9-c124-4194-8f50-51e13b30c5bc" />

**Before:** the app crashes
**After:** an error screen is shown
