### PR TITLE
feat(IT-Wallet): [SIW-4617] Use guided tour for wallet add action

### DIFF
--- a/apps/main-app/ts/components/ui/IOHeaderFirstLevel.tsx
+++ b/apps/main-app/ts/components/ui/IOHeaderFirstLevel.tsx
@@ -1,0 +1,186 @@
+import {
+  alertEdgeToEdgeInsetTransitionConfig,
+  H2,
+  HeaderActionProps,
+  HStack,
+  IconButton,
+  IOColors,
+  IOVisualCostants,
+  useIOTheme,
+  WithTestID
+} from "@pagopa/io-app-design-system";
+import { useEffect, useLayoutEffect, useRef } from "react";
+import {
+  AccessibilityInfo,
+  findNodeHandle,
+  StyleSheet,
+  View
+} from "react-native";
+import Animated, {
+  AnimatedRef,
+  useAnimatedStyle,
+  useScrollOffset,
+  useSharedValue,
+  withTiming
+} from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import {
+  GuidedTour,
+  GuidedTourProps
+} from "../../features/tour/components/GuidedTour";
+
+export type HeaderFirstLevelAction = HeaderActionProps & {
+  tourGuideProps?: GuidedTourProps;
+};
+
+export type HeaderFirstLevelActions =
+  | readonly []
+  | readonly [HeaderFirstLevelAction]
+  | readonly [HeaderFirstLevelAction, HeaderFirstLevelAction]
+  | readonly [
+      HeaderFirstLevelAction,
+      HeaderFirstLevelAction,
+      HeaderFirstLevelAction
+    ];
+
+type Variant = "primary" | "contrast";
+
+export type IOHeaderFirstLevelProps = WithTestID<{
+  title: string;
+  actions: HeaderFirstLevelActions;
+  animatedRef?: AnimatedRef<Animated.ScrollView>;
+  animatedFlatListRef?: AnimatedRef<Animated.FlatList<any>>;
+  ignoreSafeAreaMargin?: boolean;
+  variant?: Variant;
+}>;
+
+const styles = StyleSheet.create({
+  headerInner: {
+    paddingHorizontal: IOVisualCostants.appMarginDefault,
+    height: IOVisualCostants.headerHeight,
+    width: "100%",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between"
+  },
+  headerDivider: {
+    position: "absolute",
+    width: "100%",
+    height: StyleSheet.hairlineWidth,
+    left: 0,
+    right: 0,
+    bottom: 0
+  }
+});
+
+const renderAction = (action: HeaderFirstLevelAction, variant: Variant) => {
+  const { tourGuideProps, ...iconButtonProps } = action;
+  const actionKey = `header-first-level-action-${action.icon}`;
+  const button = (
+    <IconButton key={actionKey} {...iconButtonProps} color={variant} />
+  );
+
+  return tourGuideProps ? (
+    <GuidedTour key={actionKey} {...tourGuideProps}>
+      {button}
+    </GuidedTour>
+  ) : (
+    button
+  );
+};
+
+export const hasHeaderFirstLevelTourActions = (
+  actions: HeaderFirstLevelActions
+): boolean => actions.some(action => action.tourGuideProps !== undefined);
+
+export const IOHeaderFirstLevel = ({
+  title,
+  testID,
+  actions = [],
+  ignoreSafeAreaMargin = false,
+  animatedRef,
+  variant = "primary",
+  animatedFlatListRef
+}: IOHeaderFirstLevelProps) => {
+  const titleRef = useRef<View>(null);
+  const insets = useSafeAreaInsets();
+  const theme = useIOTheme();
+  const paddingTop = useSharedValue(ignoreSafeAreaMargin ? 0 : insets.top);
+  const isPrimary = variant === "primary";
+
+  useLayoutEffect(() => {
+    const reactNode = findNodeHandle(titleRef.current);
+    if (reactNode !== null) {
+      AccessibilityInfo.setAccessibilityFocus(reactNode);
+    }
+  }, []);
+
+  const offset = useScrollOffset(
+    (animatedRef as AnimatedRef<Animated.ScrollView>) ||
+      (animatedFlatListRef as AnimatedRef<Animated.FlatList<any>>)
+  );
+
+  useEffect(() => {
+    // eslint-disable-next-line functional/immutable-data
+    paddingTop.value = withTiming(
+      ignoreSafeAreaMargin ? 0 : insets.top,
+      alertEdgeToEdgeInsetTransitionConfig
+    );
+  }, [ignoreSafeAreaMargin, insets.top, paddingTop]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    paddingTop: paddingTop.value
+  }));
+
+  const animatedDivider = useAnimatedStyle(() => ({
+    opacity: withTiming(offset.value > 0 ? 1 : 0, { duration: 200 })
+  }));
+
+  return (
+    <Animated.View
+      style={[
+        {
+          backgroundColor: isPrimary
+            ? IOColors[theme["appBackground-primary"]]
+            : IOColors[theme["appBackground-accent"]]
+        },
+        animatedStyle
+      ]}
+      accessibilityRole="header"
+      testID={testID}
+    >
+      {(animatedRef || animatedFlatListRef) && isPrimary && (
+        <Animated.View
+          style={[
+            {
+              ...styles.headerDivider,
+              backgroundColor: IOColors[theme["divider-default"]]
+            },
+            animatedDivider
+          ]}
+        />
+      )}
+
+      <View style={styles.headerInner}>
+        <View ref={titleRef} accessible accessibilityRole="header">
+          <H2
+            weight="Bold"
+            style={{ flexShrink: 1 }}
+            numberOfLines={1}
+            color={
+              isPrimary
+                ? theme["textHeading-default"]
+                : theme["textHeading-constrast"]
+            }
+            maxFontSizeMultiplier={1.25}
+          >
+            {title}
+          </H2>
+        </View>
+        <HStack space={16} style={{ flexShrink: 0 }}>
+          {actions.map(action => renderAction(action, variant))}
+        </HStack>
+      </View>
+    </Animated.View>
+  );
+};

--- a/apps/main-app/ts/components/ui/__test__/IOHeaderFirstLevel.test.tsx
+++ b/apps/main-app/ts/components/ui/__test__/IOHeaderFirstLevel.test.tsx
@@ -1,0 +1,73 @@
+import { IOThemeContextProvider } from "@pagopa/io-app-design-system";
+import { fireEvent, render } from "@testing-library/react-native";
+import { View as MockView } from "react-native";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+import { GuidedTour } from "../../../features/tour/components/GuidedTour";
+import { IOHeaderFirstLevel } from "../IOHeaderFirstLevel";
+
+jest.mock("../../../features/tour/components/GuidedTour", () => ({
+  GuidedTour: jest.fn(({ children }) => (
+    <MockView testID="guided-tour-wrapper">{children}</MockView>
+  ))
+}));
+
+const mockGuidedTour = GuidedTour as jest.Mock;
+
+describe("IOHeaderFirstLevel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("wraps only actions with tourGuideProps in GuidedTour", () => {
+    const onPress = jest.fn();
+
+    const { getByLabelText, getByTestId } = render(
+      <SafeAreaProvider
+        initialMetrics={{
+          frame: { x: 0, y: 0, width: 320, height: 640 },
+          insets: { top: 0, left: 0, right: 0, bottom: 0 }
+        }}
+      >
+        <IOThemeContextProvider theme="light">
+          <IOHeaderFirstLevel
+            title="Wallet"
+            actions={[
+              {
+                icon: "add",
+                accessibilityLabel: "Add",
+                onPress,
+                tourGuideProps: {
+                  groupId: "itw",
+                  index: 2,
+                  title: "Add a credential",
+                  description: "Use add"
+                }
+              },
+              {
+                icon: "help",
+                accessibilityLabel: "Help",
+                onPress: jest.fn()
+              }
+            ]}
+          />
+        </IOThemeContextProvider>
+      </SafeAreaProvider>
+    );
+
+    expect(getByTestId("guided-tour-wrapper")).toBeTruthy();
+    expect(mockGuidedTour).toHaveBeenCalledTimes(1);
+    expect(mockGuidedTour).toHaveBeenCalledWith(
+      expect.objectContaining({
+        groupId: "itw",
+        index: 2,
+        title: "Add a credential",
+        description: "Use add"
+      }),
+      undefined
+    );
+
+    fireEvent.press(getByLabelText("Add"));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/main-app/ts/features/itwallet/tour/hooks/useItwGuidedTour.ts
+++ b/apps/main-app/ts/features/itwallet/tour/hooks/useItwGuidedTour.ts
@@ -1,51 +1,20 @@
-import { useHeaderHeight } from "@react-navigation/elements";
 import { useFocusEffect } from "@react-navigation/native";
-import I18n from "i18next";
 import { useCallback } from "react";
-import { Dimensions, Platform } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useIODispatch, useIOSelector } from "../../../../store/hooks";
 import { offlineAccessReasonSelector } from "../../../ingress/store/selectors";
-import { useGuidedTourRegion } from "../../../tour/components/useGuidedTourRegion";
 import { startTourAction } from "../../../tour/store/actions";
 import { isTourCompletedSelector } from "../../../tour/store/selectors";
 import { itwIsL3EnabledSelector } from "../../common/store/selectors/preferences";
-import {
-  ITW_TOUR_GROUP_ID,
-  ITW_TOUR_STEP_ADD_BUTTON
-} from "../utils/constants";
+import { ITW_TOUR_GROUP_ID } from "../utils/constants";
 
 export const useItwGuidedTour = () => {
   const dispatch = useIODispatch();
-  const headerHeight = useHeaderHeight();
-  const insets = useSafeAreaInsets();
   const offlineAccessReason = useIOSelector(offlineAccessReasonSelector);
 
-  const { width: screenWidth } = Dimensions.get("window");
   const isItwActive = useIOSelector(itwIsL3EnabledSelector);
   const isCompleted = useIOSelector(state =>
     isTourCompletedSelector(state, ITW_TOUR_GROUP_ID)
   );
-
-  const headerRegion = useCallback(
-    () => ({
-      x: 0,
-      y: Platform.OS === "ios" ? insets.top : 0,
-      width: screenWidth,
-      height: headerHeight - insets.top
-    }),
-    [insets.top, screenWidth, headerHeight]
-  );
-
-  // Adds the tour guide feature to the header, highlighting the "Add" button
-  useGuidedTourRegion({
-    groupId: ITW_TOUR_GROUP_ID,
-    index: ITW_TOUR_STEP_ADD_BUTTON,
-    title: I18n.t("features.itWallet.tour.addCredential.title"),
-    description: I18n.t("features.itWallet.tour.addCredential.description"),
-    region: headerRegion,
-    cutoutStyle: { cornerRadius: 0 }
-  });
 
   /**
    * Starts the tour guide for the ITW on screen focus when:

--- a/apps/main-app/ts/features/tour/components/GuidedTour.tsx
+++ b/apps/main-app/ts/features/tour/components/GuidedTour.tsx
@@ -20,6 +20,7 @@ export type GuidedTourProps = {
   title: string;
   description: string;
   cutoutStyle?: TourCutoutStyle;
+  cutoutPadding?: number;
 };
 
 export const GuidedTour = (props: PropsWithChildren<GuidedTourProps>) => {
@@ -43,12 +44,14 @@ export const GuidedTour = (props: PropsWithChildren<GuidedTourProps>) => {
     activeGroupId === props.groupId &&
     items.length > 0 &&
     items[stepIndex]?.index === props.index;
+  const cutoutPadding = props.cutoutPadding ?? 0;
 
   useEffect(() => {
     registerItem(props.groupId, props.index, animatedRef, {
       title: props.title,
       description: props.description,
-      cutoutStyle: props.cutoutStyle
+      cutoutStyle: props.cutoutStyle,
+      cutoutPadding
     });
 
     return () => {
@@ -62,6 +65,7 @@ export const GuidedTour = (props: PropsWithChildren<GuidedTourProps>) => {
     props.title,
     props.description,
     props.cutoutStyle,
+    cutoutPadding,
     animatedRef
   ]);
 
@@ -88,21 +92,23 @@ export const GuidedTour = (props: PropsWithChildren<GuidedTourProps>) => {
     const ox = overlay?.pageX ?? 0;
     const oy = overlay?.pageY ?? 0;
 
-    const newX = target.pageX - ox;
-    const newY = target.pageY - oy;
+    const paddedX = target.pageX - ox - cutoutPadding;
+    const paddedY = target.pageY - oy - cutoutPadding;
+    const paddedWidth = target.width + cutoutPadding * 2;
+    const paddedHeight = target.height + cutoutPadding * 2;
 
     // Only update when the position actually changed to avoid
     // unnecessary Skia canvas redraws.
     if (
-      newX !== cutoutX.value ||
-      newY !== cutoutY.value ||
-      target.width !== cutoutW.value ||
-      target.height !== cutoutH.value
+      paddedX !== cutoutX.value ||
+      paddedY !== cutoutY.value ||
+      paddedWidth !== cutoutW.value ||
+      paddedHeight !== cutoutH.value
     ) {
-      cutoutX.value = newX;
-      cutoutY.value = newY;
-      cutoutW.value = target.width;
-      cutoutH.value = target.height;
+      cutoutX.value = paddedX;
+      cutoutY.value = paddedY;
+      cutoutW.value = paddedWidth;
+      cutoutH.value = paddedHeight;
     }
   }, false);
 

--- a/apps/main-app/ts/features/tour/components/TourProvider.tsx
+++ b/apps/main-app/ts/features/tour/components/TourProvider.tsx
@@ -19,6 +19,7 @@ import {
   unregisterTourItemAction
 } from "../store/actions";
 import { TourCutoutStyle, TourItemMeasurement } from "../types";
+import { getPaddedTourMeasurement } from "../utils/measurement";
 import { TourOverlay } from "./TourOverlay";
 
 type TourItemConfig = {
@@ -27,6 +28,7 @@ type TourItemConfig = {
   title: string;
   description: string;
   cutoutStyle?: TourCutoutStyle;
+  cutoutPadding?: number;
 };
 
 type ScrollRef = {
@@ -44,6 +46,7 @@ type TourContextValue = {
       title: string;
       description: string;
       cutoutStyle?: TourCutoutStyle;
+      cutoutPadding?: number;
     }
   ) => void;
   unregisterItem: (groupId: string, index: number) => void;
@@ -124,6 +127,7 @@ export const TourProvider = ({ children }: PropsWithChildren) => {
         title: string;
         description: string;
         cutoutStyle?: TourCutoutStyle;
+        cutoutPadding?: number;
       }
     ) => {
       dispatch(registerTourItemAction({ groupId, index }));
@@ -131,7 +135,8 @@ export const TourProvider = ({ children }: PropsWithChildren) => {
         ref: viewRef,
         title: config.title,
         description: config.description,
-        cutoutStyle: config.cutoutStyle
+        cutoutStyle: config.cutoutStyle,
+        cutoutPadding: config.cutoutPadding
       });
     },
     [dispatch]
@@ -197,7 +202,10 @@ export const TourProvider = ({ children }: PropsWithChildren) => {
       };
       (node as unknown as View).measureInWindow((x, y, width, height) => {
         if (width !== 0 || height !== 0) {
-          result.value = { x, y, width, height };
+          result.value = getPaddedTourMeasurement(
+            { x, y, width, height },
+            item.cutoutPadding
+          );
         }
       });
       return result.value;

--- a/apps/main-app/ts/features/tour/utils/__tests__/measurement.test.ts
+++ b/apps/main-app/ts/features/tour/utils/__tests__/measurement.test.ts
@@ -1,0 +1,33 @@
+import { getPaddedTourMeasurement } from "../measurement";
+
+describe("getPaddedTourMeasurement", () => {
+  it("expands the measurement by the given padding on each side", () => {
+    expect(
+      getPaddedTourMeasurement(
+        {
+          x: 24,
+          y: 56,
+          width: 24,
+          height: 24
+        },
+        8
+      )
+    ).toEqual({
+      x: 16,
+      y: 48,
+      width: 40,
+      height: 40
+    });
+  });
+
+  it("keeps the measurement unchanged when padding is not provided", () => {
+    const measurement = {
+      x: 24,
+      y: 56,
+      width: 24,
+      height: 24
+    };
+
+    expect(getPaddedTourMeasurement(measurement)).toEqual(measurement);
+  });
+});

--- a/apps/main-app/ts/features/tour/utils/measurement.ts
+++ b/apps/main-app/ts/features/tour/utils/measurement.ts
@@ -1,0 +1,15 @@
+import { TourItemMeasurement } from "../types";
+
+/**
+ * Expands a guided tour measurement so the cutout can cover the whole
+ * tappable target even when the rendered element is visually smaller.
+ */
+export const getPaddedTourMeasurement = (
+  measurement: TourItemMeasurement,
+  padding = 0
+): TourItemMeasurement => ({
+  x: measurement.x - padding,
+  y: measurement.y - padding,
+  width: measurement.width + padding * 2,
+  height: measurement.height + padding * 2
+});

--- a/apps/main-app/ts/features/wallet/screens/WalletHomeScreen.tsx
+++ b/apps/main-app/ts/features/wallet/screens/WalletHomeScreen.tsx
@@ -33,6 +33,7 @@ import { ITW_PROXIMITY_ROUTES } from "../../itwallet/presentation/proximity/navi
 import { hasPresentableCredentialsSelector } from "../../itwallet/presentation/proximity/store/selectors/credentials";
 import {
   ITW_TOUR_GROUP_ID,
+  ITW_TOUR_STEP_ADD_BUTTON,
   ITW_TOUR_STEP_QR_BUTTON
 } from "../../itwallet/tour/utils/constants.ts";
 import { WalletCardsContainer } from "../components/WalletCardsContainer";
@@ -52,6 +53,8 @@ type ScreenProps = IOStackNavigationRouteProps<
   MainTabParamsList,
   "WALLET_HOME"
 >;
+
+const HEADER_ACTION_HIT_SLOP = 8;
 
 const WalletHomeScreen = ({ route }: ScreenProps) => {
   const navigation = useIONavigation();
@@ -109,7 +112,16 @@ const WalletHomeScreen = ({ route }: ScreenProps) => {
         {
           accessibilityLabel: I18n.t("features.wallet.home.screen.legacy.cta"),
           icon: "add",
-          onPress: handleAddToWalletButtonPress
+          onPress: handleAddToWalletButtonPress,
+          tourGuideProps: {
+            groupId: ITW_TOUR_GROUP_ID,
+            index: ITW_TOUR_STEP_ADD_BUTTON,
+            title: I18n.t("features.itWallet.tour.addCredential.title"),
+            description: I18n.t(
+              "features.itWallet.tour.addCredential.description"
+            ),
+            cutoutPadding: HEADER_ACTION_HIT_SLOP
+          }
         }
       ],
       variant: "primary"

--- a/apps/main-app/ts/features/wallet/screens/__tests__/WalletHomeScreen.test.tsx
+++ b/apps/main-app/ts/features/wallet/screens/__tests__/WalletHomeScreen.test.tsx
@@ -1,15 +1,30 @@
 import configureMockStore from "redux-mock-store";
+import { useHeaderFirstLevel } from "../../../../hooks/useHeaderFirstLevel";
 import ROUTES from "../../../../navigation/routes";
 import { applicationChangeState } from "../../../../store/actions/application";
 import { appReducer } from "../../../../store/reducers";
 import { GlobalState } from "../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../utils/testWrapper";
+import {
+  ITW_TOUR_GROUP_ID,
+  ITW_TOUR_STEP_ADD_BUTTON
+} from "../../../itwallet/tour/utils/constants";
 import * as walletSelectors from "../../store/selectors";
 import { WalletHomeScreen } from "../WalletHomeScreen";
+
+jest.mock("../../../../hooks/useHeaderFirstLevel", () => ({
+  useHeaderFirstLevel: jest.fn()
+}));
+
+const mockUseHeaderFirstLevel = useHeaderFirstLevel as jest.Mock;
 
 describe("WalletHomeScreen", () => {
   jest.useFakeTimers();
   jest.runAllTimers();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   it("should not render screen actions if the wallet is empty", () => {
     jest
@@ -21,6 +36,26 @@ describe("WalletHomeScreen", () => {
     jest.runOnlyPendingTimers();
 
     expect(queryByTestId("walletAddCardButtonTestID")).toBeNull();
+  });
+
+  it("sets the IT Wallet guided tour props on the add header action", () => {
+    renderComponent();
+
+    expect(mockUseHeaderFirstLevel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headerProps: expect.objectContaining({
+          actions: [
+            expect.objectContaining({
+              icon: "add",
+              tourGuideProps: expect.objectContaining({
+                groupId: ITW_TOUR_GROUP_ID,
+                index: ITW_TOUR_STEP_ADD_BUTTON
+              })
+            })
+          ]
+        })
+      })
+    );
   });
 });
 

--- a/apps/main-app/ts/hooks/useHeaderFirstLevel.tsx
+++ b/apps/main-app/ts/hooks/useHeaderFirstLevel.tsx
@@ -1,5 +1,10 @@
 import { HeaderFirstLevel } from "@pagopa/io-app-design-system";
 import { useLayoutEffect, useMemo } from "react";
+import {
+  HeaderFirstLevelActions,
+  hasHeaderFirstLevelTourActions,
+  IOHeaderFirstLevel
+} from "../components/ui/IOHeaderFirstLevel";
 import { useIONavigation } from "../navigation/params/AppParamsList";
 import { MainTabParamsList } from "../navigation/params/MainTabParamsList";
 import { useIOAlertVisible } from "../components/StatusMessages/IOAlertVisibleContext";
@@ -19,7 +24,7 @@ type HeaderFirstLevelHookProps = Omit<
   HeaderFirstLevel,
   "ignoreSafeAreaMargin" | "actions"
 > & {
-  actions?: HeaderFirstLevel["actions"];
+  actions?: HeaderFirstLevelActions;
 };
 
 /**
@@ -35,8 +40,8 @@ export const useHeaderFirstLevel = ({
   const actionHelp = useHeaderFirstLevelActionPropHelp(currentRoute);
   const actionSettings = useHeaderFirstLevelActionPropSettings();
   const { isAlertVisible } = useIOAlertVisible();
-  const actions: HeaderFirstLevel["actions"] = useMemo(() => {
-    const fallbackActions: HeaderFirstLevel["actions"] = [
+  const actions: HeaderFirstLevelActions = useMemo(() => {
+    const fallbackActions: HeaderFirstLevelActions = [
       actionSettings,
       actionHelp
     ];
@@ -64,9 +69,13 @@ export const useHeaderFirstLevel = ({
   }, [actionSettings, actionHelp, incomingActions]);
 
   useLayoutEffect(() => {
+    const HeaderComponent = hasHeaderFirstLevelTourActions(actions)
+      ? IOHeaderFirstLevel
+      : HeaderFirstLevel;
+
     navigation.setOptions({
       header: () => (
-        <HeaderFirstLevel
+        <HeaderComponent
           {...rest}
           actions={actions}
           ignoreSafeAreaMargin={isAlertVisible}


### PR DESCRIPTION
## Short description

Update the IT Wallet guided tour so the “Add document” step highlights the “+” header action itself, instead of a manually measured header region. The step is now attached to the header action through `GuidedTour`, so the cutout follows the real button position and size.

Copy updates for the tour steps are handled separately in #8209 (SIW-4475).

## List of changes proposed in this pull request

- Add `IOHeaderFirstLevel`, an app-level wrapper of the design system `HeaderFirstLevel` that supports `tourGuideProps` on header actions without changing the design system.
- Attach the IT Wallet “Add document” tour step directly to the Wallet home “+” header action.
- Remove the manual `useGuidedTourRegion` registration (screen-size based) from `useItwGuidedTour`.
- Add `cutoutPadding` support to `GuidedTour` measurements so the highlighted area can cover the full tappable area of the header action.
- Add tests for the header wrapper, the Wallet home tour props, and the padded tour measurements.

## How to test

Automated:

```bash
pnpm --dir apps/main-app exec jest --coverage=false ts/features/tour/utils/__tests__/measurement.test.ts ts/components/ui/__test__/IOHeaderFirstLevel.test.tsx ts/features/wallet/screens/__tests__/WalletHomeScreen.test.tsx
```

Manual:

- Open the Wallet home with IT Wallet active and the guided tour not completed.
- Verify the “Add document” step highlights the “+” button in the header (cutout centered on the button, not on the whole header).
- Verify tapping “+” still opens the add document flow.
- Verify the other header actions (settings, help) still render and work as before.
- Verify the remaining tour steps still work and the tour can be completed.
