### PR TITLE
chore: [IOPLT-2016] Removed unused dependencies from `api-types` library

### DIFF
--- a/libs/api-types/package.json
+++ b/libs/api-types/package.json
@@ -12,5 +12,9 @@
   "devDependencies": {
     "@pagopa/openapi-codegen-ts": "^14.0.0",
     "typescript": "catalog:"
+  },
+  "dependencies": {
+    "fp-ts": "^2.16.9",
+    "io-ts": "^2.2.22"
   }
 }

--- a/libs/api-types/package.json
+++ b/libs/api-types/package.json
@@ -12,10 +12,5 @@
   "devDependencies": {
     "@pagopa/openapi-codegen-ts": "^14.0.0",
     "typescript": "catalog:"
-  },
-  "dependencies": {
-    "@pagopa/ts-commons": "^10.15.0",
-    "fp-ts": "^2.16.9",
-    "io-ts": "^2.2.22"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -937,6 +937,13 @@ importers:
         version: 8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
 
   libs/api-types:
+    dependencies:
+      fp-ts:
+        specifier: ^2.16.9
+        version: 2.16.11
+      io-ts:
+        specifier: ^2.2.22
+        version: 2.2.22(fp-ts@2.16.11)
     devDependencies:
       '@pagopa/openapi-codegen-ts':
         specifier: ^14.0.0
@@ -6532,6 +6539,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -937,16 +937,6 @@ importers:
         version: 8.65.0(eslint@9.39.4(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
 
   libs/api-types:
-    dependencies:
-      '@pagopa/ts-commons':
-        specifier: ^10.15.0
-        version: 10.15.0(supports-color@8.1.1)
-      fp-ts:
-        specifier: ^2.16.9
-        version: 2.16.11
-      io-ts:
-        specifier: ^2.2.22
-        version: 2.2.22(fp-ts@2.16.11)
     devDependencies:
       '@pagopa/openapi-codegen-ts':
         specifier: ^14.0.0


### PR DESCRIPTION
## Short description
This PR is removing some unused dependencies from `api-types` library as they are not used

## List of changes proposed in this pull request
- Removed unused dependencies

## How to test
- `pnpm validate` script should pass;
- Check with `pnpx knip` that there are no more unused dependencies for `api-types` library;
- Ensure `api-types` is generating types correctly 
