### PR TITLE
feat(IT-Wallet): [SIW-0000] Use UAT CieID app in IT-Wallet pre environment

### DIFF
--- a/apps/main-app/ts/features/itwallet/common/store/selectors/environment.ts
+++ b/apps/main-app/ts/features/itwallet/common/store/selectors/environment.ts
@@ -10,6 +10,17 @@ export const selectItwEnv = (state: GlobalState) =>
   state.features.itWallet.environment.env ?? "prod";
 
 /**
+ * True when the IT-Wallet pre-production environment is selected.
+ *
+ * In this case the CieID app-to-app flow must target the UAT CieID app
+ * (a different Android package name), otherwise the production CieID app
+ * would authenticate against production IdP endpoints, which are not
+ * compatible with the pre-production IT-Wallet ecosystem.
+ */
+export const selectItwIsCieIdUatEnv = (state: GlobalState) =>
+  selectItwEnv(state) === "pre";
+
+/**
  * Select the IT-Wallet specification version depending on the user configuration.
  *
  * The version is derived from the whitelist status and the optional presence of a PID,

--- a/apps/main-app/ts/features/itwallet/identification/cieId/hooks/useCieIdApp.ts
+++ b/apps/main-app/ts/features/itwallet/identification/cieId/hooks/useCieIdApp.ts
@@ -5,6 +5,7 @@ import * as t from "io-ts";
 import { useCallback, useEffect, useState } from "react";
 import { Linking } from "react-native";
 
+import { useIOSelector } from "../../../../../store/hooks";
 import { convertUnknownToError } from "../../../../../utils/errors";
 import { isAndroid, isIos } from "../../../../../utils/platform";
 import {
@@ -13,6 +14,7 @@ import {
   IO_LOGIN_CIE_SOURCE_APP,
   IO_LOGIN_CIE_URL_SCHEME
 } from "../../../../authentication/login/cie/utils/cie";
+import { selectItwIsCieIdUatEnv } from "../../../common/store/selectors/environment";
 import { ItwEidIssuanceMachineContext } from "../../../machine/eid/provider";
 
 type CieIdHookResult = {
@@ -58,6 +60,7 @@ const extractCieIdErrorFromUrl = (url: string) =>
  */
 export const useCieIdApp = (): CieIdHookResult => {
   const machineRef = ItwEidIssuanceMachineContext.useActorRef();
+  const isUatEnvironment = useIOSelector(selectItwIsCieIdUatEnv);
   const [authUrl, setAuthUrl] = useState<O.Option<string>>(O.none);
   const [isAppLaunched, setIsAppLaunched] = useState(false);
 
@@ -90,13 +93,17 @@ export const useCieIdApp = (): CieIdHookResult => {
     (url: string) => {
       // Use the new CieID app-to-app flow on Android
       if (isAndroid) {
-        openCieIdApp(url, result => {
-          if (result.id === "URL") {
-            setAuthUrl(O.some(result.url));
-          } else {
-            handleAuthenticationFailure(result);
-          }
-        });
+        openCieIdApp(
+          url,
+          result => {
+            if (result.id === "URL") {
+              setAuthUrl(O.some(result.url));
+            } else {
+              handleAuthenticationFailure(result);
+            }
+          },
+          isUatEnvironment
+        );
       }
 
       // Try to directly open the CieID app on iOS
@@ -106,7 +113,7 @@ export const useCieIdApp = (): CieIdHookResult => {
           .catch(handleAuthenticationFailure);
       }
     },
-    [handleAuthenticationFailure]
+    [handleAuthenticationFailure, isUatEnvironment]
   );
 
   useEffect(() => {

--- a/apps/main-app/ts/features/itwallet/identification/cieId/screens/ItwCieIdLoginScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/identification/cieId/screens/ItwCieIdLoginScreen.tsx
@@ -11,7 +11,10 @@ import { useHeaderSecondLevel } from "../../../../../hooks/useHeaderSecondLevel"
 import { useIOSelector } from "../../../../../store/hooks";
 import { originSchemasWhiteList } from "../../../../authentication/common/utils/originSchemasWhiteList";
 import { useItwDismissalDialog } from "../../../common/hooks/useItwDismissalDialog";
-import { selectItwEnv } from "../../../common/store/selectors/environment";
+import {
+  selectItwEnv,
+  selectItwIsCieIdUatEnv
+} from "../../../common/store/selectors/environment";
 import { getEnv } from "../../../common/utils/environment";
 import { ItwEidIssuanceMachineContext } from "../../../machine/eid/provider";
 import { selectAuthUrlOption } from "../../../machine/eid/selectors";
@@ -37,6 +40,7 @@ const isAuthenticationUrl = (url: string) => {
  */
 const ItwCieIdLoginScreen = () => {
   const { ISSUANCE_REDIRECT_URI } = pipe(useIOSelector(selectItwEnv), getEnv);
+  const isCieIdUatEnv = useIOSelector(selectItwIsCieIdUatEnv);
 
   const initialAuthUrl =
     ItwEidIssuanceMachineContext.useSelector(selectAuthUrlOption);
@@ -70,17 +74,17 @@ const ItwCieIdLoginScreen = () => {
   const onLoadEnd = useCallback(() => {
     // When CieId app-to-app flow is enabled, stop loading only after we got
     // the authUrl from CieId app, so the user doesn't see the login screen.
-    if (isCieIdAvailable() ? !!authUrl : true) {
+    if (isCieIdAvailable(isCieIdUatEnv) ? !!authUrl : true) {
       setWebViewLoading(false);
     }
-  }, [authUrl]);
+  }, [authUrl, isCieIdUatEnv]);
 
   const handleShouldStartLoading = useCallback(
     (event: WebViewNavigation): boolean => {
       const url = event.url;
 
       // When CieID is available, use a flow that launches the app
-      if (isAuthenticationUrl(url) && isCieIdAvailable()) {
+      if (isAuthenticationUrl(url) && isCieIdAvailable(isCieIdUatEnv)) {
         startCieIdAppAuthentication(url);
         return false;
       }
@@ -88,7 +92,7 @@ const ItwCieIdLoginScreen = () => {
       // When CieID is not available, fallback to the regular webview
       return true;
     },
-    [startCieIdAppAuthentication]
+    [startCieIdAppAuthentication, isCieIdUatEnv]
   );
 
   const handleNavigationStateChange = useCallback(


### PR DESCRIPTION
## Short description
The IT-Wallet CieID identification flow always targeted the production CieID app, even when the IT-Wallet environment was set to `pre`. This made it impossible to complete an app-to-app CieID identification against the pre-production ecosystem. The flow now selects the UAT CieID app when the IT-Wallet environment is `pre`.

## List of changes proposed in this pull request
- Add `selectItwIsCieIdUatEnv` selector, `true` when the IT-Wallet environment is `pre`
- Pass the UAT flag to `openCieIdApp` in `useCieIdApp`
- Pass the UAT flag to `isCieIdAvailable` in `ItwCieIdLoginScreen`

## How to test
> [!IMPORTANT]
> `@pagopa/io-react-native-cieid` hardcodes the UAT package name as `it.ipzs.cieid.collaudo`, but the CieID test app is published as `it.ipzs.cieid.coll`. Until the library is updated, testing requires manually replacing `it.ipzs.cieid.collaudo` with `it.ipzs.cieid.coll` in `node_modules/@pagopa/io-react-native-cieid` (both `android/src/main/AndroidManifest.xml` and the `src`/`lib` sources), then doing a clean Android build so the manifest merge is regenerated.

Android only, **DEV ONLY**; on iOS a single `CIEID` URL scheme exists, so there is no UAT variant to select and behaviour is unchanged.

1. Install the CieID test app (`it.ipzs.cieid.coll`) on the device
2. Apply the `node_modules` change above and run a clean Android build
3. From the developer section, set the IT-Wallet environment to `pre`
4. Start the IT-Wallet activation and choose CieID as the identification method
5. Expected: the CieID **test** app opens and returns to IO, completing the identification
