### PR TITLE
fix(IT-Wallet): [SIW-4716] Enhance offline functionality with proximity features 

### DIFF
--- a/apps/main-app/ts/features/itwallet/presentation/details/screens/ItwPresentationCredentialDetailScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/details/screens/ItwPresentationCredentialDetailScreen.tsx
@@ -18,7 +18,9 @@ import {
 } from "../../../../../navigation/params/AppParamsList.ts";
 import { useIODispatch, useIOSelector } from "../../../../../store/hooks.ts";
 import { usePreventScreenCapture } from "../../../../../utils/hooks/usePreventScreenCapture.ts";
+import { isConnectedSelector } from "../../../../connectivity/store/selectors";
 import { identificationRequest } from "../../../../identification/store/actions";
+import { offlineAccessReasonSelector } from "../../../../ingress/store/selectors";
 import { trackCredentialRenewStart } from "../../../analytics";
 import { getMixPanelCredential } from "../../../analytics/utils";
 import { CREDENTIAL_STATUS_MAP } from "../../../analytics/utils/types.ts";
@@ -176,6 +178,9 @@ export const ItwPresentationCredentialDetail = ({
   const itwFeaturesEnabled = useIOSelector(itwLifecycleIsITWalletValidSelector);
   const isL3Credential = useIOSelector(itwLifecycleIsITWalletValidSelector);
   const isProximityEnabled = useIOSelector(isItwProximityEnabledSelector);
+  const isConnected = useIOSelector(isConnectedSelector);
+  const offlineAccessReason = useIOSelector(offlineAccessReasonSelector);
+  const isOffline = offlineAccessReason !== undefined || !isConnected;
   const { status = "valid" } = useIOSelector(state =>
     itwCredentialStatusSelector(state, credential.credentialType)
   );
@@ -265,7 +270,7 @@ export const ItwPresentationCredentialDetail = ({
       };
     }
 
-    if (isProximityEnabled && isPresentableCredential) {
+    if ((isProximityEnabled || isOffline) && isPresentableCredential) {
       return {
         label: I18n.t("features.itWallet.presentation.ctas.present"),
         icon: "productITWallet",
@@ -308,6 +313,7 @@ export const ItwPresentationCredentialDetail = ({
     isL3Credential,
     isPresentableCredential,
     isProximityEnabled,
+    isOffline,
     contentClaim,
     navigation,
     mixPanelCredential,

--- a/apps/main-app/ts/features/itwallet/wallet/screens/ItwOfflineWalletScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/wallet/screens/ItwOfflineWalletScreen.tsx
@@ -2,9 +2,16 @@ import { HeaderFirstLevel } from "@io-app/design-system";
 import I18n from "i18next";
 import { useEffect } from "react";
 
-import { IOScrollView } from "../../../../components/ui/IOScrollView";
+import {
+  IOScrollView,
+  IOScrollViewActions
+} from "../../../../components/ui/IOScrollView";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList.ts";
+import { useIOSelector } from "../../../../store/hooks";
 import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
+import { trackItwProximityShowQrCode } from "../../presentation/proximity/analytics";
+import { ITW_PROXIMITY_ROUTES } from "../../presentation/proximity/navigation/routes";
+import { hasPresentableCredentialsSelector } from "../../presentation/proximity/store/selectors/credentials";
 import { trackItwOfflineWallet } from "../analytics";
 import { ItwOfflineAccessGate } from "../components/ItwOfflineAccessGate.tsx";
 import { ItwWalletCardsContainer } from "../components/ItwWalletCardsContainer";
@@ -24,6 +31,30 @@ const OfflineWalletScreenContent = () => {
     });
   }, [navigation]);
 
+  const hasPresentableCredentials = useIOSelector(
+    hasPresentableCredentialsSelector
+  );
+  const proximityActionProps: IOScrollViewActions["primary"] | undefined =
+    hasPresentableCredentials
+      ? {
+          label: I18n.t("features.itWallet.presentation.ctas.present"),
+          icon: "productITWallet",
+          iconPosition: "end",
+          onPress: () => {
+            trackItwProximityShowQrCode({
+              credential: "general",
+              position: "WALLET_HOME"
+            });
+            navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
+              screen: ITW_PROXIMITY_ROUTES.PRESENTMENT,
+              params: {
+                source: "WALLET_HOME"
+              }
+            });
+          }
+        }
+      : undefined;
+
   return (
     <>
       <HeaderFirstLevel
@@ -31,7 +62,14 @@ const OfflineWalletScreenContent = () => {
         ignoreSafeAreaMargin={true}
         title={I18n.t("wallet.wallet")}
       />
-      <IOScrollView excludeSafeAreaMargins={true}>
+      <IOScrollView
+        actions={
+          proximityActionProps
+            ? { type: "SingleButton", primary: proximityActionProps }
+            : undefined
+        }
+        excludeSafeAreaMargins={true}
+      >
         <ItwWalletCardsContainer />
       </IOScrollView>
     </>

--- a/apps/main-app/ts/navigation/OfflineStackNavigator.tsx
+++ b/apps/main-app/ts/navigation/OfflineStackNavigator.tsx
@@ -1,8 +1,13 @@
-import { createStackNavigator } from "@react-navigation/stack";
+import {
+  createStackNavigator,
+  TransitionPresets
+} from "@react-navigation/stack";
 
 import { OfflineFailureScreen } from "../components/error/OfflineFailure";
 import { ItwStackNavigator } from "../features/itwallet/navigation/ItwStackNavigator";
 import { ITW_ROUTES } from "../features/itwallet/navigation/routes";
+import { ItwProximityStackNavigator } from "../features/itwallet/presentation/proximity/navigation/ItwProximityStackNavigator";
+import { ITW_PROXIMITY_ROUTES } from "../features/itwallet/presentation/proximity/navigation/routes";
 import { isGestureEnabled } from "../utils/navigation";
 import { AppParamsList } from "./params/AppParamsList";
 import ROUTES from "./routes";
@@ -21,6 +26,16 @@ const OfflineStackNavigator = () => (
       component={ItwStackNavigator}
       name={ITW_ROUTES.MAIN}
       options={{ gestureEnabled: isGestureEnabled, headerShown: false }}
+    />
+
+    <Stack.Screen
+      component={ItwProximityStackNavigator}
+      name={ITW_PROXIMITY_ROUTES.MAIN}
+      options={{
+        ...TransitionPresets.ModalSlideFromBottomIOS,
+        gestureEnabled: isGestureEnabled,
+        headerShown: false
+      }}
     />
 
     <Stack.Screen


### PR DESCRIPTION
## Short description

This PR adds offline support for proximity presentation.
## Changes proposed in this pull request

- Added proximity presentation to the offline navigation stack.
- Added a CTA to `ItwOfflineWalletScreen`, ensuring that the “Mostra il codice QR” button is always visible when a credential can be presented.
- Added an `isOffline` check to the credential details screen so that the “Mostra il codice QR” button is also available there.
## How to test
1. Make sure you have a presentable credential, such as an mDL.
2. Go offline.
3. Open both the Wallet screen and the credential details screen  and verify that the “Mostra il codice QR” button is visible and that tapping it navigates to the correct screen.