### PR TITLE
chore(IT-Wallet): [SIW-4713] Add accessibility labels for QR code proximity component

### DIFF
--- a/apps/main-app/locales/it/index.json
+++ b/apps/main-app/locales/it/index.json
@@ -2088,6 +2088,7 @@
               "or": "oppure"
             },
             "qrCode": {
+              "accessibilityLabel": "Immagine del codice QR da mostrare a chi verifica i documenti digitali",
               "error": "Abbiamo avuto un problema nel generare il QR Code."
             },
             "title": "Avvia una verifica"

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/components/ItwProximityQrCodeImage.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/components/ItwProximityQrCodeImage.tsx
@@ -105,7 +105,14 @@ export const ItwProximityQrCodeImage = ({ source }: Props) => {
   }
 
   return (
-    <Animated.View entering={FadeIn.duration(200)}>
+    <Animated.View
+      accessibilityLabel={I18n.t(
+        "features.itWallet.presentation.proximity.engagement.qrCode.accessibilityLabel"
+      )}
+      accessibilityRole="image"
+      accessible={true}
+      entering={FadeIn.duration(200)}
+    >
       <QRCode
         color={theme["textBody-default"]}
         errorCorrectionLevel="H"

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityQrCodeScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityQrCodeScreen.test.tsx
@@ -50,15 +50,20 @@ describe("ItwProximityPresentmentScreen", () => {
   });
 
   it("should render QR code when ready", () => {
+    const component = renderComponent(
+      {
+        machineState: "displayQrCode",
+        qrCodeString: "mock-qr-code-string"
+      },
+      { source: "WALLET_HOME" }
+    );
+
     expect(
-      renderComponent(
-        {
-          machineState: "displayQrCode",
-          qrCodeString: "mock-qr-code-string"
-        },
-        { source: "WALLET_HOME" }
+      component.getByLabelText(
+        "Immagine del codice QR da mostrare a chi verifica i documenti digitali"
       )
-    ).toMatchSnapshot();
+    ).toBeTruthy();
+    expect(component).toMatchSnapshot();
   });
 
   it("should render error state when QR code generation fails", () => {

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/__snapshots__/ItwProximityQrCodeScreen.test.tsx.snap
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/__snapshots__/ItwProximityQrCodeScreen.test.tsx.snap
@@ -667,6 +667,9 @@ exports[`ItwProximityPresentmentScreen should render QR code when ready 1`] = `
                                 </Text>
                               </View>
                               <View
+                                accessibilityLabel="Immagine del codice QR da mostrare a chi verifica i documenti digitali"
+                                accessibilityRole="image"
+                                accessible={true}
                                 collapsable={false}
                                 entering={
                                   FadeIn {
@@ -6982,6 +6985,9 @@ exports[`ItwProximityPresentmentScreen when credentials are expired should rende
                                 </Text>
                               </View>
                               <View
+                                accessibilityLabel="Immagine del codice QR da mostrare a chi verifica i documenti digitali"
+                                accessibilityRole="image"
+                                accessible={true}
                                 collapsable={false}
                                 entering={
                                   FadeIn {


### PR DESCRIPTION
## Short description
This PR adds accessibility support to the proximity presentation QR code.

## List of changes proposed in this pull request
- Added accessibility properties to the QRCode view
- Improved the unit tests
- Added the Italian translation
## How to test
1. Open the proximity presentation QR code
2. Using TalkBack or VoiceOver, verify that the QR code is focusable and has the following accessibility label: "Immagine del codice QR da mostrare a chi verifica i documenti digitali"