### PR TITLE
fix(IT-Wallet): [SIW-0000] Update re-activation banner navigation to use `navigateToDiscoveryScreen`

### DIFF
--- a/apps/main-app/ts/features/itwallet/discovery/components/ItwDiscoveryBanner.tsx
+++ b/apps/main-app/ts/features/itwallet/discovery/components/ItwDiscoveryBanner.tsx
@@ -97,13 +97,6 @@ export const ItwDiscoveryBanner = ({
     });
   };
 
-  const navigateToDocumentOnboardingScreen = () => {
-    trackItwDiscoveryBannerTap(trackBannerProperties);
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.L3_ONBOARDING
-    });
-  };
-
   const handleOnDismiss = () => {
     trackItwDiscoveryBannerClosure(trackBannerProperties);
     onDismiss?.();
@@ -131,7 +124,7 @@ export const ItwDiscoveryBanner = ({
         color="turquoise"
         onClose={handleOnDismiss}
         labelClose={I18n.t("global.buttons.close")}
-        onPress={navigateToDocumentOnboardingScreen}
+        onPress={navigateToDiscoveryScreen}
       />
     );
   }

--- a/apps/main-app/ts/features/itwallet/discovery/components/__tests__/ItwDiscoveryBanner.test.tsx
+++ b/apps/main-app/ts/features/itwallet/discovery/components/__tests__/ItwDiscoveryBanner.test.tsx
@@ -170,7 +170,7 @@ describe("ItwDiscoveryBanner", () => {
       }
     );
 
-    it("should navigate to onboarding when reactivation banner action is pressed", () => {
+    it("should navigate to discovery screen when reactivation banner action is pressed", () => {
       setupMocks({
         name: "reactivation banner",
         isWalletActive: false,
@@ -185,7 +185,8 @@ describe("ItwDiscoveryBanner", () => {
       fireEvent.press(getByTestId("itwReactivationBannerTestID"));
 
       expect(mockNavigate).toHaveBeenCalledWith(ITW_ROUTES.MAIN, {
-        screen: ITW_ROUTES.L3_ONBOARDING
+        screen: ITW_ROUTES.DISCOVERY.INFO,
+        params: { level: "l3" }
       });
     });
   });


### PR DESCRIPTION
## Short description
ITW L3 reactivation banner "Inizia" CTA now opens discovery screen instead of issuing credential directly.

## List of changes proposed in this pull request
- `ItwDiscoveryBanner.tsx`: reactivation banner (`isRemotelyActive` branch) `onPress` now calls `navigateToDiscoveryScreen` (→ `ITW_ROUTES.DISCOVERY.INFO`, `{level:"l3"}`), same as normal L3 activation flow
- Removed now-unused `navigateToDocumentOnboardingScreen` (previously navigated to `ITW_ROUTES.L3_ONBOARDING`, credential catalogue)

## How to test
1. Trigger ITW L3 reactivation banner state ("Riattiva i tuoi documenti digitali su IO" / "Per ragioni di sicurezza, se cambi dispositivo...")
2. Tap "Inizia"
3. Verify app opens discovery screen (level l3), not credential catalogue / direct issuance