### PR TITLE
fix(IT-Wallet): [SIW-0000] Replace reset with navigate in `closeIssuance`

### DIFF
--- a/apps/main-app/ts/features/itwallet/machine/eid/actions.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/actions.ts
@@ -255,19 +255,9 @@ export const createEidIssuanceActionsImplementation = (
     );
     const isReissuance = context.mode === "reissuance";
 
-    navigation.reset({
-      index: 1,
-      routes: [
-        {
-          name: ROUTES.MAIN,
-          params: {
-            screen: ROUTES.WALLET_HOME,
-            params: {
-              requiredEidFeedback: isReissuance && !isSurveyHidden
-            }
-          }
-        }
-      ]
+    navigation.navigate(ROUTES.MAIN, {
+      screen: ROUTES.WALLET_HOME,
+      params: { requiredEidFeedback: isReissuance && !isSurveyHidden }
     });
   },
 


### PR DESCRIPTION
## Short description
Fixes the unnatural navigation transition shown when going back from the IT-Wallet discovery info screen. After the React Navigation downgrade to v6 (#8198), the `closeIssuance` machine action was switched from `popTo` to `navigation.reset`, which rebuilds the whole stack and produces a forward-push transition instead of a natural back animation.

## List of changes proposed in this pull request
- Replace `navigation.reset` with `navigation.navigate` to the existing wallet home in the eID machine `closeIssuance` action (RN6 equivalent of the previous `popTo`), restoring the natural back transition while preserving the `requiredEidFeedback` param for the reissuance flow.

## How to test
1. Have IT-Wallet active.
2. From the wallet, open the IT-Wallet discovery info screen (e.g. via the engagement banner).
3. Tap back and confirm the dismissal dialog.
4. Expected: a smooth back/pop transition to the wallet home, no stack rebuild or forward-push flash.
5. Also verify the reissuance flow still lands on the wallet home and triggers the eID feedback survey.