### PR TITLE
chore: [IOPLT-000] Remove @types/node-fetch

### DIFF
--- a/apps/main-app/package.json
+++ b/apps/main-app/package.json
@@ -180,7 +180,6 @@
     "@types/jest": "catalog:",
     "@types/lodash": "^4.14.157",
     "@types/node": "^10.1.0",
-    "@types/node-fetch": "^2.1.7",
     "@types/pako": "^2.0.0",
     "@types/react": "catalog:",
     "@types/react-native-background-timer": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -625,9 +625,6 @@ importers:
       '@types/node':
         specifier: ^10.1.0
         version: 10.17.28
-      '@types/node-fetch':
-        specifier: ^2.1.7
-        version: 2.5.7
       '@types/pako':
         specifier: ^2.0.0
         version: 2.0.0
@@ -3866,9 +3863,6 @@ packages:
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
-  '@types/node-fetch@2.5.7':
-    resolution: {integrity: sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==}
-
   '@types/node@10.17.28':
     resolution: {integrity: sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==}
 
@@ -6370,10 +6364,6 @@ packages:
   form-data-encoder@2.1.4:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
-
-  form-data@3.0.0:
-    resolution: {integrity: sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==}
-    engines: {node: '>= 6'}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -15263,11 +15253,6 @@ snapshots:
 
   '@types/minimist@1.2.5': {}
 
-  '@types/node-fetch@2.5.7':
-    dependencies:
-      '@types/node': 16.9.6
-      form-data: 3.0.0
-
   '@types/node@10.17.28': {}
 
   '@types/node@16.9.6': {}
@@ -18382,12 +18367,6 @@ snapshots:
       signal-exit: 4.1.0
 
   form-data-encoder@2.1.4: {}
-
-  form-data@3.0.0:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
 
   form-data@4.0.5:
     dependencies:


### PR DESCRIPTION
## Short description
This PR removes `@/types/node-fetch` from the dev dependencies as `node-fetch` is only imported in a `.js` file for jest mocks.

## List of changes proposed in this pull request
- Remove `@/types/node-fetch`.

## How to test
Static check should pass.
