### PR TITLE
fix(IT-Wallet): [SIW-000]: Unmounting CIE gif on focus loss

### DIFF
--- a/apps/main-app/ts/features/itwallet/identification/cie/components/ItwCiePreparationScreenContent.tsx
+++ b/apps/main-app/ts/features/itwallet/identification/cie/components/ItwCiePreparationScreenContent.tsx
@@ -1,4 +1,5 @@
 import { ContentWrapper, VStack } from "@io-app/design-system";
+import { useIsFocused } from "@react-navigation/core";
 import { PropsWithChildren } from "react";
 import {
   Dimensions,
@@ -26,29 +27,41 @@ export const ItwCiePreparationScreenContent = ({
   actions,
   children,
   goBack
-}: PropsWithChildren<Props>) => (
-  <IOScrollViewWithLargeHeader
-    actions={actions}
-    description={description}
-    goBack={goBack}
-    headerActionsProp={{ showHelp: true }}
-    title={{ label: title }}
-  >
-    <ContentWrapper>
-      <VStack space={16}>
-        {children}
-        <View style={styles.imageContainer}>
-          <Image
-            accessibilityIgnoresInvertColors
-            resizeMode="contain"
-            source={imageSrc}
-            style={styles.image}
-          />
-        </View>
-      </VStack>
-    </ContentWrapper>
-  </IOScrollViewWithLargeHeader>
-);
+}: PropsWithChildren<Props>) => {
+  // The image source can be an animated GIF. Since native GIF playback isn't
+  // driven by React re-renders, the animation keeps running as long as the
+  // `Image` view stays mounted, which is still the case when this screen is
+  // pushed to the back stack after navigating forward. Unmounting the image
+  // while the screen isn't focused stops the animation instead of letting it
+  // run indefinitely in the background.
+  const isFocused = useIsFocused();
+
+  return (
+    <IOScrollViewWithLargeHeader
+      actions={actions}
+      description={description}
+      goBack={goBack}
+      headerActionsProp={{ showHelp: true }}
+      title={{ label: title }}
+    >
+      <ContentWrapper>
+        <VStack space={16}>
+          {children}
+          <View style={styles.imageContainer}>
+            {isFocused && (
+              <Image
+                accessibilityIgnoresInvertColors
+                resizeMode="contain"
+                source={imageSrc}
+                style={styles.image}
+              />
+            )}
+          </View>
+        </VStack>
+      </ContentWrapper>
+    </IOScrollViewWithLargeHeader>
+  );
+};
 
 const screenHeight = Dimensions.get("window").height;
 


### PR DESCRIPTION
## Short description
This pull request updates the `ItwCiePreparationScreenContent` component to optimize image animation handling, specifically for animated GIFs. The main improvement is that the image is now only rendered when the screen is focused, preventing unnecessary background animation and resource usage.

## List of changes proposed in this pull request
- Add `Image` render condition with `useIsFocused`, ensuring that animated GIFs do not continue running in the background.

## How to test
Enable the `Perf Monitor` tool and check `RAM` values 


## Preview

| Master | SIW-000 |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/639448bb-8841-47b7-8839-4373b55c587e"/> | <video src="https://github.com/user-attachments/assets/84c4764d-4e8e-478c-80e3-d95fb91db2c6"/> | 




