### PR TITLE
feat(IT-Wallet): [SIW-4551] Align credential offer intro screen to catalogue intro screen

### DIFF
--- a/apps/main-app/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialIntroductionScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialIntroductionScreen.tsx
@@ -2,6 +2,7 @@ import {
   ContentWrapper,
   H2,
   IOColors,
+  IOMarkdown,
   VSpacer
 } from "@pagopa/io-app-design-system";
 import { useFocusEffect } from "@react-navigation/native";
@@ -20,7 +21,6 @@ import {
 import { getMixPanelCredential } from "../../analytics/utils";
 import { itwLifecycleIsITWalletValidSelector } from "../../lifecycle/store/selectors";
 import { ItwCredentialIssuanceMachineContext } from "../../machine/credential/provider";
-import IOMarkdown from "../../../../components/IOMarkdown";
 import { IOScrollView } from "../../../../components/ui/IOScrollView";
 import {
   selectCredentialTypeOption,

--- a/apps/main-app/ts/features/itwallet/offer/screens/ItwIssuanceCredentialOfferIntro.tsx
+++ b/apps/main-app/ts/features/itwallet/offer/screens/ItwIssuanceCredentialOfferIntro.tsx
@@ -1,9 +1,15 @@
-import { Body, H2, VSpacer, VStack } from "@pagopa/io-app-design-system";
+import {
+  ContentWrapper,
+  H2,
+  IOColors,
+  IOMarkdown,
+  VSpacer
+} from "@pagopa/io-app-design-system";
 import { useFocusEffect, useNavigation } from "@react-navigation/native";
 import * as O from "fp-ts/lib/Option";
 import I18n from "i18next";
-import { useCallback } from "react";
-import IOMarkdown from "../../../../components/IOMarkdown";
+import { useCallback, useEffect } from "react";
+import { Image, StyleSheet, View } from "react-native";
 import { IOScrollView } from "../../../../components/ui/IOScrollView";
 import { useHeaderSecondLevel } from "../../../../hooks/useHeaderSecondLevel";
 import {
@@ -25,6 +31,9 @@ import {
 } from "../../machine/credential/selectors";
 import { ItwParamsList } from "../../navigation/ItwParamsList";
 import { ItwRemoteLoadingScreen } from "../../presentation/remote/components/ItwRemoteLoadingScreen";
+import introHeroSource from "../../../../../img/features/itWallet/issuance/intro_hero.png";
+
+const introHeroUri = Image.resolveAssetSource(introHeroSource).uri;
 
 export type ItwIssuanceCredentialOfferScreenNavigationParams = {
   itwCredentialOfferUri: string;
@@ -91,10 +100,17 @@ const ContentView = ({ credentialOfferUri }: ContentViewProps) => {
     machineRef.send({ type: "confirm-credential-offer" });
   }, [machineRef]);
 
-  if (
-    O.isNone(resolvedCredentialOfferOption) ||
-    O.isNone(credentialTypeOption)
-  ) {
+  const isResolved =
+    O.isSome(resolvedCredentialOfferOption) && O.isSome(credentialTypeOption);
+  const shouldSkipIntro = isResolved && O.isNone(introductionContentOption);
+
+  useEffect(() => {
+    if (shouldSkipIntro) {
+      handleContinue();
+    }
+  }, [shouldSkipIntro, handleContinue]);
+
+  if (!isResolved || shouldSkipIntro) {
     return <ItwRemoteLoadingScreen title={I18n.t("global.genericWaiting")} />;
   }
 
@@ -109,6 +125,7 @@ const ContentView = ({ credentialOfferUri }: ContentViewProps) => {
 
   return (
     <IOScrollView
+      includeContentMargins={false}
       actions={{
         type: "SingleButton",
         primary: {
@@ -117,20 +134,39 @@ const ContentView = ({ credentialOfferUri }: ContentViewProps) => {
         }
       }}
     >
-      <VStack>
+      <Image
+        accessibilityIgnoresInvertColors
+        source={{ uri: introHeroUri }}
+        style={styles.hero}
+      />
+      <ContentWrapper marginTop={24}>
         <H2>{title}</H2>
-        <Body>
-          {I18n.t("features.itWallet.issuance.credentialIntro.subtitle")}
-        </Body>
-      </VStack>
-      {O.isSome(introductionContentOption) && (
-        <>
-          <VSpacer size={16} />
-          <IOMarkdown content={introductionContentOption.value} />
-        </>
-      )}
+        <VSpacer size={16} />
+        {O.isSome(introductionContentOption) && (
+          <View style={styles.contentBox}>
+            <IOMarkdown content={introductionContentOption.value} />
+          </View>
+        )}
+      </ContentWrapper>
     </IOScrollView>
   );
 };
+
+const styles = StyleSheet.create({
+  hero: {
+    width: "100%",
+    height: "auto",
+    resizeMode: "cover",
+    aspectRatio: 4 / 3,
+    opacity: 0.8
+  },
+  contentBox: {
+    borderRadius: 8,
+    borderWidth: 1,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderColor: IOColors["grey-100"]
+  }
+});
 
 export { ItwIssuanceCredentialOfferIntroScreen };


### PR DESCRIPTION
## Short description
Skip the credential offer intro screen when no starting content is available, and align its layout with the catalogue credential intro screen.

## List of changes proposed in this pull request
- `ItwIssuanceCredentialOfferIntro.tsx`: auto-confirm and skip rendering when `authentic_sources[0].user_information` is absent, instead of showing an empty screen
- Aligned offer intro screen layout (hero image + boxed markdown) with `ItwIssuanceCredentialIntroductionScreen.tsx`
- Switched both intro screens from the deprecated local `IOMarkdown` wrapper to the DS `IOMarkdown` (`@pagopa/io-app-design-system`)

## How to test
1. Trigger a credential offer deep link for a credential type whose catalogue metadata has no `authentic_sources[0].user_information` → intro screen should be skipped, flow proceeds directly to trust issuer verification
2. Trigger a credential offer deep link for a credential type with `user_information` set → intro screen shows hero image + markdown content, matching catalogue intro screen style
3. Confirm catalogue-flow credential add (non-offer) still renders intro screen correctly with DS `IOMarkdown`