### PR TITLE
ci: [IOAPPX-000] Remove deployment write permission from static checks

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -12,7 +12,6 @@ jobs:
     environment: dev
     permissions:
       contents: read
-      deployments: write
     concurrency:
       group: ${{ github.workflow }}-pr-staticcheck-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true


### PR DESCRIPTION
## Short description
This PR removes the deployment write permission from static checks because it's not required. It currently makes the nightly job fail.
