### PR TITLE
feat(IT-Wallet): [SIW-4712] Align tracking survey IDs for PID activation flow

### DIFF
--- a/apps/main-app/ts/features/itwallet/analytics/utils/types.ts
+++ b/apps/main-app/ts/features/itwallet/analytics/utils/types.ts
@@ -219,4 +219,5 @@ type QualtricsSurveyId =
   | "confirm_eid_flow_exit"
   | "confirm_eid_flow_success"
   | "itw_credential_exit"
-  | "itw_eid_activation_exit";
+  | "itw_pid_activation_exit"
+  | "itw_pid_activation_success";

--- a/apps/main-app/ts/features/itwallet/common/components/ItwActivationSuccessFeedbackBanner.tsx
+++ b/apps/main-app/ts/features/itwallet/common/components/ItwActivationSuccessFeedbackBanner.tsx
@@ -31,7 +31,7 @@ const ItwActivationSuccessFeedbackBanner = ({
 
   const trackingProps: TrackQualtricsSurvey = useMemo(
     () => ({
-      survey_id: "confirm_eid_flow_success",
+      survey_id: "itw_pid_activation_success",
       survey_page: routeName
     }),
     [routeName]

--- a/apps/main-app/ts/features/itwallet/common/hooks/useItwActivationExitSurveyBottomSheet.tsx
+++ b/apps/main-app/ts/features/itwallet/common/hooks/useItwActivationExitSurveyBottomSheet.tsx
@@ -55,7 +55,7 @@ export const useItwActivationExitSurveyBottomSheet = ({
 
   const trackingProps: TrackQualtricsSurvey = useMemo(
     () => ({
-      survey_id: "itw_eid_activation_exit",
+      survey_id: "itw_pid_activation_exit",
       survey_page: routeName
     }),
     [routeName]


### PR DESCRIPTION
## Short description
This PR aligns the `survey_id` property values used by the SURVEY_REQUEST / SURVEY_REQUEST_ACCEPTED / SURVEY_REQUEST_DECLINED tracking events for the survey entry points tied to the PID activation flow.

## List of changes proposed in this pull request
- Updated `QualtricsSurveyId` in `analytics/utils/types.ts`: replaced `itw_eid_activation_exit` with `itw_pid_activation_exit` and added `itw_pid_activation_success`
- `useItwActivationExitSurveyBottomSheet`: `survey_id` → `itw_pid_activation_exit` (PID activation exit survey)
- `ItwActivationSuccessFeedbackBanner`: `survey_id` → `itw_pid_activation_success` (PID activation success survey)
- Confirmed `itw_credential_exit` (document abandon survey) was already correct, no change needed
- Verified SURVEY_REQUEST/SURVEY_REQUEST_ACCEPTED/SURVEY_REQUEST_DECLINED are already correctly fired with `survey_id` and `survey_page` properties at all three entry points
  
## How to test
1. Start the PID activation flow and abandon it at one of the tracked steps (intro, disambiguation, select_method,
  cie_preparation, pid_preview)
2. Check in Mixpanel debug that `SURVEY_REQUEST` is sent with `survey_id: itw_pid_activation_exit` when returning to Wallet Home, `SURVEY_REQUEST_ACCEPTED` on tapping the bottom sheet's primary CTA, `SURVEY_REQUEST_DECLINED` on dismiss without tapping the CTA
3. Successfully complete PID activation and verify the banner fires `SURVEY_REQUEST` with `survey_id: itw_pid_activation_success` and `SURVEY_REQUEST_ACCEPTED` on CTA tap
4. Abandon a credential request flow (e.g. from preview or trust issuer) and verify `survey_id: itw_credential_exit` on all three events