### PR TITLE
fix: [IEL-715] prevented double FCI_POLL_FILLED_DOCUMENT_FAILURE tracking on MP

### DIFF
--- a/apps/main-app/ts/features/fci/saga/networking/handleCreateFilledDocument.ts
+++ b/apps/main-app/ts/features/fci/saga/networking/handleCreateFilledDocument.ts
@@ -22,7 +22,7 @@ import {
   fciLoadQtspFilledDocument,
   fciPollFilledDocument
 } from "../../store/actions";
-import { fciPollFilledDocumentReadySelector } from "../../store/reducers/fciPollFilledDocument";
+import { fciPollFilledDocumentSettledSelector } from "../../store/reducers/fciPollFilledDocument";
 
 // Polling frequency timeout
 const POLLING_FREQ_TIMEOUT = 2000 as Millisecond;
@@ -120,10 +120,13 @@ export function* watchFciPollSaga(
       yield* put(fciPollFilledDocument.cancel());
     } finally {
       if (yield* cancelled()) {
-        const isFilledDocumentReady: ReturnType<
-          typeof fciPollFilledDocumentReadySelector
-        > = yield* select(fciPollFilledDocumentReadySelector);
-        if (!isFilledDocumentReady) {
+        // isSettled checks if the document is ready AND if there's already an
+        // error we are aware of, so we dont double track it (as it is already
+        // tracked in the catch block above)
+        const isSettled: ReturnType<
+          typeof fciPollFilledDocumentSettledSelector
+        > = yield* select(fciPollFilledDocumentSettledSelector);
+        if (!isSettled) {
           yield* put(
             fciPollFilledDocument.failure(
               getNetworkError(new Error("Polling cancelled"))

--- a/apps/main-app/ts/features/fci/store/reducers/fciPollFilledDocument.ts
+++ b/apps/main-app/ts/features/fci/store/reducers/fciPollFilledDocument.ts
@@ -49,4 +49,10 @@ export const fciPollFilledDocumentErrorSelector = createSelector(
     pot.isError(pollFilledDocument) ? pollFilledDocument.error : undefined
 );
 
+export const fciPollFilledDocumentSettledSelector = createSelector(
+  fciPollFilledDocumentReadySelector,
+  fciPollFilledDocumentErrorSelector,
+  (isReady, error) => isReady || error !== undefined
+);
+
 export default reducer;


### PR DESCRIPTION
## Short description
This PR fixes a bug in the FCI filled-document polling saga (`watchFciPollSaga`) where a real network/API failure could be tracked twice: once for the actual error, and a second time by the `finally` block, as it was checking only for a document state if ready or not without considering if it got a failure already recorded in the `catch` block

## List of changes proposed in this pull request
-  added `fciPollFilledDocumentSettledSelector`, checks for document ready state and errors
- updated `watchFciPollSaga` to use the new selector to track only previously untracked errors.

## How to test
Run the app with dev server and start a FCI signing flow:
- force a network error to check that the error is tracked only once by the `catch` block, for example in proxyman set the following rule `*/sign/v1/qtsp/clauses/filled_document` with body 
```
HTTP/1.1 201 Created
Content-Type: application/json; charset=utf-8

{"filled_document_url":"http:\\any.unreachable.host"}
```
- rename the file of the dev server assets/fci/pdf/template.pdf to anything else ( not refactoring ) and this will cause the max polling retries with a `final` block failure
