### PR TITLE
chore(IT-Wallet): [SIW-4487] Add consent denied handling in proximity flow

### DIFF
--- a/apps/main-app/locales/it/index.json
+++ b/apps/main-app/locales/it/index.json
@@ -2102,6 +2102,10 @@
             "subtitle": "Attendi qualche secondo...",
             "title": "In attesa di connessione per la verifica..."
           },
+          "consentDenied": {
+            "subtitle": "Puoi avviare una nuova verifica premendo “Avvia verifica” dalla sezione Portafoglio.",
+            "title": "Hai interrotto la verifica"
+          },
           "engagement": {
             "banner": {
               "action": "Scopri di più",

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/machine.test.ts
@@ -622,8 +622,7 @@ describe("itwProximityMachine", () => {
     expect(terminateSession).toHaveBeenCalledTimes(1);
   });
 
-  it("close from ClaimsDisclosure terminates the session and closes the flow", async () => {
-    terminateSession.mockResolvedValue(undefined);
+  it("close from ClaimsDisclosure terminates the session and shows the consent denied failure", () => {
     const actor = createActor(mockedMachine, {
       snapshot: makeSnapshot({ Presentment: "ClaimsDisclosure" })
     });
@@ -631,12 +630,13 @@ describe("itwProximityMachine", () => {
     actor.start();
     actor.send({ type: "close" });
 
-    expect(actor.getSnapshot().value).toStrictEqual({
-      Presentment: "Terminating"
-    });
-    // Allow the terminateProximitySession promise to resolve
-    await new Promise(resolve => setTimeout(resolve, 0));
-    expect(closeProximity).toHaveBeenCalledTimes(1);
+    expect(actor.getSnapshot().value).toBe("Failure");
+    expect(actor.getSnapshot().context.failure?.type).toBe(
+      ProximityFailureType.CONSENT_DENIED
+    );
+    expect(navigateToFailureScreen).toHaveBeenCalledTimes(1);
+    expect(terminateSession).toHaveBeenCalledTimes(1);
+    expect(closeProximity).not.toHaveBeenCalled();
   });
 
   it("holder-consent with NFC retrieval moves to StoreConsent", () => {

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/failure.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/failure.ts
@@ -6,6 +6,7 @@ import {
 import { ProximityEvents } from "./events";
 
 export enum ProximityFailureType {
+  CONSENT_DENIED = "CONSENT_DENIED",
   MISSING_CREDENTIALS = "MISSING_CREDENTIALS",
   RELYING_PARTY_GENERIC = "RELYING_PARTY_GENERIC",
   TIMEOUT = "TIMEOUT",
@@ -23,6 +24,7 @@ export type ProximityFailure =
  * Type that maps known reasons with the corresponding failure, in order to avoid unknowns as much as possible.
  */
 export type ReasonTypeByFailure = {
+  [ProximityFailureType.CONSENT_DENIED]: undefined;
   [ProximityFailureType.MISSING_CREDENTIALS]: MissingCredentialError;
   [ProximityFailureType.RELYING_PARTY_GENERIC]: Error;
   [ProximityFailureType.TIMEOUT]: TimeoutError;

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/machine.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/machine.ts
@@ -37,12 +37,6 @@ export const itwProximityMachine = setup({
      */
 
     setFailure: assign(({ event }) => ({ failure: mapEventToFailure(event) })),
-    setConsentDeniedFailure: assign(() => ({
-      failure: {
-        type: ProximityFailureType.CONSENT_DENIED,
-        reason: undefined
-      }
-    })),
 
     /**
      * Navigation
@@ -439,7 +433,12 @@ export const itwProximityMachine = setup({
               }
             ],
             close: {
-              actions: "setConsentDeniedFailure",
+              actions: assign(() => ({
+                failure: {
+                  type: ProximityFailureType.CONSENT_DENIED,
+                  reason: undefined
+                }
+              })),
               target: "#itwProximityMachine.Failure"
             }
           }

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/machine.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/machine.ts
@@ -18,7 +18,7 @@ import {
 } from "./actors";
 import { Context, InitialContext } from "./context";
 import { ProximityEvents } from "./events";
-import { mapEventToFailure } from "./failure";
+import { mapEventToFailure, ProximityFailureType } from "./failure";
 import { ItwPresentationTags } from "./tags";
 
 const notImplemented = () => {
@@ -37,6 +37,12 @@ export const itwProximityMachine = setup({
      */
 
     setFailure: assign(({ event }) => ({ failure: mapEventToFailure(event) })),
+    setConsentDeniedFailure: assign(() => ({
+      failure: {
+        type: ProximityFailureType.CONSENT_DENIED,
+        reason: undefined
+      }
+    })),
 
     /**
      * Navigation
@@ -433,7 +439,8 @@ export const itwProximityMachine = setup({
               }
             ],
             close: {
-              target: "#itwProximityMachine.Presentment.Terminating"
+              actions: "setConsentDeniedFailure",
+              target: "#itwProximityMachine.Failure"
             }
           }
         },

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwProximityClaimsDisclosureScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwProximityClaimsDisclosureScreen.tsx
@@ -87,8 +87,12 @@ const ContentView = ({ proximityDetails }: ContentViewProps) => {
     generateDynamicUrlSelector(state, "io_showcase", ITW_IPZS_PRIVACY_URL_BODY)
   );
 
+  const handleDismiss = useCallback(() => {
+    machineRef.send({ type: "close" });
+  }, [machineRef]);
+
   const dismissalDialog = useItwDismissalDialog({
-    handleDismiss: () => machineRef.send({ type: "close" }),
+    handleDismiss,
     customLabels: {
       body: I18n.t(
         "features.itWallet.presentation.proximity.selectiveDisclosure.alert.message"
@@ -115,7 +119,7 @@ const ContentView = ({ proximityDetails }: ContentViewProps) => {
         />
       )
     });
-  }, [navigation, machineRef, dismissalDialog]);
+  }, [navigation, dismissalDialog]);
 
   const handleConfirm = () => {
     trackItwProximityContinuePresentation({ proximity_flow: proximityFlow });

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwProximityFailureScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwProximityFailureScreen.tsx
@@ -83,6 +83,20 @@ const ContentView = ({ failure }: ContentViewProps) => {
   const getOperationResultScreenContentProps =
     (): OperationResultScreenContentProps => {
       switch (failure.type) {
+        case ProximityFailureType.CONSENT_DENIED:
+          return {
+            title: I18n.t(
+              "features.itWallet.presentation.proximity.consentDenied.title"
+            ),
+            subtitle: I18n.t(
+              "features.itWallet.presentation.proximity.consentDenied.subtitle"
+            ),
+            pictogram: "accessDenied",
+            action: {
+              label: I18n.t("global.buttons.close"),
+              onPress: () => machineRef.send({ type: "close" })
+            }
+          };
         case ProximityFailureType.RELYING_PARTY_GENERIC:
           return {
             title: I18n.t(


### PR DESCRIPTION
## Short description
This PR add consent denied handling events for proximity flow
## List of changes proposed in this pull request
- Added Proximity failure `CONSENT_DENIED`
- Added case `ProximityFailureType.CONSENT_DENIED:` for proximity failure screen
- Added `setConsentDeniedFailure` to machine events, so denied case is covered and navigable
- Wrapped `handleDimiss` with memoization to avoid wrong re-render and navigation
- Added unit tests

## How to test
1. Start a proximity flow
2. Deny consent by tapping the X and confirm modal
3. Verify that the navigation correctly land in consent denied failure screen

## Preview

https://github.com/user-attachments/assets/944d68cd-934d-4847-9854-deed1869b5dc

