### PR TITLE
chore: [IEL-684]] Fci's retry now check signature request status

### DIFF
--- a/apps/main-app/ts/features/fci/saga/__tests__/index.test.ts
+++ b/apps/main-app/ts/features/fci/saga/__tests__/index.test.ts
@@ -6,6 +6,7 @@ import { CommonActions, StackActions } from "@react-navigation/native";
 import NavigationService from "../../../../navigation/NavigationService";
 import { FCI_ROUTES } from "../../navigation/routes";
 import ROUTES from "../../../../navigation/routes";
+import { SignatureRequestStatusEnum } from "../../../../../definitions/fci/SignatureRequestStatus";
 import { identificationSuccess } from "../../../identification/store/actions";
 import {
   fciClearStateRequest,
@@ -170,21 +171,77 @@ describe("FCI Saga Tests", () => {
   describe("watchFciSignatureRequestRetrySaga", () => {
     const signatureRequestId = "test-signature-id" as NonEmptyString;
     const action = fciSignatureRequestRetryFromId(signatureRequestId);
+    const futureDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+    const pastDate = new Date(Date.now() - 1000);
 
-    it("should cancel download preview and dispatch fciStartRequest on success", () =>
+    it("should cancel download preview and start signing flow when status is WAIT_FOR_SIGNATURE and not expired", () =>
       expectSaga(watchFciSignatureRequestRetrySaga, action)
         .put(fciSignatureRequestFromId.request(signatureRequestId))
         .dispatch(
           fciSignatureRequestFromId.success({
             ...mockSignatureRequestDetailView,
-            id: signatureRequestId
+            id: signatureRequestId,
+            status: SignatureRequestStatusEnum.WAIT_FOR_SIGNATURE,
+            expires_at: futureDate
           })
         )
         .put(fciDownloadPreview.cancel())
         .put(fciStartRequest())
         .run());
 
-    it("should not start flow when signature request fails", () =>
+    const nonSignableStatuses = [
+      {
+        name: "WAIT_FOR_SIGNATURE expired",
+        status: SignatureRequestStatusEnum.WAIT_FOR_SIGNATURE,
+        expires_at: pastDate
+      },
+      {
+        name: "SIGNED",
+        status: SignatureRequestStatusEnum.SIGNED,
+        expires_at: futureDate
+      },
+      {
+        name: "WAIT_FOR_QTSP",
+        status: SignatureRequestStatusEnum.WAIT_FOR_QTSP,
+        expires_at: futureDate
+      },
+      {
+        name: "REJECTED",
+        status: SignatureRequestStatusEnum.REJECTED,
+        expires_at: futureDate
+      },
+      {
+        name: "CANCELLED",
+        status: SignatureRequestStatusEnum.CANCELLED,
+        expires_at: futureDate
+      }
+    ];
+
+    test.each(nonSignableStatuses)(
+      "should navigate to ROUTER and not start signing flow when status is $name",
+      ({ status, expires_at }) =>
+        expectSaga(watchFciSignatureRequestRetrySaga, action)
+          .put(fciSignatureRequestFromId.request(signatureRequestId))
+          .dispatch(
+            fciSignatureRequestFromId.success({
+              ...mockSignatureRequestDetailView,
+              id: signatureRequestId,
+              status,
+              expires_at
+            })
+          )
+          .call(
+            NavigationService.dispatchNavigationAction,
+            StackActions.replace(FCI_ROUTES.MAIN, {
+              screen: FCI_ROUTES.ROUTER,
+              params: { signatureRequestId }
+            })
+          )
+          .not.put(fciStartRequest())
+          .run()
+    );
+
+    it("should not start flow when signature request fetch fails", () =>
       expectSaga(watchFciSignatureRequestRetrySaga, action)
         .put(fciSignatureRequestFromId.request(signatureRequestId))
         .dispatch(

--- a/apps/main-app/ts/features/fci/saga/index.ts
+++ b/apps/main-app/ts/features/fci/saga/index.ts
@@ -46,6 +46,7 @@ import {
 } from "../store/reducers/fciQtspClauses";
 import { fciDocumentSignaturesSelector } from "../store/reducers/fciDocumentSignatures";
 import { KeyInfo } from "../../lollipop/utils/crypto";
+import { SignatureRequestStatusEnum } from "../../../../definitions/fci/SignatureRequestStatus";
 import { createFciClient } from "../api/backendFci";
 import { spidLevelFromSessionInfoSelector } from "../../authentication/common/store/selectors";
 import { isFciSecurityLevelCheckRemoteFFEnabledSelector } from "../store/selectors/remoteConfig";
@@ -246,13 +247,27 @@ function* watchFciSignatureRequestRetrySaga(
 
     if (isActionOf(fciSignatureRequestFromId.success, result)) {
       if (result.payload.id === action.payload) {
-        /**
-         * when restarting the flow from 'DocumentUnavailableScreen',
-         * FciDocumentsScreen will still get pot error if not reset
-         */
-        yield* put(fciDownloadPreview.cancel());
-        // start a new signing flow
-        yield* put(fciStartRequest());
+        const { status, expires_at } = result.payload;
+        const isSignable =
+          status === SignatureRequestStatusEnum.WAIT_FOR_SIGNATURE &&
+          new Date(expires_at) >= new Date();
+
+        if (isSignable) {
+          /**
+           * when restarting the flow from 'DocumentUnavailableScreen',
+           * FciDocumentsScreen will still get pot error if not reset
+           */
+          yield* put(fciDownloadPreview.cancel());
+          yield* put(fciStartRequest());
+        } else {
+          yield* call(
+            NavigationService.dispatchNavigationAction,
+            StackActions.replace(FCI_ROUTES.MAIN, {
+              screen: FCI_ROUTES.ROUTER,
+              params: { signatureRequestId: action.payload }
+            })
+          );
+        }
         return;
       }
 


### PR DESCRIPTION
## Short description
In this PR `watchFciSignatureRequestRetrySaga` has been improved so that a user getting an error even when he successfully sign ( for example doubled signature request, the first request with 200 status code not received by the app and a second one with error leading to a retry caused by an already signed request) now before retry we check the signature status.

## List of changes proposed in this pull request
- `watchFciSignatureRequestRetrySaga` now checks the status (and expiry) of the freshly fetched signature request before deciding what to do

## How to test
Start the app with the dev server and proxyman ready, start a FCI flow with a pending request and at the start of the flow take the **\*/api/sign/v1/signature-requests/\*** raw response aside for later, then in the app get to the last step of the signing flow and just before completing the request:
Set on Proxyman the following "Map Local" rule:
***/api/sign/v1/signatures**
`HTTP/1.1 400 Bad Request`
Then press on the app the sign button ( which will lead to retry screen `FCI_TYP`), and again on Proxyman set:
**\*/api/sign/v1/signature-requests/\***
(paste the previously saved response changing only `status":"WAIT_FOR_SIGNATURE"` to `status":"SIGNED"`)`HTTP/1.1 200 OK....`
Now the app should redirect the user to the signature completed screen.

<table><tr><th>Before</th><th>After</th></tr>
<tr><td>


https://github.com/user-attachments/assets/ee49b754-1fee-434f-b906-b0155ab811b9



</td><td>


https://github.com/user-attachments/assets/62696607-a623-4081-b670-7ac557ea4f2e



</td></tr>
</table>
