### PR TITLE
fix(IT-Wallet): [SIW-4623] Use correct specs version in background task

### DIFF
--- a/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/index.test.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/index.test.ts
@@ -9,11 +9,14 @@ import { registerStatusListProperties } from "../../analytics";
 import { refreshStaleEntries } from "../../utils/refresh";
 import { checkStatusListCoherenceSaga } from "../checkStatusListCoherenceSaga";
 import { registerStatusListFetchTaskSaga } from "../registerStatusListFetchTaskSaga";
+import { watchItwSpecsVersionStorageSaga } from "../storeItwSpecsVersionSaga";
 import { updateCredentialsStatusSaga } from "../updateCredentialsStatusSaga";
 
 describe("watchItwStatusListAuthenticatedSaga", () => {
-  it("registers the background fetch task", () => {
+  it("synchronizes the specs version and registers the background fetch task", () => {
     testSaga(watchItwStatusListAuthenticatedSaga)
+      .next()
+      .fork(watchItwSpecsVersionStorageSaga)
       .next()
       .fork(registerStatusListFetchTaskSaga)
       .next()

--- a/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/registerStatusListFetchTaskSaga.test.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/registerStatusListFetchTaskSaga.test.ts
@@ -1,5 +1,6 @@
 import { testSaga } from "redux-saga-test-plan";
 
+import { selectItwSpecsVersion } from "../../../common/store/selectors/environment";
 import { itwLifecycleStoresReset } from "../../../lifecycle/store/actions";
 import { itwLifecycleIsITWalletValidSelector } from "../../../lifecycle/store/selectors";
 import {
@@ -8,13 +9,17 @@ import {
 } from "../../tasks";
 import { registerStatusListFetchTaskSaga } from "../registerStatusListFetchTaskSaga";
 
+const ITW_VERSION = "1.3.3";
+
 describe("registerStatusListFetchTaskSaga", () => {
   it("registers the fetch task immediately when the wallet is valid", () => {
     testSaga(registerStatusListFetchTaskSaga)
       .next()
       .select(itwLifecycleIsITWalletValidSelector)
       .next(true)
-      .call(registerItwStatusListFetchTask);
+      .select(selectItwSpecsVersion)
+      .next(ITW_VERSION)
+      .call(registerItwStatusListFetchTask, ITW_VERSION);
   });
 
   it("waits for wallet activation before registering the fetch task", () => {
@@ -24,7 +29,9 @@ describe("registerStatusListFetchTaskSaga", () => {
       .next(false)
       .inspect(effect => expect(effect).toMatchObject({ type: "TAKE" }))
       .next()
-      .call(registerItwStatusListFetchTask);
+      .select(selectItwSpecsVersion)
+      .next(ITW_VERSION)
+      .call(registerItwStatusListFetchTask, ITW_VERSION);
   });
 
   it("registers the fetch task again after reset and reactivation", () => {
@@ -32,7 +39,9 @@ describe("registerStatusListFetchTaskSaga", () => {
       .next()
       .select(itwLifecycleIsITWalletValidSelector)
       .next(true)
-      .call(registerItwStatusListFetchTask)
+      .select(selectItwSpecsVersion)
+      .next(ITW_VERSION)
+      .call(registerItwStatusListFetchTask, ITW_VERSION)
       .next()
       .take(itwLifecycleStoresReset)
       .next()
@@ -40,7 +49,9 @@ describe("registerStatusListFetchTaskSaga", () => {
       .next()
       .select(itwLifecycleIsITWalletValidSelector)
       .next(true)
-      .call(registerItwStatusListFetchTask);
+      .select(selectItwSpecsVersion)
+      .next(ITW_VERSION)
+      .call(registerItwStatusListFetchTask, ITW_VERSION);
   });
 
   it("waits for credential storage when the wallet is still invalid after reset", () => {
@@ -48,7 +59,9 @@ describe("registerStatusListFetchTaskSaga", () => {
       .next()
       .select(itwLifecycleIsITWalletValidSelector)
       .next(true)
-      .call(registerItwStatusListFetchTask)
+      .select(selectItwSpecsVersion)
+      .next(ITW_VERSION)
+      .call(registerItwStatusListFetchTask, ITW_VERSION)
       .next()
       .take(itwLifecycleStoresReset)
       .next()
@@ -58,6 +71,8 @@ describe("registerStatusListFetchTaskSaga", () => {
       .next(false)
       .inspect(effect => expect(effect).toMatchObject({ type: "TAKE" }))
       .next()
-      .call(registerItwStatusListFetchTask);
+      .select(selectItwSpecsVersion)
+      .next(ITW_VERSION)
+      .call(registerItwStatusListFetchTask, ITW_VERSION);
   });
 });

--- a/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/storeItwSpecsVersionSaga.test.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/saga/__tests__/storeItwSpecsVersionSaga.test.ts
@@ -1,0 +1,69 @@
+import { testSaga } from "redux-saga-test-plan";
+
+import { CredentialType } from "../../../common/utils/itwMocksUtils";
+import { CredentialMetadata } from "../../../common/utils/itwTypesUtils";
+import { itwCredentialsStore } from "../../../credentials/store/actions";
+import { storeItwSpecsVersion } from "../../utils/storage";
+import {
+  handleItwSpecsVersionStorageSaga,
+  isItwCredentialsStoreWithEid,
+  watchItwSpecsVersionStorageSaga
+} from "../storeItwSpecsVersionSaga";
+
+const eid = {
+  credentialType: CredentialType.PID,
+  spec_version: "1.3.3"
+} as CredentialMetadata;
+
+const drivingLicense = {
+  credentialType: CredentialType.DRIVING_LICENSE
+} as CredentialMetadata;
+
+const eidStoreAction = itwCredentialsStore([eid]);
+
+describe("isItwCredentialsStoreWithEid", () => {
+  it("matches credential store actions containing an eID", () => {
+    expect(isItwCredentialsStoreWithEid(eidStoreAction)).toBe(true);
+  });
+
+  it("rejects credential store actions without an eID", () => {
+    expect(
+      isItwCredentialsStoreWithEid(itwCredentialsStore([drivingLicense]))
+    ).toBe(false);
+  });
+
+  it("rejects unrelated actions", () => {
+    expect(isItwCredentialsStoreWithEid({ type: "unrelated" })).toBe(false);
+  });
+});
+
+describe("handleItwSpecsVersionStorageSaga", () => {
+  it("persists the specs version from the stored eID", () => {
+    testSaga(handleItwSpecsVersionStorageSaga, eidStoreAction)
+      .next()
+      .call(storeItwSpecsVersion, "1.3.3")
+      .next()
+      .isDone();
+  });
+
+  it("swallows storage failures", () => {
+    testSaga(handleItwSpecsVersionStorageSaga, eidStoreAction)
+      .next()
+      .call(storeItwSpecsVersion, "1.3.3")
+      .throw(new Error("storage failure"))
+      .isDone();
+  });
+});
+
+describe("watchItwSpecsVersionStorageSaga", () => {
+  it("takes the latest credential store action containing an eID", () => {
+    testSaga(watchItwSpecsVersionStorageSaga)
+      .next()
+      .takeLatest(
+        isItwCredentialsStoreWithEid,
+        handleItwSpecsVersionStorageSaga
+      )
+      .next()
+      .isDone();
+  });
+});

--- a/apps/main-app/ts/features/itwallet/statusList/saga/index.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/saga/index.ts
@@ -7,9 +7,12 @@ import { registerStatusListProperties } from "../analytics";
 import { refreshStaleEntries } from "../utils/refresh";
 import { checkStatusListCoherenceSaga } from "./checkStatusListCoherenceSaga";
 import { registerStatusListFetchTaskSaga } from "./registerStatusListFetchTaskSaga";
+import { watchItwSpecsVersionStorageSaga } from "./storeItwSpecsVersionSaga";
 import { updateCredentialsStatusSaga } from "./updateCredentialsStatusSaga";
 
 export function* watchItwStatusListAuthenticatedSaga(): SagaIterator {
+  // Keep the background-task specs version synchronized with eID changes
+  yield* fork(watchItwSpecsVersionStorageSaga);
   // Register the background task for Status List fetch only for active wallet instances
   yield* fork(registerStatusListFetchTaskSaga);
 }

--- a/apps/main-app/ts/features/itwallet/statusList/saga/registerStatusListFetchTaskSaga.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/saga/registerStatusListFetchTaskSaga.ts
@@ -2,6 +2,7 @@ import { SagaIterator } from "redux-saga";
 import { call, select, take } from "typed-redux-saga/macro";
 
 import { waitForItWalletActivation } from "../../common/saga/utils";
+import { selectItwSpecsVersion } from "../../common/store/selectors/environment";
 import { itwLifecycleStoresReset } from "../../lifecycle/store/actions";
 import { itwLifecycleIsITWalletValidSelector } from "../../lifecycle/store/selectors";
 import {
@@ -22,7 +23,8 @@ export function* registerStatusListFetchTaskSaga(): SagaIterator {
     }
 
     // Register only for active wallet instances (idempotent).
-    yield* call(registerItwStatusListFetchTask);
+    const itwVersion = yield* select(selectItwSpecsVersion);
+    yield* call(registerItwStatusListFetchTask, itwVersion);
 
     // On wallet reset, unregister and loop to await the next reactivation.
     yield* take(itwLifecycleStoresReset);

--- a/apps/main-app/ts/features/itwallet/statusList/saga/storeItwSpecsVersionSaga.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/saga/storeItwSpecsVersionSaga.ts
@@ -1,0 +1,48 @@
+import { type ItwVersion } from "@pagopa/io-react-native-wallet";
+import { SagaIterator } from "redux-saga";
+import { call, takeLatest } from "typed-redux-saga/macro";
+import { Action, isActionOf } from "typesafe-actions";
+
+import { CredentialType } from "../../common/utils/itwMocksUtils";
+import { itwCredentialsStore } from "../../credentials/store/actions";
+import { storeItwSpecsVersion } from "../utils/storage";
+
+/**
+ * Matches credential store actions containing an eID.
+ */
+export const isItwCredentialsStoreWithEid = (
+  action: Action
+): action is ReturnType<typeof itwCredentialsStore> =>
+  isActionOf(itwCredentialsStore, action) &&
+  action.payload.some(
+    credential => credential.credentialType === CredentialType.PID
+  );
+
+/**
+ * Persists the specs version carried by the stored eID.
+ * Storage failures are ignored because this background-task projection must not
+ * affect credential storage.
+ */
+export function* handleItwSpecsVersionStorageSaga(
+  action: ReturnType<typeof itwCredentialsStore>
+): SagaIterator {
+  const eid = action.payload.find(
+    credential => credential.credentialType === CredentialType.PID
+  ) as (typeof action.payload)[number];
+
+  try {
+    yield* call(storeItwSpecsVersion, eid.spec_version as ItwVersion);
+  } catch {
+    // Credential storage remains authoritative; registration retries the projection.
+  }
+}
+
+/**
+ * Keeps the background-task specs version synchronized with the latest eID.
+ */
+export function* watchItwSpecsVersionStorageSaga(): SagaIterator {
+  yield* takeLatest(
+    isItwCredentialsStoreWithEid,
+    handleItwSpecsVersionStorageSaga
+  );
+}

--- a/apps/main-app/ts/features/itwallet/statusList/tasks/__tests__/index.test.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/tasks/__tests__/index.test.ts
@@ -1,0 +1,117 @@
+import { ItwVersion } from "@pagopa/io-react-native-wallet";
+import * as BackgroundTask from "expo-background-task";
+import * as TaskManager from "expo-task-manager";
+
+import { ITW_STATUS_LIST_FETCH_TASK, registerItwStatusListFetchTask } from "..";
+import {
+  trackItwStatusListFetchRegistered,
+  trackItwStatusListFetchRegisterFailure
+} from "../../analytics";
+import { refreshStaleEntries } from "../../utils/refresh";
+import { getItwSpecsVersion, storeItwSpecsVersion } from "../../utils/storage";
+
+jest.mock("../../analytics", () => ({
+  trackItwStatusListFetchRegistered: jest.fn(),
+  trackItwStatusListFetchRegisterFailure: jest.fn()
+}));
+jest.mock("../../utils/refresh", () => ({
+  refreshStaleEntries: jest.fn()
+}));
+jest.mock("../../utils/storage", () => ({
+  getItwSpecsVersion: jest.fn(),
+  storeItwSpecsVersion: jest.fn()
+}));
+
+const mockDefineTask = jest.mocked(TaskManager.defineTask);
+const mockIsTaskRegistered = jest.mocked(TaskManager.isTaskRegisteredAsync);
+const mockRegisterTask = jest.mocked(BackgroundTask.registerTaskAsync);
+const mockGetItwSpecsVersion = jest.mocked(getItwSpecsVersion);
+const mockStoreItwSpecsVersion = jest.mocked(storeItwSpecsVersion);
+const mockRefreshStaleEntries = jest.mocked(refreshStaleEntries);
+const mockTrackRegistered = jest.mocked(trackItwStatusListFetchRegistered);
+const mockTrackRegisterFailure = jest.mocked(
+  trackItwStatusListFetchRegisterFailure
+);
+
+const taskExecutor = mockDefineTask.mock.calls.find(
+  ([taskName]) => taskName === ITW_STATUS_LIST_FETCH_TASK
+)?.[1];
+
+if (!taskExecutor) {
+  throw new Error("ITW Status List background task is not defined");
+}
+
+const taskBody = {
+  data: {},
+  error: null,
+  executionInfo: {
+    eventId: "event-id",
+    taskName: ITW_STATUS_LIST_FETCH_TASK
+  }
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsTaskRegistered.mockResolvedValue(false);
+  mockRegisterTask.mockResolvedValue(undefined);
+  mockStoreItwSpecsVersion.mockResolvedValue(undefined);
+  mockRefreshStaleEntries.mockResolvedValue(undefined);
+});
+
+describe("ITW Status List background task", () => {
+  it("refreshes stale entries using the stored IT-Wallet specs version", async () => {
+    mockGetItwSpecsVersion.mockResolvedValue("1.3.3");
+
+    await expect(taskExecutor(taskBody)).resolves.toBe(
+      BackgroundTask.BackgroundTaskResult.Success
+    );
+    expect(mockRefreshStaleEntries).toHaveBeenCalledWith({
+      itwVersion: "1.3.3"
+    });
+  });
+
+  it("fails when the IT-Wallet specs version cannot be read", async () => {
+    mockGetItwSpecsVersion.mockRejectedValue(new Error("missing version"));
+
+    await expect(taskExecutor(taskBody)).resolves.toBe(
+      BackgroundTask.BackgroundTaskResult.Failed
+    );
+    expect(mockRefreshStaleEntries).not.toHaveBeenCalled();
+  });
+});
+
+describe("registerItwStatusListFetchTask", () => {
+  it("stores the current specs version before registering the task", async () => {
+    const itwVersion: ItwVersion = "1.3.3";
+
+    await registerItwStatusListFetchTask(itwVersion);
+
+    expect(mockStoreItwSpecsVersion).toHaveBeenCalledWith(itwVersion);
+    expect(mockStoreItwSpecsVersion.mock.invocationCallOrder[0]).toBeLessThan(
+      mockIsTaskRegistered.mock.invocationCallOrder[0]
+    );
+    expect(mockRegisterTask).toHaveBeenCalledWith(ITW_STATUS_LIST_FETCH_TASK, {
+      minimumInterval: 60 * 12
+    });
+    expect(mockTrackRegistered).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates the stored specs version when the task is already registered", async () => {
+    mockIsTaskRegistered.mockResolvedValue(true);
+
+    await registerItwStatusListFetchTask("1.3.3");
+
+    expect(mockStoreItwSpecsVersion).toHaveBeenCalledWith("1.3.3");
+    expect(mockRegisterTask).not.toHaveBeenCalled();
+  });
+
+  it("does not register the task when storing the specs version fails", async () => {
+    mockStoreItwSpecsVersion.mockRejectedValue(new Error("storage failure"));
+
+    await registerItwStatusListFetchTask("1.3.3");
+
+    expect(mockIsTaskRegistered).not.toHaveBeenCalled();
+    expect(mockRegisterTask).not.toHaveBeenCalled();
+    expect(mockTrackRegisterFailure).toHaveBeenCalledWith("storage failure");
+  });
+});

--- a/apps/main-app/ts/features/itwallet/statusList/tasks/index.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/tasks/index.ts
@@ -1,3 +1,4 @@
+import { ItwVersion } from "@pagopa/io-react-native-wallet";
 import * as BackgroundTask from "expo-background-task";
 import * as TaskManager from "expo-task-manager";
 
@@ -6,6 +7,7 @@ import {
   trackItwStatusListFetchRegisterFailure
 } from "../analytics";
 import { refreshStaleEntries } from "../utils/refresh";
+import { getItwSpecsVersion, storeItwSpecsVersion } from "../utils/storage";
 
 /**
  * Identifier for the ITW Status List background fetch task.
@@ -24,13 +26,13 @@ const ITW_STATUS_LIST_FETCH_TASK_INTERVAL_MINUTES = 60 * 12;
  * Register the ITW Status List fetch task handler with expo-task-manager.
  * Important: must be defined at module level.
  *
- * Current behavior: stores the background wake-up timestamp (used later for analytics).
- * Status List refresh/fetch logic will be added separately.
+ * Reads the specs version persisted during foreground registration, then refreshes
+ * stale Status List entries without depending on Redux.
  */
 TaskManager.defineTask(ITW_STATUS_LIST_FETCH_TASK, async () => {
   try {
-    // TODO SIW-4623: get itw version in the background task
-    await refreshStaleEntries({ itwVersion: "1.3.3" });
+    const itwVersion = await getItwSpecsVersion();
+    await refreshStaleEntries({ itwVersion });
     return BackgroundTask.BackgroundTaskResult.Success;
   } catch {
     return BackgroundTask.BackgroundTaskResult.Failed;
@@ -38,11 +40,17 @@ TaskManager.defineTask(ITW_STATUS_LIST_FETCH_TASK, async () => {
 });
 
 /**
- * Registers the ITW Status List background fetch task with expo-background-task
- * if the background task API is available and the task is not already registered.
+ * Persists the current IT-Wallet specs version and registers the Status List
+ * background fetch task when it is not already registered.
+ *
+ * Persisting happens on every call so app updates can change the background
+ * task version without requiring the OS task registration to be recreated.
  */
-export const registerItwStatusListFetchTask = async (): Promise<void> => {
+export const registerItwStatusListFetchTask = async (
+  itwVersion: ItwVersion
+): Promise<void> => {
   try {
+    await storeItwSpecsVersion(itwVersion);
     const isRegistered = await TaskManager.isTaskRegisteredAsync(
       ITW_STATUS_LIST_FETCH_TASK
     );

--- a/apps/main-app/ts/features/itwallet/statusList/utils/__tests__/storage.test.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/utils/__tests__/storage.test.ts
@@ -1,8 +1,13 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
-import { STORAGE_KEY_LAST_CHECK_TIME } from "../consts";
 import {
+  STORAGE_KEY_ITW_SPECS_VERSION,
+  STORAGE_KEY_LAST_CHECK_TIME
+} from "../consts";
+import {
+  getItwSpecsVersion,
   getLastStatusListCheckTimestamps,
+  storeItwSpecsVersion,
   storeLastStatusListCheckTimestamp
 } from "../storage";
 
@@ -11,6 +16,31 @@ jest.mock("@react-native-async-storage/async-storage", () =>
 );
 
 beforeEach(() => AsyncStorage.clear());
+
+describe("IT-Wallet specs version storage", () => {
+  it("stores and retrieves the specs version", async () => {
+    await storeItwSpecsVersion("1.3.3");
+
+    await expect(
+      AsyncStorage.getItem(STORAGE_KEY_ITW_SPECS_VERSION)
+    ).resolves.toBe("1.3.3");
+    await expect(getItwSpecsVersion()).resolves.toBe("1.3.3");
+  });
+
+  it("throws when no specs version is stored", async () => {
+    await expect(getItwSpecsVersion()).rejects.toThrow(
+      "IT-Wallet specs version not found"
+    );
+  });
+
+  it("propagates AsyncStorage errors", async () => {
+    jest
+      .spyOn(AsyncStorage, "getItem")
+      .mockRejectedValueOnce(new Error("boom"));
+
+    await expect(getItwSpecsVersion()).rejects.toThrow("boom");
+  });
+});
 
 describe("storeLastStatusListCheckTimestamp", () => {
   it("stores the timestamp list under the expected key", async () => {

--- a/apps/main-app/ts/features/itwallet/statusList/utils/consts.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/utils/consts.ts
@@ -1,3 +1,5 @@
 export const STORAGE_PREFIX = "@io.itwallet.statusList";
 
 export const STORAGE_KEY_LAST_CHECK_TIME = `${STORAGE_PREFIX}:lastCheckTime`;
+
+export const STORAGE_KEY_ITW_SPECS_VERSION = `${STORAGE_PREFIX}:itwSpecsVersion`;

--- a/apps/main-app/ts/features/itwallet/statusList/utils/storage.ts
+++ b/apps/main-app/ts/features/itwallet/statusList/utils/storage.ts
@@ -1,11 +1,43 @@
+import { ItwVersion } from "@pagopa/io-react-native-wallet";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { z } from "zod";
 
-import { STORAGE_KEY_LAST_CHECK_TIME } from "./consts";
+import {
+  STORAGE_KEY_ITW_SPECS_VERSION,
+  STORAGE_KEY_LAST_CHECK_TIME
+} from "./consts";
 
 const LastStatusListCheckTimestampsSchema = z
   .union([z.array(z.number()), z.number().transform(timestamp => [timestamp])])
   .transform(timestamps => timestamps.slice(-10));
+
+/**
+ * Persists the IT-Wallet specs version selected while Redux is available, so
+ * the Status List background task can use the same version.
+ *
+ * @param itwVersion Current IT-Wallet specs version
+ */
+export const storeItwSpecsVersion = async (
+  itwVersion: ItwVersion
+): Promise<void> =>
+  AsyncStorage.setItem(STORAGE_KEY_ITW_SPECS_VERSION, itwVersion);
+
+/**
+ * Retrieves the IT-Wallet specs version persisted for the Status List
+ * background task.
+ *
+ * Only {@link storeItwSpecsVersion} writes this value, preserving the
+ * {@link ItwVersion} invariant at the storage boundary.
+ *
+ * @throws If no specs version was persisted or AsyncStorage cannot be read
+ */
+export const getItwSpecsVersion = async (): Promise<ItwVersion> => {
+  const itwVersion = await AsyncStorage.getItem(STORAGE_KEY_ITW_SPECS_VERSION);
+  if (itwVersion === null) {
+    throw new Error("IT-Wallet specs version not found");
+  }
+  return itwVersion as ItwVersion;
+};
 
 /**
  * Stores the timestamps of the latest checks made of the Status List


### PR DESCRIPTION
## Short description
Resolve the IT-Wallet technical specs version used by Status List refreshes running outside Redux, removing the hardcoded version from the background task.

## List of changes proposed in this pull request
- Persist the current specs version during background-task registration to bootstrap existing or rehydrated wallets
- Watch the latest `itwCredentialsStore` action containing an eID and persist the credential's `spec_version` for same-session updates
- Read the persisted version from the Status List background task before refreshing stale entries
- Return a failed background-task result when the version cannot be retrieved
- Cover storage, task execution, registration, eID action filtering, saga synchronization, and failure handling with tests

## How to test
1. Activate or reissue an IT-Wallet eID.
2. Verify `@io.itwallet.statusList:itwSpecsVersion` contains the eID `spec_version` using an inspection tool such as Reactotron.
3. Trigger the Status List background worker from the IT-Wallet playground.
4. Verify stale Status Lists are refreshed with the persisted version and the task succeeds.
5. Remove the persisted version and verify the task reports failure without refreshing entries.
