### PR TITLE
chore: [IOPTL-000] Prevent relative imports from design system

### DIFF
--- a/apps/main-app/eslint.config.mjs
+++ b/apps/main-app/eslint.config.mjs
@@ -4,8 +4,30 @@ export default [
   ...baseConfig,
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
-    // Override or add rules here
-    rules: {}
+    ignores: [
+      '**/*.test.{ts,tsx}',
+      '**/{__tests__,__mocks__}/**/*.{ts,tsx}'
+    ],
+    rules: {
+      // Consumers must use the public design-system API instead of its monorepo path or private modules.
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: [
+                'libs/design-system/**',
+                '**/libs/design-system/**',
+                '@io-app/design-system/**',
+                '@pagopa/io-app-design-system/**'
+              ],
+              message:
+                'Import from "@io-app/design-system" to use the design system public API.'
+            }
+          ]
+        }
+      ]
+    }
   },
   {
     ignores: [

--- a/apps/main-app/eslint.config.mjs
+++ b/apps/main-app/eslint.config.mjs
@@ -4,10 +4,6 @@ export default [
   ...baseConfig,
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
-    ignores: [
-      '**/*.test.{ts,tsx}',
-      '**/{__tests__,__mocks__}/**/*.{ts,tsx}'
-    ],
     rules: {
       // Consumers must use the public design-system API instead of its monorepo path or internals
       'no-restricted-imports': [

--- a/apps/main-app/eslint.config.mjs
+++ b/apps/main-app/eslint.config.mjs
@@ -9,20 +9,18 @@ export default [
       '**/{__tests__,__mocks__}/**/*.{ts,tsx}'
     ],
     rules: {
-      // Consumers must use the public design-system API instead of its monorepo path or private modules.
+      // Consumers must use the public design-system API instead of its monorepo path or internals
       'no-restricted-imports': [
         'error',
         {
           patterns: [
             {
               group: [
-                'libs/design-system/**',
-                '**/libs/design-system/**',
-                '@io-app/design-system/**',
-                '@pagopa/io-app-design-system/**'
+                '**/libs/design-system/**', // Avoid monorepo path
+                '@io-app/design-system/**' // Avoid internals
               ],
               message:
-                'Import from "@io-app/design-system" to use the design system public API.'
+                'Import from "@io-app/design-system" to use the design system.'
             }
           ]
         }


### PR DESCRIPTION
## Short description
This PR prevents relative imports from the design system.

## List of changes proposed in this pull request
- Add an eslint rule which raises an error when using relative imports for the design system;
- Update a test which was using a relative import.

## How to test
Change a few imports with their relative counterpart. The linting should fail. 
