### PR TITLE
fix(IT-Wallet): [SIW-4652] Fix tour guide visibility issue

### DIFF
--- a/apps/main-app/ts/features/itwallet/tour/hooks/__tests__/useItwGuidedTour.test.tsx
+++ b/apps/main-app/ts/features/itwallet/tour/hooks/__tests__/useItwGuidedTour.test.tsx
@@ -7,6 +7,7 @@ import { applicationChangeState } from "../../../../../store/actions/application
 import * as lifecycleSelectors from "../../../lifecycle/store/selectors";
 import * as tourSelectors from "../../../../tour/store/selectors";
 import * as ingressSelectors from "../../../../ingress/store/selectors";
+import { OfflineAccessReasonEnum } from "../../../../ingress/store/reducer";
 import { startTourAction } from "../../../../tour/store/actions";
 import { ITW_TOUR_GROUP_ID } from "../../utils/constants";
 import { useItwGuidedTour } from "../useItwGuidedTour";
@@ -89,7 +90,7 @@ describe("useItwGuidedTour", () => {
     const store = renderHook({
       isItWalletValid: true,
       isCompleted: false,
-      offlineAccessReason: "SESSION_EXPIRED"
+      offlineAccessReason: OfflineAccessReasonEnum.TIMEOUT
     });
 
     jest.advanceTimersByTime(300);
@@ -103,7 +104,7 @@ describe("useItwGuidedTour", () => {
 type Params = {
   isItWalletValid: boolean;
   isCompleted: boolean;
-  offlineAccessReason: string | undefined;
+  offlineAccessReason: OfflineAccessReasonEnum | undefined;
 };
 
 const renderHook = ({
@@ -119,8 +120,7 @@ const renderHook = ({
     .mockReturnValue(isCompleted);
   jest
     .spyOn(ingressSelectors, "offlineAccessReasonSelector")
-
-    .mockReturnValue(offlineAccessReason as any);
+    .mockReturnValue(offlineAccessReason);
 
   const initialState = appReducer(undefined, applicationChangeState("active"));
   const mockStore = configureMockStore<GlobalState>();

--- a/apps/main-app/ts/features/itwallet/tour/hooks/__tests__/useItwGuidedTour.test.tsx
+++ b/apps/main-app/ts/features/itwallet/tour/hooks/__tests__/useItwGuidedTour.test.tsx
@@ -1,0 +1,141 @@
+import { Provider } from "react-redux";
+import configureMockStore from "redux-mock-store";
+import { render } from "@testing-library/react-native";
+import { GlobalState } from "../../../../../store/reducers/types";
+import { appReducer } from "../../../../../store/reducers";
+import { applicationChangeState } from "../../../../../store/actions/application";
+import * as lifecycleSelectors from "../../../lifecycle/store/selectors";
+import * as tourSelectors from "../../../../tour/store/selectors";
+import * as ingressSelectors from "../../../../ingress/store/selectors";
+import { startTourAction } from "../../../../tour/store/actions";
+import { ITW_TOUR_GROUP_ID } from "../../utils/constants";
+import { useItwGuidedTour } from "../useItwGuidedTour";
+
+jest.mock("@react-navigation/elements", () => ({
+  useHeaderHeight: () => 100
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 })
+}));
+
+jest.mock("../../../../tour/components/useGuidedTourRegion", () => ({
+  useGuidedTourRegion: jest.fn()
+}));
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  // Run the focus callback like a plain effect, since the test does not
+  // render inside a NavigationContainer.
+  useFocusEffect: (callback: () => void) =>
+    require("react").useEffect(callback, [callback])
+}));
+
+describe("useItwGuidedTour", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("starts the tour when the wallet is in L3 mode, not completed and not offline", () => {
+    const store = renderHook({
+      isItWalletValid: true,
+      isCompleted: false,
+      offlineAccessReason: undefined
+    });
+
+    jest.advanceTimersByTime(300);
+
+    expect(store.getActions()).toContainEqual(
+      startTourAction({ groupId: ITW_TOUR_GROUP_ID })
+    );
+  });
+
+  // Non regression test: the tour guide must never start when the wallet is
+  // only in L2 mode ("documenti su IO"), even if whitelisted for L3.
+  it("does not start the tour when the wallet is not in L3 mode", () => {
+    const store = renderHook({
+      isItWalletValid: false,
+      isCompleted: false,
+      offlineAccessReason: undefined
+    });
+
+    jest.advanceTimersByTime(300);
+
+    expect(store.getActions()).not.toContainEqual(
+      startTourAction({ groupId: ITW_TOUR_GROUP_ID })
+    );
+  });
+
+  it("does not start the tour when it was already completed", () => {
+    const store = renderHook({
+      isItWalletValid: true,
+      isCompleted: true,
+      offlineAccessReason: undefined
+    });
+
+    jest.advanceTimersByTime(300);
+
+    expect(store.getActions()).not.toContainEqual(
+      startTourAction({ groupId: ITW_TOUR_GROUP_ID })
+    );
+  });
+
+  it("does not start the tour when the app is in offline mode", () => {
+    const store = renderHook({
+      isItWalletValid: true,
+      isCompleted: false,
+      offlineAccessReason: "SESSION_EXPIRED"
+    });
+
+    jest.advanceTimersByTime(300);
+
+    expect(store.getActions()).not.toContainEqual(
+      startTourAction({ groupId: ITW_TOUR_GROUP_ID })
+    );
+  });
+});
+
+type Params = {
+  isItWalletValid: boolean;
+  isCompleted: boolean;
+  offlineAccessReason: string | undefined;
+};
+
+const renderHook = ({
+  isItWalletValid,
+  isCompleted,
+  offlineAccessReason
+}: Params) => {
+  jest
+    .spyOn(lifecycleSelectors, "itwLifecycleIsITWalletValidSelector")
+    .mockReturnValue(isItWalletValid);
+  jest
+    .spyOn(tourSelectors, "isTourCompletedSelector")
+    .mockReturnValue(isCompleted);
+  jest
+    .spyOn(ingressSelectors, "offlineAccessReasonSelector")
+
+    .mockReturnValue(offlineAccessReason as any);
+
+  const initialState = appReducer(undefined, applicationChangeState("active"));
+  const mockStore = configureMockStore<GlobalState>();
+  const store = mockStore(initialState);
+
+  const TestComponent = () => {
+    useItwGuidedTour();
+    return null;
+  };
+
+  render(
+    <Provider store={store}>
+      <TestComponent />
+    </Provider>
+  );
+
+  return store;
+};

--- a/apps/main-app/ts/features/itwallet/tour/hooks/useItwGuidedTour.ts
+++ b/apps/main-app/ts/features/itwallet/tour/hooks/useItwGuidedTour.ts
@@ -9,7 +9,7 @@ import { offlineAccessReasonSelector } from "../../../ingress/store/selectors";
 import { useGuidedTourRegion } from "../../../tour/components/useGuidedTourRegion";
 import { startTourAction } from "../../../tour/store/actions";
 import { isTourCompletedSelector } from "../../../tour/store/selectors";
-import { itwIsL3EnabledSelector } from "../../common/store/selectors/preferences";
+import { itwLifecycleIsITWalletValidSelector } from "../../lifecycle/store/selectors";
 import {
   ITW_TOUR_GROUP_ID,
   ITW_TOUR_STEP_ADD_BUTTON
@@ -22,7 +22,7 @@ export const useItwGuidedTour = () => {
   const offlineAccessReason = useIOSelector(offlineAccessReasonSelector);
 
   const { width: screenWidth } = Dimensions.get("window");
-  const isItwActive = useIOSelector(itwIsL3EnabledSelector);
+  const isItwActive = useIOSelector(itwLifecycleIsITWalletValidSelector);
   const isCompleted = useIOSelector(state =>
     isTourCompletedSelector(state, ITW_TOUR_GROUP_ID)
   );


### PR DESCRIPTION
## Short description
Fix IT-Wallet tour guide activating outside L3 mode.

## List of changes proposed in this pull request
- `useItwGuidedTour.ts`: swap `itwIsL3EnabledSelector` (whitelist-eligibility only) for `itwLifecycleIsITWalletValidSelector` (actual L3 mode check) as tour activation gate
- Add `useItwGuidedTour.test.tsx` with non-regression test for L2-mode ("documenti su IO") blocking tour start

## How to test
1. As a whitelisted user in L2 mode (no L3 credential issued), open wallet screen
2. Verify tour guide does NOT start
3. Issue L3 credential, reopen wallet screen
4. Verify tour guide starts as expected