### PR TITLE
feat: [SIW-4810] Implement CieID environment selection logic and updated related components

### DIFF
--- a/apps/main-app/ios/Podfile.lock
+++ b/apps/main-app/ios/Podfile.lock
@@ -211,7 +211,7 @@ PODS:
     - Mixpanel-swift (= 5.2.0)
     - React-Core
   - OpenSSL-Universal (3.6.2000)
-  - pagopa-io-react-native-cieid (0.4.0):
+  - pagopa-io-react-native-cieid (0.5.2):
     - boost
     - DoubleConversion
     - fast_float
@@ -4402,7 +4402,7 @@ SPEC CHECKSUMS:
   Mixpanel-swift: de454db5987bf6f601106520a44663fc556e8cfa
   MixpanelReactNative: 1f0d8718b2be7174f719ed5db8e8f75d7975dea4
   OpenSSL-Universal: ecee7b138fa75a74ecf00d7ffd248fb584739b9e
-  pagopa-io-react-native-cieid: ff8a232612c44f72846202a4b857a4e16ff9db4d
+  pagopa-io-react-native-cieid: 3969ed1784e0b9041baf892b461be3640315acd1
   pagopa-io-react-native-crypto: eb62bb6767b44ea610ce169d855c89604b9e96d9
   pagopa-io-react-native-integrity: 3e84754db0333a531db86f83f786f60a6da22337
   pagopa-io-react-native-jwt: d268a7aa7a0c63e809386209e589224e0c0c04c0

--- a/apps/main-app/package.json
+++ b/apps/main-app/package.json
@@ -44,7 +44,7 @@
     "@io-app/design-system": "workspace:@pagopa/io-app-design-system@*",
     "@pagopa/io-pagopa-commons": "^3.1.0",
     "@pagopa/io-react-native-cie": "1.3.6",
-    "@pagopa/io-react-native-cieid": "0.4.0",
+    "@pagopa/io-react-native-cieid": "0.5.2",
     "@pagopa/io-react-native-crypto": "^1.2.3",
     "@pagopa/io-react-native-http-client": "1.2.0",
     "@pagopa/io-react-native-integrity": "^0.3.2",

--- a/apps/main-app/ts/features/authentication/activeSessionLogin/screens/cieId/ActiveSessionCieIdLoginScreen.tsx
+++ b/apps/main-app/ts/features/authentication/activeSessionLogin/screens/cieId/ActiveSessionCieIdLoginScreen.tsx
@@ -28,6 +28,7 @@ import {
   WHITELISTED_DOMAINS
 } from "../../../login/cie/shared/utils";
 import {
+  getCieIdEnvironment,
   getCieIDLoginUri,
   isAuthenticationUrl
 } from "../../../login/cie/utils";
@@ -197,7 +198,7 @@ const ActiveSessionCieIdLoginWebView = ({
               checkIfUrlIsWhitelisted(result.url);
             }
           },
-          isUat
+          getCieIdEnvironment(isUat)
         );
       }
     },

--- a/apps/main-app/ts/features/authentication/login/cie/components/CieIdLoginWebView.tsx
+++ b/apps/main-app/ts/features/authentication/login/cie/components/CieIdLoginWebView.tsx
@@ -33,7 +33,11 @@ import {
   originSchemasWhiteList,
   WHITELISTED_DOMAINS
 } from "../shared/utils";
-import { getCieIDLoginUri, isAuthenticationUrl } from "../utils";
+import {
+  getCieIdEnvironment,
+  getCieIDLoginUri,
+  isAuthenticationUrl
+} from "../utils";
 import {
   CIE_ID_ERROR,
   CIE_ID_ERROR_MESSAGE,
@@ -187,7 +191,7 @@ const CieIdLoginWebView = ({ spidLevel, isUat }: CieIdLoginProps) => {
               checkIfUrlIsWhitelisted(result.url);
             }
           },
-          isUat
+          getCieIdEnvironment(isUat)
         );
       }
     },

--- a/apps/main-app/ts/features/authentication/login/cie/utils/__tests__/index.test.ts
+++ b/apps/main-app/ts/features/authentication/login/cie/utils/__tests__/index.test.ts
@@ -1,0 +1,11 @@
+import { getCieIdEnvironment } from "..";
+
+describe("getCieIdEnvironment", () => {
+  it("should target the preprod CieID app when UAT is enabled", () => {
+    expect(getCieIdEnvironment(true)).toEqual("preprod");
+  });
+
+  it("should target the production CieID app when UAT is disabled", () => {
+    expect(getCieIdEnvironment(false)).toEqual("production");
+  });
+});

--- a/apps/main-app/ts/features/authentication/login/cie/utils/index.ts
+++ b/apps/main-app/ts/features/authentication/login/cie/utils/index.ts
@@ -1,3 +1,5 @@
+import { CieIdEnvironment } from "@pagopa/io-react-native-cieid";
+
 import { cieLoginFlowWithDevServerEnabled } from "../../../../../config";
 import { isDevEnv } from "../../../../../utils/environment";
 
@@ -5,6 +7,12 @@ export type SpidLevel = "SpidL2" | "SpidL3";
 
 export const cieFlowForDevServerEnabled =
   isDevEnv && cieLoginFlowWithDevServerEnabled;
+
+/**
+ * Maps the CIE login UAT flag to the CieID app environment to open.
+ */
+export const getCieIdEnvironment = (isUat: boolean): CieIdEnvironment =>
+  isUat ? "preprod" : "production";
 
 export const getCieIDLoginUri = (
   spidLevel: SpidLevel,

--- a/apps/main-app/ts/features/authentication/login/hooks/useNavigateToLoginMethod.tsx
+++ b/apps/main-app/ts/features/authentication/login/hooks/useNavigateToLoginMethod.tsx
@@ -17,7 +17,11 @@ import {
   isCieLoginUatEnabledSelector,
   isCieSupportedSelector
 } from "../../login/cie/store/selectors";
-import { cieFlowForDevServerEnabled, SpidLevel } from "../../login/cie/utils";
+import {
+  cieFlowForDevServerEnabled,
+  getCieIdEnvironment,
+  SpidLevel
+} from "../../login/cie/utils";
 import {
   ChosenIdentifier,
   Identifier
@@ -110,7 +114,10 @@ const useNavigateToLoginMethod = () => {
         dispatch(cieIDSetSelectedSecurityLevel(spidLevel));
       }
 
-      if (isCieIdAvailable(isCieUatEnabled) || cieFlowForDevServerEnabled) {
+      if (
+        isCieIdAvailable(getCieIdEnvironment(isCieUatEnabled)) ||
+        cieFlowForDevServerEnabled
+      ) {
         const params = {
           spidLevel,
           isUat: isCieUatEnabled

--- a/apps/main-app/ts/features/itwallet/common/store/selectors/__tests__/environment.test.ts
+++ b/apps/main-app/ts/features/itwallet/common/store/selectors/__tests__/environment.test.ts
@@ -3,7 +3,11 @@ import * as O from "fp-ts/lib/Option";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import { CredentialType } from "../../../utils/itwMocksUtils";
 import { CredentialFormat } from "../../../utils/itwTypesUtils";
-import { selectItwEnv, selectItwSpecsVersion } from "../environment";
+import {
+  selectItwCieIdEnvironment,
+  selectItwEnv,
+  selectItwSpecsVersion
+} from "../environment";
 
 describe("selectItwEnv", () => {
   it("should return the correct environment", () => {
@@ -32,6 +36,35 @@ describe("selectItwEnv", () => {
     } as GlobalState;
 
     expect(selectItwEnv(state)).toEqual("prod");
+  });
+});
+
+describe("selectItwCieIdEnvironment", () => {
+  const stateWithEnv = (env: string | undefined) =>
+    ({
+      features: {
+        itWallet: {
+          environment: {
+            env
+          }
+        }
+      }
+    }) as GlobalState;
+
+  it("should target the coll CieID app in the pre environment", () => {
+    expect(selectItwCieIdEnvironment(stateWithEnv("pre"))).toEqual("coll");
+  });
+
+  it("should target the production CieID app in the prod environment", () => {
+    expect(selectItwCieIdEnvironment(stateWithEnv("prod"))).toEqual(
+      "production"
+    );
+  });
+
+  it("should target the production CieID app when the environment is not set", () => {
+    expect(selectItwCieIdEnvironment(stateWithEnv(undefined))).toEqual(
+      "production"
+    );
   });
 });
 

--- a/apps/main-app/ts/features/itwallet/common/store/selectors/environment.ts
+++ b/apps/main-app/ts/features/itwallet/common/store/selectors/environment.ts
@@ -1,3 +1,4 @@
+import { CieIdEnvironment } from "@pagopa/io-react-native-cieid";
 import { ItwVersion } from "@pagopa/io-react-native-wallet";
 import * as O from "fp-ts/lib/Option";
 import { createSelector } from "reselect";
@@ -10,15 +11,19 @@ export const selectItwEnv = (state: GlobalState) =>
   state.features.itWallet.environment.env ?? "prod";
 
 /**
- * True when the IT-Wallet pre-production environment is selected.
+ * The CieID app environment that the app-to-app flow must target.
  *
- * In this case the CieID app-to-app flow must target the UAT CieID app
- * (a different Android package name), otherwise the production CieID app
- * would authenticate against production IdP endpoints, which are not
- * compatible with the pre-production IT-Wallet ecosystem.
+ * The IT-Wallet pre-production environment is paired with the `coll` CieID app
+ * (`it.ipzs.cieid.coll`, a different Android package name), otherwise the
+ * production CieID app would authenticate against production IdP endpoints,
+ * which are not compatible with the pre-production IT-Wallet ecosystem.
+ *
+ * Note that this is not the `preprod` CieID environment
+ * (`it.ipzs.cieid.collaudo`), which is only used by the CIE login UAT flag.
  */
-export const selectItwIsCieIdUatEnv = (state: GlobalState) =>
-  selectItwEnv(state) === "pre";
+export const selectItwCieIdEnvironment = (
+  state: GlobalState
+): CieIdEnvironment => (selectItwEnv(state) === "pre" ? "coll" : "production");
 
 /**
  * Select the IT-Wallet specification version depending on the user configuration.

--- a/apps/main-app/ts/features/itwallet/identification/cieId/hooks/useCieIdApp.ts
+++ b/apps/main-app/ts/features/itwallet/identification/cieId/hooks/useCieIdApp.ts
@@ -14,7 +14,7 @@ import {
   IO_LOGIN_CIE_SOURCE_APP,
   IO_LOGIN_CIE_URL_SCHEME
 } from "../../../../authentication/login/cie/utils/cie";
-import { selectItwIsCieIdUatEnv } from "../../../common/store/selectors/environment";
+import { selectItwCieIdEnvironment } from "../../../common/store/selectors/environment";
 import { ItwEidIssuanceMachineContext } from "../../../machine/eid/provider";
 
 type CieIdHookResult = {
@@ -60,7 +60,7 @@ const extractCieIdErrorFromUrl = (url: string) =>
  */
 export const useCieIdApp = (): CieIdHookResult => {
   const machineRef = ItwEidIssuanceMachineContext.useActorRef();
-  const isUatEnvironment = useIOSelector(selectItwIsCieIdUatEnv);
+  const cieIdEnvironment = useIOSelector(selectItwCieIdEnvironment);
   const [authUrl, setAuthUrl] = useState<O.Option<string>>(O.none);
   const [isAppLaunched, setIsAppLaunched] = useState(false);
 
@@ -102,7 +102,7 @@ export const useCieIdApp = (): CieIdHookResult => {
               handleAuthenticationFailure(result);
             }
           },
-          isUatEnvironment
+          cieIdEnvironment
         );
       }
 
@@ -113,7 +113,7 @@ export const useCieIdApp = (): CieIdHookResult => {
           .catch(handleAuthenticationFailure);
       }
     },
-    [handleAuthenticationFailure, isUatEnvironment]
+    [handleAuthenticationFailure, cieIdEnvironment]
   );
 
   useEffect(() => {

--- a/apps/main-app/ts/features/itwallet/identification/cieId/screens/ItwCieIdLoginScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/identification/cieId/screens/ItwCieIdLoginScreen.tsx
@@ -12,8 +12,8 @@ import { useIOSelector } from "../../../../../store/hooks";
 import { originSchemasWhiteList } from "../../../../authentication/common/utils/originSchemasWhiteList";
 import { useItwDismissalDialog } from "../../../common/hooks/useItwDismissalDialog";
 import {
-  selectItwEnv,
-  selectItwIsCieIdUatEnv
+  selectItwCieIdEnvironment,
+  selectItwEnv
 } from "../../../common/store/selectors/environment";
 import { getEnv } from "../../../common/utils/environment";
 import { ItwEidIssuanceMachineContext } from "../../../machine/eid/provider";
@@ -40,7 +40,7 @@ const isAuthenticationUrl = (url: string) => {
  */
 const ItwCieIdLoginScreen = () => {
   const { ISSUANCE_REDIRECT_URI } = pipe(useIOSelector(selectItwEnv), getEnv);
-  const isCieIdUatEnv = useIOSelector(selectItwIsCieIdUatEnv);
+  const cieIdEnvironment = useIOSelector(selectItwCieIdEnvironment);
 
   const initialAuthUrl =
     ItwEidIssuanceMachineContext.useSelector(selectAuthUrlOption);
@@ -74,17 +74,17 @@ const ItwCieIdLoginScreen = () => {
   const onLoadEnd = useCallback(() => {
     // When CieId app-to-app flow is enabled, stop loading only after we got
     // the authUrl from CieId app, so the user doesn't see the login screen.
-    if (isCieIdAvailable(isCieIdUatEnv) ? !!authUrl : true) {
+    if (isCieIdAvailable(cieIdEnvironment) ? !!authUrl : true) {
       setWebViewLoading(false);
     }
-  }, [authUrl, isCieIdUatEnv]);
+  }, [authUrl, cieIdEnvironment]);
 
   const handleShouldStartLoading = useCallback(
     (event: WebViewNavigation): boolean => {
       const url = event.url;
 
       // When CieID is available, use a flow that launches the app
-      if (isAuthenticationUrl(url) && isCieIdAvailable(isCieIdUatEnv)) {
+      if (isAuthenticationUrl(url) && isCieIdAvailable(cieIdEnvironment)) {
         startCieIdAppAuthentication(url);
         return false;
       }
@@ -92,7 +92,7 @@ const ItwCieIdLoginScreen = () => {
       // When CieID is not available, fallback to the regular webview
       return true;
     },
-    [startCieIdAppAuthentication, isCieIdUatEnv]
+    [startCieIdAppAuthentication, cieIdEnvironment]
   );
 
   const handleNavigationStateChange = useCallback(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,8 +228,8 @@ importers:
         specifier: 1.3.6
         version: 1.3.6(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@6.0.3))(@react-native/metro-config@0.83.6(@babel/core@7.29.0))(@types/react@19.2.16)(react@19.2.0))(react@19.2.0)
       '@pagopa/io-react-native-cieid':
-        specifier: 0.4.0
-        version: 0.4.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@6.0.3))(@react-native/metro-config@0.83.6(@babel/core@7.29.0))(@types/react@19.2.16)(react@19.2.0))(react@19.2.0)
+        specifier: 0.5.2
+        version: 0.5.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@6.0.3))(@react-native/metro-config@0.83.6(@babel/core@7.29.0))(@types/react@19.2.16)(react@19.2.0))(react@19.2.0)
       '@pagopa/io-react-native-crypto':
         specifier: ^1.2.3
         version: 1.2.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@6.0.3))(@react-native/metro-config@0.83.6(@babel/core@7.29.0))(@types/react@19.2.16)(react@19.2.0))(react@19.2.0)
@@ -2902,8 +2902,8 @@ packages:
       react: '>=19.1'
       react-native: '>=0.81'
 
-  '@pagopa/io-react-native-cieid@0.4.0':
-    resolution: {integrity: sha512-hOAIoFFzZ0HMJ1EDbcTq0+ZePt6Fa+jtRgizxQpCEWEBrFcb2AeS+6ykwMEjlHDGxOC/22poT7i6zl5eGR6pXQ==}
+  '@pagopa/io-react-native-cieid@0.5.2':
+    resolution: {integrity: sha512-NJjrTgRn8o4dglQiPYI6VM/S/84n1hIIARGCh9Yf7vU4uJ/TlgizzKEPZsnY85pk6ODm59Yn6zRjvjjW5YW/bw==}
     peerDependencies:
       react: '>=19.1'
       react-native: '>=0.81'
@@ -13819,7 +13819,7 @@ snapshots:
       react-native: 0.83.6(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@6.0.3))(@react-native/metro-config@0.83.6(@babel/core@7.29.0))(@types/react@19.2.16)(react@19.2.0)
       zod: 3.25.76
 
-  '@pagopa/io-react-native-cieid@0.4.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@6.0.3))(@react-native/metro-config@0.83.6(@babel/core@7.29.0))(@types/react@19.2.16)(react@19.2.0))(react@19.2.0)':
+  '@pagopa/io-react-native-cieid@0.5.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@6.0.3))(@react-native/metro-config@0.83.6(@babel/core@7.29.0))(@types/react@19.2.16)(react@19.2.0))(react@19.2.0)':
     dependencies:
       react: 19.2.0
       react-native: 0.83.6(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@6.0.3))(@react-native/metro-config@0.83.6(@babel/core@7.29.0))(@types/react@19.2.16)(react@19.2.0)


### PR DESCRIPTION
## Short description
Updates `@pagopa/io-react-native-cieid` from `0.4.0` to `0.5.2` and links the IT Wallet `pre` environment to the new `coll` CieID app.

The library replaced its `isUatEnvironment: boolean` parameter with a `CieIdEnvironment` string union (`'production' | 'preprod' | 'coll'`), so every `isCieIdAvailable` and `openCieIdApp` call site had to be migrated.

IT Wallet `pre` now opens `it.ipzs.cieid.coll` instead of `it.ipzs.cieid.collaudo`. The CIE login UAT flag keeps its current behaviour, mapping to `preprod`, which is the same collaudo package it already used. The two non production flows therefore point at different CieID apps on purpose:

| Flow | Maps to | Android package name |
| ---- | ------- | -------------------- |
| IT Wallet `pre` | `coll` | `it.ipzs.cieid.coll` |
| IT Wallet `prod` | `production` | `it.ipzs.cieid` |
| CIE login, UAT enabled | `preprod` | `it.ipzs.cieid.collaudo` |
| CIE login, UAT disabled | `production` | `it.ipzs.cieid` |

## List of changes proposed in this pull request
- Bumped `@pagopa/io-react-native-cieid` to `0.5.2` in `apps/main-app/package.json`, with the updated `pnpm-lock.yaml`
- `itwallet/common/store/selectors/environment.ts`: replaced `selectItwIsCieIdUatEnv` (boolean) with `selectItwCieIdEnvironment` 
- `itwallet/common/store/selectors/environment.ts`: replaced `selectItwIsCieIdUatEnv` (boolean) with `selectItwCieIdEnvironment`, returning `coll` for `pre` and `production` otherwise, and updated the `useCieIdApp` and `ItwCieIdLoginScreen` consumers
- `authentication/login/cie/utils/index.ts`: added `getCieIdEnvironment(isUat)`, used by `useNavigateToLoginMethod`, `CieIdLoginWebView` and `ActiveSessionCieIdLoginScreen`. The `isUat` props and navigation params are untouched, since they also drive the `xx_servizicie_coll` entityID in `getCieIDLoginUri`, so the conversion happens only at the library boundary
- Added tests for `selectItwCieIdEnvironment` and `getCieIdEnvironment`

## How to test
On an Android device, check which CieID apps are installed with `adb shell pm list packages | grep it.ipzs.cieid`.

**CieID login flow**
1. Enable the CIE login UAT flag and log in with CieID. The pre-prod app must open, exactly as on `main`.
2. Disable the flag and log in again. The production CieID app must open.
3. With no CieID app installed, confirm you are still routed to the "CIE not installed" screen.

**IT Wallet CieID flow (only if u have the collaudo credentials and collaudo (green) app)**
1. Set the IT Wallet environment to `pre` in the developer section and start the eID issuance with CieID. With `it.ipzs.cieid.coll` installed, the app-to-app flow must open that app.
2. Uninstall `it.ipzs.cieid.coll` and repeat. The flow must fall back to the regular WebView login instead of failing.
3. Set the environment to `prod` and confirm the production CieID app is opened.

**No regressions**
1. Complete a full CieID login end to end and confirm the session is created as before.
2. Complete a full IT Wallet eID issuance with CieID and confirm the credential is obtained.
3. Check the iOS CieID flows are unaffected, since iOS uses the shared `CIEID://` URL scheme for every environment and does not depend on the package name.