### PR TITLE
feat(IT-Wallet): [SIW-4493] Fix CTA presentation screen

### DIFF
--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwProximityFailureScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwProximityFailureScreen.tsx
@@ -1,4 +1,4 @@
-import { Body, VSpacer } from "@io-app/design-system";
+import { Body, FooterActions, VSpacer } from "@io-app/design-system";
 import I18n from "i18next";
 
 import {
@@ -7,8 +7,11 @@ import {
 } from "../../../../../components/screens/OperationResultScreenContent.tsx";
 import { useDebugInfo } from "../../../../../hooks/useDebugInfo.ts";
 import { useIOSelector } from "../../../../../store/hooks.ts";
+import { generateDynamicUrlSelector } from "../../../../../store/reducers/backendStatus/remoteConfig.ts";
+import { DOCUMENTS_ON_IO_FAQ_12_URL_BODY } from "../../../../../urls.ts";
 import { isDefined } from "../../../../../utils/guards.ts";
 import { useIOBottomSheetModal } from "../../../../../utils/hooks/bottomSheet.tsx";
+import { openWebUrl } from "../../../../../utils/url.ts";
 import { useAvoidHardwareBackButton } from "../../../../../utils/useAvoidHardwareBackButton.ts";
 import { useItwDisableGestureNavigation } from "../../../common/hooks/useItwDisableGestureNavigation.ts";
 import { serializeFailureReason } from "../../../common/utils/itwStoreUtils.ts";
@@ -36,6 +39,13 @@ const ContentView = ({ failure }: ContentViewProps) => {
   const getCredentialTypeFromDocType = useIOSelector(
     itwCredentialTypeFromDocTypeSelector
   );
+  const faqUrl = useIOSelector(state =>
+    generateDynamicUrlSelector(
+      state,
+      "io_showcase",
+      DOCUMENTS_ON_IO_FAQ_12_URL_BODY
+    )
+  );
 
   useDebugInfo({
     failure: serializeFailureReason(failure)
@@ -56,6 +66,17 @@ const ContentView = ({ failure }: ContentViewProps) => {
     ),
     title: I18n.t(
       "features.itWallet.presentation.proximity.relyingParty.untrustedRp.bottomSheet.title"
+    ),
+    footer: (
+      <FooterActions
+        actions={{
+          type: "SingleButton",
+          primary: {
+            label: I18n.t("global.buttons.findOutMore"),
+            onPress: () => openWebUrl(faqUrl)
+          }
+        }}
+      />
     )
   });
 

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/__snapshots__/ItwProximityFailureScreen.test.tsx.snap
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/__snapshots__/ItwProximityFailureScreen.test.tsx.snap
@@ -833,7 +833,14 @@ L'app può condividere i tuoi dati solo con enti e soggetti autorizzati.
                             <View
                               style={
                                 {
-                                  "height": 0,
+                                  "height": 48,
+                                }
+                              }
+                            />
+                            <View
+                              style={
+                                {
+                                  "height": 48,
                                 }
                               }
                             />
@@ -1727,7 +1734,14 @@ L'app può condividere i tuoi dati solo con enti e soggetti autorizzati.
                             <View
                               style={
                                 {
-                                  "height": 0,
+                                  "height": 48,
+                                }
+                              }
+                            />
+                            <View
+                              style={
+                                {
+                                  "height": 48,
                                 }
                               }
                             />
@@ -2880,7 +2894,14 @@ L'app può condividere i tuoi dati solo con enti e soggetti autorizzati.
                             <View
                               style={
                                 {
-                                  "height": 0,
+                                  "height": 48,
+                                }
+                              }
+                            />
+                            <View
+                              style={
+                                {
+                                  "height": 48,
                                 }
                               }
                             />


### PR DESCRIPTION
## Short description
This PR adds the missing "Scopri di più" CTA to the "Chi può leggere i tuoi dati?" bottom sheet shown on the proximity presentation failure screen, so users who cannot complete the document verification can reach the related FAQ.

## List of changes proposed in this pull request
- Added a `FooterActions` footer with a "Scopri di più" button to the untrusted RP bottom sheet in `ItwProximityFailureScreen`
- The CTA opens the "Documenti su IO" FAQ, resolved via `generateDynamicUrlSelector` with the existing `DOCUMENTS_ON_IO_FAQ_12_URL_BODY`
- Reused the existing `global.buttons.findOutMore` i18n key, so no new copy is required
- Updated the `ItwProximityFailureScreen` snapshots (the bottom sheet adds bottom spacing when a footer is present)

## How to test
1. Enable the `ITW_PROXIMITY_FAILURE` debug scenario (or trigger a proximity presentation with an untrusted relying party)
2. On the "Non è possibile verificare il documento" screen, tap the secondary action "Cosa significa?"
3. The "Chi può leggere i tuoi dati?" bottom sheet opens: verify the "Scopri di più" button is visible and pinned to the bottom
4. Tap "Scopri di più" and verify the FAQ page opens in the browser
5. Verify the other failure types (generic error, timeout, unexpected) still render correctly and are unaffected