### PR TITLE
feat(IT-Wallet): [SIW-3824] Add accessibility labels for IT-Wallet ID card

### DIFF
--- a/apps/main-app/ts/features/itwallet/wallet/components/ItwCredentialWalletCard.tsx
+++ b/apps/main-app/ts/features/itwallet/wallet/components/ItwCredentialWalletCard.tsx
@@ -1,3 +1,5 @@
+import I18n from "i18next";
+
 import { useOfflineToastGuard } from "../../../../hooks/useOfflineToastGuard";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { useIOSelector } from "../../../../store/hooks";
@@ -7,7 +9,9 @@ import {
   ItwCredentialCard,
   ItwCredentialCardLegacy
 } from "../../common/components/ItwCredentialCard";
+import { useItwCredentialName } from "../../common/hooks/useItwCredentialName";
 import { itwShouldUpgradeCredentialSelector } from "../../common/store/selectors";
+import { CredentialType } from "../../common/utils/itwMocksUtils";
 import { itwLifecycleIsITWalletValidSelector } from "../../lifecycle/store/selectors";
 import { ITW_ROUTES } from "../../navigation/routes";
 
@@ -21,11 +25,19 @@ export type ItwCredentialWalletCardProps = ItwCredentialCard & {
 const WrappedItwCredentialCard = (props: ItwCredentialWalletCardProps) => {
   const { credentialType, issuedAt, onPress } = props;
   const navigation = useIONavigation();
+  const credentialName = useItwCredentialName(credentialType);
   const needsItwUpgrade = useIOSelector(
     itwShouldUpgradeCredentialSelector(credentialType, issuedAt)
   );
   const withItwDesign =
     useIOSelector(itwLifecycleIsITWalletValidSelector) || props.withItwDesign;
+
+  // The PID card displays the IT-Wallet ID logo instead of a textual title,
+  // so its name must be exposed explicitly to screen readers
+  const accessibilityLabel =
+    withItwDesign && credentialType === CredentialType.PID
+      ? I18n.t("features.itWallet.credentialName.pid")
+      : credentialName;
 
   const handleCredentialUpgrade = useOfflineToastGuard(() =>
     navigation.navigate(ITW_ROUTES.MAIN, {
@@ -54,6 +66,7 @@ const WrappedItwCredentialCard = (props: ItwCredentialWalletCardProps) => {
 
   return (
     <WalletCardPressableBase
+      accessibilityLabel={accessibilityLabel}
       onPress={handleOnPress}
       testID="ItwCredentialWalletCardTestID"
     >

--- a/apps/main-app/ts/features/itwallet/wallet/components/__tests__/ItwCredentialWalletCard.test.tsx
+++ b/apps/main-app/ts/features/itwallet/wallet/components/__tests__/ItwCredentialWalletCard.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent } from "@testing-library/react-native";
+import I18n from "i18next";
 import { createStore } from "redux";
 
 import { applicationChangeState } from "../../../../../store/actions/application";
@@ -95,6 +96,29 @@ describe("WrappedItwCredentialCard", () => {
 
     expect(mockNavigation).not.toHaveBeenCalled();
   });
+
+  const accessibilityScenarios = [
+    {
+      name: "PID, which renders the IT-Wallet ID logo",
+      props: { credentialType: "pid", withItwDesign: true },
+      expectedLabel: I18n.t("features.itWallet.credentialName.pid")
+    },
+    {
+      name: "mDL",
+      props: { credentialType: "mDL", withItwDesign: true },
+      expectedLabel: I18n.t("features.itWallet.credentialName.mdl")
+    }
+  ];
+
+  it.each(accessibilityScenarios)(
+    "should expose the credential name as accessibility label ($name)",
+    ({ props, expectedLabel }) => {
+      const { getByTestId } = renderComponent(props);
+      const button = getByTestId("ItwCredentialWalletCardTestID");
+
+      expect(button.props.accessibilityLabel).toBe(expectedLabel);
+    }
+  );
 });
 
 const renderComponent = (props: ItwCredentialWalletCardProps) => {


### PR DESCRIPTION
## Short description
The IT-Wallet ID card in the Wallet was announced by VoiceOver only as "Pulsante", with no accessible name: its title is rendered as an SVG logo, so there was no text for the screen reader to fall back on, and the pressable wrapper had no `accessibilityLabel`.

Now every IT-Wallet credential card exposes its name as accessible label:
- PID card (new IT-Wallet design) → "IT-Wallet ID"
- Other credentials → the resolved credential name shown on the card

## List of changes proposed in this pull request
- `ItwCredentialWalletCard`: pass `accessibilityLabel` to `WalletCardPressableBase`
- PID with new design uses `features.itWallet.credentialName.pid` (the catalogue resolver returns the legacy "Identità Digitale" for PID)
- Added tests covering the accessible label for PID and mDL cards

## How to test
1. Enable VoiceOver (iOS) / TalkBack (Android)
2. Go to the Wallet with an active IT-Wallet ID
3. Focus the IT-Wallet ID card → announced as "IT-Wallet ID, pulsante" (previously just "Pulsante")
4. Focus other credential cards (e.g. Patente di guida) → announced with their credential name