### PR TITLE
fix(IT-Wallet): [SIW-4773] Credential issuance intro back navigation from a presentation failure

### DIFF
--- a/apps/main-app/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialIntroductionScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/issuance/screens/ItwIssuanceCredentialIntroductionScreen.tsx
@@ -57,8 +57,7 @@ export const ItwIssuanceCredentialIntroductionScreen = (props: ScreenProps) => {
   );
 
   useHeaderSecondLevel({
-    title: "",
-    goBack: () => machineRef.send({ type: "back" })
+    title: ""
   });
 
   // Send the requested credential type to the machine when the issuance flow

--- a/apps/main-app/ts/features/itwallet/machine/credential/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/credential/__tests__/machine.test.ts
@@ -830,6 +830,29 @@ describe("itwCredentialIssuanceMachine", () => {
     expect(navigateToCredentialIntroductionScreen).toHaveBeenCalledTimes(1);
   });
 
+  it("should clear the selected credential when leaving the introduction screen", async () => {
+    hasValidWalletInstanceAttestation.mockImplementation(() => true);
+    hasCredentialIntroContent.mockImplementation(() => true);
+
+    const actor = createActor(mockedMachine);
+    actor.start();
+    actor.send({
+      type: "select-credential",
+      credentialType: "education_degree",
+      mode: "issuance"
+    });
+
+    await waitForActor(actor, snapshot =>
+      snapshot.matches("CredentialIntroduction")
+    );
+
+    actor.send({ type: "back" });
+
+    expect(actor.getSnapshot().value).toStrictEqual("Idle");
+    expect(actor.getSnapshot().context.credentialType).toBeUndefined();
+    expect(navigateToCardOnboardingScreen).not.toHaveBeenCalled();
+  });
+
   describe("Credential Offer flow", () => {
     it("Should process a credential offer and populate the resolved offer in context", async () => {
       processCredentialOffer.mockImplementation(() =>

--- a/apps/main-app/ts/features/itwallet/machine/credential/machine.ts
+++ b/apps/main-app/ts/features/itwallet/machine/credential/machine.ts
@@ -248,10 +248,7 @@ export const itwCredentialIssuanceMachine = setup({
         },
         back: {
           target: "Idle",
-          actions: [
-            assign({ credentialType: undefined }),
-            "navigateToCardOnboardingScreen"
-          ]
+          actions: [assign({ credentialType: undefined })]
         }
       }
     },


### PR DESCRIPTION
## Short description
Fix credential issuance introduction back navigation so native navigation returns to credential onboarding without duplicate navigation.

## List of changes proposed in this pull request
- Remove the custom back handler from the credential introduction screen.
- Reset the selected credential when leaving the introduction state without navigating to onboarding from the machine action.
- Add regression coverage for the credential reset behavior.

## How to test

### Issuance from onboarding screen

1. Open Wallet > IT Wallet credential onboarding.
2. Select an available credential and open its credential introduction screen.
3. Use header/system back. Verify return to onboarding once, with no blank screen or duplicate navigation.
4. Start the same credential addition again, continue from the introduction screen, and verify issuance proceeds.

### Issuance from proximity "missing credential" failure screen

1. Start proximity presentation with a request for a credential absent from the wallet. 
2. Verify the missing-credential failure screen appears.
3. Tap the add-credential action.
4. Once the credential intro appears, tap on header/system back.
5. Verify return to the wallet.