### PR TITLE
feat(IT-Wallet): [SIW-4639] Add loading indicator to continue button in credential offer intro screen

### DIFF
--- a/apps/main-app/ts/features/itwallet/offer/screens/ItwIssuanceCredentialOfferIntro.tsx
+++ b/apps/main-app/ts/features/itwallet/offer/screens/ItwIssuanceCredentialOfferIntro.tsx
@@ -30,6 +30,7 @@ import { itwCredentialSelector } from "../../credentials/store/selectors";
 import { ItwCredentialIssuanceMachineContext } from "../../machine/credential/provider";
 import {
   selectCredentialTypeOption,
+  selectIsLoading,
   selectResolvedCredentialOfferOption
 } from "../../machine/credential/selectors";
 import { ItwParamsList } from "../../navigation/ItwParamsList";
@@ -76,6 +77,8 @@ const ContentView = ({ credentialOfferUri }: ContentViewProps) => {
   const credentialTypeOption = ItwCredentialIssuanceMachineContext.useSelector(
     selectCredentialTypeOption
   );
+  const isLoading =
+    ItwCredentialIssuanceMachineContext.useSelector(selectIsLoading);
   const credentialType = O.toUndefined(credentialTypeOption);
   const introductionContent = useIOSelector(
     itwCredentialIntroContentSelector(credentialType)
@@ -172,7 +175,8 @@ const ContentView = ({ credentialOfferUri }: ContentViewProps) => {
         type: "SingleButton",
         primary: {
           label: I18n.t("global.buttons.continue"),
-          onPress: handleContinue
+          onPress: handleContinue,
+          loading: isLoading
         }
       }}
     >


### PR DESCRIPTION
## Short description
Continue button on credential-offer intro screen did not show loading state while machine confirmed offer, giving no feedback for the delay.

## List of changes
- Wire `selectIsLoading` machine selector into `ItwIssuanceCredentialOfferIntro.tsx`
- Pass `loading` prop to primary CTA in `IOScrollView`'s `SingleButton` action

## How to test
- Start credential offer issuance flow
- Button shows spinner until machine processes `confirm-credential-offer`