### PR TITLE
feat(IT-Wallet): [SIW-4774] Fix error page when requesting PID with another person's CIE

### DIFF
--- a/apps/main-app/ts/features/itwallet/common/utils/__tests__/itwFailureUtils.test.ts
+++ b/apps/main-app/ts/features/itwallet/common/utils/__tests__/itwFailureUtils.test.ts
@@ -3,7 +3,7 @@ import { Errors } from "@pagopa/io-react-native-wallet";
 import {
   isAnprPid404Failure,
   isAssertionGenerationError,
-  isMrtdTaxIdCodeMismatchFailure
+  isTaxIdCodeMismatchFailure
 } from "../itwFailureUtils";
 
 describe("isAssertionGenerationError", () => {
@@ -68,7 +68,7 @@ describe("isAnprPid404Failure", () => {
   });
 });
 
-describe("isMrtdTaxIdCodeMismatchFailure", () => {
+describe("isTaxIdCodeMismatchFailure", () => {
   it("returns true for MRTD tax id code mismatch issuer errors", () => {
     const error = new Errors.IssuerResponseError({
       message: "MRTD PoP verification failed",
@@ -76,7 +76,7 @@ describe("isMrtdTaxIdCodeMismatchFailure", () => {
       statusCode: 400
     });
 
-    expect(isMrtdTaxIdCodeMismatchFailure(error)).toBe(true);
+    expect(isTaxIdCodeMismatchFailure(error)).toBe(true);
   });
 
   it("returns false when the issuer error reason is not tax_id_code_mismatch", () => {
@@ -86,7 +86,7 @@ describe("isMrtdTaxIdCodeMismatchFailure", () => {
       statusCode: 400
     });
 
-    expect(isMrtdTaxIdCodeMismatchFailure(error)).toBe(false);
+    expect(isTaxIdCodeMismatchFailure(error)).toBe(false);
   });
 
   it("returns false when the status code is not 400", () => {
@@ -96,11 +96,11 @@ describe("isMrtdTaxIdCodeMismatchFailure", () => {
       statusCode: 500
     });
 
-    expect(isMrtdTaxIdCodeMismatchFailure(error)).toBe(false);
+    expect(isTaxIdCodeMismatchFailure(error)).toBe(false);
   });
 
   it("returns false for unrelated errors", () => {
-    expect(isMrtdTaxIdCodeMismatchFailure(new Error("UNEXPECTED"))).toBe(false);
-    expect(isMrtdTaxIdCodeMismatchFailure(undefined)).toBe(false);
+    expect(isTaxIdCodeMismatchFailure(new Error("UNEXPECTED"))).toBe(false);
+    expect(isTaxIdCodeMismatchFailure(undefined)).toBe(false);
   });
 });

--- a/apps/main-app/ts/features/itwallet/common/utils/itwFailureUtils.ts
+++ b/apps/main-app/ts/features/itwallet/common/utils/itwFailureUtils.ts
@@ -57,7 +57,7 @@ const anprPid404Failure = z.object({
   })
 });
 
-const mrtdTaxIdCodeMismatchFailure = z.object({
+const taxIdCodeMismatchFailure = z.object({
   statusCode: z.literal(400),
   reason: z.object({
     error: z.literal("tax_id_code_mismatch")
@@ -95,14 +95,14 @@ export const enrichErrorWithMetadata =
   };
 
 /**
- * Guard used to identify MRTD PoP failures caused by a CIE belonging to a
- * different fiscal code than the identity used during authentication.
+ * Guard used to identify issuer failures caused by a digital identity belonging
+ * to a different fiscal code than the identity used to access IO.
  */
-export const isMrtdTaxIdCodeMismatchFailure = (
+export const isTaxIdCodeMismatchFailure = (
   e: unknown
 ): e is Errors.IssuerResponseError =>
   Errors.isIssuerResponseError(e) &&
-  mrtdTaxIdCodeMismatchFailure.safeParse(e).success;
+  taxIdCodeMismatchFailure.safeParse(e).success;
 
 /**
  * Shape of a credential status assertion response error.

--- a/apps/main-app/ts/features/itwallet/machine/eid/__tests__/failure.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/__tests__/failure.test.ts
@@ -3,24 +3,53 @@ import { Errors } from "@pagopa/io-react-native-wallet";
 import { IssuanceFailureType, mapEventToFailure } from "../failure";
 
 describe("mapEventToFailure", () => {
-  it("maps MRTD tax id code mismatch errors to the dedicated failure", () => {
-    const error = new Errors.IssuerResponseError({
-      message: "MRTD PoP verification failed",
-      reason: { error: "tax_id_code_mismatch" },
-      statusCode: 400
-    });
-
-    expect(
-      mapEventToFailure({
-        type: "error",
-        scope: "cie-mrtd-pop",
-        error
-      })
-    ).toStrictEqual({
-      type: IssuanceFailureType.CIE_NOT_MATCHING_AUTHENTICATION_IDENTITY,
-      reason: error
-    });
+  const taxIdCodeMismatchError = new Errors.IssuerResponseError({
+    message: "Identity mismatch",
+    reason: { error: "tax_id_code_mismatch" },
+    statusCode: 400
   });
+
+  const identityMismatchScenarios = [
+    {
+      name: "CIE+PIN",
+      identificationMode: "ciePin",
+      expectedType: IssuanceFailureType.NOT_MATCHING_IDENTITY
+    },
+    {
+      name: "SPID+CIE",
+      identificationMode: "spid",
+      expectedType: IssuanceFailureType.CIE_NOT_MATCHING_AUTHENTICATION_IDENTITY
+    },
+    {
+      name: "CieID",
+      identificationMode: "cieId",
+      expectedType: IssuanceFailureType.CIE_NOT_MATCHING_AUTHENTICATION_IDENTITY
+    },
+    {
+      name: "missing identification mode",
+      identificationMode: undefined,
+      expectedType: IssuanceFailureType.CIE_NOT_MATCHING_AUTHENTICATION_IDENTITY
+    }
+  ] as const;
+
+  test.each(identityMismatchScenarios)(
+    "maps tax id code mismatch errors for $name to $expectedType",
+    ({ identificationMode, expectedType }) => {
+      expect(
+        mapEventToFailure(
+          {
+            type: "error",
+            scope: "cie-mrtd-pop",
+            error: taxIdCodeMismatchError
+          },
+          identificationMode
+        )
+      ).toStrictEqual({
+        type: expectedType,
+        reason: taxIdCodeMismatchError
+      });
+    }
+  );
 
   it("keeps mapping generic issuer errors to ISSUER_GENERIC", () => {
     const error = new Errors.IssuerResponseError({

--- a/apps/main-app/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
@@ -1,3 +1,4 @@
+import { Errors } from "@pagopa/io-react-native-wallet";
 import { waitFor } from "@testing-library/react-native";
 import _ from "lodash";
 import {
@@ -1482,6 +1483,110 @@ describe("itwEidIssuanceMachine", () => {
     expect(requestEid).toHaveBeenCalledTimes(1);
 
     expect(actor.getSnapshot().value).toStrictEqual("Failure");
+  });
+
+  it("Should map a CIE+PIN tax id code mismatch to NOT_MATCHING_IDENTITY", async () => {
+    const error = new Errors.IssuerResponseError({
+      message: "Unable to obtain the requested credential",
+      reason: { error: "tax_id_code_mismatch" },
+      statusCode: 400
+    });
+    startAuthFlow.mockResolvedValue({});
+    requestAccessToken.mockResolvedValue(T_ACCESS_TOKEN);
+    requestEid.mockRejectedValue(error);
+
+    const initialSnapshot: MachineSnapshot = createActor(
+      itwEidIssuanceMachine
+    ).getSnapshot();
+    const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
+      value: { UserIdentification: { CiePin: "PreparationCie" } },
+      context: {
+        level: "l3",
+        integrityKeyTag: T_INTEGRITY_KEY,
+        walletInstanceAttestation: { jwt: T_WIA },
+        identification: {
+          mode: "ciePin",
+          level: "L3",
+          pin: "12345678"
+        }
+      }
+    } as MachineSnapshot);
+
+    const actor = createActor(mockedMachine, { snapshot });
+    actor.start();
+
+    actor.send({ type: "next" });
+
+    await waitFor(() => expect(startAuthFlow).toHaveBeenCalledTimes(1));
+
+    actor.send({
+      type: "user-identification-completed",
+      authRedirectUrl: "http://test.it"
+    });
+
+    await waitForActor(actor, state => state.matches("Failure"));
+
+    expect(actor.getSnapshot().context.failure).toStrictEqual({
+      type: IssuanceFailureType.NOT_MATCHING_IDENTITY,
+      reason: error
+    });
+  });
+
+  it("Should preserve the dedicated CIE failure for a SPID+CIE tax id code mismatch", async () => {
+    const error = new Errors.IssuerResponseError({
+      message: "MRTD PoP verification failed",
+      reason: { error: "tax_id_code_mismatch" },
+      statusCode: 400
+    });
+    validateMrtdPoPChallenge.mockRejectedValue(error);
+
+    const initialSnapshot = createActor(itwEidIssuanceMachine).getSnapshot();
+    const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
+      value: { MrtdPoP: "SigningChallenge" },
+      context: {
+        level: "l3",
+        identification: {
+          mode: "spid",
+          level: "L2",
+          idpId: idps[0].id
+        },
+        walletInstanceAttestation: { jwt: T_WIA },
+        authenticationContext: {},
+        mrtdContext: {
+          challenge: "mock-challenge",
+          mrtd_auth_session: "mock-session",
+          mrtd_pop_nonce: "mock-nonce",
+          validationUrl: "http://validation.test.it"
+        }
+      }
+    } as MachineSnapshot);
+
+    const actor = createActor(mockedMachine, { snapshot });
+    actor.start();
+
+    actor.send({
+      type: "mrtd-challenged-signed",
+      data: {
+        nis_data: {
+          nis: "nis-data",
+          signedChallenge: "signed-challenge",
+          publicKey: "public-key",
+          sod: "ias-sod"
+        },
+        mrtd_data: {
+          dg1: "dg1-data",
+          dg11: "dg11-data",
+          sod: "mrtd-sod"
+        }
+      }
+    });
+
+    await waitForActor(actor, state => state.matches("Failure"));
+
+    expect(actor.getSnapshot().context.failure).toStrictEqual({
+      type: IssuanceFailureType.CIE_NOT_MATCHING_AUTHENTICATION_IDENTITY,
+      reason: error
+    });
   });
 
   it("Should fail with a not matching identity when the issued eID does not match the authenticated user", async () => {

--- a/apps/main-app/ts/features/itwallet/machine/eid/failure.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/failure.ts
@@ -7,9 +7,9 @@ import {
   isAssertionGenerationError,
   isFederationError,
   isLocalIntegrityError,
-  isMrtdTaxIdCodeMismatchFailure
+  isTaxIdCodeMismatchFailure
 } from "../../common/utils/itwFailureUtils";
-import { type EidIssuanceEvents } from "./events";
+import { type EidIssuanceEvents, type IdentificationMode } from "./events";
 
 const {
   isIssuerResponseError,
@@ -48,7 +48,9 @@ export type ReasonTypeByFailure = {
   [IssuanceFailureType.HARDWARE_KEY_INVALID]: IntegrityError;
   [IssuanceFailureType.ISSUER_GENERIC]: Errors.IssuerResponseError;
   [IssuanceFailureType.MRTD_CHALLENGE_INIT_ERROR]: Errors.IssuerResponseError;
-  [IssuanceFailureType.NOT_MATCHING_IDENTITY]: string;
+  [IssuanceFailureType.NOT_MATCHING_IDENTITY]:
+    | Errors.IssuerResponseError
+    | string;
   [IssuanceFailureType.PID_ANPR_CREDENTIAL_NOT_FOUND]: Errors.IssuerResponseError;
   [IssuanceFailureType.UNEXPECTED]: unknown;
   [IssuanceFailureType.UNSUPPORTED_DEVICE]:
@@ -68,10 +70,12 @@ type TypedIssuanceFailures = {
  * Maps an event dispatched by the eID issuance machine to a failure object.
  * If the event is not an error event, a generic failure is returned.
  * @param event - The event to map
+ * @param identificationMode - The identification method used during issuance
  * @returns a failure object which can be used to fill the failure screen with the appropriate content
  */
 export const mapEventToFailure = (
-  event: EidIssuanceEvents
+  event: EidIssuanceEvents,
+  identificationMode?: IdentificationMode
 ): IssuanceFailure => {
   if (!("error" in event)) {
     return {
@@ -115,9 +119,12 @@ export const mapEventToFailure = (
     };
   }
 
-  if (isMrtdTaxIdCodeMismatchFailure(error)) {
+  if (isTaxIdCodeMismatchFailure(error)) {
     return {
-      type: IssuanceFailureType.CIE_NOT_MATCHING_AUTHENTICATION_IDENTITY,
+      type:
+        identificationMode === "ciePin"
+          ? IssuanceFailureType.NOT_MATCHING_IDENTITY
+          : IssuanceFailureType.CIE_NOT_MATCHING_AUTHENTICATION_IDENTITY,
       reason: error
     };
   }

--- a/apps/main-app/ts/features/itwallet/machine/eid/machine.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/machine.ts
@@ -134,7 +134,9 @@ export const itwEidIssuanceMachine = setup({
       }
       return { identification: { mode: "cieId", level: "L3" } as const };
     }),
-    setFailure: assign(({ event }) => ({ failure: mapEventToFailure(event) })),
+    setFailure: assign(({ context, event }) => ({
+      failure: mapEventToFailure(event, context.identification?.mode)
+    })),
     /**
      * Save the final redirect url in the machine context for later reuse.
      * This action is the same for the three identification methods.


### PR DESCRIPTION
## Short description

This PR fixes PID issuance error handling when a user activates IT-Wallet through CIE+PIN using a CIE belonging to a different person.

A `tax_id_code_mismatch` is now mapped according to the identification method, showing the “Identità non riconosciuta” screen for CIE+PIN while preserving the existing SPID+CIE behavior.

## List of changes proposed in this pull request

- Map CIE+PIN `tax_id_code_mismatch` errors to `NOT_MATCHING_IDENTITY`.
- Preserve `CIE_NOT_MATCHING_AUTHENTICATION_IDENTITY` for SPID+CIE.
- Pass the identification mode to the issuance failure mapper.
- Add regression tests for both flows.

## How to test

1. Log in to IO with one user.
2. Start IT-Wallet activation using CIE+PIN.
3. Use a CIE belonging to a different person.
4. Verify that the “Identità non riconosciuta” screen is displayed.
5. Verify that a SPID+CIE mismatch still displays the existing dedicated CIE mismatch screen.