### PR TITLE
refactor: [IOPID-4089] remove fp-ts from toThumbprint

### DIFF
--- a/apps/main-app/ts/features/lollipop/playgrounds/LollipopPlayground.tsx
+++ b/apps/main-app/ts/features/lollipop/playgrounds/LollipopPlayground.tsx
@@ -55,7 +55,7 @@ const LollipopPlayground = () => {
           keyInfo: {
             keyTag: keyTag.value,
             publicKey: maybePublicKey.value,
-            publicKeyThumbprint: toThumbprint(maybePublicKey)
+            publicKeyThumbprint: toThumbprint(maybePublicKey.value)
           },
           signBody: state.doSignBody
         });

--- a/apps/main-app/ts/features/lollipop/utils/__tests__/thumbprint.test.ts
+++ b/apps/main-app/ts/features/lollipop/utils/__tests__/thumbprint.test.ts
@@ -1,5 +1,4 @@
 import { PublicKey } from "@pagopa/io-react-native-crypto";
-import * as O from "fp-ts/lib/Option";
 import { jwkThumbprintByEncoding } from "jwk-thumbprint";
 
 import { toBase64EncodedThumbprint, toThumbprint } from "../crypto";
@@ -16,22 +15,22 @@ const expectedThumbprint = "SXn6l6BNlwAb60cJUKpvKB3H-UQbe2slQ_8LBR70cfA";
 
 describe("Test toThumbprint", () => {
   it("should return the correct thumbprint", () => {
-    const thumbprint = toThumbprint(O.some(jwkPublicKey));
+    const thumbprint = toThumbprint(jwkPublicKey);
     expect(thumbprint).toEqual(expectedThumbprint);
   });
 
   it("should return undefined", () => {
-    const thumbprint = toThumbprint(O.none);
+    const thumbprint = toThumbprint(undefined);
     expect(thumbprint).toBeUndefined();
   });
 
   it("should return the same result as toBase64EncodedThumbprint", () => {
-    const thumbprint = toThumbprint(O.some(jwkPublicKey));
+    const thumbprint = toThumbprint(jwkPublicKey);
     expect(thumbprint).toEqual(toBase64EncodedThumbprint(jwkPublicKey));
   });
 
   it("should return the same result as as jwkThumbprintByEncoding", () => {
-    const thumbprint = toThumbprint(O.some(jwkPublicKey));
+    const thumbprint = toThumbprint(jwkPublicKey);
     const thumbprintFromLib = jwkThumbprintByEncoding(
       jwkPublicKey,
       DEFAULT_LOLLIPOP_HASH_ALGORITHM_CLIENT,

--- a/apps/main-app/ts/features/lollipop/utils/crypto.ts
+++ b/apps/main-app/ts/features/lollipop/utils/crypto.ts
@@ -3,8 +3,6 @@ import {
   isKeyStrongboxBacked,
   PublicKey
 } from "@pagopa/io-react-native-crypto";
-import { pipe } from "fp-ts/lib/function";
-import * as O from "fp-ts/lib/Option";
 import { jwkThumbprintByEncoding } from "jwk-thumbprint";
 
 import {
@@ -29,15 +27,13 @@ export const toBase64EncodedThumbprint = (key: PublicKey) =>
     "base64url"
   );
 
-export const toThumbprint = (key: O.Option<PublicKey>) =>
-  pipe(
-    key,
-    O.chainNullableK(toBase64EncodedThumbprint),
-    O.fold(
-      () => undefined,
-      thumbprint => thumbprint
-    )
-  );
+export const toThumbprint = (key: PublicKey | undefined) => {
+  if (key === undefined) {
+    return undefined;
+  }
+  const base64EncodedThumbprint = toBase64EncodedThumbprint(key);
+  return base64EncodedThumbprint;
+};
 
 /**
  * Check if the key is backed by Strongbox and track the result only on Android.

--- a/apps/main-app/ts/features/lollipop/utils/crypto.ts
+++ b/apps/main-app/ts/features/lollipop/utils/crypto.ts
@@ -28,11 +28,10 @@ export const toBase64EncodedThumbprint = (key: PublicKey) =>
   );
 
 export const toThumbprint = (key: PublicKey | undefined) => {
-  if (key === undefined) {
-    return undefined;
+  if (key) {
+    return toBase64EncodedThumbprint(key);
   }
-  const base64EncodedThumbprint = toBase64EncodedThumbprint(key);
-  return base64EncodedThumbprint;
+  return undefined;
 };
 
 /**

--- a/apps/main-app/ts/features/settings/devMode/components/DeveloperModeSection.tsx
+++ b/apps/main-app/ts/features/settings/devMode/components/DeveloperModeSection.tsx
@@ -14,6 +14,7 @@ import {
   VSpacer
 } from "@io-app/design-system";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as O from "fp-ts/lib/Option";
 import I18n from "i18next";
 import { ComponentProps, useContext } from "react";
 import { Alert, FlatList, ListRenderItemInfo } from "react-native";
@@ -206,7 +207,9 @@ const DeveloperDataSection = () => {
   );
   const publicKey = useIOSelector(lollipopPublicKeySelector);
   const deviceUniqueId = getDeviceId();
-  const thumbprint = toThumbprint(publicKey);
+
+  const publicKeyValue = O.toUndefined(publicKey);
+  const thumbprint = toThumbprint(publicKeyValue);
 
   const devDataCopyListItems: ReadonlyArray<DevDataCopyListItem> = [
     {


### PR DESCRIPTION
## Short description
remove fp-ts from toThumbprint

## List of changes proposed in this pull request
- remove  fp-ts references on toThumbprint function
- update toThumbprint callers to input proper data

## How to test
- CI/CD should succeed
- Check that LollipopPlayground.tsx and DeveloperModeSection.tsx are still working properly