### PR TITLE
refactor: [IOPID-4093] remove fp-ts from LollipopPlaygroundContent

### DIFF
--- a/apps/main-app/ts/features/lollipop/playgrounds/LollipopPlaygroundContent.tsx
+++ b/apps/main-app/ts/features/lollipop/playgrounds/LollipopPlaygroundContent.tsx
@@ -6,12 +6,10 @@ import {
   IOColors,
   VSpacer
 } from "@io-app/design-system";
-import * as O from "fp-ts/lib/Option";
 import { useState } from "react";
 import { StyleSheet, TextInput, View } from "react-native";
 
 import { WithTestID } from "../../../types/WithTestID";
-import { maybeNotNullyString } from "../../../utils/strings";
 import { LollipopPlaygroundState } from "./LollipopPlayground";
 
 const styles = StyleSheet.create({
@@ -50,7 +48,7 @@ type Props = WithTestID<{
 const LollipopPlaygroundContent = (props: Props) => {
   const [httpRequestBodyText, setHttpRequestBodyText] = useState<string>("");
 
-  const isMessageBodySet = O.isSome(maybeNotNullyString(httpRequestBodyText));
+  const isMessageBodySet = !!httpRequestBodyText.trim();
 
   return (
     <View style={styles.column}>

--- a/apps/main-app/ts/features/lollipop/playgrounds/__tests__/LollipopPlaygroundContent.test.tsx
+++ b/apps/main-app/ts/features/lollipop/playgrounds/__tests__/LollipopPlaygroundContent.test.tsx
@@ -25,64 +25,59 @@ const renderComponent = (
     />
   );
 
-  return { ...utils, onCheckBoxPress, onClearButtonPress, onSignButtonPress };
+  const signButton = utils.getByLabelText("Sign message with body");
+  const clearButton = utils.getByLabelText("Clear");
+
+  return {
+    ...utils,
+    onClearButtonPress,
+    onSignButtonPress,
+    signButton,
+    clearButton
+  };
 };
 
 describe("LollipopPlaygroundContent", () => {
-  beforeEach(() => jest.clearAllMocks());
+  it("should keep the sign and clear buttons disabled when the body is empty", () => {
+    const { signButton, clearButton } = renderComponent();
 
-  it("should not call onSignButtonPress when the body is empty", () => {
-    const { getByLabelText, onSignButtonPress } = renderComponent();
-
-    fireEvent.press(getByLabelText("Sign message with body"));
-
-    expect(onSignButtonPress).not.toHaveBeenCalled();
+    expect(signButton).toBeDisabled();
+    expect(clearButton).toBeDisabled();
   });
 
-  it("should not call onSignButtonPress when the body is only whitespace", () => {
-    const { getByLabelText, getByPlaceholderText, onSignButtonPress } =
-      renderComponent();
+  it("should keep the sign and clear buttons disabled when the body is only whitespace", () => {
+    const { getByPlaceholderText, signButton, clearButton } = renderComponent();
 
     fireEvent.changeText(
       getByPlaceholderText("paste your body message here"),
       "   "
     );
-    fireEvent.press(getByLabelText("Sign message with body"));
 
-    expect(onSignButtonPress).not.toHaveBeenCalled();
+    expect(signButton).toBeDisabled();
+    expect(clearButton).toBeDisabled();
   });
 
-  it("should call onSignButtonPress with the typed text when the body is not empty", () => {
-    const { getByLabelText, getByPlaceholderText, onSignButtonPress } =
-      renderComponent();
+  it("should enable the sign and clear buttons when the body is not empty", () => {
+    const {
+      getByPlaceholderText,
+      signButton,
+      clearButton,
+      onSignButtonPress,
+      onClearButtonPress
+    } = renderComponent();
 
     fireEvent.changeText(
       getByPlaceholderText("paste your body message here"),
       "hello"
     );
-    fireEvent.press(getByLabelText("Sign message with body"));
 
+    expect(signButton).not.toBeDisabled();
+    expect(clearButton).not.toBeDisabled();
+
+    fireEvent.press(signButton);
     expect(onSignButtonPress).toHaveBeenCalledWith("hello");
-  });
 
-  it("should not call onClearButtonPress when the body is empty", () => {
-    const { getByLabelText, onClearButtonPress } = renderComponent();
-
-    fireEvent.press(getByLabelText("Clear"));
-
-    expect(onClearButtonPress).not.toHaveBeenCalled();
-  });
-
-  it("should call onClearButtonPress when the body is not empty", () => {
-    const { getByLabelText, getByPlaceholderText, onClearButtonPress } =
-      renderComponent();
-
-    fireEvent.changeText(
-      getByPlaceholderText("paste your body message here"),
-      "hello"
-    );
-    fireEvent.press(getByLabelText("Clear"));
-
+    fireEvent.press(clearButton);
     expect(onClearButtonPress).toHaveBeenCalled();
   });
 });

--- a/apps/main-app/ts/features/lollipop/playgrounds/__tests__/LollipopPlaygroundContent.test.tsx
+++ b/apps/main-app/ts/features/lollipop/playgrounds/__tests__/LollipopPlaygroundContent.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { LollipopPlaygroundState } from "../LollipopPlayground";
+import LollipopPlaygroundContent from "../LollipopPlaygroundContent";
+
+const basePlaygroundState: LollipopPlaygroundState = {
+  doSignBody: true,
+  isVerificationSuccess: undefined,
+  verificationResult: undefined
+};
+
+const renderComponent = (
+  playgroundState: LollipopPlaygroundState = basePlaygroundState
+) => {
+  const onCheckBoxPress = jest.fn();
+  const onClearButtonPress = jest.fn();
+  const onSignButtonPress = jest.fn();
+
+  const utils = render(
+    <LollipopPlaygroundContent
+      onCheckBoxPress={onCheckBoxPress}
+      onClearButtonPress={onClearButtonPress}
+      onSignButtonPress={onSignButtonPress}
+      playgroundState={playgroundState}
+    />
+  );
+
+  return { ...utils, onCheckBoxPress, onClearButtonPress, onSignButtonPress };
+};
+
+describe("LollipopPlaygroundContent", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("should not call onSignButtonPress when the body is empty", () => {
+    const { getByLabelText, onSignButtonPress } = renderComponent();
+
+    fireEvent.press(getByLabelText("Sign message with body"));
+
+    expect(onSignButtonPress).not.toHaveBeenCalled();
+  });
+
+  it("should not call onSignButtonPress when the body is only whitespace", () => {
+    const { getByLabelText, getByPlaceholderText, onSignButtonPress } =
+      renderComponent();
+
+    fireEvent.changeText(
+      getByPlaceholderText("paste your body message here"),
+      "   "
+    );
+    fireEvent.press(getByLabelText("Sign message with body"));
+
+    expect(onSignButtonPress).not.toHaveBeenCalled();
+  });
+
+  it("should call onSignButtonPress with the typed text when the body is not empty", () => {
+    const { getByLabelText, getByPlaceholderText, onSignButtonPress } =
+      renderComponent();
+
+    fireEvent.changeText(
+      getByPlaceholderText("paste your body message here"),
+      "hello"
+    );
+    fireEvent.press(getByLabelText("Sign message with body"));
+
+    expect(onSignButtonPress).toHaveBeenCalledWith("hello");
+  });
+
+  it("should not call onClearButtonPress when the body is empty", () => {
+    const { getByLabelText, onClearButtonPress } = renderComponent();
+
+    fireEvent.press(getByLabelText("Clear"));
+
+    expect(onClearButtonPress).not.toHaveBeenCalled();
+  });
+
+  it("should call onClearButtonPress when the body is not empty", () => {
+    const { getByLabelText, getByPlaceholderText, onClearButtonPress } =
+      renderComponent();
+
+    fireEvent.changeText(
+      getByPlaceholderText("paste your body message here"),
+      "hello"
+    );
+    fireEvent.press(getByLabelText("Clear"));
+
+    expect(onClearButtonPress).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Short description
remove fp-ts from LollipopPlaygroundContent

## List of changes proposed in this pull request
- remove fp-ts references (O.isSome, maybeNotNullyString) from LollipopPlaygroundContent
- add unit tests covering the sign/clear button enabled state based on the message body content

## How to test
- CI/CD should succeed
- Check that the Lollipop Playground screen still enables/disables the Sign and Clear buttons correctly based on the HTTP request body content

