### PR TITLE
feat: [IEG-3134] [FIMS] Pass the Mixpanel ID to enabled FIMS destinations

### DIFF
--- a/apps/main-app/scripts/generate-api-models.sh
+++ b/apps/main-app/scripts/generate-api-models.sh
@@ -2,7 +2,7 @@
 
 IO_BACKEND_VERSION=v20.0.0
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=IEG-3133-FIMS-tracking-Enriched-Urls
+IO_SERVICES_METADATA_VERSION=1.1.1
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.23.1
 # IO Wallet user function version

--- a/apps/main-app/scripts/generate-api-models.sh
+++ b/apps/main-app/scripts/generate-api-models.sh
@@ -2,7 +2,7 @@
 
 IO_BACKEND_VERSION=v20.0.0
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=1.1.2
+IO_SERVICES_METADATA_VERSION=IEG-3133-FIMS-tracking-Enriched-Urls
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.23.1
 # IO Wallet user function version

--- a/apps/main-app/scripts/generate-api-models.sh
+++ b/apps/main-app/scripts/generate-api-models.sh
@@ -2,7 +2,7 @@
 
 IO_BACKEND_VERSION=v20.0.0
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=IEG-3133-FIMS-tracking-Enriched-Urls
+IO_SERVICES_METADATA_VERSION=1.1.3
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.23.1
 # IO Wallet user function version

--- a/apps/main-app/scripts/generate-api-models.sh
+++ b/apps/main-app/scripts/generate-api-models.sh
@@ -2,7 +2,7 @@
 
 IO_BACKEND_VERSION=v20.0.0
 # need to change after merge on io-services-metadata
-IO_SERVICES_METADATA_VERSION=1.1.1
+IO_SERVICES_METADATA_VERSION=IEG-3133-FIMS-tracking-Enriched-Urls
 # Session manager version
 IO_SESSION_MANAGER_VERSION=1.23.1
 # IO Wallet user function version

--- a/apps/main-app/ts/features/fims/singleSignOn/saga/__tests__/handleFimsAuthorizationOrImplicitCodeFlow.test.ts
+++ b/apps/main-app/ts/features/fims/singleSignOn/saga/__tests__/handleFimsAuthorizationOrImplicitCodeFlow.test.ts
@@ -288,6 +288,18 @@ describe("enrichFimsRedirectUrl", () => {
       .isDone();
   });
 
+  it("should return the redirect URL when the allowlist is empty", () => {
+    testSaga(enrichFimsRedirectUrl, redirectUrl)
+      .next()
+      .select(fimsTrackingEnrichedUrlsSelector)
+      .next([])
+      .select(isMixpanelEnabled)
+      .next(true)
+      .returns(redirectUrl)
+      .next()
+      .isDone();
+  });
+
   it("should return the redirect URL when retrieving the device ID fails", () => {
     testSaga(enrichFimsRedirectUrl, redirectUrl)
       .next()
@@ -313,8 +325,8 @@ describe("enrichFimsRedirectUrl", () => {
       .call(getDeviceId)
       .next(deviceId)
       .call(enrichFimsDestinationUrl, redirectUrl, [redirectUrl], deviceId)
-      .next(`${redirectUrl}?device=${deviceId}`)
-      .returns(`${redirectUrl}?device=${deviceId}`)
+      .next(`${redirectUrl}?mixpanelId=${deviceId}`)
+      .returns(`${redirectUrl}?mixpanelId=${deviceId}`)
       .next()
       .isDone();
   });

--- a/apps/main-app/ts/features/fims/singleSignOn/saga/__tests__/handleFimsAuthorizationOrImplicitCodeFlow.test.ts
+++ b/apps/main-app/ts/features/fims/singleSignOn/saga/__tests__/handleFimsAuthorizationOrImplicitCodeFlow.test.ts
@@ -300,20 +300,6 @@ describe("enrichFimsRedirectUrl", () => {
       .isDone();
   });
 
-  it("should return the redirect URL when retrieving the device ID fails", () => {
-    testSaga(enrichFimsRedirectUrl, redirectUrl)
-      .next()
-      .select(fimsTrackingEnrichedUrlsSelector)
-      .next([redirectUrl])
-      .select(isMixpanelEnabled)
-      .next(true)
-      .call(getDeviceId)
-      .throw(new Error("Device ID unavailable"))
-      .returns(redirectUrl)
-      .next()
-      .isDone();
-  });
-
   it("should enrich an allowed redirect URL", () => {
     const deviceId = "mixpanel-device-id";
     testSaga(enrichFimsRedirectUrl, redirectUrl)

--- a/apps/main-app/ts/features/fims/singleSignOn/saga/__tests__/handleFimsAuthorizationOrImplicitCodeFlow.test.ts
+++ b/apps/main-app/ts/features/fims/singleSignOn/saga/__tests__/handleFimsAuthorizationOrImplicitCodeFlow.test.ts
@@ -274,7 +274,7 @@ describe("handleFimsAuthorizationOrImplicitCodeFlow", () => {
 });
 
 describe("enrichFimsRedirectUrl", () => {
-  const redirectUrl = "https://rp.example.it/fims/landing";
+  const redirectUrl = "https://trusted.test/callback";
 
   it("should return the redirect URL when Mixpanel is disabled", () => {
     testSaga(enrichFimsRedirectUrl, redirectUrl)

--- a/apps/main-app/ts/features/fims/singleSignOn/saga/__tests__/handleFimsAuthorizationOrImplicitCodeFlow.test.ts
+++ b/apps/main-app/ts/features/fims/singleSignOn/saga/__tests__/handleFimsAuthorizationOrImplicitCodeFlow.test.ts
@@ -2,10 +2,15 @@ import { HttpClientSuccessResponse } from "@pagopa/io-react-native-http-client";
 import * as LoginUtils from "@pagopa/io-react-native-login-utils";
 import { testSaga } from "redux-saga-test-plan";
 
+import { fimsTrackingEnrichedUrlsSelector } from "../../../../../store/reducers/backendStatus/remoteConfig";
+import { isMixpanelEnabled } from "../../../../../store/reducers/persistedPreferences";
+import { getDeviceId } from "../../../../../utils/device";
 import { fimsSignAndRetrieveInAppBrowserUrlAction } from "../../store/actions";
 import { fimsEphemeralSessionOniOSSelector } from "../../store/selectors";
+import { enrichFimsDestinationUrl } from "../../utils";
 import {
   computeAndTrackInAppBrowserOpening,
+  enrichFimsRedirectUrl,
   handleFimsAuthorizationOrImplicitCodeFlow,
   handleInAppBrowserErrorIfNeeded,
   postToRelyingPartyWithImplicitCodeFlow,
@@ -50,6 +55,11 @@ describe("handleFimsAuthorizationOrImplicitCodeFlow", () => {
         .next()
         .call(computeAndTrackInAppBrowserOpening)
         .next()
+        .call(
+          enrichFimsRedirectUrl,
+          "https://relyingParty.url/inAppBrowserLandingPage"
+        )
+        .next("https://relyingParty.url/inAppBrowserLandingPage")
         .select(fimsEphemeralSessionOniOSSelector)
         .next(false)
         .call(
@@ -93,6 +103,11 @@ describe("handleFimsAuthorizationOrImplicitCodeFlow", () => {
         .next()
         .call(computeAndTrackInAppBrowserOpening)
         .next()
+        .call(
+          enrichFimsRedirectUrl,
+          "https://relyingParty.url/inAppBrowserLandingPage"
+        )
+        .next("https://relyingParty.url/inAppBrowserLandingPage")
         .select(fimsEphemeralSessionOniOSSelector)
         .next(true)
         .call(
@@ -235,6 +250,11 @@ describe("handleFimsAuthorizationOrImplicitCodeFlow", () => {
         .next()
         .call(computeAndTrackInAppBrowserOpening)
         .next()
+        .call(
+          enrichFimsRedirectUrl,
+          "https://relyingParty.url/inAppBrowserLandingPage"
+        )
+        .next("https://relyingParty.url/inAppBrowserLandingPage")
         .select(fimsEphemeralSessionOniOSSelector)
         .next(false)
         .call(
@@ -250,5 +270,52 @@ describe("handleFimsAuthorizationOrImplicitCodeFlow", () => {
         .next()
         .isDone();
     });
+  });
+});
+
+describe("enrichFimsRedirectUrl", () => {
+  const redirectUrl = "https://rp.example.it/fims/landing";
+
+  it("should return the redirect URL when Mixpanel is disabled", () => {
+    testSaga(enrichFimsRedirectUrl, redirectUrl)
+      .next()
+      .select(fimsTrackingEnrichedUrlsSelector)
+      .next([redirectUrl])
+      .select(isMixpanelEnabled)
+      .next(false)
+      .returns(redirectUrl)
+      .next()
+      .isDone();
+  });
+
+  it("should return the redirect URL when retrieving the device ID fails", () => {
+    testSaga(enrichFimsRedirectUrl, redirectUrl)
+      .next()
+      .select(fimsTrackingEnrichedUrlsSelector)
+      .next([redirectUrl])
+      .select(isMixpanelEnabled)
+      .next(true)
+      .call(getDeviceId)
+      .throw(new Error("Device ID unavailable"))
+      .returns(redirectUrl)
+      .next()
+      .isDone();
+  });
+
+  it("should enrich an allowed redirect URL", () => {
+    const deviceId = "mixpanel-device-id";
+    testSaga(enrichFimsRedirectUrl, redirectUrl)
+      .next()
+      .select(fimsTrackingEnrichedUrlsSelector)
+      .next([redirectUrl])
+      .select(isMixpanelEnabled)
+      .next(true)
+      .call(getDeviceId)
+      .next(deviceId)
+      .call(enrichFimsDestinationUrl, redirectUrl, [redirectUrl], deviceId)
+      .next(`${redirectUrl}?device=${deviceId}`)
+      .returns(`${redirectUrl}?device=${deviceId}`)
+      .next()
+      .isDone();
   });
 });

--- a/apps/main-app/ts/features/fims/singleSignOn/saga/handleFimsAuthorizationOrImplicitCodeFlow.ts
+++ b/apps/main-app/ts/features/fims/singleSignOn/saga/handleFimsAuthorizationOrImplicitCodeFlow.ts
@@ -438,15 +438,11 @@ export function* enrichFimsRedirectUrl(
     return redirectUrl;
   }
 
-  try {
-    const mixpanelDeviceId = yield* call(getDeviceId);
-    return yield* call(
-      enrichFimsDestinationUrl,
-      redirectUrl,
-      trackingEnrichedUrls,
-      mixpanelDeviceId
-    );
-  } catch {
-    return redirectUrl;
-  }
+  const mixpanelDeviceId = yield* call(getDeviceId);
+  return yield* call(
+    enrichFimsDestinationUrl,
+    redirectUrl,
+    trackingEnrichedUrls,
+    mixpanelDeviceId
+  );
 }

--- a/apps/main-app/ts/features/fims/singleSignOn/saga/handleFimsAuthorizationOrImplicitCodeFlow.ts
+++ b/apps/main-app/ts/features/fims/singleSignOn/saga/handleFimsAuthorizationOrImplicitCodeFlow.ts
@@ -19,7 +19,10 @@ import {
 import { call, put, select } from "typed-redux-saga/macro";
 import { ActionType } from "typesafe-actions";
 
+import { fimsTrackingEnrichedUrlsSelector } from "../../../../store/reducers/backendStatus/remoteConfig";
+import { isMixpanelEnabled } from "../../../../store/reducers/persistedPreferences";
 import { ReduxSagaEffect } from "../../../../types/utils";
+import { getDeviceId } from "../../../../utils/device";
 import { LollipopConfig } from "../../../lollipop";
 import { generateKeyInfo } from "../../../lollipop/saga";
 import {
@@ -35,6 +38,7 @@ import {
   fimsEphemeralSessionOniOSSelector,
   relyingPartyServiceIdSelector
 } from "../store/selectors";
+import { enrichFimsDestinationUrl } from "../utils";
 import {
   absoluteRedirectUrlFromHttpClientResponse,
   computeAndTrackAuthenticationError,
@@ -44,6 +48,28 @@ import {
 } from "./sagaUtils";
 
 // note: IAB => InAppBrowser
+
+export function* enrichFimsRedirectUrl(
+  redirectUrl: string
+): Generator<ReduxSagaEffect, string, any> {
+  const trackingEnrichedUrls = yield* select(fimsTrackingEnrichedUrlsSelector);
+  const mixpanelEnabled = yield* select(isMixpanelEnabled);
+  if (!mixpanelEnabled || trackingEnrichedUrls.length === 0) {
+    return redirectUrl;
+  }
+
+  try {
+    const mixpanelDeviceId = yield* call(getDeviceId);
+    return yield* call(
+      enrichFimsDestinationUrl,
+      redirectUrl,
+      trackingEnrichedUrls,
+      mixpanelDeviceId
+    );
+  } catch {
+    return redirectUrl;
+  }
+}
 
 export function* handleFimsAuthorizationOrImplicitCodeFlow(
   action: ActionType<
@@ -102,13 +128,17 @@ export function* handleFimsAuthorizationOrImplicitCodeFlow(
   yield* call(handleFimsResourcesDeallocation);
   yield* call(computeAndTrackInAppBrowserOpening);
 
+  const enrichedInAppBrowserRedirectUrl = yield* call(
+    enrichFimsRedirectUrl,
+    inAppBrowserRedirectUrl
+  );
   const ephemeralSessionOniOS = yield* select(
     fimsEphemeralSessionOniOSSelector
   );
   try {
     yield* call(
       openAuthenticationSession,
-      inAppBrowserRedirectUrl,
+      enrichedInAppBrowserRedirectUrl,
       "iossoapi",
       !ephemeralSessionOniOS
     );

--- a/apps/main-app/ts/features/fims/singleSignOn/saga/handleFimsAuthorizationOrImplicitCodeFlow.ts
+++ b/apps/main-app/ts/features/fims/singleSignOn/saga/handleFimsAuthorizationOrImplicitCodeFlow.ts
@@ -49,28 +49,6 @@ import {
 
 // note: IAB => InAppBrowser
 
-export function* enrichFimsRedirectUrl(
-  redirectUrl: string
-): Generator<ReduxSagaEffect, string, any> {
-  const trackingEnrichedUrls = yield* select(fimsTrackingEnrichedUrlsSelector);
-  const mixpanelEnabled = yield* select(isMixpanelEnabled);
-  if (!mixpanelEnabled || trackingEnrichedUrls.length === 0) {
-    return redirectUrl;
-  }
-
-  try {
-    const mixpanelDeviceId = yield* call(getDeviceId);
-    return yield* call(
-      enrichFimsDestinationUrl,
-      redirectUrl,
-      trackingEnrichedUrls,
-      mixpanelDeviceId
-    );
-  } catch {
-    return redirectUrl;
-  }
-}
-
 export function* handleFimsAuthorizationOrImplicitCodeFlow(
   action: ActionType<
     (typeof fimsSignAndRetrieveInAppBrowserUrlAction)["request"]
@@ -450,3 +428,25 @@ const inAppBrowserErrorToHumanReadable = (error: unknown) => {
   }
   return JSON.stringify(error);
 };
+
+export function* enrichFimsRedirectUrl(
+  redirectUrl: string
+): Generator<ReduxSagaEffect, string, any> {
+  const trackingEnrichedUrls = yield* select(fimsTrackingEnrichedUrlsSelector);
+  const mixpanelEnabled = yield* select(isMixpanelEnabled);
+  if (!mixpanelEnabled || trackingEnrichedUrls.length === 0) {
+    return redirectUrl;
+  }
+
+  try {
+    const mixpanelDeviceId = yield* call(getDeviceId);
+    return yield* call(
+      enrichFimsDestinationUrl,
+      redirectUrl,
+      trackingEnrichedUrls,
+      mixpanelDeviceId
+    );
+  } catch {
+    return redirectUrl;
+  }
+}

--- a/apps/main-app/ts/features/fims/singleSignOn/utils/__test__/index.test.ts
+++ b/apps/main-app/ts/features/fims/singleSignOn/utils/__test__/index.test.ts
@@ -65,7 +65,7 @@ describe("isIoFIMSLink", () => {
 });
 
 describe("enrichFimsDestinationUrl", () => {
-  const allowedUrl = "https://rp.example.it/fims/landing";
+  const allowedUrl = "https://trusted.test/callback";
   const deviceId = "mixpanel-device-id";
 
   it.each([
@@ -83,10 +83,10 @@ describe("enrichFimsDestinationUrl", () => {
     },
     {
       name: "the allowlist uses a different case and trailing slash",
-      destinationUrl: "https://RP.EXAMPLE.IT/FIMS/LANDING?token=one-shot",
-      trackingEnrichedUrls: ["https://rp.example.it/fims/landing/"],
+      destinationUrl: "https://TRUSTED.TEST/CALLBACK?token=one-shot",
+      trackingEnrichedUrls: ["https://trusted.test/callback/"],
       expectedUrl:
-        "https://RP.EXAMPLE.IT/FIMS/LANDING?token=one-shot&mixpanelId=mixpanel-device-id"
+        "https://TRUSTED.TEST/CALLBACK?token=one-shot&mixpanelId=mixpanel-device-id"
     },
     {
       name: "the allowlist URL contains query parameters and a fragment",
@@ -104,10 +104,10 @@ describe("enrichFimsDestinationUrl", () => {
   );
 
   it.each([
-    "https://rp.example.it/fims/another-path",
-    "https://attacker.example/https://rp.example.it/fims/landing",
-    "https://attacker.example/?redirect=https://rp.example.it/fims/landing",
-    "https://attacker.example/#https://rp.example.it/fims/landing",
+    "https://trusted.test/another-path",
+    `https://attacker.test/${allowedUrl}`,
+    `https://attacker.test/?redirect=${allowedUrl}`,
+    `https://attacker.test/#${allowedUrl}`,
     "not-a-url"
   ])("returns an unchanged URL when it is not allowed: %s", destinationUrl => {
     expect(
@@ -122,14 +122,11 @@ describe("enrichFimsDestinationUrl", () => {
     },
     {
       name: "the only allowlist URL does not match",
-      trackingEnrichedUrls: ["https://rp.example.it/fims/another-path"]
+      trackingEnrichedUrls: ["https://trusted.test/another-path"]
     },
     {
       name: "only the second allowlist URL matches",
-      trackingEnrichedUrls: [
-        "https://rp.example.it/fims/another-path",
-        allowedUrl
-      ]
+      trackingEnrichedUrls: ["https://trusted.test/another-path", allowedUrl]
     }
   ])("handles $name", ({ trackingEnrichedUrls }) => {
     const expectedUrl = trackingEnrichedUrls.includes(allowedUrl)

--- a/apps/main-app/ts/features/fims/singleSignOn/utils/__test__/index.test.ts
+++ b/apps/main-app/ts/features/fims/singleSignOn/utils/__test__/index.test.ts
@@ -103,7 +103,13 @@ describe("enrichFimsDestinationUrl", () => {
     }
   );
 
-  it.each(["https://rp.example.it/fims/another-path", "not-a-url"])(
+  it.each([
+    "https://rp.example.it/fims/another-path",
+    "https://attacker.example/https://rp.example.it/fims/landing",
+    "https://attacker.example/?redirect=https://rp.example.it/fims/landing",
+    "https://attacker.example/#https://rp.example.it/fims/landing",
+    "not-a-url"
+  ])(
     "returns an unchanged URL when it is not allowed: %s",
     destinationUrl => {
       expect(

--- a/apps/main-app/ts/features/fims/singleSignOn/utils/__test__/index.test.ts
+++ b/apps/main-app/ts/features/fims/singleSignOn/utils/__test__/index.test.ts
@@ -111,4 +111,30 @@ describe("enrichFimsDestinationUrl", () => {
       ).toBe(destinationUrl);
     }
   );
+
+  it.each([
+    {
+      name: "the allowlist is empty",
+      trackingEnrichedUrls: []
+    },
+    {
+      name: "the only allowlist URL does not match",
+      trackingEnrichedUrls: ["https://rp.example.it/fims/another-path"]
+    },
+    {
+      name: "only the second allowlist URL matches",
+      trackingEnrichedUrls: [
+        "https://rp.example.it/fims/another-path",
+        allowedUrl
+      ]
+    }
+  ])("handles $name", ({ trackingEnrichedUrls }) => {
+    const expectedUrl = trackingEnrichedUrls.includes(allowedUrl)
+      ? `${allowedUrl}?mixpanelId=${deviceId}`
+      : allowedUrl;
+
+    expect(
+      enrichFimsDestinationUrl(allowedUrl, trackingEnrichedUrls, deviceId)
+    ).toBe(expectedUrl);
+  });
 });

--- a/apps/main-app/ts/features/fims/singleSignOn/utils/__test__/index.test.ts
+++ b/apps/main-app/ts/features/fims/singleSignOn/utils/__test__/index.test.ts
@@ -109,14 +109,11 @@ describe("enrichFimsDestinationUrl", () => {
     "https://attacker.example/?redirect=https://rp.example.it/fims/landing",
     "https://attacker.example/#https://rp.example.it/fims/landing",
     "not-a-url"
-  ])(
-    "returns an unchanged URL when it is not allowed: %s",
-    destinationUrl => {
-      expect(
-        enrichFimsDestinationUrl(destinationUrl, [allowedUrl], deviceId)
-      ).toBe(destinationUrl);
-    }
-  );
+  ])("returns an unchanged URL when it is not allowed: %s", destinationUrl => {
+    expect(
+      enrichFimsDestinationUrl(destinationUrl, [allowedUrl], deviceId)
+    ).toBe(destinationUrl);
+  });
 
   it.each([
     {

--- a/apps/main-app/ts/features/fims/singleSignOn/utils/__test__/index.test.ts
+++ b/apps/main-app/ts/features/fims/singleSignOn/utils/__test__/index.test.ts
@@ -72,18 +72,36 @@ describe("enrichFimsDestinationUrl", () => {
     {
       name: "the destination matches the allowlist",
       destinationUrl: allowedUrl,
-      expectedUrl: `${allowedUrl}?device=${deviceId}`
+      trackingEnrichedUrls: [allowedUrl],
+      expectedUrl: `${allowedUrl}?mixpanelId=${deviceId}`
     },
     {
       name: "the destination contains query parameters and a fragment",
       destinationUrl: `${allowedUrl}?token=one-shot#result`,
-      expectedUrl: `${allowedUrl}?token=one-shot&device=${deviceId}#result`
+      trackingEnrichedUrls: [allowedUrl],
+      expectedUrl: `${allowedUrl}?token=one-shot&mixpanelId=${deviceId}#result`
+    },
+    {
+      name: "the allowlist uses a different case and trailing slash",
+      destinationUrl: "https://RP.EXAMPLE.IT/FIMS/LANDING?token=one-shot",
+      trackingEnrichedUrls: ["https://rp.example.it/fims/landing/"],
+      expectedUrl:
+        "https://RP.EXAMPLE.IT/FIMS/LANDING?token=one-shot&mixpanelId=mixpanel-device-id"
+    },
+    {
+      name: "the allowlist URL contains query parameters and a fragment",
+      destinationUrl: allowedUrl,
+      trackingEnrichedUrls: [`${allowedUrl}?configuration=value#section`],
+      expectedUrl: `${allowedUrl}?mixpanelId=${deviceId}`
     }
-  ])("enriches the URL when $name", ({ destinationUrl, expectedUrl }) => {
-    expect(
-      enrichFimsDestinationUrl(destinationUrl, [allowedUrl], deviceId)
-    ).toBe(expectedUrl);
-  });
+  ])(
+    "enriches the URL when $name",
+    ({ destinationUrl, trackingEnrichedUrls, expectedUrl }) => {
+      expect(
+        enrichFimsDestinationUrl(destinationUrl, trackingEnrichedUrls, deviceId)
+      ).toBe(expectedUrl);
+    }
+  );
 
   it.each(["https://rp.example.it/fims/another-path", "not-a-url"])(
     "returns an unchanged URL when it is not allowed: %s",

--- a/apps/main-app/ts/features/fims/singleSignOn/utils/__test__/index.test.ts
+++ b/apps/main-app/ts/features/fims/singleSignOn/utils/__test__/index.test.ts
@@ -1,4 +1,8 @@
-import { isFIMSLink, removeFIMSPrefixFromUrl } from "..";
+import {
+  enrichFimsDestinationUrl,
+  isFIMSLink,
+  removeFIMSPrefixFromUrl
+} from "..";
 
 describe("index", () => {
   describe("removeFIMSPrefixFromUrl", () => {
@@ -58,4 +62,35 @@ describe("isIoFIMSLink", () => {
       expect(isIOFIMSLink).toBe(false);
     });
   });
+});
+
+describe("enrichFimsDestinationUrl", () => {
+  const allowedUrl = "https://rp.example.it/fims/landing";
+  const deviceId = "mixpanel-device-id";
+
+  it.each([
+    {
+      name: "the destination matches the allowlist",
+      destinationUrl: allowedUrl,
+      expectedUrl: `${allowedUrl}?device=${deviceId}`
+    },
+    {
+      name: "the destination contains query parameters and a fragment",
+      destinationUrl: `${allowedUrl}?token=one-shot#result`,
+      expectedUrl: `${allowedUrl}?token=one-shot&device=${deviceId}#result`
+    }
+  ])("enriches the URL when $name", ({ destinationUrl, expectedUrl }) => {
+    expect(
+      enrichFimsDestinationUrl(destinationUrl, [allowedUrl], deviceId)
+    ).toBe(expectedUrl);
+  });
+
+  it.each(["https://rp.example.it/fims/another-path", "not-a-url"])(
+    "returns an unchanged URL when it is not allowed: %s",
+    destinationUrl => {
+      expect(
+        enrichFimsDestinationUrl(destinationUrl, [allowedUrl], deviceId)
+      ).toBe(destinationUrl);
+    }
+  );
 });

--- a/apps/main-app/ts/features/fims/singleSignOn/utils/__test__/index.test.ts
+++ b/apps/main-app/ts/features/fims/singleSignOn/utils/__test__/index.test.ts
@@ -118,21 +118,20 @@ describe("enrichFimsDestinationUrl", () => {
   it.each([
     {
       name: "the allowlist is empty",
-      trackingEnrichedUrls: []
+      trackingEnrichedUrls: [],
+      expectedUrl: allowedUrl
     },
     {
       name: "the only allowlist URL does not match",
-      trackingEnrichedUrls: ["https://trusted.test/another-path"]
+      trackingEnrichedUrls: ["https://trusted.test/another-path"],
+      expectedUrl: allowedUrl
     },
     {
       name: "only the second allowlist URL matches",
-      trackingEnrichedUrls: ["https://trusted.test/another-path", allowedUrl]
+      trackingEnrichedUrls: ["https://trusted.test/another-path", allowedUrl],
+      expectedUrl: `${allowedUrl}?mixpanelId=${deviceId}`
     }
-  ])("handles $name", ({ trackingEnrichedUrls }) => {
-    const expectedUrl = trackingEnrichedUrls.includes(allowedUrl)
-      ? `${allowedUrl}?mixpanelId=${deviceId}`
-      : allowedUrl;
-
+  ])("handles $name", ({ trackingEnrichedUrls, expectedUrl }) => {
     expect(
       enrichFimsDestinationUrl(allowedUrl, trackingEnrichedUrls, deviceId)
     ).toBe(expectedUrl);

--- a/apps/main-app/ts/features/fims/singleSignOn/utils/index.ts
+++ b/apps/main-app/ts/features/fims/singleSignOn/utils/index.ts
@@ -77,3 +77,26 @@ export const removeFIMSPrefixFromUrl = (fimsUrlWithProtocol: string) => {
 
 export const isFIMSLink = (href: string): boolean =>
   href.toLowerCase().startsWith(IO_FIMS_LINK_PREFIX);
+
+/**
+ * Adds the Mixpanel device ID only when the redirect destination is explicitly
+ * allowed by remote configuration. Query parameters and fragments do not take
+ * part in the allowlist comparison.
+ */
+export const enrichFimsDestinationUrl = (
+  destinationUrl: string,
+  trackingEnrichedUrls: ReadonlyArray<string>,
+  mixpanelDeviceId: string
+): string => {
+  try {
+    const parsedDestinationUrl = new URL(destinationUrl);
+    const destinationFullPath = `${parsedDestinationUrl.origin}${parsedDestinationUrl.pathname}`;
+    if (!trackingEnrichedUrls.includes(destinationFullPath)) {
+      return destinationUrl;
+    }
+    parsedDestinationUrl.searchParams.set("device", mixpanelDeviceId);
+    return parsedDestinationUrl.toString();
+  } catch {
+    return destinationUrl;
+  }
+};

--- a/apps/main-app/ts/features/fims/singleSignOn/utils/index.ts
+++ b/apps/main-app/ts/features/fims/singleSignOn/utils/index.ts
@@ -1,4 +1,5 @@
 import * as pot from "@pagopa/ts-commons/lib/pot";
+import { URL as PolyfillURL } from "react-native-url-polyfill";
 import { ActionType } from "typesafe-actions";
 
 import { startApplicationInitialization } from "../../../../store/actions/application";
@@ -78,6 +79,15 @@ export const removeFIMSPrefixFromUrl = (fimsUrlWithProtocol: string) => {
 export const isFIMSLink = (href: string): boolean =>
   href.toLowerCase().startsWith(IO_FIMS_LINK_PREFIX);
 
+const normalizeUrl = (rawUrl: string): string => {
+  try {
+    const url = new PolyfillURL(rawUrl);
+    return `${url.origin}${url.pathname}`.toLowerCase().replace(/\/$/, "");
+  } catch {
+    return rawUrl.trim().toLowerCase().replace(/\/$/, "");
+  }
+};
+
 /**
  * Adds the Mixpanel device ID only when the redirect destination is explicitly
  * allowed by remote configuration. Query parameters and fragments do not take
@@ -89,12 +99,15 @@ export const enrichFimsDestinationUrl = (
   mixpanelDeviceId: string
 ): string => {
   try {
-    const parsedDestinationUrl = new URL(destinationUrl);
-    const destinationFullPath = `${parsedDestinationUrl.origin}${parsedDestinationUrl.pathname}`;
-    if (!trackingEnrichedUrls.includes(destinationFullPath)) {
+    const parsedDestinationUrl = new PolyfillURL(destinationUrl);
+    const normalizedDestinationUrl = normalizeUrl(destinationUrl);
+    const isAllowedDestination = trackingEnrichedUrls.some(
+      allowedUrl => normalizeUrl(allowedUrl) === normalizedDestinationUrl
+    );
+    if (!isAllowedDestination) {
       return destinationUrl;
     }
-    parsedDestinationUrl.searchParams.set("device", mixpanelDeviceId);
+    parsedDestinationUrl.searchParams.set("mixpanelId", mixpanelDeviceId);
     return parsedDestinationUrl.toString();
   } catch {
     return destinationUrl;

--- a/apps/main-app/ts/store/reducers/backendStatus/__tests__/remoteConfig.test.ts
+++ b/apps/main-app/ts/store/reducers/backendStatus/__tests__/remoteConfig.test.ts
@@ -341,7 +341,7 @@ describe("remoteConfig", () => {
 
   describe("fimsTrackingEnrichedUrlsSelector", () => {
     it("should return the configured URL allowlist", () => {
-      const trackingEnrichedUrls = ["https://rp.example.it/fims/landing"];
+      const trackingEnrichedUrls = ["https://trusted.test/callback"];
       const state = {
         remoteConfig: O.some({
           fims: { trackingEnrichedUrls }

--- a/apps/main-app/ts/store/reducers/backendStatus/__tests__/remoteConfig.test.ts
+++ b/apps/main-app/ts/store/reducers/backendStatus/__tests__/remoteConfig.test.ts
@@ -11,6 +11,7 @@ import {
   engagementCGNDiscoveryBannerSelector,
   fimsServiceConfiguration,
   fimsServiceIdInCookieDisabledListSelector,
+  fimsTrackingEnrichedUrlsSelector,
   fseDiscoveryBannerWebUrlSelector,
   generateDynamicUrlSelector,
   isAarInAppDelegationRemoteEnabledSelector,
@@ -335,6 +336,25 @@ describe("remoteConfig", () => {
         "unmatchingConfId"
       );
       expect(serviceConfiguration).toBeUndefined();
+    });
+  });
+
+  describe("fimsTrackingEnrichedUrlsSelector", () => {
+    it("should return the configured URL allowlist", () => {
+      const trackingEnrichedUrls = ["https://rp.example.it/fims/landing"];
+      const state = {
+        remoteConfig: O.some({
+          fims: { trackingEnrichedUrls }
+        })
+      } as GlobalState;
+
+      expect(fimsTrackingEnrichedUrlsSelector(state)).toEqual(
+        trackingEnrichedUrls
+      );
+    });
+
+    it("should return an empty allowlist when it is not configured", () => {
+      expect(fimsTrackingEnrichedUrlsSelector(noneStore)).toEqual([]);
     });
   });
 

--- a/apps/main-app/ts/store/reducers/backendStatus/__tests__/remoteConfig.test.ts
+++ b/apps/main-app/ts/store/reducers/backendStatus/__tests__/remoteConfig.test.ts
@@ -356,6 +356,14 @@ describe("remoteConfig", () => {
     it("should return an empty allowlist when it is not configured", () => {
       expect(fimsTrackingEnrichedUrlsSelector(noneStore)).toEqual([]);
     });
+
+    it("should return an empty allowlist when the FIMS config is empty", () => {
+      const state = {
+        remoteConfig: O.some({ fims: {} })
+      } as GlobalState;
+
+      expect(fimsTrackingEnrichedUrlsSelector(state)).toEqual([]);
+    });
   });
 
   describe("messageSurveyBannerUriSelector", () => {

--- a/apps/main-app/ts/store/reducers/backendStatus/remoteConfig.ts
+++ b/apps/main-app/ts/store/reducers/backendStatus/remoteConfig.ts
@@ -220,6 +220,16 @@ export const fimsServiceConfiguration = createSelector(
     )
 );
 
+export const fimsTrackingEnrichedUrlsSelector = createSelector(
+  remoteConfigSelector,
+  (remoteConfig): ReadonlyArray<string> =>
+    pipe(
+      remoteConfig,
+      O.chainNullableK(config => config.fims.trackingEnrichedUrls),
+      O.getOrElse(() => emptyArray)
+    )
+);
+
 /**
  * Checks if a service should share iOS cookies in the FIMS flow.
  * Returns true if the serviceId is in the iOSCookieDisabledServiceIds list,

--- a/apps/main-app/ts/store/reducers/backendStatus/remoteConfig.ts
+++ b/apps/main-app/ts/store/reducers/backendStatus/remoteConfig.ts
@@ -223,11 +223,7 @@ export const fimsServiceConfiguration = createSelector(
 export const fimsTrackingEnrichedUrlsSelector = createSelector(
   remoteConfigSelector,
   (remoteConfig): ReadonlyArray<string> =>
-    pipe(
-      remoteConfig,
-      O.chainNullableK(config => config.fims.trackingEnrichedUrls),
-      O.getOrElse(() => emptyArray)
-    )
+    O.toUndefined(remoteConfig)?.fims.trackingEnrichedUrls ?? emptyArray
 );
 
 /**


### PR DESCRIPTION
## Short description
This pull request introduces a mechanism to selectively enrich FIMS redirect URLs with the Mixpanel device ID, but only for URLs explicitly allowed by remote configuration. The enrichment is controlled by feature flags and robustly handles error scenarios. The changes include new selectors, utility functions, saga logic, and comprehensive tests to ensure correct behavior.

This PR depends on https://github.com/pagopa/io-dev-api-server/pull/617


## List of changes proposed in this pull request
**FIMS Redirect URL Enrichment:**

* Added the `enrichFimsDestinationUrl` utility function, which appends the Mixpanel device ID to allowed redirect URLs, based on a configurable allowlist. If the URL is not allowed or is invalid, it is returned unchanged.
* Introduced the `enrichFimsRedirectUrl` saga, which uses the allowlist and Mixpanel enablement flag to determine if enrichment should occur, and safely handles device ID retrieval failures.
* Updated the FIMS authorization saga to use the enriched redirect URL when opening the authentication session.

**Configuration and State Management:**

* Added the `fimsTrackingEnrichedUrlsSelector` to retrieve the allowlist from remote configuration, with tests to verify correct selector behavior. [[1]](diffhunk://#diff-bbcaa878d6ddd74dcce6ecdc79cdc69a9b374700bfa387a58e9553a59ead7f4dR223-R232) [[2]](diffhunk://#diff-c334d60ada2ac4436f621e9955fb4059dffe762285635b8ed3c0309929a6ee8cR342-R360)

**Testing Enhancements:**

* Added unit tests for `enrichFimsDestinationUrl` and `enrichFimsRedirectUrl`, covering all relevant scenarios (Mixpanel enabled/disabled, device ID retrieval failure, allowed/disallowed URLs). [[1]](diffhunk://#diff-a32c47cbb3037b97820e15cb4ee3a0620c07f10d4d0f0fa2b18f58d5bdb4b27dR66-R96) [[2]](diffhunk://#diff-3001b79a0db6924c3ab679508a9eaa178201a1846eeff04ed8348cde3640069eR275-R321)

**Supporting Changes:**

* Updated the API models generation script to use the latest `io-services-metadata` branch for enriched URLs support.

These changes ensure that device tracking for FIMS flows is only performed for explicitly allowed URLs and only when Mixpanel tracking is enabled, improving privacy and configurability.

## How to test
all checks must pass
