### PR TITLE
chore: [SIW-4365] Bump `xstate` and `@xstate/react` versions

### DIFF
--- a/apps/main-app/package.json
+++ b/apps/main-app/package.json
@@ -78,7 +78,7 @@
     "@swmansion/react-native-bottom-sheet": "0.15.1",
     "@textlint/ast-node-types": "14.0.4",
     "@textlint/markdown-to-ast": "^14.0.4",
-    "@xstate/react": "^5.0.5",
+    "@xstate/react": "^6.1.0",
     "async-mutex": "^0.1.3",
     "buffer": "^4.9.1",
     "color": "^3.0.0",

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/provider.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/provider.test.tsx
@@ -1,0 +1,83 @@
+import { render } from "@testing-library/react-native";
+import { ReactNode } from "react";
+import { View } from "react-native";
+
+import { useIOSelector } from "../../../../../../store/hooks.ts";
+import { isDebugModeEnabledSelector } from "../../../../../../store/reducers/debug.ts";
+import {
+  ItwProximityMachineContext,
+  ItwProximityMachineProvider
+} from "../provider.tsx";
+
+jest.mock("@xstate/react", () => ({
+  createActorContext: jest.fn(() => ({
+    Provider: ({ children }: { children: ReactNode }) => children,
+    useActorRef: jest.fn(),
+    useSelector: jest.fn()
+  }))
+}));
+
+jest.mock("../../../../../../hooks/useDebugInfo.ts", () => ({
+  useDebugInfo: jest.fn()
+}));
+
+jest.mock("../../../../../../navigation/params/AppParamsList.ts", () => ({
+  useIONavigation: jest.fn(() => ({}))
+}));
+
+jest.mock("../../../../../../store/hooks.ts", () => ({
+  useIOSelector: jest.fn(),
+  useIOStore: jest.fn(() => ({}))
+}));
+
+jest.mock("../../../../common/utils/environment.ts", () => ({
+  getEnv: jest.fn(() => ({}))
+}));
+
+jest.mock("../actions.ts", () => ({
+  createProximityActionsImplementation: jest.fn(() => ({}))
+}));
+
+jest.mock("../actors.ts", () => ({
+  createProximityActorsImplementation: jest.fn(() => ({}))
+}));
+
+jest.mock("../guards.ts", () => ({
+  createProximityGuardsImplementation: jest.fn(() => ({}))
+}));
+
+const mockUseIOSelector = jest.mocked(useIOSelector);
+const mockMachineUseSelector = jest.mocked(
+  ItwProximityMachineContext.useSelector
+);
+
+const renderProvider = (isDebugModeEnabled: boolean) => {
+  mockUseIOSelector.mockImplementation(selector =>
+    selector === isDebugModeEnabledSelector ? isDebugModeEnabled : undefined
+  );
+
+  return render(
+    <ItwProximityMachineProvider>
+      <View testID="provider-child" />
+    </ItwProximityMachineProvider>
+  );
+};
+
+describe("ItwProximityMachineProvider", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not subscribe to machine debug data when debug mode is disabled", () => {
+    const { getByTestId } = renderProvider(false);
+
+    expect(getByTestId("provider-child")).toBeTruthy();
+    expect(mockMachineUseSelector).not.toHaveBeenCalled();
+  });
+
+  it("subscribes to machine debug data when debug mode is enabled", () => {
+    renderProvider(true);
+
+    expect(mockMachineUseSelector).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/provider.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/provider.tsx
@@ -4,6 +4,7 @@ import { PropsWithChildren } from "react";
 import { useDebugInfo } from "../../../../../hooks/useDebugInfo.ts";
 import { useIONavigation } from "../../../../../navigation/params/AppParamsList.ts";
 import { useIOSelector, useIOStore } from "../../../../../store/hooks.ts";
+import { isDebugModeEnabledSelector } from "../../../../../store/reducers/debug.ts";
 import { selectItwEnv } from "../../../common/store/selectors/environment.ts";
 import { getEnv } from "../../../common/utils/environment.ts";
 import { createProximityActionsImplementation } from "./actions.ts";
@@ -40,6 +41,12 @@ export const ItwProximityMachineProvider = ({
  * Convenience component to display debug info about the machine state in the ladybug component.
  */
 const DebugData = () => {
+  const isDebugModeEnabled = useIOSelector(isDebugModeEnabledSelector);
+
+  return isDebugModeEnabled ? <MachineDebugData /> : null;
+};
+
+const MachineDebugData = () => {
   const state = ItwProximityMachineContext.useSelector(({ value }) => value);
   const context = ItwProximityMachineContext.useSelector(({ context: c }) => c);
 

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/selectors.test.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/selectors.test.ts
@@ -1,0 +1,62 @@
+import { decode as decodeJwt } from "@pagopa/io-react-native-jwt";
+import _ from "lodash";
+import { createActor, StateFrom } from "xstate";
+
+import { ItwRemoteMachine, itwRemoteMachine } from "../machine.ts";
+import { selectUnverifiedRequestObject } from "../selectors.ts";
+
+jest.mock("@pagopa/io-react-native-jwt", () => ({
+  decode: jest.fn()
+}));
+
+const mockDecodeJwt = jest.mocked(decodeJwt);
+
+type MachineSnapshot = StateFrom<ItwRemoteMachine>;
+
+const createSnapshot = (requestObjectEncodedJwt?: string): MachineSnapshot => {
+  const initialSnapshot = createActor(itwRemoteMachine).getSnapshot();
+
+  return _.merge(undefined, initialSnapshot, {
+    context: { requestObjectEncodedJwt }
+  } as MachineSnapshot);
+};
+
+describe("selectUnverifiedRequestObject", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDecodeJwt.mockImplementation(token => ({
+      payload: { state: token },
+      protectedHeader: {}
+    }));
+  });
+
+  it("reuses decoded request object while encoded JWT is unchanged", () => {
+    const firstResult = selectUnverifiedRequestObject(
+      createSnapshot("encoded-request-object")
+    );
+    const secondResult = selectUnverifiedRequestObject(
+      createSnapshot("encoded-request-object")
+    );
+
+    expect(secondResult).toBe(firstResult);
+    expect(mockDecodeJwt).toHaveBeenCalledTimes(1);
+  });
+
+  it("decodes request object again when encoded JWT changes", () => {
+    const firstResult = selectUnverifiedRequestObject(
+      createSnapshot("first-request-object")
+    );
+    const secondResult = selectUnverifiedRequestObject(
+      createSnapshot("second-request-object")
+    );
+
+    expect(secondResult).not.toBe(firstResult);
+    expect(secondResult).toEqual({ state: "second-request-object" });
+    expect(mockDecodeJwt).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not decode an absent request object", () => {
+    expect(selectUnverifiedRequestObject(createSnapshot())).toBeNull();
+    expect(mockDecodeJwt).not.toHaveBeenCalled();
+  });
+});

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/selectors.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/selectors.ts
@@ -1,4 +1,5 @@
 import { decode as decodeJwt } from "@pagopa/io-react-native-jwt";
+import { createSelector } from "reselect";
 import { StateFrom } from "xstate";
 
 import { RequestObject } from "../../../common/utils/itwTypesUtils";
@@ -34,14 +35,13 @@ export const selectUserSelectedOptionalCredentials = (
 // It is used in scenarios where, due to a validation error during Request Object processing,
 // it becomes necessary to extract certain internal information (e.g., `response_uri`)
 // in order to communicate the details of the failed operation to the Relying Party.
-export const selectUnverifiedRequestObject = (
-  snapshot: MachineSnapshot
-): null | RequestObject => {
-  const { requestObjectEncodedJwt } = snapshot.context;
-  return requestObjectEncodedJwt
-    ? (decodeJwt(requestObjectEncodedJwt).payload as RequestObject)
-    : null;
-};
+export const selectUnverifiedRequestObject = createSelector(
+  (snapshot: MachineSnapshot) => snapshot.context.requestObjectEncodedJwt,
+  requestObjectEncodedJwt =>
+    requestObjectEncodedJwt === undefined
+      ? null
+      : (decodeJwt(requestObjectEncodedJwt).payload as RequestObject)
+);
 export const selectRedirectUri = (snapshot: MachineSnapshot) =>
   snapshot.context.redirectUri;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ catalogs:
       specifier: 6.0.3
       version: 6.0.3
     xstate:
-      specifier: ^5
-      version: 5.17.4
+      specifier: ^5.32.6
+      version: 5.32.6
 
 overrides:
   pretty-format>react-is: 19.0.0
@@ -445,8 +445,8 @@ importers:
         specifier: ^14.0.4
         version: 14.0.4(supports-color@8.1.1)
       '@xstate/react':
-        specifier: ^5.0.5
-        version: 5.0.5(@types/react@19.2.16)(react@19.2.0)(xstate@5.17.4)
+        specifier: ^6.1.0
+        version: 6.1.0(@types/react@19.2.16)(react@19.2.0)(xstate@5.32.6)
       async-mutex:
         specifier: ^0.1.3
         version: 0.1.4
@@ -704,7 +704,7 @@ importers:
         version: 0.5.0
       xstate:
         specifier: 'catalog:'
-        version: 5.17.4
+        version: 5.32.6
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -4639,11 +4639,11 @@ packages:
     engines: {node: '>=10.0.0'}
     deprecated: this version has critical issues, please update to the latest version
 
-  '@xstate/react@5.0.5':
-    resolution: {integrity: sha512-MfF/cPHa3lNKJmGFpUycMbNP25qBXyZXrxc8VYNroAu0Nnk0DV5WzAkTcQXma0xEC4dSwsoA+YQuKbZATtqvgg==}
+  '@xstate/react@6.1.0':
+    resolution: {integrity: sha512-ep9F0jGTI63B/jE8GHdMpUqtuz7yRebNaKv8EMUaiSi29NOglywc2X2YSOV/ygbIK+LtmgZ0q9anoEA2iBSEOw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      xstate: ^5.19.4
+      xstate: ^5.28.0
     peerDependenciesMeta:
       xstate:
         optional: true
@@ -11171,8 +11171,8 @@ packages:
     resolution: {integrity: sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ==}
     engines: {node: '>=0.6.0'}
 
-  xstate@5.17.4:
-    resolution: {integrity: sha512-KM2FYVOUJ04HlOO4TY3wEXqoYPR/XsDu+ewm+IWw0vilXqND0jVfvv04tEFwp8Mkk7I/oHXM8t1Ex9xJyUS4ZA==}
+  xstate@5.32.6:
+    resolution: {integrity: sha512-WfA8WNrh6r9osuGwVm+aIPM4jmMW2LKHV1Yv9thYpOtL4HVF/kobh95K/O8v2jDCpDmP2EoY+6uvuqHXCZ6ZLw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -17744,13 +17744,13 @@ snapshots:
 
   '@xmldom/xmldom@0.8.10': {}
 
-  '@xstate/react@5.0.5(@types/react@19.2.16)(react@19.2.0)(xstate@5.17.4)':
+  '@xstate/react@6.1.0(@types/react@19.2.16)(react@19.2.0)(xstate@5.32.6)':
     dependencies:
       react: 19.2.0
       use-isomorphic-layout-effect: 1.1.2(@types/react@19.2.16)(react@19.2.0)
       use-sync-external-store: 1.6.0(react@19.2.0)
     optionalDependencies:
-      xstate: 5.17.4
+      xstate: 5.32.6
     transitivePeerDependencies:
       - '@types/react'
 
@@ -26894,7 +26894,7 @@ snapshots:
 
   xpath@0.0.27: {}
 
-  xstate@5.17.4: {}
+  xstate@5.32.6: {}
 
   xtend@4.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -72,7 +72,7 @@ catalog:
   # --- State management ---
   redux: "4.1.1"
   react-redux: "8.1.3"
-  xstate: "^5"
+  xstate: "^5.32.6"
 
   # --- Design System ---
   react-native-worklets: "^0.8.3"


### PR DESCRIPTION
## Short description
Upgrade XState dependencies to current stable versions, adding React 19 support and aligning the core/runtime peer requirements.

## List of changes proposed in this pull request
- Upgrade `xstate` from 5.17.4 to 5.32.6.
- Upgrade `@xstate/react` from 4.1.3 to 6.1.0.
- Refresh the pnpm lockfile with the updated dependency graph.

## How to test
- Non regression tests for all affected flows:
  - IT-Wallet
    - Wallet activation (L2 and L3)
    - Wallet upgrade to L3 including credentials upgrade
    - Wallet reissuance (L2 and L3)
    - Credential obtainment
    - Proximity presentation, both BLE and NFC
    - Remote presentation
    - Credential offer
  - ID Pay
    - Initiative onboarding
    - Initiative configuration
    - Payment

