### PR TITLE
refactor: [IOPID-4091] remove fp-ts from LollipopCheckStatus

### DIFF
--- a/apps/main-app/ts/features/authentication/activeSessionLogin/__tests__/ActiveSessionCieIdLoginScreen.test.tsx
+++ b/apps/main-app/ts/features/authentication/activeSessionLogin/__tests__/ActiveSessionCieIdLoginScreen.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent } from "@testing-library/react-native";
-import * as O from "fp-ts/lib/Option";
 import { EmitterSubscription, Linking } from "react-native";
 import { createStore } from "redux";
 
@@ -87,7 +86,7 @@ describe("ActiveSessionCieIdLoginScreen", () => {
 
   it("should dispatch activeSessionLoginSuccess when token is present in URL", () => {
     jest.spyOn(loginHooks, "useLollipopLoginSource").mockReturnValue({
-      lollipopCheckStatus: { status: "none", url: O.none },
+      lollipopCheckStatus: { status: "none" },
       retryLollipopLogin: jest.fn(),
       shouldBlockUrlNavigationWhileCheckingLollipop: jest.fn(),
       webviewSource: { uri: "https://example.com/login" }
@@ -109,7 +108,7 @@ describe("ActiveSessionCieIdLoginScreen", () => {
 
   it("should dispatch activeSessionLoginFailure and navigate to AUTH_ERROR_SCREEN when error code is in URL", () => {
     jest.spyOn(loginHooks, "useLollipopLoginSource").mockReturnValue({
-      lollipopCheckStatus: { status: "none", url: O.none },
+      lollipopCheckStatus: { status: "none" },
       retryLollipopLogin: jest.fn(),
       shouldBlockUrlNavigationWhileCheckingLollipop: jest.fn(),
       webviewSource: { uri: "https://example.com/login" }
@@ -153,7 +152,7 @@ describe("ActiveSessionCieIdLoginScreen", () => {
     jest.spyOn(loginHooks, "useLollipopLoginSource").mockReturnValue({
       webviewSource: { uri: API_PREFIX_URL },
       shouldBlockUrlNavigationWhileCheckingLollipop: () => false,
-      lollipopCheckStatus: { status: "none", url: O.none },
+      lollipopCheckStatus: { status: "none" },
       retryLollipopLogin: jest.fn()
     });
 
@@ -219,7 +218,7 @@ describe("ActiveSessionCieIdLoginScreen", () => {
     jest.spyOn(loginHooks, "useLollipopLoginSource").mockReturnValue({
       webviewSource: { uri: API_PREFIX_URL },
       shouldBlockUrlNavigationWhileCheckingLollipop: blocker,
-      lollipopCheckStatus: { status: "none", url: O.none },
+      lollipopCheckStatus: { status: "none" },
       retryLollipopLogin: jest.fn()
     });
 

--- a/apps/main-app/ts/features/authentication/activeSessionLogin/__tests__/ActiveSessionIdpLoginScreen.test.tsx
+++ b/apps/main-app/ts/features/authentication/activeSessionLogin/__tests__/ActiveSessionIdpLoginScreen.test.tsx
@@ -1,5 +1,4 @@
 import { fireEvent } from "@testing-library/react-native";
-import * as O from "fp-ts/lib/Option";
 import { createStore } from "redux";
 
 import { applicationChangeState } from "../../../../store/actions/application";
@@ -37,7 +36,7 @@ describe("ActiveSessionIdpLoginScreen", () => {
     jest
       .spyOn(useLollipopLoginSource, "useLollipopLoginSource")
       .mockReturnValue({
-        lollipopCheckStatus: { status: "none", url: O.none },
+        lollipopCheckStatus: { status: "none" },
         retryLollipopLogin: jest.fn(),
         shouldBlockUrlNavigationWhileCheckingLollipop: jest.fn(),
         webviewSource: { uri: "https://example.com/login" }
@@ -74,7 +73,7 @@ describe("ActiveSessionIdpLoginScreen", () => {
     jest
       .spyOn(useLollipopLoginSource, "useLollipopLoginSource")
       .mockReturnValue({
-        lollipopCheckStatus: { status: "none", url: O.none },
+        lollipopCheckStatus: { status: "none" },
         retryLollipopLogin: jest.fn(),
         shouldBlockUrlNavigationWhileCheckingLollipop: jest.fn(),
         webviewSource: undefined

--- a/apps/main-app/ts/features/authentication/login/idp/screens/__test__/IdpLoginScreen.test.tsx
+++ b/apps/main-app/ts/features/authentication/login/idp/screens/__test__/IdpLoginScreen.test.tsx
@@ -1,5 +1,4 @@
 import * as pot from "@pagopa/ts-commons/lib/pot";
-import * as O from "fp-ts/lib/Option";
 import { createStore } from "redux";
 
 import { applicationChangeState } from "../../../../../../store/actions/application";
@@ -34,7 +33,7 @@ describe("IdpLoginScreen", () => {
   jest.spyOn(IOHooks, "useIODispatch").mockReturnValue(mockDispatch);
 
   jest.spyOn(useLollipopLoginSource, "useLollipopLoginSource").mockReturnValue({
-    lollipopCheckStatus: { status: "none", url: O.none },
+    lollipopCheckStatus: { status: "none" },
     retryLollipopLogin: jest.fn(),
     shouldBlockUrlNavigationWhileCheckingLollipop: jest.fn(),
     webviewSource: { uri: "https://example.com/login" }

--- a/apps/main-app/ts/features/lollipop/hooks/useLollipopLoginSource.tsx
+++ b/apps/main-app/ts/features/lollipop/hooks/useLollipopLoginSource.tsx
@@ -35,7 +35,7 @@ export const useLollipopLoginSource = (
   loginUri?: string
 ) => {
   const [lollipopCheckStatus, setLollipopCheckStatus] =
-    useState<LollipopCheckStatus>({ status: "none", url: O.none });
+    useState<LollipopCheckStatus>({ status: "none" });
   const [webviewSource, setWebviewSource] = useState<undefined | WebViewSource>(
     undefined
   );
@@ -61,7 +61,7 @@ export const useLollipopLoginSource = (
         () => {
           setLollipopCheckStatus({
             status: "trusted",
-            url: O.some(eventUrl)
+            url: eventUrl
           });
           setWebviewSource({ uri: eventUrl });
         },
@@ -69,7 +69,7 @@ export const useLollipopLoginSource = (
           trackLollipopIdpLoginFailure(reason);
           setLollipopCheckStatus({
             status: "untrusted",
-            url: O.some(eventUrl)
+            url: eventUrl
           });
           onLollipopCheckFailure();
         }
@@ -137,7 +137,7 @@ export const useLollipopLoginSource = (
   ]);
 
   const retryLollipopLogin = useCallback(() => {
-    setLollipopCheckStatus({ status: "none", url: O.none });
+    setLollipopCheckStatus({ status: "none" });
     // We must set webviewSource to undefined before requesting
     // any changes to loginSource otherwise on the next component
     // refresh (triggered by a different value of loginSource),
@@ -162,7 +162,7 @@ export const useLollipopLoginSource = (
             // Start Lollipop verification process
             setLollipopCheckStatus({
               status: "checking",
-              url: O.some(url)
+              url
             });
             verifyLollipop(url, urlEncodedSamlRequest, maybeEphemeralPublicKey);
             // Prevent the WebView from loading the current URL (its

--- a/apps/main-app/ts/features/lollipop/types/LollipopCheckStatus.ts
+++ b/apps/main-app/ts/features/lollipop/types/LollipopCheckStatus.ts
@@ -1,6 +1,3 @@
-// Type used to handle the LolliPOP checks.
-import * as O from "fp-ts/lib/Option";
-
 // None means that the component state is ready to start a
 // verification process if a SAMLRequest query parameter is detected
 // Checking means that LolliPOP signature verification is happening
@@ -12,5 +9,5 @@ import * as O from "fp-ts/lib/Option";
 // and the user cannot proceed with the login
 export type LollipopCheckStatus = {
   status: "checking" | "none" | "trusted" | "untrusted";
-  url: O.Option<string>;
+  url?: string;
 };


### PR DESCRIPTION
## Short description
remove fp-ts from LollipopCheckStatus

## List of changes proposed in this pull request
- remove fp-ts references on LollipopCheckStatus type
- update useLollipopLoginSource and related test mocks to input proper data

## How to test
- Check that CIE and IDP login WebView flows still complete correctly (SAML request detection → checking → trusted/untrusted → successful login or auth error screen)
- CI/CD should succeed