### PR TITLE
feat(IT-Wallet): [SIW-4493] Copy/design not following Figma

### DIFF
--- a/apps/main-app/locales/it/index.json
+++ b/apps/main-app/locales/it/index.json
@@ -1512,7 +1512,7 @@
         "nfc": {
           "description": "Per consentire a IO di leggere la tua CIE, attiva l'NFC dalle Impostazioni del tuo dispositivo.",
           "header": "Come fare",
-          "primaryAction": "Apri impostazioni",
+          "primaryAction": "Apri Impostazioni",
           "secondaryAction": "Continua",
           "steps": {
             "1": "Apri \"Impostazioni\"",
@@ -1999,7 +1999,7 @@
           "bluetooth": {
             "activation": {
               "actions": {
-                "primary": "Apri impostazioni",
+                "primary": "Apri Impostazioni",
                 "secondary": "Continua"
               },
               "alert": {
@@ -2027,7 +2027,7 @@
             },
             "permissions": {
               "actions": {
-                "primary": "Apri impostazioni",
+                "primary": "Apri Impostazioni",
                 "secondary": "Continua"
               },
               "alert": {
@@ -2089,10 +2089,10 @@
                 "secondary": "Continua"
               },
               "alert": {
-                "action": "Attiva NFC",
+                "action": "Ho capito",
                 "close": "Chiudi",
-                "message": "Attiva l’NFC per permettere la verifica dei tuoi documenti digitali",
-                "title": "È richiesto l’utilizzo del Bluetooth per continuare"
+                "message": "Vai a Impostazioni e modifica le preferenze, poi riprova.",
+                "title": "Attiva l'NFC per continuare"
               },
               "listItems": {
                 "step1": {
@@ -2116,7 +2116,8 @@
           "nfcEngagement": {
             "ready": {
               "android": "Avvicina il telefono al lettore",
-              "ios": "Pronto per la verifica"
+              "ios": "Pronto per la verifica",
+              "hceModalMessage": "Avvicina il telefono al lettore"
             },
             "sending": "Verifica in corso",
             "success": "Verifica completata!"

--- a/apps/main-app/locales/it/index.json
+++ b/apps/main-app/locales/it/index.json
@@ -2145,10 +2145,11 @@
           },
           "selectiveDisclosure": {
             "alert": {
-              "message": "Non potrai completare la verifica del documento."
+              "message": "Potrai riprovare in un secondo momento.",
+              "title": "Vuoi interrompere la verifica?"
             },
             "subtitle": "Saranno condivisi con **{{relyingParty}}** solo per il tempo necessario all’accesso ai servizi richiesti.",
-            "title": "Consenti la verifica di questi dati per procedere",
+            "title": "Consenti la verifica di questi dati per continuare",
             "tos": "I tuoi dati saranno trattati in sicurezza. Se prosegui, dichiari di aver letto e compreso l'**[Informativa Privacy e i Termini e Condizioni d’uso]({{privacyUrl}})**."
           },
           "sendDocumentsLoading": {

--- a/apps/main-app/locales/it/index.json
+++ b/apps/main-app/locales/it/index.json
@@ -2136,6 +2136,7 @@
             "untrustedRp": {
               "bottomSheet": {
                 "content": "IO controlla sempre chi sta richiedendo la lettura dei tuoi dati e non ti permette di continuare se non riconosce il sistema utilizzato per la verifica.\n\nL'app può condividere i tuoi dati solo con enti e soggetti autorizzati.",
+                "primaryAction": "Scopri di più",
                 "title": "Chi può leggere i tuoi dati?"
               },
               "primaryAction": "Chiudi",

--- a/apps/main-app/locales/it/index.json
+++ b/apps/main-app/locales/it/index.json
@@ -2149,7 +2149,7 @@
             },
             "subtitle": "Saranno condivisi con **{{relyingParty}}** solo per il tempo necessario all’accesso ai servizi richiesti.",
             "title": "Consenti la verifica di questi dati per procedere",
-            "tos": "I tuoi dati saranno trattati in sicurezza. Se prosegui, dichiari di aver letto e compreso l'[Informativa Privacy e i Termini e Condizioni d’uso]({{privacyUrl}})."
+            "tos": "I tuoi dati saranno trattati in sicurezza. Se prosegui, dichiari di aver letto e compreso l'**[Informativa Privacy e i Termini e Condizioni d’uso]({{privacyUrl}})**."
           },
           "sendDocumentsLoading": {
             "0": {

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/actors.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/actors.ts
@@ -1,4 +1,6 @@
 import { ISO18013_5 } from "@pagopa/io-react-native-iso18013";
+import i18n from "i18next";
+import { Platform } from "react-native";
 import { fromCallback, fromPromise } from "xstate";
 
 import type { EventsPayload } from "../utils/types";
@@ -70,6 +72,14 @@ export const createProximityActorsImplementation = (env: Env) => {
 
       // Ensure any existing session is closed before starting a new one
       await ISO18013_5.close().catch(() => null);
+
+      if (Platform.OS === "ios") {
+        ISO18013_5.setHceModalMessage(
+          i18n.t(
+            "features.itWallet.presentation.proximity.nfcEngagement.ready.hceModalMessage"
+          )
+        );
+      }
 
       await ISO18013_5.startEngagement({
         engagementModes,

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwNfcActivationScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwNfcActivationScreen.tsx
@@ -35,17 +35,6 @@ export const ItwNfcActivationScreen = () => {
           text: I18n.t(
             "features.itWallet.presentation.proximity.nfc.activation.alert.action"
           ),
-          onPress: () => {
-            void openNfcPreferences();
-          }
-        },
-        {
-          text: I18n.t(
-            "features.itWallet.presentation.proximity.nfc.activation.alert.close"
-          ),
-          onPress: () => {
-            machineRef.send({ type: "close" });
-          },
           style: "cancel"
         }
       ]

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwProximityClaimsDisclosureScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwProximityClaimsDisclosureScreen.tsx
@@ -149,7 +149,7 @@ const ContentView = ({ proximityDetails }: ContentViewProps) => {
           <VStack space={16}>
             <H2>
               {I18n.t(
-                "features.itWallet.presentation.proximity.selectiveDisclosure.title"
+                "features.itWallet.presentation.selectiveDisclosure.title"
               )}
             </H2>
             <IOMarkdownLite

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwProximityClaimsDisclosureScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwProximityClaimsDisclosureScreen.tsx
@@ -78,6 +78,9 @@ const ContentView = ({ proximityDetails }: ContentViewProps) => {
     customLabels: {
       body: I18n.t(
         "features.itWallet.presentation.proximity.selectiveDisclosure.alert.message"
+      ),
+      title: I18n.t(
+        "features.itWallet.presentation.proximity.selectiveDisclosure.alert.title"
       )
     },
     dismissalContext: {
@@ -149,7 +152,7 @@ const ContentView = ({ proximityDetails }: ContentViewProps) => {
           <VStack space={16}>
             <H2>
               {I18n.t(
-                "features.itWallet.presentation.selectiveDisclosure.title"
+                "features.itWallet.presentation.proximity.selectiveDisclosure.title"
               )}
             </H2>
             <IOMarkdownLite

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwProximityFailureScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwProximityFailureScreen.tsx
@@ -1,4 +1,4 @@
-import { Body, VSpacer } from "@io-app/design-system";
+import { Body, FooterActions, VSpacer } from "@io-app/design-system";
 import I18n from "i18next";
 
 import {
@@ -6,7 +6,11 @@ import {
   OperationResultScreenContentProps
 } from "../../../../../components/screens/OperationResultScreenContent.tsx";
 import { useDebugInfo } from "../../../../../hooks/useDebugInfo.ts";
+import { useIOSelector } from "../../../../../store/hooks.ts";
+import { generateDynamicUrlSelector } from "../../../../../store/reducers/backendStatus/remoteConfig.ts";
+import { DOCUMENTS_ON_IO_FAQ_12_URL_BODY } from "../../../../../urls.ts";
 import { useIOBottomSheetModal } from "../../../../../utils/hooks/bottomSheet.tsx";
+import { openWebUrl } from "../../../../../utils/url.ts";
 import { useAvoidHardwareBackButton } from "../../../../../utils/useAvoidHardwareBackButton.ts";
 import { useItwDisableGestureNavigation } from "../../../common/hooks/useItwDisableGestureNavigation.ts";
 import { serializeFailureReason } from "../../../common/utils/itwStoreUtils.ts";
@@ -29,6 +33,13 @@ type ContentViewProps = { failure: ProximityFailure };
 
 const ContentView = ({ failure }: ContentViewProps) => {
   const machineRef = ItwProximityMachineContext.useActorRef();
+  const faqUrl = useIOSelector(state =>
+    generateDynamicUrlSelector(
+      state,
+      "io_showcase",
+      DOCUMENTS_ON_IO_FAQ_12_URL_BODY
+    )
+  );
 
   useDebugInfo({
     failure: serializeFailureReason(failure)
@@ -47,6 +58,19 @@ const ContentView = ({ failure }: ContentViewProps) => {
     ),
     title: I18n.t(
       "features.itWallet.presentation.proximity.relyingParty.untrustedRp.bottomSheet.title"
+    ),
+    footer: (
+      <FooterActions
+        actions={{
+          type: "SingleButton",
+          primary: {
+            label: I18n.t(
+              "features.itWallet.presentation.proximity.relyingParty.untrustedRp.bottomSheet.primaryAction"
+            ),
+            onPress: () => openWebUrl(faqUrl)
+          }
+        }}
+      />
     )
   });
 

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityFailureScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityFailureScreen.test.tsx
@@ -1,10 +1,13 @@
+import { fireEvent } from "@testing-library/react-native";
 import { createStore } from "redux";
 import { createActor } from "xstate";
 
 import { applicationChangeState } from "../../../../../../store/actions/application";
 import { appReducer } from "../../../../../../store/reducers";
 import { GlobalState } from "../../../../../../store/reducers/types";
+import * as bottomSheet from "../../../../../../utils/hooks/bottomSheet";
 import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper";
+import * as url from "../../../../../../utils/url";
 import { ITW_ROUTES } from "../../../../navigation/routes";
 import { ProximityFailure, ProximityFailureType } from "../../machine/failure";
 import { itwProximityMachine } from "../../machine/machine";
@@ -13,6 +16,8 @@ import { TimeoutError, UntrustedRpError } from "../../utils/errors";
 import { ItwProximityFailureScreen } from "../ItwProximityFailureScreen";
 
 describe("ItwProximityFailureScreen", () => {
+  afterEach(() => jest.restoreAllMocks());
+
   test.each<ProximityFailure>([
     {
       type: ProximityFailureType.RELYING_PARTY_GENERIC,
@@ -28,6 +33,30 @@ describe("ItwProximityFailureScreen", () => {
     }
   ])("should render failure screen for $type", failure => {
     expect(renderComponent(failure)).toMatchSnapshot();
+  });
+
+  it("opens the FAQ from the untrusted verifier bottom sheet", () => {
+    const mockOpenWebUrl = jest.spyOn(url, "openWebUrl").mockImplementation();
+    jest
+      .spyOn(bottomSheet, "useIOBottomSheetModal")
+      .mockImplementation(params => ({
+        bottomSheet: (
+          <>
+            {params.component}
+            {params.footer}
+          </>
+        ),
+        dismiss: jest.fn(),
+        present: jest.fn()
+      }));
+    const { getByLabelText } = renderComponent({
+      type: ProximityFailureType.UNTRUSTED_RP,
+      reason: new UntrustedRpError("Untrusted RP")
+    });
+
+    fireEvent.press(getByLabelText("Scopri di più"));
+
+    expect(mockOpenWebUrl).toHaveBeenCalledWith(expect.any(String));
   });
 });
 

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/__snapshots__/ItwProximityFailureScreen.test.tsx.snap
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/__snapshots__/ItwProximityFailureScreen.test.tsx.snap
@@ -833,7 +833,14 @@ L'app può condividere i tuoi dati solo con enti e soggetti autorizzati.
                             <View
                               style={
                                 {
-                                  "height": 0,
+                                  "height": 48,
+                                }
+                              }
+                            />
+                            <View
+                              style={
+                                {
+                                  "height": 48,
                                 }
                               }
                             />
@@ -1727,7 +1734,14 @@ L'app può condividere i tuoi dati solo con enti e soggetti autorizzati.
                             <View
                               style={
                                 {
-                                  "height": 0,
+                                  "height": 48,
+                                }
+                              }
+                            />
+                            <View
+                              style={
+                                {
+                                  "height": 48,
                                 }
                               }
                             />
@@ -2880,7 +2894,14 @@ L'app può condividere i tuoi dati solo con enti e soggetti autorizzati.
                             <View
                               style={
                                 {
-                                  "height": 0,
+                                  "height": 48,
+                                }
+                              }
+                            />
+                            <View
+                              style={
+                                {
+                                  "height": 48,
                                 }
                               }
                             />


### PR DESCRIPTION
## Short description

Improved the IT Wallet proximity-verification experience by aligning the copy with the latest design and adding a help path for untrusted verifiers.

## List of changes proposed in this pull request

- Updated NFC, Bluetooth, selective-disclosure, and Terms & Conditions copy.
- Simplified the NFC activation alert.
- Added the iOS HCE modal message for NFC engagement.
- Added a “Learn more” action to the untrusted-verifier bottom sheet, linking to the Documents on IO FAQ.
- Updated failure-screen snapshots and added coverage for the FAQ-link interaction.

## How to test

1. Start an IT Wallet proximity verification flow.
2. Verify the updated copy in NFC activation, Bluetooth permissions, and selective disclosure screens.
3. On iOS, start an NFC engagement and verify the HCE modal message.
4. Simulate an untrusted verifier and select “Learn more” from the bottom sheet.
5. Verify that the Documents on IO FAQ page opens.