### PR TITLE
feat(IT-Wallet): [SIW-4621] Add Status List repository

### DIFF
--- a/apps/main-app/ts/features/itwallet/common/saga/index.ts
+++ b/apps/main-app/ts/features/itwallet/common/saga/index.ts
@@ -24,7 +24,7 @@ import {
   checkWalletInstanceInconsistencySaga,
   checkWalletInstanceStateSaga
 } from "../../lifecycle/saga/checkWalletInstanceStateSaga";
-import { watchItwTasksSaga } from "../../statusList/saga";
+import { watchItwStatusListSaga } from "../../statusList/saga";
 import { checkFiscalCodeEnabledSaga } from "../../trialSystem/saga/checkFiscalCodeIsEnabledSaga";
 import {
   itwSetAuthLevel,
@@ -47,7 +47,7 @@ export function* watchItwSaga(): SagaIterator {
   // Check if the fiscal code is enabled, to enable the L3
   yield* fork(checkFiscalCodeEnabledSaga);
   // Registers and watches background tasks
-  yield* fork(watchItwTasksSaga);
+  yield* fork(watchItwStatusListSaga);
   // Watch ITW analytics lifecycle (initial sync and reactive updates)
   yield* fork(watchItwAnalyticsSaga);
 

--- a/apps/main-app/ts/features/itwallet/playgrounds/components/ItwStatusListSection.tsx
+++ b/apps/main-app/ts/features/itwallet/playgrounds/components/ItwStatusListSection.tsx
@@ -16,10 +16,7 @@ import { clipboardSetStringWithFeedback } from "../../../../utils/clipboard";
 import { isDevEnv } from "../../../../utils/environment";
 import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
 import { ITW_STATUS_LIST_FETCH_TASK } from "../../statusList/tasks";
-import {
-  getLastStatusListCheckTimestamp,
-  getLastStatusListFetchTimestamp
-} from "../../statusList/utils/storage";
+import { getLastStatusListCheckTimestamp } from "../../statusList/utils/storage";
 
 const formatDate = (timestamp: number | undefined): string =>
   timestamp ? format(new Date(timestamp), "DD/MM/YY HH:mm:ss") : "n/a";
@@ -38,16 +35,11 @@ const formatAge = (lastFetchTime: number | undefined): string => {
 
 export const ItwStatusListSection = () => {
   const [lastCheckTime, setLastCheckTime] = useState<number>();
-  const [lastFetchTime, setLastFetchTime] = useState<number>();
 
   useEffect(() => {
     getLastStatusListCheckTimestamp()
       .then(setLastCheckTime)
       .catch(() => setLastCheckTime(undefined));
-
-    getLastStatusListFetchTimestamp()
-      .then(setLastFetchTime)
-      .catch(() => setLastFetchTime(undefined));
   }, []);
 
   return (
@@ -55,9 +47,7 @@ export const ItwStatusListSection = () => {
       <ListItemHeader label="Status List" />
       <ListItemInfo label="Last check" value={formatDate(lastCheckTime)} />
       <Divider />
-      <ListItemInfo label="Last fetch" value={formatDate(lastFetchTime)} />
-      <Divider />
-      <ListItemInfo label="Age" value={formatAge(lastFetchTime)} />
+      <ListItemInfo label="Age" value={formatAge(lastCheckTime)} />
       <VSpacer size={8} />
       <IOButton
         variant="solid"

--- a/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/checkStatusListCoherenceSaga.test.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/checkStatusListCoherenceSaga.test.ts
@@ -13,8 +13,6 @@ const makePayload = (sub: string): CredentialStatus.StatusList => ({
 
 describe("checkStatusListCoherenceSaga", () => {
   it("removes cached URIs that are no longer referenced", () => {
-    expect.hasAssertions();
-
     const referencedUris = ["https://issuer.example/status/1"];
     const cached = [
       makePayload("https://issuer.example/status/1"),
@@ -35,8 +33,6 @@ describe("checkStatusListCoherenceSaga", () => {
   });
 
   it("does not remove anything when every cached URI is referenced", () => {
-    expect.hasAssertions();
-
     const referencedUris = [
       "https://issuer.example/status/1",
       "https://issuer.example/status/1"

--- a/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/checkStatusListCoherenceSaga.test.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/checkStatusListCoherenceSaga.test.ts
@@ -1,0 +1,55 @@
+import { type CredentialStatus } from "@pagopa/io-react-native-wallet";
+import { testSaga } from "redux-saga-test-plan";
+import { checkStatusListCoherenceSaga } from "../checkStatusListCoherenceSaga";
+import { itwStatusListReferencedUrisSelector } from "../../store/selectors";
+import { StatusListRepository } from "../../utils/repository";
+
+const makePayload = (sub: string): CredentialStatus.StatusList => ({
+  sub,
+  iat: 1690000000,
+  exp: 1700000000,
+  status_list: { bits: 2, lst: "eNrbuRgAAhcBXQ" }
+});
+
+describe("checkStatusListCoherenceSaga", () => {
+  it("removes cached URIs that are no longer referenced", () => {
+    expect.hasAssertions();
+
+    const referencedUris = ["https://issuer.example/status/1"];
+    const cached = [
+      makePayload("https://issuer.example/status/1"),
+      makePayload("https://issuer.example/status/2")
+    ];
+
+    testSaga(checkStatusListCoherenceSaga)
+      .next()
+      .select(itwStatusListReferencedUrisSelector)
+      .next(referencedUris)
+      .call(StatusListRepository.list)
+      .next(cached)
+      .call(StatusListRepository.removeMany, [
+        "https://issuer.example/status/2"
+      ])
+      .next()
+      .isDone();
+  });
+
+  it("does not remove anything when every cached URI is referenced", () => {
+    expect.hasAssertions();
+
+    const referencedUris = [
+      "https://issuer.example/status/1",
+      "https://issuer.example/status/1"
+    ];
+    const cached = [makePayload("https://issuer.example/status/1")];
+
+    testSaga(checkStatusListCoherenceSaga)
+      .next()
+      .select(itwStatusListReferencedUrisSelector)
+      .next(referencedUris)
+      .call(StatusListRepository.list)
+      .next(cached)
+      .next()
+      .isDone();
+  });
+});

--- a/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/index.test.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/index.test.ts
@@ -6,8 +6,6 @@ import { watchItwStatusListSaga } from "..";
 
 describe("watchItwStatusListSaga", () => {
   it("stops when L3 is not enabled", () => {
-    expect.hasAssertions();
-
     testSaga(watchItwStatusListSaga)
       .next()
       .select(itwIsL3EnabledSelector)
@@ -16,8 +14,6 @@ describe("watchItwStatusListSaga", () => {
   });
 
   it("forks status list sagas when L3 is enabled", () => {
-    expect.hasAssertions();
-
     testSaga(watchItwStatusListSaga)
       .next()
       .select(itwIsL3EnabledSelector)

--- a/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/index.test.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/index.test.ts
@@ -1,45 +1,31 @@
 import { testSaga } from "redux-saga-test-plan";
-import { registerStatusListFetchTaskSaga } from "..";
-import { itwCredentialsStore } from "../../../credentials/store/actions";
-import { itwLifecycleStoresReset } from "../../../lifecycle/store/actions";
-import { itwLifecycleIsValidSelector } from "../../../lifecycle/store/selectors";
-import {
-  registerItwStatusListFetchTask,
-  unregisterItwStatusListFetchTask
-} from "../../tasks/manager";
+import { itwIsL3EnabledSelector } from "../../../common/store/selectors/preferences";
+import { checkStatusListCoherenceSaga } from "../checkStatusListCoherenceSaga";
+import { registerStatusListFetchTaskSaga } from "../registerStatusListFetchTaskSaga";
+import { watchItwStatusListSaga } from "..";
 
-describe("registerStatusListFetchTaskSaga", () => {
-  it("registers the fetch task immediately when the wallet is valid", () => {
-    testSaga(registerStatusListFetchTaskSaga)
-      .next()
-      .select(itwLifecycleIsValidSelector)
-      .next(true)
-      .call(registerItwStatusListFetchTask);
-  });
+describe("watchItwStatusListSaga", () => {
+  it("stops when L3 is not enabled", () => {
+    expect.hasAssertions();
 
-  it("waits for wallet activation before registering the fetch task", () => {
-    testSaga(registerStatusListFetchTaskSaga)
+    testSaga(watchItwStatusListSaga)
       .next()
-      .select(itwLifecycleIsValidSelector)
+      .select(itwIsL3EnabledSelector)
       .next(false)
-      .take(itwCredentialsStore)
-      .next()
-      .call(registerItwStatusListFetchTask);
+      .isDone();
   });
 
-  it("registers the fetch task again after reset and reactivation", () => {
-    testSaga(registerStatusListFetchTaskSaga)
+  it("forks status list sagas when L3 is enabled", () => {
+    expect.hasAssertions();
+
+    testSaga(watchItwStatusListSaga)
       .next()
-      .select(itwLifecycleIsValidSelector)
+      .select(itwIsL3EnabledSelector)
       .next(true)
-      .call(registerItwStatusListFetchTask)
+      .fork(registerStatusListFetchTaskSaga)
       .next()
-      .take(itwLifecycleStoresReset)
+      .fork(checkStatusListCoherenceSaga)
       .next()
-      .call(unregisterItwStatusListFetchTask)
-      .next()
-      .select(itwLifecycleIsValidSelector)
-      .next(true)
-      .call(registerItwStatusListFetchTask);
+      .isDone();
   });
 });

--- a/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/registerStatusListFetchTaskSaga.test.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/registerStatusListFetchTaskSaga.test.ts
@@ -1,0 +1,51 @@
+import { testSaga } from "redux-saga-test-plan";
+import { itwCredentialsStore } from "../../../credentials/store/actions";
+import { itwLifecycleStoresReset } from "../../../lifecycle/store/actions";
+import { itwLifecycleIsValidSelector } from "../../../lifecycle/store/selectors";
+import {
+  registerItwStatusListFetchTask,
+  unregisterItwStatusListFetchTask
+} from "../../tasks/manager";
+import { registerStatusListFetchTaskSaga } from "../registerStatusListFetchTaskSaga";
+
+describe("registerStatusListFetchTaskSaga", () => {
+  it("registers the fetch task immediately when the wallet is valid", () => {
+    expect.hasAssertions();
+
+    testSaga(registerStatusListFetchTaskSaga)
+      .next()
+      .select(itwLifecycleIsValidSelector)
+      .next(true)
+      .call(registerItwStatusListFetchTask);
+  });
+
+  it("waits for wallet activation before registering the fetch task", () => {
+    expect.hasAssertions();
+
+    testSaga(registerStatusListFetchTaskSaga)
+      .next()
+      .select(itwLifecycleIsValidSelector)
+      .next(false)
+      .take(itwCredentialsStore)
+      .next()
+      .call(registerItwStatusListFetchTask);
+  });
+
+  it("registers the fetch task again after reset and reactivation", () => {
+    expect.hasAssertions();
+
+    testSaga(registerStatusListFetchTaskSaga)
+      .next()
+      .select(itwLifecycleIsValidSelector)
+      .next(true)
+      .call(registerItwStatusListFetchTask)
+      .next()
+      .take(itwLifecycleStoresReset)
+      .next()
+      .call(unregisterItwStatusListFetchTask)
+      .next()
+      .select(itwLifecycleIsValidSelector)
+      .next(true)
+      .call(registerItwStatusListFetchTask);
+  });
+});

--- a/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/registerStatusListFetchTaskSaga.test.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/registerStatusListFetchTaskSaga.test.ts
@@ -10,8 +10,6 @@ import { registerStatusListFetchTaskSaga } from "../registerStatusListFetchTaskS
 
 describe("registerStatusListFetchTaskSaga", () => {
   it("registers the fetch task immediately when the wallet is valid", () => {
-    expect.hasAssertions();
-
     testSaga(registerStatusListFetchTaskSaga)
       .next()
       .select(itwLifecycleIsValidSelector)
@@ -20,8 +18,6 @@ describe("registerStatusListFetchTaskSaga", () => {
   });
 
   it("waits for wallet activation before registering the fetch task", () => {
-    expect.hasAssertions();
-
     testSaga(registerStatusListFetchTaskSaga)
       .next()
       .select(itwLifecycleIsValidSelector)
@@ -32,8 +28,6 @@ describe("registerStatusListFetchTaskSaga", () => {
   });
 
   it("registers the fetch task again after reset and reactivation", () => {
-    expect.hasAssertions();
-
     testSaga(registerStatusListFetchTaskSaga)
       .next()
       .select(itwLifecycleIsValidSelector)

--- a/apps/main-app/ts/features/itwallet/statusList/saga/checkStatusListCoherenceSaga.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/saga/checkStatusListCoherenceSaga.ts
@@ -1,0 +1,23 @@
+import { call, select } from "typed-redux-saga/macro";
+import { itwStatusListReferencedUrisSelector } from "../store/selectors";
+import { StatusListRepository } from "../utils/repository";
+
+/**
+ * Runs startup coherence for the Status List Token cache pruning stored entries
+ * no longer referenced by any owner
+ */
+export function* checkStatusListCoherenceSaga() {
+  const referencedUris = yield* select(itwStatusListReferencedUrisSelector);
+  const cached = yield* call(StatusListRepository.list);
+
+  const uniqueRefs = new Set(referencedUris);
+
+  // Remove unreferenced: cached but not referenced by any owner
+  const unreferenced = cached
+    .map(payload => payload.sub)
+    .filter(uri => !uniqueRefs.has(uri));
+
+  if (unreferenced.length > 0) {
+    yield* call(StatusListRepository.removeMany, unreferenced);
+  }
+}

--- a/apps/main-app/ts/features/itwallet/statusList/saga/index.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/saga/index.ts
@@ -1,35 +1,12 @@
 import { SagaIterator } from "redux-saga";
-import { call, fork, select, take } from "typed-redux-saga/macro";
+import { fork, select } from "typed-redux-saga/macro";
 import { itwIsL3EnabledSelector } from "../../common/store/selectors/preferences";
-import { itwCredentialsStore } from "../../credentials/store/actions";
-import { itwLifecycleStoresReset } from "../../lifecycle/store/actions";
-import { itwLifecycleIsValidSelector } from "../../lifecycle/store/selectors";
-import {
-  registerItwStatusListFetchTask,
-  unregisterItwStatusListFetchTask
-} from "../tasks/manager";
+import { checkStatusListCoherenceSaga } from "./checkStatusListCoherenceSaga";
+import { registerStatusListFetchTaskSaga } from "./registerStatusListFetchTaskSaga";
 
-/**
- * Registers the ITW Status List fetch task with expo-background-task.
- */
-export function* registerStatusListFetchTaskSaga(): SagaIterator {
-  while (true) {
-    const isWalletValid = yield* select(itwLifecycleIsValidSelector);
-    if (!isWalletValid) {
-      // Wait for a credential store, a strong signal of wallet activation.
-      yield* take(itwCredentialsStore);
-    }
+export { registerStatusListFetchTaskSaga };
 
-    // Register only for active wallet instances (idempotent).
-    yield* call(registerItwStatusListFetchTask);
-
-    // On wallet reset, unregister and loop to await the next reactivation.
-    yield* take(itwLifecycleStoresReset);
-    yield* call(unregisterItwStatusListFetchTask);
-  }
-}
-
-export function* watchItwTasksSaga(): SagaIterator {
+export function* watchItwStatusListSaga(): SagaIterator {
   const isWhitelisted = yield* select(itwIsL3EnabledSelector);
   if (!isWhitelisted) {
     // If the user is not whitelisted for L3 features, we can skip background
@@ -40,6 +17,8 @@ export function* watchItwTasksSaga(): SagaIterator {
 
   // Register the background task for Status List fetch only for active wallet instances
   yield* fork(registerStatusListFetchTaskSaga);
+  // Run startup coherence for the Status List Token cache
+  yield* fork(checkStatusListCoherenceSaga);
 
   // Register Status List super properties
   // TODO [SIW-4474] Add super property registration

--- a/apps/main-app/ts/features/itwallet/statusList/saga/registerStatusListFetchTaskSaga.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/saga/registerStatusListFetchTaskSaga.ts
@@ -1,0 +1,29 @@
+import { SagaIterator } from "redux-saga";
+import { call, select, take } from "typed-redux-saga/macro";
+import { itwCredentialsStore } from "../../credentials/store/actions";
+import { itwLifecycleStoresReset } from "../../lifecycle/store/actions";
+import { itwLifecycleIsValidSelector } from "../../lifecycle/store/selectors";
+import {
+  registerItwStatusListFetchTask,
+  unregisterItwStatusListFetchTask
+} from "../tasks/manager";
+
+/**
+ * Registers the ITW Status List fetch task with expo-background-task.
+ */
+export function* registerStatusListFetchTaskSaga(): SagaIterator {
+  while (true) {
+    const isWalletValid = yield* select(itwLifecycleIsValidSelector);
+    if (!isWalletValid) {
+      // Wait for a credential store, a strong signal of wallet activation.
+      yield* take(itwCredentialsStore);
+    }
+
+    // Register only for active wallet instances (idempotent).
+    yield* call(registerItwStatusListFetchTask);
+
+    // On wallet reset, unregister and loop to await the next reactivation.
+    yield* take(itwLifecycleStoresReset);
+    yield* call(unregisterItwStatusListFetchTask);
+  }
+}

--- a/apps/main-app/ts/features/itwallet/statusList/store/selectors/index.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/store/selectors/index.ts
@@ -1,0 +1,16 @@
+import { GlobalState } from "../../../../../store/reducers/types";
+
+/**
+ * Collects the Status List URIs referenced by all current owners
+ * (credentials, Wallet Instance Attestations, Wallet Unit Attestations).
+ *
+ * Returns `undefined` when owner metadata does not yet expose Status List
+ * references, so that startup coherence can distinguish "no owners exist"
+ * from "owner metadata not available" and avoid wiping the cache.
+ *
+ * TODO: [SIW-2162] Wire actual URI extraction once owner types expose
+ * Status List references in their Redux state.
+ */
+export const itwStatusListReferencedUrisSelector = (
+  _state: GlobalState
+): ReadonlyArray<string> => [];

--- a/apps/main-app/ts/features/itwallet/statusList/utils/__tests__/repository.test.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/utils/__tests__/repository.test.ts
@@ -1,0 +1,193 @@
+import { type CredentialStatus } from "@pagopa/io-react-native-wallet";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { STORAGE_PREFIX } from "../consts";
+import { StatusListRepository, STORAGE_ENTRY_PREFIX } from "../repository";
+import { STORAGE_KEY_LAST_CHECK_TIME } from "../storage";
+
+jest.mock("@react-native-async-storage/async-storage", () =>
+  require("@react-native-async-storage/async-storage/jest/async-storage-mock")
+);
+
+const makeUri = (id: number) => `https://issuer.example/status/${id}`;
+
+const makePayload = (id: number): CredentialStatus.StatusList => ({
+  sub: makeUri(id),
+  iat: 1690000000,
+  exp: 1700000000,
+  status_list: { bits: 2, lst: "eNrbuRgAAhcBXQ" }
+});
+
+const makeEntryKey = (uri: string) =>
+  `${STORAGE_ENTRY_PREFIX}${encodeURIComponent(uri)}`;
+
+describe("repository", () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  describe("upsert and get", () => {
+    it("persists an entry and retrieves it by URI", async () => {
+      const payload = makePayload(1);
+      await StatusListRepository.upsert(makeUri(1), payload);
+
+      const result = await StatusListRepository.get(makeUri(1));
+      expect(result).toEqual(payload);
+    });
+
+    it("stores entries under the entry namespace", async () => {
+      await StatusListRepository.upsert(makeUri(1), makePayload(1));
+
+      await expect(
+        AsyncStorage.getItem(makeEntryKey(makeUri(1)))
+      ).resolves.toBe(JSON.stringify(makePayload(1)));
+      await expect(
+        AsyncStorage.getItem(
+          `${STORAGE_PREFIX}:${encodeURIComponent(makeUri(1))}`
+        )
+      ).resolves.toBeNull();
+    });
+
+    it("overwrites an existing entry for the same URI", async () => {
+      const payload1 = makePayload(1);
+      const payload2 = { ...makePayload(1), iat: 1695000000 };
+
+      await StatusListRepository.upsert(makeUri(1), payload1);
+      await StatusListRepository.upsert(makeUri(1), payload2);
+
+      const result = await StatusListRepository.get(makeUri(1));
+      expect(result).toEqual(payload2);
+    });
+
+    it("does not duplicate entries on re-upsert", async () => {
+      const payload = makePayload(1);
+      await StatusListRepository.upsert(makeUri(1), payload);
+      await StatusListRepository.upsert(makeUri(1), payload);
+
+      const entries = await StatusListRepository.list();
+      expect(entries).toHaveLength(1);
+    });
+
+    it("keeps concurrently inserted entries visible without index write races", async () => {
+      await Promise.all([
+        StatusListRepository.upsert(makeUri(1), makePayload(1)),
+        StatusListRepository.upsert(makeUri(2), makePayload(2))
+      ]);
+
+      const entries = await StatusListRepository.list();
+      expect(entries.map(payload => payload.sub).sort()).toEqual([
+        makeUri(1),
+        makeUri(2)
+      ]);
+    });
+  });
+
+  describe("get", () => {
+    it("returns undefined for a non-existent URI", async () => {
+      const result = await StatusListRepository.get(makeUri(999));
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined for malformed stored data", async () => {
+      await AsyncStorage.setItem(makeEntryKey(makeUri(1)), "not-valid-json{{");
+
+      const result = await StatusListRepository.get(makeUri(1));
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("list", () => {
+    it("returns empty array when no entries exist", async () => {
+      const entries = await StatusListRepository.list();
+      expect(entries).toEqual([]);
+    });
+
+    it("returns all valid entries", async () => {
+      await StatusListRepository.upsert(makeUri(1), makePayload(1));
+      await StatusListRepository.upsert(makeUri(2), makePayload(2));
+
+      const entries = await StatusListRepository.list();
+      expect(entries).toHaveLength(2);
+    });
+
+    it("ignores other storage keys with the same feature prefix", async () => {
+      await StatusListRepository.upsert(makeUri(1), makePayload(1));
+      await AsyncStorage.setItem(STORAGE_KEY_LAST_CHECK_TIME, "1700000000000");
+
+      const entries = await StatusListRepository.list();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].sub).toBe(makeUri(1));
+    });
+
+    it("does not mutate storage when an entry is malformed", async () => {
+      await StatusListRepository.upsert(makeUri(1), makePayload(1));
+      await StatusListRepository.upsert(makeUri(2), makePayload(2));
+
+      await AsyncStorage.setItem(makeEntryKey(makeUri(1)), "corrupt");
+
+      await expect(StatusListRepository.list()).rejects.toThrow();
+      await expect(
+        AsyncStorage.getItem(makeEntryKey(makeUri(1)))
+      ).resolves.toBe("corrupt");
+    });
+  });
+
+  describe("remove", () => {
+    it("removes an entry by URI", async () => {
+      await StatusListRepository.upsert(makeUri(1), makePayload(1));
+      await StatusListRepository.remove(makeUri(1));
+
+      const result = await StatusListRepository.get(makeUri(1));
+      expect(result).toBeUndefined();
+
+      const entries = await StatusListRepository.list();
+      expect(entries).toHaveLength(0);
+    });
+
+    it("is a no-op for a non-existent URI", async () => {
+      await expect(
+        StatusListRepository.remove(makeUri(999))
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe("removeMany", () => {
+    it("removes multiple entries", async () => {
+      await StatusListRepository.upsert(makeUri(1), makePayload(1));
+      await StatusListRepository.upsert(makeUri(2), makePayload(2));
+      await StatusListRepository.upsert(makeUri(3), makePayload(3));
+
+      await StatusListRepository.removeMany([makeUri(1), makeUri(3)]);
+
+      const entries = await StatusListRepository.list();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].sub).toBe(makeUri(2));
+    });
+
+    it("is a no-op for empty array", async () => {
+      await expect(StatusListRepository.removeMany([])).resolves.not.toThrow();
+    });
+  });
+
+  describe("clear", () => {
+    it("removes all entries", async () => {
+      await StatusListRepository.upsert(makeUri(1), makePayload(1));
+      await StatusListRepository.upsert(makeUri(2), makePayload(2));
+
+      await StatusListRepository.clear();
+
+      const entries = await StatusListRepository.list();
+      expect(entries).toEqual([]);
+    });
+
+    it("keeps non-entry keys with the same feature prefix", async () => {
+      await StatusListRepository.upsert(makeUri(1), makePayload(1));
+      await AsyncStorage.setItem(STORAGE_KEY_LAST_CHECK_TIME, "1700000000000");
+
+      await StatusListRepository.clear();
+
+      await expect(
+        AsyncStorage.getItem(STORAGE_KEY_LAST_CHECK_TIME)
+      ).resolves.toBe("1700000000000");
+    });
+  });
+});

--- a/apps/main-app/ts/features/itwallet/statusList/utils/__tests__/storage.test.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/utils/__tests__/storage.test.ts
@@ -1,0 +1,59 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import {
+  getLastStatusListCheckTimestamp,
+  STORAGE_KEY_LAST_CHECK_TIME,
+  storeLastStatusListCheckTimestamp
+} from "../storage";
+
+jest.mock("@react-native-async-storage/async-storage", () =>
+  require("@react-native-async-storage/async-storage/jest/async-storage-mock")
+);
+
+describe("storage", () => {
+  beforeEach(async () => {
+    jest.restoreAllMocks();
+    await AsyncStorage.clear();
+  });
+
+  describe("storeLastStatusListCheckTimestamp", () => {
+    it("stores the timestamp as a string under the expected key", async () => {
+      await storeLastStatusListCheckTimestamp(1700000000000);
+
+      await expect(
+        AsyncStorage.getItem(STORAGE_KEY_LAST_CHECK_TIME)
+      ).resolves.toBe("1700000000000");
+    });
+
+    it("swallows AsyncStorage errors", async () => {
+      jest
+        .spyOn(AsyncStorage, "setItem")
+        .mockRejectedValueOnce(new Error("boom"));
+
+      await expect(
+        storeLastStatusListCheckTimestamp(1700000000000)
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("getLastStatusListCheckTimestamp", () => {
+    it("returns the stored timestamp as number", async () => {
+      await AsyncStorage.setItem(STORAGE_KEY_LAST_CHECK_TIME, "1700000000000");
+
+      await expect(getLastStatusListCheckTimestamp()).resolves.toBe(
+        1700000000000
+      );
+    });
+
+    it("returns undefined when no timestamp is stored", async () => {
+      await expect(getLastStatusListCheckTimestamp()).resolves.toBeUndefined();
+    });
+
+    it("returns undefined on AsyncStorage errors", async () => {
+      jest
+        .spyOn(AsyncStorage, "getItem")
+        .mockRejectedValueOnce(new Error("boom"));
+
+      await expect(getLastStatusListCheckTimestamp()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/apps/main-app/ts/features/itwallet/statusList/utils/consts.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/utils/consts.ts
@@ -1,0 +1,1 @@
+export const STORAGE_PREFIX = "@io.itwallet.statusList";

--- a/apps/main-app/ts/features/itwallet/statusList/utils/repository.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/utils/repository.ts
@@ -1,0 +1,102 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { CredentialStatus } from "@pagopa/io-react-native-wallet";
+import { STORAGE_PREFIX } from "./consts";
+
+export const STORAGE_ENTRY_PREFIX = `${STORAGE_PREFIX}:entry:`;
+
+/**
+ * Encodes a raw URI into a safe AsyncStorage key.
+ * Keeps encoding internal so callers always use the raw URI.
+ */
+const entryKey = (uri: string): string =>
+  `${STORAGE_ENTRY_PREFIX}${encodeURIComponent(uri)}`;
+
+/**
+ * Reads all cached Status List entry keys.
+ * Other feature keys sharing the same storage prefix are ignored.
+ */
+const readEntryKeys = async (): Promise<Array<string>> => {
+  const keys = await AsyncStorage.getAllKeys();
+  return keys.filter(key => key.startsWith(STORAGE_ENTRY_PREFIX));
+};
+
+/**
+ * Lists all cached Status List Token payloads.
+ */
+const list = async (): Promise<Array<CredentialStatus.StatusList>> => {
+  const keys = await readEntryKeys();
+  if (keys.length === 0) {
+    return [];
+  }
+  const pairs = await AsyncStorage.multiGet(keys);
+  return pairs.flatMap(([, raw]) =>
+    raw ? [CredentialStatus.StatusList.parse(JSON.parse(raw))] : []
+  );
+};
+
+/**
+ * Retrieves a single cached Status List Token payload by its URI.
+ * Returns `undefined` if not found or if validation fails.
+ */
+const get = async (
+  uri: string
+): Promise<CredentialStatus.StatusList | undefined> => {
+  try {
+    const raw = await AsyncStorage.getItem(entryKey(uri));
+    if (!raw) {
+      return undefined;
+    }
+    return CredentialStatus.StatusList.parse(JSON.parse(raw));
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Persists a Status List Token payload, validating it before writing.
+ */
+const upsert = async (
+  uri: string,
+  payload: CredentialStatus.StatusList
+): Promise<void> => {
+  CredentialStatus.StatusList.parse(payload);
+  await AsyncStorage.setItem(entryKey(uri), JSON.stringify(payload));
+};
+
+/**
+ * Removes a single cached Status List Token by its URI.
+ */
+const remove = async (uri: string): Promise<void> => {
+  await AsyncStorage.removeItem(entryKey(uri));
+};
+
+/**
+ * Removes multiple cached Status List Tokens by their URIs.
+ */
+const removeMany = async (uris: Array<string>): Promise<void> => {
+  if (uris.length === 0) {
+    return;
+  }
+
+  const keys = uris.map(entryKey);
+  await AsyncStorage.multiRemove(keys);
+};
+
+/**
+ * Removes all cached Status List Token entries.
+ */
+const clear = async (): Promise<void> => {
+  const keys = await readEntryKeys();
+  if (keys.length > 0) {
+    await AsyncStorage.multiRemove(keys);
+  }
+};
+
+export const StatusListRepository = {
+  list,
+  get,
+  upsert,
+  remove,
+  removeMany,
+  clear
+};

--- a/apps/main-app/ts/features/itwallet/statusList/utils/storage.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/utils/storage.ts
@@ -1,9 +1,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { STORAGE_PREFIX } from "./consts";
 
-// Storage keys for the ITW Status List feature.
-const STORAGE_PREFIX = "@io.itwallet.statusList";
-const STORAGE_KEY_LAST_CHECK_TIME = `${STORAGE_PREFIX}:lastCheckTime`;
-const STORAGE_KEY_LAST_FETCH_TIME = `${STORAGE_PREFIX}:lastFetchTime`;
+export const STORAGE_KEY_LAST_CHECK_TIME = `${STORAGE_PREFIX}:lastCheckTime`;
 
 /**
  * Stores the timestamp of the last check made of the Status List
@@ -34,45 +32,6 @@ export const getLastStatusListCheckTimestamp = async (): Promise<
 > => {
   try {
     const raw = await AsyncStorage.getItem(STORAGE_KEY_LAST_CHECK_TIME);
-    return raw ? parseInt(raw, 10) : undefined;
-  } catch {
-    return undefined;
-  }
-};
-
-/**
- * Stores the timestamp of the last successful fetch of the Status List, used
- * to compute the age of the Status List and decide whether a refresh is needed.
- *
- * @param timestamp The timestamp to store, in milliseconds since the Unix epoch
- */
-export const storeLastStatusListFetchTimestamp = async (
-  timestamp: number
-): Promise<void> => {
-  try {
-    await AsyncStorage.setItem(
-      STORAGE_KEY_LAST_FETCH_TIME,
-      timestamp.toString()
-    );
-  } catch {
-    // Since the store happens outside the app context, there's no way to log or
-    // track this error
-  }
-};
-
-/**
- * Retrieves the timestamp of the last successfull fetch of the ITW Status List,
- * used to compute the age of the Status List and decide whether a refresh is
- * needed.
- *
- * @returns A promise that resolves to the timestamp of the last check in
- * milliseconds since the Unix epoch
- */
-export const getLastStatusListFetchTimestamp = async (): Promise<
-  number | undefined
-> => {
-  try {
-    const raw = await AsyncStorage.getItem(STORAGE_KEY_LAST_FETCH_TIME);
     return raw ? parseInt(raw, 10) : undefined;
   } catch {
     return undefined;


### PR DESCRIPTION
## Short description
This PR implements the Status List persistence logic, with a repository that abstract Async Storage and redux-saga logic wiring.

> [!NOTE]
> We chose **Async Storage** because the persistence of Stats Lust needs to be accessible even when the device is locked, which would not be possible using **Secure Storage**.

## List of changes proposed in this pull request
- Added `StatusListRepository` which abstract AsyncStorage persistence for Status List tokens
- Added `checkStatusListCoherenceSaga` for Status List tokens coherence check between what's inside Redux and what's in AsyncStorage
- Added `itwStatusListReferencedUrisSelector`, currently no-op since we do not have any SL stored yet
- Added tests
- Refactored sagas moving function to dedicated files

## How to test
Static checks should pass
