### PR TITLE
ci: [IOPLT-1958] Adds cleanup_mode to push-lokalise action

### DIFF
--- a/.github/workflows/push-lokalise.yml
+++ b/.github/workflows/push-lokalise.yml
@@ -27,3 +27,5 @@ jobs:
         translations_path: |
           apps/main-app/locales
         file_ext: json
+        additional_params: |
+          cleanup_mode: true


### PR DESCRIPTION
## Short description
This PR adds the cleanup_mode param to action to upload on lokalise changes on the main language.
This option makes it possible to delete translation keys on lokalise ones they're removed locally on the json file.