### PR TITLE
fix: [SIW-4365] prevent credential upgrade loops

### DIFF
--- a/apps/main-app/ts/features/itwallet/machine/upgrade/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/upgrade/__tests__/machine.test.ts
@@ -1,4 +1,11 @@
-import { createActor, fromCallback, fromPromise, waitFor } from "xstate";
+import {
+  createActor,
+  fromCallback,
+  fromPromise,
+  getInitialMicrosteps,
+  getMicrosteps,
+  waitFor
+} from "xstate";
 
 import { ItwSessionExpiredError } from "../../../api/client";
 import { CredentialMetadata } from "../../../common/utils/itwTypesUtils";
@@ -9,6 +16,7 @@ import {
   UpgradeCredentialOutput,
   UpgradeCredentialParams
 } from "../actors";
+import { getInitialContext } from "../context";
 import { itwCredentialUpgradeMachine } from "../machine";
 
 const mockLoadContext = jest.fn(() => Promise.resolve({} as LoadContextOutput));
@@ -35,7 +43,82 @@ const makeUpgradeOutput = (
   walletUnitAttestations: { wua1: "wua-jwt" }
 });
 
+const firstCredential = makeCredential({ credentialType: "A" });
+const secondCredential = makeCredential({ credentialType: "B" });
+const eventlessTransitionScenarios = [
+  {
+    name: "another credential remains",
+    credentials: [firstCredential, secondCredential],
+    expectedStates: ["Checking", "RequestAccessToken"]
+  },
+  {
+    name: "the last credential completes",
+    credentials: [firstCredential],
+    expectedStates: ["Checking", "Completed"]
+  }
+];
+
+const makeMachineInput = (credentials: ReadonlyArray<CredentialMetadata>) => ({
+  credentials,
+  issuanceMode: "upgrade" as const,
+  itwVersion: "1.3.3" as const
+});
+
+const getUpgradeCompletionMicrosteps = (
+  credentials: ReadonlyArray<CredentialMetadata>
+) => {
+  const input = makeMachineInput(credentials);
+  const snapshot = itwCredentialUpgradeMachine.resolveState({
+    value: "UpgradeCredential",
+    context: {
+      ...getInitialContext(input),
+      credentialIndex: 0
+    }
+  });
+
+  return getMicrosteps(itwCredentialUpgradeMachine, snapshot, {
+    type: "xstate.done.actor.upgradeCredential",
+    actorId: "upgradeCredential",
+    output: makeUpgradeOutput(credentials[0])
+  });
+};
+
 describe("itwCredentialUpgradeMachine", () => {
+  test.each(eventlessTransitionScenarios)(
+    "should include the eventless transition when $name",
+    ({ credentials, expectedStates }) => {
+      const microsteps = getUpgradeCompletionMicrosteps(credentials);
+
+      expect(microsteps.map(([snapshot]) => snapshot.value)).toEqual(
+        expectedStates
+      );
+    }
+  );
+
+  it("should calibrate its iteration limit against legitimate microsteps", () => {
+    const input = makeMachineInput([firstCredential, secondCredential]);
+    const initialMicrosteps = getInitialMicrosteps(
+      itwCredentialUpgradeMachine,
+      input
+    );
+
+    expect(initialMicrosteps.map(([snapshot]) => snapshot.value)).toEqual([
+      "LoadingContext"
+    ]);
+
+    const eventlessMicrostepDepths = eventlessTransitionScenarios.map(
+      ({ credentials }) => getUpgradeCompletionMicrosteps(credentials).length
+    );
+    const legitimateMicrostepDepth = Math.max(
+      initialMicrosteps.length,
+      ...eventlessMicrostepDepths
+    );
+
+    expect(itwCredentialUpgradeMachine.options.maxIterations).toBe(
+      legitimateMicrostepDepth
+    );
+  });
+
   it("should immediately complete if there are no credentials", async () => {
     const mockRequestAccessToken = jest.fn();
     const mockUpgradeCredential = jest.fn(() =>

--- a/apps/main-app/ts/features/itwallet/machine/upgrade/machine.ts
+++ b/apps/main-app/ts/features/itwallet/machine/upgrade/machine.ts
@@ -18,6 +18,9 @@ const notImplemented = () => {
   throw new Error("Not implemented");
 };
 
+// Longest legitimate macrostep handles one event, then one eventless transition.
+const MAX_ITERATIONS_PER_MACROSTEP = 2;
+
 export const itwCredentialUpgradeMachine = setup({
   types: {
     events: {} as CredentialUpgradeEvents,
@@ -70,6 +73,9 @@ export const itwCredentialUpgradeMachine = setup({
 }).createMachine({
   /** @xstate-layout N4IgpgJg5mDOIC5QEsAuB3AwgJ0mAdqsgIYA2AqgA5TbERgCyxAxgBbL5gB0mrYzAaw5QAxAG0ADAF1EoSgHtYaZPPyyQAD0QA2ACwBOLgHZ92gBx6AzPssSjZgDQgAnogCMAVkvGATNo8eFmYS5mb6PgC+EU5oWLj0hCQU1LT0TGwc3Lz8QviiYm4ySCAKSkSq6loIlnpcEmYe4dpGHm76Nk6uCGZuXAbtYWESdroSHlExGDh4iWRUNHSMLOycXPOpYNMJRGQiEKrcHABu8gKHU-EEO8kLacuZaymLW1dJCMfyzMTl+JJSf+pSsoKsUqrYfFx9EZ-IE3D4fG4JLoPJ1EPCJJCvHCjLojG5bJYzBMQLEXrMbht0ituOtnpdySIwNhsPJsFxKKRvgAzVkAWy4pPp11pdwyqxFmyFbw+Xx+fwBxSBP0qiHBkOhAR68MRyNRCGxfXaULc5iM9jaRii0RA+Hk9HgxUFM2FT1F1MBimBalBiAAtNo9f66sMQ6GQwjiU7tkkJVSHtlBMIPWUVN7QFUPH5IQiLIEfEYQj5HC53K11f4LHYfJZGuZIxdnTHXUsxTTm2TrsmvSqELofHq3GauLZcR49OY-JYfLp63FG3Nm3HVph5LyOWBUJAu8qfQh7Lo+mZdDVkfoTRI3LoBx4MUY-K0zJZB24jzOrUA */
   id: "itwCredentialUpgradeMachine",
+  options: {
+    maxIterations: MAX_ITERATIONS_PER_MACROSTEP
+  },
   context: ({ input }) => getInitialContext(input),
   initial: "LoadingContext",
   states: {


### PR DESCRIPTION
## Short description
Protect IT-Wallet credential upgrades from accidental infinite eventless-transition loops.

Depends on #8495.

## List of changes proposed in this pull request
- Measure legitimate initialization and eventless-transition microstep depth.
- Configure a calibrated two-iteration macrostep limit.
- Add regression coverage for remaining-credential and completion branches.

## How to test
- Run `apps/main-app/ts/features/itwallet/machine/upgrade/__tests__/machine.test.ts`.
- Run `pnpm nx affected --target=lint,tsc-noemit`.
- Run `pnpm prettify`.

Jira: https://pagopa.atlassian.net/browse/SIW-4365
