### PR TITLE
chore: [IEL-671,IEL-672] changed useFciCheckService bottomsheet and copy update

### DIFF
--- a/apps/main-app/locales/it/index.json
+++ b/apps/main-app/locales/it/index.json
@@ -2840,10 +2840,9 @@
         }
       },
       "checkService": {
-        "title": "Attiva i messaggi",
-        "content": "Per ricevere i documenti firmati devi attivare l’opzione che consente al servizio di inviarti messaggi. Se non la attivi, puoi completare la firma ma non riceverai i documenti firmati.",
-        "cancel": "Non ora",
-        "confirm": "Attiva"
+        "title": "Ricevi i documenti firmati",
+        "content": "Per ricevere su IO i documenti firmati, attiva l’opzione che consente al servizio di inviarti messaggi.\nSe chiudi, completerai la firma ma non riceverai il messaggio con i documenti firmati.",
+        "confirm": "Ok, attiva"
       },
       "noFields": {
         "title": "Firma tutto il documento",
@@ -2879,7 +2878,7 @@
       },
       "thankYouPage": {
         "title": "Fatto!",
-        "content": "Riceverai un messaggio su IO con l’esito della tua richiesta.",
+        "content": "Se hai attivato i messaggi del servizio, riceverai su IO l’esito della tua richiesta.",
         "cta": "Chiudi"
       },
       "documentUnavailablePage": {

--- a/apps/main-app/ts/features/fci/hooks/useFciCheckService.tsx
+++ b/apps/main-app/ts/features/fci/hooks/useFciCheckService.tsx
@@ -1,7 +1,7 @@
-import { Body, FooterActionsInline } from "@pagopa/io-app-design-system";
+import { Body, ContentWrapper, VSpacer } from "@pagopa/io-app-design-system";
 import * as pot from "@pagopa/ts-commons/lib/pot";
-import { ComponentProps } from "react";
 import I18n from "i18next";
+import { IOButton } from "@pagopa/io-app-design-system/src/components/buttons";
 import { ServiceId } from "../../../../definitions/services/ServiceId";
 import { useIODispatch, useIOSelector } from "../../../store/hooks";
 import { useIOBottomSheetModal } from "../../../utils/hooks/bottomSheet";
@@ -10,8 +10,7 @@ import { isServicePreferenceResponseSuccess } from "../../services/details/types
 import {
   trackFciUxConversion,
   trackFciBottomsheetMessagePermissionRequest,
-  trackFciBottomsheetMessagePermissionAccepted,
-  trackFciBottomsheetMessagePermissionDeclined
+  trackFciBottomsheetMessagePermissionAccepted
 } from "../analytics";
 import { fciStartSigningRequest } from "../store/actions";
 import { fciEnvironmentSelector } from "../store/reducers/fciEnvironment";
@@ -29,43 +28,27 @@ export const useFciCheckService = () => {
   );
   const fciEnvironment = useIOSelector(fciEnvironmentSelector);
   const servicePreferenceValue = pot.getOrElse(servicePreferencePot, undefined);
-  const cancelButtonProps: ComponentProps<
-    typeof FooterActionsInline
-  >["startAction"] = {
-    color: "primary",
-    onPress: () => {
-      trackFciBottomsheetMessagePermissionDeclined();
-      dispatch(fciStartSigningRequest());
-      dismiss();
-    },
-    label: I18n.t("features.fci.checkService.cancel")
+
+  const onConfirm = () => {
+    trackFciBottomsheetMessagePermissionAccepted();
+    if (
+      fciServiceId &&
+      servicePreferenceValue &&
+      isServicePreferenceResponseSuccess(servicePreferenceValue)
+    ) {
+      const sp = { ...servicePreferenceValue.value, inbox: true };
+      dispatch(
+        upsertServicePreference.request({
+          id: fciServiceId as ServiceId,
+          ...sp
+        })
+      );
+    }
+    trackFciUxConversion(fciEnvironment);
+    dispatch(fciStartSigningRequest());
+    dismiss();
   };
 
-  const confirmButtonProps: ComponentProps<
-    typeof FooterActionsInline
-  >["endAction"] = {
-    color: "primary",
-    onPress: () => {
-      trackFciBottomsheetMessagePermissionAccepted();
-      if (
-        fciServiceId &&
-        servicePreferenceValue &&
-        isServicePreferenceResponseSuccess(servicePreferenceValue)
-      ) {
-        const sp = { ...servicePreferenceValue.value, inbox: true };
-        dispatch(
-          upsertServicePreference.request({
-            id: fciServiceId as ServiceId,
-            ...sp
-          })
-        );
-      }
-      trackFciUxConversion(fciEnvironment);
-      dispatch(fciStartSigningRequest());
-      dismiss();
-    },
-    label: I18n.t("features.fci.checkService.confirm")
-  };
   const {
     present: presentBottomSheet,
     bottomSheet,
@@ -79,10 +62,15 @@ export const useFciCheckService = () => {
     title: I18n.t("features.fci.checkService.title"),
     snapPoint: [320],
     footer: (
-      <FooterActionsInline
-        startAction={cancelButtonProps}
-        endAction={confirmButtonProps}
-      />
+      <ContentWrapper>
+        <IOButton
+          fullWidth
+          variant="solid"
+          label={I18n.t("features.fci.checkService.confirm")}
+          onPress={onConfirm}
+        />
+        <VSpacer size={32} />
+      </ContentWrapper>
     )
   });
 

--- a/apps/main-app/ts/features/fci/hooks/useFciCheckService.tsx
+++ b/apps/main-app/ts/features/fci/hooks/useFciCheckService.tsx
@@ -10,7 +10,8 @@ import { isServicePreferenceResponseSuccess } from "../../services/details/types
 import {
   trackFciUxConversion,
   trackFciBottomsheetMessagePermissionRequest,
-  trackFciBottomsheetMessagePermissionAccepted
+  trackFciBottomsheetMessagePermissionAccepted,
+  trackFciBottomsheetMessagePermissionDeclined
 } from "../analytics";
 import { fciStartSigningRequest } from "../store/actions";
 import { fciEnvironmentSelector } from "../store/reducers/fciEnvironment";
@@ -29,7 +30,13 @@ export const useFciCheckService = () => {
   const fciEnvironment = useIOSelector(fciEnvironmentSelector);
   const servicePreferenceValue = pot.getOrElse(servicePreferencePot, undefined);
 
-  const onConfirm = () => {
+  const handleDismiss = () => {
+    trackFciBottomsheetMessagePermissionDeclined();
+    dispatch(fciStartSigningRequest());
+    dismiss();
+  };
+
+  const handleConfirm = () => {
     trackFciBottomsheetMessagePermissionAccepted();
     if (
       fciServiceId &&
@@ -54,6 +61,7 @@ export const useFciCheckService = () => {
     bottomSheet,
     dismiss
   } = useIOBottomSheetModal({
+    onDismiss: handleDismiss,
     component: (
       <Body weight={"Regular"}>
         {I18n.t("features.fci.checkService.content")}
@@ -68,7 +76,7 @@ export const useFciCheckService = () => {
           fullWidth
           variant="solid"
           label={I18n.t("features.fci.checkService.confirm")}
-          onPress={onConfirm}
+          onPress={handleConfirm}
         />
       </ContentWrapper>
     )

--- a/apps/main-app/ts/features/fci/hooks/useFciCheckService.tsx
+++ b/apps/main-app/ts/features/fci/hooks/useFciCheckService.tsx
@@ -63,13 +63,13 @@ export const useFciCheckService = () => {
     snapPoint: [320],
     footer: (
       <ContentWrapper>
+        <VSpacer size={16} />
         <IOButton
           fullWidth
           variant="solid"
           label={I18n.t("features.fci.checkService.confirm")}
           onPress={onConfirm}
         />
-        <VSpacer size={32} />
       </ContentWrapper>
     )
   });


### PR DESCRIPTION
## Short description
This PR replaces the two-button layout (confirm + cancel) with a single confirm button in `useFciCheckService` bottomsheet and changes the copy for both the bottom sheet and the thank-you page.

## List of changes proposed in this pull request
- Replaced `FooterActionsInline` with a single full-width `IOButton` in the `useFciCheckService` bottomsheet
- Removed `useFciCheckService` cancel button along with its `trackFciBottomsheetMessagePermissionDeclined` MP event call
- Updated Copy

## How to test
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.


<table><tr><th>Before</th><th>After</th></tr><tr>
<td>

<img width="411" height="882" alt="image" src="https://github.com/user-attachments/assets/2d787769-ac2c-441d-9bc7-88faf95928aa" />


</td><td>
<img width="409" height="881" alt="image" src="https://github.com/user-attachments/assets/97b23cc6-7e84-41b2-a29d-a9000993a2e9" />




</td>
</tr>
<tr><td>
<img width="415" height="884" alt="image" src="https://github.com/user-attachments/assets/e837db6d-ed42-480f-9663-53592283484e" />

</td><td>
<img width="414" height="890" alt="image" src="https://github.com/user-attachments/assets/52607553-1ef6-476a-99ca-da6a04c582ff" />

</td></tr></table>