### PR TITLE
fix: [IOPLT-000] `react-native-ble-plx` permissions and build issues

### DIFF
--- a/apps/main-app/android/app/src/main/AndroidManifest.xml
+++ b/apps/main-app/android/app/src/main/AndroidManifest.xml
@@ -57,9 +57,9 @@
   <uses-permission 
     android:name="android.permission.BLUETOOTH_ADMIN" 
     android:maxSdkVersion="30" />
-  <!-- Declared without maxSdkVersion to match react-native-ble-plx's own manifest and avoid a merge conflict -->
-  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission-sdk-23
+    android:name="android.permission.ACCESS_FINE_LOCATION"
+    android:maxSdkVersion="30" />
 
   <application android:name=".MainApplication" android:label="@string/app_name"
     android:icon="@mipmap/ic_launcher" android:usesCleartextTraffic="${usesCleartextTraffic}"

--- a/apps/main-app/android/app/src/main/AndroidManifest.xml
+++ b/apps/main-app/android/app/src/main/AndroidManifest.xml
@@ -57,9 +57,9 @@
   <uses-permission 
     android:name="android.permission.BLUETOOTH_ADMIN" 
     android:maxSdkVersion="30" />
-  <uses-permission 
-    android:name="android.permission.ACCESS_FINE_LOCATION" 
-    android:maxSdkVersion="30" />
+  <!-- Declared without maxSdkVersion to match react-native-ble-plx's own manifest and avoid a merge conflict -->
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
   <application android:name=".MainApplication" android:label="@string/app_name"
     android:icon="@mipmap/ic_launcher" android:usesCleartextTraffic="${usesCleartextTraffic}"

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/utils/ble.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/utils/ble.ts
@@ -51,15 +51,24 @@ export const checkBluetoothPermissions = async () => {
   return true;
 };
 
-// Shared instance used only to query the current Bluetooth adapter state.
-const bleManager = new BleManager();
+// This workaround ensures that the BleManager instance is created lazily,
+// preventing the Bluetooth permission prompt from appearing immediately upon module import.
+// eslint-disable-next-line functional/no-let
+let bleManager: BleManager | undefined;
+
+const getBleManager = () => {
+  if (!bleManager) {
+    bleManager = new BleManager();
+  }
+  return bleManager;
+};
 
 /**
  * Checks if Bluetooth is currently activated on the device.
  * @returns A promise that resolves to true if Bluetooth is powered on, or false otherwise.
  */
 export const checkBluetoothActivation = async () => {
-  const bluetoothState = await bleManager.state();
+  const bluetoothState = await getBleManager().state();
   return bluetoothState === State.PoweredOn;
 };
 


### PR DESCRIPTION
## Short description
This pull request solves some issue related to `react-native-ble-plx` library

## List of changes proposed in this pull request
- Changed the declaration of location permissions by adding `ACCESS_COARSE_LOCATION` and removing the `maxSdkVersion` restriction from `ACCESS_FINE_LOCATION`, ensuring compatibility with `react-native-ble-plx` and avoiding merge conflicts;
- Preventing bluetooth permission prompt immediately at app installation  

## How to test
- On first installation bluetooth permission are prompt only when bluetooth is needed;
- Android build should not failed now