### PR TITLE
fix(IT-Wallet): [SIW-000] Fix banners rendering in ITW home screen

### DIFF
--- a/apps/main-app/ts/features/itwallet/common/components/ItwWalletReadyBanner.tsx
+++ b/apps/main-app/ts/features/itwallet/common/components/ItwWalletReadyBanner.tsx
@@ -1,6 +1,5 @@
 import { Banner } from "@pagopa/io-app-design-system";
 import I18n from "i18next";
-import { View } from "react-native";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { useIOSelector } from "../../../../store/hooks";
 import { ITW_ROUTES } from "../../navigation/routes";
@@ -25,28 +24,24 @@ export const ItwWalletReadyBanner = () => {
   };
 
   return (
-    <View style={{ marginHorizontal: -8 }}>
-      <Banner
-        testID="itwWalletReadyBannerTestID"
-        title={
-          isNewItwRenderable
-            ? undefined
-            : I18n.t(
-                "features.itWallet.issuance.emptyWallet.readyBannerL2.title"
-              )
-        }
-        content={I18n.t(
-          isNewItwRenderable
-            ? "features.itWallet.issuance.emptyWallet.readyBanner.content"
-            : "features.itWallet.issuance.emptyWallet.readyBannerL2.content"
-        )}
-        action={I18n.t(
-          "features.itWallet.issuance.emptyWallet.readyBanner.action"
-        )}
-        color="turquoise"
-        onPress={handleOnPress}
-        pictogramName="itWallet"
-      />
-    </View>
+    <Banner
+      testID="itwWalletReadyBannerTestID"
+      title={
+        isNewItwRenderable
+          ? undefined
+          : I18n.t("features.itWallet.issuance.emptyWallet.readyBannerL2.title")
+      }
+      content={I18n.t(
+        isNewItwRenderable
+          ? "features.itWallet.issuance.emptyWallet.readyBanner.content"
+          : "features.itWallet.issuance.emptyWallet.readyBannerL2.content"
+      )}
+      action={I18n.t(
+        "features.itWallet.issuance.emptyWallet.readyBanner.action"
+      )}
+      color="turquoise"
+      onPress={handleOnPress}
+      pictogramName="itWallet"
+    />
   );
 };

--- a/apps/main-app/ts/features/itwallet/common/components/__tests__/__snapshots__/ItwWalletReadyBanner.test.tsx.snap
+++ b/apps/main-app/ts/features/itwallet/common/components/__tests__/__snapshots__/ItwWalletReadyBanner.test.tsx.snap
@@ -341,410 +341,402 @@ exports[`ItwWalletReadyBanner should match snapshot when ITW new interface activ
                       }
                     >
                       <View
-                        style={
+                        accessibilityState={
                           {
-                            "marginHorizontal": -8,
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
                           }
                         }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={false}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        testID="itwWalletReadyBannerTestID"
                       >
                         <View
-                          accessibilityState={
-                            {
-                              "busy": undefined,
-                              "checked": undefined,
-                              "disabled": undefined,
-                              "expanded": undefined,
-                              "selected": undefined,
-                            }
-                          }
-                          accessibilityValue={
-                            {
-                              "max": undefined,
-                              "min": undefined,
-                              "now": undefined,
-                              "text": undefined,
-                            }
-                          }
-                          accessible={false}
                           collapsable={false}
-                          focusable={true}
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onResponderGrant={[Function]}
-                          onResponderMove={[Function]}
-                          onResponderRelease={[Function]}
-                          onResponderTerminate={[Function]}
-                          onResponderTerminationRequest={[Function]}
-                          onStartShouldSetResponder={[Function]}
-                          testID="itwWalletReadyBannerTestID"
+                          jestAnimatedProps={
+                            {
+                              "value": {},
+                            }
+                          }
+                          jestAnimatedStyle={
+                            {
+                              "value": {
+                                "transform": [
+                                  {
+                                    "scale": 1,
+                                  },
+                                ],
+                              },
+                            }
+                          }
+                          jestInlineStyle={
+                            [
+                              {
+                                "alignContent": "center",
+                                "alignItems": "flex-start",
+                                "borderCurve": "continuous",
+                                "borderRadius": 8,
+                                "flexDirection": "row",
+                                "padding": 16,
+                              },
+                              {
+                                "backgroundColor": "#DBF9FA",
+                              },
+                            ]
+                          }
+                          style={
+                            [
+                              {
+                                "alignContent": "center",
+                                "alignItems": "flex-start",
+                                "borderCurve": "continuous",
+                                "borderRadius": 8,
+                                "flexDirection": "row",
+                                "padding": 16,
+                              },
+                              {
+                                "backgroundColor": "#DBF9FA",
+                              },
+                              {
+                                "transform": [
+                                  {
+                                    "scale": 1,
+                                  },
+                                ],
+                              },
+                            ]
+                          }
                         >
                           <View
-                            collapsable={false}
-                            jestAnimatedProps={
-                              {
-                                "value": {},
-                              }
-                            }
-                            jestAnimatedStyle={
-                              {
-                                "value": {
-                                  "transform": [
-                                    {
-                                      "scale": 1,
-                                    },
-                                  ],
-                                },
-                              }
-                            }
-                            jestInlineStyle={
-                              [
-                                {
-                                  "alignContent": "center",
-                                  "alignItems": "flex-start",
-                                  "borderCurve": "continuous",
-                                  "borderRadius": 8,
-                                  "flexDirection": "row",
-                                  "padding": 16,
-                                },
-                                {
-                                  "backgroundColor": "#DBF9FA",
-                                },
-                              ]
-                            }
+                            accessibilityLabel="È tutto pronto! Ora puoi aggiungere il primo documento al Portafoglio di IO. Aggiungi documento"
+                            accessibilityRole="button"
+                            accessible={true}
                             style={
-                              [
-                                {
-                                  "alignContent": "center",
-                                  "alignItems": "flex-start",
-                                  "borderCurve": "continuous",
-                                  "borderRadius": 8,
-                                  "flexDirection": "row",
-                                  "padding": 16,
-                                },
-                                {
-                                  "backgroundColor": "#DBF9FA",
-                                },
-                                {
-                                  "transform": [
-                                    {
-                                      "scale": 1,
-                                    },
-                                  ],
-                                },
-                              ]
+                              {
+                                "alignSelf": "center",
+                                "flex": 1,
+                                "gap": 4,
+                              }
                             }
                           >
-                            <View
-                              accessibilityLabel="È tutto pronto! Ora puoi aggiungere il primo documento al Portafoglio di IO. Aggiungi documento"
-                              accessibilityRole="button"
-                              accessible={true}
-                              style={
-                                {
-                                  "alignSelf": "center",
-                                  "flex": 1,
-                                  "gap": 4,
-                                }
-                              }
-                            >
-                              <Text
-                                allowFontScaling={true}
-                                dynamicTypeRamp="headline"
-                                maxFontSizeMultiplier={1.5}
-                                style={
-                                  [
-                                    {},
-                                    {
-                                      "color": "#031344",
-                                      "fontFamily": "Titillio",
-                                      "fontSize": 16,
-                                      "fontStyle": "normal",
-                                      "fontWeight": "600",
-                                      "lineHeight": 24,
-                                    },
-                                  ]
-                                }
-                              >
-                                È tutto pronto!
-                              </Text>
-                              <Text
-                                allowFontScaling={true}
-                                dynamicTypeRamp="footnote"
-                                maxFontSizeMultiplier={1.5}
-                                style={
-                                  [
-                                    {},
-                                    {
-                                      "color": "#555C70",
-                                      "fontFamily": "Titillio",
-                                      "fontSize": 14,
-                                      "fontStyle": "normal",
-                                      "fontWeight": "400",
-                                      "lineHeight": 21,
-                                    },
-                                  ]
-                                }
-                              >
-                                Ora puoi aggiungere il primo documento al Portafoglio di IO.
-                              </Text>
-                              <View
-                                accessibilityElementsHidden={true}
-                                accessibilityLabel="Aggiungi documento"
-                                accessibilityRole="button"
-                                accessibilityState={
-                                  {
-                                    "busy": undefined,
-                                    "checked": undefined,
-                                    "disabled": undefined,
-                                    "expanded": undefined,
-                                    "selected": undefined,
-                                  }
-                                }
-                                accessibilityValue={
-                                  {
-                                    "max": undefined,
-                                    "min": undefined,
-                                    "now": undefined,
-                                    "text": undefined,
-                                  }
-                                }
-                                accessible={true}
-                                collapsable={false}
-                                focusable={true}
-                                importantForAccessibility="no-hide-descendants"
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onResponderGrant={[Function]}
-                                onResponderMove={[Function]}
-                                onResponderRelease={[Function]}
-                                onResponderTerminate={[Function]}
-                                onResponderTerminationRequest={[Function]}
-                                onStartShouldSetResponder={[Function]}
-                                pointerEvents="none"
-                              >
-                                <View
-                                  style={
-                                    {
-                                      "height": 8,
-                                    }
-                                  }
-                                />
-                                <Text
-                                  accessibilityElementsHidden={true}
-                                  accessible={false}
-                                  allowFontScaling={true}
-                                  ellipsizeMode="tail"
-                                  importantForAccessibility="no-hide-descendants"
-                                  maxFontSizeMultiplier={1.5}
-                                  numberOfLines={1}
-                                  style={
-                                    [
-                                      {},
-                                      {
-                                        "color": "#0B3EE3",
-                                        "fontFamily": "Titillio",
-                                        "fontSize": 16,
-                                        "fontStyle": "normal",
-                                        "fontWeight": "600",
-                                        "lineHeight": undefined,
-                                      },
-                                    ]
-                                  }
-                                >
-                                  Aggiungi documento
-                                </Text>
-                              </View>
-                            </View>
-                            <View
+                            <Text
+                              allowFontScaling={true}
+                              dynamicTypeRamp="headline"
+                              maxFontSizeMultiplier={1.5}
                               style={
                                 [
+                                  {},
                                   {
-                                    "marginRight": -16,
-                                  },
-                                  {
-                                    "alignSelf": "center",
+                                    "color": "#031344",
+                                    "fontFamily": "Titillio",
+                                    "fontSize": 16,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "600",
+                                    "lineHeight": 24,
                                   },
                                 ]
                               }
                             >
-                              <RNSVGSvgView
-                                align="xMidYMid"
-                                bbHeight={80}
-                                bbWidth={80}
-                                focusable={false}
-                                height={80}
-                                meetOrSlice={0}
-                                minX={0}
-                                minY={0}
+                              È tutto pronto!
+                            </Text>
+                            <Text
+                              allowFontScaling={true}
+                              dynamicTypeRamp="footnote"
+                              maxFontSizeMultiplier={1.5}
+                              style={
+                                [
+                                  {},
+                                  {
+                                    "color": "#555C70",
+                                    "fontFamily": "Titillio",
+                                    "fontSize": 14,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "400",
+                                    "lineHeight": 21,
+                                  },
+                                ]
+                              }
+                            >
+                              Ora puoi aggiungere il primo documento al Portafoglio di IO.
+                            </Text>
+                            <View
+                              accessibilityElementsHidden={true}
+                              accessibilityLabel="Aggiungi documento"
+                              accessibilityRole="button"
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              importantForAccessibility="no-hide-descendants"
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              pointerEvents="none"
+                            >
+                              <View
+                                style={
+                                  {
+                                    "height": 8,
+                                  }
+                                }
+                              />
+                              <Text
+                                accessibilityElementsHidden={true}
+                                accessible={false}
+                                allowFontScaling={true}
+                                ellipsizeMode="tail"
+                                importantForAccessibility="no-hide-descendants"
+                                maxFontSizeMultiplier={1.5}
+                                numberOfLines={1}
                                 style={
                                   [
+                                    {},
                                     {
-                                      "backgroundColor": "transparent",
-                                      "borderWidth": 0,
-                                    },
-                                    {
-                                      "flex": 0,
-                                      "height": 80,
-                                      "width": 80,
+                                      "color": "#0B3EE3",
+                                      "fontFamily": "Titillio",
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "600",
+                                      "lineHeight": undefined,
                                     },
                                   ]
                                 }
-                                vbHeight={240}
-                                vbWidth={240}
-                                width={80}
                               >
-                                <RNSVGGroup
+                                Aggiungi documento
+                              </Text>
+                            </View>
+                          </View>
+                          <View
+                            style={
+                              [
+                                {
+                                  "marginRight": -16,
+                                },
+                                {
+                                  "alignSelf": "center",
+                                },
+                              ]
+                            }
+                          >
+                            <RNSVGSvgView
+                              align="xMidYMid"
+                              bbHeight={80}
+                              bbWidth={80}
+                              focusable={false}
+                              height={80}
+                              meetOrSlice={0}
+                              minX={0}
+                              minY={0}
+                              style={
+                                [
+                                  {
+                                    "backgroundColor": "transparent",
+                                    "borderWidth": 0,
+                                  },
+                                  {
+                                    "flex": 0,
+                                    "height": 80,
+                                    "width": 80,
+                                  },
+                                ]
+                              }
+                              vbHeight={240}
+                              vbWidth={240}
+                              width={80}
+                            >
+                              <RNSVGGroup
+                                fill={
+                                  {
+                                    "payload": 4278190080,
+                                    "type": 0,
+                                  }
+                                }
+                              >
+                                <RNSVGPath
+                                  d="M12 47c0-8.8366 7.1634-16 16-16h71c8.837 0 16 7.1634 16 16v151c0 8.837-7.163 16-16 16H28c-8.8366 0-16-7.163-16-16V47Z"
                                   fill={
                                     {
-                                      "payload": 4278190080,
+                                      "payload": 4289392367,
                                       "type": 0,
                                     }
                                   }
-                                >
-                                  <RNSVGPath
-                                    d="M12 47c0-8.8366 7.1634-16 16-16h71c8.837 0 16 7.1634 16 16v151c0 8.837-7.163 16-16 16H28c-8.8366 0-16-7.163-16-16V47Z"
-                                    fill={
-                                      {
-                                        "payload": 4289392367,
-                                        "type": 0,
-                                      }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M16 50.9292C16 42.1317 23.1317 35 31.9292 35h64.1416C104.868 35 112 42.1317 112 50.9292V195.071c0 8.797-7.132 15.929-15.9292 15.929H31.9292C23.1317 211 16 203.868 16 195.071V50.9292ZM31.9292 37C24.2363 37 18 43.2363 18 50.9292V195.071C18 202.764 24.2363 209 31.9292 209h64.1416C103.764 209 110 202.764 110 195.071V50.9292C110 43.2363 103.764 37 96.0708 37H31.9292Z"
+                                  fill={
+                                    {
+                                      "payload": 4278240714,
+                                      "type": 0,
                                     }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M42 45c0-1.6569 1.3431-3 3-3h37c1.6569 0 3 1.3431 3 3s-1.3431 3-3 3H45c-1.6569 0-3-1.3431-3-3Z"
+                                  fill={
+                                    {
+                                      "payload": 4278240714,
+                                      "type": 0,
                                     }
-                                  />
-                                  <RNSVGPath
-                                    d="M16 50.9292C16 42.1317 23.1317 35 31.9292 35h64.1416C104.868 35 112 42.1317 112 50.9292V195.071c0 8.797-7.132 15.929-15.9292 15.929H31.9292C23.1317 211 16 203.868 16 195.071V50.9292ZM31.9292 37C24.2363 37 18 43.2363 18 50.9292V195.071C18 202.764 24.2363 209 31.9292 209h64.1416C103.764 209 110 202.764 110 195.071V50.9292C110 43.2363 103.764 37 96.0708 37H31.9292Z"
-                                    fill={
-                                      {
-                                        "payload": 4278240714,
-                                        "type": 0,
-                                      }
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M24.1953 82.863c0-5.1409 4.1675-9.3083 9.3083-9.3083h61.9925c5.1409 0 9.3079 4.1674 9.3079 9.3083v34.511c0 5.141-4.167 9.309-9.3079 9.309H33.5036c-5.1408 0-9.3083-4.168-9.3083-9.309V82.863Zm9.3083-7.3083c-4.0363 0-7.3083 3.272-7.3083 7.3083v34.511c0 4.036 3.272 7.309 7.3083 7.309h61.9925c4.0362 0 7.3079-3.273 7.3079-7.309V82.863c0-4.0363-3.2717-7.3083-7.3079-7.3083H33.5036Z"
+                                  fill={
+                                    {
+                                      "payload": 4278240714,
+                                      "type": 0,
                                     }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M103.679 114.82H25.0703v-2h78.6087v2ZM92.1746 80.0312c-3.3303 0-6.0301 2.6998-6.0301 6.0301s2.6998 6.0301 6.0301 6.0301 6.0301-2.6998 6.0301-6.0301-2.6998-6.0301-6.0301-6.0301Zm-8.0301 6.0301c0-4.4349 3.5952-8.0301 8.0301-8.0301 4.4349 0 8.0304 3.5952 8.0304 8.0301 0 4.4349-3.5955 8.0301-8.0304 8.0301-4.4349 0-8.0301-3.5952-8.0301-8.0301ZM52.9121 84.5039c0 .5523-.4477 1-1 1h-19.812c-.5523 0-1-.4477-1-1s.4477-1 1-1h19.812c.5523 0 1 .4477 1 1ZM52.9121 88.9766c0 .5522-.4477 1-1 1h-19.812c-.5523 0-1-.4478-1-1 0-.5523.4477-1 1-1h19.812c.5523 0 1 .4477 1 1ZM55.1054 69.4473c-.494.247-1.0947.0468-1.3417-.4472L48.6582 58.789c-.247-.494-.0468-1.0947.4472-1.3417.4939-.247 1.0946-.0467 1.3416.4472l5.1056 10.2112c.247.494.0467 1.0946-.4472 1.3416ZM71.122 68.5218c-.4848-.2644-.6635-.8719-.399-1.3567l5.0423-9.2442c.2645-.4849.8719-.6635 1.3567-.3991.4849.2645.6635.8719.3991 1.3568l-5.0423 9.2442c-.2645.4848-.8719.6635-1.3568.399ZM56.9411 132.336c.5201.185.7911.758.6054 1.278l-4.3274 12.116c-.1857.52-.7579.791-1.278.606-.5201-.186-.7912-.758-.6054-1.279l4.3273-12.116c.1857-.52.758-.791 1.2781-.605ZM72.9084 131.579c.5015-.231 1.0956-.012 1.3271.489l5.1618 11.184c.2315.502.0126 1.096-.4889 1.327-.5014.232-1.0955.013-1.327-.489l-5.1619-11.184c-.2314-.501-.0125-1.095.4889-1.327Z"
+                                  fill={
+                                    {
+                                      "payload": 4278240714,
+                                      "type": 0,
                                     }
-                                  />
-                                  <RNSVGPath
-                                    d="M42 45c0-1.6569 1.3431-3 3-3h37c1.6569 0 3 1.3431 3 3s-1.3431 3-3 3H45c-1.6569 0-3-1.3431-3-3Z"
-                                    fill={
-                                      {
-                                        "payload": 4278240714,
-                                        "type": 0,
-                                      }
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M133.026 95.4111c10.19-1.93 81.474-6.4098 109.474 9.0889l1.41-3.74c-24.41-15.7622-101.104-11.2689-111.624-9.2689-5.67 1.07-9.65 6.1-9.26 11.6799.25 3.64 2.38 8.28 11.09 9.68 15.98 2.57 29.78-.26 30.36-.38l-.82-3.92c-.14.03-13.65 2.8-28.9.34-7.4-1.2-7.66-4.82-7.74-6.01-.25-3.5599 2.33-6.7699 6.01-7.4699Z"
+                                  fill={
+                                    {
+                                      "payload": 4278927075,
+                                      "type": 0,
                                     }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M169.026 134.771c-.25 0-.5-.01-.74-.04-2.86-.28-4.82-2.19-5.36-5.23-.75-4.24 1.3-10.09 6.11-17.36 3.44-5.21 7.03-9.24 7.18-9.41l2.98 2.67c-3.83 4.28-13.5 16.84-12.33 23.41.28 1.59 1.04 1.88 1.81 1.95 4.02.4 12.54-5.66 14.87-11.62l3.72 1.46c-2.77 7.07-12.05 14.18-18.25 14.18l.01-.01Z"
+                                  fill={
+                                    {
+                                      "payload": 4278927075,
+                                      "type": 0,
                                     }
-                                  />
-                                  <RNSVGPath
-                                    d="M24.1953 82.863c0-5.1409 4.1675-9.3083 9.3083-9.3083h61.9925c5.1409 0 9.3079 4.1674 9.3079 9.3083v34.511c0 5.141-4.167 9.309-9.3079 9.309H33.5036c-5.1408 0-9.3083-4.168-9.3083-9.309V82.863Zm9.3083-7.3083c-4.0363 0-7.3083 3.272-7.3083 7.3083v34.511c0 4.036 3.272 7.309 7.3083 7.309h61.9925c4.0362 0 7.3079-3.273 7.3079-7.309V82.863c0-4.0363-3.2717-7.3083-7.3079-7.3083H33.5036Z"
-                                    fill={
-                                      {
-                                        "payload": 4278240714,
-                                        "type": 0,
-                                      }
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M189.457 135.551c-.76-3.95-6.5-7.16-8.65-8.07l1.55-3.69c.4.17 9.71 4.14 11.03 11l-3.93.75v.01ZM155.287 133.011c-3.2 0-6.37-.78-8.24-3.29-2.41-3.24-3.22-8.18-2-12.31.99-3.35 3.17-5.81 6.13-6.91.74-.28 1.53-.47 2.35-.57l.5 3.97c-.52.06-1.01.18-1.46.35-2.25.84-3.25 2.8-3.69 4.29-.86 2.93-.3 6.54 1.37 8.78 2.42 3.25 11.11.99 13.96-.06l1.38 3.75c-.84.31-5.61 1.99-10.31 1.99l.01.01Z"
+                                  fill={
+                                    {
+                                      "payload": 4278927075,
+                                      "type": 0,
                                     }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M168.897 147.651c-2.27 0-4.46-.51-6.55-1.52-8.18-3.97-11.68-14.35-11.83-14.79l3.8-1.25c.03.09 3.14 9.23 9.79 12.45 2.91 1.41 6.03 1.48 9.51.21 3.5-1.27 5.57-2.79 5.68-4.17.14-1.9-3.15-4.62-5.42-5.85l1.9-3.52c.81.44 7.89 4.42 7.51 9.66-.23 3.15-3.02 5.72-8.3 7.64-2.08.76-4.12 1.14-6.09 1.14Z"
+                                  fill={
+                                    {
+                                      "payload": 4278927075,
+                                      "type": 0,
                                     }
-                                  />
-                                  <RNSVGPath
-                                    d="M103.679 114.82H25.0703v-2h78.6087v2ZM92.1746 80.0312c-3.3303 0-6.0301 2.6998-6.0301 6.0301s2.6998 6.0301 6.0301 6.0301 6.0301-2.6998 6.0301-6.0301-2.6998-6.0301-6.0301-6.0301Zm-8.0301 6.0301c0-4.4349 3.5952-8.0301 8.0301-8.0301 4.4349 0 8.0304 3.5952 8.0304 8.0301 0 4.4349-3.5955 8.0301-8.0304 8.0301-4.4349 0-8.0301-3.5952-8.0301-8.0301ZM52.9121 84.5039c0 .5523-.4477 1-1 1h-19.812c-.5523 0-1-.4477-1-1s.4477-1 1-1h19.812c.5523 0 1 .4477 1 1ZM52.9121 88.9766c0 .5522-.4477 1-1 1h-19.812c-.5523 0-1-.4478-1-1 0-.5523.4477-1 1-1h19.812c.5523 0 1 .4477 1 1ZM55.1054 69.4473c-.494.247-1.0947.0468-1.3417-.4472L48.6582 58.789c-.247-.494-.0468-1.0947.4472-1.3417.4939-.247 1.0946-.0467 1.3416.4472l5.1056 10.2112c.247.494.0467 1.0946-.4472 1.3416ZM71.122 68.5218c-.4848-.2644-.6635-.8719-.399-1.3567l5.0423-9.2442c.2645-.4849.8719-.6635 1.3567-.3991.4849.2645.6635.8719.3991 1.3568l-5.0423 9.2442c-.2645.4848-.8719.6635-1.3568.399ZM56.9411 132.336c.5201.185.7911.758.6054 1.278l-4.3274 12.116c-.1857.52-.7579.791-1.278.606-.5201-.186-.7912-.758-.6054-1.279l4.3273-12.116c.1857-.52.758-.791 1.2781-.605ZM72.9084 131.579c.5015-.231 1.0956-.012 1.3271.489l5.1618 11.184c.2315.502.0126 1.096-.4889 1.327-.5014.232-1.0955.013-1.327-.489l-5.1619-11.184c-.2314-.501-.0125-1.095.4889-1.327Z"
-                                    fill={
-                                      {
-                                        "payload": 4278240714,
-                                        "type": 0,
-                                      }
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M241 156.998c-35.5 4.5-64.721-10.34-65.647-10.804l1.798-3.575c.218.104 30.849 14.379 63.595 10.389l.254 3.99Z"
+                                  fill={
+                                    {
+                                      "payload": 4278927075,
+                                      "type": 0,
                                     }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
-                                    }
-                                  />
-                                  <RNSVGPath
-                                    d="M133.026 95.4111c10.19-1.93 81.474-6.4098 109.474 9.0889l1.41-3.74c-24.41-15.7622-101.104-11.2689-111.624-9.2689-5.67 1.07-9.65 6.1-9.26 11.6799.25 3.64 2.38 8.28 11.09 9.68 15.98 2.57 29.78-.26 30.36-.38l-.82-3.92c-.14.03-13.65 2.8-28.9.34-7.4-1.2-7.66-4.82-7.74-6.01-.25-3.5599 2.33-6.7699 6.01-7.4699Z"
-                                    fill={
-                                      {
-                                        "payload": 4278927075,
-                                        "type": 0,
-                                      }
-                                    }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
-                                    }
-                                  />
-                                  <RNSVGPath
-                                    d="M169.026 134.771c-.25 0-.5-.01-.74-.04-2.86-.28-4.82-2.19-5.36-5.23-.75-4.24 1.3-10.09 6.11-17.36 3.44-5.21 7.03-9.24 7.18-9.41l2.98 2.67c-3.83 4.28-13.5 16.84-12.33 23.41.28 1.59 1.04 1.88 1.81 1.95 4.02.4 12.54-5.66 14.87-11.62l3.72 1.46c-2.77 7.07-12.05 14.18-18.25 14.18l.01-.01Z"
-                                    fill={
-                                      {
-                                        "payload": 4278927075,
-                                        "type": 0,
-                                      }
-                                    }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
-                                    }
-                                  />
-                                  <RNSVGPath
-                                    d="M189.457 135.551c-.76-3.95-6.5-7.16-8.65-8.07l1.55-3.69c.4.17 9.71 4.14 11.03 11l-3.93.75v.01ZM155.287 133.011c-3.2 0-6.37-.78-8.24-3.29-2.41-3.24-3.22-8.18-2-12.31.99-3.35 3.17-5.81 6.13-6.91.74-.28 1.53-.47 2.35-.57l.5 3.97c-.52.06-1.01.18-1.46.35-2.25.84-3.25 2.8-3.69 4.29-.86 2.93-.3 6.54 1.37 8.78 2.42 3.25 11.11.99 13.96-.06l1.38 3.75c-.84.31-5.61 1.99-10.31 1.99l.01.01Z"
-                                    fill={
-                                      {
-                                        "payload": 4278927075,
-                                        "type": 0,
-                                      }
-                                    }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
-                                    }
-                                  />
-                                  <RNSVGPath
-                                    d="M168.897 147.651c-2.27 0-4.46-.51-6.55-1.52-8.18-3.97-11.68-14.35-11.83-14.79l3.8-1.25c.03.09 3.14 9.23 9.79 12.45 2.91 1.41 6.03 1.48 9.51.21 3.5-1.27 5.57-2.79 5.68-4.17.14-1.9-3.15-4.62-5.42-5.85l1.9-3.52c.81.44 7.89 4.42 7.51 9.66-.23 3.15-3.02 5.72-8.3 7.64-2.08.76-4.12 1.14-6.09 1.14Z"
-                                    fill={
-                                      {
-                                        "payload": 4278927075,
-                                        "type": 0,
-                                      }
-                                    }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
-                                    }
-                                  />
-                                  <RNSVGPath
-                                    d="M241 156.998c-35.5 4.5-64.721-10.34-65.647-10.804l1.798-3.575c.218.104 30.849 14.379 63.595 10.389l.254 3.99Z"
-                                    fill={
-                                      {
-                                        "payload": 4278927075,
-                                        "type": 0,
-                                      }
-                                    }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
-                                    }
-                                  />
-                                </RNSVGGroup>
-                              </RNSVGSvgView>
-                            </View>
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                              </RNSVGGroup>
+                            </RNSVGSvgView>
                           </View>
                         </View>
                       </View>
@@ -1102,390 +1094,382 @@ exports[`ItwWalletReadyBanner should match snapshot when ITW new interface activ
                       }
                     >
                       <View
-                        style={
+                        accessibilityState={
                           {
-                            "marginHorizontal": -8,
+                            "busy": undefined,
+                            "checked": undefined,
+                            "disabled": undefined,
+                            "expanded": undefined,
+                            "selected": undefined,
                           }
                         }
+                        accessibilityValue={
+                          {
+                            "max": undefined,
+                            "min": undefined,
+                            "now": undefined,
+                            "text": undefined,
+                          }
+                        }
+                        accessible={false}
+                        collapsable={false}
+                        focusable={true}
+                        onBlur={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onResponderGrant={[Function]}
+                        onResponderMove={[Function]}
+                        onResponderRelease={[Function]}
+                        onResponderTerminate={[Function]}
+                        onResponderTerminationRequest={[Function]}
+                        onStartShouldSetResponder={[Function]}
+                        testID="itwWalletReadyBannerTestID"
                       >
                         <View
-                          accessibilityState={
-                            {
-                              "busy": undefined,
-                              "checked": undefined,
-                              "disabled": undefined,
-                              "expanded": undefined,
-                              "selected": undefined,
-                            }
-                          }
-                          accessibilityValue={
-                            {
-                              "max": undefined,
-                              "min": undefined,
-                              "now": undefined,
-                              "text": undefined,
-                            }
-                          }
-                          accessible={false}
                           collapsable={false}
-                          focusable={true}
-                          onBlur={[Function]}
-                          onClick={[Function]}
-                          onFocus={[Function]}
-                          onResponderGrant={[Function]}
-                          onResponderMove={[Function]}
-                          onResponderRelease={[Function]}
-                          onResponderTerminate={[Function]}
-                          onResponderTerminationRequest={[Function]}
-                          onStartShouldSetResponder={[Function]}
-                          testID="itwWalletReadyBannerTestID"
+                          jestAnimatedProps={
+                            {
+                              "value": {},
+                            }
+                          }
+                          jestAnimatedStyle={
+                            {
+                              "value": {
+                                "transform": [
+                                  {
+                                    "scale": 1,
+                                  },
+                                ],
+                              },
+                            }
+                          }
+                          jestInlineStyle={
+                            [
+                              {
+                                "alignContent": "center",
+                                "alignItems": "flex-start",
+                                "borderCurve": "continuous",
+                                "borderRadius": 8,
+                                "flexDirection": "row",
+                                "padding": 16,
+                              },
+                              {
+                                "backgroundColor": "#DBF9FA",
+                              },
+                            ]
+                          }
+                          style={
+                            [
+                              {
+                                "alignContent": "center",
+                                "alignItems": "flex-start",
+                                "borderCurve": "continuous",
+                                "borderRadius": 8,
+                                "flexDirection": "row",
+                                "padding": 16,
+                              },
+                              {
+                                "backgroundColor": "#DBF9FA",
+                              },
+                              {
+                                "transform": [
+                                  {
+                                    "scale": 1,
+                                  },
+                                ],
+                              },
+                            ]
+                          }
                         >
                           <View
-                            collapsable={false}
-                            jestAnimatedProps={
-                              {
-                                "value": {},
-                              }
-                            }
-                            jestAnimatedStyle={
-                              {
-                                "value": {
-                                  "transform": [
-                                    {
-                                      "scale": 1,
-                                    },
-                                  ],
-                                },
-                              }
-                            }
-                            jestInlineStyle={
-                              [
-                                {
-                                  "alignContent": "center",
-                                  "alignItems": "flex-start",
-                                  "borderCurve": "continuous",
-                                  "borderRadius": 8,
-                                  "flexDirection": "row",
-                                  "padding": 16,
-                                },
-                                {
-                                  "backgroundColor": "#DBF9FA",
-                                },
-                              ]
-                            }
+                            accessibilityLabel="È tutto pronto: aggiungi un documento al tuo Portafoglio di IO. Aggiungi documento"
+                            accessibilityRole="button"
+                            accessible={true}
                             style={
-                              [
-                                {
-                                  "alignContent": "center",
-                                  "alignItems": "flex-start",
-                                  "borderCurve": "continuous",
-                                  "borderRadius": 8,
-                                  "flexDirection": "row",
-                                  "padding": 16,
-                                },
-                                {
-                                  "backgroundColor": "#DBF9FA",
-                                },
-                                {
-                                  "transform": [
-                                    {
-                                      "scale": 1,
-                                    },
-                                  ],
-                                },
-                              ]
+                              {
+                                "alignSelf": "center",
+                                "flex": 1,
+                                "gap": 4,
+                              }
                             }
                           >
-                            <View
-                              accessibilityLabel="È tutto pronto: aggiungi un documento al tuo Portafoglio di IO. Aggiungi documento"
-                              accessibilityRole="button"
-                              accessible={true}
-                              style={
-                                {
-                                  "alignSelf": "center",
-                                  "flex": 1,
-                                  "gap": 4,
-                                }
-                              }
-                            >
-                              <Text
-                                allowFontScaling={true}
-                                dynamicTypeRamp="footnote"
-                                maxFontSizeMultiplier={1.5}
-                                style={
-                                  [
-                                    {},
-                                    {
-                                      "color": "#555C70",
-                                      "fontFamily": "Titillio",
-                                      "fontSize": 14,
-                                      "fontStyle": "normal",
-                                      "fontWeight": "400",
-                                      "lineHeight": 21,
-                                    },
-                                  ]
-                                }
-                              >
-                                È tutto pronto: aggiungi un documento al tuo Portafoglio di IO.
-                              </Text>
-                              <View
-                                accessibilityElementsHidden={true}
-                                accessibilityLabel="Aggiungi documento"
-                                accessibilityRole="button"
-                                accessibilityState={
-                                  {
-                                    "busy": undefined,
-                                    "checked": undefined,
-                                    "disabled": undefined,
-                                    "expanded": undefined,
-                                    "selected": undefined,
-                                  }
-                                }
-                                accessibilityValue={
-                                  {
-                                    "max": undefined,
-                                    "min": undefined,
-                                    "now": undefined,
-                                    "text": undefined,
-                                  }
-                                }
-                                accessible={true}
-                                collapsable={false}
-                                focusable={true}
-                                importantForAccessibility="no-hide-descendants"
-                                onBlur={[Function]}
-                                onClick={[Function]}
-                                onFocus={[Function]}
-                                onResponderGrant={[Function]}
-                                onResponderMove={[Function]}
-                                onResponderRelease={[Function]}
-                                onResponderTerminate={[Function]}
-                                onResponderTerminationRequest={[Function]}
-                                onStartShouldSetResponder={[Function]}
-                                pointerEvents="none"
-                              >
-                                <View
-                                  style={
-                                    {
-                                      "height": 8,
-                                    }
-                                  }
-                                />
-                                <Text
-                                  accessibilityElementsHidden={true}
-                                  accessible={false}
-                                  allowFontScaling={true}
-                                  ellipsizeMode="tail"
-                                  importantForAccessibility="no-hide-descendants"
-                                  maxFontSizeMultiplier={1.5}
-                                  numberOfLines={1}
-                                  style={
-                                    [
-                                      {},
-                                      {
-                                        "color": "#0B3EE3",
-                                        "fontFamily": "Titillio",
-                                        "fontSize": 16,
-                                        "fontStyle": "normal",
-                                        "fontWeight": "600",
-                                        "lineHeight": undefined,
-                                      },
-                                    ]
-                                  }
-                                >
-                                  Aggiungi documento
-                                </Text>
-                              </View>
-                            </View>
-                            <View
+                            <Text
+                              allowFontScaling={true}
+                              dynamicTypeRamp="footnote"
+                              maxFontSizeMultiplier={1.5}
                               style={
                                 [
+                                  {},
                                   {
-                                    "marginRight": -16,
-                                  },
-                                  {
-                                    "alignSelf": "center",
+                                    "color": "#555C70",
+                                    "fontFamily": "Titillio",
+                                    "fontSize": 14,
+                                    "fontStyle": "normal",
+                                    "fontWeight": "400",
+                                    "lineHeight": 21,
                                   },
                                 ]
                               }
                             >
-                              <RNSVGSvgView
-                                align="xMidYMid"
-                                bbHeight={80}
-                                bbWidth={80}
-                                focusable={false}
-                                height={80}
-                                meetOrSlice={0}
-                                minX={0}
-                                minY={0}
+                              È tutto pronto: aggiungi un documento al tuo Portafoglio di IO.
+                            </Text>
+                            <View
+                              accessibilityElementsHidden={true}
+                              accessibilityLabel="Aggiungi documento"
+                              accessibilityRole="button"
+                              accessibilityState={
+                                {
+                                  "busy": undefined,
+                                  "checked": undefined,
+                                  "disabled": undefined,
+                                  "expanded": undefined,
+                                  "selected": undefined,
+                                }
+                              }
+                              accessibilityValue={
+                                {
+                                  "max": undefined,
+                                  "min": undefined,
+                                  "now": undefined,
+                                  "text": undefined,
+                                }
+                              }
+                              accessible={true}
+                              collapsable={false}
+                              focusable={true}
+                              importantForAccessibility="no-hide-descendants"
+                              onBlur={[Function]}
+                              onClick={[Function]}
+                              onFocus={[Function]}
+                              onResponderGrant={[Function]}
+                              onResponderMove={[Function]}
+                              onResponderRelease={[Function]}
+                              onResponderTerminate={[Function]}
+                              onResponderTerminationRequest={[Function]}
+                              onStartShouldSetResponder={[Function]}
+                              pointerEvents="none"
+                            >
+                              <View
+                                style={
+                                  {
+                                    "height": 8,
+                                  }
+                                }
+                              />
+                              <Text
+                                accessibilityElementsHidden={true}
+                                accessible={false}
+                                allowFontScaling={true}
+                                ellipsizeMode="tail"
+                                importantForAccessibility="no-hide-descendants"
+                                maxFontSizeMultiplier={1.5}
+                                numberOfLines={1}
                                 style={
                                   [
+                                    {},
                                     {
-                                      "backgroundColor": "transparent",
-                                      "borderWidth": 0,
-                                    },
-                                    {
-                                      "flex": 0,
-                                      "height": 80,
-                                      "width": 80,
+                                      "color": "#0B3EE3",
+                                      "fontFamily": "Titillio",
+                                      "fontSize": 16,
+                                      "fontStyle": "normal",
+                                      "fontWeight": "600",
+                                      "lineHeight": undefined,
                                     },
                                   ]
                                 }
-                                vbHeight={240}
-                                vbWidth={240}
-                                width={80}
                               >
-                                <RNSVGGroup
+                                Aggiungi documento
+                              </Text>
+                            </View>
+                          </View>
+                          <View
+                            style={
+                              [
+                                {
+                                  "marginRight": -16,
+                                },
+                                {
+                                  "alignSelf": "center",
+                                },
+                              ]
+                            }
+                          >
+                            <RNSVGSvgView
+                              align="xMidYMid"
+                              bbHeight={80}
+                              bbWidth={80}
+                              focusable={false}
+                              height={80}
+                              meetOrSlice={0}
+                              minX={0}
+                              minY={0}
+                              style={
+                                [
+                                  {
+                                    "backgroundColor": "transparent",
+                                    "borderWidth": 0,
+                                  },
+                                  {
+                                    "flex": 0,
+                                    "height": 80,
+                                    "width": 80,
+                                  },
+                                ]
+                              }
+                              vbHeight={240}
+                              vbWidth={240}
+                              width={80}
+                            >
+                              <RNSVGGroup
+                                fill={
+                                  {
+                                    "payload": 4278190080,
+                                    "type": 0,
+                                  }
+                                }
+                              >
+                                <RNSVGPath
+                                  d="M12 47c0-8.8366 7.1634-16 16-16h71c8.837 0 16 7.1634 16 16v151c0 8.837-7.163 16-16 16H28c-8.8366 0-16-7.163-16-16V47Z"
                                   fill={
                                     {
-                                      "payload": 4278190080,
+                                      "payload": 4289392367,
                                       "type": 0,
                                     }
                                   }
-                                >
-                                  <RNSVGPath
-                                    d="M12 47c0-8.8366 7.1634-16 16-16h71c8.837 0 16 7.1634 16 16v151c0 8.837-7.163 16-16 16H28c-8.8366 0-16-7.163-16-16V47Z"
-                                    fill={
-                                      {
-                                        "payload": 4289392367,
-                                        "type": 0,
-                                      }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M16 50.9292C16 42.1317 23.1317 35 31.9292 35h64.1416C104.868 35 112 42.1317 112 50.9292V195.071c0 8.797-7.132 15.929-15.9292 15.929H31.9292C23.1317 211 16 203.868 16 195.071V50.9292ZM31.9292 37C24.2363 37 18 43.2363 18 50.9292V195.071C18 202.764 24.2363 209 31.9292 209h64.1416C103.764 209 110 202.764 110 195.071V50.9292C110 43.2363 103.764 37 96.0708 37H31.9292Z"
+                                  fill={
+                                    {
+                                      "payload": 4278240714,
+                                      "type": 0,
                                     }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M42 45c0-1.6569 1.3431-3 3-3h37c1.6569 0 3 1.3431 3 3s-1.3431 3-3 3H45c-1.6569 0-3-1.3431-3-3Z"
+                                  fill={
+                                    {
+                                      "payload": 4278240714,
+                                      "type": 0,
                                     }
-                                  />
-                                  <RNSVGPath
-                                    d="M16 50.9292C16 42.1317 23.1317 35 31.9292 35h64.1416C104.868 35 112 42.1317 112 50.9292V195.071c0 8.797-7.132 15.929-15.9292 15.929H31.9292C23.1317 211 16 203.868 16 195.071V50.9292ZM31.9292 37C24.2363 37 18 43.2363 18 50.9292V195.071C18 202.764 24.2363 209 31.9292 209h64.1416C103.764 209 110 202.764 110 195.071V50.9292C110 43.2363 103.764 37 96.0708 37H31.9292Z"
-                                    fill={
-                                      {
-                                        "payload": 4278240714,
-                                        "type": 0,
-                                      }
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M24.1953 82.863c0-5.1409 4.1675-9.3083 9.3083-9.3083h61.9925c5.1409 0 9.3079 4.1674 9.3079 9.3083v34.511c0 5.141-4.167 9.309-9.3079 9.309H33.5036c-5.1408 0-9.3083-4.168-9.3083-9.309V82.863Zm9.3083-7.3083c-4.0363 0-7.3083 3.272-7.3083 7.3083v34.511c0 4.036 3.272 7.309 7.3083 7.309h61.9925c4.0362 0 7.3079-3.273 7.3079-7.309V82.863c0-4.0363-3.2717-7.3083-7.3079-7.3083H33.5036Z"
+                                  fill={
+                                    {
+                                      "payload": 4278240714,
+                                      "type": 0,
                                     }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M103.679 114.82H25.0703v-2h78.6087v2ZM92.1746 80.0312c-3.3303 0-6.0301 2.6998-6.0301 6.0301s2.6998 6.0301 6.0301 6.0301 6.0301-2.6998 6.0301-6.0301-2.6998-6.0301-6.0301-6.0301Zm-8.0301 6.0301c0-4.4349 3.5952-8.0301 8.0301-8.0301 4.4349 0 8.0304 3.5952 8.0304 8.0301 0 4.4349-3.5955 8.0301-8.0304 8.0301-4.4349 0-8.0301-3.5952-8.0301-8.0301ZM52.9121 84.5039c0 .5523-.4477 1-1 1h-19.812c-.5523 0-1-.4477-1-1s.4477-1 1-1h19.812c.5523 0 1 .4477 1 1ZM52.9121 88.9766c0 .5522-.4477 1-1 1h-19.812c-.5523 0-1-.4478-1-1 0-.5523.4477-1 1-1h19.812c.5523 0 1 .4477 1 1ZM55.1054 69.4473c-.494.247-1.0947.0468-1.3417-.4472L48.6582 58.789c-.247-.494-.0468-1.0947.4472-1.3417.4939-.247 1.0946-.0467 1.3416.4472l5.1056 10.2112c.247.494.0467 1.0946-.4472 1.3416ZM71.122 68.5218c-.4848-.2644-.6635-.8719-.399-1.3567l5.0423-9.2442c.2645-.4849.8719-.6635 1.3567-.3991.4849.2645.6635.8719.3991 1.3568l-5.0423 9.2442c-.2645.4848-.8719.6635-1.3568.399ZM56.9411 132.336c.5201.185.7911.758.6054 1.278l-4.3274 12.116c-.1857.52-.7579.791-1.278.606-.5201-.186-.7912-.758-.6054-1.279l4.3273-12.116c.1857-.52.758-.791 1.2781-.605ZM72.9084 131.579c.5015-.231 1.0956-.012 1.3271.489l5.1618 11.184c.2315.502.0126 1.096-.4889 1.327-.5014.232-1.0955.013-1.327-.489l-5.1619-11.184c-.2314-.501-.0125-1.095.4889-1.327Z"
+                                  fill={
+                                    {
+                                      "payload": 4278240714,
+                                      "type": 0,
                                     }
-                                  />
-                                  <RNSVGPath
-                                    d="M42 45c0-1.6569 1.3431-3 3-3h37c1.6569 0 3 1.3431 3 3s-1.3431 3-3 3H45c-1.6569 0-3-1.3431-3-3Z"
-                                    fill={
-                                      {
-                                        "payload": 4278240714,
-                                        "type": 0,
-                                      }
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M133.026 95.4111c10.19-1.93 81.474-6.4098 109.474 9.0889l1.41-3.74c-24.41-15.7622-101.104-11.2689-111.624-9.2689-5.67 1.07-9.65 6.1-9.26 11.6799.25 3.64 2.38 8.28 11.09 9.68 15.98 2.57 29.78-.26 30.36-.38l-.82-3.92c-.14.03-13.65 2.8-28.9.34-7.4-1.2-7.66-4.82-7.74-6.01-.25-3.5599 2.33-6.7699 6.01-7.4699Z"
+                                  fill={
+                                    {
+                                      "payload": 4278927075,
+                                      "type": 0,
                                     }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M169.026 134.771c-.25 0-.5-.01-.74-.04-2.86-.28-4.82-2.19-5.36-5.23-.75-4.24 1.3-10.09 6.11-17.36 3.44-5.21 7.03-9.24 7.18-9.41l2.98 2.67c-3.83 4.28-13.5 16.84-12.33 23.41.28 1.59 1.04 1.88 1.81 1.95 4.02.4 12.54-5.66 14.87-11.62l3.72 1.46c-2.77 7.07-12.05 14.18-18.25 14.18l.01-.01Z"
+                                  fill={
+                                    {
+                                      "payload": 4278927075,
+                                      "type": 0,
                                     }
-                                  />
-                                  <RNSVGPath
-                                    d="M24.1953 82.863c0-5.1409 4.1675-9.3083 9.3083-9.3083h61.9925c5.1409 0 9.3079 4.1674 9.3079 9.3083v34.511c0 5.141-4.167 9.309-9.3079 9.309H33.5036c-5.1408 0-9.3083-4.168-9.3083-9.309V82.863Zm9.3083-7.3083c-4.0363 0-7.3083 3.272-7.3083 7.3083v34.511c0 4.036 3.272 7.309 7.3083 7.309h61.9925c4.0362 0 7.3079-3.273 7.3079-7.309V82.863c0-4.0363-3.2717-7.3083-7.3079-7.3083H33.5036Z"
-                                    fill={
-                                      {
-                                        "payload": 4278240714,
-                                        "type": 0,
-                                      }
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M189.457 135.551c-.76-3.95-6.5-7.16-8.65-8.07l1.55-3.69c.4.17 9.71 4.14 11.03 11l-3.93.75v.01ZM155.287 133.011c-3.2 0-6.37-.78-8.24-3.29-2.41-3.24-3.22-8.18-2-12.31.99-3.35 3.17-5.81 6.13-6.91.74-.28 1.53-.47 2.35-.57l.5 3.97c-.52.06-1.01.18-1.46.35-2.25.84-3.25 2.8-3.69 4.29-.86 2.93-.3 6.54 1.37 8.78 2.42 3.25 11.11.99 13.96-.06l1.38 3.75c-.84.31-5.61 1.99-10.31 1.99l.01.01Z"
+                                  fill={
+                                    {
+                                      "payload": 4278927075,
+                                      "type": 0,
                                     }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M168.897 147.651c-2.27 0-4.46-.51-6.55-1.52-8.18-3.97-11.68-14.35-11.83-14.79l3.8-1.25c.03.09 3.14 9.23 9.79 12.45 2.91 1.41 6.03 1.48 9.51.21 3.5-1.27 5.57-2.79 5.68-4.17.14-1.9-3.15-4.62-5.42-5.85l1.9-3.52c.81.44 7.89 4.42 7.51 9.66-.23 3.15-3.02 5.72-8.3 7.64-2.08.76-4.12 1.14-6.09 1.14Z"
+                                  fill={
+                                    {
+                                      "payload": 4278927075,
+                                      "type": 0,
                                     }
-                                  />
-                                  <RNSVGPath
-                                    d="M103.679 114.82H25.0703v-2h78.6087v2ZM92.1746 80.0312c-3.3303 0-6.0301 2.6998-6.0301 6.0301s2.6998 6.0301 6.0301 6.0301 6.0301-2.6998 6.0301-6.0301-2.6998-6.0301-6.0301-6.0301Zm-8.0301 6.0301c0-4.4349 3.5952-8.0301 8.0301-8.0301 4.4349 0 8.0304 3.5952 8.0304 8.0301 0 4.4349-3.5955 8.0301-8.0304 8.0301-4.4349 0-8.0301-3.5952-8.0301-8.0301ZM52.9121 84.5039c0 .5523-.4477 1-1 1h-19.812c-.5523 0-1-.4477-1-1s.4477-1 1-1h19.812c.5523 0 1 .4477 1 1ZM52.9121 88.9766c0 .5522-.4477 1-1 1h-19.812c-.5523 0-1-.4478-1-1 0-.5523.4477-1 1-1h19.812c.5523 0 1 .4477 1 1ZM55.1054 69.4473c-.494.247-1.0947.0468-1.3417-.4472L48.6582 58.789c-.247-.494-.0468-1.0947.4472-1.3417.4939-.247 1.0946-.0467 1.3416.4472l5.1056 10.2112c.247.494.0467 1.0946-.4472 1.3416ZM71.122 68.5218c-.4848-.2644-.6635-.8719-.399-1.3567l5.0423-9.2442c.2645-.4849.8719-.6635 1.3567-.3991.4849.2645.6635.8719.3991 1.3568l-5.0423 9.2442c-.2645.4848-.8719.6635-1.3568.399ZM56.9411 132.336c.5201.185.7911.758.6054 1.278l-4.3274 12.116c-.1857.52-.7579.791-1.278.606-.5201-.186-.7912-.758-.6054-1.279l4.3273-12.116c.1857-.52.758-.791 1.2781-.605ZM72.9084 131.579c.5015-.231 1.0956-.012 1.3271.489l5.1618 11.184c.2315.502.0126 1.096-.4889 1.327-.5014.232-1.0955.013-1.327-.489l-5.1619-11.184c-.2314-.501-.0125-1.095.4889-1.327Z"
-                                    fill={
-                                      {
-                                        "payload": 4278240714,
-                                        "type": 0,
-                                      }
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                                <RNSVGPath
+                                  d="M241 156.998c-35.5 4.5-64.721-10.34-65.647-10.804l1.798-3.575c.218.104 30.849 14.379 63.595 10.389l.254 3.99Z"
+                                  fill={
+                                    {
+                                      "payload": 4278927075,
+                                      "type": 0,
                                     }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
-                                    }
-                                  />
-                                  <RNSVGPath
-                                    d="M133.026 95.4111c10.19-1.93 81.474-6.4098 109.474 9.0889l1.41-3.74c-24.41-15.7622-101.104-11.2689-111.624-9.2689-5.67 1.07-9.65 6.1-9.26 11.6799.25 3.64 2.38 8.28 11.09 9.68 15.98 2.57 29.78-.26 30.36-.38l-.82-3.92c-.14.03-13.65 2.8-28.9.34-7.4-1.2-7.66-4.82-7.74-6.01-.25-3.5599 2.33-6.7699 6.01-7.4699Z"
-                                    fill={
-                                      {
-                                        "payload": 4278927075,
-                                        "type": 0,
-                                      }
-                                    }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
-                                    }
-                                  />
-                                  <RNSVGPath
-                                    d="M169.026 134.771c-.25 0-.5-.01-.74-.04-2.86-.28-4.82-2.19-5.36-5.23-.75-4.24 1.3-10.09 6.11-17.36 3.44-5.21 7.03-9.24 7.18-9.41l2.98 2.67c-3.83 4.28-13.5 16.84-12.33 23.41.28 1.59 1.04 1.88 1.81 1.95 4.02.4 12.54-5.66 14.87-11.62l3.72 1.46c-2.77 7.07-12.05 14.18-18.25 14.18l.01-.01Z"
-                                    fill={
-                                      {
-                                        "payload": 4278927075,
-                                        "type": 0,
-                                      }
-                                    }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
-                                    }
-                                  />
-                                  <RNSVGPath
-                                    d="M189.457 135.551c-.76-3.95-6.5-7.16-8.65-8.07l1.55-3.69c.4.17 9.71 4.14 11.03 11l-3.93.75v.01ZM155.287 133.011c-3.2 0-6.37-.78-8.24-3.29-2.41-3.24-3.22-8.18-2-12.31.99-3.35 3.17-5.81 6.13-6.91.74-.28 1.53-.47 2.35-.57l.5 3.97c-.52.06-1.01.18-1.46.35-2.25.84-3.25 2.8-3.69 4.29-.86 2.93-.3 6.54 1.37 8.78 2.42 3.25 11.11.99 13.96-.06l1.38 3.75c-.84.31-5.61 1.99-10.31 1.99l.01.01Z"
-                                    fill={
-                                      {
-                                        "payload": 4278927075,
-                                        "type": 0,
-                                      }
-                                    }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
-                                    }
-                                  />
-                                  <RNSVGPath
-                                    d="M168.897 147.651c-2.27 0-4.46-.51-6.55-1.52-8.18-3.97-11.68-14.35-11.83-14.79l3.8-1.25c.03.09 3.14 9.23 9.79 12.45 2.91 1.41 6.03 1.48 9.51.21 3.5-1.27 5.57-2.79 5.68-4.17.14-1.9-3.15-4.62-5.42-5.85l1.9-3.52c.81.44 7.89 4.42 7.51 9.66-.23 3.15-3.02 5.72-8.3 7.64-2.08.76-4.12 1.14-6.09 1.14Z"
-                                    fill={
-                                      {
-                                        "payload": 4278927075,
-                                        "type": 0,
-                                      }
-                                    }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
-                                    }
-                                  />
-                                  <RNSVGPath
-                                    d="M241 156.998c-35.5 4.5-64.721-10.34-65.647-10.804l1.798-3.575c.218.104 30.849 14.379 63.595 10.389l.254 3.99Z"
-                                    fill={
-                                      {
-                                        "payload": 4278927075,
-                                        "type": 0,
-                                      }
-                                    }
-                                    propList={
-                                      [
-                                        "fill",
-                                      ]
-                                    }
-                                  />
-                                </RNSVGGroup>
-                              </RNSVGSvgView>
-                            </View>
+                                  }
+                                  propList={
+                                    [
+                                      "fill",
+                                    ]
+                                  }
+                                />
+                              </RNSVGGroup>
+                            </RNSVGSvgView>
                           </View>
                         </View>
                       </View>

--- a/apps/main-app/ts/features/itwallet/wallet/components/ItwWalletCardsContainer.tsx
+++ b/apps/main-app/ts/features/itwallet/wallet/components/ItwWalletCardsContainer.tsx
@@ -97,10 +97,16 @@ export const ItwWalletCardsContainer = withWalletCategoryFilter("itw", () => {
   const sectionHeader = useMemo((): React.ReactElement => {
     if (isNewItwRenderable) {
       return (
-        <ListItemHeader
-          testID={"walletCardsCategoryItwIdCardHeaderTestID"}
-          label={I18n.t("features.wallet.cards.categories.itw")}
-        />
+        <>
+          <ListItemHeader
+            testID={"walletCardsCategoryItwIdCardHeaderTestID"}
+            label={I18n.t("features.wallet.cards.categories.itw")}
+          />
+          {/* IT-Wallet renders the PID card below the header */}
+          <View style={styles.cardsWrapper}>
+            <ItwWalletIdCard isStacked={cards.length > 0} />
+          </View>
+        </>
       );
     }
     return (
@@ -124,14 +130,12 @@ export const ItwWalletCardsContainer = withWalletCategoryFilter("itw", () => {
         }}
       />
     );
-  }, [iconColor, isNewItwRenderable, eidInfoBottomSheet.present]);
+  }, [iconColor, isNewItwRenderable, cards, eidInfoBottomSheet.present]);
 
   return (
     <View>
       <VStack space={16}>
-        {shouldRenderUpgradeBanner && <ItwDiscoveryBanner flow="wallet" />}
         {shouldRenderL2EngagementBanner && <ItwL2EngagementBanner />}
-        <ItwWalletReadyBanner />
         {!shouldHideEidAlert && (
           <ItwEidLifecycleAlert
             lifecycleStatus={LIFECYCLE_STATUS}
@@ -142,8 +146,13 @@ export const ItwWalletCardsContainer = withWalletCategoryFilter("itw", () => {
       </VStack>
 
       {sectionHeader}
-      <View style={styles.cardsWrapper}>
-        {isNewItwRenderable && <ItwWalletIdCard isStacked={cards.length > 0} />}
+
+      <View style={[styles.cardsWrapper, { gap: 16 }]}>
+        <View style={styles.bannersWrapper}>
+          {shouldRenderUpgradeBanner && <ItwDiscoveryBanner flow="wallet" />}
+          <ItwWalletReadyBanner />
+        </View>
+
         {cards.length > 0 && (
           <GuidedTour
             groupId={ITW_TOUR_GROUP_ID}
@@ -169,5 +178,8 @@ export const ItwWalletCardsContainer = withWalletCategoryFilter("itw", () => {
 const styles = StyleSheet.create({
   cardsWrapper: {
     marginHorizontal: -8
+  },
+  bannersWrapper: {
+    marginHorizontal: 8
   }
 });

--- a/apps/main-app/ts/features/wallet/components/WalletCardsContainer.tsx
+++ b/apps/main-app/ts/features/wallet/components/WalletCardsContainer.tsx
@@ -146,11 +146,12 @@ export {
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1
+    flex: 1,
+    paddingVertical: 8
   },
   walletContent: {
     flex: 1,
-    gap: 8
+    gap: 16
   },
   cardsWrapper: {
     marginHorizontal: -8


### PR DESCRIPTION
## Short description
This PR fixes the positions of the ITW home screen banners

## List of changes proposed in this pull request
- `ItwWalletReadyBanner`: removed horizontal padding
- `ItWalletCardsContainer`: 
  - moved `ItwWalletIdCard` in the `sectionHeader` component to simplify rendering logic
  - moved `ItwDiscoveryBanner` and `ItwWalletReadyBanner` below section header

## How to test
Discovery and upgrade banners should follow Figma specifications:
- https://www.figma.com/design/ADn7iuJTCGbBwBo31X51Tc/General_ITW-2026
- https://www.figma.com/design/pVD9XCba7crkg5yOIdJCXl/-Doc-su-IO----Approved-only
