### PR TITLE
fix: [IOPLT-000] Adds missing purpose string on plist after calendar library switch

### DIFF
--- a/apps/main-app/ios/IO/Info.plist
+++ b/apps/main-app/ios/IO/Info.plist
@@ -76,7 +76,11 @@
     <string>IO richiede l'accesso al Bluetooth per completare la verifica dei documenti</string>
     <key>NSBluetoothPeripheralUsageDescription</key>
     <string>IO richiede l'accesso al Bluetooth per completare la verifica dei documenti</string>
+    <key>NSCalendarsUsageDescription</key>
+    <string>So that you’ll be able to add deadlines to your calendar and set a reminder.</string>
     <key>NSCalendarsFullAccessUsageDescription</key>
+    <string>So that you’ll be able to add deadlines to your calendar and set a reminder.</string>
+    <key>NSRemindersUsageDescription</key>
     <string>So that you’ll be able to add deadlines to your calendar and set a reminder.</string>
     <key>NSRemindersFullAccessUsageDescription</key>
     <string>So that you’ll be able to add deadlines to your calendar and set a reminder.</string>


### PR DESCRIPTION
## Short description
This PR adds missing entries on plist for iOS permissions after the switch to expo-calendars