### PR TITLE
ci: [IOPTL-0000] Run every check during release workflows

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -24,8 +24,12 @@ jobs:
         uses: ./.github/actions/setup-composite
       - name: Sets the base and head SHAs required for `nx affected` command
         uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
-      - id: run-validate
+      - id: run-affected-checks
+        if: github.event_name == 'pull_request'
         run: pnpm validate
+      - id: run-all-checks
+        if: github.event_name != 'pull_request'
+        run: pnpm validate-all
       - id: knip
         name: Check unused files and/or references
         # Advisory only: reports code this PR left unused, and can never block a

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "prepare": "lefthook install --reset-hooks-path",
     "validate": "nx affected --targets=lint,test,tsc-noemit --configuration=ci --nx-bail",
+    "validate-all": "nx run-many --targets=lint,test,tsc-noemit --configuration=ci --nx-bail",
     "prettify": "prettier --write \"**/(src|ts|locales)/**/*.(ts|tsx|json)\"",
     "prettier:check": "prettier --check \"**/(src|ts|locales)/**/*.(ts|tsx|json)\"",
     "knip": "knip --reporter json --no-exit-code --no-progress",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prepare": "lefthook install --reset-hooks-path",
     "validate": "nx affected --targets=lint,test,tsc-noemit --configuration=ci --nx-bail",
-    "validate-all": "nx run-many --targets=lint,test,tsc-noemit --configuration=ci --nx-bail",
+    "validate-all": "nx run-many --targets=lint,test,tsc-noemit --configuration=ci",
     "prettify": "prettier --write \"**/(src|ts|locales)/**/*.(ts|tsx|json)\"",
     "prettier:check": "prettier --check \"**/(src|ts|locales)/**/*.(ts|tsx|json)\"",
     "knip": "knip --reporter json --no-exit-code --no-progress",


### PR DESCRIPTION
## Short description
This PR fixes a small regression which occurred while migrating to nx. Instead of running `pnpm validate` which refers to the previous commit while running a release workflow, it now runs every check on every project each time, restoring the old behaviour.

## List of changes proposed in this pull request
- Add a `validate-all` script and call it conditionally during the static checks workflow while checking only affected projects in pull requests.

## How to test
N/A
