### PR TITLE
refactor: [IOPID-4102] migrate lollipop publicKey from Option to native type

### DIFF
--- a/apps/main-app/ts/features/lollipop/__tests__/login.test.ts
+++ b/apps/main-app/ts/features/lollipop/__tests__/login.test.ts
@@ -58,7 +58,7 @@ describe(`Test login with lollipop check and store aligned with server`, () => {
   it(`should not put sessionIvalid or call restartCleanApplication`, async () =>
     expectSaga(
       checkLollipopSessionAssertionAndInvalidateIfNeeded,
-      O.some(DATA_FROM_SERVER.publicKeyForAssertionRef),
+      DATA_FROM_SERVER.publicKeyForAssertionRef,
       O.some(DATA_FROM_SERVER.publicSession)
     )
       .provide(mockedFunctions)
@@ -71,7 +71,7 @@ describe(`Test login with both store key and server key undefined`, () => {
   it(`should put sessionIvalid and call restartCleanApplication`, async () =>
     expectSaga(
       checkLollipopSessionAssertionAndInvalidateIfNeeded,
-      O.none,
+      undefined,
       O.none
     )
       .provide(mockedFunctions)
@@ -84,7 +84,7 @@ describe(`Test login with store key and session undefined`, () => {
   it(`should put sessionIvalid and call restartCleanApplication`, async () =>
     expectSaga(
       checkLollipopSessionAssertionAndInvalidateIfNeeded,
-      O.some(DATA_FROM_SERVER.publicKeyForAssertionRef),
+      DATA_FROM_SERVER.publicKeyForAssertionRef,
       O.none
     )
       .provide(mockedFunctions)
@@ -97,7 +97,7 @@ describe(`Test login with store key undefined and session LollipopAssertion unde
   it(`should put sessionIvalid and call restartCleanApplication`, async () =>
     expectSaga(
       checkLollipopSessionAssertionAndInvalidateIfNeeded,
-      O.none,
+      undefined,
       O.some(DATA_FROM_SERVER.publicSessionWithUndefinedKey)
     )
       .provide(mockedFunctions)
@@ -110,7 +110,7 @@ describe(`Test login with lollipop check and store out of alignment with server`
   it(`should put sessionIvalid and call restartCleanApplication(different key)`, async () =>
     expectSaga(
       checkLollipopSessionAssertionAndInvalidateIfNeeded,
-      O.some(DATA_FROM_SERVER.publicKeyForAssertionRef),
+      DATA_FROM_SERVER.publicKeyForAssertionRef,
       O.some(DATA_FROM_SERVER.publicSessionWithFakeKey)
     )
       .provide(mockedFunctions)
@@ -121,7 +121,7 @@ describe(`Test login with lollipop check and store out of alignment with server`
   it(`should put sessionIvalid and call restartCleanApplication(server key undefined)`, async () =>
     expectSaga(
       checkLollipopSessionAssertionAndInvalidateIfNeeded,
-      O.some(DATA_FROM_SERVER.publicKeyForAssertionRef),
+      DATA_FROM_SERVER.publicKeyForAssertionRef,
       O.some(DATA_FROM_SERVER.publicSessionWithUndefinedKey)
     )
       .provide(mockedFunctions)
@@ -132,7 +132,7 @@ describe(`Test login with lollipop check and store out of alignment with server`
   it(`should put sessionIvalid and call restartCleanApplication(store key undefined)`, async () =>
     expectSaga(
       checkLollipopSessionAssertionAndInvalidateIfNeeded,
-      O.none,
+      undefined,
       O.some(DATA_FROM_SERVER.publicSession)
     )
       .provide(mockedFunctions)

--- a/apps/main-app/ts/features/lollipop/navigation/__tests__/index.test.ts
+++ b/apps/main-app/ts/features/lollipop/navigation/__tests__/index.test.ts
@@ -1,0 +1,24 @@
+import { testSaga } from "redux-saga-test-plan";
+
+import { checkPublicKeyAndBlockIfNeeded } from "..";
+import { lollipopSetSupportedDevice } from "../../store/actions/lollipop";
+import { lollipopPublicKeySelector } from "../../store/reducers/lollipop";
+
+describe("checkPublicKeyAndBlockIfNeeded", () => {
+  it("should not block the navigation when publicKey is defined", () => {
+    testSaga(checkPublicKeyAndBlockIfNeeded)
+      .next()
+      .select(lollipopPublicKeySelector)
+      .next({ kty: "EC" } as any)
+      .returns(false);
+  });
+  it("should block the navigation when publicKey is undefined", () => {
+    testSaga(checkPublicKeyAndBlockIfNeeded)
+      .next()
+      .select(lollipopPublicKeySelector)
+      .next(undefined)
+      .put(lollipopSetSupportedDevice(false))
+      .next()
+      .returns(true);
+  });
+});

--- a/apps/main-app/ts/features/lollipop/navigation/index.ts
+++ b/apps/main-app/ts/features/lollipop/navigation/index.ts
@@ -1,4 +1,3 @@
-import * as O from "fp-ts/lib/Option";
 import { put, select } from "typed-redux-saga/macro";
 
 import { lollipopSetSupportedDevice } from "../store/actions/lollipop";
@@ -6,7 +5,7 @@ import { lollipopPublicKeySelector } from "../store/reducers/lollipop";
 
 export function* checkPublicKeyAndBlockIfNeeded() {
   const publicKey = yield* select(lollipopPublicKeySelector);
-  if (O.isNone(publicKey)) {
+  if (publicKey == null) {
     yield* put(lollipopSetSupportedDevice(false));
     return true;
   }

--- a/apps/main-app/ts/features/lollipop/playgrounds/LollipopPlayground.tsx
+++ b/apps/main-app/ts/features/lollipop/playgrounds/LollipopPlayground.tsx
@@ -1,6 +1,5 @@
 import { ContentWrapper } from "@io-app/design-system";
 import * as E from "fp-ts/lib/Either";
-import * as O from "fp-ts/lib/Option";
 import { useCallback, useState } from "react";
 import { ScrollView } from "react-native";
 
@@ -49,13 +48,13 @@ const LollipopPlayground = () => {
       const bodyMessage = {
         message: body
       };
-      if (maybeSessionToken && O.isSome(maybePublicKey) && keyTag != null) {
+      if (maybeSessionToken && maybePublicKey != null && keyTag != null) {
         const { signMessage } = identityClientManager.getClient(apiUrlPrefix, {
           token: maybeSessionToken,
           keyInfo: {
             keyTag,
-            publicKey: maybePublicKey.value,
-            publicKeyThumbprint: toThumbprint(maybePublicKey.value)
+            publicKey: maybePublicKey,
+            publicKeyThumbprint: toThumbprint(maybePublicKey)
           },
           signBody: state.doSignBody
         });

--- a/apps/main-app/ts/features/lollipop/playgrounds/__tests__/LollipopPlayground.test.tsx
+++ b/apps/main-app/ts/features/lollipop/playgrounds/__tests__/LollipopPlayground.test.tsx
@@ -1,7 +1,6 @@
 import { PublicKey } from "@pagopa/io-react-native-crypto";
 import { render, waitFor } from "@testing-library/react-native";
 import * as E from "fp-ts/lib/Either";
-import * as O from "fp-ts/lib/Option";
 
 import { identityClientManager } from "../../../../api/IdentityClientManager";
 import { useIOSelector } from "../../../../store/hooks";
@@ -30,7 +29,6 @@ jest.mock("../LollipopPlaygroundContent", () => ({
   }
 }));
 
-const mockPublicKey = "mockPublicKey" as unknown as PublicKey;
 const mockSignMessage = jest.fn();
 
 jest.spyOn(identityClientManager, "getClient").mockReturnValue({
@@ -39,14 +37,14 @@ jest.spyOn(identityClientManager, "getClient").mockReturnValue({
 
 const selectorValues = (overrides: {
   keyTag?: string;
-  publicKey?: O.Option<PublicKey>;
+  publicKey?: PublicKey;
   sessionToken?: string;
 }) => {
   const keyTag = "keyTag" in overrides ? overrides.keyTag : "mock-key-tag";
   const sessionToken =
     "sessionToken" in overrides ? overrides.sessionToken : "mock-session-token";
-  const { publicKey = O.some(mockPublicKey) } = overrides;
-
+  const publicKey =
+    "publicKey" in overrides ? overrides.publicKey : "mock-public-yey";
   (useIOSelector as jest.Mock).mockImplementation(selector => {
     if (selector === sessionTokenSelector) {
       return sessionToken;
@@ -95,8 +93,8 @@ describe("LollipopPlayground", () => {
     expect(mockSignMessage).not.toHaveBeenCalled();
   });
 
-  it("should not call signMessage when publicKey is None", () => {
-    selectorValues({ publicKey: O.none });
+  it("should not call signMessage when publicKey is undefined", () => {
+    selectorValues({ publicKey: undefined });
     render(<LollipopPlayground />);
 
     capturedOnSignButtonPress?.("body");

--- a/apps/main-app/ts/features/lollipop/saga/__tests__/index.test.ts
+++ b/apps/main-app/ts/features/lollipop/saga/__tests__/index.test.ts
@@ -1,5 +1,4 @@
 import { getPublicKey, PublicKey } from "@pagopa/io-react-native-crypto";
-import * as O from "fp-ts/lib/Option";
 import { testSaga } from "redux-saga-test-plan";
 
 import {
@@ -31,8 +30,8 @@ jest.mock("../../utils/crypto", () => ({
 }));
 
 describe("generateKeyInfo", () => {
-  it("should return a full KeyInfo when both keyTag is defined and publicKey is Some", () => {
-    const result = generateKeyInfo("keyTag", O.some(mockPublicKey));
+  it("should return a full KeyInfo when both keyTag and publicKey are defined", () => {
+    const result = generateKeyInfo("keyTag", mockPublicKey);
     expect(result).toEqual({
       keyTag: "keyTag",
       publicKey: mockPublicKey,
@@ -41,7 +40,7 @@ describe("generateKeyInfo", () => {
   });
 
   it("should return an empty KeyInfo when keyTag is undefined", () => {
-    const result = generateKeyInfo(undefined, O.some(mockPublicKey));
+    const result = generateKeyInfo(undefined, mockPublicKey);
     expect(result).toEqual({
       keyTag: undefined,
       publicKey: undefined,
@@ -49,8 +48,8 @@ describe("generateKeyInfo", () => {
     });
   });
 
-  it("should return an empty KeyInfo when publicKey is None", () => {
-    const result = generateKeyInfo("keyTag", O.none);
+  it("should return an empty KeyInfo when publicKey is undefined", () => {
+    const result = generateKeyInfo("keyTag", undefined);
     expect(result).toEqual({
       keyTag: undefined,
       publicKey: undefined,
@@ -72,8 +71,8 @@ describe("getKeyInfo", () => {
       .select(lollipopKeyTagSelector)
       .next("keyTag")
       .select(lollipopPublicKeySelector)
-      .next(O.some(mockPublicKey))
-      .call(generateKeyInfo, "keyTag", O.some(mockPublicKey))
+      .next(mockPublicKey)
+      .call(generateKeyInfo, "keyTag", mockPublicKey)
       .next(keyInfo)
       .returns(keyInfo);
   });

--- a/apps/main-app/ts/features/lollipop/saga/index.ts
+++ b/apps/main-app/ts/features/lollipop/saga/index.ts
@@ -45,26 +45,26 @@ export function* checkLollipopSessionAssertionAndInvalidateIfNeeded(
   publicKey: PublicKey | undefined,
   maybeSessionInformation: O.Option<PublicSession>
 ) {
-  const lollipopCheckResult =
-    O.isSome(maybeSessionInformation) && publicKey != null
-      ? `${DEFAULT_LOLLIPOP_HASH_ALGORITHM_SERVER}-${toBase64EncodedThumbprint(publicKey)}` ===
-        maybeSessionInformation.value.lollipopAssertionRef
-      : false;
-
-  if (!lollipopCheckResult) {
-    void mixpanelTrack(
-      "LOGIN_UNEXPECTED_REQUEST_ID",
-      buildEventProperties("KO", undefined)
-    );
-    yield* put(sessionInvalid());
-    // We want to take a little time before restarting the application
-    // to let the action sessionInvalid be dispatched and handled.
-    yield* delay(WAIT_A_BIT_AFTER_SESSION_EXPIRED);
-    yield* call(restartCleanApplication);
-    return false;
+  if (O.isSome(maybeSessionInformation) && publicKey) {
+    const publicKeyThumbprint = toBase64EncodedThumbprint(publicKey);
+    const localAssertionRef = `${DEFAULT_LOLLIPOP_HASH_ALGORITHM_SERVER}-${publicKeyThumbprint}`;
+    const areTheSame =
+      localAssertionRef === maybeSessionInformation.value.lollipopAssertionRef;
+    if (areTheSame) {
+      return true;
+    }
   }
 
-  return true;
+  void mixpanelTrack(
+    "LOGIN_UNEXPECTED_REQUEST_ID",
+    buildEventProperties("KO", undefined)
+  );
+  yield* put(sessionInvalid());
+  // We want to take a little time before restarting the application
+  // to let the action sessionInvalid be dispatched and handled.
+  yield* delay(WAIT_A_BIT_AFTER_SESSION_EXPIRED);
+  yield* call(restartCleanApplication);
+  return false;
 }
 
 export function* deleteCurrentLollipopKeyAndGenerateNewKeyTag() {

--- a/apps/main-app/ts/features/lollipop/saga/index.ts
+++ b/apps/main-app/ts/features/lollipop/saga/index.ts
@@ -203,16 +203,12 @@ function* generateCryptoKeyPair(keyTag: string) {
 
 export const generateKeyInfo = (
   keyTag: string | undefined,
-  maybePublicKey: O.Option<PublicKey>
+  maybePublicKey: PublicKey | undefined
 ) => {
-  if (!keyTag) {
+  if (!keyTag || maybePublicKey == null) {
     return defaultKeyInfo();
   }
-  return pipe(
-    maybePublicKey,
-    O.map(publicKey => keyInfoFromKeyTagAndPublicKey(keyTag, publicKey)),
-    O.getOrElse(defaultKeyInfo)
-  );
+  return keyInfoFromKeyTagAndPublicKey(keyTag, maybePublicKey);
 };
 
 const keyInfoFromKeyTagAndPublicKey = (

--- a/apps/main-app/ts/features/lollipop/saga/index.ts
+++ b/apps/main-app/ts/features/lollipop/saga/index.ts
@@ -48,9 +48,9 @@ export function* checkLollipopSessionAssertionAndInvalidateIfNeeded(
   if (O.isSome(maybeSessionInformation) && publicKey) {
     const publicKeyThumbprint = toBase64EncodedThumbprint(publicKey);
     const localAssertionRef = `${DEFAULT_LOLLIPOP_HASH_ALGORITHM_SERVER}-${publicKeyThumbprint}`;
-    const areTheSame =
+    const doesLocalAssertionRefMatchSession =
       localAssertionRef === maybeSessionInformation.value.lollipopAssertionRef;
-    if (areTheSame) {
+    if (doesLocalAssertionRefMatchSession) {
       return true;
     }
   }

--- a/apps/main-app/ts/features/lollipop/saga/index.ts
+++ b/apps/main-app/ts/features/lollipop/saga/index.ts
@@ -42,30 +42,14 @@ import { DEFAULT_LOLLIPOP_HASH_ALGORITHM_SERVER } from "../utils/login";
 const WAIT_A_BIT_AFTER_SESSION_EXPIRED = 1000 as Millisecond;
 
 export function* checkLollipopSessionAssertionAndInvalidateIfNeeded(
-  maybePublicKey: O.Option<PublicKey>,
+  publicKey: PublicKey | undefined,
   maybeSessionInformation: O.Option<PublicSession>
 ) {
-  const lollipopCheckResult = pipe(
-    maybeSessionInformation,
-    O.chainNullableK(
-      sessionInformation => sessionInformation.lollipopAssertionRef
-    ),
-    O.chain(sessionLollipopAssertionRef =>
-      pipe(
-        maybePublicKey,
-        O.map(publicKey =>
-          pipe(
-            toBase64EncodedThumbprint(publicKey),
-            publicKeyThumbprint =>
-              `${DEFAULT_LOLLIPOP_HASH_ALGORITHM_SERVER}-${publicKeyThumbprint}`,
-            localLollipopAssertionRef =>
-              localLollipopAssertionRef === sessionLollipopAssertionRef
-          )
-        )
-      )
-    ),
-    O.getOrElse(() => false)
-  );
+  const lollipopCheckResult =
+    O.isSome(maybeSessionInformation) && publicKey != null
+      ? `${DEFAULT_LOLLIPOP_HASH_ALGORITHM_SERVER}-${toBase64EncodedThumbprint(publicKey)}` ===
+        maybeSessionInformation.value.lollipopAssertionRef
+      : false;
 
   if (!lollipopCheckResult) {
     void mixpanelTrack(

--- a/apps/main-app/ts/features/lollipop/store/reducers/__tests__/lollipop.test.ts
+++ b/apps/main-app/ts/features/lollipop/store/reducers/__tests__/lollipop.test.ts
@@ -1,5 +1,4 @@
 import { PublicKey } from "@pagopa/io-react-native-crypto";
-import * as O from "fp-ts/lib/Option";
 
 import { applicationChangeState } from "../../../../../store/actions/application";
 import { appReducer } from "../../../../../store/reducers";
@@ -40,9 +39,7 @@ describe("Lollipop state", () => {
       lollipopState,
       lollipopSetPublicKey({ publicKey: publicKey.publicKey })
     );
-    expect(newLollipopState.publicKey).toStrictEqual(
-      O.some(publicKey.publicKey)
-    );
+    expect(newLollipopState.publicKey).toStrictEqual(publicKey.publicKey);
   });
 
   it("should handle lollipopRemovePublicKey action", () => {
@@ -55,7 +52,7 @@ describe("Lollipop state", () => {
       stateWithPublicKey,
       lollipopRemovePublicKey()
     );
-    expect(newLollipopState.publicKey).toBe(O.none);
+    expect(newLollipopState.publicKey).toBe(undefined);
   });
 
   it("should handle lollipopSetEphemeralPublicKey action", () => {

--- a/apps/main-app/ts/features/lollipop/store/reducers/lollipop.ts
+++ b/apps/main-app/ts/features/lollipop/store/reducers/lollipop.ts
@@ -2,7 +2,6 @@ import { PublicKey } from "@pagopa/io-react-native-crypto";
 /**
  * A reducer for lollipop.
  */
-import * as O from "fp-ts/lib/Option";
 import { createSelector } from "reselect";
 import { getType } from "typesafe-actions";
 import { v4 as uuid } from "uuid";
@@ -40,7 +39,7 @@ const ephemeralInitialState = () => ({
 
 export type InMemoryLollipopData = {
   ephemeralKey: EphemeralKey;
-  publicKey: O.Option<PublicKey>;
+  publicKey: PublicKey | undefined;
   supportedDevice: boolean;
 };
 export type LollipopState = InMemoryLollipopData & PersistedLollipopData;
@@ -51,7 +50,7 @@ export type PersistedLollipopData = {
 
 export const initialLollipopState: LollipopState = {
   keyTag: undefined,
-  publicKey: O.none,
+  publicKey: undefined,
   supportedDevice: true,
   ephemeralKey: ephemeralInitialState()
 };
@@ -82,7 +81,7 @@ export default function lollipopReducer(
       return {
         ...state,
         keyTag: state.ephemeralKey.ephemeralKeyTag,
-        publicKey: O.fromNullable(state.ephemeralKey.ephemeralPublicKey),
+        publicKey: state.ephemeralKey.ephemeralPublicKey,
         ephemeralKey: ephemeralInitialState()
       };
     case getType(lollipopKeyTagSave):
@@ -93,7 +92,7 @@ export default function lollipopReducer(
     case getType(lollipopRemovePublicKey):
       return {
         ...state,
-        publicKey: O.none
+        publicKey: undefined
       };
     case getType(lollipopSetEphemeralPublicKey):
       return {
@@ -106,7 +105,7 @@ export default function lollipopReducer(
     case getType(lollipopSetPublicKey):
       return {
         ...state,
-        publicKey: O.some(action.payload.publicKey)
+        publicKey: action.payload.publicKey
       };
     case getType(lollipopSetSupportedDevice):
       return {

--- a/apps/main-app/ts/features/settings/devMode/components/DeveloperModeSection.tsx
+++ b/apps/main-app/ts/features/settings/devMode/components/DeveloperModeSection.tsx
@@ -14,7 +14,6 @@ import {
   VSpacer
 } from "@io-app/design-system";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import * as O from "fp-ts/lib/Option";
 import I18n from "i18next";
 import { ComponentProps, useContext } from "react";
 import { Alert, FlatList, ListRenderItemInfo } from "react-native";
@@ -208,8 +207,7 @@ const DeveloperDataSection = () => {
   const publicKey = useIOSelector(lollipopPublicKeySelector);
   const deviceUniqueId = getDeviceId();
 
-  const publicKeyValue = O.toUndefined(publicKey);
-  const thumbprint = toThumbprint(publicKeyValue);
+  const thumbprint = toThumbprint(publicKey);
 
   const devDataCopyListItems: ReadonlyArray<DevDataCopyListItem> = [
     {

--- a/apps/main-app/ts/features/settings/devMode/components/__test__/DeveloperModeSection.test.tsx
+++ b/apps/main-app/ts/features/settings/devMode/components/__test__/DeveloperModeSection.test.tsx
@@ -1,0 +1,50 @@
+import { PublicKey } from "@pagopa/io-react-native-crypto";
+import { createStore } from "redux";
+
+import { applicationChangeState } from "../../../../../store/actions/application";
+import { setDebugModeEnabled } from "../../../../../store/actions/debug";
+import { appReducer } from "../../../../../store/reducers";
+import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
+import {
+  lollipopRemovePublicKey,
+  lollipopSetPublicKey
+} from "../../../../lollipop/store/actions/lollipop";
+import DeveloperModeSection from "../DeveloperModeSection";
+
+const mockPublicKey: PublicKey = {
+  kty: "EC",
+  crv: "P-256",
+  x: "mock-x",
+  y: "mock-y"
+};
+
+const renderComponent = (publicKey: PublicKey | undefined) => {
+  const globalState = appReducer(undefined, applicationChangeState("active"));
+  const store = createStore(appReducer, globalState as any);
+  store.dispatch(setDebugModeEnabled(true));
+  store.dispatch(
+    publicKey != null
+      ? lollipopSetPublicKey({ publicKey })
+      : lollipopRemovePublicKey()
+  );
+  return renderScreenWithNavigationStoreContext(
+    DeveloperModeSection,
+    "DEVELOPER_MODE_SECTION",
+    {},
+    store
+  );
+};
+
+describe("DeveloperModeSection", () => {
+  it("should show the Thumbprint item when publicKey is defined", () => {
+    const component = renderComponent(mockPublicKey);
+
+    expect(component.getByText("Thumbprint")).toBeTruthy();
+  });
+
+  it("should not show the Thumbprint item when publicKey is undefined", () => {
+    const component = renderComponent(undefined);
+
+    expect(component.queryByText("Thumbprint")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Short description
Migrates the lollipop `publicKey` from `O.Option<PublicKey>` (fp-ts) to a native `PublicKey | undefined` type across store, saga, navigation, playground and dev-mode section.

## List of changes proposed in this pull request
- `store/reducers/lollipop.ts`: `publicKey` state changed from `O.Option<PublicKey>` to `PublicKey | undefined`
- `saga/index.ts`: `generateKeyInfo`, `getKeyInfo` and `checkLollipopSessionAssertionAndInvalidateIfNeeded` adapted to the native type
- `navigation/index.ts`: `checkPublicKeyAndBlockIfNeeded` adapted to the native type
- `playgrounds/LollipopPlayground.tsx`: adapted to the native type
- `settings/devMode/components/DeveloperModeSection.tsx`: removed unneeded `O.toUndefined` conversion
- Updated/added tests for all the above

## How to test
- Run `pnpm nx affected --target=lint,tsc-noemit` and the lollipop/dev-mode test suites — all green
- Log in and verify the lollipop key generation/session-assertion flow still works as expected
- Open Developer Mode section (debug mode enabled) and verify the Thumbprint item shows/hides correctly based on the public key
