### PR TITLE
ci: [IOPLT-000] Remove double backslash from lokalise pull

### DIFF
--- a/.github/workflows/pull-lokalise.yml
+++ b/.github/workflows/pull-lokalise.yml
@@ -33,3 +33,4 @@ jobs:
           filter_langs:
             - it
             - en
+          replace_breaks: false


### PR DESCRIPTION
## Short description
This PR removes a double backslash on export for line breaks on locales file from lokalise