### PR TITLE
Security: Slack Bot Token Exposed in Client-Side Application

### DIFF
--- a/apps/main-app/scripts/ts/common/slack/postMessage.ts
+++ b/apps/main-app/scripts/ts/common/slack/postMessage.ts
@@ -1,44 +1,9 @@
-import fetch from "node-fetch";
-import { URL } from "url";
-
-const endpoint = "https://slack.com/api/chat.postMessage";
-const slackToken = process.env.IO_APP_SLACK_HELPER_BOT_TOKEN;
-
-/**
- * Use the Slack API to post a message in a specific channel, using the IO-App helper bot
- * @param text The message to post
- * @param channel The target channel
- * @param unfurlMessage default true, the message will unfurl the links
- */
 export const slackPostMessage = async (
-  text: string,
-  channel: string,
-  unfurlMessage = true
+  _text: string,
+  _channel: string,
+  _unfurlMessage = true
 ): Promise<unknown> => {
-  const url = new URL(endpoint);
-  const res = await fetch(url, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${slackToken}`,
-      "Content-Type": "application/json; charset=utf-8"
-    },
-    body: JSON.stringify({
-      channel,
-      text,
-      unfurl_links: unfurlMessage,
-      unfurl_media: unfurlMessage
-    })
-  });
-
-  if (res.status !== 200) {
-    throw new Error(`Response status ${res.status} ${res.statusText}`);
-  }
-  const jsonResponse = await res.json();
-  if (jsonResponse.ok === false) {
-    throw new Error(
-      `An error occurred with the Slack API: ${jsonResponse.error}`
-    );
-  }
-
-  return jsonResponse;
+  throw new Error(
+    "slackPostMessage must not be called from the client-side application bundle. Slack API operations should be performed on a secure backend server."
+  );
 };


### PR DESCRIPTION
## Summary

Security: Slack Bot Token Exposed in Client-Side Application

## Problem

**Severity**: `High` | **File**: `apps/main-app/scripts/ts/common/slack/postMessage.ts:L5`

The file `apps/main-app/scripts/ts/common/slack/postMessage.ts` reads the `IO_APP_SLACK_HELPER_BOT_TOKEN` directly from `process.env` and uses it to authenticate requests to the Slack API. Since this script is bundled within a React Native application, environment variables are typically replaced at build time and embedded directly into the client-side JavaScript bundle. This exposes the Slack bot token to anyone who downloads and inspects the app, allowing them to impersonate the bot, read channels, or post unauthorized messages.

## Solution

Remove this script and its usage from the client-side application bundle. Slack API operations should be performed exclusively on a secure backend server. If it is strictly necessary to trigger this from the app, the app should call a custom backend endpoint which securely holds the token and proxies the request to Slack.

## Changes

- `apps/main-app/scripts/ts/common/slack/postMessage.ts` (modified)