### PR TITLE
chore(IT-Wallet): [SIW-4700] Remove recommended badge from ITW auth flows

### DIFF
--- a/apps/main-app/locales/it/index.json
+++ b/apps/main-app/locales/it/index.json
@@ -1460,14 +1460,12 @@
               }
             },
             "ciePin": {
-              "badge": "consigliato",
               "bottomSheet": {
                 "entry-1": "La tua Carta di Identità Elettronica (CIE)",
                 "entry-2": "Il PIN a 8 cifre della CIE",
                 "subtitle": "Hai bisogno di:",
                 "title": "Continua con CIE + PIN"
               },
-              "reissuanceBadge": "Consigliato",
               "subtitle": {
                 "default": "Dovrai usare la Carta di Identità Elettronica (CIE) e inserire il suo PIN di 8 cifre.",
                 "l3": "Ha una durata di 12 mesi"

--- a/apps/main-app/ts/features/itwallet/identification/common/components/CiePinMethodModule.tsx
+++ b/apps/main-app/ts/features/itwallet/identification/common/components/CiePinMethodModule.tsx
@@ -1,4 +1,4 @@
-import { Badge, ModuleNavigationAlt } from "@io-app/design-system";
+import { ModuleNavigationAlt } from "@io-app/design-system";
 import I18n from "i18next";
 import { useCallback } from "react";
 
@@ -27,20 +27,10 @@ export const CiePinMethodModule = ({
     isL3
   });
 
-  const badgeProps: Badge = {
-    testID: "CiePinRecommendedBadgeTestID",
-    text: I18n.t(
-      "features.itWallet.identification.modeSelection.mode.ciePin.badge"
-    ),
-    variant: "highlight",
-    outline: false
-  };
-
   if (isL3) {
     return (
       <>
         <ModuleNavigationAlt
-          badge={!isReissuanceMode ? badgeProps : undefined}
           icon="fiscalCodeIndividual"
           onPress={() => {
             trackItWalletIDMethodSelected({

--- a/apps/main-app/ts/features/itwallet/identification/common/components/__tests__/__snapshots__/CiePinMethodModule.test.tsx.snap
+++ b/apps/main-app/ts/features/itwallet/identification/common/components/__tests__/__snapshots__/CiePinMethodModule.test.tsx.snap
@@ -620,56 +620,6 @@ exports[`CiePinMethodModule When isL3 is true and isReissuance mode is false ren
             }
           }
         >
-          <View
-            accessible={true}
-            style={
-              [
-                {
-                  "alignItems": "center",
-                  "borderCurve": "continuous",
-                  "flexDirection": "row",
-                  "justifyContent": "center",
-                  "overflow": "hidden",
-                },
-                {
-                  "borderRadius": 36,
-                  "paddingHorizontal": 12,
-                  "paddingVertical": 6,
-                },
-                {
-                  "backgroundColor": "rgba(97,220,223,0.2)",
-                },
-              ]
-            }
-            testID="CiePinRecommendedBadgeTestID"
-          >
-            <Text
-              allowFontScaling={true}
-              ellipsizeMode="tail"
-              maxFontSizeMultiplier={1.5}
-              numberOfLines={1}
-              style={
-                [
-                  {},
-                  {
-                    "color": "#61DCDF",
-                    "fontFamily": "Titillio",
-                    "fontSize": 12,
-                    "fontStyle": "normal",
-                    "fontWeight": "600",
-                    "lineHeight": 16,
-                  },
-                  {
-                    "alignSelf": "center",
-                    "letterSpacing": 0.5,
-                    "textTransform": "uppercase",
-                  },
-                ]
-              }
-            >
-              consigliato
-            </Text>
-          </View>
           <View>
             <Text
               allowFontScaling={true}

--- a/apps/main-app/ts/features/itwallet/identification/common/screens/ItwIdentificationModeSelectionScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/identification/common/screens/ItwIdentificationModeSelectionScreen.tsx
@@ -218,17 +218,6 @@ const GroupedMethodList = ({
     {(!isCiePinDisabled || !isCieIdDisabled) && (
       <VStack space={8}>
         <ListItemHeader
-          endElement={{
-            type: "badge",
-            componentProps: {
-              text: I18n.t(
-                "features.itWallet.identification.modeSelection.mode.ciePin.reissuanceBadge"
-              ),
-              variant: "highlight",
-              outline: false,
-              testID: "CiePinReissuanceBadgeTestID"
-            }
-          }}
           label={I18n.t(
             "features.itWallet.identification.modeSelection.frequency.every12Months"
           )}

--- a/apps/main-app/ts/features/itwallet/identification/common/screens/__tests__/ItwIdentificationModeSelectionScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/identification/common/screens/__tests__/ItwIdentificationModeSelectionScreen.test.tsx
@@ -47,13 +47,12 @@ describe("ItwIdentificationModeSelectionScreen", () => {
     jest.clearAllMocks();
   });
 
-  it("[issuance, l2] shows all L2 methods, no badges, no noCie button", () => {
+  it("[issuance, l2] shows all L2 methods and no noCie button", () => {
     const { queryByTestId } = renderComponent("issuance", "l2");
 
     expect(queryByTestId("CiePinMethodModuleTestIDL2")).not.toBeNull();
     expect(queryByTestId("SpidMethodModuleTestIDL2")).not.toBeNull();
     expect(queryByTestId("CieIDMethodModuleTestIDL2")).not.toBeNull();
-    expect(queryByTestId("CiePinRecommendedBadgeTestID")).toBeNull();
     expect(queryByTestId("noCieButtonTestID")).toBeNull();
   });
 
@@ -76,15 +75,13 @@ describe("ItwIdentificationModeSelectionScreen", () => {
     expect(queryByTestId("CieIDMethodModuleTestIDL2")).not.toBeNull();
   });
 
-  it("[issuance, l3] shows all L3 methods with the recommended badge and the noCie button", () => {
+  it("[issuance, l3] shows all L3 methods and the noCie button", () => {
     const { queryByTestId } = renderComponent("issuance", "l3");
 
     expect(queryByTestId("CiePinMethodModuleTestIDL3")).not.toBeNull();
-    expect(queryByTestId("CiePinRecommendedBadgeTestID")).not.toBeNull();
     expect(queryByTestId("SpidMethodModuleTestIDL3")).not.toBeNull();
     expect(queryByTestId("CieIDMethodModuleTestIDL3")).not.toBeNull();
     expect(queryByTestId("noCieButtonTestID")).not.toBeNull();
-    expect(queryByTestId("CiePinReissuanceBadgeTestID")).toBeNull();
   });
 
   it("[reissuance, l2] shows all L2 methods, no frequency headers", () => {
@@ -97,7 +94,7 @@ describe("ItwIdentificationModeSelectionScreen", () => {
     expect(queryByText(every90Days())).toBeNull();
   });
 
-  it("[reissuance, l3] shows all L3 methods with frequency headers and reissuance badge, no noCie button", () => {
+  it("[reissuance, l3] shows all L3 methods with frequency headers and no noCie button", () => {
     const { queryByTestId, queryByText } = renderComponent("reissuance", "l3");
 
     expect(queryByTestId("CiePinMethodModuleTestIDL3")).not.toBeNull();
@@ -105,7 +102,6 @@ describe("ItwIdentificationModeSelectionScreen", () => {
     expect(queryByTestId("CieIDMethodModuleTestIDL3")).not.toBeNull();
     expect(queryByText(every12Months())).not.toBeNull();
     expect(queryByText(every90Days())).not.toBeNull();
-    expect(queryByTestId("CiePinReissuanceBadgeTestID")).not.toBeNull();
     expect(queryByTestId("noCieButtonTestID")).toBeNull();
   });
 


### PR DESCRIPTION
## Short description
This PR remove the "Consigliato" badge from IT-Wallet issuance and reissuance flow during authentication steps.
## List of changes proposed in this pull request
- Remove badge from `CiePinMethod` selection during issuance
- Remove badge from [ItwIdentificationModeSelectionScreen.tsx](https://github.com/pagopa/io-app/pull/8349/changes#diff-69b0a7b5cf2e276f9e50ac09d49de0cacb7690a78a810282fc16e949d66f9885) during reissuance flow

## How to test
Start both an issuance and a reissuance flow and verify that the badge "Consigliato" is not showed during authentication steps.