### PR TITLE
chore(IT-Wallet): [SIW-4669] Temporarily disable PRE env status banner

### DIFF
--- a/apps/main-app/ts/features/wallet/components/WalletCardsContainer.tsx
+++ b/apps/main-app/ts/features/wallet/components/WalletCardsContainer.tsx
@@ -6,7 +6,6 @@ import Animated, { LinearTransition } from "react-native-reanimated";
 import { useDebugInfo } from "../../../hooks/useDebugInfo";
 import { useIOSelector } from "../../../store/hooks";
 import ItwActivationSuccessFeedbackBanner from "../../itwallet/common/components/ItwActivationSuccessFeedbackBanner";
-import { ItwEnvironmentAlert } from "../../itwallet/common/components/ItwEnvironmentAlert";
 import { ItwL2EngagementBanner } from "../../itwallet/common/components/ItwL2EngagementBanner";
 import { ItwWalletNotAvailableBanner } from "../../itwallet/common/components/ItwWalletNotAvailableBanner";
 import { ItwDiscoveryBannerStandalone } from "../../itwallet/common/components/discoveryBanner/ItwDiscoveryBannerStandalone";
@@ -97,7 +96,7 @@ const WalletCardsContainer = () => {
       style={styles.container}
       layout={LinearTransition.duration(200)}
     >
-      <ItwEnvironmentAlert />
+      {/* <ItwEnvironmentAlert /> */}
       <ItwWalletNotAvailableBanner />
       <ItwDiscoveryBannerStandalone />
 


### PR DESCRIPTION
## Short description
Remove PRE env status banner from the wallet screen

## List of changes proposed in this pull request
- Removed `ItwEnvironmentAlert` component from wallet screen

## How to test
- Go to **Settings > Playgrounds > Documenti su IO**. Switch to PRE environment. 
- Return to the wallet screen.
- Verify the status banner is not visibile.
