### PR TITLE
fix: [IEG-3155] CGN header accessibility focus on landing

### DIFF
--- a/apps/main-app/ts/features/bonus/cgn/components/CgnAnimatedHeader.tsx
+++ b/apps/main-app/ts/features/bonus/cgn/components/CgnAnimatedHeader.tsx
@@ -9,6 +9,7 @@ import {
   VSpacer
 } from "@io-app/design-system";
 import I18n from "i18next";
+import { useEffect, useRef } from "react";
 import { ActivityIndicator, Platform, StyleSheet, View } from "react-native";
 import Animated, {
   SharedValue,
@@ -17,6 +18,7 @@ import Animated, {
 } from "react-native-reanimated";
 
 import cgnLogo from "../../../../../img/bonus/cgn/cgn_logo.png";
+import { setAccessibilityFocus } from "../../../../utils/accessibility";
 import { CgnAnimatedBackground } from "./CgnAnimatedBackground";
 
 type CgnAnimatedHeaderProps = {
@@ -42,6 +44,12 @@ const CgnAnimatedHeader = ({
   const indicatorColor = isDark
     ? IOColors["blueIO-50"]
     : IOColors["blueItalia-850"];
+
+  const titleRef = useRef<View>(null);
+
+  useEffect(() => {
+    setAccessibilityFocus(titleRef);
+  }, []);
 
   // Fallback SharedValues so hooks are always called unconditionally
   const defaultPullProgress = useSharedValue(0);
@@ -106,7 +114,12 @@ const CgnAnimatedHeader = ({
         >
           <HStack space={16} style={{ alignItems: "center" }}>
             <Avatar logoUri={cgnLogo} size="medium" />
-            <View style={{ flex: 1 }}>
+            <View
+              accessibilityRole="header"
+              accessible
+              ref={titleRef}
+              style={{ flex: 1 }}
+            >
               <H3>{I18n.t("bonus.cgn.merchantsList.screenTitle")}</H3>
             </View>
           </HStack>


### PR DESCRIPTION
## Short description
This pull request improves accessibility for the `CGN` by ensuring that the screen title is automatically focused for screen readers when the component mounts in `CGN_MERCHANTS_CATEGORIES` screen

## List of changes proposed in this pull request
- Added `titleRef` to the title `View` and used the `setAccessibilityFocus` utility to set initial accessibility focus when the component mounts;
- Add missing `accessibilityRole="header"` and `accessible` props.

## How to test
- Navigate into `CGN_DETAILS` with ScreenReader/TalkBack enabled;
- Tap twice on `Scopri le opportunità CGN`;
- Ensure that landing into `CGN_MERCHANTS_CATEGORIES` the focus is moving into the title `Scopri le opportunità`