### PR TITLE
chore(IT-Wallet): [SIW-4365] Optimize IT-Wallet machine selectors

### DIFF
--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/provider.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/provider.test.tsx
@@ -1,0 +1,83 @@
+import { render } from "@testing-library/react-native";
+import { ReactNode } from "react";
+import { View } from "react-native";
+
+import { useIOSelector } from "../../../../../../store/hooks.ts";
+import { isDebugModeEnabledSelector } from "../../../../../../store/reducers/debug.ts";
+import {
+  ItwProximityMachineContext,
+  ItwProximityMachineProvider
+} from "../provider.tsx";
+
+jest.mock("@xstate/react", () => ({
+  createActorContext: jest.fn(() => ({
+    Provider: ({ children }: { children: ReactNode }) => children,
+    useActorRef: jest.fn(),
+    useSelector: jest.fn()
+  }))
+}));
+
+jest.mock("../../../../../../hooks/useDebugInfo.ts", () => ({
+  useDebugInfo: jest.fn()
+}));
+
+jest.mock("../../../../../../navigation/params/AppParamsList.ts", () => ({
+  useIONavigation: jest.fn(() => ({}))
+}));
+
+jest.mock("../../../../../../store/hooks.ts", () => ({
+  useIOSelector: jest.fn(),
+  useIOStore: jest.fn(() => ({}))
+}));
+
+jest.mock("../../../../common/utils/environment.ts", () => ({
+  getEnv: jest.fn(() => ({}))
+}));
+
+jest.mock("../actions.ts", () => ({
+  createProximityActionsImplementation: jest.fn(() => ({}))
+}));
+
+jest.mock("../actors.ts", () => ({
+  createProximityActorsImplementation: jest.fn(() => ({}))
+}));
+
+jest.mock("../guards.ts", () => ({
+  createProximityGuardsImplementation: jest.fn(() => ({}))
+}));
+
+const mockUseIOSelector = jest.mocked(useIOSelector);
+const mockMachineUseSelector = jest.mocked(
+  ItwProximityMachineContext.useSelector
+);
+
+const renderProvider = (isDebugModeEnabled: boolean) => {
+  mockUseIOSelector.mockImplementation(selector =>
+    selector === isDebugModeEnabledSelector ? isDebugModeEnabled : undefined
+  );
+
+  return render(
+    <ItwProximityMachineProvider>
+      <View testID="provider-child" />
+    </ItwProximityMachineProvider>
+  );
+};
+
+describe("ItwProximityMachineProvider", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("does not subscribe to machine debug data when debug mode is disabled", () => {
+    const { getByTestId } = renderProvider(false);
+
+    expect(getByTestId("provider-child")).toBeTruthy();
+    expect(mockMachineUseSelector).not.toHaveBeenCalled();
+  });
+
+  it("subscribes to machine debug data when debug mode is enabled", () => {
+    renderProvider(true);
+
+    expect(mockMachineUseSelector).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/provider.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/provider.tsx
@@ -4,6 +4,7 @@ import { PropsWithChildren } from "react";
 import { useDebugInfo } from "../../../../../hooks/useDebugInfo.ts";
 import { useIONavigation } from "../../../../../navigation/params/AppParamsList.ts";
 import { useIOSelector, useIOStore } from "../../../../../store/hooks.ts";
+import { isDebugModeEnabledSelector } from "../../../../../store/reducers/debug.ts";
 import { selectItwEnv } from "../../../common/store/selectors/environment.ts";
 import { getEnv } from "../../../common/utils/environment.ts";
 import { createProximityActionsImplementation } from "./actions.ts";
@@ -40,6 +41,12 @@ export const ItwProximityMachineProvider = ({
  * Convenience component to display debug info about the machine state in the ladybug component.
  */
 const DebugData = () => {
+  const isDebugModeEnabled = useIOSelector(isDebugModeEnabledSelector);
+
+  return isDebugModeEnabled ? <MachineDebugData /> : null;
+};
+
+const MachineDebugData = () => {
   const state = ItwProximityMachineContext.useSelector(({ value }) => value);
   const context = ItwProximityMachineContext.useSelector(({ context: c }) => c);
 

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/selectors.test.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/selectors.test.ts
@@ -1,0 +1,62 @@
+import { decode as decodeJwt } from "@pagopa/io-react-native-jwt";
+import _ from "lodash";
+import { createActor, StateFrom } from "xstate";
+
+import { ItwRemoteMachine, itwRemoteMachine } from "../machine.ts";
+import { selectUnverifiedRequestObject } from "../selectors.ts";
+
+jest.mock("@pagopa/io-react-native-jwt", () => ({
+  decode: jest.fn()
+}));
+
+const mockDecodeJwt = jest.mocked(decodeJwt);
+
+type MachineSnapshot = StateFrom<ItwRemoteMachine>;
+
+const createSnapshot = (requestObjectEncodedJwt?: string): MachineSnapshot => {
+  const initialSnapshot = createActor(itwRemoteMachine).getSnapshot();
+
+  return _.merge(undefined, initialSnapshot, {
+    context: { requestObjectEncodedJwt }
+  } as MachineSnapshot);
+};
+
+describe("selectUnverifiedRequestObject", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDecodeJwt.mockImplementation(token => ({
+      payload: { state: token },
+      protectedHeader: {}
+    }));
+  });
+
+  it("reuses decoded request object while encoded JWT is unchanged", () => {
+    const firstResult = selectUnverifiedRequestObject(
+      createSnapshot("encoded-request-object")
+    );
+    const secondResult = selectUnverifiedRequestObject(
+      createSnapshot("encoded-request-object")
+    );
+
+    expect(secondResult).toBe(firstResult);
+    expect(mockDecodeJwt).toHaveBeenCalledTimes(1);
+  });
+
+  it("decodes request object again when encoded JWT changes", () => {
+    const firstResult = selectUnverifiedRequestObject(
+      createSnapshot("first-request-object")
+    );
+    const secondResult = selectUnverifiedRequestObject(
+      createSnapshot("second-request-object")
+    );
+
+    expect(secondResult).not.toBe(firstResult);
+    expect(secondResult).toEqual({ state: "second-request-object" });
+    expect(mockDecodeJwt).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not decode an absent request object", () => {
+    expect(selectUnverifiedRequestObject(createSnapshot())).toBeNull();
+    expect(mockDecodeJwt).not.toHaveBeenCalled();
+  });
+});

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/selectors.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/selectors.ts
@@ -1,6 +1,7 @@
 import { decode as decodeJwt } from "@pagopa/io-react-native-jwt";
-import { constNull, pipe } from "fp-ts/lib/function";
+import { pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/Option";
+import { createSelector } from "reselect";
 import { StateFrom } from "xstate";
 
 import { RequestObject } from "../../../common/utils/itwTypesUtils";
@@ -36,13 +37,13 @@ export const selectUserSelectedOptionalCredentials = (
 // It is used in scenarios where, due to a validation error during Request Object processing,
 // it becomes necessary to extract certain internal information (e.g., `response_uri`)
 // in order to communicate the details of the failed operation to the Relying Party.
-export const selectUnverifiedRequestObject = (snapshot: MachineSnapshot) =>
-  pipe(
-    O.fromNullable(snapshot.context.requestObjectEncodedJwt),
-    O.map(decodeJwt),
-    O.map(jwt => jwt.payload as RequestObject),
-    O.getOrElseW(constNull)
-  );
+export const selectUnverifiedRequestObject = createSelector(
+  (snapshot: MachineSnapshot) => snapshot.context.requestObjectEncodedJwt,
+  requestObjectEncodedJwt =>
+    requestObjectEncodedJwt === undefined
+      ? null
+      : (decodeJwt(requestObjectEncodedJwt).payload as RequestObject)
+);
 export const selectRedirectUri = (snapshot: MachineSnapshot) =>
   snapshot.context.redirectUri;
 


### PR DESCRIPTION
Depends on https://github.com/pagopa/io-app/pull/8490

## Short description
Reduce avoidable IT-Wallet XState selector work introduced by broad debug subscriptions and repeated JWT decoding.

## List of changes proposed in this pull request
- Memoize remote-presentation request-object decoding by encoded JWT value.
- Avoid proximity machine state/context subscriptions while debug mode is disabled.
- Add regression tests for selector memoization and debug subscription gating.

## How to test
- Proximity and remote presentation flows should work as before.

