### PR TITLE
refactor(IT-Wallet): [SIW-4366] Inject IT-Wallet machine deps via input

### DIFF
--- a/apps/main-app/ts/features/itwallet/common/utils/itwStoreUtils.ts
+++ b/apps/main-app/ts/features/itwallet/common/utils/itwStoreUtils.ts
@@ -1,4 +1,3 @@
-import { useIOStore } from "../../../../store/hooks";
 import { GlobalState } from "../../../../store/reducers/types";
 import { itwIntegrityServiceStatusSelector } from "../../issuance/store/selectors";
 import { type CredentialIssuanceFailure } from "../../machine/credential/failure";
@@ -111,9 +110,9 @@ const mapFailureReason = (reason: unknown) => {
  * @param store The Redux store instance.
  * @throws Error if the integrity service is not ready within the timeout period.
  */
-export const ensureIntegrityServiceIsStoreReadyOrThrow = async (
-  store: ReturnType<typeof useIOStore>
-): Promise<void> => {
+export const ensureIntegrityServiceIsStoreReadyOrThrow = async (store: {
+  getState(): GlobalState;
+}): Promise<void> => {
   const integrityServiceStatus = await pollForStoreValue({
     getState: store.getState,
     selector: itwIntegrityServiceStatusSelector,

--- a/apps/main-app/ts/features/itwallet/discovery/screens/__tests__/ItwDiscoveryInfoScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/discovery/screens/__tests__/ItwDiscoveryInfoScreen.test.tsx
@@ -6,9 +6,9 @@ import { GlobalState } from "../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
 import * as identificationSelectors from "../../../identification/common/store/selectors";
 import { EidIssuanceLevel } from "../../../machine/eid/context";
-import { EidIssuanceMachineDeps } from "../../../machine/eid/input";
 import { itwEidIssuanceMachine } from "../../../machine/eid/machine";
 import { ItwEidIssuanceMachineContext } from "../../../machine/eid/provider";
+import { testEidIssuanceDeps } from "../../../machine/utils/testDeps";
 import { ITW_ROUTES } from "../../../navigation/routes";
 import {
   ItwDiscoveryInfoScreen,
@@ -91,7 +91,7 @@ const renderComponent = (level: EidIssuanceLevel | undefined) => {
     return (
       <ItwEidIssuanceMachineContext.Provider
         logic={logic}
-        options={{ input: { deps: {} as EidIssuanceMachineDeps } }}
+        options={{ input: { deps: testEidIssuanceDeps() } }}
       >
         <ItwDiscoveryInfoScreen {...props} />
       </ItwEidIssuanceMachineContext.Provider>

--- a/apps/main-app/ts/features/itwallet/discovery/screens/__tests__/ItwDiscoveryInfoScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/discovery/screens/__tests__/ItwDiscoveryInfoScreen.test.tsx
@@ -6,6 +6,7 @@ import { GlobalState } from "../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
 import * as identificationSelectors from "../../../identification/common/store/selectors";
 import { EidIssuanceLevel } from "../../../machine/eid/context";
+import { EidIssuanceMachineDeps } from "../../../machine/eid/input";
 import { itwEidIssuanceMachine } from "../../../machine/eid/machine";
 import { ItwEidIssuanceMachineContext } from "../../../machine/eid/provider";
 import { ITW_ROUTES } from "../../../navigation/routes";
@@ -88,7 +89,10 @@ const renderComponent = (level: EidIssuanceLevel | undefined) => {
     });
 
     return (
-      <ItwEidIssuanceMachineContext.Provider logic={logic}>
+      <ItwEidIssuanceMachineContext.Provider
+        logic={logic}
+        options={{ input: { deps: {} as EidIssuanceMachineDeps } }}
+      >
         <ItwDiscoveryInfoScreen {...props} />
       </ItwEidIssuanceMachineContext.Provider>
     );

--- a/apps/main-app/ts/features/itwallet/discovery/screens/__tests__/ItwIpzsPrivacyScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/discovery/screens/__tests__/ItwIpzsPrivacyScreen.test.tsx
@@ -7,6 +7,7 @@ import { GlobalState } from "../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
 import { trackItwPrivacyScreen } from "../../../analytics";
 import { EidIssuanceLevel } from "../../../machine/eid/context";
+import { EidIssuanceMachineDeps } from "../../../machine/eid/input";
 import { itwEidIssuanceMachine } from "../../../machine/eid/machine";
 import { ItwEidIssuanceMachineContext } from "../../../machine/eid/provider";
 import { ITW_ROUTES } from "../../../navigation/routes";
@@ -55,7 +56,9 @@ const renderComponent = (level: EidIssuanceLevel) => {
     }
   });
 
-  const initialSnapshot = createActor(itwEidIssuanceMachine).getSnapshot();
+  const initialSnapshot = createActor(logic, {
+    input: { deps: {} as EidIssuanceMachineDeps }
+  }).getSnapshot();
   const snapshot: typeof initialSnapshot = {
     ...initialSnapshot,
     value: "IpzsPrivacyAcceptance",

--- a/apps/main-app/ts/features/itwallet/discovery/screens/__tests__/ItwIpzsPrivacyScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/discovery/screens/__tests__/ItwIpzsPrivacyScreen.test.tsx
@@ -7,9 +7,9 @@ import { GlobalState } from "../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
 import { trackItwPrivacyScreen } from "../../../analytics";
 import { EidIssuanceLevel } from "../../../machine/eid/context";
-import { EidIssuanceMachineDeps } from "../../../machine/eid/input";
 import { itwEidIssuanceMachine } from "../../../machine/eid/machine";
 import { ItwEidIssuanceMachineContext } from "../../../machine/eid/provider";
+import { testEidIssuanceDeps } from "../../../machine/utils/testDeps";
 import { ITW_ROUTES } from "../../../navigation/routes";
 import ItwIpzsPrivacyScreen from "../ItwIpzsPrivacyScreen";
 
@@ -57,7 +57,7 @@ const renderComponent = (level: EidIssuanceLevel) => {
   });
 
   const initialSnapshot = createActor(logic, {
-    input: { deps: {} as EidIssuanceMachineDeps }
+    input: { deps: testEidIssuanceDeps() }
   }).getSnapshot();
   const snapshot: typeof initialSnapshot = {
     ...initialSnapshot,

--- a/apps/main-app/ts/features/itwallet/identification/cieId/screens/__tests__/ItwCieIdLoginScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/identification/cieId/screens/__tests__/ItwCieIdLoginScreen.test.tsx
@@ -10,9 +10,9 @@ import { applicationChangeState } from "../../../../../../store/actions/applicat
 import { appReducer } from "../../../../../../store/reducers";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper";
-import { EidIssuanceMachineDeps } from "../../../../machine/eid/input";
 import { itwEidIssuanceMachine } from "../../../../machine/eid/machine";
 import { ItwEidIssuanceMachineContext } from "../../../../machine/eid/provider";
+import { testEidIssuanceDeps } from "../../../../machine/utils/testDeps";
 import { ITW_ROUTES } from "../../../../navigation/routes";
 import ItwCieIdLoginScreen from "../../../cieId/screens/ItwCieIdLoginScreen";
 
@@ -158,7 +158,7 @@ const renderComponent = () => {
   });
 
   const initialSnapshot = createActor(logic, {
-    input: { deps: {} as EidIssuanceMachineDeps }
+    input: { deps: testEidIssuanceDeps() }
   }).getSnapshot();
 
   let machineRef: ActorRefFrom<typeof itwEidIssuanceMachine> | undefined;

--- a/apps/main-app/ts/features/itwallet/identification/cieId/screens/__tests__/ItwCieIdLoginScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/identification/cieId/screens/__tests__/ItwCieIdLoginScreen.test.tsx
@@ -10,6 +10,7 @@ import { applicationChangeState } from "../../../../../../store/actions/applicat
 import { appReducer } from "../../../../../../store/reducers";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper";
+import { EidIssuanceMachineDeps } from "../../../../machine/eid/input";
 import { itwEidIssuanceMachine } from "../../../../machine/eid/machine";
 import { ItwEidIssuanceMachineContext } from "../../../../machine/eid/provider";
 import { ITW_ROUTES } from "../../../../navigation/routes";
@@ -156,7 +157,9 @@ const renderComponent = () => {
     actions: { onInit: jest.fn(), navigateToFailureScreen: jest.fn() }
   });
 
-  const initialSnapshot = createActor(itwEidIssuanceMachine).getSnapshot();
+  const initialSnapshot = createActor(logic, {
+    input: { deps: {} as EidIssuanceMachineDeps }
+  }).getSnapshot();
 
   let machineRef: ActorRefFrom<typeof itwEidIssuanceMachine> | undefined;
   const CaptureMachineRef = () => {

--- a/apps/main-app/ts/features/itwallet/identification/common/screens/__tests__/ItwIdentificationModeSelectionScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/identification/common/screens/__tests__/ItwIdentificationModeSelectionScreen.test.tsx
@@ -11,6 +11,7 @@ import {
   EidIssuanceLevel,
   EidIssuanceMode
 } from "../../../../machine/eid/context.ts";
+import { EidIssuanceMachineDeps } from "../../../../machine/eid/input";
 import { itwEidIssuanceMachine } from "../../../../machine/eid/machine";
 import { ItwEidIssuanceMachineContext } from "../../../../machine/eid/provider";
 import { ITW_ROUTES } from "../../../../navigation/routes";
@@ -166,7 +167,9 @@ const renderComponent = (mode: EidIssuanceMode, level: EidIssuanceLevel) => {
       }
     });
 
-    const initialSnapshot = createActor(itwEidIssuanceMachine).getSnapshot();
+    const initialSnapshot = createActor(logic, {
+      input: { deps: {} as EidIssuanceMachineDeps }
+    }).getSnapshot();
     const snapshot: typeof initialSnapshot = {
       ...initialSnapshot,
       value: { UserIdentification: "Identification" },

--- a/apps/main-app/ts/features/itwallet/identification/common/screens/__tests__/ItwIdentificationModeSelectionScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/identification/common/screens/__tests__/ItwIdentificationModeSelectionScreen.test.tsx
@@ -11,9 +11,9 @@ import {
   EidIssuanceLevel,
   EidIssuanceMode
 } from "../../../../machine/eid/context.ts";
-import { EidIssuanceMachineDeps } from "../../../../machine/eid/input";
 import { itwEidIssuanceMachine } from "../../../../machine/eid/machine";
 import { ItwEidIssuanceMachineContext } from "../../../../machine/eid/provider";
+import { testEidIssuanceDeps } from "../../../../machine/utils/testDeps";
 import { ITW_ROUTES } from "../../../../navigation/routes";
 import * as identificationSelectors from "../../store/selectors";
 import {
@@ -168,7 +168,7 @@ const renderComponent = (mode: EidIssuanceMode, level: EidIssuanceLevel) => {
     });
 
     const initialSnapshot = createActor(logic, {
-      input: { deps: {} as EidIssuanceMachineDeps }
+      input: { deps: testEidIssuanceDeps() }
     }).getSnapshot();
     const snapshot: typeof initialSnapshot = {
       ...initialSnapshot,

--- a/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceCredentialAuthScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceCredentialAuthScreen.test.tsx
@@ -4,6 +4,7 @@ import { applicationChangeState } from "../../../../../store/actions/application
 import { appReducer } from "../../../../../store/reducers";
 import { GlobalState } from "../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
+import { CredentialIssuanceMachineDeps } from "../../../machine/credential/input";
 import { itwCredentialIssuanceMachine } from "../../../machine/credential/machine";
 import { ItwCredentialIssuanceMachineContext } from "../../../machine/credential/provider";
 import { ITW_ROUTES } from "../../../navigation/routes";
@@ -31,7 +32,10 @@ const renderComponent = () => {
 
   return renderScreenWithNavigationStoreContext<GlobalState>(
     () => (
-      <ItwCredentialIssuanceMachineContext.Provider logic={logic}>
+      <ItwCredentialIssuanceMachineContext.Provider
+        logic={logic}
+        options={{ input: { deps: {} as CredentialIssuanceMachineDeps } }}
+      >
         <ItwIssuanceCredentialTrustIssuerScreen />
       </ItwCredentialIssuanceMachineContext.Provider>
     ),

--- a/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceCredentialAuthScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceCredentialAuthScreen.test.tsx
@@ -4,9 +4,9 @@ import { applicationChangeState } from "../../../../../store/actions/application
 import { appReducer } from "../../../../../store/reducers";
 import { GlobalState } from "../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
-import { CredentialIssuanceMachineDeps } from "../../../machine/credential/input";
 import { itwCredentialIssuanceMachine } from "../../../machine/credential/machine";
 import { ItwCredentialIssuanceMachineContext } from "../../../machine/credential/provider";
+import { testCredentialIssuanceDeps } from "../../../machine/utils/testDeps";
 import { ITW_ROUTES } from "../../../navigation/routes";
 import { ItwIssuanceCredentialTrustIssuerScreen } from "../ItwIssuanceCredentialTrustIssuerScreen";
 
@@ -34,7 +34,7 @@ const renderComponent = () => {
     () => (
       <ItwCredentialIssuanceMachineContext.Provider
         logic={logic}
-        options={{ input: { deps: {} as CredentialIssuanceMachineDeps } }}
+        options={{ input: { deps: testCredentialIssuanceDeps() } }}
       >
         <ItwIssuanceCredentialTrustIssuerScreen />
       </ItwCredentialIssuanceMachineContext.Provider>

--- a/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceCredentialPreviewScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceCredentialPreviewScreen.test.tsx
@@ -8,6 +8,7 @@ import { GlobalState } from "../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
 import { ItwStoredCredentialsMocks } from "../../../common/utils/itwMocksUtils";
 import { Context } from "../../../machine/credential/context";
+import { CredentialIssuanceMachineDeps } from "../../../machine/credential/input";
 import { itwCredentialIssuanceMachine } from "../../../machine/credential/machine";
 import { ItwCredentialIssuanceMachineContext } from "../../../machine/credential/provider";
 import { ITW_ROUTES } from "../../../navigation/routes";
@@ -60,9 +61,10 @@ describe("ItwIssuanceCredentialPreviewScreen", () => {
 
 const renderComponent = (contextOverrides: Partial<Context> = {}) => {
   const initialState = appReducer(undefined, applicationChangeState("active"));
-  const initialSnapshot = createActor(
-    itwCredentialIssuanceMachine
-  ).getSnapshot();
+  const store = createStore(appReducer, initialState as any);
+  const initialSnapshot = createActor(itwCredentialIssuanceMachine, {
+    input: { deps: { store } as CredentialIssuanceMachineDeps }
+  }).getSnapshot();
   const snapshot: typeof initialSnapshot = {
     ...initialSnapshot,
     context: {
@@ -79,6 +81,6 @@ const renderComponent = (contextOverrides: Partial<Context> = {}) => {
     ),
     ITW_ROUTES.ISSUANCE.CREDENTIAL_PREVIEW,
     {},
-    createStore(appReducer, initialState as any)
+    store
   );
 };

--- a/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceCredentialPreviewScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceCredentialPreviewScreen.test.tsx
@@ -8,9 +8,9 @@ import { GlobalState } from "../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
 import { ItwStoredCredentialsMocks } from "../../../common/utils/itwMocksUtils";
 import { Context } from "../../../machine/credential/context";
-import { CredentialIssuanceMachineDeps } from "../../../machine/credential/input";
 import { itwCredentialIssuanceMachine } from "../../../machine/credential/machine";
 import { ItwCredentialIssuanceMachineContext } from "../../../machine/credential/provider";
+import { testCredentialIssuanceDeps } from "../../../machine/utils/testDeps";
 import { ITW_ROUTES } from "../../../navigation/routes";
 import { ItwIssuanceCredentialPreviewScreen } from "../ItwIssuanceCredentialPreviewScreen";
 
@@ -63,7 +63,7 @@ const renderComponent = (contextOverrides: Partial<Context> = {}) => {
   const initialState = appReducer(undefined, applicationChangeState("active"));
   const store = createStore(appReducer, initialState as any);
   const initialSnapshot = createActor(itwCredentialIssuanceMachine, {
-    input: { deps: { store } as CredentialIssuanceMachineDeps }
+    input: { deps: testCredentialIssuanceDeps({ store }) }
   }).getSnapshot();
   const snapshot: typeof initialSnapshot = {
     ...initialSnapshot,

--- a/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceEidFailureScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceEidFailureScreen.test.tsx
@@ -13,9 +13,12 @@ import {
   IssuanceFailure,
   IssuanceFailureType
 } from "../../../machine/eid/failure";
-import { EidIssuanceMachineDeps } from "../../../machine/eid/input";
 import { itwEidIssuanceMachine } from "../../../machine/eid/machine";
 import { ItwEidIssuanceMachineContext } from "../../../machine/eid/provider";
+import {
+  testEidIssuanceDeps,
+  testMachineStore
+} from "../../../machine/utils/testDeps";
 import { ITW_ROUTES } from "../../../navigation/routes";
 import { ItwIssuanceEidFailureScreen } from "../ItwIssuanceEidFailureScreen";
 
@@ -132,9 +135,9 @@ const renderComponent = (
   const initialState = appReducer(undefined, applicationChangeState("active"));
   const initialSnapshot = createActor(itwEidIssuanceMachine, {
     input: {
-      deps: {
-        store: { getState: () => initialState }
-      } as EidIssuanceMachineDeps
+      deps: testEidIssuanceDeps({
+        store: testMachineStore({ getState: () => initialState })
+      })
     }
   }).getSnapshot();
   const snapshot: typeof initialSnapshot = {

--- a/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceEidFailureScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceEidFailureScreen.test.tsx
@@ -13,6 +13,7 @@ import {
   IssuanceFailure,
   IssuanceFailureType
 } from "../../../machine/eid/failure";
+import { EidIssuanceMachineDeps } from "../../../machine/eid/input";
 import { itwEidIssuanceMachine } from "../../../machine/eid/machine";
 import { ItwEidIssuanceMachineContext } from "../../../machine/eid/provider";
 import { ITW_ROUTES } from "../../../navigation/routes";
@@ -129,7 +130,13 @@ const renderComponent = (
   level?: EidIssuanceLevel
 ) => {
   const initialState = appReducer(undefined, applicationChangeState("active"));
-  const initialSnapshot = createActor(itwEidIssuanceMachine).getSnapshot();
+  const initialSnapshot = createActor(itwEidIssuanceMachine, {
+    input: {
+      deps: {
+        store: { getState: () => initialState }
+      } as EidIssuanceMachineDeps
+    }
+  }).getSnapshot();
   const snapshot: typeof initialSnapshot = {
     ...initialSnapshot,
     value: "Failure",

--- a/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceEidPreviewScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceEidPreviewScreen.test.tsx
@@ -7,6 +7,7 @@ import { appReducer } from "../../../../../store/reducers";
 import { GlobalState } from "../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
 import { ItwStoredCredentialsMocks } from "../../../common/utils/itwMocksUtils";
+import { EidIssuanceMachineDeps } from "../../../machine/eid/input";
 import {
   ItwEidIssuanceMachine,
   itwEidIssuanceMachine
@@ -81,7 +82,13 @@ const renderComponent = ({
   value: { Issuance: "CheckingIdentityMatch" | "DisplayingPreview" };
 }) => {
   const initialState = appReducer(undefined, applicationChangeState("active"));
-  const initialSnapshot = createActor(itwEidIssuanceMachine).getSnapshot();
+  const initialSnapshot = createActor(itwEidIssuanceMachine, {
+    input: {
+      deps: {
+        store: { getState: () => initialState }
+      } as EidIssuanceMachineDeps
+    }
+  }).getSnapshot();
   const snapshot: MachineSnapshot = {
     ...initialSnapshot,
     value,

--- a/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceEidPreviewScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceEidPreviewScreen.test.tsx
@@ -7,12 +7,15 @@ import { appReducer } from "../../../../../store/reducers";
 import { GlobalState } from "../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
 import { ItwStoredCredentialsMocks } from "../../../common/utils/itwMocksUtils";
-import { EidIssuanceMachineDeps } from "../../../machine/eid/input";
 import {
   ItwEidIssuanceMachine,
   itwEidIssuanceMachine
 } from "../../../machine/eid/machine";
 import { ItwTags } from "../../../machine/tags";
+import {
+  testEidIssuanceDeps,
+  testMachineStore
+} from "../../../machine/utils/testDeps";
 import { ITW_ROUTES } from "../../../navigation/routes";
 import { trackItwRequestSuccess } from "../../analytics";
 import { ItwIssuanceEidPreviewScreen } from "../ItwIssuanceEidPreviewScreen";
@@ -84,9 +87,9 @@ const renderComponent = ({
   const initialState = appReducer(undefined, applicationChangeState("active"));
   const initialSnapshot = createActor(itwEidIssuanceMachine, {
     input: {
-      deps: {
-        store: { getState: () => initialState }
-      } as EidIssuanceMachineDeps
+      deps: testEidIssuanceDeps({
+        store: testMachineStore({ getState: () => initialState })
+      })
     }
   }).getSnapshot();
   const snapshot: MachineSnapshot = {

--- a/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceEidResultScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceEidResultScreen.test.tsx
@@ -10,9 +10,12 @@ import { renderScreenWithNavigationStoreContext } from "../../../../../utils/tes
 import { CredentialMetadata } from "../../../common/utils/itwTypesUtils";
 import * as credentialsSelectors from "../../../credentials/store/selectors";
 import { Context, EidIssuanceLevel } from "../../../machine/eid/context";
-import { EidIssuanceMachineDeps } from "../../../machine/eid/input";
 import { itwEidIssuanceMachine } from "../../../machine/eid/machine";
 import { ItwEidIssuanceMachineContext } from "../../../machine/eid/provider";
+import {
+  testEidIssuanceDeps,
+  testMachineStore
+} from "../../../machine/utils/testDeps";
 import { ITW_ROUTES } from "../../../navigation/routes";
 import { trackBackToWallet } from "../../analytics";
 import { ItwIssuanceEidResultScreen } from "../ItwIssuanceEidResultScreen";
@@ -326,9 +329,9 @@ const renderComponent = (
   const initialState = appReducer(undefined, applicationChangeState("active"));
   const initialSnapshot = createActor(itwEidIssuanceMachine, {
     input: {
-      deps: {
-        store: { getState: () => initialState }
-      } as EidIssuanceMachineDeps
+      deps: testEidIssuanceDeps({
+        store: testMachineStore({ getState: () => initialState })
+      })
     }
   }).getSnapshot();
   const snapshot: typeof initialSnapshot = {

--- a/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceEidResultScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceEidResultScreen.test.tsx
@@ -10,6 +10,7 @@ import { renderScreenWithNavigationStoreContext } from "../../../../../utils/tes
 import { CredentialMetadata } from "../../../common/utils/itwTypesUtils";
 import * as credentialsSelectors from "../../../credentials/store/selectors";
 import { Context, EidIssuanceLevel } from "../../../machine/eid/context";
+import { EidIssuanceMachineDeps } from "../../../machine/eid/input";
 import { itwEidIssuanceMachine } from "../../../machine/eid/machine";
 import { ItwEidIssuanceMachineContext } from "../../../machine/eid/provider";
 import { ITW_ROUTES } from "../../../navigation/routes";
@@ -323,7 +324,13 @@ const renderComponent = (
   contextOverrides: Partial<Context> = {}
 ) => {
   const initialState = appReducer(undefined, applicationChangeState("active"));
-  const initialSnapshot = createActor(itwEidIssuanceMachine).getSnapshot();
+  const initialSnapshot = createActor(itwEidIssuanceMachine, {
+    input: {
+      deps: {
+        store: { getState: () => initialState }
+      } as EidIssuanceMachineDeps
+    }
+  }).getSnapshot();
   const snapshot: typeof initialSnapshot = {
     ...initialSnapshot,
     context: {

--- a/apps/main-app/ts/features/itwallet/machine/credential/__tests__/actions.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/credential/__tests__/actions.test.ts
@@ -1,21 +1,12 @@
-import { createCredentialIssuanceActionsImplementation } from "../actions";
 import { itwCredentialIssuanceMachine, notImplemented } from "../machine";
 
-describe("createCredentialIssuanceActionsImplementation", () => {
+describe("credential issuance actions", () => {
   it("implements every action the machine declares", () => {
-    const implemented = Object.keys(
-      createCredentialIssuanceActionsImplementation(
-        {} as never,
-        {} as never,
-        {} as never
-      )
-    );
     const missing = Object.entries(
       itwCredentialIssuanceMachine.implementations.actions
     )
-      .filter(([, impl]) => impl === notImplemented)
-      .map(([name]) => name)
-      .filter(name => !implemented.includes(name));
+      .filter(([, implementation]) => implementation === notImplemented)
+      .map(([name]) => name);
 
     expect(missing).toEqual([]);
   });

--- a/apps/main-app/ts/features/itwallet/machine/credential/__tests__/actors.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/credential/__tests__/actors.test.ts
@@ -1,29 +1,34 @@
-import { Env } from "../../../common/utils/environment";
-import { createCredentialIssuanceActorsImplementation } from "../actors";
+import { waitForSessionRefreshActor } from "../../utils/actors";
+import {
+  getWalletAttestationActor,
+  obtainAccessTokenActor,
+  obtainCredentialActor,
+  obtainCredentialStatusActor,
+  processCredentialOfferActor,
+  requestCredentialActor,
+  verifyTrustFederationActor
+} from "../actors";
 import { itwCredentialIssuanceMachine } from "../machine";
 
-describe("createCredentialIssuanceActorsImplementation", () => {
+describe("credential issuance actors", () => {
   /**
    * `machine.provide()` accepts partial implementations, so a missing actor is
    * not caught by the type-checker and only surfaces at runtime as a
-   * `notImplemented` crash (e.g. `waitForSessionRefresh` when the session
-   * expires). Non-regression: the factory must implement every actor declared
-   * in the machine setup.
+   * `notImplemented` crash (e.g. `waitForSessionRefreshActor` when the session
+   * expires). Non-regression: named exports plus the shared session-refresh
+   * actor must cover every actor declared in the machine setup.
    */
   it("implements every actor declared in the machine setup", () => {
-    const env = {} as Env;
-    const itwVersion = "1.4.6";
-    const store = {
-      getState: jest.fn(),
-      subscribe: jest.fn(),
-      dispatch: jest.fn()
+    const actors = {
+      verifyTrustFederation: verifyTrustFederationActor,
+      getWalletAttestation: getWalletAttestationActor,
+      requestCredential: requestCredentialActor,
+      obtainAccessToken: obtainAccessTokenActor,
+      obtainCredential: obtainCredentialActor,
+      obtainCredentialStatus: obtainCredentialStatusActor,
+      processCredentialOffer: processCredentialOfferActor,
+      waitForSessionRefresh: waitForSessionRefreshActor
     };
-
-    const actors = createCredentialIssuanceActorsImplementation(
-      env,
-      itwVersion,
-      store as never
-    );
 
     const declaredActors = Object.keys(
       itwCredentialIssuanceMachine.implementations.actors

--- a/apps/main-app/ts/features/itwallet/machine/credential/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/credential/__tests__/machine.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../../../common/utils/itwTypesUtils";
 import { ItwTags } from "../../tags";
 import {
+  GetWalletAttestationActorInput,
   GetWalletAttestationActorOutput,
   ObtainAccessTokenActorInput,
   ObtainCredentialActorInput,
@@ -33,12 +34,15 @@ import {
 } from "../actors";
 import { Context, InitialContext } from "../context";
 import { CredentialIssuanceFailureType } from "../failure";
+import { CredentialIssuanceMachineDeps } from "../input";
 import {
   ItwCredentialIssuanceMachine,
   itwCredentialIssuanceMachine
 } from "../machine";
 
 type MachineSnapshot = StateFrom<ItwCredentialIssuanceMachine>;
+
+const T_DEPS = {} as CredentialIssuanceMachineDeps;
 
 const T_WIA = "abcdefg";
 const T_KA = { ka1: "ka-jwt" };
@@ -167,8 +171,10 @@ describe("itwCredentialIssuanceMachine", () => {
       verifyTrustFederation: fromPromise<void, VerifyTrustFederationActorInput>(
         verifyTrustFederation
       ),
-      getWalletAttestation:
-        fromPromise<GetWalletAttestationActorOutput>(getWalletAttestation),
+      getWalletAttestation: fromPromise<
+        GetWalletAttestationActorOutput,
+        GetWalletAttestationActorInput
+      >(getWalletAttestation),
       requestCredential: fromPromise<
         RequestCredentialActorOutput,
         RequestCredentialActorInput
@@ -230,11 +236,14 @@ describe("itwCredentialIssuanceMachine", () => {
      * Start
      */
 
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     expect(actor.getSnapshot().value).toStrictEqual("Idle");
-    expect(actor.getSnapshot().context).toStrictEqual(InitialContext);
+    expect(actor.getSnapshot().context).toStrictEqual({
+      ...InitialContext,
+      deps: T_DEPS
+    });
     expect(actor.getSnapshot().tags).toStrictEqual(new Set([ItwTags.Loading]));
 
     actor.send({
@@ -394,12 +403,13 @@ describe("itwCredentialIssuanceMachine", () => {
      * Start
      */
 
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     expect(actor.getSnapshot().value).toStrictEqual("Idle");
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
-      ...InitialContext
+      ...InitialContext,
+      deps: T_DEPS
     });
     expect(actor.getSnapshot().tags).toStrictEqual(new Set([ItwTags.Loading]));
 
@@ -436,9 +446,9 @@ describe("itwCredentialIssuanceMachine", () => {
   it("Should not store the credential if the user closes the issuance", () => {
     /** Initial part is the same as the previous test, we can start from the preview */
 
-    const initialSnapshot: MachineSnapshot = createActor(
-      itwCredentialIssuanceMachine
-    ).getSnapshot();
+    const initialSnapshot: MachineSnapshot = createActor(mockedMachine, {
+      input: { deps: T_DEPS }
+    }).getSnapshot();
 
     const snapshot = _.merge(undefined, initialSnapshot, {
       value: "DisplayingCredentialPreview",
@@ -450,7 +460,8 @@ describe("itwCredentialIssuanceMachine", () => {
     });
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -474,7 +485,7 @@ describe("itwCredentialIssuanceMachine", () => {
   // TODO: SIW-2947 Fix this test
 
   /*  it("Should go to failure if wallet instance attestation obtainment fails", async () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     await waitFor(() => expect(onInit).toHaveBeenCalledTimes(1));
@@ -548,7 +559,7 @@ describe("itwCredentialIssuanceMachine", () => {
     }));
     hasValidWalletInstanceAttestation.mockImplementation(() => true);
 
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     expect(actor.getSnapshot().value).toStrictEqual("Idle");
@@ -611,16 +622,17 @@ describe("itwCredentialIssuanceMachine", () => {
   it("Should close the issuance if the user does not confirm trust issuer data", () => {
     /** Initial part is the same as the previous test, we can start from the preview */
 
-    const initialSnapshot: MachineSnapshot = createActor(
-      itwCredentialIssuanceMachine
-    ).getSnapshot();
+    const initialSnapshot: MachineSnapshot = createActor(mockedMachine, {
+      input: { deps: T_DEPS }
+    }).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(initialSnapshot, {
       value: "DisplayingTrustIssuer"
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -638,16 +650,17 @@ describe("itwCredentialIssuanceMachine", () => {
   it("Should go to failure if credential issaunce fails", async () => {
     /** Initial part is the same as the previous test, we can start from the preview */
 
-    const initialSnapshot: MachineSnapshot = createActor(
-      itwCredentialIssuanceMachine
-    ).getSnapshot();
+    const initialSnapshot: MachineSnapshot = createActor(mockedMachine, {
+      input: { deps: T_DEPS }
+    }).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(initialSnapshot, {
       value: "DisplayingTrustIssuer"
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -687,7 +700,7 @@ describe("itwCredentialIssuanceMachine", () => {
   });
 
   it("Should navigate to the next screen if mode is 'reissaunce'", async () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     isSkipNavigation.mockImplementation(() => false);
@@ -729,7 +742,7 @@ describe("itwCredentialIssuanceMachine", () => {
   });
 
   it("should not call navigateToExtendedLoadingScreen before 5000ms in TrustFederationVerification state", async () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     requestCredential.mockImplementation(
       () =>
         new Promise(resolve =>
@@ -765,7 +778,7 @@ describe("itwCredentialIssuanceMachine", () => {
   });
 
   it("should call navigateToExtendedLoadingScreen once after 5000ms in TrustFederationVerification state", async () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     requestCredential.mockImplementation(
       () =>
         new Promise(resolve =>
@@ -811,7 +824,7 @@ describe("itwCredentialIssuanceMachine", () => {
     hasValidWalletInstanceAttestation.mockImplementation(() => true);
     hasCredentialIntroContent.mockImplementation(() => true);
 
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     actor.send({
@@ -830,7 +843,7 @@ describe("itwCredentialIssuanceMachine", () => {
     hasValidWalletInstanceAttestation.mockImplementation(() => true);
     hasCredentialIntroContent.mockImplementation(() => true);
 
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
     actor.send({
       type: "select-credential",
@@ -857,7 +870,7 @@ describe("itwCredentialIssuanceMachine", () => {
       hasValidWalletInstanceAttestation.mockImplementation(() => true);
       hasCredentialIntroContent.mockImplementation(() => false);
 
-      const actor = createActor(mockedMachine);
+      const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
       actor.start();
 
       expect(actor.getSnapshot().value).toStrictEqual("Idle");
@@ -898,7 +911,7 @@ describe("itwCredentialIssuanceMachine", () => {
         Promise.resolve(T_RESOLVED_CREDENTIAL_OFFER)
       );
 
-      const actor = createActor(mockedMachine);
+      const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
       actor.start();
 
       actor.send({
@@ -933,7 +946,7 @@ describe("itwCredentialIssuanceMachine", () => {
         })
       );
 
-      const actor = createActor(mockedMachine);
+      const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
       actor.start();
 
       actor.send({
@@ -986,7 +999,7 @@ describe("itwCredentialIssuanceMachine", () => {
         })
       );
 
-      const actor = createActor(mockedMachine);
+      const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
       actor.start();
 
       actor.send({
@@ -1021,7 +1034,7 @@ describe("itwCredentialIssuanceMachine", () => {
       );
       isEidExpired.mockImplementation(() => true);
 
-      const actor = createActor(mockedMachine);
+      const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
       actor.start();
 
       actor.send({
@@ -1056,15 +1069,18 @@ describe("itwCredentialIssuanceMachine", () => {
       })
     );
 
-    const initialSnapshot = createActor(
-      itwCredentialIssuanceMachine
-    ).getSnapshot();
+    const initialSnapshot = createActor(mockedMachine, {
+      input: { deps: T_DEPS }
+    }).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(initialSnapshot, {
       value: "DisplayingTrustIssuer"
     } as MachineSnapshot);
 
-    const actor = createActor(mockedMachine, { snapshot });
+    const actor = createActor(mockedMachine, {
+      snapshot,
+      input: { deps: T_DEPS }
+    });
     actor.start();
 
     actor.send({ type: "confirm-trust-data" });

--- a/apps/main-app/ts/features/itwallet/machine/credential/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/credential/__tests__/machine.test.ts
@@ -19,6 +19,7 @@ import {
   RequestObject
 } from "../../../common/utils/itwTypesUtils";
 import { ItwTags } from "../../tags";
+import { testCredentialIssuanceDeps } from "../../utils/testDeps";
 import {
   GetWalletAttestationActorInput,
   GetWalletAttestationActorOutput,
@@ -34,7 +35,6 @@ import {
 } from "../actors";
 import { Context, InitialContext } from "../context";
 import { CredentialIssuanceFailureType } from "../failure";
-import { CredentialIssuanceMachineDeps } from "../input";
 import {
   ItwCredentialIssuanceMachine,
   itwCredentialIssuanceMachine
@@ -42,7 +42,7 @@ import {
 
 type MachineSnapshot = StateFrom<ItwCredentialIssuanceMachine>;
 
-const T_DEPS = {} as CredentialIssuanceMachineDeps;
+const T_DEPS = testCredentialIssuanceDeps();
 
 const T_WIA = "abcdefg";
 const T_KA = { ka1: "ka-jwt" };

--- a/apps/main-app/ts/features/itwallet/machine/credential/actions.ts
+++ b/apps/main-app/ts/features/itwallet/machine/credential/actions.ts
@@ -1,10 +1,7 @@
-import { IOToast } from "@io-app/design-system";
 import I18n from "i18next";
 import { ActionArgs, assertEvent, assign } from "xstate";
 
-import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import ROUTES from "../../../../navigation/routes";
-import { useIOStore } from "../../../../store/hooks";
 import { assert } from "../../../../utils/assert";
 import { isRouteInNavigationState } from "../../../../utils/navigation";
 import { checkCurrentSession } from "../../../authentication/common/store/actions";
@@ -35,237 +32,231 @@ import { itwWalletInstanceAttestationSelector } from "../../walletInstance/store
 import { Context } from "./context";
 import { CredentialIssuanceEvents } from "./events";
 
-export const createCredentialIssuanceActionsImplementation = (
-  navigation: ReturnType<typeof useIONavigation>,
-  store: ReturnType<typeof useIOStore>,
-  toast: IOToast
-) => ({
-  onInit: assign<
-    Context,
-    CredentialIssuanceEvents,
-    unknown,
-    CredentialIssuanceEvents,
-    any
-  >(() => {
-    const state = store.getState();
+type CredentialIssuanceActionArgs = ActionArgs<
+  Context,
+  CredentialIssuanceEvents,
+  CredentialIssuanceEvents
+>;
 
-    return {
-      isItWalletValid: itwLifecycleIsITWalletValidSelector(state),
-      walletInstanceAttestation: itwWalletInstanceAttestationSelector(state),
-      credentialsCatalogue: itwCredentialsCatalogueByTypesSelector(state),
-      isWalletValid: itwLifecycleIsValidSelector(state)
-    };
-  }),
+/**
+ * Initializes the credential issuance machine from the Redux store.
+ */
+export const onInitAction = assign<
+  Context,
+  CredentialIssuanceEvents,
+  unknown,
+  CredentialIssuanceEvents,
+  any
+>(({ context }) => {
+  const state = context.deps.store.getState();
 
-  navigateToCredentialIntroductionScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.ISSUANCE.CREDENTIAL_INTRODUCTION
-    });
-  },
-
-  navigateToTrustIssuerScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.ISSUANCE.CREDENTIAL_TRUST_ISSUER
-    });
-  },
-
-  navigateToCredentialPreviewScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.ISSUANCE.CREDENTIAL_PREVIEW
-    });
-  },
-
-  navigateToFailureScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.ISSUANCE.CREDENTIAL_FAILURE
-    });
-  },
-
-  navigateToWallet: () => {
-    toast.success(I18n.t("features.itWallet.issuance.credentialResult.toast"));
-    navigation.reset({
-      index: 1,
-      routes: [
-        {
-          name: ROUTES.MAIN,
-          params: {
-            screen: ROUTES.WALLET_HOME
-          }
-        }
-      ]
-    });
-  },
-
-  navigateToEidVerificationExpiredScreen: () => {
-    navigation.replace(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.PRESENTATION.EID_VERIFICATION_EXPIRED
-    });
-  },
-
-  navigateToCardOnboardingScreen: ({
-    context
-  }: ActionArgs<
-    Context,
-    CredentialIssuanceEvents,
-    CredentialIssuanceEvents
-  >) => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: context.isItWalletValid
-        ? ITW_ROUTES.L3_ONBOARDING
-        : ITW_ROUTES.ONBOARDING
-    });
-  },
-
-  closeIssuance: ({
-    event
-  }: ActionArgs<
-    Context,
-    CredentialIssuanceEvents,
-    CredentialIssuanceEvents
-  >) => {
-    const isWalletInNavigationState = isRouteInNavigationState(
-      navigation.getState(),
-      ROUTES.WALLET_HOME
-    );
-
-    if (!isWalletInNavigationState && navigation.canGoBack()) {
-      navigation.goBack();
-      return;
-    }
-
-    assertEvent(event, "close");
-    const { surveyStep, surveyCredential } = event;
-
-    if (surveyStep && surveyCredential) {
-      store.dispatch(
-        itwSetCredentialExitSurvey({
-          step: surveyStep,
-          credential: surveyCredential
-        })
-      );
-    }
-
-    navigation.navigate(ROUTES.MAIN, {
-      screen: ROUTES.WALLET_HOME,
-      params: {}
-    });
-  },
-
-  storeWalletInstanceAttestation: ({
-    context
-  }: ActionArgs<
-    Context,
-    CredentialIssuanceEvents,
-    CredentialIssuanceEvents
-  >) => {
-    assert(
-      context.walletInstanceAttestation,
-      "walletInstanceAttestation is undefined"
-    );
-    store.dispatch(
-      itwWalletInstanceAttestationStore(context.walletInstanceAttestation)
-    );
-  },
-
-  storeCredential: ({
-    context
-  }: ActionArgs<
-    Context,
-    CredentialIssuanceEvents,
-    CredentialIssuanceEvents
-  >) => {
-    assert(context.credentialType, "credentialType is undefined");
-    assert(context.credentials, "credentials is undefined");
-    // A credential offer (deeplink/QR code) is the only alternative entry point to the
-    // catalogue/list for issuing a credential, so its presence in the context is what
-    // distinguishes the two flows for analytics purposes.
-    const origin: CredentialMetadata["origin"] = context.resolvedCredentialOffer
-      ? "credentialOffer"
-      : "catalogue";
-    const credentials = context.credentials.map(bundle => ({
-      ...bundle,
-      metadata: { ...bundle.metadata, origin }
-    }));
-    // Removes any credentials with the same type and stores the new ones atomically
-    store.dispatch(itwCredentialsReplaceByType(credentials, {}));
-    // Clear older upgrade-failed flag for this credential after a successful issuance/upgrade.
-    store.dispatch(itwClearCredentialUpgradeFailed(context.credentialType));
-    // Stores Key Attestations separately if present
-    if (context.keyAttestations) {
-      store.dispatch(itwKeyAttestationsStore(context.keyAttestations));
-    }
-  },
-
-  trackStartAddCredential: ({
-    context
-  }: ActionArgs<
-    Context,
-    CredentialIssuanceEvents,
-    CredentialIssuanceEvents
-  >) => {
-    if (context.credentialType) {
-      const isItwL3 = itwLifecycleIsITWalletValidSelector(store.getState());
-      const credential = getMixPanelCredential(context.credentialType, isItwL3);
-      trackStartAddNewCredential(credential);
-    }
-  },
-
-  trackAddCredential: ({
-    context
-  }: ActionArgs<
-    Context,
-    CredentialIssuanceEvents,
-    CredentialIssuanceEvents
-  >) => {
-    if (context.credentialType) {
-      const state = store.getState();
-      const isItwL3 = itwLifecycleIsITWalletValidSelector(state);
-      const credential = getMixPanelCredential(context.credentialType, isItwL3);
-      trackSaveCredentialSuccess({
-        credential,
-        credential_details: itwMixPanelCredentialDetailsSelector(state)
-      });
-    }
-  },
-
-  handleSessionExpired: () =>
-    store.dispatch(checkCurrentSession.success({ isSessionValid: false })),
-
-  trackCredentialIssuingDataShare: ({
-    context
-  }: ActionArgs<Context, CredentialIssuanceEvents, CredentialIssuanceEvents>) =>
-    trackDataShareEvent(context, store),
-
-  trackCredentialIssuingDataShareAccepted: ({
-    context
-  }: ActionArgs<Context, CredentialIssuanceEvents, CredentialIssuanceEvents>) =>
-    trackDataShareEvent(context, store, true),
-
-  trackStartCredentialReissuing: ({
-    context
-  }: ActionArgs<
-    Context,
-    CredentialIssuanceEvents,
-    CredentialIssuanceEvents
-  >) => {
-    assert(context.credentialType, "credentialType is undefined");
-    trackStartCredentialUpgrade(
-      getMixPanelCredential(context.credentialType, context.isItWalletValid)
-    );
-  }
+  return {
+    isItWalletValid: itwLifecycleIsITWalletValidSelector(state),
+    walletInstanceAttestation: itwWalletInstanceAttestationSelector(state),
+    credentialsCatalogue: itwCredentialsCatalogueByTypesSelector(state),
+    isWalletValid: itwLifecycleIsValidSelector(state)
+  };
 });
 
-const trackDataShareEvent = (
-  context: Context,
-  store: ReturnType<typeof useIOStore>,
-  isAccepted = false
-) => {
+export const navigateToCredentialIntroductionScreenAction = ({
+  context
+}: CredentialIssuanceActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.ISSUANCE.CREDENTIAL_INTRODUCTION
+  });
+};
+
+export const navigateToTrustIssuerScreenAction = ({
+  context
+}: CredentialIssuanceActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.ISSUANCE.CREDENTIAL_TRUST_ISSUER
+  });
+};
+
+export const navigateToCredentialPreviewScreenAction = ({
+  context
+}: CredentialIssuanceActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.ISSUANCE.CREDENTIAL_PREVIEW
+  });
+};
+
+export const navigateToFailureScreenAction = ({
+  context
+}: CredentialIssuanceActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.ISSUANCE.CREDENTIAL_FAILURE
+  });
+};
+
+export const navigateToWalletAction = ({
+  context
+}: CredentialIssuanceActionArgs) => {
+  context.deps.toast.success(
+    I18n.t("features.itWallet.issuance.credentialResult.toast")
+  );
+  context.deps.navigation.reset({
+    index: 1,
+    routes: [
+      {
+        name: ROUTES.MAIN,
+        params: {
+          screen: ROUTES.WALLET_HOME
+        }
+      }
+    ]
+  });
+};
+
+export const navigateToEidVerificationExpiredScreenAction = ({
+  context
+}: CredentialIssuanceActionArgs) => {
+  context.deps.navigation.replace(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.PRESENTATION.EID_VERIFICATION_EXPIRED
+  });
+};
+
+export const navigateToCardOnboardingScreenAction = ({
+  context
+}: CredentialIssuanceActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: context.isItWalletValid
+      ? ITW_ROUTES.L3_ONBOARDING
+      : ITW_ROUTES.ONBOARDING
+  });
+};
+
+export const closeIssuanceAction = ({
+  context,
+  event
+}: CredentialIssuanceActionArgs) => {
+  const { navigation, store } = context.deps;
+  const isWalletInNavigationState = isRouteInNavigationState(
+    navigation.getState(),
+    ROUTES.WALLET_HOME
+  );
+
+  if (!isWalletInNavigationState && navigation.canGoBack()) {
+    navigation.goBack();
+    return;
+  }
+
+  assertEvent(event, "close");
+  const { surveyStep, surveyCredential } = event;
+
+  if (surveyStep && surveyCredential) {
+    store.dispatch(
+      itwSetCredentialExitSurvey({
+        step: surveyStep,
+        credential: surveyCredential
+      })
+    );
+  }
+
+  navigation.navigate(ROUTES.MAIN, {
+    screen: ROUTES.WALLET_HOME,
+    params: {}
+  });
+};
+
+export const storeWalletInstanceAttestationAction = ({
+  context
+}: CredentialIssuanceActionArgs) => {
+  assert(
+    context.walletInstanceAttestation,
+    "walletInstanceAttestation is undefined"
+  );
+  context.deps.store.dispatch(
+    itwWalletInstanceAttestationStore(context.walletInstanceAttestation)
+  );
+};
+
+export const storeCredentialAction = ({
+  context
+}: CredentialIssuanceActionArgs) => {
+  assert(context.credentialType, "credentialType is undefined");
+  assert(context.credentials, "credentials is undefined");
+  const { store } = context.deps;
+  // A credential offer (deeplink/QR code) is the only alternative entry point to the
+  // catalogue/list for issuing a credential, so its presence in the context is what
+  // distinguishes the two flows for analytics purposes.
+  const origin: CredentialMetadata["origin"] = context.resolvedCredentialOffer
+    ? "credentialOffer"
+    : "catalogue";
+  const credentials = context.credentials.map(bundle => ({
+    ...bundle,
+    metadata: { ...bundle.metadata, origin }
+  }));
+  // Removes any credentials with the same type and stores the new ones atomically
+  store.dispatch(itwCredentialsReplaceByType(credentials, {}));
+  // Clear older upgrade-failed flag for this credential after a successful issuance/upgrade.
+  store.dispatch(itwClearCredentialUpgradeFailed(context.credentialType));
+  // Stores Key Attestations separately if present
+  if (context.keyAttestations) {
+    store.dispatch(itwKeyAttestationsStore(context.keyAttestations));
+  }
+};
+
+export const trackStartAddCredentialAction = ({
+  context
+}: CredentialIssuanceActionArgs) => {
+  if (context.credentialType) {
+    const isItwL3 = itwLifecycleIsITWalletValidSelector(
+      context.deps.store.getState()
+    );
+    const credential = getMixPanelCredential(context.credentialType, isItwL3);
+    trackStartAddNewCredential(credential);
+  }
+};
+
+export const trackAddCredentialAction = ({
+  context
+}: CredentialIssuanceActionArgs) => {
+  if (context.credentialType) {
+    const state = context.deps.store.getState();
+    const isItwL3 = itwLifecycleIsITWalletValidSelector(state);
+    const credential = getMixPanelCredential(context.credentialType, isItwL3);
+    trackSaveCredentialSuccess({
+      credential,
+      credential_details: itwMixPanelCredentialDetailsSelector(state)
+    });
+  }
+};
+
+export const handleSessionExpiredAction = ({
+  context
+}: CredentialIssuanceActionArgs) =>
+  context.deps.store.dispatch(
+    checkCurrentSession.success({ isSessionValid: false })
+  );
+
+export const trackCredentialIssuingDataShareAction = ({
+  context
+}: CredentialIssuanceActionArgs) => trackDataShareEvent(context);
+
+export const trackCredentialIssuingDataShareAcceptedAction = ({
+  context
+}: CredentialIssuanceActionArgs) => trackDataShareEvent(context, true);
+
+export const trackStartCredentialReissuingAction = ({
+  context
+}: CredentialIssuanceActionArgs) => {
+  assert(context.credentialType, "credentialType is undefined");
+  trackStartCredentialUpgrade(
+    getMixPanelCredential(context.credentialType, context.isItWalletValid)
+  );
+};
+
+const trackDataShareEvent = (context: Context, isAccepted = false) => {
   if (context.credentialType) {
     const { credentialType } = context;
     if (!credentialType) {
       return;
     }
-    const isItwL3 = itwLifecycleIsITWalletValidSelector(store.getState());
+    const isItwL3 = itwLifecycleIsITWalletValidSelector(
+      context.deps.store.getState()
+    );
     const credential = getMixPanelCredential(context.credentialType, isItwL3);
 
     const trackDataFn = isAccepted

--- a/apps/main-app/ts/features/itwallet/machine/credential/actors.ts
+++ b/apps/main-app/ts/features/itwallet/machine/credential/actors.ts
@@ -1,14 +1,9 @@
-import type {
-  CredentialOffer,
-  ItwVersion
-} from "@pagopa/io-react-native-wallet";
+import type { CredentialOffer } from "@pagopa/io-react-native-wallet";
 
 import { fromPromise } from "xstate";
 
-import { useIOStore } from "../../../../store/hooks";
 import { assert } from "../../../../utils/assert";
 import { sessionTokenSelector } from "../../../authentication/common/store/selectors";
-import { Env } from "../../common/utils/environment";
 import * as itwAttestationUtils from "../../common/utils/itwAttestationUtils";
 import * as credentialIssuanceUtils from "../../common/utils/itwCredentialIssuanceUtils";
 import { isAssertionGenerationError } from "../../common/utils/itwFailureUtils";
@@ -28,8 +23,12 @@ import { itwStoreIntegrityKeyTag } from "../../issuance/store/actions";
 import { itwIntegrityKeyTagSelector } from "../../issuance/store/selectors";
 import { itwSetWalletInstanceRenewalError } from "../../walletInstance/store/actions";
 import { itwWalletInstanceRenewalErrorSelector } from "../../walletInstance/store/selectors";
-import { createCommonActorsImplementation } from "../utils/actors";
 import { Context } from "./context";
+import { CredentialIssuanceMachineDeps } from "./input";
+
+export type GetWalletAttestationActorInput = {
+  deps: CredentialIssuanceMachineDeps;
+};
 
 export type GetWalletAttestationActorOutput = Awaited<
   ReturnType<typeof itwAttestationUtils.getWalletInstanceAttestation>
@@ -40,11 +39,15 @@ export type ObtainAccessTokenActorInput = Partial<
     Parameters<credentialIssuanceUtils.CompleteAuthFlow>[0],
     "env" | "itwVersion" | "pid"
   >
->;
+> & {
+  deps: CredentialIssuanceMachineDeps;
+};
 
 export type ObtainCredentialActorInput = Partial<
   Parameters<credentialIssuanceUtils.ObtainCredential>[0]
->;
+> & {
+  deps: CredentialIssuanceMachineDeps;
+};
 
 export type ObtainCredentialActorOutput = {
   credentials: ReadonlyArray<CredentialBundle>;
@@ -54,10 +57,13 @@ export type ObtainCredentialActorOutput = {
 export type ObtainCredentialStatusActorInput = Pick<
   Context,
   "credentials" | "issuerConf"
->;
+> & {
+  deps: CredentialIssuanceMachineDeps;
+};
 
 export type ProcessCredentialOfferActorInput = {
   credentialOfferUri: Context["credentialOfferUri"];
+  deps: CredentialIssuanceMachineDeps;
 };
 
 export type ProcessCredentialOfferActorOutput = {
@@ -67,7 +73,9 @@ export type ProcessCredentialOfferActorOutput = {
 
 export type RequestCredentialActorInput = Partial<
   Parameters<credentialIssuanceUtils.RequestCredential>[0]
->;
+> & {
+  deps: CredentialIssuanceMachineDeps;
+};
 
 export type RequestCredentialActorOutput = Awaited<
   ReturnType<typeof credentialIssuanceUtils.requestCredential>
@@ -76,7 +84,9 @@ export type RequestCredentialActorOutput = Awaited<
 export type VerifyTrustFederationActorInput = Pick<
   Context,
   "resolvedCredentialOffer"
->;
+> & {
+  deps: CredentialIssuanceMachineDeps;
+};
 
 /**
  * Builds the dictionary of Key Attestations generated during issuance, keyed by their
@@ -97,258 +107,232 @@ const extractKeyAttestations = (
     {} as Record<string, string>
   );
 
-/**
- * Creates the actors for the eid issuance machine
- * @param env - The environment to use for the IT Wallet API calls
- * @param itwVersion - IT-Wallet technical specs version
- * @param store the IOStore
- * @returns the actors
- */
-export const createCredentialIssuanceActorsImplementation = (
-  env: Env,
-  itwVersion: ItwVersion,
-  store: ReturnType<typeof useIOStore>
-) => {
-  const verifyTrustFederation = fromPromise<
-    void,
-    VerifyTrustFederationActorInput
-  >(async ({ input }) => {
-    const ioWallet = getIoWallet(itwVersion);
-    const credentialIssuer =
-      input.resolvedCredentialOffer?.offer.credential_issuer ??
-      env.WALLET_EAA_PROVIDER_BASE_URL.value(itwVersion);
-    // Evaluate the issuer trust
-    const trustAnchorEntityConfig =
-      await ioWallet.Trust.getTrustAnchorEntityConfiguration(
-        env.WALLET_TA_BASE_URL
-      );
-
-    // Create the trust chain for the PID provider
-    const builtChainJwts = await ioWallet.Trust.buildTrustChain(
-      credentialIssuer,
-      trustAnchorEntityConfig
+export const verifyTrustFederationActor = fromPromise<
+  void,
+  VerifyTrustFederationActorInput
+>(async ({ input }) => {
+  const { env, itwVersion } = input.deps;
+  const ioWallet = getIoWallet(itwVersion);
+  const credentialIssuer =
+    input.resolvedCredentialOffer?.offer.credential_issuer ??
+    env.WALLET_EAA_PROVIDER_BASE_URL.value(itwVersion);
+  // Evaluate the issuer trust
+  const trustAnchorEntityConfig =
+    await ioWallet.Trust.getTrustAnchorEntityConfiguration(
+      env.WALLET_TA_BASE_URL
     );
 
-    // Perform full validation on the built chain
-    await ioWallet.Trust.verifyTrustChain(
-      trustAnchorEntityConfig,
-      builtChainJwts,
-      {
-        connectTimeout: 10000,
-        readTimeout: 10000,
-        requireCrl: true
-      }
-    );
-  });
-
-  const getWalletAttestation = fromPromise<GetWalletAttestationActorOutput>(
-    async () => {
-      const sessionToken = sessionTokenSelector(store.getState());
-      const integrityKeyTag = itwIntegrityKeyTagSelector(store.getState());
-
-      assert(sessionToken, "sessionToken is undefined");
-      assert(integrityKeyTag, "integrityKeyTag is not present");
-
-      try {
-        return await itwAttestationUtils.getWalletInstanceAttestation(
-          env,
-          itwVersion,
-          integrityKeyTag,
-          sessionToken
-        );
-      } catch (firstError) {
-        // On iOS, the stored DCAppAttest key can become invalid (DCErrorInvalidKey,
-        // com.apple.devicecheck.error 3), causing GENERATION_ASSERTION_FAILED during
-        // assertion generation. We recover by creating a new wallet instance with a
-        // fresh key and retrying the attestation once.
-        const isRenewalError = itwWalletInstanceRenewalErrorSelector(
-          store.getState()
-        );
-
-        // If the error is not related to assertion generation or if we've already attempted a renewal, we throw the error and prompt the user to retry.
-        if (!isAssertionGenerationError(firstError) || isRenewalError) {
-          throw firstError;
-        }
-
-        // Otherwise, we attempt to recover by creating a new wallet instance,
-        // which will generate a new hardware key tag,
-        // and retrying the attestation with the new key tag.
-        const newHardwareKeyTag =
-          await itwAttestationUtils.getIntegrityHardwareKeyTag();
-        store.dispatch(itwStoreIntegrityKeyTag(newHardwareKeyTag));
-        await itwAttestationUtils.registerWalletInstance(
-          env,
-          itwVersion,
-          newHardwareKeyTag,
-          sessionToken,
-          { isRenewal: true }
-        );
-
-        return await itwAttestationUtils
-          .getWalletInstanceAttestation(
-            env,
-            itwVersion,
-            newHardwareKeyTag,
-            sessionToken
-          )
-          .then(attestation => {
-            // Track the successful renewal in Mixpanel
-            trackWalletInstanceRenewalSuccess();
-            return attestation;
-          })
-          .catch(error => {
-            // If the attestation retrieval fails again after renewing the wallet instance,
-            // we set a flag in the store to prevent further renewal attempts and prompt the user with an error.
-            store.dispatch(itwSetWalletInstanceRenewalError(true));
-            // Track the renewal failure in Mixpanel
-            trackWalletInstanceRenewalFailure(error);
-            throw error;
-          });
-      }
-    }
+  // Create the trust chain for the PID provider
+  const builtChainJwts = await ioWallet.Trust.buildTrustChain(
+    credentialIssuer,
+    trustAnchorEntityConfig
   );
 
-  const requestCredential = fromPromise<
-    RequestCredentialActorOutput,
-    RequestCredentialActorInput
-  >(async ({ input }) => {
-    const {
-      credentialType,
-      walletInstanceAttestation,
-      skipMdocIssuance = true,
-      resolvedCredentialOffer
-    } = input;
-
-    assert(credentialType, "credentialType is undefined");
-    assert(walletInstanceAttestation, "walletInstanceAttestation is undefined");
-
-    const eid = itwCredentialsEidSelector(store.getState());
-    assert(eid, "eID is undefined");
-
-    // Retrieve the PID credential before showing the trust issuer screen so the
-    // requested DCQL claims can be evaluated and displayed to the user.
-    const pidCredential = await CredentialsVault.get(eid.credentialId);
-    assert(pidCredential, "PID credential not found in secure storage");
-
-    const pid: CredentialBundle = {
-      metadata: eid,
-      credential: pidCredential
-    };
-
-    const result = await credentialIssuanceUtils.requestCredential({
-      env,
-      itwVersion,
-      credentialType,
-      walletInstanceAttestation,
-      skipMdocIssuance,
-      resolvedCredentialOffer,
-      pid
-    });
-    return result;
-  });
-
-  const obtainAccessToken = fromPromise<
-    CredentialAccessToken,
-    ObtainAccessTokenActorInput
-  >(async ({ input }) => {
-    const {
-      codeVerifier,
-      issuerConf,
-      walletInstanceAttestation,
-      requestedCredential,
-      evaluatedDcqlQuery,
-      responseMode
-    } = input;
-
-    assert(codeVerifier, "codeVerifier is undefined");
-    assert(issuerConf, "issuerConf is undefined");
-    assert(walletInstanceAttestation, "walletInstanceAttestation is undefined");
-    assert(requestedCredential, "requestedCredential is undefined");
-    assert(evaluatedDcqlQuery, "evaluatedDcqlQuery is undefined");
-
-    const { accessToken } = await credentialIssuanceUtils.completeAuthFlow({
-      env,
-      itwVersion,
-      codeVerifier,
-      issuerConf,
-      walletInstanceAttestation,
-      requestedCredential,
-      responseMode,
-      evaluatedDcqlQuery
-    });
-    return accessToken;
-  });
-
-  // To ensure a smooth experience when the session token expires, it is important to keep this actor
-  // retriable: it must fail as early as possible when `generateKeysWithKeyAttestation` is
-  // rejected for session expired, so it can be reentered and retried from where it failed.
-  const obtainCredential = fromPromise<
-    ObtainCredentialActorOutput,
-    ObtainCredentialActorInput
-  >(async ({ input }) => {
-    const { credentialType, accessToken, issuerConf, clientId } = input;
-    const state = store.getState();
-    const sessionToken = sessionTokenSelector(state);
-    const integrityKeyTag = itwIntegrityKeyTagSelector(state);
-
-    assert(credentialType, "credentialType is undefined");
-    assert(issuerConf, "issuerConf is undefined");
-    assert(clientId, "clientId is undefined");
-    assert(sessionToken, "sessionToken is undefined");
-    assert(accessToken, "accessToken is undefined");
-    assert(integrityKeyTag, "integrityKeyTag is undefined");
-
-    // The Key Attestation makes use of the integrity service
-    if (getIoWallet(itwVersion).KeyAttestation.isSupported) {
-      await ensureIntegrityServiceIsStoreReadyOrThrow(store);
+  // Perform full validation on the built chain
+  await ioWallet.Trust.verifyTrustChain(
+    trustAnchorEntityConfig,
+    builtChainJwts,
+    {
+      connectTimeout: 10000,
+      readTimeout: 10000,
+      requireCrl: true
     }
+  );
+});
 
-    // Decide whether to obtain the credential in batch (multiple copies) based on the app-side
-    // configuration and the issuer's advertised batch size. One-time-use credentials are obtained
-    // in batch so the wallet holds several copies, each consumed on a single presentation.
-    const batchSize = credentialIssuanceUtils.getEffectiveBatchSize(
-      credentialType,
-      issuerConf.credential_issuance_batch_size
+export const getWalletAttestationActor = fromPromise<
+  GetWalletAttestationActorOutput,
+  GetWalletAttestationActorInput
+>(async ({ input }) => {
+  const { env, itwVersion, store } = input.deps;
+  const sessionToken = sessionTokenSelector(store.getState());
+  const integrityKeyTag = itwIntegrityKeyTagSelector(store.getState());
+
+  assert(sessionToken, "sessionToken is undefined");
+  assert(integrityKeyTag, "integrityKeyTag is not present");
+
+  try {
+    return await itwAttestationUtils.getWalletInstanceAttestation(
+      env,
+      itwVersion,
+      integrityKeyTag,
+      sessionToken
+    );
+  } catch (firstError) {
+    // On iOS, the stored DCAppAttest key can become invalid (DCErrorInvalidKey,
+    // com.apple.devicecheck.error 3), causing GENERATION_ASSERTION_FAILED during
+    // assertion generation. We recover by creating a new wallet instance with a
+    // fresh key and retrying the attestation once.
+    const isRenewalError = itwWalletInstanceRenewalErrorSelector(
+      store.getState()
     );
 
-    const keyGenParams = {
-      env,
-      itwVersion,
-      hardwareKeyTag: integrityKeyTag,
-      sessionToken
-    };
-
-    if (batchSize > 1) {
-      const authorizedCredentials =
-        await credentialIssuanceUtils.generateBatchKeysWithKeyAttestation(
-          accessToken,
-          batchSize,
-          keyGenParams
-        );
-
-      const credentials = await credentialIssuanceUtils.obtainCredentialsBatch({
-        authorizedCredentials,
-        env,
-        itwVersion,
-        accessToken,
-        credentialType,
-        issuerConf,
-        clientId
-      });
-
-      return {
-        credentials,
-        keyAttestations: extractKeyAttestations(authorizedCredentials)
-      };
+    // If the error is not related to assertion generation or if we've already attempted a renewal, we throw the error and prompt the user to retry.
+    if (!isAssertionGenerationError(firstError) || isRenewalError) {
+      throw firstError;
     }
 
+    // Otherwise, we attempt to recover by creating a new wallet instance,
+    // which will generate a new hardware key tag,
+    // and retrying the attestation with the new key tag.
+    const newHardwareKeyTag =
+      await itwAttestationUtils.getIntegrityHardwareKeyTag();
+    store.dispatch(itwStoreIntegrityKeyTag(newHardwareKeyTag));
+    await itwAttestationUtils.registerWalletInstance(
+      env,
+      itwVersion,
+      newHardwareKeyTag,
+      sessionToken,
+      { isRenewal: true }
+    );
+
+    return await itwAttestationUtils
+      .getWalletInstanceAttestation(
+        env,
+        itwVersion,
+        newHardwareKeyTag,
+        sessionToken
+      )
+      .then(attestation => {
+        // Track the successful renewal in Mixpanel
+        trackWalletInstanceRenewalSuccess();
+        return attestation;
+      })
+      .catch(error => {
+        // If the attestation retrieval fails again after renewing the wallet instance,
+        // we set a flag in the store to prevent further renewal attempts and prompt the user with an error.
+        store.dispatch(itwSetWalletInstanceRenewalError(true));
+        // Track the renewal failure in Mixpanel
+        trackWalletInstanceRenewalFailure(error);
+        throw error;
+      });
+  }
+});
+
+export const requestCredentialActor = fromPromise<
+  RequestCredentialActorOutput,
+  RequestCredentialActorInput
+>(async ({ input }) => {
+  const {
+    credentialType,
+    walletInstanceAttestation,
+    skipMdocIssuance = true,
+    resolvedCredentialOffer,
+    deps
+  } = input;
+  const { env, itwVersion, store } = deps;
+
+  assert(credentialType, "credentialType is undefined");
+  assert(walletInstanceAttestation, "walletInstanceAttestation is undefined");
+
+  const eid = itwCredentialsEidSelector(store.getState());
+  assert(eid, "eID is undefined");
+
+  // Retrieve the PID credential before showing the trust issuer screen so the
+  // requested DCQL claims can be evaluated and displayed to the user.
+  const pidCredential = await CredentialsVault.get(eid.credentialId);
+  assert(pidCredential, "PID credential not found in secure storage");
+
+  const pid: CredentialBundle = {
+    metadata: eid,
+    credential: pidCredential
+  };
+
+  const result = await credentialIssuanceUtils.requestCredential({
+    env,
+    itwVersion,
+    credentialType,
+    walletInstanceAttestation,
+    skipMdocIssuance,
+    resolvedCredentialOffer,
+    pid
+  });
+  return result;
+});
+
+export const obtainAccessTokenActor = fromPromise<
+  CredentialAccessToken,
+  ObtainAccessTokenActorInput
+>(async ({ input }) => {
+  const {
+    codeVerifier,
+    issuerConf,
+    walletInstanceAttestation,
+    requestedCredential,
+    evaluatedDcqlQuery,
+    responseMode,
+    deps
+  } = input;
+  const { env, itwVersion } = deps;
+
+  assert(codeVerifier, "codeVerifier is undefined");
+  assert(issuerConf, "issuerConf is undefined");
+  assert(walletInstanceAttestation, "walletInstanceAttestation is undefined");
+  assert(requestedCredential, "requestedCredential is undefined");
+  assert(evaluatedDcqlQuery, "evaluatedDcqlQuery is undefined");
+
+  const { accessToken } = await credentialIssuanceUtils.completeAuthFlow({
+    env,
+    itwVersion,
+    codeVerifier,
+    issuerConf,
+    walletInstanceAttestation,
+    requestedCredential,
+    responseMode,
+    evaluatedDcqlQuery
+  });
+  return accessToken;
+});
+
+// To ensure a smooth experience when the session token expires, it is important to keep this actor
+// retriable: it must fail as early as possible when `generateKeysWithKeyAttestation` is
+// rejected for session expired, so it can be reentered and retried from where it failed.
+export const obtainCredentialActor = fromPromise<
+  ObtainCredentialActorOutput,
+  ObtainCredentialActorInput
+>(async ({ input }) => {
+  const { credentialType, accessToken, issuerConf, clientId, deps } = input;
+  const { env, itwVersion, store } = deps;
+  const state = store.getState();
+  const sessionToken = sessionTokenSelector(state);
+  const integrityKeyTag = itwIntegrityKeyTagSelector(state);
+
+  assert(credentialType, "credentialType is undefined");
+  assert(issuerConf, "issuerConf is undefined");
+  assert(clientId, "clientId is undefined");
+  assert(sessionToken, "sessionToken is undefined");
+  assert(accessToken, "accessToken is undefined");
+  assert(integrityKeyTag, "integrityKeyTag is undefined");
+
+  // The Key Attestation makes use of the integrity service
+  if (getIoWallet(itwVersion).KeyAttestation.isSupported) {
+    await ensureIntegrityServiceIsStoreReadyOrThrow(store);
+  }
+
+  // Decide whether to obtain the credential in batch (multiple copies) based on the app-side
+  // configuration and the issuer's advertised batch size. One-time-use credentials are obtained
+  // in batch so the wallet holds several copies, each consumed on a single presentation.
+  const batchSize = credentialIssuanceUtils.getEffectiveBatchSize(
+    credentialType,
+    issuerConf.credential_issuance_batch_size
+  );
+
+  const keyGenParams = {
+    env,
+    itwVersion,
+    hardwareKeyTag: integrityKeyTag,
+    sessionToken
+  };
+
+  if (batchSize > 1) {
     const authorizedCredentials =
-      await credentialIssuanceUtils.generateKeysWithKeyAttestation(
+      await credentialIssuanceUtils.generateBatchKeysWithKeyAttestation(
         accessToken,
+        batchSize,
         keyGenParams
       );
 
-    const credentials = await credentialIssuanceUtils.obtainCredential({
+    const credentials = await credentialIssuanceUtils.obtainCredentialsBatch({
       authorizedCredentials,
       env,
       itwVersion,
@@ -362,47 +346,59 @@ export const createCredentialIssuanceActorsImplementation = (
       credentials,
       keyAttestations: extractKeyAttestations(authorizedCredentials)
     };
-  });
+  }
 
-  const obtainCredentialStatus = fromPromise<
-    ReadonlyArray<CredentialBundle>,
-    ObtainCredentialStatusActorInput
-  >(async ({ input }) => {
-    assert(input.credentials, "credentials are undefined");
-
-    return await credentialIssuanceUtils.attachCredentialsStatus({
-      credentials: input.credentials,
-      env,
-      itwVersion,
-      issuerConf: input.issuerConf
-    });
-  });
-
-  const processCredentialOffer = fromPromise<
-    ProcessCredentialOfferActorOutput,
-    ProcessCredentialOfferActorInput
-  >(async ({ input }) => {
-    assert(input.credentialOfferUri, "credentialOfferUri is undefined");
-
-    const wallet = getIoWallet(itwVersion);
-
-    const offer = await wallet.CredentialsOffer.resolveCredentialOffer(
-      input.credentialOfferUri
+  const authorizedCredentials =
+    await credentialIssuanceUtils.generateKeysWithKeyAttestation(
+      accessToken,
+      keyGenParams
     );
 
-    const grantDetails = wallet.CredentialsOffer.extractGrantDetails(offer);
-
-    return { offer, grantDetails };
+  const credentials = await credentialIssuanceUtils.obtainCredential({
+    authorizedCredentials,
+    env,
+    itwVersion,
+    accessToken,
+    credentialType,
+    issuerConf,
+    clientId
   });
 
   return {
-    verifyTrustFederation,
-    getWalletAttestation,
-    obtainAccessToken,
-    requestCredential,
-    obtainCredential,
-    obtainCredentialStatus,
-    processCredentialOffer,
-    ...createCommonActorsImplementation(store)
+    credentials,
+    keyAttestations: extractKeyAttestations(authorizedCredentials)
   };
-};
+});
+
+export const obtainCredentialStatusActor = fromPromise<
+  ReadonlyArray<CredentialBundle>,
+  ObtainCredentialStatusActorInput
+>(async ({ input }) => {
+  assert(input.credentials, "credentials are undefined");
+  const { env, itwVersion } = input.deps;
+
+  return await credentialIssuanceUtils.attachCredentialsStatus({
+    credentials: input.credentials,
+    env,
+    itwVersion,
+    issuerConf: input.issuerConf
+  });
+});
+
+export const processCredentialOfferActor = fromPromise<
+  ProcessCredentialOfferActorOutput,
+  ProcessCredentialOfferActorInput
+>(async ({ input }) => {
+  assert(input.credentialOfferUri, "credentialOfferUri is undefined");
+  const { itwVersion } = input.deps;
+
+  const wallet = getIoWallet(itwVersion);
+
+  const offer = await wallet.CredentialsOffer.resolveCredentialOffer(
+    input.credentialOfferUri
+  );
+
+  const grantDetails = wallet.CredentialsOffer.extractGrantDetails(offer);
+
+  return { offer, grantDetails };
+});

--- a/apps/main-app/ts/features/itwallet/machine/credential/context.ts
+++ b/apps/main-app/ts/features/itwallet/machine/credential/context.ts
@@ -10,6 +10,7 @@ import {
   WalletInstanceAttestations
 } from "../../common/utils/itwTypesUtils";
 import { CredentialIssuanceFailure } from "./failure";
+import { CredentialIssuanceMachineDeps } from "./input";
 
 export type Context = {
   /**
@@ -28,6 +29,10 @@ export type Context = {
    * The type of the credential being issued.
    */
   credentialType: string | undefined;
+  /**
+   * Runtime dependencies injected via machine input
+   */
+  deps: CredentialIssuanceMachineDeps;
   /**
    * Result of evaluating the issuer DCQL query against the PID before the trust issuer screen.
    * It is reused to show the requested claims and complete the authorization without recalculating.
@@ -81,7 +86,7 @@ export type Context = {
  */
 export type CredentialIssuanceMode = "issuance" | "reissuance" | "upgrade";
 
-export const InitialContext: Context = {
+export const InitialContext: Omit<Context, "deps"> = {
   mode: "issuance",
   isItWalletValid: false,
   isWalletValid: false,

--- a/apps/main-app/ts/features/itwallet/machine/credential/guards.ts
+++ b/apps/main-app/ts/features/itwallet/machine/credential/guards.ts
@@ -1,6 +1,3 @@
-import { ItwVersion } from "@pagopa/io-react-native-wallet";
-
-import { useIOStore } from "../../../../store/hooks";
 import { ItwSessionExpiredError } from "../../api/client";
 import { isWalletInstanceAttestationValid } from "../../common/utils/itwAttestationUtils";
 import { itwCredentialsEidStatusSelector } from "../../credentials/store/selectors";
@@ -8,34 +5,38 @@ import { itwCredentialIntroContentSelector } from "../../credentialsCatalogue/st
 import { Context } from "./context";
 import { CredentialIssuanceEvents } from "./events";
 
-export const createCredentialIssuanceGuardsImplementation = (
-  store: ReturnType<typeof useIOStore>,
-  itwVersion: ItwVersion
-) => ({
-  isSessionExpired: ({ event }: { event: CredentialIssuanceEvents }) =>
-    "error" in event && event.error instanceof ItwSessionExpiredError,
+type GuardArgs = {
+  context: Context;
+  event: CredentialIssuanceEvents;
+};
 
-  hasValidWalletInstanceAttestation: ({ context }: { context: Context }) => {
-    const attestation = context.walletInstanceAttestation?.jwt;
-    if (!attestation) {
-      return false;
-    }
-    return isWalletInstanceAttestationValid(itwVersion, attestation);
-  },
+export const isSessionExpiredGuard = ({ event }: GuardArgs) =>
+  "error" in event && event.error instanceof ItwSessionExpiredError;
 
-  isEidExpired: () => {
-    const eidStatus = itwCredentialsEidStatusSelector(store.getState());
-
-    return eidStatus === "jwtExpired";
-  },
-
-  hasCredentialIntroContent: ({ context }: { context: Context }) => {
-    if (!context.credentialType) {
-      return false;
-    }
-    const credentialIntroContent = itwCredentialIntroContentSelector(
-      context.credentialType
-    )(store.getState());
-    return Boolean(credentialIntroContent);
+export const hasValidWalletInstanceAttestationGuard = ({
+  context
+}: GuardArgs) => {
+  const attestation = context.walletInstanceAttestation?.jwt;
+  if (!attestation) {
+    return false;
   }
-});
+  return isWalletInstanceAttestationValid(context.deps.itwVersion, attestation);
+};
+
+export const isEidExpiredGuard = ({ context }: GuardArgs) => {
+  const eidStatus = itwCredentialsEidStatusSelector(
+    context.deps.store.getState()
+  );
+
+  return eidStatus === "jwtExpired";
+};
+
+export const hasCredentialIntroContentGuard = ({ context }: GuardArgs) => {
+  if (!context.credentialType) {
+    return false;
+  }
+  const credentialIntroContent = itwCredentialIntroContentSelector(
+    context.credentialType
+  )(context.deps.store.getState());
+  return Boolean(credentialIntroContent);
+};

--- a/apps/main-app/ts/features/itwallet/machine/credential/input.ts
+++ b/apps/main-app/ts/features/itwallet/machine/credential/input.ts
@@ -1,16 +1,14 @@
-import { IOToast } from "@io-app/design-system";
 import { ItwVersion } from "@pagopa/io-react-native-wallet";
 
-import { useIONavigation } from "../../../../navigation/params/AppParamsList";
-import { useIOStore } from "../../../../store/hooks";
 import { Env } from "../../common/utils/environment";
+import { MachineNavigation, MachineStore, MachineToast } from "../utils/deps";
 
 export type CredentialIssuanceMachineDeps = {
   env: Env;
   itwVersion: ItwVersion;
-  navigation: ReturnType<typeof useIONavigation>;
-  store: ReturnType<typeof useIOStore>;
-  toast: IOToast;
+  navigation: MachineNavigation;
+  store: MachineStore;
+  toast: MachineToast;
 };
 
 export type Input = { deps: CredentialIssuanceMachineDeps };

--- a/apps/main-app/ts/features/itwallet/machine/credential/input.ts
+++ b/apps/main-app/ts/features/itwallet/machine/credential/input.ts
@@ -1,25 +1,16 @@
-import { useIOToast } from "@io-app/design-system";
+import { IOToast } from "@io-app/design-system";
 import { ItwVersion } from "@pagopa/io-react-native-wallet";
 
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { useIOStore } from "../../../../store/hooks";
 import { Env } from "../../common/utils/environment";
 
-export type Input = {
-  /**
-   * The credential type to get the trustmark for
-   */
-  credentialType: string;
-  /**
-   * Runtime dependencies injected by the machine provider
-   */
-  deps: TrustmarkMachineDeps;
-};
-
-export type TrustmarkMachineDeps = {
+export type CredentialIssuanceMachineDeps = {
   env: Env;
   itwVersion: ItwVersion;
   navigation: ReturnType<typeof useIONavigation>;
   store: ReturnType<typeof useIOStore>;
-  toast: ReturnType<typeof useIOToast>;
+  toast: IOToast;
 };
+
+export type Input = { deps: CredentialIssuanceMachineDeps };

--- a/apps/main-app/ts/features/itwallet/machine/credential/machine.ts
+++ b/apps/main-app/ts/features/itwallet/machine/credential/machine.ts
@@ -9,7 +9,7 @@ export { notImplemented } from "./setup";
 
 export const itwCredentialIssuanceMachine = itwCredentialSetup.createMachine({
   id: "itwCredentialIssuanceMachine",
-  context: { ...InitialContext },
+  context: ({ input }) => ({ ...InitialContext, deps: input.deps }),
   initial: "Idle",
   states: {
     Idle: {
@@ -44,7 +44,8 @@ export const itwCredentialIssuanceMachine = itwCredentialSetup.createMachine({
       invoke: {
         src: "processCredentialOffer",
         input: ({ context }) => ({
-          credentialOfferUri: context.credentialOfferUri
+          credentialOfferUri: context.credentialOfferUri,
+          deps: context.deps
         }),
         onDone: {
           target: "CredentialOfferResolved",
@@ -143,7 +144,8 @@ export const itwCredentialIssuanceMachine = itwCredentialSetup.createMachine({
       invoke: {
         src: "verifyTrustFederation",
         input: ({ context }) => ({
-          resolvedCredentialOffer: context.resolvedCredentialOffer
+          resolvedCredentialOffer: context.resolvedCredentialOffer,
+          deps: context.deps
         }),
         onDone: {
           target: "CheckingWalletInstanceAttestation"
@@ -181,6 +183,7 @@ export const itwCredentialIssuanceMachine = itwCredentialSetup.createMachine({
       tags: [ItwTags.Loading],
       invoke: {
         src: "getWalletAttestation",
+        input: ({ context }) => ({ deps: context.deps }),
         onDone: {
           target: "RequestingCredential",
           actions: [
@@ -211,7 +214,8 @@ export const itwCredentialIssuanceMachine = itwCredentialSetup.createMachine({
           credentialType: context.credentialType,
           walletInstanceAttestation: context.walletInstanceAttestation?.jwt,
           resolvedCredentialOffer: context.resolvedCredentialOffer,
-          skipMdocIssuance: !context.isItWalletValid // Do not request mDoc credentials for non IT-Wallet instances
+          skipMdocIssuance: !context.isItWalletValid, // Do not request mDoc credentials for non IT-Wallet instances
+          deps: context.deps
         }),
         onDone: {
           target: "DisplayingTrustIssuer",

--- a/apps/main-app/ts/features/itwallet/machine/credential/machine.ts
+++ b/apps/main-app/ts/features/itwallet/machine/credential/machine.ts
@@ -78,7 +78,7 @@ export const itwCredentialIssuanceMachine = itwCredentialSetup.createMachine({
       on: {
         "confirm-credential-offer": {
           target: "EvaluateFlow",
-          actions: ["onInit", assign({ mode: "issuance" as const })]
+          actions: ["onInit", assign({ mode: "issuance" })]
         },
         close: {
           target: "Idle",

--- a/apps/main-app/ts/features/itwallet/machine/credential/provider.tsx
+++ b/apps/main-app/ts/features/itwallet/machine/credential/provider.tsx
@@ -9,9 +9,6 @@ import {
   selectItwSpecsVersion
 } from "../../common/store/selectors/environment";
 import { getEnv } from "../../common/utils/environment";
-import { createCredentialIssuanceActionsImplementation } from "./actions.ts";
-import { createCredentialIssuanceActorsImplementation } from "./actors.ts";
-import { createCredentialIssuanceGuardsImplementation } from "./guards.ts";
 import { itwCredentialIssuanceMachine } from "./machine.ts";
 
 export const ItwCredentialIssuanceMachineContext = createActorContext(
@@ -28,19 +25,14 @@ export const ItwCredentialIssuanceMachineProvider = (
   const env = getEnv(useIOSelector(selectItwEnv));
   const itwVersion = useIOSelector(selectItwSpecsVersion);
 
-  const credentialIssuanceMachine = itwCredentialIssuanceMachine.provide({
-    guards: createCredentialIssuanceGuardsImplementation(store, itwVersion),
-    actions: createCredentialIssuanceActionsImplementation(
-      navigation,
-      store,
-      toast
-    ),
-    actors: createCredentialIssuanceActorsImplementation(env, itwVersion, store)
-  });
-
   return (
     <ItwCredentialIssuanceMachineContext.Provider
-      logic={credentialIssuanceMachine}
+      logic={itwCredentialIssuanceMachine}
+      options={{
+        input: {
+          deps: { env, itwVersion, navigation, store, toast }
+        }
+      }}
     >
       {props.children}
     </ItwCredentialIssuanceMachineContext.Provider>

--- a/apps/main-app/ts/features/itwallet/machine/credential/setup.ts
+++ b/apps/main-app/ts/features/itwallet/machine/credential/setup.ts
@@ -1,24 +1,44 @@
-import { assign, fromCallback, fromPromise, setup } from "xstate";
+import { assign, setup } from "xstate";
 
+import { waitForSessionRefreshActor } from "../utils/actors";
 import {
-  CredentialAccessToken,
-  CredentialBundle
-} from "../../common/utils/itwTypesUtils";
+  closeIssuanceAction,
+  handleSessionExpiredAction,
+  navigateToCardOnboardingScreenAction,
+  navigateToCredentialIntroductionScreenAction,
+  navigateToCredentialPreviewScreenAction,
+  navigateToEidVerificationExpiredScreenAction,
+  navigateToFailureScreenAction,
+  navigateToTrustIssuerScreenAction,
+  navigateToWalletAction,
+  onInitAction,
+  storeCredentialAction,
+  storeWalletInstanceAttestationAction,
+  trackAddCredentialAction,
+  trackCredentialIssuingDataShareAcceptedAction,
+  trackCredentialIssuingDataShareAction,
+  trackStartAddCredentialAction,
+  trackStartCredentialReissuingAction
+} from "./actions";
 import {
-  GetWalletAttestationActorOutput,
-  ObtainAccessTokenActorInput,
-  ObtainCredentialActorInput,
-  ObtainCredentialActorOutput,
-  ObtainCredentialStatusActorInput,
-  ProcessCredentialOfferActorInput,
-  ProcessCredentialOfferActorOutput,
-  RequestCredentialActorInput,
-  RequestCredentialActorOutput,
-  VerifyTrustFederationActorInput
+  getWalletAttestationActor,
+  obtainAccessTokenActor,
+  obtainCredentialActor,
+  obtainCredentialStatusActor,
+  processCredentialOfferActor,
+  requestCredentialActor,
+  verifyTrustFederationActor
 } from "./actors";
 import { Context } from "./context";
 import { CredentialIssuanceEvents } from "./events";
 import { mapEventToFailure } from "./failure";
+import {
+  hasCredentialIntroContentGuard,
+  hasValidWalletInstanceAttestationGuard,
+  isEidExpiredGuard,
+  isSessionExpiredGuard
+} from "./guards";
+import { Input } from "./input";
 
 /** Placeholder used to detect provider implementations that were not injected. */
 export const notImplemented = () => {
@@ -29,11 +49,12 @@ export const notImplemented = () => {
 export const itwCredentialSetup = setup({
   types: {
     context: {} as Context,
+    input: {} as Input,
     events: {} as CredentialIssuanceEvents
   },
   actions: {
-    onInit: notImplemented,
-    handleSessionExpired: notImplemented,
+    onInit: onInitAction,
+    handleSessionExpired: handleSessionExpiredAction,
 
     /**
      * Context manipulation actions
@@ -45,64 +66,49 @@ export const itwCredentialSetup = setup({
      * Navigation actions
      */
 
-    navigateToCredentialIntroductionScreen: notImplemented,
-    navigateToTrustIssuerScreen: notImplemented,
-    navigateToCredentialPreviewScreen: notImplemented,
-    navigateToFailureScreen: notImplemented,
-    navigateToWallet: notImplemented,
-    navigateToEidVerificationExpiredScreen: notImplemented,
-    closeIssuance: notImplemented,
-    navigateToCardOnboardingScreen: notImplemented,
+    navigateToCredentialIntroductionScreen:
+      navigateToCredentialIntroductionScreenAction,
+    navigateToTrustIssuerScreen: navigateToTrustIssuerScreenAction,
+    navigateToCredentialPreviewScreen: navigateToCredentialPreviewScreenAction,
+    navigateToFailureScreen: navigateToFailureScreenAction,
+    navigateToWallet: navigateToWalletAction,
+    navigateToEidVerificationExpiredScreen:
+      navigateToEidVerificationExpiredScreenAction,
+    closeIssuance: closeIssuanceAction,
+    navigateToCardOnboardingScreen: navigateToCardOnboardingScreenAction,
 
     /**
      * Store actions
      */
 
-    storeWalletInstanceAttestation: notImplemented,
-    storeCredential: notImplemented,
+    storeWalletInstanceAttestation: storeWalletInstanceAttestationAction,
+    storeCredential: storeCredentialAction,
 
     /**
      * Analytics actions
      */
 
-    trackStartAddCredential: notImplemented,
-    trackStartCredentialReissuing: notImplemented,
-    trackAddCredential: notImplemented,
-    trackCredentialIssuingDataShare: notImplemented,
-    trackCredentialIssuingDataShareAccepted: notImplemented
+    trackStartAddCredential: trackStartAddCredentialAction,
+    trackStartCredentialReissuing: trackStartCredentialReissuingAction,
+    trackAddCredential: trackAddCredentialAction,
+    trackCredentialIssuingDataShare: trackCredentialIssuingDataShareAction,
+    trackCredentialIssuingDataShareAccepted:
+      trackCredentialIssuingDataShareAcceptedAction
   },
   actors: {
-    verifyTrustFederation: fromPromise<void, VerifyTrustFederationActorInput>(
-      notImplemented
-    ),
-    getWalletAttestation:
-      fromPromise<GetWalletAttestationActorOutput>(notImplemented),
-    requestCredential: fromPromise<
-      RequestCredentialActorOutput,
-      RequestCredentialActorInput
-    >(notImplemented),
-    obtainAccessToken: fromPromise<
-      CredentialAccessToken,
-      ObtainAccessTokenActorInput
-    >(notImplemented),
-    obtainCredential: fromPromise<
-      ObtainCredentialActorOutput,
-      ObtainCredentialActorInput
-    >(notImplemented),
-    obtainCredentialStatus: fromPromise<
-      ReadonlyArray<CredentialBundle>,
-      ObtainCredentialStatusActorInput
-    >(notImplemented),
-    processCredentialOffer: fromPromise<
-      ProcessCredentialOfferActorOutput,
-      ProcessCredentialOfferActorInput
-    >(notImplemented),
-    waitForSessionRefresh: fromCallback(notImplemented)
+    verifyTrustFederation: verifyTrustFederationActor,
+    getWalletAttestation: getWalletAttestationActor,
+    requestCredential: requestCredentialActor,
+    obtainAccessToken: obtainAccessTokenActor,
+    obtainCredential: obtainCredentialActor,
+    obtainCredentialStatus: obtainCredentialStatusActor,
+    processCredentialOffer: processCredentialOfferActor,
+    waitForSessionRefresh: waitForSessionRefreshActor
   },
   guards: {
-    isSessionExpired: notImplemented,
-    hasValidWalletInstanceAttestation: notImplemented,
-    isEidExpired: notImplemented,
-    hasCredentialIntroContent: notImplemented
+    isSessionExpired: isSessionExpiredGuard,
+    hasValidWalletInstanceAttestation: hasValidWalletInstanceAttestationGuard,
+    isEidExpired: isEidExpiredGuard,
+    hasCredentialIntroContent: hasCredentialIntroContentGuard
   }
 });

--- a/apps/main-app/ts/features/itwallet/machine/credential/state/issuance.ts
+++ b/apps/main-app/ts/features/itwallet/machine/credential/state/issuance.ts
@@ -12,7 +12,8 @@ export const issuanceState = itwCredentialSetup.createStateConfig({
   states: {
     WaitingForSessionRefresh: {
       invoke: {
-        src: "waitForSessionRefresh"
+        src: "waitForSessionRefresh",
+        input: ({ context }) => ({ deps: context.deps })
       },
       on: {
         "session-refresh-complete": { target: "ObtainingCredential" }
@@ -27,7 +28,8 @@ export const issuanceState = itwCredentialSetup.createStateConfig({
           codeVerifier: context.codeVerifier,
           issuerConf: context.issuerConf,
           walletInstanceAttestation: context.walletInstanceAttestation?.jwt,
-          responseMode: context.responseMode
+          responseMode: context.responseMode,
+          deps: context.deps
         }),
         onDone: {
           target: "ObtainingCredential",
@@ -51,7 +53,8 @@ export const issuanceState = itwCredentialSetup.createStateConfig({
           codeVerifier: context.codeVerifier,
           requestedCredential: context.requestedCredential,
           issuerConf: context.issuerConf,
-          accessToken: context.accessToken
+          accessToken: context.accessToken,
+          deps: context.deps
         }),
         onDone: {
           target: "ObtainingCredentialStatus",
@@ -75,7 +78,8 @@ export const issuanceState = itwCredentialSetup.createStateConfig({
         src: "obtainCredentialStatus",
         input: ({ context }) => ({
           credentials: context.credentials,
-          issuerConf: context.issuerConf
+          issuerConf: context.issuerConf,
+          deps: context.deps
         }),
         onDone: {
           target: "Completed",

--- a/apps/main-app/ts/features/itwallet/machine/eid/__tests__/actors.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/__tests__/actors.test.ts
@@ -2,7 +2,6 @@ import { CredentialStatus } from "@pagopa/io-react-native-wallet";
 import { AnyActorLogic, createActor } from "xstate";
 
 import { useIOStore } from "../../../../../store/hooks";
-import { Env } from "../../../common/utils/environment";
 import { getIoWallet } from "../../../common/utils/itwIoWallet";
 import { ItwStoredCredentialsMocks } from "../../../common/utils/itwMocksUtils";
 import { itwCredentialsReplaceByType } from "../../../credentials/store/actions";
@@ -16,10 +15,12 @@ import {
   itwStoreWalletInstanceStatusList
 } from "../../../walletInstance/store/actions";
 import {
-  createEidIssuanceActorsImplementation,
+  obtainStatusListActor,
   ObtainStatusListActorOutput,
+  storeEidCredentialActor,
   StoreEidCredentialActorParams
 } from "../actors";
+import { EidIssuanceMachineDeps } from "../input";
 
 jest.mock("../../../common/utils/itwIoWallet", () => ({
   getIoWallet: jest.fn()
@@ -50,7 +51,6 @@ const STATUS_LIST_PAYLOAD: CredentialStatus.StatusList = {
   status_list: { bits: 1, lst: "eNrbuRgAAhcBXQ" }
 };
 const KEYS = [{ kty: "EC" as const, kid: "wallet-provider-key" }];
-const TRUST_ANCHOR_BASE_URL = "https://trust-anchor.example";
 const EID = {
   credential: "eid-jwt",
   metadata: ItwStoredCredentialsMocks.eid
@@ -105,10 +105,6 @@ describe("eID issuance actors", () => {
     dispatch,
     getState: jest.fn()
   } as unknown as ReturnType<typeof useIOStore>;
-  const actors = createEidIssuanceActorsImplementation(
-    { WALLET_TA_BASE_URL: TRUST_ANCHOR_BASE_URL } as Env,
-    store
-  );
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -127,7 +123,7 @@ describe("eID issuance actors", () => {
     });
 
     const result = await runActor<ObtainStatusListActorOutput>(
-      actors.obtainStatusList,
+      obtainStatusListActor,
       {
         itwVersion: ITW_VERSION,
         keyAttestations: {
@@ -159,7 +155,7 @@ describe("eID issuance actors", () => {
     mockGetIoWallet.mockReturnValue(createWallet() as never);
 
     await expect(
-      runActor(actors.obtainStatusList, {
+      runActor(obtainStatusListActor, {
         itwVersion: ITW_VERSION,
         keyAttestations: undefined
       })
@@ -170,7 +166,7 @@ describe("eID issuance actors", () => {
     mockGetIoWallet.mockReturnValue(createWallet(false) as never);
 
     await expect(
-      runActor(actors.obtainStatusList, {
+      runActor(obtainStatusListActor, {
         itwVersion: ITW_VERSION,
         keyAttestations: undefined
       })
@@ -185,7 +181,7 @@ describe("eID issuance actors", () => {
     mockGetCredentialStatus.mockRejectedValue(error);
 
     await expect(
-      runActor(actors.obtainStatusList, {
+      runActor(obtainStatusListActor, {
         itwVersion: ITW_VERSION,
         keyAttestations: { "ka-1": "ka-1-jwt" }
       })
@@ -204,10 +200,11 @@ describe("eID issuance actors", () => {
         idx: 0,
         parsedStatusList: STATUS_LIST_PAYLOAD,
         uri: KA_STATUS_LIST_URI
-      }
+      },
+      deps: { store } as EidIssuanceMachineDeps
     };
 
-    await expect(runActor(actors.storeEidCredential, input)).resolves.toBe(
+    await expect(runActor(storeEidCredentialActor, input)).resolves.toBe(
       undefined
     );
 
@@ -235,12 +232,11 @@ describe("eID issuance actors", () => {
         idx: 0,
         parsedStatusList: STATUS_LIST_PAYLOAD,
         uri: KA_STATUS_LIST_URI
-      }
+      },
+      deps: { store } as EidIssuanceMachineDeps
     };
 
-    await expect(runActor(actors.storeEidCredential, input)).rejects.toBe(
-      error
-    );
+    await expect(runActor(storeEidCredentialActor, input)).rejects.toBe(error);
     expect(dispatch).not.toHaveBeenCalled();
   });
 });

--- a/apps/main-app/ts/features/itwallet/machine/eid/__tests__/actors.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/__tests__/actors.test.ts
@@ -1,7 +1,6 @@
 import { CredentialStatus } from "@pagopa/io-react-native-wallet";
 import { AnyActorLogic, createActor } from "xstate";
 
-import { useIOStore } from "../../../../../store/hooks";
 import { getIoWallet } from "../../../common/utils/itwIoWallet";
 import { ItwStoredCredentialsMocks } from "../../../common/utils/itwMocksUtils";
 import { itwCredentialsReplaceByType } from "../../../credentials/store/actions";
@@ -14,13 +13,13 @@ import {
   itwKeyAttestationsStore,
   itwStoreWalletInstanceStatusList
 } from "../../../walletInstance/store/actions";
+import { testEidIssuanceDeps, testMachineStore } from "../../utils/testDeps";
 import {
   obtainStatusListActor,
   ObtainStatusListActorOutput,
   storeEidCredentialActor,
   StoreEidCredentialActorParams
 } from "../actors";
-import { EidIssuanceMachineDeps } from "../input";
 
 jest.mock("../../../common/utils/itwIoWallet", () => ({
   getIoWallet: jest.fn()
@@ -101,10 +100,10 @@ describe("eID issuance actors", () => {
       }
     }
   );
-  const store = {
+  const store = testMachineStore({
     dispatch,
     getState: jest.fn()
-  } as unknown as ReturnType<typeof useIOStore>;
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -201,7 +200,7 @@ describe("eID issuance actors", () => {
         parsedStatusList: STATUS_LIST_PAYLOAD,
         uri: KA_STATUS_LIST_URI
       },
-      deps: { store } as EidIssuanceMachineDeps
+      deps: testEidIssuanceDeps({ store })
     };
 
     await expect(runActor(storeEidCredentialActor, input)).resolves.toBe(
@@ -233,7 +232,7 @@ describe("eID issuance actors", () => {
         parsedStatusList: STATUS_LIST_PAYLOAD,
         uri: KA_STATUS_LIST_URI
       },
-      deps: { store } as EidIssuanceMachineDeps
+      deps: testEidIssuanceDeps({ store })
     };
 
     await expect(runActor(storeEidCredentialActor, input)).rejects.toBe(error);

--- a/apps/main-app/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
@@ -9,6 +9,8 @@ import {
   waitFor as waitForActor
 } from "xstate";
 
+import { applicationChangeState } from "../../../../../store/actions/application";
+import { appReducer } from "../../../../../store/reducers";
 import { idps } from "../../../../../utils/idps";
 import { ItwStoredCredentialsMocks } from "../../../common/utils/itwMocksUtils";
 import {
@@ -41,9 +43,16 @@ import {
   MrtdPoPContext
 } from "../context";
 import { IssuanceFailureType } from "../failure";
+import { EidIssuanceMachineDeps } from "../input";
 import { ItwEidIssuanceMachine, itwEidIssuanceMachine } from "../machine";
 
 type MachineSnapshot = StateFrom<ItwEidIssuanceMachine>;
+
+const T_DEPS = {
+  store: {
+    getState: () => appReducer(undefined, applicationChangeState("active"))
+  }
+} as EidIssuanceMachineDeps;
 
 const T_INTEGRITY_KEY = "abc";
 const T_WIA = "abcdefg";
@@ -191,16 +200,18 @@ describe("itwEidIssuanceMachine", () => {
       storeWalletActivationFeedbackBannerData
     },
     actors: {
-      verifyTrustFederation: fromPromise<void, WithItwVersion>(
-        verifyTrustFederation
-      ),
+      verifyTrustFederation: fromPromise<
+        void,
+        WithItwVersion<{ deps: EidIssuanceMachineDeps }>
+      >(verifyTrustFederation),
       createWalletInstance: fromPromise<
         string,
         CreateWalletInstanceActorParams
       >(createWalletInstance),
-      revokeWalletInstance: fromPromise<void, WithItwVersion>(
-        revokeWalletInstance
-      ),
+      revokeWalletInstance: fromPromise<
+        void,
+        WithItwVersion<{ deps: EidIssuanceMachineDeps }>
+      >(revokeWalletInstance),
       getWalletAttestation: fromPromise<
         WalletInstanceAttestations,
         GetWalletAttestationActorParams
@@ -255,13 +266,16 @@ describe("itwEidIssuanceMachine", () => {
   it("Should fail if trust federation verification fails", async () => {
     verifyTrustFederation.mockImplementation(() => Promise.reject());
 
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     await waitFor(() => expect(onInit).toHaveBeenCalledTimes(1));
 
     expect(actor.getSnapshot().value).toStrictEqual("Idle");
-    expect(actor.getSnapshot().context).toStrictEqual(InitialContext);
+    expect(actor.getSnapshot().context).toStrictEqual({
+      ...InitialContext,
+      deps: T_DEPS
+    });
     expect(actor.getSnapshot().tags).toStrictEqual(new Set());
 
     /**
@@ -311,13 +325,16 @@ describe("itwEidIssuanceMachine", () => {
     );
     issuedEidMatchesAuthenticatedUser.mockImplementation(() => true);
 
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     await waitFor(() => expect(onInit).toHaveBeenCalledTimes(1));
 
     expect(actor.getSnapshot().value).toStrictEqual("Idle");
-    expect(actor.getSnapshot().context).toStrictEqual(InitialContext);
+    expect(actor.getSnapshot().context).toStrictEqual({
+      ...InitialContext,
+      deps: T_DEPS
+    });
     expect(actor.getSnapshot().tags).toStrictEqual(new Set());
 
     /**
@@ -436,6 +453,7 @@ describe("itwEidIssuanceMachine", () => {
 
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       ...InitialContext,
+      deps: T_DEPS,
       mode: "issuance",
       level: "l2-fallback",
       integrityKeyTag: T_INTEGRITY_KEY,
@@ -495,6 +513,7 @@ describe("itwEidIssuanceMachine", () => {
 
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       ...InitialContext,
+      deps: T_DEPS,
       mode: "issuance",
       level: "l2-fallback",
       integrityKeyTag: T_INTEGRITY_KEY,
@@ -532,7 +551,8 @@ describe("itwEidIssuanceMachine", () => {
     issuedEidMatchesAuthenticatedUser.mockImplementation(() => true);
 
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -546,7 +566,8 @@ describe("itwEidIssuanceMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -566,6 +587,7 @@ describe("itwEidIssuanceMachine", () => {
 
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       ...InitialContext,
+      deps: T_DEPS,
       level: "l2",
       mode: "issuance",
       integrityKeyTag: T_INTEGRITY_KEY,
@@ -615,7 +637,8 @@ describe("itwEidIssuanceMachine", () => {
     startAuthFlow.mockImplementation(() => Promise.resolve({}));
 
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -629,7 +652,8 @@ describe("itwEidIssuanceMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -656,7 +680,8 @@ describe("itwEidIssuanceMachine", () => {
     startAuthFlow.mockImplementation(() => Promise.resolve({}));
 
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -670,7 +695,8 @@ describe("itwEidIssuanceMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -696,7 +722,8 @@ describe("itwEidIssuanceMachine", () => {
   describe("updateCieIdIdentificationLevel", () => {
     const buildCieIdCompletingSnapshot = (level: "l2" | "l3") => {
       const initialSnapshot: MachineSnapshot = createActor(
-        itwEidIssuanceMachine
+        itwEidIssuanceMachine,
+        { input: { deps: T_DEPS } }
       ).getSnapshot();
 
       return _.merge(undefined, initialSnapshot, {
@@ -722,7 +749,8 @@ describe("itwEidIssuanceMachine", () => {
 
     it("Should update identification level to L3 when challenge_info is absent in L3 flow", () => {
       const actor = createActor(mockedMachine, {
-        snapshot: buildCieIdCompletingSnapshot("l3")
+        snapshot: buildCieIdCompletingSnapshot("l3"),
+        input: { deps: T_DEPS }
       });
       actor.start();
 
@@ -740,7 +768,8 @@ describe("itwEidIssuanceMachine", () => {
 
     it("Should keep identification level at L2 when challenge_info is present in L3 flow", () => {
       const actor = createActor(mockedMachine, {
-        snapshot: buildCieIdCompletingSnapshot("l3")
+        snapshot: buildCieIdCompletingSnapshot("l3"),
+        input: { deps: T_DEPS }
       });
       actor.start();
 
@@ -759,7 +788,8 @@ describe("itwEidIssuanceMachine", () => {
 
     it("Should keep identification level at L2 in L2 flow regardless of challenge_info", () => {
       const actor = createActor(mockedMachine, {
-        snapshot: buildCieIdCompletingSnapshot("l2")
+        snapshot: buildCieIdCompletingSnapshot("l2"),
+        input: { deps: T_DEPS }
       });
       actor.start();
 
@@ -779,7 +809,8 @@ describe("itwEidIssuanceMachine", () => {
     /** Initial part is the same as the previous test, we can start from the identification */
 
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -795,7 +826,8 @@ describe("itwEidIssuanceMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -824,6 +856,7 @@ describe("itwEidIssuanceMachine", () => {
     expect(actor.getSnapshot().tags).toStrictEqual(new Set());
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       ...InitialContext,
+      deps: T_DEPS,
       integrityKeyTag: T_INTEGRITY_KEY,
       walletInstanceAttestation: { jwt: T_WIA },
       identification: undefined,
@@ -852,6 +885,7 @@ describe("itwEidIssuanceMachine", () => {
     });
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       ...InitialContext,
+      deps: T_DEPS,
       integrityKeyTag: T_INTEGRITY_KEY,
       walletInstanceAttestation: { jwt: T_WIA },
       identification: {
@@ -920,7 +954,8 @@ describe("itwEidIssuanceMachine", () => {
     /** Initial part is the same as the previous test, we can start from the identification */
 
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -940,7 +975,8 @@ describe("itwEidIssuanceMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -960,6 +996,7 @@ describe("itwEidIssuanceMachine", () => {
     expect(actor.getSnapshot().tags).toStrictEqual(new Set());
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       ...InitialContext,
+      deps: T_DEPS,
       integrityKeyTag: T_INTEGRITY_KEY,
       walletInstanceAttestation: { jwt: T_WIA },
       identification: undefined,
@@ -985,6 +1022,7 @@ describe("itwEidIssuanceMachine", () => {
     });
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       ...InitialContext,
+      deps: T_DEPS,
       integrityKeyTag: T_INTEGRITY_KEY,
       walletInstanceAttestation: { jwt: T_WIA },
       identification: undefined,
@@ -999,7 +1037,8 @@ describe("itwEidIssuanceMachine", () => {
 
   it("Should skip Wallet Instance creation", async () => {
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -1009,7 +1048,8 @@ describe("itwEidIssuanceMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -1060,7 +1100,8 @@ describe("itwEidIssuanceMachine", () => {
     hasValidWalletInstanceAttestation.mockImplementation(() => true);
 
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -1071,7 +1112,8 @@ describe("itwEidIssuanceMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -1116,7 +1158,8 @@ describe("itwEidIssuanceMachine", () => {
     verifyTrustFederation.mockImplementation(() => Promise.resolve());
 
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -1126,7 +1169,10 @@ describe("itwEidIssuanceMachine", () => {
       }
     } as MachineSnapshot);
 
-    const actor = createActor(mockedMachine, { snapshot });
+    const actor = createActor(mockedMachine, {
+      snapshot,
+      input: { deps: T_DEPS }
+    });
     actor.start();
 
     actor.send({ type: "start", mode: "issuance", level: "l3" });
@@ -1145,7 +1191,7 @@ describe("itwEidIssuanceMachine", () => {
   });
 
   it("Should navigate to IPZS privacy from ToS acceptance without changing state", () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     actor.send({ type: "start", mode: "issuance", level: "l3" });
@@ -1157,7 +1203,8 @@ describe("itwEidIssuanceMachine", () => {
 
   it("Should allow the user to add a new credential once eID issuance is complete", () => {
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -1165,7 +1212,8 @@ describe("itwEidIssuanceMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -1181,7 +1229,8 @@ describe("itwEidIssuanceMachine", () => {
     storeEidCredentialActor.mockResolvedValue(undefined);
 
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -1196,7 +1245,10 @@ describe("itwEidIssuanceMachine", () => {
       }
     } as MachineSnapshot);
 
-    const actor = createActor(mockedMachine, { snapshot });
+    const actor = createActor(mockedMachine, {
+      snapshot,
+      input: { deps: T_DEPS }
+    });
     actor.start();
 
     actor.send({ type: "add-to-wallet" });
@@ -1210,13 +1262,16 @@ describe("itwEidIssuanceMachine", () => {
   });
 
   it("Should return to TOS acceptance if session expires when creating a Wallet Instance", async () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     await waitFor(() => expect(onInit).toHaveBeenCalledTimes(1));
 
     expect(actor.getSnapshot().value).toStrictEqual("Idle");
-    expect(actor.getSnapshot().context).toStrictEqual(InitialContext);
+    expect(actor.getSnapshot().context).toStrictEqual({
+      ...InitialContext,
+      deps: T_DEPS
+    });
     expect(actor.getSnapshot().tags).toStrictEqual(new Set());
 
     /**
@@ -1228,6 +1283,7 @@ describe("itwEidIssuanceMachine", () => {
     expect(actor.getSnapshot().value).toStrictEqual("TosAcceptance");
     expect(actor.getSnapshot().context).toStrictEqual({
       ...InitialContext,
+      deps: T_DEPS,
       mode: "issuance",
       level: "l2"
     });
@@ -1271,13 +1327,16 @@ describe("itwEidIssuanceMachine", () => {
   });
 
   it("Should return to TOS acceptance if session expires when obtaining a Wallet Instance Attestation", async () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     await waitFor(() => expect(onInit).toHaveBeenCalledTimes(1));
 
     expect(actor.getSnapshot().value).toStrictEqual("Idle");
-    expect(actor.getSnapshot().context).toStrictEqual(InitialContext);
+    expect(actor.getSnapshot().context).toStrictEqual({
+      ...InitialContext,
+      deps: T_DEPS
+    });
     expect(actor.getSnapshot().tags).toStrictEqual(new Set());
 
     /**
@@ -1328,13 +1387,16 @@ describe("itwEidIssuanceMachine", () => {
   });
 
   it("Should fail when creating Wallet Instance", async () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     await waitFor(() => expect(onInit).toHaveBeenCalledTimes(1));
 
     expect(actor.getSnapshot().value).toStrictEqual("Idle");
-    expect(actor.getSnapshot().context).toStrictEqual(InitialContext);
+    expect(actor.getSnapshot().context).toStrictEqual({
+      ...InitialContext,
+      deps: T_DEPS
+    });
     expect(actor.getSnapshot().tags).toStrictEqual(new Set());
 
     /**
@@ -1380,13 +1442,16 @@ describe("itwEidIssuanceMachine", () => {
   });
 
   it("Should fail when obtaining Wallet Instance Attestation", async () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     await waitFor(() => expect(onInit).toHaveBeenCalledTimes(1));
 
     expect(actor.getSnapshot().value).toStrictEqual("Idle");
-    expect(actor.getSnapshot().context).toStrictEqual(InitialContext);
+    expect(actor.getSnapshot().context).toStrictEqual({
+      ...InitialContext,
+      deps: T_DEPS
+    });
     expect(actor.getSnapshot().tags).toStrictEqual(new Set());
 
     /**
@@ -1441,7 +1506,8 @@ describe("itwEidIssuanceMachine", () => {
     requestEid.mockImplementation(() => Promise.reject({}));
 
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -1449,7 +1515,8 @@ describe("itwEidIssuanceMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -1506,7 +1573,8 @@ describe("itwEidIssuanceMachine", () => {
     issuedEidMatchesAuthenticatedUser.mockImplementation(() => false);
 
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -1524,7 +1592,8 @@ describe("itwEidIssuanceMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -1552,7 +1621,9 @@ describe("itwEidIssuanceMachine", () => {
     obtainStatusList.mockResolvedValue(T_WALLET_INSTANCE_STATUS_LIST);
     issuedEidMatchesAuthenticatedUser.mockReturnValue(true);
 
-    const initialSnapshot = createActor(itwEidIssuanceMachine).getSnapshot();
+    const initialSnapshot = createActor(itwEidIssuanceMachine, {
+      input: { deps: T_DEPS }
+    }).getSnapshot();
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
       value: { Issuance: "WaitingForSessionRefresh" },
       context: {
@@ -1561,7 +1632,10 @@ describe("itwEidIssuanceMachine", () => {
       }
     });
 
-    const actor = createActor(mockedMachine, { snapshot });
+    const actor = createActor(mockedMachine, {
+      snapshot,
+      input: { deps: T_DEPS }
+    });
     actor.start();
     actor.send({ type: "session-refresh-complete" });
 
@@ -1587,12 +1661,17 @@ describe("itwEidIssuanceMachine", () => {
     requestEid.mockResolvedValue(T_EID_REQUEST_OUTPUT);
     obtainStatusList.mockRejectedValue(error);
 
-    const initialSnapshot = createActor(itwEidIssuanceMachine).getSnapshot();
+    const initialSnapshot = createActor(itwEidIssuanceMachine, {
+      input: { deps: T_DEPS }
+    }).getSnapshot();
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
       value: { Issuance: "WaitingForSessionRefresh" }
     });
 
-    const actor = createActor(mockedMachine, { snapshot });
+    const actor = createActor(mockedMachine, {
+      snapshot,
+      input: { deps: T_DEPS }
+    });
     actor.start();
     actor.send({ type: "session-refresh-complete" });
 
@@ -1617,7 +1696,8 @@ describe("itwEidIssuanceMachine", () => {
     issuedEidMatchesAuthenticatedUser.mockImplementation(() => true);
 
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -1637,7 +1717,8 @@ describe("itwEidIssuanceMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -1660,13 +1741,16 @@ describe("itwEidIssuanceMachine", () => {
   });
 
   it("Should handle 401 when creating wallet instance", async () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     await waitFor(() => expect(onInit).toHaveBeenCalledTimes(1));
 
     expect(actor.getSnapshot().value).toStrictEqual("Idle");
-    expect(actor.getSnapshot().context).toStrictEqual(InitialContext);
+    expect(actor.getSnapshot().context).toStrictEqual({
+      ...InitialContext,
+      deps: T_DEPS
+    });
     expect(actor.getSnapshot().tags).toStrictEqual(new Set());
 
     /**
@@ -1713,7 +1797,8 @@ describe("itwEidIssuanceMachine", () => {
 
   it("Should handle 401 when revoking wallet instance", async () => {
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -1721,7 +1806,8 @@ describe("itwEidIssuanceMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -1747,11 +1833,14 @@ describe("itwEidIssuanceMachine", () => {
     // The wallet instance and attestation already exist
     const initialContext = {
       ...InitialContext,
+      deps: T_DEPS,
       integrityKeyTag: T_INTEGRITY_KEY,
       walletInstanceAttestation: { jwt: T_WIA }
     };
 
-    const baseSnapshot = createActor(itwEidIssuanceMachine).getSnapshot();
+    const baseSnapshot = createActor(itwEidIssuanceMachine, {
+      input: { deps: T_DEPS }
+    }).getSnapshot();
 
     const snapshot: MachineSnapshot = {
       ...baseSnapshot,
@@ -1759,7 +1848,8 @@ describe("itwEidIssuanceMachine", () => {
     };
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
 
     actor.start();
@@ -1921,7 +2011,8 @@ describe("itwEidIssuanceMachine", () => {
 
   it("Should go back to Idle state if mode is 'reissuing'", async () => {
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -1932,7 +2023,8 @@ describe("itwEidIssuanceMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -1943,7 +2035,8 @@ describe("itwEidIssuanceMachine", () => {
 
   it("Should go back to IpzsPrivacyAcceptance state if mode is 'issuing'", async () => {
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -1951,7 +2044,8 @@ describe("itwEidIssuanceMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -1961,11 +2055,14 @@ describe("itwEidIssuanceMachine", () => {
   });
 
   it("should cleanup integrity key tag and fail when obtaining Wallet Instance Attestation fails", async () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     expect(actor.getSnapshot().value).toStrictEqual("Idle");
-    expect(actor.getSnapshot().context).toStrictEqual(InitialContext);
+    expect(actor.getSnapshot().context).toStrictEqual({
+      ...InitialContext,
+      deps: T_DEPS
+    });
     expect(actor.getSnapshot().tags).toStrictEqual(new Set());
 
     /**
@@ -2023,6 +2120,7 @@ describe("itwEidIssuanceMachine", () => {
   it("should NOT cleanup integrity key tag when wallet is valid and attestation fails", async () => {
     const initialContext = {
       ...InitialContext,
+      deps: T_DEPS,
       integrityKeyTag: T_INTEGRITY_KEY,
       walletInstanceAttestation: { jwt: T_WIA },
       eid: { credential: "", metadata: ItwStoredCredentialsMocks.eid },
@@ -2031,7 +2129,9 @@ describe("itwEidIssuanceMachine", () => {
       ] as ReadonlyArray<CredentialMetadata>
     };
 
-    const baseSnapshot = createActor(itwEidIssuanceMachine).getSnapshot();
+    const baseSnapshot = createActor(itwEidIssuanceMachine, {
+      input: { deps: T_DEPS }
+    }).getSnapshot();
 
     const snapshot: MachineSnapshot = {
       ...baseSnapshot,
@@ -2039,7 +2139,8 @@ describe("itwEidIssuanceMachine", () => {
     };
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
 
     actor.start();
@@ -2075,7 +2176,8 @@ describe("itwEidIssuanceMachine", () => {
 
   it("Should go to Wallet Instance Creation and then IpzsPrivacyAcceptance if there is no integrity key tag but a valid WIA exists", async () => {
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -2087,7 +2189,8 @@ describe("itwEidIssuanceMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
 
     verifyTrustFederation.mockImplementation(() => Promise.resolve());
@@ -2144,7 +2247,8 @@ describe("itwEidIssuanceMachine", () => {
 
   it("Should navigate to CieWarning screen when 'go-to-cie-warning' event is received", async () => {
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshotInModeSelection: MachineSnapshot = _.merge(
@@ -2154,6 +2258,7 @@ describe("itwEidIssuanceMachine", () => {
         value: { UserIdentification: "Identification" },
         context: {
           ...InitialContext,
+          deps: T_DEPS,
           integrityKeyTag: T_INTEGRITY_KEY,
           walletInstanceAttestation: { jwt: T_WIA }
         }
@@ -2161,7 +2266,8 @@ describe("itwEidIssuanceMachine", () => {
     );
 
     const actor = createActor(mockedMachine, {
-      snapshot: snapshotInModeSelection
+      snapshot: snapshotInModeSelection,
+      input: { deps: T_DEPS }
     });
 
     actor.start();
@@ -2193,7 +2299,8 @@ describe("itwEidIssuanceMachine", () => {
 
   it("Should navigate to InsertingCardPin through the preparation screens if L3 is enabled", async () => {
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
       value: { UserIdentification: "Identification" },
@@ -2208,7 +2315,10 @@ describe("itwEidIssuanceMachine", () => {
       }
     } as MachineSnapshot);
 
-    const actor = createActor(mockedMachine, { snapshot });
+    const actor = createActor(mockedMachine, {
+      snapshot,
+      input: { deps: T_DEPS }
+    });
     actor.start();
 
     actor.send({ type: "select-identification-mode", mode: "ciePin" });
@@ -2244,7 +2354,8 @@ describe("itwEidIssuanceMachine", () => {
 
   it("Should not track identification method selection when switching from CiePin to Spid", () => {
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
       value: {
@@ -2259,7 +2370,10 @@ describe("itwEidIssuanceMachine", () => {
       }
     } as MachineSnapshot);
 
-    const actor = createActor(mockedMachine, { snapshot });
+    const actor = createActor(mockedMachine, {
+      snapshot,
+      input: { deps: T_DEPS }
+    });
     actor.start();
 
     actor.send({ type: "select-identification-mode", mode: "spid" });
@@ -2274,7 +2388,8 @@ describe("itwEidIssuanceMachine", () => {
 
   it("Should track identification method selection and set CieID to L2 when switching from CiePin", () => {
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
       value: {
@@ -2289,7 +2404,10 @@ describe("itwEidIssuanceMachine", () => {
       }
     } as MachineSnapshot);
 
-    const actor = createActor(mockedMachine, { snapshot });
+    const actor = createActor(mockedMachine, {
+      snapshot,
+      input: { deps: T_DEPS }
+    });
     actor.start();
 
     actor.send({ type: "select-identification-mode", mode: "cieId" });
@@ -2310,7 +2428,8 @@ describe("itwEidIssuanceMachine", () => {
 
   it("Should return to PreparationPin when navigating back from CieWarning", async () => {
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
       value: { UserIdentification: "Identification" },
@@ -2325,7 +2444,10 @@ describe("itwEidIssuanceMachine", () => {
       }
     } as MachineSnapshot);
 
-    const actor = createActor(mockedMachine, { snapshot });
+    const actor = createActor(mockedMachine, {
+      snapshot,
+      input: { deps: T_DEPS }
+    });
     actor.start();
 
     actor.send({ type: "select-identification-mode", mode: "ciePin" });
@@ -2371,12 +2493,14 @@ describe("itwEidIssuanceMachine", () => {
     startAuthFlow.mockImplementation(() => Promise.resolve({}));
 
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
       value: { UserIdentification: { CiePin: "PreparationPin" } },
       context: {
         ...InitialContext,
+        deps: T_DEPS,
         level: "l3",
         mode: "issuance",
         integrityKeyTag: T_INTEGRITY_KEY,
@@ -2388,7 +2512,10 @@ describe("itwEidIssuanceMachine", () => {
       }
     } as MachineSnapshot);
 
-    const actor = createActor(mockedMachine, { snapshot });
+    const actor = createActor(mockedMachine, {
+      snapshot,
+      input: { deps: T_DEPS }
+    });
     actor.start();
 
     actor.send({ type: "select-identification-mode", mode: "cieId" });
@@ -2410,13 +2537,16 @@ describe("itwEidIssuanceMachine", () => {
   });
 
   it("Should initialize the machine context with L3 active", async () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     await waitFor(() => expect(onInit).toHaveBeenCalledTimes(1));
 
     expect(actor.getSnapshot().value).toStrictEqual("Idle");
-    expect(actor.getSnapshot().context).toStrictEqual(InitialContext);
+    expect(actor.getSnapshot().context).toStrictEqual({
+      ...InitialContext,
+      deps: T_DEPS
+    });
     expect(actor.getSnapshot().tags).toStrictEqual(new Set());
 
     /**
@@ -2435,7 +2565,8 @@ describe("itwEidIssuanceMachine", () => {
 
   it("Should handle credentials upgrade", async () => {
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -2452,7 +2583,10 @@ describe("itwEidIssuanceMachine", () => {
       }
     } as MachineSnapshot);
 
-    const actor = createActor(mockedMachine, { snapshot });
+    const actor = createActor(mockedMachine, {
+      snapshot,
+      input: { deps: T_DEPS }
+    });
     actor.start();
 
     const subIntro = actor.subscribe(snap => {
@@ -2476,7 +2610,8 @@ describe("itwEidIssuanceMachine", () => {
 
   it("Should skip credentials upgrade if no credentials are present", async () => {
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
       value: { Issuance: "DisplayingPreview" },
@@ -2490,7 +2625,10 @@ describe("itwEidIssuanceMachine", () => {
       }
     } as MachineSnapshot);
 
-    const actor = createActor(mockedMachine, { snapshot });
+    const actor = createActor(mockedMachine, {
+      snapshot,
+      input: { deps: T_DEPS }
+    });
     actor.start();
 
     actor.send({ type: "add-to-wallet" });
@@ -2499,7 +2637,7 @@ describe("itwEidIssuanceMachine", () => {
   });
 
   it("should call navigateToIpzsPrivacyScreen once after 5000ms in TrustFederationVerification state", async () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     verifyTrustFederation.mockImplementation(
       () => new Promise(resolve => setTimeout(() => resolve({}), 6000))
     );
@@ -2520,7 +2658,7 @@ describe("itwEidIssuanceMachine", () => {
   });
 
   it("should call navigateToL2IdentificationScreen once after 5000ms in TrustFederationVerification state", async () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     verifyTrustFederation.mockImplementation(
       () => new Promise(resolve => setTimeout(() => resolve({}), 6000))
     );
@@ -2541,7 +2679,8 @@ describe("itwEidIssuanceMachine", () => {
   it("Should start the MRTD PoP flow", async () => {
     /** Initial part - setup with L3 and existing WIA */
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -2555,7 +2694,8 @@ describe("itwEidIssuanceMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
-      snapshot
+      snapshot,
+      input: { deps: T_DEPS }
     });
     actor.start();
 
@@ -2770,7 +2910,8 @@ describe("itwEidIssuanceMachine", () => {
 
   it("Should skip MrtdPoP state entirely and go straight to Issuance when challenge_info is absent (LoA High)", async () => {
     const initialSnapshot: MachineSnapshot = createActor(
-      itwEidIssuanceMachine
+      itwEidIssuanceMachine,
+      { input: { deps: T_DEPS } }
     ).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
@@ -2783,7 +2924,10 @@ describe("itwEidIssuanceMachine", () => {
       }
     } as MachineSnapshot);
 
-    const actor = createActor(mockedMachine, { snapshot });
+    const actor = createActor(mockedMachine, {
+      snapshot,
+      input: { deps: T_DEPS }
+    });
     actor.start();
 
     startAuthFlow.mockImplementation(() => Promise.resolve({}));
@@ -2835,7 +2979,9 @@ describe("itwEidIssuanceMachine", () => {
     isSessionExpired.mockImplementation(() => true);
     issuedEidMatchesAuthenticatedUser.mockImplementation(() => true);
 
-    const initialSnapshot = createActor(itwEidIssuanceMachine).getSnapshot();
+    const initialSnapshot = createActor(itwEidIssuanceMachine, {
+      input: { deps: T_DEPS }
+    }).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
       value: { UserIdentification: { CiePin: "ReadingCieCard" } },
@@ -2853,7 +2999,10 @@ describe("itwEidIssuanceMachine", () => {
       }
     } as MachineSnapshot);
 
-    const actor = createActor(mockedMachine, { snapshot });
+    const actor = createActor(mockedMachine, {
+      snapshot,
+      input: { deps: T_DEPS }
+    });
 
     actor.start();
     actor.send({
@@ -2894,7 +3043,7 @@ describe("itwEidIssuanceMachine", () => {
       credentialsToUpgrade: {}
     }));
 
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
     actor.send({ type: "start", mode: "upgrade", level: "l3" });
     actor.send({ type: "accept-tos" });
@@ -2910,7 +3059,7 @@ describe("itwEidIssuanceMachine", () => {
       credentialsToUpgrade: {}
     }));
 
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
     actor.send({ type: "start", mode: "issuance", level: "l3" });
     actor.send({ type: "accept-tos" });
@@ -2960,7 +3109,7 @@ describe("itwEidIssuanceMachine itwVersion routing", () => {
     "Mode: $mode, level: $level -> ITW: $expected",
     ({ mode, level, expected }) => {
       createWalletInstance.mockResolvedValue(T_INTEGRITY_KEY);
-      const actor = createActor(mockedMachine);
+      const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
       actor.start();
       actor.send({ type: "start", mode, level });
       expect(actor.getSnapshot().context.itwVersion).toBe(expected);

--- a/apps/main-app/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
@@ -9,8 +9,6 @@ import {
   waitFor as waitForActor
 } from "xstate";
 
-import { applicationChangeState } from "../../../../../store/actions/application";
-import { appReducer } from "../../../../../store/reducers";
 import { idps } from "../../../../../utils/idps";
 import { ItwStoredCredentialsMocks } from "../../../common/utils/itwMocksUtils";
 import {
@@ -21,6 +19,7 @@ import {
 import { CieWarningType } from "../../../identification/cie/utils/types";
 import { ItwTags } from "../../tags";
 import { itwCredentialUpgradeMachine } from "../../upgrade/machine";
+import { testEidIssuanceDeps } from "../../utils/testDeps";
 import {
   CreateWalletInstanceActorParams,
   GetWalletAttestationActorParams,
@@ -48,11 +47,7 @@ import { ItwEidIssuanceMachine, itwEidIssuanceMachine } from "../machine";
 
 type MachineSnapshot = StateFrom<ItwEidIssuanceMachine>;
 
-const T_DEPS = {
-  store: {
-    getState: () => appReducer(undefined, applicationChangeState("active"))
-  }
-} as EidIssuanceMachineDeps;
+const T_DEPS = testEidIssuanceDeps();
 
 const T_INTEGRITY_KEY = "abc";
 const T_WIA = "abcdefg";

--- a/apps/main-app/ts/features/itwallet/machine/eid/actions.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/actions.ts
@@ -1,10 +1,7 @@
-import { IOToast } from "@io-app/design-system";
 import I18n from "i18next";
 import { ActionArgs, assertEvent, assign } from "xstate";
 
-import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import ROUTES from "../../../../navigation/routes";
-import { useIOStore } from "../../../../store/hooks";
 import { assert } from "../../../../utils/assert";
 import { isRouteInNavigationState } from "../../../../utils/navigation";
 import { checkCurrentSession } from "../../../authentication/common/store/actions";
@@ -12,8 +9,8 @@ import {
   trackItWalletIDMethodSelected,
   trackItWalletIntroScreen,
   trackItwDeactivated,
-  trackItwIdAuthenticationCompleted,
-  trackItwIdVerifiedDocument,
+  trackItwIdAuthenticationCompleted as trackItwIdAuthenticationCompletedEvent,
+  trackItwIdVerifiedDocument as trackItwIdVerifiedDocumentEvent,
   trackSaveCredentialSuccess
 } from "../../analytics";
 import { itwMixPanelCredentialDetailsSelector } from "../../analytics/store/selectors";
@@ -47,378 +44,404 @@ import { itwWalletInstanceAttestationSelector } from "../../walletInstance/store
 import { Context } from "./context";
 import { EidIssuanceEvents } from "./events";
 
-export const createEidIssuanceActionsImplementation = (
-  navigation: ReturnType<typeof useIONavigation>,
-  store: ReturnType<typeof useIOStore>,
-  toast: IOToast
-) => ({
-  onInit: assign<Context, EidIssuanceEvents, unknown, EidIssuanceEvents, any>(
-    () => {
-      const state = store.getState();
-      const storedIntegrityKeyTag = itwIntegrityKeyTagSelector(state);
-      const walletInstanceAttestation =
-        itwWalletInstanceAttestationSelector(state);
-      const credentials = itwCredentialsSelector(state);
+type EidActionArgs = ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>;
 
-      return {
-        // Get the IT-Wallet version from the global store; this can be overriden during the issuance flow.
-        itwVersion: selectItwSpecsVersion(state),
-        integrityKeyTag: storedIntegrityKeyTag,
-        walletInstanceAttestation,
-        credentialsToUpgrade: Object.values(credentials)
-      };
-    }
-  ),
+export const onInitAction = assign<
+  Context,
+  EidIssuanceEvents,
+  unknown,
+  EidIssuanceEvents,
+  any
+>(({ context }) => {
+  const state = context.deps.store.getState();
+  const storedIntegrityKeyTag = itwIntegrityKeyTagSelector(state);
+  const walletInstanceAttestation = itwWalletInstanceAttestationSelector(state);
+  const credentials = itwCredentialsSelector(state);
 
-  navigateToTosScreen: ({
-    context
-  }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.DISCOVERY.INFO,
-      params: { level: context.level }
-    });
-  },
-
-  navigateToIpzsPrivacyScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.DISCOVERY.IPZS_PRIVACY
-    });
-  },
-
-  navigateToIdentificationScreen: ({
-    context
-  }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.IDENTIFICATION.MODE_SELECTION,
-      params: { eidReissuing: context.mode === "reissuance" }
-    });
-  },
-
-  navigateToIdpSelectionScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.IDENTIFICATION.IDP_SELECTION
-    });
-  },
-
-  navigateToSpidLoginScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.IDENTIFICATION.SPID.LOGIN
-    });
-  },
-
-  navigateToCieIdLoginScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.IDENTIFICATION.CIE_ID.LOGIN
-    });
-  },
-
-  navigateToEidPreviewScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.ISSUANCE.EID_PREVIEW
-    });
-  },
-
-  navigateToSuccessScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.ISSUANCE.EID_RESULT
-    });
-  },
-
-  navigateToFailureScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.ISSUANCE.EID_FAILURE
-    });
-  },
-
-  navigateToNfcInstructionsScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.IDENTIFICATION.CIE.ACTIVATE_NFC
-    });
-  },
-
-  navigateToWallet: () => {
-    toast.success(I18n.t("features.itWallet.issuance.credentialResult.toast"));
-    navigation.reset({
-      index: 1,
-      routes: [
-        {
-          name: ROUTES.MAIN,
-          params: {
-            screen: ROUTES.WALLET_HOME
-          }
-        }
-      ]
-    });
-  },
-
-  navigateToCredentialCatalog: ({
-    context
-  }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
-    navigation.replace(ITW_ROUTES.MAIN, {
-      screen:
-        context.level === "l3"
-          ? ITW_ROUTES.L3_ONBOARDING
-          : context.level === "l2-fallback"
-            ? ITW_ROUTES.L2_ONBOARDING
-            : ITW_ROUTES.ONBOARDING
-    });
-  },
-
-  navigateToCieNfcPreparationScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.IDENTIFICATION.CIE.PREPARATION.NFC_SCREEN
-    });
-  },
-
-  navigateToCiePinPreparationScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.IDENTIFICATION.CIE.PREPARATION.PIN_SCREEN
-    });
-  },
-
-  navigateToCiePinScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.IDENTIFICATION.CIE.PIN_SCREEN
-    });
-  },
-
-  navigateToCieCardPreparationScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.IDENTIFICATION.CIE.PREPARATION.CARD_SCREEN
-    });
-  },
-
-  navigateToCieCanPreparationScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.IDENTIFICATION.CIE.PREPARATION.CAN_SCREEN
-    });
-  },
-
-  navigateToCieCanScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.IDENTIFICATION.CIE.CAN_SCREEN
-    });
-  },
-
-  navigateToCieAuthenticationScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.IDENTIFICATION.CIE.AUTH_SCREEN
-    });
-  },
-
-  navigateToCieInternalAuthAndMrtdScreen: ({
-    context
-  }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
-    assert(context.mrtdContext, "mrtdContext is undefined");
-    assert(context.mrtdContext.can, "CAN is undefined");
-
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.IDENTIFICATION.CIE.INTERNAL_AUTH_MRTD_SCREEN,
-      params: {
-        can: context.mrtdContext.can,
-        challenge: context.mrtdContext.challenge
-      }
-    });
-  },
-
-  navigateToWalletRevocationScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.WALLET_REVOCATION_SCREEN
-    });
-  },
-
-  navigateToCieWarningScreen: ({
-    event
-  }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
-    assertEvent(event, "go-to-cie-warning");
-
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.IDENTIFICATION.CIE_WARNING,
-      params: {
-        type: event.warning,
-        routeName: event.routeName
-      }
-    });
-  },
-
-  closeIssuance: ({
-    context,
-    event
-  }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
-    const isWalletInNavigationState = isRouteInNavigationState(
-      navigation.getState(),
-      ROUTES.WALLET_HOME
-    );
-
-    if (!isWalletInNavigationState && navigation.canGoBack()) {
-      navigation.goBack();
-      return;
-    }
-
-    const isSurveyHidden = itwIsPidReissuingSurveyHiddenSelector(
-      store.getState()
-    );
-    const isReissuance = context.mode === "reissuance";
-
-    const surveyStep = event.type === "close" ? event.surveyStep : undefined;
-
-    if (isReissuance && !isSurveyHidden) {
-      store.dispatch(itwSetFeedbackBottomSheetVisible(true));
-    } else if (surveyStep) {
-      store.dispatch(itwSetActivationExitSurvey({ step: surveyStep }));
-    }
-
-    navigation.navigate(ROUTES.MAIN, {
-      screen: ROUTES.WALLET_HOME,
-      params: {}
-    });
-  },
-
-  storeIntegrityKeyTag: ({
-    context
-  }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
-    assert(context.integrityKeyTag, "integrityKeyTag is undefined");
-    store.dispatch(itwStoreIntegrityKeyTag(context.integrityKeyTag));
-  },
-
-  cleanupIntegrityKeyTag: () => {
-    // Remove the integrity key tag from the store
-    store.dispatch(itwRemoveIntegrityKeyTag());
-  },
-
-  storeWalletInstanceAttestation: ({
-    context
-  }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
-    assert(
-      context.walletInstanceAttestation,
-      "walletInstanceAttestation is undefined"
-    );
-    store.dispatch(
-      itwWalletInstanceAttestationStore(context.walletInstanceAttestation)
-    );
-  },
-
-  handleSessionExpired: () =>
-    store.dispatch(checkCurrentSession.success({ isSessionValid: false })),
-
-  resetWalletInstance: () => {
-    store.dispatch(itwLifecycleWalletReset());
-    store.dispatch(itwSetAuthLevel(undefined));
-    store.dispatch(itwSetIdentificationMode(undefined));
-    toast.success(I18n.t("features.itWallet.issuance.credentialResult.toast"));
-  },
-
-  storeAuthLevel: ({
-    context
-  }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
-    // Save the auth level in the preferences
-    store.dispatch(itwSetAuthLevel(context.identification?.level));
-    store.dispatch(itwSetIdentificationMode(context.identification?.mode));
-  },
-
-  storeWalletActivationFeedbackBannerData: ({
-    context
-  }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
-    // Store banner data only for:
-    // - credential-triggered activation (credentialType set): user skips success page
-    // - upgrade flow (mode === "upgrade")
-    // Regular issuance with "Add document" CTA keeps the banner on the success page directly.
-    // This survey is reserved to IT-Wallet (L3): "Documenti su IO" (L2/l2-fallback) must never trigger it.
-    if (
-      context.level !== "l3" ||
-      (!context.credentialType && context.mode !== "upgrade")
-    ) {
-      return;
-    }
-    const docStatus = context.mode === "upgrade" ? "active" : "not_active";
-    const authMethod = toSurveyAuthMethod(context.identification);
-    store.dispatch(
-      itwSetWalletActivationFeedbackBannerData({
-        docStatus,
-        authMethod
-      })
-    );
-    store.dispatch(itwShowBanner("activationSuccessFeedback"));
-  },
-
-  storeCredentialUpgradeFailures: ({
-    event
-  }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
-    assertEvent(event, "xstate.done.actor.credentialUpgradeMachine");
-    store.dispatch(
-      itwSetCredentialUpgradeFailed(
-        event.output.failedCredentials.map(
-          failedCredential => failedCredential.credentialType
-        )
-      )
-    );
-  },
-
-  trackIntroScreen: ({
-    context
-  }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
-    trackItWalletIntroScreen(context.level === "l3" ? "L3" : "L2");
-  },
-
-  trackWalletInstanceCreation: ({
-    context
-  }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
-    trackSaveCredentialSuccess({
-      credential: context.level === "l3" ? "ITW_PID" : "ITW_ID_V2",
-      ITW_ID_method: context.identification
-        ? toItwIdMethod(context.identification)
-        : undefined,
-      credential_details: itwMixPanelCredentialDetailsSelector(store.getState())
-    });
-  },
-
-  trackWalletInstanceRevocation: () => {
-    const isItwL3 = itwLifecycleIsITWalletValidSelector(store.getState());
-    trackItwDeactivated(isItwL3 ? "ITW_PID" : "ITW_ID_V2");
-  },
-
-  trackIdentificationMethodSelected: ({
-    context,
-    event
-  }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
-    assertEvent(event, "select-identification-mode");
-    if (context.level === "l3") {
-      return;
-    }
-
-    trackItWalletIDMethodSelected({
-      ITW_ID_method: event.mode,
-      itw_flow: "L2"
-    });
-  },
-
-  // Track SPID+CIE first phase
-  trackItwIdAuthenticationCompleted: ({
-    context
-  }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
-    assert(context.identification, "identification context is undefined");
-    assert(
-      context.identification.mode !== "ciePin",
-      "identification mode can not be ciePin"
-    );
-
-    trackItwIdAuthenticationCompleted(context.identification);
-  },
-
-  // Track SPID+CIE final phase
-  trackItwIdVerifiedDocument: ({
-    context
-  }: ActionArgs<Context, EidIssuanceEvents, EidIssuanceEvents>) => {
-    assert(context.identification, "identification context is undefined");
-    assert(
-      context.identification.mode !== "ciePin",
-      "identification mode can not be ciePin"
-    );
-
-    trackItwIdVerifiedDocument(toItwIdMethod(context.identification));
-  },
-
-  refreshCredentialsCatalogue: () => {
-    store.dispatch(itwFetchCredentialsCatalogue.request());
-  }
+  return {
+    // Get the IT-Wallet version from the global store; this can be overriden during the issuance flow.
+    itwVersion: selectItwSpecsVersion(state),
+    integrityKeyTag: storedIntegrityKeyTag,
+    walletInstanceAttestation,
+    credentialsToUpgrade: Object.values(credentials)
+  };
 });
+
+export const navigateToTosScreenAction = ({ context }: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.DISCOVERY.INFO,
+    params: { level: context.level }
+  });
+};
+
+export const navigateToIpzsPrivacyScreenAction = ({
+  context
+}: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.DISCOVERY.IPZS_PRIVACY
+  });
+};
+
+export const navigateToIdentificationScreenAction = ({
+  context
+}: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.IDENTIFICATION.MODE_SELECTION,
+    params: { eidReissuing: context.mode === "reissuance" }
+  });
+};
+
+export const navigateToIdpSelectionScreenAction = ({
+  context
+}: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.IDENTIFICATION.IDP_SELECTION
+  });
+};
+
+export const navigateToSpidLoginScreenAction = ({ context }: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.IDENTIFICATION.SPID.LOGIN
+  });
+};
+
+export const navigateToCieIdLoginScreenAction = ({
+  context
+}: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.IDENTIFICATION.CIE_ID.LOGIN
+  });
+};
+
+export const navigateToEidPreviewScreenAction = ({
+  context
+}: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.ISSUANCE.EID_PREVIEW
+  });
+};
+
+export const navigateToSuccessScreenAction = ({ context }: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.ISSUANCE.EID_RESULT
+  });
+};
+
+export const navigateToFailureScreenAction = ({ context }: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.ISSUANCE.EID_FAILURE
+  });
+};
+
+export const navigateToNfcInstructionsScreenAction = ({
+  context
+}: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.IDENTIFICATION.CIE.ACTIVATE_NFC
+  });
+};
+
+export const navigateToWalletAction = ({ context }: EidActionArgs) => {
+  const { toast, navigation } = context.deps;
+  toast.success(I18n.t("features.itWallet.issuance.credentialResult.toast"));
+  navigation.reset({
+    index: 1,
+    routes: [
+      {
+        name: ROUTES.MAIN,
+        params: {
+          screen: ROUTES.WALLET_HOME
+        }
+      }
+    ]
+  });
+};
+
+export const navigateToCredentialCatalogAction = ({
+  context
+}: EidActionArgs) => {
+  context.deps.navigation.replace(ITW_ROUTES.MAIN, {
+    screen:
+      context.level === "l3"
+        ? ITW_ROUTES.L3_ONBOARDING
+        : context.level === "l2-fallback"
+          ? ITW_ROUTES.L2_ONBOARDING
+          : ITW_ROUTES.ONBOARDING
+  });
+};
+
+export const navigateToCieNfcPreparationScreenAction = ({
+  context
+}: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.IDENTIFICATION.CIE.PREPARATION.NFC_SCREEN
+  });
+};
+
+export const navigateToCiePinPreparationScreenAction = ({
+  context
+}: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.IDENTIFICATION.CIE.PREPARATION.PIN_SCREEN
+  });
+};
+
+export const navigateToCiePinScreenAction = ({ context }: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.IDENTIFICATION.CIE.PIN_SCREEN
+  });
+};
+
+export const navigateToCieCardPreparationScreenAction = ({
+  context
+}: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.IDENTIFICATION.CIE.PREPARATION.CARD_SCREEN
+  });
+};
+
+export const navigateToCieCanPreparationScreenAction = ({
+  context
+}: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.IDENTIFICATION.CIE.PREPARATION.CAN_SCREEN
+  });
+};
+
+export const navigateToCieCanScreenAction = ({ context }: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.IDENTIFICATION.CIE.CAN_SCREEN
+  });
+};
+
+export const navigateToCieAuthenticationScreenAction = ({
+  context
+}: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.IDENTIFICATION.CIE.AUTH_SCREEN
+  });
+};
+
+export const navigateToCieInternalAuthAndMrtdScreenAction = ({
+  context
+}: EidActionArgs) => {
+  assert(context.mrtdContext, "mrtdContext is undefined");
+  assert(context.mrtdContext.can, "CAN is undefined");
+
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.IDENTIFICATION.CIE.INTERNAL_AUTH_MRTD_SCREEN,
+    params: {
+      can: context.mrtdContext.can,
+      challenge: context.mrtdContext.challenge
+    }
+  });
+};
+
+export const navigateToWalletRevocationScreenAction = ({
+  context
+}: EidActionArgs) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.WALLET_REVOCATION_SCREEN
+  });
+};
+
+export const navigateToCieWarningScreenAction = ({
+  context,
+  event
+}: EidActionArgs) => {
+  assertEvent(event, "go-to-cie-warning");
+
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.IDENTIFICATION.CIE_WARNING,
+    params: {
+      type: event.warning,
+      routeName: event.routeName
+    }
+  });
+};
+
+export const closeIssuanceAction = ({ context, event }: EidActionArgs) => {
+  const { navigation, store } = context.deps;
+  const isWalletInNavigationState = isRouteInNavigationState(
+    navigation.getState(),
+    ROUTES.WALLET_HOME
+  );
+
+  if (!isWalletInNavigationState && navigation.canGoBack()) {
+    navigation.goBack();
+    return;
+  }
+
+  const isSurveyHidden = itwIsPidReissuingSurveyHiddenSelector(
+    store.getState()
+  );
+  const isReissuance = context.mode === "reissuance";
+
+  const surveyStep = event.type === "close" ? event.surveyStep : undefined;
+
+  if (isReissuance && !isSurveyHidden) {
+    store.dispatch(itwSetFeedbackBottomSheetVisible(true));
+  } else if (surveyStep) {
+    store.dispatch(itwSetActivationExitSurvey({ step: surveyStep }));
+  }
+
+  navigation.navigate(ROUTES.MAIN, {
+    screen: ROUTES.WALLET_HOME,
+    params: {}
+  });
+};
+
+export const storeIntegrityKeyTagAction = ({ context }: EidActionArgs) => {
+  assert(context.integrityKeyTag, "integrityKeyTag is undefined");
+  context.deps.store.dispatch(itwStoreIntegrityKeyTag(context.integrityKeyTag));
+};
+
+export const cleanupIntegrityKeyTagAction = ({ context }: EidActionArgs) => {
+  // Remove the integrity key tag from the store
+  context.deps.store.dispatch(itwRemoveIntegrityKeyTag());
+};
+
+export const storeWalletInstanceAttestationAction = ({
+  context
+}: EidActionArgs) => {
+  assert(
+    context.walletInstanceAttestation,
+    "walletInstanceAttestation is undefined"
+  );
+  context.deps.store.dispatch(
+    itwWalletInstanceAttestationStore(context.walletInstanceAttestation)
+  );
+};
+
+export const handleSessionExpiredAction = ({ context }: EidActionArgs) =>
+  context.deps.store.dispatch(
+    checkCurrentSession.success({ isSessionValid: false })
+  );
+
+export const resetWalletInstanceAction = ({ context }: EidActionArgs) => {
+  const { store, toast } = context.deps;
+  store.dispatch(itwLifecycleWalletReset());
+  store.dispatch(itwSetAuthLevel(undefined));
+  store.dispatch(itwSetIdentificationMode(undefined));
+  toast.success(I18n.t("features.itWallet.issuance.credentialResult.toast"));
+};
+
+export const storeAuthLevelAction = ({ context }: EidActionArgs) => {
+  const { store } = context.deps;
+  // Save the auth level in the preferences
+  store.dispatch(itwSetAuthLevel(context.identification?.level));
+  store.dispatch(itwSetIdentificationMode(context.identification?.mode));
+};
+
+export const storeWalletActivationFeedbackBannerDataAction = ({
+  context
+}: EidActionArgs) => {
+  // Store banner data only for:
+  // - credential-triggered activation (credentialType set): user skips success page
+  // - upgrade flow (mode === "upgrade")
+  // Regular issuance with "Add document" CTA keeps the banner on the success page directly.
+  // This survey is reserved to IT-Wallet (L3): "Documenti su IO" (L2/l2-fallback) must never trigger it.
+  if (
+    context.level !== "l3" ||
+    (!context.credentialType && context.mode !== "upgrade")
+  ) {
+    return;
+  }
+  const docStatus = context.mode === "upgrade" ? "active" : "not_active";
+  const authMethod = toSurveyAuthMethod(context.identification);
+  context.deps.store.dispatch(
+    itwSetWalletActivationFeedbackBannerData({
+      docStatus,
+      authMethod
+    })
+  );
+  context.deps.store.dispatch(itwShowBanner("activationSuccessFeedback"));
+};
+
+export const storeCredentialUpgradeFailuresAction = ({
+  context,
+  event
+}: EidActionArgs) => {
+  assertEvent(event, "xstate.done.actor.credentialUpgradeMachine");
+  context.deps.store.dispatch(
+    itwSetCredentialUpgradeFailed(
+      event.output.failedCredentials.map(
+        failedCredential => failedCredential.credentialType
+      )
+    )
+  );
+};
+
+export const trackIntroScreenAction = ({ context }: EidActionArgs) => {
+  trackItWalletIntroScreen(context.level === "l3" ? "L3" : "L2");
+};
+
+export const trackWalletInstanceCreationAction = ({
+  context
+}: EidActionArgs) => {
+  trackSaveCredentialSuccess({
+    credential: context.level === "l3" ? "ITW_PID" : "ITW_ID_V2",
+    ITW_ID_method: context.identification
+      ? toItwIdMethod(context.identification)
+      : undefined,
+    credential_details: itwMixPanelCredentialDetailsSelector(
+      context.deps.store.getState()
+    )
+  });
+};
+
+export const trackWalletInstanceRevocationAction = ({
+  context
+}: EidActionArgs) => {
+  const isItwL3 = itwLifecycleIsITWalletValidSelector(
+    context.deps.store.getState()
+  );
+  trackItwDeactivated(isItwL3 ? "ITW_PID" : "ITW_ID_V2");
+};
+
+export const trackIdentificationMethodSelectedAction = ({
+  context,
+  event
+}: EidActionArgs) => {
+  assertEvent(event, "select-identification-mode");
+  if (context.level === "l3") {
+    return;
+  }
+
+  trackItWalletIDMethodSelected({
+    ITW_ID_method: event.mode,
+    itw_flow: "L2"
+  });
+};
+
+// Track SPID+CIE first phase
+export const trackItwIdAuthenticationCompletedAction = ({
+  context
+}: EidActionArgs) => {
+  assert(context.identification, "identification context is undefined");
+  assert(
+    context.identification.mode !== "ciePin",
+    "identification mode can not be ciePin"
+  );
+
+  trackItwIdAuthenticationCompletedEvent(context.identification);
+};
+
+// Track SPID+CIE final phase
+export const trackItwIdVerifiedDocumentAction = ({
+  context
+}: EidActionArgs) => {
+  assert(context.identification, "identification context is undefined");
+  assert(
+    context.identification.mode !== "ciePin",
+    "identification mode can not be ciePin"
+  );
+
+  trackItwIdVerifiedDocumentEvent(toItwIdMethod(context.identification));
+};
+
+export const refreshCredentialsCatalogueAction = ({
+  context
+}: EidActionArgs) => {
+  context.deps.store.dispatch(itwFetchCredentialsCatalogue.request());
+};

--- a/apps/main-app/ts/features/itwallet/machine/eid/actors.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/actors.ts
@@ -451,8 +451,7 @@ export const obtainStatusListActor = fromPromise<
 
   // For the Status List we'll need just one of the KAs, as they all
   // reference the same Status List. We can take the first one.
-  const [keyAttestationId, keyAttestation] =
-    Object.entries(keyAttestations)[0];
+  const [keyAttestationId, keyAttestation] = Object.entries(keyAttestations)[0];
 
   // Fetch the JWKS from the Wallet Provider's OpenID Federation metadata,
   const keys = await getKeysForKaStatusList(keyAttestation);

--- a/apps/main-app/ts/features/itwallet/machine/eid/actors.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/actors.ts
@@ -11,13 +11,11 @@ import type {
   MrtdPoPContext
 } from "./context";
 
-import { useIOStore } from "../../../../store/hooks";
 import { assert } from "../../../../utils/assert";
 import { sessionTokenSelector } from "../../../authentication/common/store/selectors";
 import * as cieUtils from "../../../authentication/login/cie/utils/cie";
 import { trackItwRequest } from "../../analytics";
 import { toItwIdMethod } from "../../analytics/utils/types";
-import { Env } from "../../common/utils/environment";
 import {
   getIntegrityHardwareKeyTag,
   getWalletInstanceAttestation,
@@ -55,21 +53,21 @@ import {
   itwStoreWalletInstanceStatusList
 } from "../../walletInstance/store/actions";
 import { itwWalletInstanceRenewalErrorSelector } from "../../walletInstance/store/selectors";
-import { createCredentialUpgradeActionsImplementation } from "../upgrade/actions";
-import { createCredentialUpgradeActorsImplementation } from "../upgrade/actors";
-import { itwCredentialUpgradeMachine } from "../upgrade/machine";
-import { createCommonActorsImplementation } from "../utils/actors";
+import { EidIssuanceMachineDeps } from "./input";
 
 export type CreateWalletInstanceActorParams = WithItwVersion<{
+  deps: EidIssuanceMachineDeps;
   isRenewal: boolean;
 }>;
 
 export type GetWalletAttestationActorParams = WithItwVersion<{
+  deps: EidIssuanceMachineDeps;
   integrityKeyTag: string | undefined;
 }>;
 
 export type InitMrtdPoPChallengeActorParams = WithItwVersion<{
   authenticationContext: AuthenticationContext | undefined;
+  deps: EidIssuanceMachineDeps;
   walletInstanceAttestation: string | undefined;
 }>;
 
@@ -82,6 +80,7 @@ export type ObtainStatusListActorOutput = Context["walletInstanceStatusList"];
 
 export type RequestAccessTokenActorParams = WithItwVersion<{
   authenticationContext: AuthenticationContext | undefined;
+  deps: EidIssuanceMachineDeps;
   walletInstanceAttestation: string | undefined;
 }>;
 
@@ -93,18 +92,21 @@ export type RequestEidActorOutput = {
 export type RequestEidActorParams = WithItwVersion<{
   accessToken: CredentialAccessToken | undefined;
   authenticationContext: AuthenticationContext | undefined;
+  deps: EidIssuanceMachineDeps;
   identification: IdentificationContext | undefined;
   integrityKeyTag: string | undefined;
   level: EidIssuanceLevel | undefined;
 }>;
 
 export type StartAuthFlowActorParams = WithItwVersion<{
+  deps: EidIssuanceMachineDeps;
   identification: IdentificationContext | undefined;
   walletInstanceAttestation: string | undefined;
   withMRTDPoP: boolean;
 }>;
 
 export type StoreEidCredentialActorParams = {
+  deps: EidIssuanceMachineDeps;
   eid: CredentialBundle | undefined;
   keyAttestations?: Record<string, string>;
   walletInstanceStatusList?: Context["walletInstanceStatusList"];
@@ -112,6 +114,7 @@ export type StoreEidCredentialActorParams = {
 
 export type ValidateMrtdPoPChallengeActorParams = WithItwVersion<{
   authenticationContext: AuthenticationContext | undefined;
+  deps: EidIssuanceMachineDeps;
   mrtdContext: MrtdPoPContext | undefined;
   walletInstanceAttestation: string | undefined;
 }>;
@@ -120,378 +123,375 @@ export type WithItwVersion<T = { [K: string]: any }> = T & {
   itwVersion: ItwVersion;
 };
 
-/**
- * Creates the actors for the eid issuance machine
- * @param env - The environment to use for the IT Wallet API calls
- * @param store the IOStore
- * @returns the actors
- */
-export const createEidIssuanceActorsImplementation = (
-  env: Env,
-  store: ReturnType<typeof useIOStore>
-) => ({
-  getCieStatus: fromPromise<CieContext>(async () => {
-    const [isNFCEnabled, isCIEAuthenticationSupported] = await Promise.all([
-      cieUtils.isNfcEnabled(),
-      CieUtils.isCieAuthenticationSupported()
-    ]);
-    return {
-      isNFCEnabled,
-      isCIEAuthenticationSupported
-    };
-  }),
+export const getCieStatusActor = fromPromise<CieContext>(async () => {
+  const [isNFCEnabled, isCIEAuthenticationSupported] = await Promise.all([
+    cieUtils.isNfcEnabled(),
+    CieUtils.isCieAuthenticationSupported()
+  ]);
+  return {
+    isNFCEnabled,
+    isCIEAuthenticationSupported
+  };
+});
 
-  verifyTrustFederation: fromPromise<void, WithItwVersion>(
-    async ({ input }) => {
-      const ioWallet = getIoWallet(input.itwVersion);
-      // Evaluate the issuer trust
-      const trustAnchorEntityConfig =
-        await ioWallet.Trust.getTrustAnchorEntityConfiguration(
-          env.WALLET_TA_BASE_URL
-        );
+export const verifyTrustFederationActor = fromPromise<
+  void,
+  WithItwVersion<{ deps: EidIssuanceMachineDeps }>
+>(async ({ input }) => {
+  const { env } = input.deps;
+  const ioWallet = getIoWallet(input.itwVersion);
+  // Evaluate the issuer trust
+  const trustAnchorEntityConfig =
+    await ioWallet.Trust.getTrustAnchorEntityConfiguration(
+      env.WALLET_TA_BASE_URL
+    );
 
-      // Create the trust chain for the PID provider
-      const builtChainJwts = await ioWallet.Trust.buildTrustChain(
-        env.WALLET_PID_PROVIDER_BASE_URL.value(input.itwVersion),
-        trustAnchorEntityConfig
-      );
+  // Create the trust chain for the PID provider
+  const builtChainJwts = await ioWallet.Trust.buildTrustChain(
+    env.WALLET_PID_PROVIDER_BASE_URL.value(input.itwVersion),
+    trustAnchorEntityConfig
+  );
 
-      // Perform full validation on the built chain
-      await ioWallet.Trust.verifyTrustChain(
-        trustAnchorEntityConfig,
-        builtChainJwts,
-        {
-          connectTimeout: 10000,
-          readTimeout: 10000,
-          requireCrl: true
-        }
-      );
+  // Perform full validation on the built chain
+  await ioWallet.Trust.verifyTrustChain(
+    trustAnchorEntityConfig,
+    builtChainJwts,
+    {
+      connectTimeout: 10000,
+      readTimeout: 10000,
+      requireCrl: true
     }
-  ),
+  );
+});
 
-  createWalletInstance: fromPromise<string, CreateWalletInstanceActorParams>(
-    async ({ input }) => {
-      const sessionToken = sessionTokenSelector(store.getState());
-      assert(sessionToken, "sessionToken is undefined");
+export const createWalletInstanceActor = fromPromise<
+  string,
+  CreateWalletInstanceActorParams
+>(async ({ input }) => {
+  const { env, store } = input.deps;
+  const sessionToken = sessionTokenSelector(store.getState());
+  assert(sessionToken, "sessionToken is undefined");
 
-      // Reset the wallet store to prevent having dirty state before registering a new wallet instance.
-      // This is skipped for renewal otherwise the entire wallet is lost if the user abandons the flow.
-      if (!input.isRenewal) {
-        store.dispatch(itwLifecycleStoresReset());
-      }
+  // Reset the wallet store to prevent having dirty state before registering a new wallet instance.
+  // This is skipped for renewal otherwise the entire wallet is lost if the user abandons the flow.
+  if (!input.isRenewal) {
+    store.dispatch(itwLifecycleStoresReset());
+  }
 
-      // Await the integrity preparation before requesting the integrity key tag
-      await ensureIntegrityServiceIsStoreReadyOrThrow(store);
+  // Await the integrity preparation before requesting the integrity key tag
+  await ensureIntegrityServiceIsStoreReadyOrThrow(store);
 
-      const hardwareKeyTag = await getIntegrityHardwareKeyTag();
-      await registerWalletInstance(
-        env,
-        input.itwVersion,
-        hardwareKeyTag,
-        sessionToken,
-        { isRenewal: input.isRenewal }
-      );
+  const hardwareKeyTag = await getIntegrityHardwareKeyTag();
+  await registerWalletInstance(
+    env,
+    input.itwVersion,
+    hardwareKeyTag,
+    sessionToken,
+    { isRenewal: input.isRenewal }
+  );
 
-      return hardwareKeyTag;
-    }
-  ),
+  return hardwareKeyTag;
+});
 
-  getWalletAttestation: fromPromise<
-    WalletInstanceAttestations,
-    GetWalletAttestationActorParams
-  >(async ({ input }) => {
-    const sessionToken = sessionTokenSelector(store.getState());
-    assert(sessionToken, "sessionToken is undefined");
-    assert(input.integrityKeyTag, "integrityKeyTag is undefined");
+export const getWalletAttestationActor = fromPromise<
+  WalletInstanceAttestations,
+  GetWalletAttestationActorParams
+>(async ({ input }) => {
+  const { env, store } = input.deps;
+  const sessionToken = sessionTokenSelector(store.getState());
+  assert(sessionToken, "sessionToken is undefined");
+  assert(input.integrityKeyTag, "integrityKeyTag is undefined");
 
-    try {
-      return await getWalletInstanceAttestation(
-        env,
-        input.itwVersion,
-        input.integrityKeyTag,
-        sessionToken
-      );
-    } catch (firstError) {
-      // On iOS, the stored DCAppAttest key can become invalid (DCErrorInvalidKey,
-      // com.apple.devicecheck.error 3), causing GENERATION_ASSERTION_FAILED during
-      // assertion generation. We recover by creating a new wallet instance with a
-      // fresh key and retrying the attestation once.
-      const isRenewalError = itwWalletInstanceRenewalErrorSelector(
-        store.getState()
-      );
-
-      // If the error is not related to assertion generation or if we've already attempted a renewal, we throw the error and prompt the user to retry.
-      if (!isAssertionGenerationError(firstError) || isRenewalError) {
-        throw firstError;
-      }
-
-      // Otherwise, we attempt to recover by creating a new wallet instance,
-      // which will generate a new hardware key tag,
-      // and retrying the attestation with the new key tag.
-      const newHardwareKeyTag = await getIntegrityHardwareKeyTag();
-      store.dispatch(itwStoreIntegrityKeyTag(newHardwareKeyTag));
-      await registerWalletInstance(
-        env,
-        input.itwVersion,
-        newHardwareKeyTag,
-        sessionToken,
-        { isRenewal: true }
-      );
-
-      return await getWalletInstanceAttestation(
-        env,
-        input.itwVersion,
-        newHardwareKeyTag,
-        sessionToken
-      )
-        .then(attestation => {
-          // Track the successful renewal in Mixpanel
-          trackWalletInstanceRenewalSuccess();
-          return attestation;
-        })
-        .catch(error => {
-          // If the attestation retrieval fails again after renewing the wallet instance,
-          // we set a flag in the store to prevent further renewal attempts and prompt the user with an error.
-          store.dispatch(itwSetWalletInstanceRenewalError(true));
-          // Track the renewal failure in Mixpanel
-          trackWalletInstanceRenewalFailure(error);
-          throw error;
-        });
-    }
-  }),
-
-  revokeWalletInstance: fromPromise<void, WithItwVersion>(async ({ input }) => {
-    const state = store.getState();
-    const sessionToken = sessionTokenSelector(state);
-    const integrityKeyTag = itwIntegrityKeyTagSelector(state);
-
-    if (integrityKeyTag === undefined) {
-      return;
-    }
-    assert(sessionToken, "sessionToken is undefined");
-
-    await revokeCurrentWalletInstance(
+  try {
+    return await getWalletInstanceAttestation(
       env,
       input.itwVersion,
+      input.integrityKeyTag,
+      sessionToken
+    );
+  } catch (firstError) {
+    // On iOS, the stored DCAppAttest key can become invalid (DCErrorInvalidKey,
+    // com.apple.devicecheck.error 3), causing GENERATION_ASSERTION_FAILED during
+    // assertion generation. We recover by creating a new wallet instance with a
+    // fresh key and retrying the attestation once.
+    const isRenewalError = itwWalletInstanceRenewalErrorSelector(
+      store.getState()
+    );
+
+    // If the error is not related to assertion generation or if we've already attempted a renewal, we throw the error and prompt the user to retry.
+    if (!isAssertionGenerationError(firstError) || isRenewalError) {
+      throw firstError;
+    }
+
+    // Otherwise, we attempt to recover by creating a new wallet instance,
+    // which will generate a new hardware key tag,
+    // and retrying the attestation with the new key tag.
+    const newHardwareKeyTag = await getIntegrityHardwareKeyTag();
+    store.dispatch(itwStoreIntegrityKeyTag(newHardwareKeyTag));
+    await registerWalletInstance(
+      env,
+      input.itwVersion,
+      newHardwareKeyTag,
       sessionToken,
-      integrityKeyTag
+      { isRenewal: true }
     );
 
-    // Removes all credentials stored in the secure storage, as they are all linked
-    // to the revoked wallet instance
-    await CredentialsVault.clear();
-  }),
-
-  startAuthFlow: fromPromise<AuthenticationContext, StartAuthFlowActorParams>(
-    async ({ input }) => {
-      assert(
-        input.walletInstanceAttestation,
-        "walletInstanceAttestation is undefined"
-      );
-      assert(input.identification, "identification is undefined");
-
-      const authenticationContext = await issuanceUtils.startAuthFlow({
-        env,
-        itwVersion: input.itwVersion,
-        walletAttestation: input.walletInstanceAttestation,
-        identification: input.identification,
-        withMRTDPoP: input.withMRTDPoP
+    return await getWalletInstanceAttestation(
+      env,
+      input.itwVersion,
+      newHardwareKeyTag,
+      sessionToken
+    )
+      .then(attestation => {
+        // Track the successful renewal in Mixpanel
+        trackWalletInstanceRenewalSuccess();
+        return attestation;
+      })
+      .catch(error => {
+        // If the attestation retrieval fails again after renewing the wallet instance,
+        // we set a flag in the store to prevent further renewal attempts and prompt the user with an error.
+        store.dispatch(itwSetWalletInstanceRenewalError(true));
+        // Track the renewal failure in Mixpanel
+        trackWalletInstanceRenewalFailure(error);
+        throw error;
       });
+  }
+});
 
-      return {
-        ...authenticationContext,
-        callbackUrl: "" // This is not important in this phase, it will be set after completing the auth flow
-      };
-    }
-  ),
+export const revokeWalletInstanceActor = fromPromise<
+  void,
+  WithItwVersion<{ deps: EidIssuanceMachineDeps }>
+>(async ({ input }) => {
+  const { env, store } = input.deps;
+  const state = store.getState();
+  const sessionToken = sessionTokenSelector(state);
+  const integrityKeyTag = itwIntegrityKeyTagSelector(state);
 
-  initMrtdPoPChallenge: fromPromise<
-    MrtdPoPContext,
-    InitMrtdPoPChallengeActorParams
-  >(async ({ input }) => {
-    assert(input.authenticationContext, "authenticationContext is undefined");
-    assert(
-      input.walletInstanceAttestation,
-      "walletInstanceAttestation is undefined"
-    );
+  if (integrityKeyTag === undefined) {
+    return;
+  }
+  assert(sessionToken, "sessionToken is undefined");
 
-    return mrtdUtils.initMrtdPoPChallenge({
+  await revokeCurrentWalletInstance(
+    env,
+    input.itwVersion,
+    sessionToken,
+    integrityKeyTag
+  );
+
+  // Removes all credentials stored in the secure storage, as they are all linked
+  // to the revoked wallet instance
+  await CredentialsVault.clear();
+});
+
+export const startAuthFlowActor = fromPromise<
+  AuthenticationContext,
+  StartAuthFlowActorParams
+>(async ({ input }) => {
+  const { env } = input.deps;
+  assert(
+    input.walletInstanceAttestation,
+    "walletInstanceAttestation is undefined"
+  );
+  assert(input.identification, "identification is undefined");
+
+  const authenticationContext = await issuanceUtils.startAuthFlow({
+    env,
+    itwVersion: input.itwVersion,
+    walletAttestation: input.walletInstanceAttestation,
+    identification: input.identification,
+    withMRTDPoP: input.withMRTDPoP
+  });
+
+  return {
+    ...authenticationContext,
+    callbackUrl: "" // This is not important in this phase, it will be set after completing the auth flow
+  };
+});
+
+export const initMrtdPoPChallengeActor = fromPromise<
+  MrtdPoPContext,
+  InitMrtdPoPChallengeActorParams
+>(async ({ input }) => {
+  assert(input.authenticationContext, "authenticationContext is undefined");
+  assert(
+    input.walletInstanceAttestation,
+    "walletInstanceAttestation is undefined"
+  );
+
+  return mrtdUtils.initMrtdPoPChallenge({
+    itwVersion: input.itwVersion,
+    issuerConf: input.authenticationContext.issuerConf,
+    walletInstanceAttestation: input.walletInstanceAttestation,
+    authRedirectUrl: input.authenticationContext.callbackUrl
+  });
+});
+
+export const validateMrtdPoPChallengeActor = fromPromise<
+  string,
+  ValidateMrtdPoPChallengeActorParams
+>(async ({ input }) => {
+  assert(input.authenticationContext, "authenticationContext is undefined");
+  assert(
+    input.walletInstanceAttestation,
+    "walletInstanceAttestation is undefined"
+  );
+  assert(input.mrtdContext, "mrtdContext is undefined");
+  assert(input.mrtdContext.ias, "IAS is undefined");
+  assert(input.mrtdContext.mrtd, "MRTD is undefined");
+
+  const { callbackUrl } = await mrtdUtils.validateMrtdPoPChallenge({
+    itwVersion: input.itwVersion,
+    issuerConf: input.authenticationContext.issuerConf,
+    walletInstanceAttestation: input.walletInstanceAttestation,
+    mrtd_auth_session: input.mrtdContext.mrtd_auth_session,
+    mrtd_pop_nonce: input.mrtdContext.mrtd_pop_nonce,
+    validationUrl: input.mrtdContext.validationUrl,
+    ias: input.mrtdContext.ias,
+    mrtd: input.mrtdContext.mrtd
+  });
+
+  return callbackUrl;
+});
+
+export const requestAccessTokenActor = fromPromise<
+  CredentialAccessToken,
+  RequestAccessTokenActorParams
+>(async ({ input }) => {
+  assert(
+    input.walletInstanceAttestation,
+    "walletInstanceAttestation is undefined"
+  );
+  assert(
+    input.authenticationContext,
+    "authenticationContext must exist when the identification mode is ciePin"
+  );
+
+  const { accessToken } = await issuanceUtils.completeAuthFlow({
+    ...input.authenticationContext,
+    itwVersion: input.itwVersion,
+    walletAttestation: input.walletInstanceAttestation
+  });
+  return accessToken;
+});
+
+// To ensure a smooth experience when the session token expires, it is important to keep this actor
+// retriable: it must fail as early as possible when `generateKeysWithKeyAttestation` is
+// rejected for session expired, so it can be reentered and retried from where it failed.
+export const requestEidActor = fromPromise<
+  RequestEidActorOutput,
+  RequestEidActorParams
+>(async ({ input }) => {
+  const { env, store } = input.deps;
+  assert(input.identification, "identification is undefined");
+  assert(input.integrityKeyTag, "integrityKeyTag is undefined");
+  assert(input.accessToken, "accessToken is undefined");
+  assert(input.authenticationContext, "authenticationContext is undefined");
+
+  const sessionToken = sessionTokenSelector(store.getState());
+  assert(sessionToken, "sessionToken is undefined");
+
+  // The Key Attestation makes use of the integrity service
+  if (getIoWallet(input.itwVersion).KeyAttestation.isSupported) {
+    await ensureIntegrityServiceIsStoreReadyOrThrow(store);
+  }
+
+  // Take the first element as only one credential is authorized during PID issuance
+  const [authorizedCredential] = await generateKeysWithKeyAttestation(
+    input.accessToken,
+    {
+      env,
       itwVersion: input.itwVersion,
-      issuerConf: input.authenticationContext.issuerConf,
-      walletInstanceAttestation: input.walletInstanceAttestation,
-      authRedirectUrl: input.authenticationContext.callbackUrl
-    });
-  }),
-
-  validateMrtdPoPChallenge: fromPromise<
-    string,
-    ValidateMrtdPoPChallengeActorParams
-  >(async ({ input }) => {
-    assert(input.authenticationContext, "authenticationContext is undefined");
-    assert(
-      input.walletInstanceAttestation,
-      "walletInstanceAttestation is undefined"
-    );
-    assert(input.mrtdContext, "mrtdContext is undefined");
-    assert(input.mrtdContext.ias, "IAS is undefined");
-    assert(input.mrtdContext.mrtd, "MRTD is undefined");
-
-    const { callbackUrl } = await mrtdUtils.validateMrtdPoPChallenge({
-      itwVersion: input.itwVersion,
-      issuerConf: input.authenticationContext.issuerConf,
-      walletInstanceAttestation: input.walletInstanceAttestation,
-      mrtd_auth_session: input.mrtdContext.mrtd_auth_session,
-      mrtd_pop_nonce: input.mrtdContext.mrtd_pop_nonce,
-      validationUrl: input.mrtdContext.validationUrl,
-      ias: input.mrtdContext.ias,
-      mrtd: input.mrtdContext.mrtd
-    });
-
-    return callbackUrl;
-  }),
-
-  requestAccessToken: fromPromise<
-    CredentialAccessToken,
-    RequestAccessTokenActorParams
-  >(async ({ input }) => {
-    assert(
-      input.walletInstanceAttestation,
-      "walletInstanceAttestation is undefined"
-    );
-    assert(
-      input.authenticationContext,
-      "authenticationContext must exist when the identification mode is ciePin"
-    );
-
-    const { accessToken } = await issuanceUtils.completeAuthFlow({
-      ...input.authenticationContext,
-      itwVersion: input.itwVersion,
-      walletAttestation: input.walletInstanceAttestation
-    });
-    return accessToken;
-  }),
-
-  // To ensure a smooth experience when the session token expires, it is important to keep this actor
-  // retriable: it must fail as early as possible when `generateKeysWithKeyAttestation` is
-  // rejected for session expired, so it can be reentered and retried from where it failed.
-  requestEid: fromPromise<RequestEidActorOutput, RequestEidActorParams>(
-    async ({ input }) => {
-      assert(input.identification, "identification is undefined");
-      assert(input.integrityKeyTag, "integrityKeyTag is undefined");
-      assert(input.accessToken, "accessToken is undefined");
-      assert(input.authenticationContext, "authenticationContext is undefined");
-
-      const sessionToken = sessionTokenSelector(store.getState());
-      assert(sessionToken, "sessionToken is undefined");
-
-      // The Key Attestation makes use of the integrity service
-      if (getIoWallet(input.itwVersion).KeyAttestation.isSupported) {
-        await ensureIntegrityServiceIsStoreReadyOrThrow(store);
-      }
-
-      // Take the first element as only one credential is authorized during PID issuance
-      const [authorizedCredential] = await generateKeysWithKeyAttestation(
-        input.accessToken,
-        {
-          env,
-          itwVersion: input.itwVersion,
-          hardwareKeyTag: input.integrityKeyTag,
-          sessionToken
-        }
-      );
-
-      trackItwRequest(
-        toItwIdMethod(input.identification),
-        input.level === "l3" ? "L3" : "L2"
-      );
-
-      const credential = await issuanceUtils.getPid({
-        authorizedCredential,
-        itwVersion: input.itwVersion,
-        env,
-        accessToken: input.accessToken,
-        ...input.authenticationContext
-      });
-
-      const { keyAttestationId, keyAttestation } = authorizedCredential;
-      return {
-        credential,
-        keyAttestations:
-          keyAttestationId && keyAttestation
-            ? { [keyAttestationId]: keyAttestation }
-            : {}
-      };
+      hardwareKeyTag: input.integrityKeyTag,
+      sessionToken
     }
-  ),
+  );
 
-  obtainStatusList: fromPromise<
-    ObtainStatusListActorOutput,
-    ObtainStatusListActorInput
-  >(async ({ input }) => {
-    const { itwVersion, keyAttestations } = input;
+  trackItwRequest(
+    toItwIdMethod(input.identification),
+    input.level === "l3" ? "L3" : "L2"
+  );
 
-    const ioWallet = getIoWallet(itwVersion);
-    if (
-      !ioWallet.KeyAttestation.isSupported ||
-      !ioWallet.CredentialStatus.statusList.isSupported
-    ) {
-      return undefined;
-    }
+  const credential = await issuanceUtils.getPid({
+    authorizedCredential,
+    itwVersion: input.itwVersion,
+    env,
+    accessToken: input.accessToken,
+    ...input.authenticationContext
+  });
 
-    assert(
-      keyAttestations && Object.keys(keyAttestations).length > 0,
-      "PID Key Attestations are not defined or empty"
+  const { keyAttestationId, keyAttestation } = authorizedCredential;
+  return {
+    credential,
+    keyAttestations:
+      keyAttestationId && keyAttestation
+        ? { [keyAttestationId]: keyAttestation }
+        : {}
+  };
+});
+
+export const obtainStatusListActor = fromPromise<
+  ObtainStatusListActorOutput,
+  ObtainStatusListActorInput
+>(async ({ input }) => {
+  const { itwVersion, keyAttestations } = input;
+
+  const ioWallet = getIoWallet(itwVersion);
+  if (
+    !ioWallet.KeyAttestation.isSupported ||
+    !ioWallet.CredentialStatus.statusList.isSupported
+  ) {
+    return undefined;
+  }
+
+  assert(
+    keyAttestations && Object.keys(keyAttestations).length > 0,
+    "PID Key Attestations are not defined or empty"
+  );
+
+  // For the Status List we'll need just one of the KAs, as they all
+  // reference the same Status List. We can take the first one.
+  const [keyAttestationId, keyAttestation] =
+    Object.entries(keyAttestations)[0];
+
+  // Fetch the JWKS from the Wallet Provider's OpenID Federation metadata,
+  const keys = await getKeysForKaStatusList(keyAttestation);
+
+  return await getCredentialStatusFromStatusList(
+    itwVersion,
+    keyAttestation,
+    keyAttestationId,
+    "dc+sd-jwt",
+    keys
+  );
+});
+
+export const storeEidCredentialActor = fromPromise<
+  void,
+  StoreEidCredentialActorParams
+>(async ({ input }) => {
+  const { store } = input.deps;
+  const { eid, keyAttestations, walletInstanceStatusList } = input;
+  assert(eid, "eID credential is undefined");
+
+  // Persist verified status lists before activating the wallet instance.
+  if (walletInstanceStatusList) {
+    const { parsedStatusList, idx, uri } = walletInstanceStatusList;
+    await StatusListRepository.upsert(uri, parsedStatusList);
+    store.dispatch(itwStoreWalletInstanceStatusList({ idx, uri }));
+  }
+
+  if (keyAttestations) {
+    store.dispatch(itwKeyAttestationsStore(keyAttestations));
+  }
+
+  // Waits for the credential store/replace to complete before proceeding
+  await new Promise<void>((resolve, reject) => {
+    store.dispatch(
+      itwCredentialsReplaceByType([eid], {
+        onComplete: resolve,
+        onError: reject
+      })
     );
-
-    // For the Status List we'll need just one of the KAs, as they all
-    // reference the same Status List. We can take the first one.
-    const [keyAttestationId, keyAttestation] =
-      Object.entries(keyAttestations)[0];
-
-    // Fetch the JWKS from the Wallet Provider's OpenID Federation metadata,
-    const keys = await getKeysForKaStatusList(keyAttestation);
-
-    return await getCredentialStatusFromStatusList(
-      itwVersion,
-      keyAttestation,
-      keyAttestationId,
-      "dc+sd-jwt",
-      keys
-    );
-  }),
-
-  storeEidCredential: fromPromise<void, StoreEidCredentialActorParams>(
-    async ({ input }) => {
-      const { eid, keyAttestations, walletInstanceStatusList } = input;
-      assert(eid, "eID credential is undefined");
-
-      // Persist verified status lists before activating the wallet instance.
-      if (walletInstanceStatusList) {
-        const { parsedStatusList, idx, uri } = walletInstanceStatusList;
-        await StatusListRepository.upsert(uri, parsedStatusList);
-        store.dispatch(itwStoreWalletInstanceStatusList({ idx, uri }));
-      }
-
-      if (keyAttestations) {
-        store.dispatch(itwKeyAttestationsStore(keyAttestations));
-      }
-
-      // Waits for the credential store/replace to complete before proceeding
-      await new Promise<void>((resolve, reject) => {
-        store.dispatch(
-          itwCredentialsReplaceByType([eid], {
-            onComplete: resolve,
-            onError: reject
-          })
-        );
-      });
-    }
-  ),
-
-  credentialUpgradeMachine: itwCredentialUpgradeMachine.provide({
-    actions: createCredentialUpgradeActionsImplementation(store),
-    actors: createCredentialUpgradeActorsImplementation(env, store)
-  }),
-
-  ...createCommonActorsImplementation(store)
+  });
 });

--- a/apps/main-app/ts/features/itwallet/machine/eid/context.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/context.ts
@@ -14,6 +14,7 @@ import type {
 } from "../../common/utils/itwTypesUtils";
 
 import { IssuanceFailure } from "./failure";
+import { EidIssuanceMachineDeps } from "./input";
 
 /**
  * When authenticating with CIE + PIN the flow is interrupted
@@ -63,6 +64,10 @@ export type Context = {
    * The credential type that triggered the eID issuance flow.
    */
   credentialType: string | undefined;
+  /**
+   * Runtime dependencies injected via machine input
+   */
+  deps: EidIssuanceMachineDeps;
   /**
    * The obtained PID credential
    */
@@ -175,7 +180,7 @@ export type MrtdPoPContext = {
   validationUrl: string;
 };
 
-export const InitialContext: Context = {
+export const InitialContext: Omit<Context, "deps"> = {
   itwVersion: "1.0.0", // Initial value to satisfy type constraints. It is assigned in the `onInit` action.
   mode: undefined,
   level: undefined,

--- a/apps/main-app/ts/features/itwallet/machine/eid/guards.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/guards.ts
@@ -1,4 +1,3 @@
-import { useIOStore } from "../../../../store/hooks";
 import { profileFiscalCodeSelector } from "../../../settings/common/store/selectors";
 import { ItwSessionExpiredError } from "../../api/client";
 import { isWalletInstanceAttestationValid } from "../../common/utils/itwAttestationUtils";
@@ -7,42 +6,43 @@ import { itwLifecycleIsValidSelector } from "../../lifecycle/store/selectors";
 import { Context } from "./context";
 import { EidIssuanceEvents } from "./events";
 
-type GuardsImplementationOptions = Partial<{
-  bypassIdentityMatch: boolean;
-}>;
+type GuardArgs = {
+  context: Context;
+  event: EidIssuanceEvents;
+};
 
-export const createEidIssuanceGuardsImplementation = (
-  store: ReturnType<typeof useIOStore>,
-  options?: GuardsImplementationOptions
-) => ({
-  /**
-   * Guard to check whether the user for whom the eID was issued
-   * is the same that is currently authenticated in app.
-   */
-  issuedEidMatchesAuthenticatedUser: ({ context }: { context: Context }) => {
-    if (options?.bypassIdentityMatch) {
-      return true;
-    }
+/**
+ * Guard to check whether the user for whom the eID was issued
+ * is the same that is currently authenticated in app.
+ */
+export const issuedEidMatchesAuthenticatedUserGuard = ({
+  context
+}: GuardArgs) => {
+  if (context.deps.env.BYPASS_IDENTITY_MATCH) {
+    return true;
+  }
 
-    const authenticatedUserFiscalCode = profileFiscalCodeSelector(
-      store.getState()
-    );
+  const authenticatedUserFiscalCode = profileFiscalCodeSelector(
+    context.deps.store.getState()
+  );
 
-    const eidFiscalCode = getFiscalCodeFromCredential(context.eid?.metadata);
+  const eidFiscalCode = getFiscalCodeFromCredential(context.eid?.metadata);
 
-    return authenticatedUserFiscalCode === eidFiscalCode;
-  },
+  return authenticatedUserFiscalCode === eidFiscalCode;
+};
 
-  isSessionExpired: ({ event }: { event: EidIssuanceEvents }) =>
-    "error" in event && event.error instanceof ItwSessionExpiredError,
+export const isSessionExpiredGuard = ({ event }: GuardArgs) =>
+  "error" in event && event.error instanceof ItwSessionExpiredError;
 
-  hasValidWalletInstanceAttestation: ({ context }: { context: Context }) => {
-    const attestation = context.walletInstanceAttestation?.jwt;
-    return (
-      attestation !== undefined &&
-      isWalletInstanceAttestationValid(context.itwVersion, attestation)
-    );
-  },
+export const hasValidWalletInstanceAttestationGuard = ({
+  context
+}: GuardArgs) => {
+  const attestation = context.walletInstanceAttestation?.jwt;
+  return (
+    attestation !== undefined &&
+    isWalletInstanceAttestationValid(context.itwVersion, attestation)
+  );
+};
 
-  isWalletValid: () => itwLifecycleIsValidSelector(store.getState())
-});
+export const isWalletValidGuard = ({ context }: GuardArgs) =>
+  itwLifecycleIsValidSelector(context.deps.store.getState());

--- a/apps/main-app/ts/features/itwallet/machine/eid/input.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/input.ts
@@ -1,14 +1,11 @@
-import { IOToast } from "@io-app/design-system";
-
-import { useIONavigation } from "../../../../navigation/params/AppParamsList";
-import { useIOStore } from "../../../../store/hooks";
 import { Env } from "../../common/utils/environment";
+import { MachineNavigation, MachineStore, MachineToast } from "../utils/deps";
 
 export type EidIssuanceMachineDeps = {
   env: Env;
-  navigation: ReturnType<typeof useIONavigation>;
-  store: ReturnType<typeof useIOStore>;
-  toast: IOToast;
+  navigation: MachineNavigation;
+  store: MachineStore;
+  toast: MachineToast;
 };
 
 export type Input = {

--- a/apps/main-app/ts/features/itwallet/machine/eid/input.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/input.ts
@@ -1,0 +1,19 @@
+import { IOToast } from "@io-app/design-system";
+
+import { useIONavigation } from "../../../../navigation/params/AppParamsList";
+import { useIOStore } from "../../../../store/hooks";
+import { Env } from "../../common/utils/environment";
+
+export type EidIssuanceMachineDeps = {
+  env: Env;
+  navigation: ReturnType<typeof useIONavigation>;
+  store: ReturnType<typeof useIOStore>;
+  toast: IOToast;
+};
+
+export type Input = {
+  /**
+   * Runtime dependencies injected by the machine provider
+   */
+  deps: EidIssuanceMachineDeps;
+};

--- a/apps/main-app/ts/features/itwallet/machine/eid/machine.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/machine.ts
@@ -12,7 +12,7 @@ import { userIdentificationState } from "./state/userIdentification";
 
 export const itwEidIssuanceMachine = itwEidIssuanceMachineSetup.createMachine({
   id: "itwEidIssuanceMachine",
-  context: { ...InitialContext },
+  context: ({ input }) => ({ ...InitialContext, deps: input.deps }),
   initial: "Idle",
   entry: "onInit",
   invoke: {
@@ -123,7 +123,10 @@ export const itwEidIssuanceMachine = itwEidIssuanceMachineSetup.createMachine({
       tags: [ItwTags.Loading],
       invoke: {
         src: "verifyTrustFederation",
-        input: ({ context }) => ({ itwVersion: context.itwVersion }),
+        input: ({ context }) => ({
+          itwVersion: context.itwVersion,
+          deps: context.deps
+        }),
         onDone: [
           {
             // When no integrity hardware key exists or the user is upgrading to IT-Wallet
@@ -176,7 +179,8 @@ export const itwEidIssuanceMachine = itwEidIssuanceMachineSetup.createMachine({
         src: "createWalletInstance",
         input: ({ context }) => ({
           itwVersion: context.itwVersion,
-          isRenewal: context.mode === "upgrade"
+          isRenewal: context.mode === "upgrade",
+          deps: context.deps
         }),
         onDone: {
           actions: [
@@ -205,7 +209,10 @@ export const itwEidIssuanceMachine = itwEidIssuanceMachineSetup.createMachine({
       entry: "navigateToWalletRevocationScreen",
       invoke: {
         src: "revokeWalletInstance",
-        input: ({ context }) => ({ itwVersion: context.itwVersion }),
+        input: ({ context }) => ({
+          itwVersion: context.itwVersion,
+          deps: context.deps
+        }),
         onDone: {
           actions: [
             "trackWalletInstanceRevocation",
@@ -240,7 +247,8 @@ export const itwEidIssuanceMachine = itwEidIssuanceMachineSetup.createMachine({
         src: "getWalletAttestation",
         input: ({ context }) => ({
           integrityKeyTag: context.integrityKeyTag,
-          itwVersion: context.itwVersion
+          itwVersion: context.itwVersion,
+          deps: context.deps
         }),
         onDone: [
           {

--- a/apps/main-app/ts/features/itwallet/machine/eid/provider.tsx
+++ b/apps/main-app/ts/features/itwallet/machine/eid/provider.tsx
@@ -6,9 +6,6 @@ import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { useIOSelector, useIOStore } from "../../../../store/hooks";
 import { selectItwEnv } from "../../common/store/selectors/environment";
 import { getEnv } from "../../common/utils/environment";
-import { createEidIssuanceActionsImplementation } from "./../eid/actions";
-import { createEidIssuanceActorsImplementation } from "./../eid/actors";
-import { createEidIssuanceGuardsImplementation } from "./../eid/guards";
 import { itwEidIssuanceMachine } from "./../eid/machine";
 
 export const ItwEidIssuanceMachineContext = createActorContext(
@@ -22,16 +19,15 @@ export const ItwEidIssuanceMachineProvider = (props: PropsWithChildren) => {
 
   const env = getEnv(useIOSelector(selectItwEnv));
 
-  const eidIssuanceMachine = itwEidIssuanceMachine.provide({
-    guards: createEidIssuanceGuardsImplementation(store, {
-      bypassIdentityMatch: env.BYPASS_IDENTITY_MATCH
-    }),
-    actions: createEidIssuanceActionsImplementation(navigation, store, toast),
-    actors: createEidIssuanceActorsImplementation(env, store)
-  });
-
   return (
-    <ItwEidIssuanceMachineContext.Provider logic={eidIssuanceMachine}>
+    <ItwEidIssuanceMachineContext.Provider
+      logic={itwEidIssuanceMachine}
+      options={{
+        input: {
+          deps: { env, navigation, store, toast }
+        }
+      }}
+    >
       {props.children}
     </ItwEidIssuanceMachineContext.Provider>
   );

--- a/apps/main-app/ts/features/itwallet/machine/eid/setup.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/setup.ts
@@ -1,34 +1,74 @@
-import { assertEvent, assign, fromCallback, fromPromise, setup } from "xstate";
+import { assertEvent, assign, setup } from "xstate";
 
 import { assert } from "../../../../utils/assert.ts";
-import {
-  CredentialAccessToken,
-  WalletInstanceAttestations
-} from "../../common/utils/itwTypesUtils";
 import { isMrtdPoPChallengeRequired } from "../../common/utils/mrtdUrl";
 import { itwCredentialUpgradeMachine } from "../upgrade/machine.ts";
+import { waitForSessionRefreshActor } from "../utils/actors";
 import {
-  CreateWalletInstanceActorParams,
-  GetWalletAttestationActorParams,
-  InitMrtdPoPChallengeActorParams,
-  ObtainStatusListActorInput,
-  ObtainStatusListActorOutput,
-  RequestAccessTokenActorParams,
-  RequestEidActorOutput,
-  type RequestEidActorParams,
-  StartAuthFlowActorParams,
-  StoreEidCredentialActorParams,
-  ValidateMrtdPoPChallengeActorParams,
-  WithItwVersion
+  cleanupIntegrityKeyTagAction,
+  closeIssuanceAction,
+  handleSessionExpiredAction,
+  navigateToCieAuthenticationScreenAction,
+  navigateToCieCanPreparationScreenAction,
+  navigateToCieCanScreenAction,
+  navigateToCieCardPreparationScreenAction,
+  navigateToCieIdLoginScreenAction,
+  navigateToCieInternalAuthAndMrtdScreenAction,
+  navigateToCieNfcPreparationScreenAction,
+  navigateToCiePinPreparationScreenAction,
+  navigateToCiePinScreenAction,
+  navigateToCieWarningScreenAction,
+  navigateToCredentialCatalogAction,
+  navigateToEidPreviewScreenAction,
+  navigateToFailureScreenAction,
+  navigateToIdentificationScreenAction,
+  navigateToIdpSelectionScreenAction,
+  navigateToIpzsPrivacyScreenAction,
+  navigateToNfcInstructionsScreenAction,
+  navigateToSpidLoginScreenAction,
+  navigateToSuccessScreenAction,
+  navigateToTosScreenAction,
+  navigateToWalletAction,
+  navigateToWalletRevocationScreenAction,
+  onInitAction,
+  refreshCredentialsCatalogueAction,
+  resetWalletInstanceAction,
+  storeAuthLevelAction,
+  storeCredentialUpgradeFailuresAction,
+  storeIntegrityKeyTagAction,
+  storeWalletActivationFeedbackBannerDataAction,
+  storeWalletInstanceAttestationAction,
+  trackIdentificationMethodSelectedAction,
+  trackIntroScreenAction,
+  trackItwIdAuthenticationCompletedAction,
+  trackItwIdVerifiedDocumentAction,
+  trackWalletInstanceCreationAction,
+  trackWalletInstanceRevocationAction
+} from "./actions";
+import {
+  createWalletInstanceActor,
+  getCieStatusActor,
+  getWalletAttestationActor,
+  initMrtdPoPChallengeActor,
+  obtainStatusListActor,
+  requestAccessTokenActor,
+  requestEidActor,
+  revokeWalletInstanceActor,
+  startAuthFlowActor,
+  storeEidCredentialActor,
+  validateMrtdPoPChallengeActor,
+  verifyTrustFederationActor
 } from "./actors";
-import {
-  AuthenticationContext,
-  CieContext,
-  Context,
-  MrtdPoPContext
-} from "./context";
+import { Context } from "./context";
 import { EidIssuanceEvents } from "./events";
 import { mapEventToFailure } from "./failure";
+import {
+  hasValidWalletInstanceAttestationGuard,
+  isSessionExpiredGuard,
+  issuedEidMatchesAuthenticatedUserGuard,
+  isWalletValidGuard
+} from "./guards";
+import { Input } from "./input";
 
 const notImplemented = () => {
   throw new Error("Not implemented");
@@ -38,62 +78,66 @@ const notImplemented = () => {
 export const itwEidIssuanceMachineSetup = setup({
   types: {
     context: {} as Context,
-    events: {} as EidIssuanceEvents
+    events: {} as EidIssuanceEvents,
+    input: {} as Input
   },
   actions: {
-    onInit: notImplemented,
+    onInit: onInitAction,
 
     /**
      * Navigation
      */
 
-    navigateToTosScreen: notImplemented,
-    navigateToIpzsPrivacyScreen: notImplemented,
-    navigateToIdentificationScreen: notImplemented,
-    navigateToIdpSelectionScreen: notImplemented,
-    navigateToSpidLoginScreen: notImplemented,
-    navigateToCieIdLoginScreen: notImplemented,
-    navigateToEidPreviewScreen: notImplemented,
-    navigateToSuccessScreen: notImplemented,
-    navigateToFailureScreen: notImplemented,
-    navigateToWallet: notImplemented,
-    navigateToCredentialCatalog: notImplemented,
-    navigateToCieNfcPreparationScreen: notImplemented,
-    navigateToCiePinPreparationScreen: notImplemented,
-    navigateToCieCardPreparationScreen: notImplemented,
-    navigateToCieCanPreparationScreen: notImplemented,
-    navigateToCiePinScreen: notImplemented,
-    navigateToCieAuthenticationScreen: notImplemented,
-    navigateToNfcInstructionsScreen: notImplemented,
-    navigateToWalletRevocationScreen: notImplemented,
-    navigateToCieWarningScreen: notImplemented,
-    navigateToCieCanScreen: notImplemented,
-    navigateToCieInternalAuthAndMrtdScreen: notImplemented,
-    closeIssuance: notImplemented,
+    navigateToTosScreen: navigateToTosScreenAction,
+    navigateToIpzsPrivacyScreen: navigateToIpzsPrivacyScreenAction,
+    navigateToIdentificationScreen: navigateToIdentificationScreenAction,
+    navigateToIdpSelectionScreen: navigateToIdpSelectionScreenAction,
+    navigateToSpidLoginScreen: navigateToSpidLoginScreenAction,
+    navigateToCieIdLoginScreen: navigateToCieIdLoginScreenAction,
+    navigateToEidPreviewScreen: navigateToEidPreviewScreenAction,
+    navigateToSuccessScreen: navigateToSuccessScreenAction,
+    navigateToFailureScreen: navigateToFailureScreenAction,
+    navigateToWallet: navigateToWalletAction,
+    navigateToCredentialCatalog: navigateToCredentialCatalogAction,
+    navigateToCieNfcPreparationScreen: navigateToCieNfcPreparationScreenAction,
+    navigateToCiePinPreparationScreen: navigateToCiePinPreparationScreenAction,
+    navigateToCieCardPreparationScreen:
+      navigateToCieCardPreparationScreenAction,
+    navigateToCieCanPreparationScreen: navigateToCieCanPreparationScreenAction,
+    navigateToCiePinScreen: navigateToCiePinScreenAction,
+    navigateToCieAuthenticationScreen: navigateToCieAuthenticationScreenAction,
+    navigateToNfcInstructionsScreen: navigateToNfcInstructionsScreenAction,
+    navigateToWalletRevocationScreen: navigateToWalletRevocationScreenAction,
+    navigateToCieWarningScreen: navigateToCieWarningScreenAction,
+    navigateToCieCanScreen: navigateToCieCanScreenAction,
+    navigateToCieInternalAuthAndMrtdScreen:
+      navigateToCieInternalAuthAndMrtdScreenAction,
+    closeIssuance: closeIssuanceAction,
 
     /**
      * Store update
      */
 
-    storeIntegrityKeyTag: notImplemented,
-    cleanupIntegrityKeyTag: notImplemented,
-    storeWalletInstanceAttestation: notImplemented,
-    storeAuthLevel: notImplemented,
-    storeWalletActivationFeedbackBannerData: notImplemented,
-    storeCredentialUpgradeFailures: notImplemented,
-    handleSessionExpired: notImplemented,
-    resetWalletInstance: notImplemented,
-    refreshCredentialsCatalogue: notImplemented,
+    storeIntegrityKeyTag: storeIntegrityKeyTagAction,
+    cleanupIntegrityKeyTag: cleanupIntegrityKeyTagAction,
+    storeWalletInstanceAttestation: storeWalletInstanceAttestationAction,
+    storeAuthLevel: storeAuthLevelAction,
+    storeWalletActivationFeedbackBannerData:
+      storeWalletActivationFeedbackBannerDataAction,
+    storeCredentialUpgradeFailures: storeCredentialUpgradeFailuresAction,
+    handleSessionExpired: handleSessionExpiredAction,
+    resetWalletInstance: resetWalletInstanceAction,
+    refreshCredentialsCatalogue: refreshCredentialsCatalogueAction,
 
     /**
      * Analytics
      */
 
-    trackWalletInstanceCreation: notImplemented,
-    trackWalletInstanceRevocation: notImplemented,
-    trackIdentificationMethodSelected: notImplemented,
-    trackItwIdAuthenticationCompleted: notImplemented,
-    trackItwIdVerifiedDocument: notImplemented,
+    trackWalletInstanceCreation: trackWalletInstanceCreationAction,
+    trackWalletInstanceRevocation: trackWalletInstanceRevocationAction,
+    trackIdentificationMethodSelected: trackIdentificationMethodSelectedAction,
+    trackItwIdAuthenticationCompleted: trackItwIdAuthenticationCompletedAction,
+    trackItwIdVerifiedDocument: trackItwIdVerifiedDocumentAction,
     /**
      * Context manipulation
      */
@@ -152,65 +196,42 @@ export const itwEidIssuanceMachineSetup = setup({
         }
       };
     }),
-    trackIntroScreen: notImplemented
+    trackIntroScreen: trackIntroScreenAction
   },
   actors: {
-    getCieStatus: fromPromise<CieContext>(notImplemented),
-    verifyTrustFederation: fromPromise<void, WithItwVersion>(notImplemented),
+    getCieStatus: getCieStatusActor,
+    verifyTrustFederation: verifyTrustFederationActor,
 
     /**
      * WI actors
      */
 
-    createWalletInstance: fromPromise<string, CreateWalletInstanceActorParams>(
-      notImplemented
-    ),
-    revokeWalletInstance: fromPromise<void, WithItwVersion>(notImplemented),
-    getWalletAttestation: fromPromise<
-      WalletInstanceAttestations,
-      GetWalletAttestationActorParams
-    >(notImplemented),
+    createWalletInstance: createWalletInstanceActor,
+    revokeWalletInstance: revokeWalletInstanceActor,
+    getWalletAttestation: getWalletAttestationActor,
 
     /**
      * Primary authentication actors
      */
 
-    startAuthFlow: fromPromise<AuthenticationContext, StartAuthFlowActorParams>(
-      notImplemented
-    ),
+    startAuthFlow: startAuthFlowActor,
 
     /**
      * MRTD PoP Challenge actors
      */
 
-    initMrtdPoPChallenge: fromPromise<
-      MrtdPoPContext,
-      InitMrtdPoPChallengeActorParams
-    >(notImplemented),
-    validateMrtdPoPChallenge: fromPromise<
-      string,
-      ValidateMrtdPoPChallengeActorParams
-    >(notImplemented),
+    initMrtdPoPChallenge: initMrtdPoPChallengeActor,
+    validateMrtdPoPChallenge: validateMrtdPoPChallengeActor,
 
     /**
      * PID issuance actors
      */
 
-    requestAccessToken: fromPromise<
-      CredentialAccessToken,
-      RequestAccessTokenActorParams
-    >(notImplemented),
-    requestEid: fromPromise<RequestEidActorOutput, RequestEidActorParams>(
-      notImplemented
-    ),
-    obtainStatusList: fromPromise<
-      ObtainStatusListActorOutput,
-      ObtainStatusListActorInput
-    >(notImplemented),
-    storeEidCredential: fromPromise<void, StoreEidCredentialActorParams>(
-      notImplemented
-    ),
-    waitForSessionRefresh: fromCallback(notImplemented),
+    requestAccessToken: requestAccessTokenActor,
+    requestEid: requestEidActor,
+    obtainStatusList: obtainStatusListActor,
+    storeEidCredential: storeEidCredentialActor,
+    waitForSessionRefresh: waitForSessionRefreshActor,
 
     /**
      * Credential upgrade actors
@@ -219,11 +240,11 @@ export const itwEidIssuanceMachineSetup = setup({
     credentialUpgradeMachine: itwCredentialUpgradeMachine
   },
   guards: {
-    issuedEidMatchesAuthenticatedUser: notImplemented,
-    isSessionExpired: notImplemented,
+    issuedEidMatchesAuthenticatedUser: issuedEidMatchesAuthenticatedUserGuard,
+    isSessionExpired: isSessionExpiredGuard,
     isOperationAborted: notImplemented,
     hasIntegrityKeyTag: ({ context }) => context.integrityKeyTag !== undefined,
-    hasValidWalletInstanceAttestation: notImplemented,
+    hasValidWalletInstanceAttestation: hasValidWalletInstanceAttestationGuard,
     hasCredentialsToUpgrade: ({ context }) =>
       context.credentialsToUpgrade.length > 0,
     isNFCEnabled: ({ context }) => context.cieContext?.isNFCEnabled || false,
@@ -238,6 +259,6 @@ export const itwEidIssuanceMachineSetup = setup({
       context.identification?.mode !== "ciePin" &&
       context.authenticationContext !== undefined &&
       isMrtdPoPChallengeRequired(context.authenticationContext.callbackUrl),
-    isWalletValid: notImplemented
+    isWalletValid: isWalletValidGuard
   }
 });

--- a/apps/main-app/ts/features/itwallet/machine/eid/setup.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/setup.ts
@@ -59,7 +59,7 @@ import {
   validateMrtdPoPChallengeActor,
   verifyTrustFederationActor
 } from "./actors";
-import { Context } from "./context";
+import { Context, IdentificationContext } from "./context";
 import { EidIssuanceEvents } from "./events";
 import { mapEventToFailure } from "./failure";
 import {
@@ -146,7 +146,7 @@ export const itwEidIssuanceMachineSetup = setup({
       identification: {
         mode: "cieId",
         level: "L2"
-      } as const
+      } satisfies IdentificationContext
     })),
 
     /**
@@ -163,7 +163,12 @@ export const itwEidIssuanceMachineSetup = setup({
       ) {
         return {};
       }
-      return { identification: { mode: "cieId", level: "L3" } as const };
+      return {
+        identification: {
+          mode: "cieId",
+          level: "L3"
+        } satisfies IdentificationContext
+      };
     }),
     setFailure: assign(({ event }) => ({ failure: mapEventToFailure(event) })),
     /**

--- a/apps/main-app/ts/features/itwallet/machine/eid/state/cieId.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/state/cieId.ts
@@ -18,7 +18,8 @@ export const cieIdState = itwEidIssuanceMachineSetup.createStateConfig({
           itwVersion: context.itwVersion,
           walletInstanceAttestation: context.walletInstanceAttestation?.jwt,
           identification: context.identification,
-          withMRTDPoP: context.level === "l3"
+          withMRTDPoP: context.level === "l3",
+          deps: context.deps
         }),
         onDone: {
           actions: assign(({ event }) => ({

--- a/apps/main-app/ts/features/itwallet/machine/eid/state/ciePin.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/state/ciePin.ts
@@ -102,7 +102,8 @@ export const ciePinState = itwEidIssuanceMachineSetup.createStateConfig({
           itwVersion: context.itwVersion,
           walletInstanceAttestation: context.walletInstanceAttestation?.jwt,
           identification: context.identification,
-          withMRTDPoP: false
+          withMRTDPoP: false,
+          deps: context.deps
         }),
         onDone: {
           actions: assign(({ event }) => ({

--- a/apps/main-app/ts/features/itwallet/machine/eid/state/credentialsUpgrade.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/state/credentialsUpgrade.ts
@@ -22,7 +22,11 @@ export const credentialsUpgradeState =
             return {
               itwVersion: context.itwVersion,
               credentials: context.credentialsToUpgrade,
-              issuanceMode: context.mode
+              issuanceMode: context.mode,
+              deps: {
+                env: context.deps.env,
+                store: context.deps.store
+              }
             };
           },
           onDone: {

--- a/apps/main-app/ts/features/itwallet/machine/eid/state/issuance.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/state/issuance.ts
@@ -12,7 +12,8 @@ export const issuanceState = itwEidIssuanceMachineSetup.createStateConfig({
     WaitingForSessionRefresh: {
       tags: [ItwTags.Loading],
       invoke: {
-        src: "waitForSessionRefresh"
+        src: "waitForSessionRefresh",
+        input: ({ context }) => ({ deps: context.deps })
       },
       on: {
         "session-refresh-complete": { target: "RequestingEid" }
@@ -25,7 +26,8 @@ export const issuanceState = itwEidIssuanceMachineSetup.createStateConfig({
         input: ({ context }) => ({
           itwVersion: context.itwVersion,
           authenticationContext: context.authenticationContext,
-          walletInstanceAttestation: context.walletInstanceAttestation?.jwt
+          walletInstanceAttestation: context.walletInstanceAttestation?.jwt,
+          deps: context.deps
         }),
         onDone: {
           target: "RequestingEid",
@@ -50,7 +52,8 @@ export const issuanceState = itwEidIssuanceMachineSetup.createStateConfig({
           walletInstanceAttestation: context.walletInstanceAttestation?.jwt,
           level: context.level,
           integrityKeyTag: context.integrityKeyTag,
-          accessToken: context.accessToken
+          accessToken: context.accessToken,
+          deps: context.deps
         }),
         onDone: {
           actions: assign(({ event }) => ({
@@ -131,7 +134,8 @@ export const issuanceState = itwEidIssuanceMachineSetup.createStateConfig({
         input: ({ context }) => ({
           eid: context.eid,
           keyAttestations: context.keyAttestations,
-          walletInstanceStatusList: context.walletInstanceStatusList
+          walletInstanceStatusList: context.walletInstanceStatusList,
+          deps: context.deps
         }),
         onDone: {
           target: "Completed",

--- a/apps/main-app/ts/features/itwallet/machine/eid/state/mrtdPoP.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/state/mrtdPoP.ts
@@ -18,7 +18,8 @@ export const mrtdPoPState = itwEidIssuanceMachineSetup.createStateConfig({
         input: ({ context }) => ({
           itwVersion: context.itwVersion,
           authenticationContext: context.authenticationContext,
-          walletInstanceAttestation: context.walletInstanceAttestation?.jwt
+          walletInstanceAttestation: context.walletInstanceAttestation?.jwt,
+          deps: context.deps
         }),
         onDone: {
           target: "DisplayingCanPreparationInstructions",
@@ -143,7 +144,8 @@ export const mrtdPoPState = itwEidIssuanceMachineSetup.createStateConfig({
           itwVersion: context.itwVersion,
           authenticationContext: context.authenticationContext,
           mrtdContext: context.mrtdContext,
-          walletInstanceAttestation: context.walletInstanceAttestation?.jwt
+          walletInstanceAttestation: context.walletInstanceAttestation?.jwt,
+          deps: context.deps
         }),
         onDone: {
           target: "#itwEidIssuanceMachine.MrtdPoP.Authorization",

--- a/apps/main-app/ts/features/itwallet/machine/eid/state/spid.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/state/spid.ts
@@ -39,7 +39,8 @@ export const spidState = itwEidIssuanceMachineSetup.createStateConfig({
           itwVersion: context.itwVersion,
           walletInstanceAttestation: context.walletInstanceAttestation?.jwt,
           identification: context.identification,
-          withMRTDPoP: context.level === "l3"
+          withMRTDPoP: context.level === "l3",
+          deps: context.deps
         }),
         onDone: {
           actions: assign(({ event }) => ({

--- a/apps/main-app/ts/features/itwallet/machine/upgrade/__tests__/actions.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/upgrade/__tests__/actions.test.ts
@@ -7,12 +7,13 @@ import { appReducer } from "../../../../../store/reducers";
 import { GlobalState } from "../../../../../store/reducers/types";
 import { ItwStoredCredentialsMocks } from "../../../common/utils/itwMocksUtils";
 import { itwCredentialsReplaceByType } from "../../../credentials/store/actions";
-import { createCredentialUpgradeActionsImplementation } from "../actions";
+import { storeCredentialAction } from "../actions";
 import { Context } from "../context";
 import { CredentialUpgradeEvents } from "../events";
+import { CredentialUpgradeMachineDeps } from "../input";
 
 describe("itwCredentialUpgradeMachine actions", () => {
-  describe("storeCredential", () => {
+  describe("storeCredentialAction", () => {
     it("should store the new credential removing the old one", () => {
       const mockDispatch = jest.fn();
       const mockStore = {
@@ -20,10 +21,10 @@ describe("itwCredentialUpgradeMachine actions", () => {
         dispatch: mockDispatch
       } as ReturnType<typeof useIOStore>;
 
-      const { storeCredential } =
-        createCredentialUpgradeActionsImplementation(mockStore);
-
-      storeCredential({
+      storeCredentialAction({
+        context: {
+          deps: { store: mockStore } as CredentialUpgradeMachineDeps
+        } as Context,
         event: {
           type: "xstate.done.actor.upgradeCredential",
           actorId: "upgradeCredential",

--- a/apps/main-app/ts/features/itwallet/machine/upgrade/__tests__/actions.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/upgrade/__tests__/actions.test.ts
@@ -1,29 +1,25 @@
-import { default as configureMockStore } from "redux-mock-store";
 import { ActionArgs } from "xstate";
 
-import { applicationChangeState } from "../../../../../store/actions/application";
-import { useIOStore } from "../../../../../store/hooks";
-import { appReducer } from "../../../../../store/reducers";
-import { GlobalState } from "../../../../../store/reducers/types";
 import { ItwStoredCredentialsMocks } from "../../../common/utils/itwMocksUtils";
 import { itwCredentialsReplaceByType } from "../../../credentials/store/actions";
+import {
+  testCredentialUpgradeDeps,
+  testMachineStore
+} from "../../utils/testDeps";
 import { storeCredentialAction } from "../actions";
 import { Context } from "../context";
 import { CredentialUpgradeEvents } from "../events";
-import { CredentialUpgradeMachineDeps } from "../input";
 
 describe("itwCredentialUpgradeMachine actions", () => {
   describe("storeCredentialAction", () => {
     it("should store the new credential removing the old one", () => {
       const mockDispatch = jest.fn();
-      const mockStore = {
-        ...createMockStore(),
-        dispatch: mockDispatch
-      } as ReturnType<typeof useIOStore>;
 
       storeCredentialAction({
         context: {
-          deps: { store: mockStore } as CredentialUpgradeMachineDeps
+          deps: testCredentialUpgradeDeps({
+            store: testMachineStore({ dispatch: mockDispatch })
+          })
         } as Context,
         event: {
           type: "xstate.done.actor.upgradeCredential",
@@ -58,9 +54,3 @@ describe("itwCredentialUpgradeMachine actions", () => {
     });
   });
 });
-
-const createMockStore = () => {
-  const defaultState = appReducer(undefined, applicationChangeState("active"));
-  const mockStore = configureMockStore<GlobalState>();
-  return mockStore(defaultState);
-};

--- a/apps/main-app/ts/features/itwallet/machine/upgrade/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/upgrade/__tests__/machine.test.ts
@@ -3,6 +3,7 @@ import { createActor, fromCallback, fromPromise, waitFor } from "xstate";
 import { ItwSessionExpiredError } from "../../../api/client";
 import { CredentialMetadata } from "../../../common/utils/itwTypesUtils";
 import {
+  LoadContextInput,
   LoadContextOutput,
   RequestAccessTokenOutput,
   RequestAccessTokenParams,
@@ -52,7 +53,9 @@ describe("itwCredentialUpgradeMachine", () => {
           RequestAccessTokenOutput,
           RequestAccessTokenParams
         >(mockRequestAccessToken),
-        loadContext: fromPromise<LoadContextOutput>(mockLoadContext),
+        loadContext: fromPromise<LoadContextOutput, LoadContextInput>(
+          mockLoadContext
+        ),
         upgradeCredential: fromPromise<
           UpgradeCredentialOutput,
           UpgradeCredentialParams
@@ -92,7 +95,9 @@ describe("itwCredentialUpgradeMachine", () => {
           RequestAccessTokenOutput,
           RequestAccessTokenParams
         >(mockRequestAccessToken),
-        loadContext: fromPromise<LoadContextOutput>(mockLoadContext),
+        loadContext: fromPromise<LoadContextOutput, LoadContextInput>(
+          mockLoadContext
+        ),
         upgradeCredential: fromPromise<
           UpgradeCredentialOutput,
           UpgradeCredentialParams
@@ -142,7 +147,9 @@ describe("itwCredentialUpgradeMachine", () => {
           RequestAccessTokenOutput,
           RequestAccessTokenParams
         >(mockRequestAccessToken),
-        loadContext: fromPromise<LoadContextOutput>(mockLoadContext),
+        loadContext: fromPromise<LoadContextOutput, LoadContextInput>(
+          mockLoadContext
+        ),
         upgradeCredential: fromPromise<
           UpgradeCredentialOutput,
           UpgradeCredentialParams
@@ -193,7 +200,9 @@ describe("itwCredentialUpgradeMachine", () => {
           RequestAccessTokenOutput,
           RequestAccessTokenParams
         >(mockRequestAccessToken),
-        loadContext: fromPromise<LoadContextOutput>(mockLoadContext),
+        loadContext: fromPromise<LoadContextOutput, LoadContextInput>(
+          mockLoadContext
+        ),
         upgradeCredential: fromPromise<
           UpgradeCredentialOutput,
           UpgradeCredentialParams

--- a/apps/main-app/ts/features/itwallet/machine/upgrade/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/upgrade/__tests__/machine.test.ts
@@ -2,6 +2,7 @@ import { createActor, fromCallback, fromPromise, waitFor } from "xstate";
 
 import { ItwSessionExpiredError } from "../../../api/client";
 import { CredentialMetadata } from "../../../common/utils/itwTypesUtils";
+import { testCredentialUpgradeDeps } from "../../utils/testDeps";
 import {
   LoadContextInput,
   LoadContextOutput,
@@ -10,10 +11,9 @@ import {
   UpgradeCredentialOutput,
   UpgradeCredentialParams
 } from "../actors";
-import { CredentialUpgradeMachineDeps } from "../input";
 import { itwCredentialUpgradeMachine } from "../machine";
 
-const T_DEPS = {} as CredentialUpgradeMachineDeps;
+const T_DEPS = testCredentialUpgradeDeps();
 
 const mockLoadContext = jest.fn(() => Promise.resolve({} as LoadContextOutput));
 

--- a/apps/main-app/ts/features/itwallet/machine/upgrade/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/upgrade/__tests__/machine.test.ts
@@ -9,7 +9,10 @@ import {
   UpgradeCredentialOutput,
   UpgradeCredentialParams
 } from "../actors";
+import { CredentialUpgradeMachineDeps } from "../input";
 import { itwCredentialUpgradeMachine } from "../machine";
+
+const T_DEPS = {} as CredentialUpgradeMachineDeps;
 
 const mockLoadContext = jest.fn(() => Promise.resolve({} as LoadContextOutput));
 
@@ -61,7 +64,8 @@ describe("itwCredentialUpgradeMachine", () => {
       input: {
         credentials: [],
         issuanceMode: "upgrade",
-        itwVersion: "1.4.6"
+        itwVersion: "1.4.6",
+        deps: T_DEPS
       }
     });
     actor.start();
@@ -106,7 +110,8 @@ describe("itwCredentialUpgradeMachine", () => {
       input: {
         credentials,
         issuanceMode: "upgrade",
-        itwVersion: "1.4.6"
+        itwVersion: "1.4.6",
+        deps: T_DEPS
       }
     });
     actor.start();
@@ -153,7 +158,8 @@ describe("itwCredentialUpgradeMachine", () => {
       input: {
         credentials,
         issuanceMode: "upgrade",
-        itwVersion: "1.4.6"
+        itwVersion: "1.4.6",
+        deps: T_DEPS
       }
     });
     actor.start();
@@ -206,7 +212,8 @@ describe("itwCredentialUpgradeMachine", () => {
       input: {
         credentials,
         issuanceMode: "upgrade",
-        itwVersion: "1.4.6"
+        itwVersion: "1.4.6",
+        deps: T_DEPS
       }
     });
     actor.start();

--- a/apps/main-app/ts/features/itwallet/machine/upgrade/actions.ts
+++ b/apps/main-app/ts/features/itwallet/machine/upgrade/actions.ts
@@ -1,26 +1,27 @@
 import { ActionArgs, assertEvent } from "xstate";
 
-import { useIOStore } from "../../../../store/hooks";
 import { checkCurrentSession } from "../../../authentication/common/store/actions";
 import { itwCredentialsReplaceByType } from "../../credentials/store/actions";
 import { itwKeyAttestationsStore } from "../../walletInstance/store/actions";
 import { Context } from "./context";
 import { CredentialUpgradeEvents } from "./events";
 
-export const createCredentialUpgradeActionsImplementation = (
-  store: ReturnType<typeof useIOStore>
-) => ({
-  storeCredential: ({
-    event
-  }: ActionArgs<Context, CredentialUpgradeEvents, CredentialUpgradeEvents>) => {
-    assertEvent(event, "xstate.done.actor.upgradeCredential");
-    const { credentials, keyAttestations } = event.output;
-    // Removes old credentials and stores the new ones atomically
-    store.dispatch(itwCredentialsReplaceByType(credentials, {}));
-    // Stores Key Attestations separately
-    store.dispatch(itwKeyAttestationsStore(keyAttestations));
-  },
+export const storeCredentialAction = ({
+  context,
+  event
+}: ActionArgs<Context, CredentialUpgradeEvents, CredentialUpgradeEvents>) => {
+  assertEvent(event, "xstate.done.actor.upgradeCredential");
+  const { credentials, keyAttestations } = event.output;
+  const { store } = context.deps;
+  // Removes old credentials and stores the new ones atomically
+  store.dispatch(itwCredentialsReplaceByType(credentials, {}));
+  // Stores Key Attestations separately
+  store.dispatch(itwKeyAttestationsStore(keyAttestations));
+};
 
-  handleSessionExpired: () =>
-    store.dispatch(checkCurrentSession.success({ isSessionValid: false }))
-});
+export const handleSessionExpiredAction = ({
+  context
+}: ActionArgs<Context, CredentialUpgradeEvents, CredentialUpgradeEvents>) =>
+  context.deps.store.dispatch(
+    checkCurrentSession.success({ isSessionValid: false })
+  );

--- a/apps/main-app/ts/features/itwallet/machine/upgrade/actors.ts
+++ b/apps/main-app/ts/features/itwallet/machine/upgrade/actors.ts
@@ -85,9 +85,7 @@ export const loadContextActor = fromPromise<
   const pidMetadata = itwCredentialsEidSelector(state);
   assert(pidMetadata, "PID credential is not present in the store");
 
-  const pid = await CredentialsVault.get(
-    getRepresentativeVaultId(pidMetadata)
-  );
+  const pid = await CredentialsVault.get(getRepresentativeVaultId(pidMetadata));
   assert(pid, "PID credential not found in secure storage");
 
   return {
@@ -178,15 +176,12 @@ export const upgradeCredentialActor = fromPromise<
   }
 
   const authorizedCredentials =
-    await credentialIssuanceUtils.generateKeysWithKeyAttestation(
-      accessToken,
-      {
-        env,
-        itwVersion,
-        hardwareKeyTag: integrityKeyTag,
-        sessionToken
-      }
-    );
+    await credentialIssuanceUtils.generateKeysWithKeyAttestation(accessToken, {
+      env,
+      itwVersion,
+      hardwareKeyTag: integrityKeyTag,
+      sessionToken
+    });
 
   const credentials = await credentialIssuanceUtils.obtainCredential({
     env,

--- a/apps/main-app/ts/features/itwallet/machine/upgrade/actors.ts
+++ b/apps/main-app/ts/features/itwallet/machine/upgrade/actors.ts
@@ -5,10 +5,8 @@ import type {
 
 import { fromPromise } from "xstate";
 
-import { useIOStore } from "../../../../store/hooks";
 import { assert } from "../../../../utils/assert";
 import { sessionTokenSelector } from "../../../authentication/common/store/selectors";
-import { Env } from "../../common/utils/environment";
 import * as credentialIssuanceUtils from "../../common/utils/itwCredentialIssuanceUtils";
 import { getRepresentativeVaultId } from "../../common/utils/itwCredentialUtils";
 import { getIoWallet } from "../../common/utils/itwIoWallet";
@@ -27,7 +25,11 @@ import { itwIntegrityKeyTagSelector } from "../../issuance/store/selectors";
 import { getCredentialStatusFromStatusList } from "../../statusList/utils";
 import { itwWalletInstanceAttestationSelector } from "../../walletInstance/store/selectors";
 import { EidIssuanceMode } from "../eid/context";
-import { createCommonActorsImplementation } from "../utils/actors";
+import { CredentialUpgradeMachineDeps } from "./input";
+
+export type LoadContextInput = {
+  deps: CredentialUpgradeMachineDeps;
+};
 
 export type LoadContextOutput = {
   integrityKeyTag: string;
@@ -43,6 +45,7 @@ export type RequestAccessTokenOutput = {
 
 export type RequestAccessTokenParams = WithItwVersion<{
   credential: CredentialMetadata;
+  deps: CredentialUpgradeMachineDeps;
   issuanceMode: EidIssuanceMode;
   pid: CredentialBundle | undefined;
   walletInstanceAttestation: string | undefined;
@@ -57,6 +60,7 @@ export type UpgradeCredentialOutput = {
 export type UpgradeCredentialParams = WithItwVersion<
   Partial<RequestAccessTokenOutput> & {
     credential: CredentialMetadata;
+    deps: CredentialUpgradeMachineDeps;
     integrityKeyTag: string | undefined;
   }
 >;
@@ -65,155 +69,152 @@ type WithItwVersion<T = { [K: string]: any }> = T & {
   itwVersion: ItwVersion;
 };
 
-export const createCredentialUpgradeActorsImplementation = (
-  env: Env,
-  store: ReturnType<typeof useIOStore>
-) => ({
-  loadContext: fromPromise<LoadContextOutput>(async () => {
-    const state = store.getState();
-    const walletInstanceAttestation =
-      itwWalletInstanceAttestationSelector(state);
-    assert(
-      walletInstanceAttestation,
-      "walletInstanceAttestation is not present in the store"
-    );
-    const integrityKeyTag = itwIntegrityKeyTagSelector(state);
-    assert(integrityKeyTag, "Integrity key tag is not present in the store");
+export const loadContextActor = fromPromise<
+  LoadContextOutput,
+  LoadContextInput
+>(async ({ input }) => {
+  const state = input.deps.store.getState();
+  const walletInstanceAttestation = itwWalletInstanceAttestationSelector(state);
+  assert(
+    walletInstanceAttestation,
+    "walletInstanceAttestation is not present in the store"
+  );
+  const integrityKeyTag = itwIntegrityKeyTagSelector(state);
+  assert(integrityKeyTag, "Integrity key tag is not present in the store");
 
-    const pidMetadata = itwCredentialsEidSelector(state);
-    assert(pidMetadata, "PID credential is not present in the store");
+  const pidMetadata = itwCredentialsEidSelector(state);
+  assert(pidMetadata, "PID credential is not present in the store");
 
-    const pid = await CredentialsVault.get(
-      getRepresentativeVaultId(pidMetadata)
-    );
-    assert(pid, "PID credential not found in secure storage");
+  const pid = await CredentialsVault.get(
+    getRepresentativeVaultId(pidMetadata)
+  );
+  assert(pid, "PID credential not found in secure storage");
 
-    return {
-      pid: {
-        metadata: pidMetadata,
-        credential: pid
-      },
-      walletInstanceAttestation,
-      integrityKeyTag
-    };
-  }),
+  return {
+    pid: {
+      metadata: pidMetadata,
+      credential: pid
+    },
+    walletInstanceAttestation,
+    integrityKeyTag
+  };
+});
 
-  requestAccessToken: fromPromise<
-    RequestAccessTokenOutput,
-    RequestAccessTokenParams
-  >(async ({ input }) => {
-    const { pid, walletInstanceAttestation, credential, issuanceMode } = input;
-    const isUpgrade = issuanceMode === "upgrade";
+export const requestAccessTokenActor = fromPromise<
+  RequestAccessTokenOutput,
+  RequestAccessTokenParams
+>(async ({ input }) => {
+  const { pid, walletInstanceAttestation, credential, issuanceMode } = input;
+  const { env } = input.deps;
+  const isUpgrade = issuanceMode === "upgrade";
 
-    assert(pid, "PID credential is undefined");
-    assert(walletInstanceAttestation, "walletInstanceAttestation is undefined");
+  assert(pid, "PID credential is undefined");
+  assert(walletInstanceAttestation, "walletInstanceAttestation is undefined");
 
-    const {
-      requestedCredential,
-      issuerConf,
-      clientId,
-      codeVerifier,
-      evaluatedDcqlQuery,
-      responseMode
-    } = await credentialIssuanceUtils.requestCredential({
-      env,
-      itwVersion: input.itwVersion,
-      credentialType: credential.credentialType,
-      walletInstanceAttestation,
-      // TODO [SIW-3091]: Update when the L3 PID reissuance flow is ready
-      skipMdocIssuance: !isUpgrade,
-      pid
-    });
+  const {
+    requestedCredential,
+    issuerConf,
+    clientId,
+    codeVerifier,
+    evaluatedDcqlQuery,
+    responseMode
+  } = await credentialIssuanceUtils.requestCredential({
+    env,
+    itwVersion: input.itwVersion,
+    credentialType: credential.credentialType,
+    walletInstanceAttestation,
+    // TODO [SIW-3091]: Update when the L3 PID reissuance flow is ready
+    skipMdocIssuance: !isUpgrade,
+    pid
+  });
 
-    const { accessToken } = await credentialIssuanceUtils.completeAuthFlow({
-      env,
-      itwVersion: input.itwVersion,
-      codeVerifier,
-      responseMode,
-      issuerConf,
-      walletInstanceAttestation,
-      requestedCredential,
-      evaluatedDcqlQuery
-    });
+  const { accessToken } = await credentialIssuanceUtils.completeAuthFlow({
+    env,
+    itwVersion: input.itwVersion,
+    codeVerifier,
+    responseMode,
+    issuerConf,
+    walletInstanceAttestation,
+    requestedCredential,
+    evaluatedDcqlQuery
+  });
 
-    return { accessToken, issuerConf, clientId };
-  }),
+  return { accessToken, issuerConf, clientId };
+});
 
-  /**
-   * Handles both upgrading and reissuing credentials depending on issuanceMode.
-   * - upgrade → performs credential upgrade (skipMdocIssuance = false)
-   * - reissuance → performs credential reissuing (skipMdocIssuance = true)
-   *
-   * To ensure a smooth experience when the session token expires, it is important to keep this actor
-   * retriable: it must fail as early as possible when `generateKeysWithKeyAttestation` is
-   * rejected for session expired, so it can be reentered and retried from where it failed.
-   */
-  upgradeCredential: fromPromise<
-    UpgradeCredentialOutput,
-    UpgradeCredentialParams
-  >(async ({ input }) => {
-    const {
+/**
+ * Handles both upgrading and reissuing credentials depending on issuanceMode.
+ * - upgrade → performs credential upgrade (skipMdocIssuance = false)
+ * - reissuance → performs credential reissuing (skipMdocIssuance = true)
+ *
+ * To ensure a smooth experience when the session token expires, it is important to keep this actor
+ * retriable: it must fail as early as possible when `generateKeysWithKeyAttestation` is
+ * rejected for session expired, so it can be reentered and retried from where it failed.
+ */
+export const upgradeCredentialActor = fromPromise<
+  UpgradeCredentialOutput,
+  UpgradeCredentialParams
+>(async ({ input }) => {
+  const {
+    accessToken,
+    issuerConf,
+    clientId,
+    credential,
+    integrityKeyTag,
+    itwVersion
+  } = input;
+  const { env, store } = input.deps;
+
+  const sessionToken = sessionTokenSelector(store.getState());
+  assert(sessionToken, "sessionToken is undefined");
+  assert(
+    issuerConf && clientId && accessToken && integrityKeyTag,
+    "Some of the required parameters for credential upgrade are undefined"
+  );
+
+  // The Key Attestation makes use of the integrity service
+  if (getIoWallet(itwVersion).KeyAttestation.isSupported) {
+    await ensureIntegrityServiceIsStoreReadyOrThrow(store);
+  }
+
+  const authorizedCredentials =
+    await credentialIssuanceUtils.generateKeysWithKeyAttestation(
       accessToken,
-      issuerConf,
-      clientId,
-      credential,
-      integrityKeyTag,
-      itwVersion
-    } = input;
-
-    const sessionToken = sessionTokenSelector(store.getState());
-    assert(sessionToken, "sessionToken is undefined");
-    assert(
-      issuerConf && clientId && accessToken && integrityKeyTag,
-      "Some of the required parameters for credential upgrade are undefined"
+      {
+        env,
+        itwVersion,
+        hardwareKeyTag: integrityKeyTag,
+        sessionToken
+      }
     );
 
-    // The Key Attestation makes use of the integrity service
-    if (getIoWallet(itwVersion).KeyAttestation.isSupported) {
-      await ensureIntegrityServiceIsStoreReadyOrThrow(store);
-    }
+  const credentials = await credentialIssuanceUtils.obtainCredential({
+    env,
+    itwVersion,
+    credentialType: credential.credentialType,
+    issuerConf,
+    clientId,
+    accessToken,
+    authorizedCredentials
+  });
 
-    const authorizedCredentials =
-      await credentialIssuanceUtils.generateKeysWithKeyAttestation(
-        accessToken,
-        {
-          env,
-          itwVersion,
-          hardwareKeyTag: integrityKeyTag,
-          sessionToken
-        }
-      );
+  const bundles = await enrichBundlesWithStatusList(
+    itwVersion,
+    issuerConf,
+    credentials
+  );
 
-    const credentials = await credentialIssuanceUtils.obtainCredential({
-      env,
-      itwVersion,
-      credentialType: credential.credentialType,
-      issuerConf,
-      clientId,
-      accessToken,
-      authorizedCredentials
-    });
-
-    const bundles = await enrichBundlesWithStatusList(
-      itwVersion,
-      issuerConf,
-      credentials
-    );
-
-    return {
-      credentialType: credential.credentialType,
-      credentials: bundles,
-      keyAttestations: authorizedCredentials.reduce(
-        (acc, c) =>
-          c.keyAttestationId && c.keyAttestation
-            ? { ...acc, [c.keyAttestationId]: c.keyAttestation }
-            : acc,
-        {} as Record<string, string>
-      )
-    };
-  }),
-
-  ...createCommonActorsImplementation(store)
+  return {
+    credentialType: credential.credentialType,
+    credentials: bundles,
+    keyAttestations: authorizedCredentials.reduce(
+      (acc, c) =>
+        c.keyAttestationId && c.keyAttestation
+          ? { ...acc, [c.keyAttestationId]: c.keyAttestation }
+          : acc,
+      {} as Record<string, string>
+    )
+  };
 });
 
 /**

--- a/apps/main-app/ts/features/itwallet/machine/upgrade/context.ts
+++ b/apps/main-app/ts/features/itwallet/machine/upgrade/context.ts
@@ -8,7 +8,7 @@ import {
   WalletInstanceAttestations
 } from "../../common/utils/itwTypesUtils";
 import { EidIssuanceMode } from "../eid/context";
-import { Input } from "./input";
+import { CredentialUpgradeMachineDeps, Input } from "./input";
 
 export type Context = {
   /**
@@ -25,6 +25,10 @@ export type Context = {
    * Credentials that must be upgraded to L3
    */
   credentials: ReadonlyArray<CredentialMetadata>;
+  /**
+   * Runtime dependencies injected via machine input
+   */
+  deps: CredentialUpgradeMachineDeps;
   /**
    * Credentials that failed the upgrade process
    */
@@ -59,6 +63,7 @@ export type Context = {
 };
 
 export const getInitialContext = (input: Input): Context => ({
+  deps: input.deps,
   itwVersion: input.itwVersion,
   walletInstanceAttestation: undefined,
   pid: undefined,

--- a/apps/main-app/ts/features/itwallet/machine/upgrade/input.ts
+++ b/apps/main-app/ts/features/itwallet/machine/upgrade/input.ts
@@ -1,13 +1,13 @@
 import { ItwVersion } from "@pagopa/io-react-native-wallet";
 
-import { useIOStore } from "../../../../store/hooks";
 import { Env } from "../../common/utils/environment";
 import { CredentialMetadata } from "../../common/utils/itwTypesUtils";
 import { EidIssuanceMode } from "../eid/context";
+import { MachineStore } from "../utils/deps";
 
 export type CredentialUpgradeMachineDeps = {
   env: Env;
-  store: ReturnType<typeof useIOStore>;
+  store: MachineStore;
 };
 
 export type Input = {

--- a/apps/main-app/ts/features/itwallet/machine/upgrade/input.ts
+++ b/apps/main-app/ts/features/itwallet/machine/upgrade/input.ts
@@ -1,13 +1,24 @@
 import { ItwVersion } from "@pagopa/io-react-native-wallet";
 
+import { useIOStore } from "../../../../store/hooks";
+import { Env } from "../../common/utils/environment";
 import { CredentialMetadata } from "../../common/utils/itwTypesUtils";
 import { EidIssuanceMode } from "../eid/context";
+
+export type CredentialUpgradeMachineDeps = {
+  env: Env;
+  store: ReturnType<typeof useIOStore>;
+};
 
 export type Input = {
   /**
    * Array of credentials that must be upgraded to L3
    */
   credentials: ReadonlyArray<CredentialMetadata>;
+  /**
+   * Runtime dependencies injected by the parent machine
+   */
+  deps: CredentialUpgradeMachineDeps;
   /**
    * The issuance mode considered by the credential upgrade machine.
    * - "upgrade": upgrade from Documenti su IO to IT Wallet, upgrading also owned credentials.

--- a/apps/main-app/ts/features/itwallet/machine/upgrade/machine.ts
+++ b/apps/main-app/ts/features/itwallet/machine/upgrade/machine.ts
@@ -12,6 +12,7 @@ export const itwCredentialUpgradeMachine = itwUpgradeSetup.createMachine({
     LoadingContext: {
       invoke: {
         src: "loadContext",
+        input: ({ context }) => ({ deps: context.deps }),
         onDone: {
           target: "Checking",
           actions: assign(({ event }) => ({
@@ -41,6 +42,7 @@ export const itwCredentialUpgradeMachine = itwUpgradeSetup.createMachine({
           pid: context.pid,
           walletInstanceAttestation: context.walletInstanceAttestation?.jwt,
           credential: context.credentials[context.credentialIndex],
+          deps: context.deps,
           issuanceMode: context.issuanceMode,
           itwVersion: context.itwVersion
         }),
@@ -68,7 +70,8 @@ export const itwCredentialUpgradeMachine = itwUpgradeSetup.createMachine({
           clientId: context.clientId,
           integrityKeyTag: context.integrityKeyTag,
           issuanceMode: context.issuanceMode,
-          itwVersion: context.itwVersion
+          itwVersion: context.itwVersion,
+          deps: context.deps
         }),
         onDone: {
           actions: ["storeCredential"],
@@ -89,7 +92,8 @@ export const itwCredentialUpgradeMachine = itwUpgradeSetup.createMachine({
     },
     WaitingForSessionRefresh: {
       invoke: {
-        src: "waitForSessionRefresh"
+        src: "waitForSessionRefresh",
+        input: ({ context }) => ({ deps: context.deps })
       },
       on: {
         "session-refresh-complete": { target: "UpgradeCredential" }

--- a/apps/main-app/ts/features/itwallet/machine/upgrade/setup.ts
+++ b/apps/main-app/ts/features/itwallet/machine/upgrade/setup.ts
@@ -1,22 +1,18 @@
-import { assign, fromCallback, fromPromise, setup } from "xstate";
+import { assign, setup } from "xstate";
 
 import { ItwSessionExpiredError } from "../../api/client";
+import { waitForSessionRefreshActor } from "../utils/actors";
+import { handleSessionExpiredAction, storeCredentialAction } from "./actions";
 import {
-  LoadContextOutput,
-  RequestAccessTokenOutput,
-  RequestAccessTokenParams,
-  UpgradeCredentialOutput,
-  UpgradeCredentialParams
+  loadContextActor,
+  requestAccessTokenActor,
+  upgradeCredentialActor
 } from "./actors";
 import { Context } from "./context";
 import { CredentialUpgradeEvents } from "./events";
 import { mapUpgradeEventToFailure } from "./failure";
 import { Input } from "./input";
 import { Output } from "./output";
-
-const notImplemented = () => {
-  throw new Error("Not implemented");
-};
 
 /** Defines typed credential-upgrade actors while providers inject runtime side effects. */
 export const itwUpgradeSetup = setup({
@@ -27,7 +23,7 @@ export const itwUpgradeSetup = setup({
     output: {} as Output
   },
   actions: {
-    storeCredential: notImplemented,
+    storeCredential: storeCredentialAction,
     pickNextCredential: assign({
       credentialIndex: ({ context }) => context.credentialIndex + 1
     }),
@@ -48,19 +44,13 @@ export const itwUpgradeSetup = setup({
         return [...context.failedCredentials, failedCredential];
       }
     }),
-    handleSessionExpired: notImplemented
+    handleSessionExpired: handleSessionExpiredAction
   },
   actors: {
-    requestAccessToken: fromPromise<
-      RequestAccessTokenOutput,
-      RequestAccessTokenParams
-    >(notImplemented),
-    loadContext: fromPromise<LoadContextOutput>(notImplemented),
-    upgradeCredential: fromPromise<
-      UpgradeCredentialOutput,
-      UpgradeCredentialParams
-    >(notImplemented),
-    waitForSessionRefresh: fromCallback(notImplemented)
+    requestAccessToken: requestAccessTokenActor,
+    loadContext: loadContextActor,
+    upgradeCredential: upgradeCredentialActor,
+    waitForSessionRefresh: waitForSessionRefreshActor
   },
   guards: {
     isSessionExpired: ({ event }) =>

--- a/apps/main-app/ts/features/itwallet/machine/utils/actors.ts
+++ b/apps/main-app/ts/features/itwallet/machine/utils/actors.ts
@@ -3,31 +3,31 @@ import { fromCallback } from "xstate";
 import { useIOStore } from "../../../../store/hooks";
 import { sessionTokenSelector } from "../../../authentication/common/store/selectors";
 
+export type WaitForSessionRefreshInput = {
+  deps: {
+    store: ReturnType<typeof useIOStore>;
+  };
+};
+
 /**
- * Create actors that are shared across multiple IT-Wallet state machines.
- *
- * @param store The Redux store
- * @returns An object with actors implementation
+ * Actor that waits for the session token to be refreshed in the Redux store.
+ * When the token is updated, it notifies the parent machine with a `session-refresh-complete` event.
  */
-export const createCommonActorsImplementation = (
-  store: ReturnType<typeof useIOStore>
-) => ({
-  /**
-   * Actor that waits for the session token to be refreshed in the Redux store.
-   * When the token is updated, it notifies the parent machine with a `session-refresh-complete` event.
-   */
-  waitForSessionRefresh: fromCallback(({ sendBack }) => {
-    const oldSessionToken = sessionTokenSelector(store.getState());
+export const waitForSessionRefreshActor = fromCallback<
+  { type: "session-refresh-complete" },
+  WaitForSessionRefreshInput
+>(({ sendBack, input }) => {
+  const { store } = input.deps;
+  const oldSessionToken = sessionTokenSelector(store.getState());
 
-    const unsubscribe = store.subscribe(() => {
-      const currentSessionToken = sessionTokenSelector(store.getState());
-      if (currentSessionToken !== oldSessionToken) {
-        sendBack({ type: "session-refresh-complete" });
-      }
-    });
+  const unsubscribe = store.subscribe(() => {
+    const currentSessionToken = sessionTokenSelector(store.getState());
+    if (currentSessionToken !== oldSessionToken) {
+      sendBack({ type: "session-refresh-complete" });
+    }
+  });
 
-    return () => {
-      unsubscribe();
-    };
-  })
+  return () => {
+    unsubscribe();
+  };
 });

--- a/apps/main-app/ts/features/itwallet/machine/utils/actors.ts
+++ b/apps/main-app/ts/features/itwallet/machine/utils/actors.ts
@@ -1,11 +1,11 @@
 import { fromCallback } from "xstate";
 
-import { useIOStore } from "../../../../store/hooks";
 import { sessionTokenSelector } from "../../../authentication/common/store/selectors";
+import { MachineStore } from "./deps";
 
 export type WaitForSessionRefreshInput = {
   deps: {
-    store: ReturnType<typeof useIOStore>;
+    store: MachineStore;
   };
 };
 

--- a/apps/main-app/ts/features/itwallet/machine/utils/deps.ts
+++ b/apps/main-app/ts/features/itwallet/machine/utils/deps.ts
@@ -1,0 +1,38 @@
+import { IOToast } from "@io-app/design-system";
+
+import { useIONavigation } from "../../../../navigation/params/AppParamsList";
+import { GlobalState } from "../../../../store/reducers/types";
+
+/**
+ * Navigation surface used by IT Wallet machines.
+ * Providers can pass the full `useIONavigation()` result.
+ */
+export type MachineNavigation = Pick<
+  IONavigation,
+  | "canGoBack"
+  | "getState"
+  | "goBack"
+  | "navigate"
+  | "pop"
+  | "popToTop"
+  | "replace"
+  | "reset"
+>;
+
+/**
+ * Redux store surface used by IT Wallet machines.
+ * Providers can pass the full `useIOStore()` result.
+ */
+export type MachineStore = {
+  dispatch(action: unknown): unknown;
+  getState(): GlobalState;
+  subscribe(listener: () => void): () => void;
+};
+
+/**
+ * Toast surface used by IT Wallet machines.
+ * Providers can pass the full `useIOToast()` result.
+ */
+export type MachineToast = Pick<IOToast, "error" | "success">;
+
+type IONavigation = ReturnType<typeof useIONavigation>;

--- a/apps/main-app/ts/features/itwallet/machine/utils/testDeps.ts
+++ b/apps/main-app/ts/features/itwallet/machine/utils/testDeps.ts
@@ -1,0 +1,109 @@
+import { applicationChangeState } from "../../../../store/actions/application";
+import { appReducer } from "../../../../store/reducers";
+import { getEnv } from "../../common/utils/environment";
+import { ProximityMachineDeps } from "../../presentation/proximity/machine/input";
+import { RemoteMachineDeps } from "../../presentation/remote/machine/input";
+import { TrustmarkMachineDeps } from "../../trustmark/machine/input";
+import { CredentialIssuanceMachineDeps } from "../credential/input";
+import { EidIssuanceMachineDeps } from "../eid/input";
+import { CredentialUpgradeMachineDeps } from "../upgrade/input";
+import { MachineNavigation, MachineStore, MachineToast } from "./deps";
+
+const noop = () => undefined;
+
+export const testMachineStore = (
+  store: Partial<MachineStore> = {}
+): MachineStore => ({
+  dispatch: noop,
+  getState: () => appReducer(undefined, applicationChangeState("active")),
+  subscribe: () => noop,
+  ...store
+});
+
+export const testMachineNavigation = (
+  navigation: Partial<MachineNavigation> = {}
+): MachineNavigation => ({
+  canGoBack: () => false,
+  getState: () => ({
+    index: 0,
+    key: "test",
+    routeNames: [],
+    routes: [],
+    stale: false,
+    type: "stack"
+  }),
+  goBack: noop,
+  navigate: noop,
+  pop: noop,
+  popToTop: noop,
+  replace: noop,
+  reset: noop,
+  ...navigation
+});
+
+export const testMachineToast = (
+  toast: Partial<MachineToast> = {}
+): MachineToast => ({
+  error: noop,
+  success: noop,
+  ...toast
+});
+
+export const testEidIssuanceDeps = (
+  overrides: Partial<EidIssuanceMachineDeps> = {}
+): EidIssuanceMachineDeps => ({
+  env: getEnv("pre"),
+  navigation: testMachineNavigation(),
+  store: testMachineStore(),
+  toast: testMachineToast(),
+  ...overrides
+});
+
+export const testCredentialIssuanceDeps = (
+  overrides: Partial<CredentialIssuanceMachineDeps> = {}
+): CredentialIssuanceMachineDeps => ({
+  env: getEnv("pre"),
+  itwVersion: "1.0.0",
+  navigation: testMachineNavigation(),
+  store: testMachineStore(),
+  toast: testMachineToast(),
+  ...overrides
+});
+
+export const testCredentialUpgradeDeps = (
+  overrides: Partial<CredentialUpgradeMachineDeps> = {}
+): CredentialUpgradeMachineDeps => ({
+  env: getEnv("pre"),
+  store: testMachineStore(),
+  ...overrides
+});
+
+export const testProximityDeps = (
+  overrides: Partial<ProximityMachineDeps> = {}
+): ProximityMachineDeps => ({
+  env: getEnv("pre"),
+  navigation: testMachineNavigation(),
+  store: testMachineStore(),
+  ...overrides
+});
+
+export const testRemoteDeps = (
+  overrides: Partial<RemoteMachineDeps> = {}
+): RemoteMachineDeps => ({
+  env: getEnv("pre"),
+  itwVersion: "1.0.0",
+  navigation: testMachineNavigation(),
+  store: testMachineStore(),
+  ...overrides
+});
+
+export const testTrustmarkDeps = (
+  overrides: Partial<TrustmarkMachineDeps> = {}
+): TrustmarkMachineDeps => ({
+  env: getEnv("pre"),
+  itwVersion: "1.0.0",
+  navigation: testMachineNavigation(),
+  store: testMachineStore(),
+  toast: testMachineToast(),
+  ...overrides
+});

--- a/apps/main-app/ts/features/itwallet/machine/utils/testDeps.ts
+++ b/apps/main-app/ts/features/itwallet/machine/utils/testDeps.ts
@@ -11,7 +11,9 @@ import { MachineNavigation, MachineStore, MachineToast } from "./deps";
 
 const noop = () => undefined;
 
-const testMachineStore = (store: Partial<MachineStore> = {}): MachineStore => ({
+export const testMachineStore = (
+  store: Partial<MachineStore> = {}
+): MachineStore => ({
   dispatch: noop,
   getState: () => appReducer(undefined, applicationChangeState("active")),
   subscribe: () => noop,

--- a/apps/main-app/ts/features/itwallet/machine/utils/testDeps.ts
+++ b/apps/main-app/ts/features/itwallet/machine/utils/testDeps.ts
@@ -11,16 +11,14 @@ import { MachineNavigation, MachineStore, MachineToast } from "./deps";
 
 const noop = () => undefined;
 
-export const testMachineStore = (
-  store: Partial<MachineStore> = {}
-): MachineStore => ({
+const testMachineStore = (store: Partial<MachineStore> = {}): MachineStore => ({
   dispatch: noop,
   getState: () => appReducer(undefined, applicationChangeState("active")),
   subscribe: () => noop,
   ...store
 });
 
-export const testMachineNavigation = (
+const testMachineNavigation = (
   navigation: Partial<MachineNavigation> = {}
 ): MachineNavigation => ({
   canGoBack: () => false,

--- a/apps/main-app/ts/features/itwallet/onboarding/screens/__tests__/ItwCardOnboardingL2Screen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/onboarding/screens/__tests__/ItwCardOnboardingL2Screen.test.tsx
@@ -8,6 +8,7 @@ import { GlobalState } from "../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
 import { CredentialType } from "../../../common/utils/itwMocksUtils";
 import * as credentialsSelectors from "../../../credentials/store/selectors/index";
+import { CredentialIssuanceMachineDeps } from "../../../machine/credential/input";
 import { itwCredentialIssuanceMachine } from "../../../machine/credential/machine";
 import { ItwCredentialIssuanceMachineContext } from "../../../machine/credential/provider";
 import { ITW_ROUTES } from "../../../navigation/routes";
@@ -81,7 +82,10 @@ const renderComponent = () => {
 
   return renderScreenWithNavigationStoreContext<GlobalState>(
     () => (
-      <ItwCredentialIssuanceMachineContext.Provider logic={logic}>
+      <ItwCredentialIssuanceMachineContext.Provider
+        logic={logic}
+        options={{ input: { deps: {} as CredentialIssuanceMachineDeps } }}
+      >
         <ItwCardOnboardingL2Screen />
       </ItwCredentialIssuanceMachineContext.Provider>
     ),

--- a/apps/main-app/ts/features/itwallet/onboarding/screens/__tests__/ItwCardOnboardingL2Screen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/onboarding/screens/__tests__/ItwCardOnboardingL2Screen.test.tsx
@@ -8,9 +8,9 @@ import { GlobalState } from "../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
 import { CredentialType } from "../../../common/utils/itwMocksUtils";
 import * as credentialsSelectors from "../../../credentials/store/selectors/index";
-import { CredentialIssuanceMachineDeps } from "../../../machine/credential/input";
 import { itwCredentialIssuanceMachine } from "../../../machine/credential/machine";
 import { ItwCredentialIssuanceMachineContext } from "../../../machine/credential/provider";
+import { testCredentialIssuanceDeps } from "../../../machine/utils/testDeps";
 import { ITW_ROUTES } from "../../../navigation/routes";
 import { ItwCardOnboardingL2Screen } from "../ItwCardOnboardingL2Screen";
 
@@ -84,7 +84,7 @@ const renderComponent = () => {
     () => (
       <ItwCredentialIssuanceMachineContext.Provider
         logic={logic}
-        options={{ input: { deps: {} as CredentialIssuanceMachineDeps } }}
+        options={{ input: { deps: testCredentialIssuanceDeps() } }}
       >
         <ItwCardOnboardingL2Screen />
       </ItwCredentialIssuanceMachineContext.Provider>

--- a/apps/main-app/ts/features/itwallet/onboarding/screens/__tests__/ItwCardOnboardingL3Screen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/onboarding/screens/__tests__/ItwCardOnboardingL3Screen.test.tsx
@@ -10,6 +10,7 @@ import * as envSelectors from "../../../common/store/selectors/environment";
 import { EnvType } from "../../../common/utils/environment";
 import { CredentialType } from "../../../common/utils/itwMocksUtils";
 import * as lifecycleSelectors from "../../../lifecycle/store/selectors";
+import { CredentialIssuanceMachineDeps } from "../../../machine/credential/input";
 import { itwCredentialIssuanceMachine } from "../../../machine/credential/machine";
 import { ItwCredentialIssuanceMachineContext } from "../../../machine/credential/provider";
 import { ITW_ROUTES } from "../../../navigation/routes";
@@ -140,7 +141,10 @@ const renderComponent = (params?: undefined | { page?: number }) => {
 
   return renderScreenWithNavigationStoreContext<GlobalState>(
     () => (
-      <ItwCredentialIssuanceMachineContext.Provider logic={logic}>
+      <ItwCredentialIssuanceMachineContext.Provider
+        logic={logic}
+        options={{ input: { deps: {} as CredentialIssuanceMachineDeps } }}
+      >
         <ItwCardOnboardingL3Screen
           navigation={{} as any}
           route={{ key: "x", name: ITW_ROUTES.L3_ONBOARDING, params } as any}

--- a/apps/main-app/ts/features/itwallet/onboarding/screens/__tests__/ItwCardOnboardingL3Screen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/onboarding/screens/__tests__/ItwCardOnboardingL3Screen.test.tsx
@@ -10,9 +10,9 @@ import * as envSelectors from "../../../common/store/selectors/environment";
 import { EnvType } from "../../../common/utils/environment";
 import { CredentialType } from "../../../common/utils/itwMocksUtils";
 import * as lifecycleSelectors from "../../../lifecycle/store/selectors";
-import { CredentialIssuanceMachineDeps } from "../../../machine/credential/input";
 import { itwCredentialIssuanceMachine } from "../../../machine/credential/machine";
 import { ItwCredentialIssuanceMachineContext } from "../../../machine/credential/provider";
+import { testCredentialIssuanceDeps } from "../../../machine/utils/testDeps";
 import { ITW_ROUTES } from "../../../navigation/routes";
 import { ItwCardOnboardingL3Screen } from "../ItwCardOnboardingL3Screen";
 
@@ -143,7 +143,7 @@ const renderComponent = (params?: undefined | { page?: number }) => {
     () => (
       <ItwCredentialIssuanceMachineContext.Provider
         logic={logic}
-        options={{ input: { deps: {} as CredentialIssuanceMachineDeps } }}
+        options={{ input: { deps: testCredentialIssuanceDeps() } }}
       >
         <ItwCardOnboardingL3Screen
           navigation={{} as any}

--- a/apps/main-app/ts/features/itwallet/onboarding/screens/__tests__/WalletCardOnboardingScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/onboarding/screens/__tests__/WalletCardOnboardingScreen.test.tsx
@@ -10,9 +10,9 @@ import * as itwRemoteConfigSelectors from "../../../common/store/selectors/remot
 import { EnvType } from "../../../common/utils/environment";
 import { CredentialType } from "../../../common/utils/itwMocksUtils";
 import * as itwLifecycleSelectors from "../../../lifecycle/store/selectors";
-import { CredentialIssuanceMachineDeps } from "../../../machine/credential/input";
 import { itwCredentialIssuanceMachine } from "../../../machine/credential/machine";
 import { ItwCredentialIssuanceMachineContext } from "../../../machine/credential/provider";
+import { testCredentialIssuanceDeps } from "../../../machine/utils/testDeps";
 import { ITW_ROUTES } from "../../../navigation/routes";
 import { WalletCardOnboardingScreen } from "../WalletCardOnboardingScreen";
 
@@ -179,7 +179,7 @@ const renderComponent = () => {
     () => (
       <ItwCredentialIssuanceMachineContext.Provider
         logic={logic}
-        options={{ input: { deps: {} as CredentialIssuanceMachineDeps } }}
+        options={{ input: { deps: testCredentialIssuanceDeps() } }}
       >
         <WalletCardOnboardingScreen />
       </ItwCredentialIssuanceMachineContext.Provider>

--- a/apps/main-app/ts/features/itwallet/onboarding/screens/__tests__/WalletCardOnboardingScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/onboarding/screens/__tests__/WalletCardOnboardingScreen.test.tsx
@@ -10,6 +10,7 @@ import * as itwRemoteConfigSelectors from "../../../common/store/selectors/remot
 import { EnvType } from "../../../common/utils/environment";
 import { CredentialType } from "../../../common/utils/itwMocksUtils";
 import * as itwLifecycleSelectors from "../../../lifecycle/store/selectors";
+import { CredentialIssuanceMachineDeps } from "../../../machine/credential/input";
 import { itwCredentialIssuanceMachine } from "../../../machine/credential/machine";
 import { ItwCredentialIssuanceMachineContext } from "../../../machine/credential/provider";
 import { ITW_ROUTES } from "../../../navigation/routes";
@@ -176,7 +177,10 @@ const renderComponent = () => {
 
   return renderScreenWithNavigationStoreContext<GlobalState>(
     () => (
-      <ItwCredentialIssuanceMachineContext.Provider logic={logic}>
+      <ItwCredentialIssuanceMachineContext.Provider
+        logic={logic}
+        options={{ input: { deps: {} as CredentialIssuanceMachineDeps } }}
+      >
         <WalletCardOnboardingScreen />
       </ItwCredentialIssuanceMachineContext.Provider>
     ),

--- a/apps/main-app/ts/features/itwallet/presentation/details/components/__tests__/ItwPresentationCredentialUnknownStatus.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/details/components/__tests__/ItwPresentationCredentialUnknownStatus.test.tsx
@@ -6,9 +6,9 @@ import { createStore } from "redux";
 import { applicationChangeState } from "../../../../../../store/actions/application";
 import { appReducer } from "../../../../../../store/reducers";
 import { CredentialMetadata } from "../../../../common/utils/itwTypesUtils";
-import { CredentialIssuanceMachineDeps } from "../../../../machine/credential/input";
 import { itwCredentialIssuanceMachine } from "../../../../machine/credential/machine";
 import { ItwCredentialIssuanceMachineContext } from "../../../../machine/credential/provider";
+import { testCredentialIssuanceDeps } from "../../../../machine/utils/testDeps";
 import { ItwPresentationCredentialUnknownStatus } from "../ItwPresentationCredentialUnknownStatus";
 
 jest.mock("@react-navigation/native", () => ({
@@ -78,7 +78,7 @@ const renderComponent = (component: ReactElement) => {
     <Provider store={store}>
       <ItwCredentialIssuanceMachineContext.Provider
         logic={logic}
-        options={{ input: { deps: {} as CredentialIssuanceMachineDeps } }}
+        options={{ input: { deps: testCredentialIssuanceDeps() } }}
       >
         {children}
       </ItwCredentialIssuanceMachineContext.Provider>

--- a/apps/main-app/ts/features/itwallet/presentation/details/components/__tests__/ItwPresentationCredentialUnknownStatus.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/details/components/__tests__/ItwPresentationCredentialUnknownStatus.test.tsx
@@ -6,6 +6,7 @@ import { createStore } from "redux";
 import { applicationChangeState } from "../../../../../../store/actions/application";
 import { appReducer } from "../../../../../../store/reducers";
 import { CredentialMetadata } from "../../../../common/utils/itwTypesUtils";
+import { CredentialIssuanceMachineDeps } from "../../../../machine/credential/input";
 import { itwCredentialIssuanceMachine } from "../../../../machine/credential/machine";
 import { ItwCredentialIssuanceMachineContext } from "../../../../machine/credential/provider";
 import { ItwPresentationCredentialUnknownStatus } from "../ItwPresentationCredentialUnknownStatus";
@@ -75,7 +76,10 @@ const renderComponent = (component: ReactElement) => {
 
   const Wrapper = ({ children }: PropsWithChildren) => (
     <Provider store={store}>
-      <ItwCredentialIssuanceMachineContext.Provider logic={logic}>
+      <ItwCredentialIssuanceMachineContext.Provider
+        logic={logic}
+        options={{ input: { deps: {} as CredentialIssuanceMachineDeps } }}
+      >
         {children}
       </ItwCredentialIssuanceMachineContext.Provider>
     </Provider>

--- a/apps/main-app/ts/features/itwallet/presentation/details/components/__tests__/ItwPresentationDetailFooter.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/details/components/__tests__/ItwPresentationDetailFooter.test.tsx
@@ -15,6 +15,7 @@ import {
 } from "../../../../common/utils/itwMocksUtils";
 import * as credentialSelectors from "../../../../credentials/store/selectors";
 import * as lifecycleSelectors from "../../../../lifecycle/store/selectors";
+import { CredentialIssuanceMachineDeps } from "../../../../machine/credential/input";
 import { itwCredentialIssuanceMachine } from "../../../../machine/credential/machine";
 import { ItwCredentialIssuanceMachineContext } from "../../../../machine/credential/provider";
 import { ITW_ROUTES } from "../../../../navigation/routes";
@@ -255,7 +256,10 @@ const renderComponent = (
 
   const component = renderScreenWithNavigationStoreContext<GlobalState>(
     () => (
-      <ItwCredentialIssuanceMachineContext.Provider logic={logic}>
+      <ItwCredentialIssuanceMachineContext.Provider
+        logic={logic}
+        options={{ input: { deps: {} as CredentialIssuanceMachineDeps } }}
+      >
         <ItwPresentationDetailsFooter
           credential={{
             ...ItwStoredCredentialsMocks.dc,

--- a/apps/main-app/ts/features/itwallet/presentation/details/components/__tests__/ItwPresentationDetailFooter.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/details/components/__tests__/ItwPresentationDetailFooter.test.tsx
@@ -15,9 +15,9 @@ import {
 } from "../../../../common/utils/itwMocksUtils";
 import * as credentialSelectors from "../../../../credentials/store/selectors";
 import * as lifecycleSelectors from "../../../../lifecycle/store/selectors";
-import { CredentialIssuanceMachineDeps } from "../../../../machine/credential/input";
 import { itwCredentialIssuanceMachine } from "../../../../machine/credential/machine";
 import { ItwCredentialIssuanceMachineContext } from "../../../../machine/credential/provider";
+import { testCredentialIssuanceDeps } from "../../../../machine/utils/testDeps";
 import { ITW_ROUTES } from "../../../../navigation/routes";
 import {
   itwGrantProximityConsent,
@@ -258,7 +258,7 @@ const renderComponent = (
     () => (
       <ItwCredentialIssuanceMachineContext.Provider
         logic={logic}
-        options={{ input: { deps: {} as CredentialIssuanceMachineDeps } }}
+        options={{ input: { deps: testCredentialIssuanceDeps() } }}
       >
         <ItwPresentationDetailsFooter
           credential={{

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/actions.test.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/actions.test.ts
@@ -1,4 +1,8 @@
-import { createProximityActionsImplementation } from "../actions";
+import {
+  closeProximityAction,
+  trackProximityStartAction,
+  trackQrCodeLoadingFailureAction
+} from "../actions";
 import { ProximityFailureType } from "../failure";
 
 jest.mock("../../analytics", () => ({
@@ -12,21 +16,23 @@ import {
   trackItwProximityStart
 } from "../../analytics";
 
-describe("createProximityActionsImplementation", () => {
+describe("itwProximityMachine actions", () => {
   const pop = jest.fn();
 
   const navigation = {
     pop
   } as never;
 
-  const actions = createProximityActionsImplementation(navigation, {} as any);
+  const store = {} as never;
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it("pops the proximity navigator when closing the flow", () => {
-    actions.closeProximity();
+    closeProximityAction({
+      context: { deps: { navigation, store } }
+    } as any);
 
     expect(pop).toHaveBeenCalledTimes(1);
   });
@@ -34,7 +40,7 @@ describe("createProximityActionsImplementation", () => {
   it("tracks the QR code loading failure when it occurs on the qrcode engagement mode", () => {
     const error = new Error("start failed");
 
-    actions.trackQrCodeLoadingFailure({
+    trackQrCodeLoadingFailureAction({
       context: { engagementMode: "qrcode" },
       event: { type: "xstate.error.actor.test", error }
     } as any);
@@ -48,7 +54,7 @@ describe("createProximityActionsImplementation", () => {
   it("does not track the QR code loading failure when it occurs on the nfc engagement mode", () => {
     const error = new Error("start failed");
 
-    actions.trackQrCodeLoadingFailure({
+    trackQrCodeLoadingFailureAction({
       context: { engagementMode: "nfc" },
       event: { type: "xstate.error.actor.test", error }
     } as any);
@@ -62,7 +68,7 @@ describe("createProximityActionsImplementation", () => {
   ])(
     "tracks the proximity start with proximity_flow $proximity_flow for engagementMode $engagementMode",
     ({ engagementMode, proximity_flow }) => {
-      actions.trackProximityStart({ context: { engagementMode } } as any);
+      trackProximityStartAction({ context: { engagementMode } } as any);
 
       expect(trackItwProximityStart).toHaveBeenCalledWith({ proximity_flow });
     }

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/actors.test.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/actors.test.ts
@@ -1,14 +1,10 @@
 import { ISO18013_5 } from "@pagopa/io-react-native-iso18013";
 import { AnyActorLogic, createActor } from "xstate";
 
-import { Env } from "../../../../common/utils/environment";
 import { CredentialMetadata } from "../../../../common/utils/itwTypesUtils";
 import { CredentialsVault } from "../../../../credentials/utils/vault";
 import { VerifierRequest } from "../../utils/types";
-import {
-  createProximityActorsImplementation,
-  SendDocumentsActorOutput
-} from "../actors";
+import { sendDocumentsActor, SendDocumentsActorOutput } from "../actors";
 
 const DOCUMENT_TYPE = "org.iso.18013.5.1.mDL";
 const MISSING_DOCUMENT_TYPE = "org.iso.18013.5.1.missing";
@@ -56,11 +52,15 @@ describe("proximity actors", () => {
       .mocked(ISO18013_5.generateResponse)
       .mockResolvedValue("generated-response");
     jest.mocked(ISO18013_5.sendResponse).mockResolvedValue(true);
-    const actors = createProximityActorsImplementation({ type: "prod" } as Env);
 
-    await runActor<SendDocumentsActorOutput>(actors.sendDocuments, {
+    await runActor<SendDocumentsActorOutput>(sendDocumentsActor, {
       credentials: { [DOCUMENT_TYPE]: credential },
-      verifierRequest
+      verifierRequest,
+      deps: {
+        env: { type: "prod" },
+        navigation: {} as never,
+        store: {} as never
+      }
     });
 
     expect(generateResponse).toHaveBeenCalledWith(

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/machine.test.ts
@@ -12,18 +12,18 @@ import {
   CredentialMetadata,
   WalletInstanceAttestations
 } from "../../../../common/utils/itwTypesUtils";
+import { testProximityDeps } from "../../../../machine/utils/testDeps";
 import {
   generateConsentKey,
   getConsentDataFromProximityDetails
 } from "../../store/utils";
 import { ProximityDetails, VerifierRequest } from "../../utils/types";
 import { ProximityFailureType } from "../failure";
-import { ProximityMachineDeps } from "../input";
 import { ItwProximityMachine, itwProximityMachine } from "../machine";
 
 type MachineSnapshot = StateFrom<ItwProximityMachine>;
 
-const T_DEPS = {} as ProximityMachineDeps;
+const T_DEPS = testProximityDeps();
 
 const T_WIA = { jwt: "test-wia" } as WalletInstanceAttestations;
 const T_CREDENTIALS = {} as Record<string, CredentialMetadata>;

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/machine.test.ts
@@ -18,9 +18,12 @@ import {
 } from "../../store/utils";
 import { ProximityDetails, VerifierRequest } from "../../utils/types";
 import { ProximityFailureType } from "../failure";
+import { ProximityMachineDeps } from "../input";
 import { ItwProximityMachine, itwProximityMachine } from "../machine";
 
 type MachineSnapshot = StateFrom<ItwProximityMachine>;
+
+const T_DEPS = {} as ProximityMachineDeps;
 
 const T_WIA = { jwt: "test-wia" } as WalletInstanceAttestations;
 const T_CREDENTIALS = {} as Record<string, CredentialMetadata>;
@@ -135,7 +138,9 @@ describe("itwProximityMachine", () => {
     value: MachineSnapshot["value"],
     context: Partial<MachineSnapshot["context"]> = {}
   ): MachineSnapshot => {
-    const initialSnapshot = createActor(itwProximityMachine).getSnapshot();
+    const initialSnapshot = createActor(mockedMachine, {
+      input: { deps: T_DEPS }
+    }).getSnapshot();
 
     return _.merge(undefined, initialSnapshot, {
       value,
@@ -153,7 +158,7 @@ describe("itwProximityMachine", () => {
   });
 
   it("initializes in Idle", () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
 
     actor.start();
 
@@ -162,7 +167,7 @@ describe("itwProximityMachine", () => {
   });
 
   it("close from Idle is ignored", () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
 
     actor.start();
     actor.send({ type: "close" });
@@ -173,7 +178,7 @@ describe("itwProximityMachine", () => {
 
   it("start moves to Bluetooth.CheckPermissions", () => {
     checkBluetoothPermissions.mockReturnValue(new Promise(() => {}));
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
 
     actor.start();
     actor.send({ type: "start" });
@@ -186,7 +191,7 @@ describe("itwProximityMachine", () => {
   it("granted bluetooth permissions move to Bluetooth.CheckActivation", async () => {
     checkBluetoothPermissions.mockResolvedValue(true);
     checkBluetoothActivation.mockReturnValue(new Promise(() => {}));
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
 
     actor.start();
     actor.send({ type: "start" });
@@ -198,7 +203,7 @@ describe("itwProximityMachine", () => {
 
   it("denied bluetooth permissions move to Bluetooth.RequirePermissions", async () => {
     checkBluetoothPermissions.mockResolvedValue(false);
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
 
     actor.start();
     actor.send({ type: "start" });
@@ -213,7 +218,7 @@ describe("itwProximityMachine", () => {
     checkBluetoothPermissions.mockRejectedValue(
       new Error("permissions unavailable")
     );
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
 
     actor.start();
     actor.send({ type: "start" });
@@ -226,6 +231,7 @@ describe("itwProximityMachine", () => {
 
   it("close from Bluetooth.RequirePermissions calls closeProximity", () => {
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Bluetooth: "RequirePermissions" })
     });
 
@@ -241,6 +247,7 @@ describe("itwProximityMachine", () => {
   it("continue from Bluetooth.RequirePermissions moves to Bluetooth.CheckActivation", async () => {
     checkBluetoothActivation.mockReturnValue(new Promise(() => {}));
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Bluetooth: "RequirePermissions" })
     });
 
@@ -256,7 +263,7 @@ describe("itwProximityMachine", () => {
     checkBluetoothPermissions.mockResolvedValue(true);
     checkBluetoothActivation.mockResolvedValue(true);
     startEngagement.mockReturnValue(new Promise(() => {}));
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
 
     actor.start();
     actor.send({ type: "start" });
@@ -271,7 +278,7 @@ describe("itwProximityMachine", () => {
   it("inactive bluetooth moves to Bluetooth.RequireActivation", async () => {
     checkBluetoothPermissions.mockResolvedValue(true);
     checkBluetoothActivation.mockResolvedValue(false);
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
 
     actor.start();
     actor.send({ type: "start" });
@@ -287,7 +294,7 @@ describe("itwProximityMachine", () => {
     checkBluetoothActivation.mockRejectedValue(
       new Error("bluetooth unavailable")
     );
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
 
     actor.start();
     actor.send({ type: "start" });
@@ -300,6 +307,7 @@ describe("itwProximityMachine", () => {
 
   it("close from Bluetooth.RequireActivation calls closeProximity", () => {
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Bluetooth: "RequireActivation" })
     });
 
@@ -315,6 +323,7 @@ describe("itwProximityMachine", () => {
   it("continue from Bluetooth.RequireActivation moves to Presentment.Starting", async () => {
     startEngagement.mockReturnValue(new Promise(() => {}));
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Bluetooth: "RequireActivation" })
     });
 
@@ -329,6 +338,7 @@ describe("itwProximityMachine", () => {
   it("start-nfc-presentment from AwaitingConnection enters Nfc gate", async () => {
     checkNfcActivation.mockReturnValue(new Promise(() => {}));
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Presentment: "AwaitingConnection" })
     });
 
@@ -343,6 +353,7 @@ describe("itwProximityMachine", () => {
   it("inactive NFC from start-nfc-presentment moves to Nfc.RequireActivation", async () => {
     checkNfcActivation.mockResolvedValue(false);
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Presentment: "AwaitingConnection" })
     });
 
@@ -358,6 +369,7 @@ describe("itwProximityMachine", () => {
   it("NFC activation errors from start-nfc-presentment move to Nfc.RequireActivation", async () => {
     checkNfcActivation.mockRejectedValue(new Error("nfc unavailable"));
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Presentment: "AwaitingConnection" })
     });
 
@@ -373,6 +385,7 @@ describe("itwProximityMachine", () => {
   it("close from Nfc.RequireActivation returns to Presentment", async () => {
     startEngagement.mockReturnValue(new Promise(() => {}));
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Nfc: "RequireActivation" })
     });
 
@@ -387,6 +400,7 @@ describe("itwProximityMachine", () => {
   it("continue from Nfc.RequireActivation moves to Presentment.Starting with NFC mode", async () => {
     startEngagement.mockReturnValue(new Promise(() => {}));
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Nfc: "RequireActivation" })
     });
 
@@ -404,6 +418,7 @@ describe("itwProximityMachine", () => {
   it("handles the happy path in Presentment", async () => {
     sendDocuments.mockReturnValue(new Promise(() => {}));
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Presentment: "Starting" })
     });
 
@@ -461,6 +476,7 @@ describe("itwProximityMachine", () => {
 
   it("device-connecting with QR engagement pre-navigates to claims disclosure", () => {
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Presentment: "AwaitingConnection" })
     });
 
@@ -476,6 +492,7 @@ describe("itwProximityMachine", () => {
 
   it("device-connecting with NFC engagement does not pre-navigate to claims disclosure", () => {
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot(
         { Presentment: "AwaitingConnection" },
         { engagementMode: "nfc" }
@@ -511,6 +528,7 @@ describe("itwProximityMachine", () => {
 
   it("close from Presentment.AwaitingConnection calls closeProximity", () => {
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Presentment: "AwaitingConnection" })
     });
 
@@ -525,6 +543,7 @@ describe("itwProximityMachine", () => {
 
   it("close from Presentment.Connected closes the flow and returns to Idle", () => {
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Presentment: "Connected" })
     });
 
@@ -538,6 +557,7 @@ describe("itwProximityMachine", () => {
   it("holder-consent from ClaimsDisclosure moves to SendingDocuments", () => {
     sendDocuments.mockReturnValue(new Promise(() => {}));
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot(
         { Presentment: "ClaimsDisclosure" },
         { proximityDetails: T_PROXIMITY_DETAILS }
@@ -555,6 +575,7 @@ describe("itwProximityMachine", () => {
   it("sendDocuments errors move to Failure", async () => {
     sendDocuments.mockRejectedValue(new Error("send failed"));
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot(
         { Presentment: "ClaimsDisclosure" },
         { proximityDetails: T_PROXIMITY_DETAILS }
@@ -574,6 +595,7 @@ describe("itwProximityMachine", () => {
   it("device-disconnected before SendingDocuments terminates the session and closes the flow", async () => {
     terminateSession.mockResolvedValue(undefined);
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Presentment: "AwaitingConnection" })
     });
 
@@ -594,6 +616,7 @@ describe("itwProximityMachine", () => {
 
   it("device-disconnected in ClaimsDisclosure with NFC retrieval is consumed without failure", () => {
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot(
         { Presentment: "ClaimsDisclosure" },
         { retrievalMethod: "nfc" }
@@ -613,6 +636,7 @@ describe("itwProximityMachine", () => {
 
   it("nfc-stopped from AwaitingConnection closes the proximity flow", () => {
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Presentment: "AwaitingConnection" })
     });
 
@@ -627,6 +651,7 @@ describe("itwProximityMachine", () => {
 
   it("device-error moves to Failure", async () => {
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Presentment: "AwaitingConnection" })
     });
 
@@ -643,13 +668,14 @@ describe("itwProximityMachine", () => {
 
   it("close from ClaimsDisclosure terminates the session and shows the consent denied failure", () => {
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Presentment: "ClaimsDisclosure" })
     });
 
     actor.start();
     actor.send({ type: "close" });
 
-    expect(actor.getSnapshot().matches("Failure")).toBe(true);
+    expect(actor.getSnapshot().value).toBe("Failure");
     expect(actor.getSnapshot().context.failure?.type).toBe(
       ProximityFailureType.CONSENT_DENIED
     );
@@ -658,61 +684,9 @@ describe("itwProximityMachine", () => {
     expect(closeProximity).not.toHaveBeenCalled();
   });
 
-  it("NFC close from ClaimsDisclosure after teardown does not terminate the session again", async () => {
-    terminateSession.mockResolvedValue(undefined);
-    const actor = createActor(mockedMachine, {
-      snapshot: makeSnapshot(
-        { Presentment: "Connected" },
-        { engagementMode: "nfc" }
-      )
-    });
-
-    actor.start();
-    actor.send({
-      type: "device-document-request-received",
-      proximityDetails: T_PROXIMITY_DETAILS,
-      verifierRequest: T_VERIFIER_REQUEST,
-      retrievalMethod: "nfc"
-    });
-
-    await waitFor(actor, snapshot =>
-      snapshot.matches({ Presentment: "ClaimsDisclosure" })
-    );
-    expect(actor.getSnapshot().context.sessionTerminated).toBe(true);
-
-    actor.send({ type: "close" });
-
-    await waitFor(actor, snapshot => snapshot.matches("Failure"));
-    expect(actor.getSnapshot().context.failure?.type).toBe(
-      ProximityFailureType.CONSENT_DENIED
-    );
-    expect(terminateSession).toHaveBeenCalledTimes(1);
-  });
-
-  it("NFC retry after consent resets sessionTerminated so a new engagement can terminate", async () => {
-    startEngagement.mockReturnValue(new Promise(() => {}));
-    const actor = createActor(mockedMachine, {
-      snapshot: makeSnapshot(
-        { Presentment: "StoreConsent" },
-        {
-          retrievalMethod: "nfc",
-          sessionTerminated: true,
-          proximityDetails: T_PROXIMITY_DETAILS
-        }
-      )
-    });
-
-    actor.start();
-    actor.send({ type: "continue" });
-
-    await waitFor(actor, snapshot =>
-      snapshot.matches({ Presentment: "Starting" })
-    );
-    expect(actor.getSnapshot().context.sessionTerminated).toBe(false);
-  });
-
   it("holder-consent with NFC retrieval moves to StoreConsent", () => {
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot(
         { Presentment: "ClaimsDisclosure" },
         { retrievalMethod: "nfc", proximityDetails: T_PROXIMITY_DETAILS }
@@ -733,80 +707,10 @@ describe("itwProximityMachine", () => {
     expect(navigateToStoreconsentScreen).toHaveBeenCalledTimes(1);
   });
 
-  it("duplicate document request during NFC ClaimsDisclosure does not re-terminate the session", async () => {
-    terminateSession.mockResolvedValue(undefined);
-    const actor = createActor(mockedMachine, {
-      snapshot: makeSnapshot(
-        { Presentment: "Connected" },
-        { engagementMode: "nfc" }
-      )
-    });
-
-    actor.start();
-    actor.send({
-      type: "device-document-request-received",
-      proximityDetails: T_PROXIMITY_DETAILS,
-      verifierRequest: T_VERIFIER_REQUEST,
-      retrievalMethod: "nfc"
-    });
-
-    await waitFor(actor, snapshot =>
-      snapshot.matches({ Presentment: "ClaimsDisclosure" })
-    );
-
-    actor.send({
-      type: "device-document-request-received",
-      proximityDetails: T_PROXIMITY_DETAILS_B,
-      verifierRequest: T_VERIFIER_REQUEST,
-      retrievalMethod: "ble"
-    });
-
-    expect(actor.getSnapshot().value).toStrictEqual({
-      Presentment: "ClaimsDisclosure"
-    });
-    expect(actor.getSnapshot().context.proximityDetails).toBe(
-      T_PROXIMITY_DETAILS
-    );
-    expect(terminateSession).toHaveBeenCalledTimes(1);
-  });
-
-  it("duplicate document request during TerminatingForConsent does not re-invoke terminateSession", async () => {
-    terminateSession.mockReturnValue(new Promise(() => {}));
-    const actor = createActor(mockedMachine, {
-      snapshot: makeSnapshot(
-        { Presentment: "Connected" },
-        { engagementMode: "nfc" }
-      )
-    });
-
-    actor.start();
-    actor.send({
-      type: "device-document-request-received",
-      proximityDetails: T_PROXIMITY_DETAILS,
-      verifierRequest: T_VERIFIER_REQUEST,
-      retrievalMethod: "nfc"
-    });
-
-    await waitFor(actor, snapshot =>
-      snapshot.matches({ Presentment: "TerminatingForConsent" })
-    );
-
-    actor.send({
-      type: "device-document-request-received",
-      proximityDetails: T_PROXIMITY_DETAILS_B,
-      verifierRequest: T_VERIFIER_REQUEST,
-      retrievalMethod: "ble"
-    });
-
-    expect(actor.getSnapshot().value).toStrictEqual({
-      Presentment: "TerminatingForConsent"
-    });
-    expect(terminateSession).toHaveBeenCalledTimes(1);
-  });
-
   it("NFC document request without consent terminates the session before disclosing claims", async () => {
     terminateSession.mockResolvedValue(undefined);
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot(
         { Presentment: "Connected" },
         { engagementMode: "nfc" }
@@ -832,6 +736,7 @@ describe("itwProximityMachine", () => {
   it("NFC termination failure still proceeds to claims disclosure", async () => {
     terminateSession.mockRejectedValue(new Error("terminate failed"));
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot(
         { Presentment: "Connected" },
         { engagementMode: "nfc" }
@@ -857,6 +762,7 @@ describe("itwProximityMachine", () => {
     // Never resolves: keep the machine parked in TerminatingForConsent
     terminateSession.mockReturnValue(new Promise(() => {}));
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot(
         { Presentment: "Connected" },
         { engagementMode: "nfc" }
@@ -888,6 +794,7 @@ describe("itwProximityMachine", () => {
     // Never resolves: keep the machine parked in TerminatingForConsent
     terminateSession.mockReturnValue(new Promise(() => {}));
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot(
         { Presentment: "Connected" },
         { engagementMode: "nfc" }
@@ -920,6 +827,7 @@ describe("itwProximityMachine", () => {
 
   it("device-error in ClaimsDisclosure with NFC retrieval is consumed without failure", () => {
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot(
         { Presentment: "ClaimsDisclosure" },
         { retrievalMethod: "nfc" }
@@ -942,6 +850,7 @@ describe("itwProximityMachine", () => {
   it("NFC document request with prior consent sends documents without re-terminating", async () => {
     sendDocuments.mockReturnValue(new Promise(() => {}));
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot(
         { Presentment: "Connected" },
         {
@@ -970,6 +879,7 @@ describe("itwProximityMachine", () => {
   it("NFC document request with mismatched consent key goes through TerminatingForConsent and ClaimsDisclosure", async () => {
     terminateSession.mockResolvedValue(undefined);
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot(
         { Presentment: "Connected" },
         {
@@ -1000,6 +910,7 @@ describe("itwProximityMachine", () => {
   it("store-consent from StoreConsent stores consent and moves to Retrying", () => {
     startEngagement.mockReturnValue(new Promise(() => {}));
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Presentment: "StoreConsent" })
     });
 
@@ -1015,6 +926,7 @@ describe("itwProximityMachine", () => {
   it("continue from StoreConsent skips storing and moves to Retrying", () => {
     startEngagement.mockReturnValue(new Promise(() => {}));
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: makeSnapshot({ Presentment: "StoreConsent" })
     });
 
@@ -1028,7 +940,7 @@ describe("itwProximityMachine", () => {
   });
 
   it("retry from Starting clears the failure after a startEngagement error", async () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
 
     checkBluetoothPermissions.mockResolvedValue(true);
     checkBluetoothActivation.mockResolvedValue(true);
@@ -1057,7 +969,8 @@ describe("itwProximityMachine", () => {
 
   it("close from Failure returns to Idle", () => {
     const actor = createActor(mockedMachine, {
-      snapshot: makeSnapshot({ Failure: "Idle" })
+      input: { deps: T_DEPS },
+      snapshot: makeSnapshot("Failure")
     });
 
     actor.start();

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/machine.test.ts
@@ -513,6 +513,7 @@ describe("itwProximityMachine", () => {
     "tracks %s proximity start when verifier connects",
     engagementMode => {
       const actor = createActor(mockedMachine, {
+        input: { deps: T_DEPS },
         snapshot: makeSnapshot(
           { Presentment: "Connecting" },
           { engagementMode }
@@ -675,7 +676,7 @@ describe("itwProximityMachine", () => {
     actor.start();
     actor.send({ type: "close" });
 
-    expect(actor.getSnapshot().value).toBe("Failure");
+    expect(actor.getSnapshot().matches("Failure")).toBe(true);
     expect(actor.getSnapshot().context.failure?.type).toBe(
       ProximityFailureType.CONSENT_DENIED
     );
@@ -970,7 +971,7 @@ describe("itwProximityMachine", () => {
   it("close from Failure returns to Idle", () => {
     const actor = createActor(mockedMachine, {
       input: { deps: T_DEPS },
-      snapshot: makeSnapshot("Failure")
+      snapshot: makeSnapshot({ Failure: "Idle" })
     });
 
     actor.start();

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/provider.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/provider.test.tsx
@@ -55,6 +55,9 @@ const renderProvider = (isDebugModeEnabled: boolean) => {
   mockUseIOSelector.mockImplementation(selector =>
     selector === isDebugModeEnabledSelector ? isDebugModeEnabled : undefined
   );
+  mockMachineUseSelector.mockImplementation(selector =>
+    selector({ value: "Idle", context: { deps: {} } } as never)
+  );
 
   return render(
     <ItwProximityMachineProvider>

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/actions.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/actions.ts
@@ -1,7 +1,5 @@
 import { ActionArgs, assign } from "xstate";
 
-import { useIONavigation } from "../../../../../navigation/params/AppParamsList";
-import { useIOStore } from "../../../../../store/hooks";
 import { assert } from "../../../../../utils/assert";
 import {
   trackItwProximityQrCodeLoadingFailure,
@@ -18,124 +16,149 @@ import { Context } from "./context";
 import { ProximityEvents } from "./events";
 import { mapEventToFailure } from "./failure";
 
-export const createProximityActionsImplementation = (
-  navigation: ReturnType<typeof useIONavigation>,
-  store: ReturnType<typeof useIOStore>
-) => ({
-  onInit: assign<Context, ProximityEvents, unknown, ProximityEvents, any>(
-    () => {
-      const state = store.getState();
-
-      return {
-        credentials: itwPresentableCredentialsByDocTypeSelector(state)
-      };
-    }
-  ),
-
-  navigateToBluetoothPermissionsScreen: () => {
-    navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
-      screen: ITW_PROXIMITY_ROUTES.BLUETOOTH_PERMISSIONS
-    });
-  },
-
-  navigateToBluetoothActivationScreen: () => {
-    navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
-      screen: ITW_PROXIMITY_ROUTES.BLUETOOTH_ACTIVATION
-    });
-  },
-
-  navigateToNfcActivationScreen: () => {
-    navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
-      screen: ITW_PROXIMITY_ROUTES.NFC_ACTIVATION
-    });
-  },
-
-  navigateToNfcPresentmentScreen: () => {
-    navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
-      screen: ITW_PROXIMITY_ROUTES.NFC_PRESENTMENT
-    });
-  },
-
-  navigateToPresentmentScreen: () => {
-    navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
-      screen: ITW_PROXIMITY_ROUTES.PRESENTMENT,
-      params: {}
-    });
-  },
-
-  navigateToClaimsDisclosureScreen: () => {
-    navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
-      screen: ITW_PROXIMITY_ROUTES.CLAIMS_DISCLOSURE
-    });
-  },
-
-  navigateToStoreconsentScreen: () => {
-    navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
-      screen: ITW_PROXIMITY_ROUTES.STORE_CONSENT
-    });
-  },
-
-  navigateToSuccessScreen: () => {
-    navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
-      screen: ITW_PROXIMITY_ROUTES.SUCCESS
-    });
-  },
-
-  navigateToFailureScreen: () => {
-    navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
-      screen: ITW_PROXIMITY_ROUTES.FAILURE
-    });
-  },
-
-  closeProximity: () => {
-    navigation.pop();
-  },
-
-  grantConsent: assign<Context, ProximityEvents, unknown, ProximityEvents, any>(
-    ({ context }: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
-      assert(
-        context.proximityDetails,
-        "ProximityDetails must be present in context to grant consent"
-      );
-
-      const consentData = getConsentDataFromProximityDetails(
-        context.proximityDetails
-      );
-
-      return { grantedConsentKey: generateConsentKey(consentData) };
-    }
-  ),
-
-  storeConsent: ({
-    context
-  }: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
-    assert(
-      context.proximityDetails,
-      "ProximityDetails must be present in context to store consent"
-    );
-
-    const consentData = getConsentDataFromProximityDetails(
-      context.proximityDetails
-    );
-
-    store.dispatch(itwGrantProximityConsent(consentData));
-  },
-
-  trackProximityStart: ({
-    context
-  }: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
-    trackItwProximityStart({
-      proximity_flow: context.engagementMode === "nfc" ? "nfc" : "qr_code"
-    });
-  },
-
-  trackQrCodeLoadingFailure: ({
-    context,
-    event
-  }: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
-    if (context.engagementMode === "qrcode") {
-      const { reason, type } = mapEventToFailure(event);
-      trackItwProximityQrCodeLoadingFailure({ reason, type });
-    }
-  }
+/**
+ * Initializes the proximity machine from the Redux store.
+ */
+export const onInitAction = assign<
+  Context,
+  ProximityEvents,
+  unknown,
+  ProximityEvents,
+  any
+>(({ context }) => {
+  const { store } = context.deps;
+  return {
+    credentials: itwPresentableCredentialsByDocTypeSelector(store.getState())
+  };
 });
+
+export const navigateToBluetoothPermissionsScreenAction = ({
+  context
+}: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
+  context.deps.navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
+    screen: ITW_PROXIMITY_ROUTES.BLUETOOTH_PERMISSIONS
+  });
+};
+
+export const navigateToBluetoothActivationScreenAction = ({
+  context
+}: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
+  context.deps.navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
+    screen: ITW_PROXIMITY_ROUTES.BLUETOOTH_ACTIVATION
+  });
+};
+
+export const navigateToNfcActivationScreenAction = ({
+  context
+}: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
+  context.deps.navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
+    screen: ITW_PROXIMITY_ROUTES.NFC_ACTIVATION
+  });
+};
+
+export const navigateToNfcPresentmentScreenAction = ({
+  context
+}: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
+  context.deps.navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
+    screen: ITW_PROXIMITY_ROUTES.NFC_PRESENTMENT
+  });
+};
+
+export const navigateToPresentmentScreenAction = ({
+  context
+}: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
+  context.deps.navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
+    screen: ITW_PROXIMITY_ROUTES.PRESENTMENT,
+    params: {}
+  });
+};
+
+export const navigateToClaimsDisclosureScreenAction = ({
+  context
+}: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
+  context.deps.navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
+    screen: ITW_PROXIMITY_ROUTES.CLAIMS_DISCLOSURE
+  });
+};
+
+export const navigateToStoreconsentScreenAction = ({
+  context
+}: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
+  context.deps.navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
+    screen: ITW_PROXIMITY_ROUTES.STORE_CONSENT
+  });
+};
+
+export const navigateToSuccessScreenAction = ({
+  context
+}: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
+  context.deps.navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
+    screen: ITW_PROXIMITY_ROUTES.SUCCESS
+  });
+};
+
+export const navigateToFailureScreenAction = ({
+  context
+}: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
+  context.deps.navigation.navigate(ITW_PROXIMITY_ROUTES.MAIN, {
+    screen: ITW_PROXIMITY_ROUTES.FAILURE
+  });
+};
+
+export const closeProximityAction = ({
+  context
+}: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
+  context.deps.navigation.pop();
+};
+
+export const grantConsentAction = assign<
+  Context,
+  ProximityEvents,
+  unknown,
+  ProximityEvents,
+  any
+>(({ context }: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
+  assert(
+    context.proximityDetails,
+    "ProximityDetails must be present in context to grant consent"
+  );
+
+  const consentData = getConsentDataFromProximityDetails(
+    context.proximityDetails
+  );
+
+  return { grantedConsentKey: generateConsentKey(consentData) };
+});
+
+export const storeConsentAction = ({
+  context
+}: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
+  assert(
+    context.proximityDetails,
+    "ProximityDetails must be present in context to store consent"
+  );
+
+  const consentData = getConsentDataFromProximityDetails(
+    context.proximityDetails
+  );
+
+  context.deps.store.dispatch(itwGrantProximityConsent(consentData));
+};
+
+export const trackProximityStartAction = ({
+  context
+}: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
+  trackItwProximityStart({
+    proximity_flow: context.engagementMode === "nfc" ? "nfc" : "qr_code"
+  });
+};
+
+export const trackQrCodeLoadingFailureAction = ({
+  context,
+  event
+}: ActionArgs<Context, ProximityEvents, ProximityEvents>) => {
+  if (context.engagementMode === "qrcode") {
+    const { reason, type } = mapEventToFailure(event);
+    trackItwProximityQrCodeLoadingFailure({ reason, type });
+  }
+};

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/actors.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/actors.ts
@@ -4,13 +4,12 @@ import { fromCallback, fromPromise } from "xstate";
 import type { EventsPayload } from "../utils/types";
 
 import { assert } from "../../../../../utils/assert";
-import { Env } from "../../../common/utils/environment";
 import { CredentialsVault } from "../../../credentials/utils/vault";
 import {
-  checkBluetoothActivation,
-  checkBluetoothPermissions
+  checkBluetoothActivation as checkBluetoothActivationUtil,
+  checkBluetoothPermissions as checkBluetoothPermissionsUtil
 } from "../utils/ble";
-import { checkNfcActivation } from "../utils/nfc";
+import { checkNfcActivation as checkNfcActivationUtil } from "../utils/nfc";
 import {
   generateAcceptedFields,
   getDocuments,
@@ -19,6 +18,7 @@ import {
 } from "../utils/presentation";
 import { Context } from "./context";
 import { ProximityEvents } from "./events";
+import { ProximityMachineDeps } from "./input";
 
 const SEND_RESPONSE_TIMEOUT_MS = 20000;
 
@@ -33,7 +33,9 @@ const ENGAGEMENT_CONFIG: Record<
   nfc: { engagementModes: ["nfc"], retrievalMethods: ["ble", "nfc"] }
 };
 
-export type ProximityCommunicationLogicInput = Pick<Context, "credentials">;
+export type ProximityCommunicationLogicInput = Pick<Context, "credentials"> & {
+  deps: ProximityMachineDeps;
+};
 
 export type SendDocumentsActorInput = Pick<
   Context,
@@ -49,187 +51,178 @@ export type SendErrorResponseActorOutput = Awaited<
 >;
 
 export type StartEngagementActorInput = {
+  deps: ProximityMachineDeps;
   engagementMode: ISO18013_5.EngagementMode;
 };
 
-export const createProximityActorsImplementation = (env: Env) => {
-  const checkBluetoothPermissionsActor = fromPromise<boolean>(
-    checkBluetoothPermissions
-  );
+export const checkBluetoothPermissionsActor = fromPromise<boolean>(
+  checkBluetoothPermissionsUtil
+);
 
-  const checkBluetoothActivationActor = fromPromise<boolean>(
-    checkBluetoothActivation
-  );
+export const checkBluetoothActivationActor = fromPromise<boolean>(
+  checkBluetoothActivationUtil
+);
 
-  const checkNfcActivationActor = fromPromise<boolean>(checkNfcActivation);
+export const checkNfcActivationActor = fromPromise<boolean>(
+  checkNfcActivationUtil
+);
 
-  const startEngagement = fromPromise<void, StartEngagementActorInput>(
-    async ({ input }) => {
-      const { engagementModes, retrievalMethods } =
-        ENGAGEMENT_CONFIG[input.engagementMode];
+export const startEngagementActor = fromPromise<
+  void,
+  StartEngagementActorInput
+>(async ({ input }) => {
+  const { env } = input.deps;
+  const { engagementModes, retrievalMethods } =
+    ENGAGEMENT_CONFIG[input.engagementMode];
 
-      // Ensure any existing session is closed before starting a new one
-      await ISO18013_5.close().catch(() => null);
+  // Ensure any existing session is closed before starting a new one
+  await ISO18013_5.close().catch(() => null);
 
-      await ISO18013_5.startEngagement({
-        engagementModes,
-        retrievalMethods,
-        certificates: [[env.X509_CERT_ROOT]]
-      });
-    }
-  );
-
-  const proximityCommunicationLogic = fromCallback<
-    ProximityEvents,
-    ProximityCommunicationLogicInput
-  >(({ sendBack, input }) => {
-    const { credentials } = input;
-
-    assert(
-      credentials,
-      "Missing credentials for proximity communication logic"
-    );
-
-    const handleNfcStarted = () => {
-      sendBack({ type: "nfc-started" });
-    };
-
-    const handleNfcStopped = () => {
-      sendBack({ type: "nfc-stopped" });
-    };
-
-    const handleQrCodeString = (
-      eventPayload: EventsPayload["onQrCodeString"]
-    ) => {
-      sendBack({ type: "qr-code-string", payload: eventPayload.data });
-    };
-
-    const handleDeviceConnecting = () => {
-      sendBack({ type: "device-connecting" });
-    };
-
-    const handleDeviceConnected = () => {
-      sendBack({ type: "device-connected" });
-    };
-
-    const handleDeviceDisconnected = () => {
-      sendBack({ type: "device-disconnected" });
-    };
-
-    const handleError = (eventPayload: EventsPayload["onError"]) => {
-      const { error } = eventPayload ?? {};
-      sendBack({
-        type: "device-error",
-        error
-      });
-    };
-
-    const handleDocumentRequestReceived = (
-      eventPayload: EventsPayload["onDocumentRequestReceived"]
-    ) => {
-      const { data, retrievalMethod } = eventPayload ?? {};
-
-      try {
-        assert(data, "Missing required data");
-
-        const parsedRequest = ISO18013_5.parseVerifierRequest(JSON.parse(data));
-        const proximityDetails = getProximityDetails({
-          request: parsedRequest.request,
-          credentials,
-          requireAuthenticated: env.type !== "pre"
-        });
-
-        sendBack({
-          type: "device-document-request-received",
-          proximityDetails,
-          verifierRequest: parsedRequest,
-          retrievalMethod
-        });
-      } catch (error) {
-        // Give some time to show the loading message
-        // and avoid glitches in the UI.
-        setTimeout(() => {
-          sendBack({
-            type: "device-error",
-            error
-          });
-        }, 500);
-      }
-    };
-
-    const listeners = [
-      ISO18013_5.addListener("onNfcStarted", handleNfcStarted),
-      ISO18013_5.addListener("onNfcStopped", handleNfcStopped),
-      ISO18013_5.addListener("onQrCodeString", handleQrCodeString),
-      ISO18013_5.addListener("onDeviceConnecting", handleDeviceConnecting),
-      ISO18013_5.addListener("onDeviceConnected", handleDeviceConnected),
-      ISO18013_5.addListener(
-        "onDocumentRequestReceived",
-        handleDocumentRequestReceived
-      ),
-      ISO18013_5.addListener("onDeviceDisconnected", handleDeviceDisconnected),
-      ISO18013_5.addListener("onError", handleError)
-    ];
-
-    return () => {
-      // Remove event listeners
-      listeners.forEach(listener => listener.remove());
-      // Close connection and clear all resources
-      void ISO18013_5.close().catch(() => null);
-    };
+  await ISO18013_5.startEngagement({
+    engagementModes,
+    retrievalMethods,
+    certificates: [[env.X509_CERT_ROOT]]
   });
+});
 
-  const sendDocuments = fromPromise<
-    SendDocumentsActorOutput,
-    SendDocumentsActorInput
-  >(async ({ input }) => {
-    const { verifierRequest, credentials } = input;
+export const proximityCommunicationLogicActor = fromCallback<
+  ProximityEvents,
+  ProximityCommunicationLogicInput
+>(({ sendBack, input }) => {
+  const { credentials } = input;
+  const { env } = input.deps;
 
-    assert(credentials, "Missing credentials for sending documents");
-    assert(verifierRequest, "Missing verifier request");
+  assert(credentials, "Missing credentials for proximity communication logic");
 
-    const documents = await getDocuments(
-      verifierRequest.request,
-      credentials,
-      CredentialsVault.get
-    );
-    const includedDocTypes = new Set(documents.map(({ docType }) => docType));
-    const acceptedFields = generateAcceptedFields(
-      verifierRequest.request,
-      includedDocTypes
-    );
-
-    const generatedResponse = await ISO18013_5.generateResponse(
-      documents,
-      acceptedFields
-    );
-
-    // If the timeout is exceeded, throw an exception
-    return promiseWithTimeout(
-      ISO18013_5.sendResponse(generatedResponse),
-      SEND_RESPONSE_TIMEOUT_MS
-    );
-  });
-
-  const terminateSession = fromPromise<SendErrorResponseActorOutput>(
-    async () => {
-      try {
-        return await ISO18013_5.sendErrorResponse(
-          ISO18013_5.ErrorCode.SESSION_TERMINATED
-        );
-      } finally {
-        await ISO18013_5.close().catch(() => null);
-      }
-    }
-  );
-
-  return {
-    checkBluetoothPermissions: checkBluetoothPermissionsActor,
-    checkBluetoothActivation: checkBluetoothActivationActor,
-    checkNfcActivation: checkNfcActivationActor,
-    startEngagement,
-    proximityCommunicationLogic,
-    sendDocuments,
-    terminateSession
+  const handleNfcStarted = () => {
+    sendBack({ type: "nfc-started" });
   };
-};
+
+  const handleNfcStopped = () => {
+    sendBack({ type: "nfc-stopped" });
+  };
+
+  const handleQrCodeString = (
+    eventPayload: EventsPayload["onQrCodeString"]
+  ) => {
+    sendBack({ type: "qr-code-string", payload: eventPayload.data });
+  };
+
+  const handleDeviceConnecting = () => {
+    sendBack({ type: "device-connecting" });
+  };
+
+  const handleDeviceConnected = () => {
+    sendBack({ type: "device-connected" });
+  };
+
+  const handleDeviceDisconnected = () => {
+    sendBack({ type: "device-disconnected" });
+  };
+
+  const handleError = (eventPayload: EventsPayload["onError"]) => {
+    const { error } = eventPayload ?? {};
+    sendBack({
+      type: "device-error",
+      error
+    });
+  };
+
+  const handleDocumentRequestReceived = (
+    eventPayload: EventsPayload["onDocumentRequestReceived"]
+  ) => {
+    const { data, retrievalMethod } = eventPayload ?? {};
+
+    try {
+      assert(data, "Missing required data");
+
+      const parsedRequest = ISO18013_5.parseVerifierRequest(JSON.parse(data));
+      const proximityDetails = getProximityDetails({
+        request: parsedRequest.request,
+        credentials,
+        requireAuthenticated: env.type !== "pre"
+      });
+
+      sendBack({
+        type: "device-document-request-received",
+        proximityDetails,
+        verifierRequest: parsedRequest,
+        retrievalMethod
+      });
+    } catch (error) {
+      // Give some time to show the loading message
+      // and avoid glitches in the UI.
+      setTimeout(() => {
+        sendBack({
+          type: "device-error",
+          error
+        });
+      }, 500);
+    }
+  };
+
+  const listeners = [
+    ISO18013_5.addListener("onNfcStarted", handleNfcStarted),
+    ISO18013_5.addListener("onNfcStopped", handleNfcStopped),
+    ISO18013_5.addListener("onQrCodeString", handleQrCodeString),
+    ISO18013_5.addListener("onDeviceConnecting", handleDeviceConnecting),
+    ISO18013_5.addListener("onDeviceConnected", handleDeviceConnected),
+    ISO18013_5.addListener(
+      "onDocumentRequestReceived",
+      handleDocumentRequestReceived
+    ),
+    ISO18013_5.addListener("onDeviceDisconnected", handleDeviceDisconnected),
+    ISO18013_5.addListener("onError", handleError)
+  ];
+
+  return () => {
+    // Remove event listeners
+    listeners.forEach(listener => listener.remove());
+    // Close connection and clear all resources
+    void ISO18013_5.close().catch(() => null);
+  };
+});
+
+export const sendDocumentsActor = fromPromise<
+  SendDocumentsActorOutput,
+  SendDocumentsActorInput
+>(async ({ input }) => {
+  const { verifierRequest, credentials } = input;
+
+  assert(credentials, "Missing credentials for sending documents");
+  assert(verifierRequest, "Missing verifier request");
+
+  const documents = await getDocuments(
+    verifierRequest.request,
+    credentials,
+    CredentialsVault.get
+  );
+  const includedDocTypes = new Set(documents.map(({ docType }) => docType));
+  const acceptedFields = generateAcceptedFields(
+    verifierRequest.request,
+    includedDocTypes
+  );
+
+  const generatedResponse = await ISO18013_5.generateResponse(
+    documents,
+    acceptedFields
+  );
+
+  // If the timeout is exceeded, throw an exception
+  return promiseWithTimeout(
+    ISO18013_5.sendResponse(generatedResponse),
+    SEND_RESPONSE_TIMEOUT_MS
+  );
+});
+
+export const terminateSessionActor = fromPromise<SendErrorResponseActorOutput>(
+  async () => {
+    try {
+      return await ISO18013_5.sendErrorResponse(
+        ISO18013_5.ErrorCode.SESSION_TERMINATED
+      );
+    } finally {
+      await ISO18013_5.close().catch(() => null);
+    }
+  }
+);

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/context.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/context.ts
@@ -4,12 +4,17 @@ import type { ProximityDetails, VerifierRequest } from "../utils/types";
 
 import { CredentialMetadata } from "../../../common/utils/itwTypesUtils";
 import { ProximityFailure } from "./failure";
+import { ProximityMachineDeps } from "./input";
 
 export type Context = {
   /**
    * The credentials available in the wallet, to be potentially shared with the Relying Party.
    */
   credentials: Record<string, CredentialMetadata> | undefined;
+  /**
+   * Runtime dependencies injected via machine input
+   */
+  deps: ProximityMachineDeps;
   /**
    * The engagement mode committed to for the current proximity session.
    * Defaults to "qrcode"; promoted to "nfc" only after the NFC permission gate succeeds.
@@ -50,7 +55,7 @@ export type Context = {
   verifierRequest?: VerifierRequest;
 };
 
-export const InitialContext: Context = {
+export const InitialContext: Omit<Context, "deps"> = {
   credentials: undefined,
   engagementMode: "qrcode",
   failure: undefined,

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/guards.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/guards.ts
@@ -1,4 +1,3 @@
-import { useIOStore } from "../../../../../store/hooks";
 import { itwProximityConsentExistsSelector } from "../store/selectors/consents";
 import {
   generateConsentKey,
@@ -6,25 +5,27 @@ import {
 } from "../store/utils";
 import { Context } from "./context";
 
-export const createProximityGuardsImplementation = (
-  store: ReturnType<typeof useIOStore>
-) => ({
-  hasGrantedConsent: ({ context }: { context: Context }) => {
-    if (!context.proximityDetails) {
-      return false;
-    }
+type GuardArgs = {
+  context: Context;
+};
 
-    const consentData = getConsentDataFromProximityDetails(
-      context.proximityDetails
-    );
-    const consentKey = generateConsentKey(consentData);
-
-    // Session consent: user already reviewed this exact request in the current session
-    if (context.grantedConsentKey === consentKey) {
-      return true;
-    }
-
-    // Persisted consent: user stored consent for this exact RP and claims combination
-    return itwProximityConsentExistsSelector(consentData)(store.getState());
+export const hasGrantedConsentGuard = ({ context }: GuardArgs) => {
+  if (!context.proximityDetails) {
+    return false;
   }
-});
+
+  const consentData = getConsentDataFromProximityDetails(
+    context.proximityDetails
+  );
+  const consentKey = generateConsentKey(consentData);
+
+  // Session consent: user already reviewed this exact request in the current session
+  if (context.grantedConsentKey === consentKey) {
+    return true;
+  }
+
+  // Persisted consent: user stored consent for this exact RP and claims combination
+  return itwProximityConsentExistsSelector(consentData)(
+    context.deps.store.getState()
+  );
+};

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/input.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/input.ts
@@ -1,6 +1,5 @@
-import { useIONavigation } from "../../../../../navigation/params/AppParamsList";
-import { useIOStore } from "../../../../../store/hooks";
 import { Env } from "../../../common/utils/environment";
+import { MachineNavigation, MachineStore } from "../../../machine/utils/deps";
 
 export type Input = {
   /**
@@ -11,6 +10,6 @@ export type Input = {
 
 export type ProximityMachineDeps = {
   env: Env;
-  navigation: ReturnType<typeof useIONavigation>;
-  store: ReturnType<typeof useIOStore>;
+  navigation: MachineNavigation;
+  store: MachineStore;
 };

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/input.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/input.ts
@@ -1,0 +1,16 @@
+import { useIONavigation } from "../../../../../navigation/params/AppParamsList";
+import { useIOStore } from "../../../../../store/hooks";
+import { Env } from "../../../common/utils/environment";
+
+export type Input = {
+  /**
+   * Runtime dependencies injected by the machine provider
+   */
+  deps: ProximityMachineDeps;
+};
+
+export type ProximityMachineDeps = {
+  env: Env;
+  navigation: ReturnType<typeof useIONavigation>;
+  store: ReturnType<typeof useIOStore>;
+};

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/machine.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/machine.ts
@@ -8,7 +8,7 @@ import { presentmentState } from "./state/presentment";
 
 export const itwProximityMachine = itwProximityMachineSetup.createMachine({
   id: "itwProximityMachine",
-  context: { ...InitialContext },
+  context: ({ input }) => ({ ...InitialContext, deps: input.deps }),
   initial: "Idle",
   entry: "onInit",
   states: {

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/provider.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/provider.tsx
@@ -7,9 +7,6 @@ import { useIOSelector, useIOStore } from "../../../../../store/hooks.ts";
 import { isDebugModeEnabledSelector } from "../../../../../store/reducers/debug.ts";
 import { selectItwEnv } from "../../../common/store/selectors/environment.ts";
 import { getEnv } from "../../../common/utils/environment.ts";
-import { createProximityActionsImplementation } from "./actions.ts";
-import { createProximityActorsImplementation } from "./actors.ts";
-import { createProximityGuardsImplementation } from "./guards.ts";
 import { itwProximityMachine } from "./machine.ts";
 
 export const ItwProximityMachineContext =
@@ -23,14 +20,13 @@ export const ItwProximityMachineProvider = ({
 
   const env = getEnv(useIOSelector(selectItwEnv));
 
-  const proximityMachine = itwProximityMachine.provide({
-    actions: createProximityActionsImplementation(navigation, store),
-    actors: createProximityActorsImplementation(env),
-    guards: createProximityGuardsImplementation(store)
-  });
-
   return (
-    <ItwProximityMachineContext.Provider logic={proximityMachine}>
+    <ItwProximityMachineContext.Provider
+      logic={itwProximityMachine}
+      options={{
+        input: { deps: { env, navigation, store } }
+      }}
+    >
       <DebugData />
       {children}
     </ItwProximityMachineContext.Provider>
@@ -49,10 +45,11 @@ const DebugData = () => {
 const MachineDebugData = () => {
   const state = ItwProximityMachineContext.useSelector(({ value }) => value);
   const context = ItwProximityMachineContext.useSelector(({ context: c }) => c);
+  const { deps: _, ...debugContext } = context;
 
   useDebugInfo({
     state,
-    ...context
+    ...debugContext
   });
 
   return null;

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/setup.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/setup.ts
@@ -1,28 +1,46 @@
-import { assign, fromCallback, fromPromise, setup } from "xstate";
+import { assign, setup } from "xstate";
 
 import {
-  ProximityCommunicationLogicInput,
-  SendDocumentsActorInput,
-  SendDocumentsActorOutput,
-  SendErrorResponseActorOutput,
-  StartEngagementActorInput
+  closeProximityAction,
+  grantConsentAction,
+  navigateToBluetoothActivationScreenAction,
+  navigateToBluetoothPermissionsScreenAction,
+  navigateToClaimsDisclosureScreenAction,
+  navigateToFailureScreenAction,
+  navigateToNfcActivationScreenAction,
+  navigateToNfcPresentmentScreenAction,
+  navigateToPresentmentScreenAction,
+  navigateToStoreconsentScreenAction,
+  navigateToSuccessScreenAction,
+  onInitAction,
+  storeConsentAction,
+  trackProximityStartAction,
+  trackQrCodeLoadingFailureAction
+} from "./actions";
+import {
+  checkBluetoothActivationActor,
+  checkBluetoothPermissionsActor,
+  checkNfcActivationActor,
+  proximityCommunicationLogicActor,
+  sendDocumentsActor,
+  startEngagementActor,
+  terminateSessionActor
 } from "./actors";
 import { Context } from "./context";
 import { ProximityEvents } from "./events";
 import { mapEventToFailure } from "./failure";
-
-const notImplemented = () => {
-  throw new Error("Not implemented");
-};
+import { hasGrantedConsentGuard } from "./guards";
+import { Input } from "./input";
 
 /** Keeps transport actors and provider-injected side effects typed across presentation states. */
 export const itwProximityMachineSetup = setup({
   types: {
     context: {} as Context,
+    input: {} as Input,
     events: {} as ProximityEvents
   },
   actions: {
-    onInit: notImplemented,
+    onInit: onInitAction,
     /**
      * Context manipulation
      */
@@ -35,53 +53,47 @@ export const itwProximityMachineSetup = setup({
      * Navigation
      */
 
-    navigateToBluetoothPermissionsScreen: notImplemented,
-    navigateToBluetoothActivationScreen: notImplemented,
-    navigateToNfcActivationScreen: notImplemented,
-    navigateToPresentmentScreen: notImplemented,
-    navigateToNfcPresentmentScreen: notImplemented,
-    navigateToFailureScreen: notImplemented,
-    navigateToClaimsDisclosureScreen: notImplemented,
-    navigateToStoreconsentScreen: notImplemented,
-    navigateToSuccessScreen: notImplemented,
-    closeProximity: notImplemented,
+    navigateToBluetoothPermissionsScreen:
+      navigateToBluetoothPermissionsScreenAction,
+    navigateToBluetoothActivationScreen:
+      navigateToBluetoothActivationScreenAction,
+    navigateToNfcActivationScreen: navigateToNfcActivationScreenAction,
+    navigateToPresentmentScreen: navigateToPresentmentScreenAction,
+    navigateToNfcPresentmentScreen: navigateToNfcPresentmentScreenAction,
+    navigateToFailureScreen: navigateToFailureScreenAction,
+    navigateToClaimsDisclosureScreen: navigateToClaimsDisclosureScreenAction,
+    navigateToStoreconsentScreen: navigateToStoreconsentScreenAction,
+    navigateToSuccessScreen: navigateToSuccessScreenAction,
+    closeProximity: closeProximityAction,
 
     /**
      * Consents
      */
 
-    grantConsent: notImplemented,
-    storeConsent: notImplemented,
+    grantConsent: grantConsentAction,
+    storeConsent: storeConsentAction,
 
     /**
      * Analytics
      */
 
-    trackProximityStart: notImplemented,
-    trackQrCodeLoadingFailure: notImplemented
+    trackProximityStart: trackProximityStartAction,
+    trackQrCodeLoadingFailure: trackQrCodeLoadingFailureAction
   },
   actors: {
-    checkBluetoothPermissions: fromPromise<boolean>(notImplemented),
-    checkBluetoothActivation: fromPromise<boolean>(notImplemented),
-    checkNfcActivation: fromPromise<boolean>(notImplemented),
-    proximityCommunicationLogic: fromCallback<
-      ProximityEvents,
-      ProximityCommunicationLogicInput
-    >(notImplemented),
-    startEngagement: fromPromise<void, StartEngagementActorInput>(
-      notImplemented
-    ),
-    sendDocuments: fromPromise<
-      SendDocumentsActorOutput,
-      SendDocumentsActorInput
-    >(notImplemented),
-    terminateSession: fromPromise<SendErrorResponseActorOutput>(notImplemented)
+    checkBluetoothPermissions: checkBluetoothPermissionsActor,
+    checkBluetoothActivation: checkBluetoothActivationActor,
+    checkNfcActivation: checkNfcActivationActor,
+    proximityCommunicationLogic: proximityCommunicationLogicActor,
+    startEngagement: startEngagementActor,
+    sendDocuments: sendDocumentsActor,
+    terminateSession: terminateSessionActor
   },
   guards: {
     hasFailure: ({ context }) => !!context.failure,
     isNfcRetrieval: ({ context }) => context.retrievalMethod === "nfc",
     isNfcEngagement: ({ context }) => context.engagementMode === "nfc",
     hasTerminatedSession: ({ context }) => context.sessionTerminated,
-    hasGrantedConsent: notImplemented
+    hasGrantedConsent: hasGrantedConsentGuard
   }
 });

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/state/presentment.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/state/presentment.ts
@@ -13,7 +13,8 @@ export const presentmentState = itwProximityMachineSetup.createStateConfig({
     id: "proximityCommunicationLogic",
     src: "proximityCommunicationLogic",
     input: ({ context }) => ({
-      credentials: context.credentials
+      credentials: context.credentials,
+      deps: context.deps
     }),
     onError: {
       actions: "setFailure",
@@ -120,7 +121,8 @@ export const presentmentState = itwProximityMachineSetup.createStateConfig({
       invoke: {
         src: "startEngagement",
         input: ({ context }) => ({
-          engagementMode: context.engagementMode
+          engagementMode: context.engagementMode,
+          deps: context.deps
         }),
         onDone: {
           target: "AwaitingConnection"

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityFailureScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityFailureScreen.test.tsx
@@ -5,9 +5,9 @@ import { applicationChangeState } from "../../../../../../store/actions/applicat
 import { appReducer } from "../../../../../../store/reducers";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper";
+import { testProximityDeps } from "../../../../machine/utils/testDeps";
 import { ITW_ROUTES } from "../../../../navigation/routes";
 import { ProximityFailure, ProximityFailureType } from "../../machine/failure";
-import { ProximityMachineDeps } from "../../machine/input";
 import { itwProximityMachine } from "../../machine/machine";
 import { ItwProximityMachineContext } from "../../machine/provider";
 import { TimeoutError, UntrustedRpError } from "../../utils/errors";
@@ -36,7 +36,7 @@ const renderComponent = (failure: ProximityFailure) => {
   const initialState = appReducer(undefined, applicationChangeState("active"));
   const store = createStore(appReducer, initialState as any);
   const initialSnapshot = createActor(itwProximityMachine, {
-    input: { deps: { store } as ProximityMachineDeps }
+    input: { deps: testProximityDeps({ store }) }
   }).getSnapshot();
 
   const snapshot: typeof initialSnapshot = {

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityFailureScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityFailureScreen.test.tsx
@@ -7,6 +7,7 @@ import { GlobalState } from "../../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper";
 import { ITW_ROUTES } from "../../../../navigation/routes";
 import { ProximityFailure, ProximityFailureType } from "../../machine/failure";
+import { ProximityMachineDeps } from "../../machine/input";
 import { itwProximityMachine } from "../../machine/machine";
 import { ItwProximityMachineContext } from "../../machine/provider";
 import { TimeoutError, UntrustedRpError } from "../../utils/errors";
@@ -33,7 +34,10 @@ describe("ItwProximityFailureScreen", () => {
 
 const renderComponent = (failure: ProximityFailure) => {
   const initialState = appReducer(undefined, applicationChangeState("active"));
-  const initialSnapshot = createActor(itwProximityMachine).getSnapshot();
+  const store = createStore(appReducer, initialState as any);
+  const initialSnapshot = createActor(itwProximityMachine, {
+    input: { deps: { store } as ProximityMachineDeps }
+  }).getSnapshot();
 
   const snapshot: typeof initialSnapshot = {
     ...initialSnapshot,
@@ -49,6 +53,6 @@ const renderComponent = (failure: ProximityFailure) => {
     ),
     ITW_ROUTES.PROXIMITY.FAILURE,
     {},
-    createStore(appReducer, initialState as any)
+    store
   );
 };

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityQrCodeScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityQrCodeScreen.test.tsx
@@ -6,9 +6,9 @@ import { applicationChangeState } from "../../../../../../store/actions/applicat
 import { appReducer } from "../../../../../../store/reducers";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper";
+import { testProximityDeps } from "../../../../machine/utils/testDeps";
 import { trackItwProximityQrCode } from "../../analytics";
 import { ProximityFailureType } from "../../machine/failure";
-import { ProximityMachineDeps } from "../../machine/input";
 import { itwProximityMachine } from "../../machine/machine";
 import { ItwProximityMachineContext } from "../../machine/provider";
 import { ItwPresentationTags } from "../../machine/tags";
@@ -152,7 +152,7 @@ const renderComponent = (
   const initialState = appReducer(undefined, applicationChangeState("active"));
   const store = createStore(appReducer, initialState as any);
   const initialSnapshot = createActor(itwProximityMachine, {
-    input: { deps: { store } as ProximityMachineDeps }
+    input: { deps: testProximityDeps({ store }) }
   }).getSnapshot();
 
   const snapshot = buildSnapshot(initialSnapshot, options);

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityQrCodeScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityQrCodeScreen.test.tsx
@@ -8,6 +8,7 @@ import { GlobalState } from "../../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper";
 import { trackItwProximityQrCode } from "../../analytics";
 import { ProximityFailureType } from "../../machine/failure";
+import { ProximityMachineDeps } from "../../machine/input";
 import { itwProximityMachine } from "../../machine/machine";
 import { ItwProximityMachineContext } from "../../machine/provider";
 import { ItwPresentationTags } from "../../machine/tags";
@@ -35,7 +36,8 @@ const mockShouldShowExpiredProximityCredentialsBannerSelector = jest.fn(
 );
 jest.mock("../../store/selectors/credentials", () => ({
   shouldShowExpiredProximityCredentialsBannerSelector: () =>
-    mockShouldShowExpiredProximityCredentialsBannerSelector()
+    mockShouldShowExpiredProximityCredentialsBannerSelector(),
+  itwPresentableCredentialsByDocTypeSelector: () => ({})
 }));
 
 describe("ItwProximityPresentmentScreen", () => {
@@ -148,7 +150,10 @@ const renderComponent = (
   routeParams: ItwProximityPresentmentScreenNavigationParams
 ) => {
   const initialState = appReducer(undefined, applicationChangeState("active"));
-  const initialSnapshot = createActor(itwProximityMachine).getSnapshot();
+  const store = createStore(appReducer, initialState as any);
+  const initialSnapshot = createActor(itwProximityMachine, {
+    input: { deps: { store } as ProximityMachineDeps }
+  }).getSnapshot();
 
   const snapshot = buildSnapshot(initialSnapshot, options);
 
@@ -179,7 +184,7 @@ const renderComponent = (
     ),
     ITW_PROXIMITY_ROUTES.PRESENTMENT,
     {},
-    createStore(appReducer, initialState as any)
+    store
   );
 };
 

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/actions.test.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/actions.test.ts
@@ -1,8 +1,7 @@
 import { CredentialType } from "../../../../common/utils/itwMocksUtils";
 import { CredentialMetadata } from "../../../../common/utils/itwTypesUtils";
 import { itwCredentialsConsumeInstance } from "../../../../credentials/store/actions";
-import { ITW_ROUTES } from "../../../../navigation/routes";
-import { createRemoteActionsImplementation } from "../actions";
+import { consumePresentedBatchCredentialsAction } from "../actions";
 import { Context, InitialContext } from "../context";
 
 const baseCredential: CredentialMetadata = {
@@ -28,7 +27,7 @@ const pidCredential: CredentialMetadata = {
   keyTags: undefined
 };
 
-describe("createRemoteActionsImplementation - consumePresentedBatchCredentials", () => {
+describe("consumePresentedBatchCredentialsAction", () => {
   const dispatch = jest.fn();
 
   const makeStore = (credentials: Record<string, CredentialMetadata>) => ({
@@ -49,14 +48,10 @@ describe("createRemoteActionsImplementation - consumePresentedBatchCredentials",
       [baseCredential.credentialId]: baseCredential,
       [pidCredential.credentialId]: pidCredential
     });
-    const actions = createRemoteActionsImplementation(
-      {} as never,
-      store as never
-    );
-
-    actions.consumePresentedBatchCredentials({
+    consumePresentedBatchCredentialsAction({
       context: {
         ...InitialContext,
+        deps: { store, navigation: {} as never },
         presentedKeyTags: ["key-tag-01", "pid-key-tag"]
       } as Context
     } as never);
@@ -71,14 +66,10 @@ describe("createRemoteActionsImplementation - consumePresentedBatchCredentials",
 
   it("does not dispatch when the presented credential is not in the batch allow-list (e.g. PID)", () => {
     const store = makeStore({ [pidCredential.credentialId]: pidCredential });
-    const actions = createRemoteActionsImplementation(
-      {} as never,
-      store as never
-    );
-
-    actions.consumePresentedBatchCredentials({
+    consumePresentedBatchCredentialsAction({
       context: {
         ...InitialContext,
+        deps: { store, navigation: {} as never },
         presentedKeyTags: ["pid-key-tag"]
       } as Context
     } as never);
@@ -88,14 +79,10 @@ describe("createRemoteActionsImplementation - consumePresentedBatchCredentials",
 
   it("does not dispatch when no presented keyTag matches a stored credential", () => {
     const store = makeStore({ [baseCredential.credentialId]: baseCredential });
-    const actions = createRemoteActionsImplementation(
-      {} as never,
-      store as never
-    );
-
-    actions.consumePresentedBatchCredentials({
+    consumePresentedBatchCredentialsAction({
       context: {
         ...InitialContext,
+        deps: { store, navigation: {} as never },
         presentedKeyTags: ["unknown-key-tag"]
       } as Context
     } as never);
@@ -105,32 +92,14 @@ describe("createRemoteActionsImplementation - consumePresentedBatchCredentials",
 
   it("does not dispatch when presentedKeyTags is empty", () => {
     const store = makeStore({ [baseCredential.credentialId]: baseCredential });
-    const actions = createRemoteActionsImplementation(
-      {} as never,
-      store as never
-    );
-
-    actions.consumePresentedBatchCredentials({
-      context: { ...InitialContext, presentedKeyTags: [] } as Context
+    consumePresentedBatchCredentialsAction({
+      context: {
+        ...InitialContext,
+        deps: { store, navigation: {} as never },
+        presentedKeyTags: []
+      } as Context
     } as never);
 
     expect(dispatch).not.toHaveBeenCalled();
-  });
-});
-
-describe("createRemoteActionsImplementation - navigateToIdentificationModeScreen", () => {
-  it("navigates to the eID reissuance identification mode selection screen", () => {
-    const navigate = jest.fn();
-    const actions = createRemoteActionsImplementation(
-      { navigate } as never,
-      { getState: jest.fn(), dispatch: jest.fn() } as never
-    );
-
-    actions.navigateToIdentificationModeScreen();
-
-    expect(navigate).toHaveBeenCalledWith(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.IDENTIFICATION.MODE_SELECTION,
-      params: { eidReissuing: true, level: "l3" }
-    });
   });
 });

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/actions.test.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/actions.test.ts
@@ -1,9 +1,12 @@
 import { CredentialType } from "../../../../common/utils/itwMocksUtils";
 import { CredentialMetadata } from "../../../../common/utils/itwTypesUtils";
 import { itwCredentialsConsumeInstance } from "../../../../credentials/store/actions";
+import {
+  testMachineStore,
+  testRemoteDeps
+} from "../../../../machine/utils/testDeps";
 import { consumePresentedBatchCredentialsAction } from "../actions";
 import { Context, InitialContext } from "../context";
-import { RemoteMachineDeps } from "../input";
 
 const baseCredential: CredentialMetadata = {
   credentialType: CredentialType.PROOF_OF_AGE,
@@ -31,16 +34,17 @@ const pidCredential: CredentialMetadata = {
 describe("consumePresentedBatchCredentialsAction", () => {
   const dispatch = jest.fn();
 
-  const makeStore = (credentials: Record<string, CredentialMetadata>) => ({
-    getState: jest.fn().mockReturnValue({
-      features: {
-        itWallet: {
-          credentials: { credentials }
+  const makeStore = (credentials: Record<string, CredentialMetadata>) =>
+    testMachineStore({
+      getState: jest.fn().mockReturnValue({
+        features: {
+          itWallet: {
+            credentials: { credentials }
+          }
         }
-      }
-    }),
-    dispatch
-  });
+      }),
+      dispatch
+    });
 
   beforeEach(() => jest.clearAllMocks());
 
@@ -52,10 +56,7 @@ describe("consumePresentedBatchCredentialsAction", () => {
     consumePresentedBatchCredentialsAction({
       context: {
         ...InitialContext,
-        deps: {
-          store,
-          navigation: {} as never
-        } as unknown as RemoteMachineDeps,
+        deps: testRemoteDeps({ store }),
         presentedKeyTags: ["key-tag-01", "pid-key-tag"]
       } as Context
     } as never);
@@ -73,10 +74,7 @@ describe("consumePresentedBatchCredentialsAction", () => {
     consumePresentedBatchCredentialsAction({
       context: {
         ...InitialContext,
-        deps: {
-          store,
-          navigation: {} as never
-        } as unknown as RemoteMachineDeps,
+        deps: testRemoteDeps({ store }),
         presentedKeyTags: ["pid-key-tag"]
       } as Context
     } as never);
@@ -89,10 +87,7 @@ describe("consumePresentedBatchCredentialsAction", () => {
     consumePresentedBatchCredentialsAction({
       context: {
         ...InitialContext,
-        deps: {
-          store,
-          navigation: {} as never
-        } as unknown as RemoteMachineDeps,
+        deps: testRemoteDeps({ store }),
         presentedKeyTags: ["unknown-key-tag"]
       } as Context
     } as never);
@@ -105,10 +100,7 @@ describe("consumePresentedBatchCredentialsAction", () => {
     consumePresentedBatchCredentialsAction({
       context: {
         ...InitialContext,
-        deps: {
-          store,
-          navigation: {} as never
-        } as unknown as RemoteMachineDeps,
+        deps: testRemoteDeps({ store }),
         presentedKeyTags: []
       } as Context
     } as never);

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/actions.test.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/actions.test.ts
@@ -3,6 +3,7 @@ import { CredentialMetadata } from "../../../../common/utils/itwTypesUtils";
 import { itwCredentialsConsumeInstance } from "../../../../credentials/store/actions";
 import { consumePresentedBatchCredentialsAction } from "../actions";
 import { Context, InitialContext } from "../context";
+import { RemoteMachineDeps } from "../input";
 
 const baseCredential: CredentialMetadata = {
   credentialType: CredentialType.PROOF_OF_AGE,
@@ -51,7 +52,10 @@ describe("consumePresentedBatchCredentialsAction", () => {
     consumePresentedBatchCredentialsAction({
       context: {
         ...InitialContext,
-        deps: { store, navigation: {} as never },
+        deps: {
+          store,
+          navigation: {} as never
+        } as unknown as RemoteMachineDeps,
         presentedKeyTags: ["key-tag-01", "pid-key-tag"]
       } as Context
     } as never);
@@ -69,7 +73,10 @@ describe("consumePresentedBatchCredentialsAction", () => {
     consumePresentedBatchCredentialsAction({
       context: {
         ...InitialContext,
-        deps: { store, navigation: {} as never },
+        deps: {
+          store,
+          navigation: {} as never
+        } as unknown as RemoteMachineDeps,
         presentedKeyTags: ["pid-key-tag"]
       } as Context
     } as never);
@@ -82,7 +89,10 @@ describe("consumePresentedBatchCredentialsAction", () => {
     consumePresentedBatchCredentialsAction({
       context: {
         ...InitialContext,
-        deps: { store, navigation: {} as never },
+        deps: {
+          store,
+          navigation: {} as never
+        } as unknown as RemoteMachineDeps,
         presentedKeyTags: ["unknown-key-tag"]
       } as Context
     } as never);
@@ -95,7 +105,10 @@ describe("consumePresentedBatchCredentialsAction", () => {
     consumePresentedBatchCredentialsAction({
       context: {
         ...InitialContext,
-        deps: { store, navigation: {} as never },
+        deps: {
+          store,
+          navigation: {} as never
+        } as unknown as RemoteMachineDeps,
         presentedKeyTags: []
       } as Context
     } as never);

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/machine.test.ts
@@ -18,12 +18,16 @@ import {
   GetPresentationDetailsOutput,
   GetRequestObjectInput,
   GetRequestObjectOutput,
+  GetWalletAttestationInput,
   SendAuthorizationResponseInput,
   SendAuthorizationResponseOutput
 } from "../actors.ts";
 import { Context, InitialContext } from "../context.ts";
 import { RemoteFailureType } from "../failure.ts";
+import { RemoteMachineDeps } from "../input.ts";
 import { ItwRemoteMachine, itwRemoteMachine } from "../machine.ts";
+
+const T_DEPS = {} as RemoteMachineDeps;
 
 const T_FLOW_TYPE = "cross-device";
 const T_CLIENT_ID = "clientId";
@@ -98,8 +102,10 @@ describe("itwRemoteMachine", () => {
         SendAuthorizationResponseOutput,
         SendAuthorizationResponseInput
       >(sendAuthorizationResponse),
-      getWalletAttestation:
-        fromPromise<WalletInstanceAttestations>(getWalletAttestation)
+      getWalletAttestation: fromPromise<
+        WalletInstanceAttestations,
+        GetWalletAttestationInput
+      >(getWalletAttestation)
     },
     guards: {
       isItWalletL3Active,
@@ -114,7 +120,7 @@ describe("itwRemoteMachine", () => {
   });
 
   it("should initialize correctly", () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     expect(actor.getSnapshot().value).toStrictEqual("Idle");
@@ -123,7 +129,7 @@ describe("itwRemoteMachine", () => {
   it("should transition from Idle to WalletInactive when wallet is inactive or the identification is not L3", () => {
     isItWalletL3Active.mockReturnValue(false);
 
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     actor.send({
@@ -141,8 +147,9 @@ describe("itwRemoteMachine", () => {
   });
 
   it("Should navigate to wallet when user not accept to active IT Wallet", async () => {
-    const initialSnapshot: MachineSnapshot =
-      createActor(itwRemoteMachine).getSnapshot();
+    const initialSnapshot: MachineSnapshot = createActor(mockedMachine, {
+      input: { deps: T_DEPS }
+    }).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
       value: "Failure",
@@ -152,6 +159,7 @@ describe("itwRemoteMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot
     });
     actor.start();
@@ -161,8 +169,9 @@ describe("itwRemoteMachine", () => {
   });
 
   it("Should navigate to TOS when user accept to active IT Wallet", async () => {
-    const initialSnapshot: MachineSnapshot =
-      createActor(itwRemoteMachine).getSnapshot();
+    const initialSnapshot: MachineSnapshot = createActor(mockedMachine, {
+      input: { deps: T_DEPS }
+    }).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
       value: "Failure",
@@ -172,6 +181,7 @@ describe("itwRemoteMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot
     });
     actor.start();
@@ -181,8 +191,9 @@ describe("itwRemoteMachine", () => {
   });
 
   it("Should navigate to Identification mode when user start the reissuing flow", async () => {
-    const initialSnapshot: MachineSnapshot =
-      createActor(itwRemoteMachine).getSnapshot();
+    const initialSnapshot: MachineSnapshot = createActor(mockedMachine, {
+      input: { deps: T_DEPS }
+    }).getSnapshot();
 
     const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
       value: "Failure",
@@ -192,6 +203,7 @@ describe("itwRemoteMachine", () => {
     } as MachineSnapshot);
 
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot
     });
     actor.start();
@@ -201,7 +213,7 @@ describe("itwRemoteMachine", () => {
   });
 
   it("should transition from Idle to EvaluatingRelyingPartyTrust when IT Wallet is active", () => {
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     isItWalletL3Active.mockReturnValue(true);
@@ -261,7 +273,7 @@ describe("itwRemoteMachine", () => {
     /**
      * Start the presentation
      */
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     actor.send({
@@ -271,6 +283,7 @@ describe("itwRemoteMachine", () => {
     });
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       ...InitialContext,
+      deps: T_DEPS,
       walletInstanceAttestation: T_WIA,
       credentials: T_CREDENTIALS,
       payload: qrCodePayload,
@@ -292,6 +305,7 @@ describe("itwRemoteMachine", () => {
     expect(evaluateRelyingPartyTrust).toHaveBeenCalledTimes(1);
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       ...InitialContext,
+      deps: T_DEPS,
       walletInstanceAttestation: T_WIA,
       credentials: T_CREDENTIALS,
       payload: qrCodePayload,
@@ -306,6 +320,7 @@ describe("itwRemoteMachine", () => {
     expect(getRequestObject).toHaveBeenCalledTimes(1);
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       ...InitialContext,
+      deps: T_DEPS,
       walletInstanceAttestation: T_WIA,
       credentials: T_CREDENTIALS,
       requestObjectEncodedJwt: unverifiedRequestObject,
@@ -323,6 +338,7 @@ describe("itwRemoteMachine", () => {
     expect(getPresentationDetails).toHaveBeenCalledTimes(1);
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       ...InitialContext,
+      deps: T_DEPS,
       walletInstanceAttestation: T_WIA,
       credentials: T_CREDENTIALS,
       requestObjectEncodedJwt: unverifiedRequestObject,
@@ -346,6 +362,7 @@ describe("itwRemoteMachine", () => {
     actor.send({ type: "toggle-credential", credentialIds: ["cred03"] });
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       ...InitialContext,
+      deps: T_DEPS,
       walletInstanceAttestation: T_WIA,
       credentials: T_CREDENTIALS,
       requestObjectEncodedJwt: unverifiedRequestObject,
@@ -368,6 +385,7 @@ describe("itwRemoteMachine", () => {
     expect(sendAuthorizationResponse).toHaveBeenCalledTimes(1);
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       ...InitialContext,
+      deps: T_DEPS,
       walletInstanceAttestation: T_WIA,
       credentials: T_CREDENTIALS,
       requestObjectEncodedJwt: unverifiedRequestObject,
@@ -408,7 +426,7 @@ describe("itwRemoteMachine", () => {
     getRequestObject.mockResolvedValue("encoded-jwt");
     getPresentationDetails.mockRejectedValue({ message: "ERROR" });
 
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     actor.send({
@@ -429,8 +447,11 @@ describe("itwRemoteMachine", () => {
   it("should transition to failure when an error occurs in SendingAuthorizationResponse", async () => {
     sendAuthorizationResponse.mockRejectedValue({ message: "ERROR" });
 
-    const initialSnapshot = createActor(itwRemoteMachine).getSnapshot();
+    const initialSnapshot = createActor(mockedMachine, {
+      input: { deps: T_DEPS }
+    }).getSnapshot();
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: _.merge(undefined, initialSnapshot, {
         // Start in the previous state to invoke the actor when transitioning to SendingAuthorizationResponse
         value: "ClaimsDisclosure"
@@ -454,7 +475,7 @@ describe("itwRemoteMachine", () => {
       throw new Error("Trust evaluation failed");
     });
 
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     actor.send({
@@ -472,12 +493,16 @@ describe("itwRemoteMachine", () => {
   });
 
   it("should reset the machine", async () => {
-    const initialSnapshot = createActor(itwRemoteMachine).getSnapshot();
+    const initialSnapshot = createActor(mockedMachine, {
+      input: { deps: T_DEPS }
+    }).getSnapshot();
     const actor = createActor(mockedMachine, {
+      input: { deps: T_DEPS },
       snapshot: _.merge(undefined, initialSnapshot, {
         value: "ClaimsDisclosure",
         context: {
           ...InitialContext,
+          deps: T_DEPS,
           flowType: T_FLOW_TYPE,
           payload: qrCodePayload
         }
@@ -487,7 +512,11 @@ describe("itwRemoteMachine", () => {
     actor.send({ type: "reset" });
 
     await waitFor(actor, snapshot => snapshot.matches("Idle"));
-    expect(actor.getSnapshot().context).toStrictEqual<Context>(InitialContext);
+    expect(actor.getSnapshot().context).toStrictEqual<Context>({
+      ...InitialContext,
+      deps: T_DEPS,
+      walletInstanceAttestation: T_WIA
+    });
   });
 
   it("should fetch the Wallet Attestation when it is invalid", async () => {
@@ -500,7 +529,7 @@ describe("itwRemoteMachine", () => {
     hasValidWalletInstanceAttestation.mockReturnValueOnce(false);
     getWalletAttestation.mockResolvedValue(mockWalletAttestation);
 
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     actor.send({
@@ -525,7 +554,7 @@ describe("itwRemoteMachine", () => {
     isOpenIdFederationClient.mockReturnValue(true);
     evaluateRelyingPartyTrust.mockResolvedValue({});
 
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     actor.send({
@@ -549,7 +578,7 @@ describe("itwRemoteMachine", () => {
     isOpenIdFederationClient.mockReturnValue(false);
     isX509HashClient.mockReturnValue(true);
 
-    const actor = createActor(mockedMachine);
+    const actor = createActor(mockedMachine, { input: { deps: T_DEPS } });
     actor.start();
 
     actor.send({

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/machine.test.ts
@@ -6,6 +6,7 @@ import {
   RequestObject,
   WalletInstanceAttestations
 } from "../../../../common/utils/itwTypesUtils.ts";
+import { testRemoteDeps } from "../../../../machine/utils/testDeps";
 import {
   EnrichedPresentationDetails,
   ItwRemoteRequestPayload,
@@ -24,10 +25,9 @@ import {
 } from "../actors.ts";
 import { Context, InitialContext } from "../context.ts";
 import { RemoteFailureType } from "../failure.ts";
-import { RemoteMachineDeps } from "../input.ts";
 import { ItwRemoteMachine, itwRemoteMachine } from "../machine.ts";
 
-const T_DEPS = {} as RemoteMachineDeps;
+const T_DEPS = testRemoteDeps();
 
 const T_FLOW_TYPE = "cross-device";
 const T_CLIENT_ID = "clientId";

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/selectors.test.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/selectors.test.ts
@@ -2,6 +2,7 @@ import { decode as decodeJwt } from "@pagopa/io-react-native-jwt";
 import _ from "lodash";
 import { createActor, StateFrom } from "xstate";
 
+import { RemoteMachineDeps } from "../input.ts";
 import { ItwRemoteMachine, itwRemoteMachine } from "../machine.ts";
 import { selectUnverifiedRequestObject } from "../selectors.ts";
 
@@ -13,8 +14,12 @@ const mockDecodeJwt = jest.mocked(decodeJwt);
 
 type MachineSnapshot = StateFrom<ItwRemoteMachine>;
 
+const T_DEPS = {} as RemoteMachineDeps;
+
 const createSnapshot = (requestObjectEncodedJwt?: string): MachineSnapshot => {
-  const initialSnapshot = createActor(itwRemoteMachine).getSnapshot();
+  const initialSnapshot = createActor(itwRemoteMachine, {
+    input: { deps: T_DEPS }
+  }).getSnapshot();
 
   return _.merge(undefined, initialSnapshot, {
     context: { requestObjectEncodedJwt }

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/actions.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/actions.ts
@@ -2,9 +2,7 @@ import { type ActionArgs, assign, type DoneActorEvent } from "xstate";
 
 import type { WalletInstanceAttestations } from "../../../common/utils/itwTypesUtils.ts";
 
-import { useIONavigation } from "../../../../../navigation/params/AppParamsList.ts";
 import ROUTES from "../../../../../navigation/routes.ts";
-import { useIOStore } from "../../../../../store/hooks.ts";
 import { checkCurrentSession } from "../../../../authentication/common/store/actions/index.ts";
 import { BATCH_ISSUANCE_CREDENTIALS } from "../../../common/utils/itwCredentialIssuanceUtils.ts";
 import {
@@ -28,144 +26,162 @@ import {
 import { Context } from "./context.ts";
 import { RemoteEvents } from "./events.ts";
 
-export const createRemoteActionsImplementation = (
-  navigation: ReturnType<typeof useIONavigation>,
-  store: ReturnType<typeof useIOStore>
-) => ({
-  onInit: assign<Context, RemoteEvents, unknown, RemoteEvents, any>(() => {
-    const state = store.getState();
+/**
+ * Initializes the remote presentation machine from the Redux store.
+ */
+export const onInitAction = assign<
+  Context,
+  RemoteEvents,
+  unknown,
+  RemoteEvents,
+  any
+>(({ context }) => {
+  const state = context.deps.store.getState();
 
-    return {
-      walletInstanceAttestation: itwWalletInstanceAttestationSelector(state),
-      credentials: itwCredentialsAllSelector(state)
-    };
-  }),
-
-  navigateToFailureScreen: () => {
-    navigation.navigate(ITW_REMOTE_ROUTES.MAIN, {
-      screen: ITW_REMOTE_ROUTES.FAILURE
-    });
-  },
-
-  navigateToDiscoveryScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.DISCOVERY.INFO,
-      params: { level: "l3" } // To continue with the presentation, IT-Wallet must be activated
-    });
-  },
-
-  navigateToClaimsDisclosureScreen: () => {
-    navigation.navigate(ITW_REMOTE_ROUTES.MAIN, {
-      screen: ITW_REMOTE_ROUTES.CLAIMS_DISCLOSURE
-    });
-  },
-
-  navigateToIdentificationModeScreen: () => {
-    navigation.navigate(ITW_ROUTES.MAIN, {
-      screen: ITW_ROUTES.IDENTIFICATION.MODE_SELECTION,
-      params: { eidReissuing: true, level: "l3" }
-    });
-  },
-
-  navigateToBarcodeScanScreen: () => {
-    navigation.navigate(ROUTES.BARCODE_SCAN, undefined);
-  },
-
-  navigateToAuthResponseScreen: () => {
-    navigation.navigate(ITW_REMOTE_ROUTES.MAIN, {
-      screen: ITW_REMOTE_ROUTES.AUTH_RESPONSE
-    });
-  },
-
-  closePresentation: () => {
-    navigation.popToTop();
-  },
-
-  trackRemoteDataShare: ({
-    context
-  }: ActionArgs<Context, RemoteEvents, RemoteEvents>) => {
-    if (context.presentationDetails) {
-      const { required, optional } = groupCredentialsByPurpose(
-        context.presentationDetails
-      );
-      const credential_type = getRemoteCredentialCombination(
-        context.presentationDetails
-      );
-      const requestedCredentials = [...required, ...optional];
-
-      const data_type = optional.length > 0 ? "optional" : "required";
-
-      /**
-       * Returns the request type based on the "purpose" fields in the credentials:
-       * - "no_purpose" if none are defined
-       * - "unique_purpose" if there's only one purpose, or all share the same purpose
-       * - "multiple_purpose" if there are multiple distinct valid purposes
-       * A purpose is considered valid only if it's a non-empty, non-whitespace string.
-       */
-      const purposes = [
-        ...new Set(
-          requestedCredentials
-            .map(item => item.purpose)
-            .filter((purpose): purpose is string => !!purpose?.trim())
-        )
-      ];
-
-      const request_type =
-        purposes.length === 0
-          ? "no_purpose"
-          : purposes.length === 1
-            ? "unique_purpose"
-            : "multiple_purpose";
-
-      trackItwRemoteDataShare({
-        data_type,
-        request_type,
-        credential_type
-      });
-    }
-  },
-
-  storeWalletInstanceAttestation: ({
-    event
-  }: ActionArgs<Context, RemoteEvents, RemoteEvents>) => {
-    store.dispatch(
-      itwWalletInstanceAttestationStore(
-        (event as DoneActorEvent<WalletInstanceAttestations>).output
-      )
-    );
-  },
-
-  consumePresentedBatchCredentials: ({
-    context
-  }: ActionArgs<Context, RemoteEvents, RemoteEvents>) => {
-    const credentials = itwAllStoredCredentialsSelector(store.getState());
-
-    // Restrict consumption to credential types explicitly opted in via
-    // `consumeOnPresentation` in BATCH_ISSUANCE_CREDENTIALS (currently only Proof of Age):
-    // presenting any other credential, batch or not, has no effect here.
-    const consumedInstances = context.presentedKeyTags
-      .map(keyTag => {
-        const credential = credentials.find(
-          c =>
-            BATCH_ISSUANCE_CREDENTIALS[c.credentialType]
-              ?.consumeOnPresentation === true &&
-            isBatchCredential(c) &&
-            getCredentialKeyTags(c).includes(keyTag)
-        );
-        return credential
-          ? { credentialId: credential.credentialId, keyTag }
-          : undefined;
-      })
-      .filter(
-        (instance): instance is { credentialId: string; keyTag: string } =>
-          instance !== undefined
-      );
-
-    if (consumedInstances.length > 0) {
-      store.dispatch(itwCredentialsConsumeInstance(consumedInstances));
-    }
-  },
-
-  handleSessionExpired: () =>
-    store.dispatch(checkCurrentSession.success({ isSessionValid: false }))
+  return {
+    walletInstanceAttestation: itwWalletInstanceAttestationSelector(state),
+    credentials: itwCredentialsAllSelector(state)
+  };
 });
+
+export const navigateToFailureScreenAction = ({
+  context
+}: ActionArgs<Context, RemoteEvents, RemoteEvents>) => {
+  context.deps.navigation.navigate(ITW_REMOTE_ROUTES.MAIN, {
+    screen: ITW_REMOTE_ROUTES.FAILURE
+  });
+};
+
+export const navigateToDiscoveryScreenAction = ({
+  context
+}: ActionArgs<Context, RemoteEvents, RemoteEvents>) => {
+  context.deps.navigation.navigate(ITW_ROUTES.MAIN, {
+    screen: ITW_ROUTES.DISCOVERY.INFO,
+    params: { level: "l3" } // To continue with the presentation, IT-Wallet must be activated
+  });
+};
+
+export const navigateToClaimsDisclosureScreenAction = ({
+  context
+}: ActionArgs<Context, RemoteEvents, RemoteEvents>) => {
+  context.deps.navigation.navigate(ITW_REMOTE_ROUTES.MAIN, {
+    screen: ITW_REMOTE_ROUTES.CLAIMS_DISCLOSURE
+  });
+};
+
+export const navigateToBarcodeScanScreenAction = ({
+  context
+}: ActionArgs<Context, RemoteEvents, RemoteEvents>) => {
+  context.deps.navigation.navigate(ROUTES.BARCODE_SCAN, undefined);
+};
+
+export const navigateToAuthResponseScreenAction = ({
+  context
+}: ActionArgs<Context, RemoteEvents, RemoteEvents>) => {
+  context.deps.navigation.navigate(ITW_REMOTE_ROUTES.MAIN, {
+    screen: ITW_REMOTE_ROUTES.AUTH_RESPONSE
+  });
+};
+
+export const closePresentationAction = ({
+  context
+}: ActionArgs<Context, RemoteEvents, RemoteEvents>) => {
+  context.deps.navigation.popToTop();
+};
+
+export const trackRemoteDataShareAction = ({
+  context
+}: ActionArgs<Context, RemoteEvents, RemoteEvents>) => {
+  if (context.presentationDetails) {
+    const { required, optional } = groupCredentialsByPurpose(
+      context.presentationDetails
+    );
+    const credential_type = getRemoteCredentialCombination(
+      context.presentationDetails
+    );
+    const requestedCredentials = [...required, ...optional];
+
+    const data_type = optional.length > 0 ? "optional" : "required";
+
+    /**
+     * Returns the request type based on the "purpose" fields in the credentials:
+     * - "no_purpose" if none are defined
+     * - "unique_purpose" if there's only one purpose, or all share the same purpose
+     * - "multiple_purpose" if there are multiple distinct valid purposes
+     * A purpose is considered valid only if it's a non-empty, non-whitespace string.
+     */
+    const purposes = [
+      ...new Set(
+        requestedCredentials
+          .map(item => item.purpose)
+          .filter((purpose): purpose is string => !!purpose?.trim())
+      )
+    ];
+
+    const request_type =
+      purposes.length === 0
+        ? "no_purpose"
+        : purposes.length === 1
+          ? "unique_purpose"
+          : "multiple_purpose";
+
+    trackItwRemoteDataShare({
+      data_type,
+      request_type,
+      credential_type
+    });
+  }
+};
+
+export const storeWalletInstanceAttestationAction = ({
+  context,
+  event
+}: ActionArgs<Context, RemoteEvents, RemoteEvents>) => {
+  context.deps.store.dispatch(
+    itwWalletInstanceAttestationStore(
+      (event as DoneActorEvent<WalletInstanceAttestations>).output
+    )
+  );
+};
+
+export const consumePresentedBatchCredentialsAction = ({
+  context
+}: ActionArgs<Context, RemoteEvents, RemoteEvents>) => {
+  const credentials = itwAllStoredCredentialsSelector(
+    context.deps.store.getState()
+  );
+
+  // Restrict consumption to credential types explicitly opted in via
+  // `consumeOnPresentation` in BATCH_ISSUANCE_CREDENTIALS (currently only Proof of Age):
+  // presenting any other credential, batch or not, has no effect here.
+  const consumedInstances = context.presentedKeyTags
+    .map(keyTag => {
+      const credential = credentials.find(
+        c =>
+          BATCH_ISSUANCE_CREDENTIALS[c.credentialType]
+            ?.consumeOnPresentation === true &&
+          isBatchCredential(c) &&
+          getCredentialKeyTags(c).includes(keyTag)
+      );
+      return credential
+        ? { credentialId: credential.credentialId, keyTag }
+        : undefined;
+    })
+    .filter(
+      (instance): instance is { credentialId: string; keyTag: string } =>
+        instance !== undefined
+    );
+
+  if (consumedInstances.length > 0) {
+    context.deps.store.dispatch(
+      itwCredentialsConsumeInstance(consumedInstances)
+    );
+  }
+};
+
+export const handleSessionExpiredAction = ({
+  context
+}: ActionArgs<Context, RemoteEvents, RemoteEvents>) =>
+  context.deps.store.dispatch(
+    checkCurrentSession.success({ isSessionValid: false })
+  );

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/actors.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/actors.ts
@@ -1,11 +1,9 @@
-import { ItwVersion, RemotePresentation } from "@pagopa/io-react-native-wallet";
+import { RemotePresentation } from "@pagopa/io-react-native-wallet";
 import { fromPromise } from "xstate";
 
-import { useIOStore } from "../../../../../store/hooks";
 import { assert } from "../../../../../utils/assert";
 import { IO_UNIVERSAL_LINK_PREFIX } from "../../../../../utils/navigation";
 import { sessionTokenSelector } from "../../../../authentication/common/store/selectors";
-import { Env } from "../../../common/utils/environment";
 import { getWalletInstanceAttestation } from "../../../common/utils/itwAttestationUtils";
 import { getRepresentativeVaultId } from "../../../common/utils/itwCredentialUtils";
 import { getIoWallet } from "../../../common/utils/itwIoWallet";
@@ -30,10 +28,13 @@ import {
   RelyingPartyConfiguration
 } from "../utils/itwRemoteTypeUtils";
 import { InvalidCredentialsStatusError } from "./failure";
+import { RemoteMachineDeps } from "./input";
 
 export type EvaluateRelyingPartyTrustInput = Partial<{
   qrCodePayload: ItwRemoteRequestPayload;
-}>;
+}> & {
+  deps: RemoteMachineDeps;
+};
 
 export type EvaluateRelyingPartyTrustOutput = {
   rpConf: RelyingPartyConfiguration;
@@ -45,17 +46,26 @@ export type GetPresentationDetailsInput = Partial<{
   requestObjectEncodedJwt: string;
   rpConf: RelyingPartyConfiguration;
   walletInstanceAttestation: WalletInstanceAttestations;
-}>;
+}> & {
+  deps: RemoteMachineDeps;
+};
 export type GetPresentationDetailsOutput = {
   presentationDetails: EnrichedPresentationDetails;
   requestObject: RequestObject;
 };
 export type GetRequestObjectInput = Partial<{
   qrCodePayload: ItwRemoteRequestPayload;
-}>;
+}> & {
+  deps: RemoteMachineDeps;
+};
 export type GetRequestObjectOutput = string;
 
+export type GetWalletAttestationInput = {
+  deps: RemoteMachineDeps;
+};
+
 export type SendAuthorizationResponseInput = {
+  deps: RemoteMachineDeps;
   optionalCredentials: Set<string>;
   presentationDetails?: EnrichedPresentationDetails;
   requestObject?: RequestObject;
@@ -80,243 +90,235 @@ type CredentialsByFormat = {
 };
 type CredentialsForDcql = Array<RemotePresentation.Credential4Dcql>;
 
-export const createRemoteActorsImplementation = (
-  env: Env,
-  itwVersion: ItwVersion,
-  store: ReturnType<typeof useIOStore>
-) => {
-  const evaluateRelyingPartyTrust = fromPromise<
-    EvaluateRelyingPartyTrustOutput,
-    EvaluateRelyingPartyTrustInput
-  >(async ({ input }) => {
-    const ioWallet = getIoWallet(itwVersion);
+export const evaluateRelyingPartyTrustActor = fromPromise<
+  EvaluateRelyingPartyTrustOutput,
+  EvaluateRelyingPartyTrustInput
+>(async ({ input }) => {
+  const { env, itwVersion } = input.deps;
+  const ioWallet = getIoWallet(itwVersion);
 
-    const { qrCodePayload } = input;
-    assert(qrCodePayload?.client_id, "Missing required client ID");
+  const { qrCodePayload } = input;
+  assert(qrCodePayload?.client_id, "Missing required client ID");
 
-    const rpUrl = qrCodePayload.client_id.replace(
-      ClientIdPrefix.OPENID_FEDERATION,
-      ""
+  const rpUrl = qrCodePayload.client_id.replace(
+    ClientIdPrefix.OPENID_FEDERATION,
+    ""
+  );
+
+  const trustAnchorEntityConfig =
+    await ioWallet.Trust.getTrustAnchorEntityConfiguration(
+      env.WALLET_TA_BASE_URL
     );
 
-    const trustAnchorEntityConfig =
-      await ioWallet.Trust.getTrustAnchorEntityConfiguration(
-        env.WALLET_TA_BASE_URL
-      );
+  // Create the trust chain for the Relying Party
+  const builtChainJwts = await ioWallet.Trust.buildTrustChain(
+    rpUrl,
+    trustAnchorEntityConfig
+  );
 
-    // Create the trust chain for the Relying Party
-    const builtChainJwts = await ioWallet.Trust.buildTrustChain(
-      rpUrl,
-      trustAnchorEntityConfig
-    );
-
-    // Perform full validation on the built chainW
-    await ioWallet.Trust.verifyTrustChain(
-      trustAnchorEntityConfig,
-      builtChainJwts,
-      {
-        connectTimeout: 10000,
-        readTimeout: 10000,
-        requireCrl: true
-      }
-    );
-
-    // Determine the Relying Party configuration and subject
-    const { rpConf } =
-      await ioWallet.RemotePresentation.evaluateRelyingPartyTrust(rpUrl);
-
-    return { rpConf };
-  });
-
-  // The retrieval of the Request Object is managed by a dedicated actor to enable access
-  // to the `response_uri` parameter in the event of a validation failure during its processing.
-  const getRequestObject = fromPromise<
-    GetRequestObjectOutput,
-    GetRequestObjectInput
-  >(async ({ input }) => {
-    const { qrCodePayload } = input;
-    assert(qrCodePayload, "Missing required qrCodePayload");
-
-    const ioWallet = getIoWallet(itwVersion);
-
-    // `getRequestObject` expects a full URL to be passed, so it is reconstructed from the QR code payload.
-    // The host and path segments are actually not relevant, only the query parameters are.
-    const authRequestUrl = `${IO_UNIVERSAL_LINK_PREFIX}/itw/auth?${new URLSearchParams(
-      qrCodePayload
-    )}`;
-    const { requestObjectEncodedJwt } =
-      await ioWallet.RemotePresentation.getRequestObject(authRequestUrl);
-
-    return requestObjectEncodedJwt;
-  });
-
-  const getPresentationDetails = fromPromise<
-    GetPresentationDetailsOutput,
-    GetPresentationDetailsInput
-  >(async ({ input }) => {
-    const {
-      rpConf,
-      qrCodePayload,
-      requestObjectEncodedJwt,
-      credentials,
-      walletInstanceAttestation
-    } = input;
-
-    assert(
-      walletInstanceAttestation,
-      "Missing required input walletInstanceAttestation"
-    );
-    assert(credentials, "Missing required input credentials");
-    assert(qrCodePayload, "Missing required input QR Code payload");
-    assert(
-      requestObjectEncodedJwt,
-      "Missing required input requestObjectEncodedJwt"
-    );
-
-    const ioWallet = getIoWallet(itwVersion);
-    const { client_id, state } = qrCodePayload;
-
-    const { requestObject } =
-      await ioWallet.RemotePresentation.verifyRequestObject(
-        requestObjectEncodedJwt,
-        {
-          clientId: client_id,
-          state,
-          rpConf
-        }
-      );
-
-    // Optional certificate chain validation, if supported by the specs version
-    if (
-      requestObject.x5c &&
-      ioWallet.RemotePresentation.verifyAuthRequestCertificateChain
-    ) {
-      await ioWallet.RemotePresentation.verifyAuthRequestCertificateChain(
-        requestObjectEncodedJwt,
-        { caRootCert: env.X509_CERT_ROOT }
-      );
-    }
-
-    assert(requestObject.dcql_query, "Missing required DCQL query");
-
-    // Retrieve all credentials from the vault to prepare them for the DCQL evaluation.
-    // The evaluation will require the full credential.
-    const credentialsData = await Promise.all(
-      Object.values(credentials).map(async c => {
-        // Present the representative copy (the only one for a non-batch credential).
-        const vaultId = getRepresentativeVaultId(c);
-        const credential = await CredentialsVault.get(vaultId);
-        assert(
-          credential,
-          `Credential with vaultId ${vaultId} not found in secure storage`
-        );
-        return {
-          keyTag: c.keyTag,
-          format: c.format,
-          credential
-        };
-      })
-    );
-
-    // Prepare credentials to evaluate the Relying Party request, split by format since the DCQL
-    // evaluation decodes SD-JWT and mDoc credentials (e.g. proof of age) with different parsers.
-    const { sdJwt, mdoc } =
-      prepareCredentialsForDcqlEvaluation(credentialsData);
-
-    // Evaluate the DCQL query against the credentials contained in the Wallet
-    const result = await ioWallet.RemotePresentation.evaluateDcqlQuery(
-      requestObject.dcql_query as DcqlQuery,
-      sdJwt,
-      mdoc
-    );
-
-    // Check whether any of the requested credentials cannot be presented remotely:
-    // revocation blocks any credential, while a non-valid PID cannot be sent remotely.
-    const invalidCredentials = getInvalidCredentials(result, credentials);
-
-    if (invalidCredentials.length > 0) {
-      throw new InvalidCredentialsStatusError(invalidCredentials);
-    }
-
-    // Add localization to the requested claims
-    const presentationDetails = enrichPresentationDetails(result, credentials);
-
-    return { requestObject, presentationDetails };
-  });
-
-  const sendAuthorizationResponse = fromPromise<
-    SendAuthorizationResponseOutput,
-    SendAuthorizationResponseInput
-  >(async ({ input }) => {
-    const { rpConf, presentationDetails, requestObject, optionalCredentials } =
-      input;
-
-    assert(
-      presentationDetails && requestObject,
-      "Missing required sendAuthorizationResponse actor params"
-    );
-
-    const ioWallet = getIoWallet(itwVersion);
-
-    // Get required credentials and optional credentials that have been selected by the user
-    const credentialsToPresent = presentationDetails.filter(
-      c =>
-        c.purposes.some(({ required }) => required) ||
-        optionalCredentials.has(c.id)
-    );
-
-    const remotePresentations =
-      await ioWallet.RemotePresentation.prepareRemotePresentations(
-        credentialsToPresent,
-        {
-          nonce: requestObject.nonce,
-          clientId: requestObject.client_id,
-          responseUri: requestObject.response_uri
-        }
-      );
-
-    const authResponse =
-      await ioWallet.RemotePresentation.sendAuthorizationResponse(
-        requestObject,
-        remotePresentations,
-        rpConf
-      );
-
-    return {
-      redirectUri: authResponse.redirect_uri,
-      presentedKeyTags: credentialsToPresent.map(c => c.keyTag)
-    };
-  });
-
-  const getWalletAttestation = fromPromise<WalletInstanceAttestations>(
-    async () => {
-      // In the same-device flow the app might be launched directly to the presentation machine,
-      // and the integrity service necessary to get the attestation might not yet be ready.
-      await ensureIntegrityServiceIsStoreReadyOrThrow(store);
-
-      const sessionToken = sessionTokenSelector(store.getState());
-      const integrityKeyTag = itwIntegrityKeyTagSelector(store.getState());
-
-      assert(sessionToken, "sessionToken is undefined");
-      assert(integrityKeyTag, "integrityKeyTag is undefined");
-
-      return getWalletInstanceAttestation(
-        env,
-        itwVersion,
-        integrityKeyTag,
-        sessionToken
-      );
+  // Perform full validation on the built chainW
+  await ioWallet.Trust.verifyTrustChain(
+    trustAnchorEntityConfig,
+    builtChainJwts,
+    {
+      connectTimeout: 10000,
+      readTimeout: 10000,
+      requireCrl: true
     }
   );
 
+  // Determine the Relying Party configuration and subject
+  const { rpConf } =
+    await ioWallet.RemotePresentation.evaluateRelyingPartyTrust(rpUrl);
+
+  return { rpConf };
+});
+
+// The retrieval of the Request Object is managed by a dedicated actor to enable access
+// to the `response_uri` parameter in the event of a validation failure during its processing.
+export const getRequestObjectActor = fromPromise<
+  GetRequestObjectOutput,
+  GetRequestObjectInput
+>(async ({ input }) => {
+  const { itwVersion } = input.deps;
+  const { qrCodePayload } = input;
+  assert(qrCodePayload, "Missing required qrCodePayload");
+
+  const ioWallet = getIoWallet(itwVersion);
+
+  // `getRequestObjectActor` expects a full URL to be passed, so it is reconstructed from the QR code payload.
+  // The host and path segments are actually not relevant, only the query parameters are.
+  const authRequestUrl = `${IO_UNIVERSAL_LINK_PREFIX}/itw/auth?${new URLSearchParams(
+    qrCodePayload
+  )}`;
+  const { requestObjectEncodedJwt } =
+    await ioWallet.RemotePresentation.getRequestObject(authRequestUrl);
+
+  return requestObjectEncodedJwt;
+});
+
+export const getPresentationDetailsActor = fromPromise<
+  GetPresentationDetailsOutput,
+  GetPresentationDetailsInput
+>(async ({ input }) => {
+  const { env, itwVersion } = input.deps;
+  const {
+    rpConf,
+    qrCodePayload,
+    requestObjectEncodedJwt,
+    credentials,
+    walletInstanceAttestation
+  } = input;
+
+  assert(
+    walletInstanceAttestation,
+    "Missing required input walletInstanceAttestation"
+  );
+  assert(credentials, "Missing required input credentials");
+  assert(qrCodePayload, "Missing required input QR Code payload");
+  assert(
+    requestObjectEncodedJwt,
+    "Missing required input requestObjectEncodedJwt"
+  );
+
+  const ioWallet = getIoWallet(itwVersion);
+  const { client_id, state } = qrCodePayload;
+
+  const { requestObject } =
+    await ioWallet.RemotePresentation.verifyRequestObject(
+      requestObjectEncodedJwt,
+      {
+        clientId: client_id,
+        state,
+        rpConf
+      }
+    );
+
+  // Optional certificate chain validation, if supported by the specs version
+  if (
+    requestObject.x5c &&
+    ioWallet.RemotePresentation.verifyAuthRequestCertificateChain
+  ) {
+    await ioWallet.RemotePresentation.verifyAuthRequestCertificateChain(
+      requestObjectEncodedJwt,
+      { caRootCert: env.X509_CERT_ROOT }
+    );
+  }
+
+  assert(requestObject.dcql_query, "Missing required DCQL query");
+
+  // Retrieve all credentials from the vault to prepare them for the DCQL evaluation.
+  // The evaluation will require the full credential.
+  const credentialsData = await Promise.all(
+    Object.values(credentials).map(async c => {
+      // Present the representative copy (the only one for a non-batch credential).
+      const vaultId = getRepresentativeVaultId(c);
+      const credential = await CredentialsVault.get(vaultId);
+      assert(
+        credential,
+        `Credential with vaultId ${vaultId} not found in secure storage`
+      );
+      return {
+        keyTag: c.keyTag,
+        format: c.format,
+        credential
+      };
+    })
+  );
+
+  // Prepare credentials to evaluate the Relying Party request, split by format since the DCQL
+  // evaluation decodes SD-JWT and mDoc credentials (e.g. proof of age) with different parsers.
+  const { sdJwt, mdoc } = prepareCredentialsForDcqlEvaluation(credentialsData);
+
+  // Evaluate the DCQL query against the credentials contained in the Wallet
+  const result = await ioWallet.RemotePresentation.evaluateDcqlQuery(
+    requestObject.dcql_query as DcqlQuery,
+    sdJwt,
+    mdoc
+  );
+
+  // Check whether any of the requested credentials cannot be presented remotely:
+  // revocation blocks any credential, while a non-valid PID cannot be sent remotely.
+  const invalidCredentials = getInvalidCredentials(result, credentials);
+
+  if (invalidCredentials.length > 0) {
+    throw new InvalidCredentialsStatusError(invalidCredentials);
+  }
+
+  // Add localization to the requested claims
+  const presentationDetails = enrichPresentationDetails(result, credentials);
+
+  return { requestObject, presentationDetails };
+});
+
+export const sendAuthorizationResponseActor = fromPromise<
+  SendAuthorizationResponseOutput,
+  SendAuthorizationResponseInput
+>(async ({ input }) => {
+  const { itwVersion } = input.deps;
+  const { rpConf, presentationDetails, requestObject, optionalCredentials } =
+    input;
+
+  assert(
+    presentationDetails && requestObject,
+    "Missing required sendAuthorizationResponseActor actor params"
+  );
+
+  const ioWallet = getIoWallet(itwVersion);
+
+  // Get required credentials and optional credentials that have been selected by the user
+  const credentialsToPresent = presentationDetails.filter(
+    c =>
+      c.purposes.some(({ required }) => required) ||
+      optionalCredentials.has(c.id)
+  );
+
+  const remotePresentations =
+    await ioWallet.RemotePresentation.prepareRemotePresentations(
+      credentialsToPresent,
+      {
+        nonce: requestObject.nonce,
+        clientId: requestObject.client_id,
+        responseUri: requestObject.response_uri
+      }
+    );
+
+  const authResponse =
+    await ioWallet.RemotePresentation.sendAuthorizationResponse(
+      requestObject,
+      remotePresentations,
+      rpConf
+    );
+
   return {
-    evaluateRelyingPartyTrust,
-    getRequestObject,
-    getPresentationDetails,
-    sendAuthorizationResponse,
-    getWalletAttestation
+    redirectUri: authResponse.redirect_uri,
+    presentedKeyTags: credentialsToPresent.map(c => c.keyTag)
   };
-};
+});
+
+export const getWalletAttestationActor = fromPromise<
+  WalletInstanceAttestations,
+  GetWalletAttestationInput
+>(async ({ input }) => {
+  const { env, itwVersion, store } = input.deps;
+
+  // In the same-device flow the app might be launched directly to the presentation machine,
+  // and the integrity service necessary to get the attestation might not yet be ready.
+  await ensureIntegrityServiceIsStoreReadyOrThrow(store);
+
+  const sessionToken = sessionTokenSelector(store.getState());
+  const integrityKeyTag = itwIntegrityKeyTagSelector(store.getState());
+
+  assert(sessionToken, "sessionToken is undefined");
+  assert(integrityKeyTag, "integrityKeyTag is undefined");
+
+  return getWalletInstanceAttestation(
+    env,
+    itwVersion,
+    integrityKeyTag,
+    sessionToken
+  );
+});
 
 const prepareCredentialsForDcqlEvaluation = (
   credentials: Array<{ credential: string; format: string; keyTag: string }>

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/context.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/context.ts
@@ -10,12 +10,17 @@ import {
   RelyingPartyConfiguration
 } from "../utils/itwRemoteTypeUtils";
 import { RemoteFailure } from "./failure";
+import { RemoteMachineDeps } from "./input";
 
 export type Context = {
   /**
    * The credentials available in the wallet, to be potentially shared with the Relying Party.
    */
   credentials: Record<string, CredentialMetadata> | undefined;
+  /**
+   * Runtime dependencies injected via machine input
+   */
+  deps: RemoteMachineDeps;
   /**
    * The failure of the remote presentation machine
    */
@@ -67,7 +72,7 @@ export type Context = {
   walletInstanceAttestation: undefined | WalletInstanceAttestations;
 };
 
-export const InitialContext: Context = {
+export const InitialContext: Omit<Context, "deps"> = {
   walletInstanceAttestation: undefined,
   credentials: undefined,
   payload: undefined,

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/guards.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/guards.ts
@@ -1,6 +1,3 @@
-import { ItwVersion } from "@pagopa/io-react-native-wallet";
-
-import { useIOStore } from "../../../../../store/hooks.ts";
 import { ItwSessionExpiredError } from "../../../api/client.ts";
 import { itwIsL3EnabledSelector } from "../../../common/store/selectors";
 import { isItwEnabledSelector } from "../../../common/store/selectors/remoteConfig.ts";
@@ -16,39 +13,40 @@ type GuardArgs = {
   event: RemoteEvents;
 };
 
-export const createRemoteGuardsImplementation = (
-  itwVersion: ItwVersion,
-  store: ReturnType<typeof useIOStore>
-) => ({
-  isItWalletL3Active: () =>
-    isItwEnabledSelector(store.getState()) &&
-    itwIsL3EnabledSelector(store.getState()) &&
-    itwLifecycleIsITWalletValidSelector(store.getState()),
+export const isItWalletL3ActiveGuard = ({ context }: GuardArgs) => {
+  const state = context.deps.store.getState();
+  return (
+    isItwEnabledSelector(state) &&
+    itwIsL3EnabledSelector(state) &&
+    itwLifecycleIsITWalletValidSelector(state)
+  );
+};
 
-  hasValidWalletInstanceAttestation: () => {
-    const attestation = itwWalletInstanceAttestationSelector(
-      store.getState()
-    )?.jwt;
-    return (
-      attestation !== undefined &&
-      isWalletInstanceAttestationValid(itwVersion, attestation)
-    );
-  },
+export const hasValidWalletInstanceAttestationGuard = ({
+  context
+}: GuardArgs) => {
+  const attestation = itwWalletInstanceAttestationSelector(
+    context.deps.store.getState()
+  )?.jwt;
+  return (
+    attestation !== undefined &&
+    isWalletInstanceAttestationValid(context.deps.itwVersion, attestation)
+  );
+};
 
-  isSessionExpired: ({ event }: GuardArgs) =>
-    "error" in event && event.error instanceof ItwSessionExpiredError,
+export const isSessionExpiredGuard = ({ event }: GuardArgs) =>
+  "error" in event && event.error instanceof ItwSessionExpiredError;
 
-  /**
-   * Valid OpenID Federation clients:
-   * - `openid_federation:https://rp.example`
-   * - `https://rp.example` (no prefix)
-   */
-  isOpenIdFederationClient: ({ context }: GuardArgs) =>
-    Boolean(
-      context.payload?.client_id.startsWith(ClientIdPrefix.OPENID_FEDERATION) ||
-      context.payload?.client_id.startsWith("https://")
-    ),
+/**
+ * Valid OpenID Federation clients:
+ * - `openid_federation:https://rp.example`
+ * - `https://rp.example` (no prefix)
+ */
+export const isOpenIdFederationClientGuard = ({ context }: GuardArgs) =>
+  Boolean(
+    context.payload?.client_id.startsWith(ClientIdPrefix.OPENID_FEDERATION) ||
+    context.payload?.client_id.startsWith("https://")
+  );
 
-  isX509HashClient: ({ context }: GuardArgs) =>
-    Boolean(context.payload?.client_id.startsWith(ClientIdPrefix.X509_HASH))
-});
+export const isX509HashClientGuard = ({ context }: GuardArgs) =>
+  Boolean(context.payload?.client_id.startsWith(ClientIdPrefix.X509_HASH));

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/input.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/input.ts
@@ -1,0 +1,19 @@
+import { ItwVersion } from "@pagopa/io-react-native-wallet";
+
+import { useIONavigation } from "../../../../../navigation/params/AppParamsList";
+import { useIOStore } from "../../../../../store/hooks";
+import { Env } from "../../../common/utils/environment";
+
+export type Input = {
+  /**
+   * Runtime dependencies injected by the machine provider
+   */
+  deps: RemoteMachineDeps;
+};
+
+export type RemoteMachineDeps = {
+  env: Env;
+  itwVersion: ItwVersion;
+  navigation: ReturnType<typeof useIONavigation>;
+  store: ReturnType<typeof useIOStore>;
+};

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/input.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/input.ts
@@ -1,8 +1,7 @@
 import { ItwVersion } from "@pagopa/io-react-native-wallet";
 
-import { useIONavigation } from "../../../../../navigation/params/AppParamsList";
-import { useIOStore } from "../../../../../store/hooks";
 import { Env } from "../../../common/utils/environment";
+import { MachineNavigation, MachineStore } from "../../../machine/utils/deps";
 
 export type Input = {
   /**
@@ -14,6 +13,6 @@ export type Input = {
 export type RemoteMachineDeps = {
   env: Env;
   itwVersion: ItwVersion;
-  navigation: ReturnType<typeof useIONavigation>;
-  store: ReturnType<typeof useIOStore>;
+  navigation: MachineNavigation;
+  store: MachineStore;
 };

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/machine.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/machine.ts
@@ -7,7 +7,7 @@ import { ItwPresentationTags } from "./tags";
 
 export const itwRemoteMachine = itwRemoteMachineSetup.createMachine({
   id: "itwRemoteMachine",
-  context: { ...InitialContext },
+  context: ({ input }) => ({ ...InitialContext, deps: input.deps }),
   initial: "Idle",
   entry: "onInit",
   on: {
@@ -15,6 +15,7 @@ export const itwRemoteMachine = itwRemoteMachineSetup.createMachine({
       target: ".Idle",
       actions: assign(({ context }) => ({
         ...InitialContext,
+        deps: context.deps,
         walletInstanceAttestation: context.walletInstanceAttestation
       }))
     }
@@ -86,6 +87,7 @@ export const itwRemoteMachine = itwRemoteMachineSetup.createMachine({
       tags: [ItwPresentationTags.Loading],
       invoke: {
         src: "getWalletAttestation",
+        input: ({ context }) => ({ deps: context.deps }),
         onDone: {
           target: "EvaluatingClientIdType",
           actions: [
@@ -113,7 +115,10 @@ export const itwRemoteMachine = itwRemoteMachineSetup.createMachine({
       description: "Determine whether the Relying Party is a trusted entity",
       invoke: {
         src: "evaluateRelyingPartyTrust",
-        input: ({ context }) => ({ qrCodePayload: context.payload }),
+        input: ({ context }) => ({
+          qrCodePayload: context.payload,
+          deps: context.deps
+        }),
         onDone: {
           target: "GettingRequestObject",
           actions: assign(({ event }) => event.output)
@@ -130,7 +135,8 @@ export const itwRemoteMachine = itwRemoteMachineSetup.createMachine({
       invoke: {
         src: "getRequestObject",
         input: ({ context }) => ({
-          qrCodePayload: context.payload
+          qrCodePayload: context.payload,
+          deps: context.deps
         }),
         onDone: {
           actions: assign(({ event }) => ({
@@ -155,7 +161,8 @@ export const itwRemoteMachine = itwRemoteMachineSetup.createMachine({
           credentials: context.credentials,
           qrCodePayload: context.payload,
           requestObjectEncodedJwt: context.requestObjectEncodedJwt,
-          rpConf: context.rpConf
+          rpConf: context.rpConf,
+          deps: context.deps
         }),
         onDone: {
           actions: assign(({ event }) => event.output),
@@ -206,7 +213,8 @@ export const itwRemoteMachine = itwRemoteMachineSetup.createMachine({
           rpConf: context.rpConf,
           requestObject: context.requestObject,
           presentationDetails: context.presentationDetails,
-          optionalCredentials: context.selectedOptionalCredentials
+          optionalCredentials: context.selectedOptionalCredentials,
+          deps: context.deps
         }),
         onDone: {
           actions: assign(({ event }) => ({

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/provider.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/provider.tsx
@@ -8,9 +8,6 @@ import {
   selectItwSpecsVersion
 } from "../../../common/store/selectors/environment.ts";
 import { getEnv } from "../../../common/utils/environment.ts";
-import { createRemoteActionsImplementation } from "./actions.ts";
-import { createRemoteActorsImplementation } from "./actors.ts";
-import { createRemoteGuardsImplementation } from "./guards.ts";
 import { itwRemoteMachine } from "./machine.ts";
 
 type Props = {
@@ -25,14 +22,13 @@ export const ItwRemoteMachineProvider = (props: Props) => {
   const env = getEnv(useIOSelector(selectItwEnv));
   const itwVersion = useIOSelector(selectItwSpecsVersion);
 
-  const remoteMachine = itwRemoteMachine.provide({
-    guards: createRemoteGuardsImplementation(itwVersion, store),
-    actions: createRemoteActionsImplementation(navigation, store),
-    actors: createRemoteActorsImplementation(env, itwVersion, store)
-  });
-
   return (
-    <ItwRemoteMachineContext.Provider logic={remoteMachine}>
+    <ItwRemoteMachineContext.Provider
+      logic={itwRemoteMachine}
+      options={{
+        input: { deps: { env, itwVersion, navigation, store } }
+      }}
+    >
       {props.children}
     </ItwRemoteMachineContext.Provider>
   );

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/setup.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/setup.ts
@@ -1,19 +1,36 @@
-import { assign, fromPromise, setup } from "xstate";
+import { assign, setup } from "xstate";
 
-import { type WalletInstanceAttestations } from "../../../common/utils/itwTypesUtils";
 import {
-  EvaluateRelyingPartyTrustInput,
-  EvaluateRelyingPartyTrustOutput,
-  GetPresentationDetailsInput,
-  GetPresentationDetailsOutput,
-  GetRequestObjectInput,
-  GetRequestObjectOutput,
-  SendAuthorizationResponseInput,
-  SendAuthorizationResponseOutput
+  closePresentationAction,
+  consumePresentedBatchCredentialsAction,
+  handleSessionExpiredAction,
+  navigateToAuthResponseScreenAction,
+  navigateToBarcodeScanScreenAction,
+  navigateToClaimsDisclosureScreenAction,
+  navigateToDiscoveryScreenAction,
+  navigateToFailureScreenAction,
+  onInitAction,
+  storeWalletInstanceAttestationAction,
+  trackRemoteDataShareAction
+} from "./actions";
+import {
+  evaluateRelyingPartyTrustActor,
+  getPresentationDetailsActor,
+  getRequestObjectActor,
+  getWalletAttestationActor,
+  sendAuthorizationResponseActor
 } from "./actors";
 import { Context } from "./context";
 import { RemoteEvents } from "./events";
 import { mapEventToFailure } from "./failure";
+import {
+  hasValidWalletInstanceAttestationGuard,
+  isItWalletL3ActiveGuard,
+  isOpenIdFederationClientGuard,
+  isSessionExpiredGuard,
+  isX509HashClientGuard
+} from "./guards";
+import { Input } from "./input";
 
 const notImplemented = () => {
   throw new Error("Not implemented");
@@ -23,48 +40,36 @@ const notImplemented = () => {
 export const itwRemoteMachineSetup = setup({
   types: {
     context: {} as Context,
-    events: {} as RemoteEvents
+    events: {} as RemoteEvents,
+    input: {} as Input
   },
   actions: {
-    onInit: notImplemented,
+    onInit: onInitAction,
     setFailure: assign(({ event }) => ({ failure: mapEventToFailure(event) })),
-    navigateToFailureScreen: notImplemented,
-    navigateToDiscoveryScreen: notImplemented,
-    navigateToClaimsDisclosureScreen: notImplemented,
+    navigateToFailureScreen: navigateToFailureScreenAction,
+    navigateToDiscoveryScreen: navigateToDiscoveryScreenAction,
+    navigateToClaimsDisclosureScreen: navigateToClaimsDisclosureScreenAction,
     navigateToIdentificationModeScreen: notImplemented,
-    navigateToAuthResponseScreen: notImplemented,
-    navigateToBarcodeScanScreen: notImplemented,
-    closePresentation: notImplemented,
-    trackRemoteDataShare: notImplemented,
-    storeWalletInstanceAttestation: notImplemented,
-    handleSessionExpired: notImplemented,
-    consumePresentedBatchCredentials: notImplemented
+    navigateToAuthResponseScreen: navigateToAuthResponseScreenAction,
+    navigateToBarcodeScanScreen: navigateToBarcodeScanScreenAction,
+    closePresentation: closePresentationAction,
+    trackRemoteDataShare: trackRemoteDataShareAction,
+    storeWalletInstanceAttestation: storeWalletInstanceAttestationAction,
+    handleSessionExpired: handleSessionExpiredAction,
+    consumePresentedBatchCredentials: consumePresentedBatchCredentialsAction
   },
   actors: {
-    evaluateRelyingPartyTrust: fromPromise<
-      EvaluateRelyingPartyTrustOutput,
-      EvaluateRelyingPartyTrustInput
-    >(notImplemented),
-    getRequestObject: fromPromise<
-      GetRequestObjectOutput,
-      GetRequestObjectInput
-    >(notImplemented),
-    getPresentationDetails: fromPromise<
-      GetPresentationDetailsOutput,
-      GetPresentationDetailsInput
-    >(notImplemented),
-    sendAuthorizationResponse: fromPromise<
-      SendAuthorizationResponseOutput,
-      SendAuthorizationResponseInput
-    >(notImplemented),
-    getWalletAttestation:
-      fromPromise<WalletInstanceAttestations>(notImplemented)
+    evaluateRelyingPartyTrust: evaluateRelyingPartyTrustActor,
+    getRequestObject: getRequestObjectActor,
+    getPresentationDetails: getPresentationDetailsActor,
+    sendAuthorizationResponse: sendAuthorizationResponseActor,
+    getWalletAttestation: getWalletAttestationActor
   },
   guards: {
-    isItWalletL3Active: notImplemented,
-    isSessionExpired: notImplemented,
-    hasValidWalletInstanceAttestation: notImplemented,
-    isOpenIdFederationClient: notImplemented,
-    isX509HashClient: notImplemented
+    isItWalletL3Active: isItWalletL3ActiveGuard,
+    isSessionExpired: isSessionExpiredGuard,
+    hasValidWalletInstanceAttestation: hasValidWalletInstanceAttestationGuard,
+    isOpenIdFederationClient: isOpenIdFederationClientGuard,
+    isX509HashClient: isX509HashClientGuard
   }
 });

--- a/apps/main-app/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteAuthResponseScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteAuthResponseScreen.test.tsx
@@ -5,6 +5,7 @@ import { createActor } from "xstate";
 import { applicationChangeState } from "../../../../../../store/actions/application";
 import { appReducer } from "../../../../../../store/reducers";
 import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper";
+import { RemoteMachineDeps } from "../../machine/input";
 import { itwRemoteMachine } from "../../machine/machine";
 import { ItwRemoteMachineContext } from "../../machine/provider";
 import { ITW_REMOTE_ROUTES } from "../../navigation/routes";
@@ -61,8 +62,12 @@ describe("ItwRemoteAuthResponseScreen", () => {
 });
 
 const renderComponent = (flowType: ItwRemoteFlowType, redirectUri?: string) => {
-  const initialSnapshot = createActor(itwRemoteMachine).getSnapshot();
   const initialState = appReducer(undefined, applicationChangeState("active"));
+  const store = createStore(appReducer, initialState as any);
+  const T_DEPS = { store } as RemoteMachineDeps;
+  const initialSnapshot = createActor(itwRemoteMachine, {
+    input: { deps: T_DEPS }
+  }).getSnapshot();
 
   const hydratedSnapshot: typeof initialSnapshot = {
     ...initialSnapshot,
@@ -74,7 +79,8 @@ const renderComponent = (flowType: ItwRemoteFlowType, redirectUri?: string) => {
     }
   };
   const actor = createActor(itwRemoteMachine, {
-    snapshot: hydratedSnapshot
+    snapshot: hydratedSnapshot,
+    input: { deps: T_DEPS }
   });
   actor.start();
   const snapshot = actor.getSnapshot();
@@ -87,6 +93,6 @@ const renderComponent = (flowType: ItwRemoteFlowType, redirectUri?: string) => {
     ),
     ITW_REMOTE_ROUTES.AUTH_RESPONSE,
     {},
-    createStore(appReducer, initialState as any)
+    store
   );
 };

--- a/apps/main-app/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteAuthResponseScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteAuthResponseScreen.test.tsx
@@ -5,7 +5,7 @@ import { createActor } from "xstate";
 import { applicationChangeState } from "../../../../../../store/actions/application";
 import { appReducer } from "../../../../../../store/reducers";
 import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper";
-import { RemoteMachineDeps } from "../../machine/input";
+import { testRemoteDeps } from "../../../../machine/utils/testDeps";
 import { itwRemoteMachine } from "../../machine/machine";
 import { ItwRemoteMachineContext } from "../../machine/provider";
 import { ITW_REMOTE_ROUTES } from "../../navigation/routes";
@@ -64,7 +64,7 @@ describe("ItwRemoteAuthResponseScreen", () => {
 const renderComponent = (flowType: ItwRemoteFlowType, redirectUri?: string) => {
   const initialState = appReducer(undefined, applicationChangeState("active"));
   const store = createStore(appReducer, initialState as any);
-  const T_DEPS = { store } as RemoteMachineDeps;
+  const T_DEPS = testRemoteDeps({ store });
   const initialSnapshot = createActor(itwRemoteMachine, {
     input: { deps: T_DEPS }
   }).getSnapshot();

--- a/apps/main-app/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteFailureScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteFailureScreen.test.tsx
@@ -11,8 +11,8 @@ import { appReducer } from "../../../../../../store/reducers";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper";
 import * as itwCommonSelectors from "../../../../common/store/selectors";
+import { testRemoteDeps } from "../../../../machine/utils/testDeps";
 import { RemoteFailure, RemoteFailureType } from "../../machine/failure";
-import { RemoteMachineDeps } from "../../machine/input";
 import { itwRemoteMachine } from "../../machine/machine";
 import { ItwRemoteMachineContext } from "../../machine/provider";
 import { ITW_REMOTE_ROUTES } from "../../navigation/routes";
@@ -66,7 +66,7 @@ const renderComponent = (failure: RemoteFailure) => {
   const initialState = appReducer(undefined, applicationChangeState("active"));
   const store = createStore(appReducer, initialState as any);
   const initialSnapshot = createActor(itwRemoteMachine, {
-    input: { deps: { store } as RemoteMachineDeps }
+    input: { deps: testRemoteDeps({ store }) }
   }).getSnapshot();
 
   const snapshot: typeof initialSnapshot = {

--- a/apps/main-app/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteFailureScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteFailureScreen.test.tsx
@@ -12,6 +12,7 @@ import { GlobalState } from "../../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper";
 import * as itwCommonSelectors from "../../../../common/store/selectors";
 import { RemoteFailure, RemoteFailureType } from "../../machine/failure";
+import { RemoteMachineDeps } from "../../machine/input";
 import { itwRemoteMachine } from "../../machine/machine";
 import { ItwRemoteMachineContext } from "../../machine/provider";
 import { ITW_REMOTE_ROUTES } from "../../navigation/routes";
@@ -63,7 +64,10 @@ describe("ItwRemoteFailureScreen", () => {
 
 const renderComponent = (failure: RemoteFailure) => {
   const initialState = appReducer(undefined, applicationChangeState("active"));
-  const initialSnapshot = createActor(itwRemoteMachine).getSnapshot();
+  const store = createStore(appReducer, initialState as any);
+  const initialSnapshot = createActor(itwRemoteMachine, {
+    input: { deps: { store } as RemoteMachineDeps }
+  }).getSnapshot();
 
   const snapshot: typeof initialSnapshot = {
     ...initialSnapshot,
@@ -79,6 +83,6 @@ const renderComponent = (failure: RemoteFailure) => {
     ),
     ITW_REMOTE_ROUTES.FAILURE,
     {},
-    createStore(appReducer, initialState as any)
+    store
   );
 };

--- a/apps/main-app/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteRequestValidation.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteRequestValidation.test.tsx
@@ -11,7 +11,7 @@ import { GlobalState } from "../../../../../../store/reducers/types.ts";
 import { reproduceSequence } from "../../../../../../utils/tests.ts";
 import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper.tsx";
 import { identificationSuccess } from "../../../../../identification/store/actions/index.ts";
-import { RemoteMachineDeps } from "../../machine/input.ts";
+import { testRemoteDeps } from "../../../../machine/utils/testDeps";
 import { itwRemoteMachine } from "../../machine/machine.ts";
 import { ItwRemoteMachineContext } from "../../machine/provider.tsx";
 import { ItwRemoteParamsList } from "../../navigation/ItwRemoteParamsList.ts";
@@ -194,7 +194,7 @@ const renderComponent = (
     () => (
       <ItwRemoteMachineContext.Provider
         logic={logic}
-        options={{ input: { deps: {} as RemoteMachineDeps } }}
+        options={{ input: { deps: testRemoteDeps() } }}
       >
         <ItwRemoteRequestValidationScreen
           navigation={mockNavigation}

--- a/apps/main-app/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteRequestValidation.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/screens/__tests__/ItwRemoteRequestValidation.test.tsx
@@ -11,6 +11,7 @@ import { GlobalState } from "../../../../../../store/reducers/types.ts";
 import { reproduceSequence } from "../../../../../../utils/tests.ts";
 import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper.tsx";
 import { identificationSuccess } from "../../../../../identification/store/actions/index.ts";
+import { RemoteMachineDeps } from "../../machine/input.ts";
 import { itwRemoteMachine } from "../../machine/machine.ts";
 import { ItwRemoteMachineContext } from "../../machine/provider.tsx";
 import { ItwRemoteParamsList } from "../../navigation/ItwRemoteParamsList.ts";
@@ -191,7 +192,10 @@ const renderComponent = (
 
   return renderScreenWithNavigationStoreContext<GlobalState>(
     () => (
-      <ItwRemoteMachineContext.Provider logic={logic}>
+      <ItwRemoteMachineContext.Provider
+        logic={logic}
+        options={{ input: { deps: {} as RemoteMachineDeps } }}
+      >
         <ItwRemoteRequestValidationScreen
           navigation={mockNavigation}
           route={route}

--- a/apps/main-app/ts/features/itwallet/trustmark/machine/__tests__/guards.test.ts
+++ b/apps/main-app/ts/features/itwallet/trustmark/machine/__tests__/guards.test.ts
@@ -1,25 +1,27 @@
 import { ItwSessionExpiredError } from "../../../api/client";
-import { createItwTrustmarkGuardsImplementation } from "../guards";
+import { Context } from "../context";
+import {
+  hasValidWalletInstanceAttestationGuard,
+  isSessionExpiredGuard
+} from "../guards";
 
 // Wallet Instance Attestation
 const T_WIA =
   "eyJ0eXAiOiJvYXV0aC1jbGllbnQtYXR0ZXN0YXRpb24rand0IiwiYWxnIjoiRVMyNTYiLCJraWQiOiI4VWtmcnZ0dExrcEFRT09wIn0.eyJhYWwiOiJodHRwczovL2ZvbzExLmJsb2IuY29yZS53aW5kb3dzLm5ldC9mb28vTG9BL2Jhc2ljIiwiY25mIjp7Imp3ayI6eyJjcnYiOiJQLTI1NiIsImtpZCI6Ii1DX1JVNjNqaDMyTDJDUFJ0MXlrcHZJdWNOMDRlVGdHWlBORnY2VlZPOUUiLCJrdHkiOiJFQyIsIngiOiJlRnJkQ0thY3I3UFhaT3pQR2hudHF1amQxYmZWX05IM1ZYeE1uRHJHNHJVIiwieSI6IjM5cXBMbGtBR0VWazA5SFlYN0Z0VnlKb1U2MTlTY3hWUVdaR2FiWUoyZWcifX0sImlzcyI6Imh0dHBzOi8vZm9vMTEuYmxvYi5jb3JlLndpbmRvd3MubmV0L2ZvbyIsInN1YiI6Ii1DX1JVNjNqaDMyTDJDUFJ0MXlrcHZJdWNOMDRlVGdHWlBORnY2VlZPOUUiLCJ3YWxsZXRfbGluayI6Imh0dHBzOi8vZm9vMTEuYmxvYi5jb3JlLndpbmRvd3MubmV0L2ZvbyIsIndhbGxldF9uYW1lIjoiSVQgV2FsbGV0IiwiaWF0IjoxNzU2NzEwOTM3LCJleHAiOjE3NTY3MTQ1Mzd9.7J_e6lusZXIQtji-6fr2NQFIX4voxALbL7SKMqcVdzkhz9kk-_5iYK0S__VOwV1H9VZQKnHVhX2FqJhkt1Itjg";
 
 describe("itwTrustmarkMachine guards", () => {
-  describe("isSessionExpired", () => {
+  describe("isSessionExpiredGuard", () => {
     it.each([
       [true, new ItwSessionExpiredError()],
       [false, new Error()]
     ])("returns %s if the error is %s", (expected, error) => {
-      const { isSessionExpired } =
-        createItwTrustmarkGuardsImplementation("1.0.0");
-      expect(isSessionExpired({ event: { error, type: "error" } })).toBe(
-        expected
-      );
+      expect(
+        isSessionExpiredGuard({ event: { error, type: "error" } } as never)
+      ).toBe(expected);
     });
   });
 
-  describe("hasValidWalletInstanceAttestation", () => {
+  describe("hasValidWalletInstanceAttestationGuard", () => {
     beforeEach(() => {
       jest.useFakeTimers();
     });
@@ -34,28 +36,26 @@ describe("itwTrustmarkMachine guards", () => {
     ])("returns %s if timestamp is %s", (expected, wia, timestamp) => {
       jest.setSystemTime(timestamp);
 
-      const { hasValidWalletInstanceAttestation } =
-        createItwTrustmarkGuardsImplementation("1.0.0");
       expect(
-        hasValidWalletInstanceAttestation({
+        hasValidWalletInstanceAttestationGuard({
           context: {
+            deps: { itwVersion: "1.0.0" },
             walletInstanceAttestation: { jwt: wia },
             credentialType: "mDL"
-          }
-        })
+          } as Context
+        } as never)
       ).toBe(expected);
     });
 
     it("returns false if the WIA is not valid", () => {
-      const { hasValidWalletInstanceAttestation } =
-        createItwTrustmarkGuardsImplementation("1.0.0");
       expect(
-        hasValidWalletInstanceAttestation({
+        hasValidWalletInstanceAttestationGuard({
           context: {
+            deps: { itwVersion: "1.0.0" },
             walletInstanceAttestation: { jwt: "not a WIA" },
             credentialType: "mDL"
-          }
-        })
+          } as Context
+        } as never)
       ).toEqual(false);
     });
   });

--- a/apps/main-app/ts/features/itwallet/trustmark/machine/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/trustmark/machine/__tests__/machine.test.ts
@@ -14,7 +14,10 @@ import {
   GetWalletAttestationActorOutput
 } from "../actors";
 import { type Context } from "../context";
+import { TrustmarkMachineDeps } from "../input";
 import { itwTrustmarkMachine } from "../machine";
+
+const T_DEPS = {} as TrustmarkMachineDeps;
 
 const onInit = jest.fn();
 const storeWalletInstanceAttestation = jest.fn();
@@ -81,7 +84,7 @@ describe("itwTrustmarkMachine", () => {
     );
 
     const actor = createActor(mockedMachine, {
-      input: { credentialType: "MDL" }
+      input: { credentialType: "MDL", deps: T_DEPS }
     });
 
     /**
@@ -93,6 +96,7 @@ describe("itwTrustmarkMachine", () => {
     expect(actor.getSnapshot().value).toStrictEqual("RefreshingTrustmark");
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       credentialType: "MDL",
+      deps: T_DEPS,
       walletInstanceAttestation: { jwt: "T_WIA" },
       credential: ItwStoredCredentialsMocks.mdl
     });
@@ -121,6 +125,7 @@ describe("itwTrustmarkMachine", () => {
     });
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       credentialType: "MDL",
+      deps: T_DEPS,
       walletInstanceAttestation: { jwt: "T_WIA" },
       credential: ItwStoredCredentialsMocks.mdl,
       trustmarkUrl: "T_URL",
@@ -140,6 +145,7 @@ describe("itwTrustmarkMachine", () => {
     expect(actor.getSnapshot().value).toStrictEqual("RefreshingTrustmark");
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       credentialType: "MDL",
+      deps: T_DEPS,
       walletInstanceAttestation: { jwt: "T_WIA" },
       credential: ItwStoredCredentialsMocks.mdl,
       trustmarkUrl: undefined,
@@ -168,7 +174,7 @@ describe("itwTrustmarkMachine", () => {
     );
 
     const actor = createActor(mockedMachine, {
-      input: { credentialType: "MDL" }
+      input: { credentialType: "MDL", deps: T_DEPS }
     });
 
     /**
@@ -182,6 +188,7 @@ describe("itwTrustmarkMachine", () => {
     );
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       credentialType: "MDL",
+      deps: T_DEPS,
       walletInstanceAttestation: { jwt: "T_WIA" },
       credential: ItwStoredCredentialsMocks.mdl
     });
@@ -213,6 +220,7 @@ describe("itwTrustmarkMachine", () => {
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       walletInstanceAttestation: { jwt: "T_WIA_UPDATED" },
       credentialType: "MDL",
+      deps: T_DEPS,
       credential: ItwStoredCredentialsMocks.mdl
     });
     expect(actor.getSnapshot().tags).toStrictEqual(new Set([ItwTags.Loading]));
@@ -237,7 +245,7 @@ describe("itwTrustmarkMachine", () => {
     );
 
     const actor = createActor(mockedMachine, {
-      input: { credentialType: "MDL" }
+      input: { credentialType: "MDL", deps: T_DEPS }
     });
 
     /**
@@ -251,6 +259,7 @@ describe("itwTrustmarkMachine", () => {
     );
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       credentialType: "MDL",
+      deps: T_DEPS,
       walletInstanceAttestation: { jwt: "T_WIA" },
       credential: ItwStoredCredentialsMocks.mdl
     });
@@ -292,7 +301,7 @@ describe("itwTrustmarkMachine", () => {
     );
 
     const actor = createActor(mockedMachine, {
-      input: { credentialType: "mDL" }
+      input: { credentialType: "mDL", deps: T_DEPS }
     });
 
     /**
@@ -304,6 +313,7 @@ describe("itwTrustmarkMachine", () => {
     expect(actor.getSnapshot().value).toStrictEqual("RefreshingTrustmark");
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       credentialType: "mDL",
+      deps: T_DEPS,
       walletInstanceAttestation: { jwt: "T_WIA" },
       credential: ItwStoredCredentialsMocks.mdl
     });
@@ -328,6 +338,7 @@ describe("itwTrustmarkMachine", () => {
     expect(actor.getSnapshot().value).toStrictEqual("Failure");
     expect(actor.getSnapshot().context).toStrictEqual<Context>({
       credentialType: "mDL",
+      deps: T_DEPS,
       walletInstanceAttestation: { jwt: "T_WIA" },
       credential: ItwStoredCredentialsMocks.mdl,
       attempts: 1,

--- a/apps/main-app/ts/features/itwallet/trustmark/machine/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/trustmark/machine/__tests__/machine.test.ts
@@ -8,6 +8,7 @@ import {
 
 import { ItwStoredCredentialsMocks } from "../../../common/utils/itwMocksUtils";
 import { ItwTags } from "../../../machine/tags";
+import { testTrustmarkDeps } from "../../../machine/utils/testDeps";
 import {
   GetCredentialTrustmarkUrlActorInput,
   GetCredentialTrustmarkUrlActorOutput,
@@ -15,10 +16,9 @@ import {
   GetWalletAttestationActorOutput
 } from "../actors";
 import { type Context } from "../context";
-import { TrustmarkMachineDeps } from "../input";
 import { itwTrustmarkMachine } from "../machine";
 
-const T_DEPS = {} as TrustmarkMachineDeps;
+const T_DEPS = testTrustmarkDeps();
 
 const onInit = jest.fn();
 const storeWalletInstanceAttestation = jest.fn();

--- a/apps/main-app/ts/features/itwallet/trustmark/machine/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/trustmark/machine/__tests__/machine.test.ts
@@ -11,6 +11,7 @@ import { ItwTags } from "../../../machine/tags";
 import {
   GetCredentialTrustmarkUrlActorInput,
   GetCredentialTrustmarkUrlActorOutput,
+  GetWalletAttestationActorInput,
   GetWalletAttestationActorOutput
 } from "../actors";
 import { type Context } from "../context";
@@ -40,9 +41,10 @@ const mockedMachine = itwTrustmarkMachine.provide({
     trackTrustmarkFailure
   },
   actors: {
-    getWalletAttestationActor: fromPromise<GetWalletAttestationActorOutput>(
-      getWalletAttestationActor
-    ),
+    getWalletAttestationActor: fromPromise<
+      GetWalletAttestationActorOutput,
+      GetWalletAttestationActorInput
+    >(getWalletAttestationActor),
     getCredentialTrustmarkActor: fromPromise<
       GetCredentialTrustmarkUrlActorOutput,
       GetCredentialTrustmarkUrlActorInput

--- a/apps/main-app/ts/features/itwallet/trustmark/machine/actions.ts
+++ b/apps/main-app/ts/features/itwallet/trustmark/machine/actions.ts
@@ -1,10 +1,7 @@
-import { useIOToast } from "@io-app/design-system";
 import { differenceInSeconds } from "date-fns";
 import I18n from "i18next";
 import { ActionArgs, assign } from "xstate";
 
-import { useIONavigation } from "../../../../navigation/params/AppParamsList";
-import { useIOStore } from "../../../../store/hooks";
 import { assert } from "../../../../utils/assert";
 import { checkCurrentSession } from "../../../authentication/common/store/actions";
 import { trackItwTrustmarkRenewFailure } from "../../analytics";
@@ -15,90 +12,83 @@ import { itwWalletInstanceAttestationSelector } from "../../walletInstance/store
 import { Context } from "./context";
 import { TrustmarkEvents } from "./events";
 
-export const createItwTrustmarkActionsImplementation = (
-  store: ReturnType<typeof useIOStore>,
-  navigation: ReturnType<typeof useIONavigation>,
-  toast: ReturnType<typeof useIOToast>
-) => {
-  /**
-   * Initializes the trustmark machine
-   */
-  const onInit = assign<
-    Context,
-    TrustmarkEvents,
-    unknown,
-    TrustmarkEvents,
-    any
-  >(({ context }) => ({
+/**
+ * Initializes the trustmark machine from the Redux store.
+ */
+export const onInitAction = assign<
+  Context,
+  TrustmarkEvents,
+  unknown,
+  TrustmarkEvents,
+  any
+>(({ context }) => {
+  const { store } = context.deps;
+  return {
     walletInstanceAttestation: itwWalletInstanceAttestationSelector(
       store.getState()
     ),
     credential: itwCredentialSelector(context.credentialType)(store.getState())
-  }));
-
-  const storeWalletInstanceAttestation = ({
-    context
-  }: ActionArgs<Context, TrustmarkEvents, TrustmarkEvents>) => {
-    assert(
-      context.walletInstanceAttestation,
-      "walletInstanceAttestation is undefined"
-    );
-    store.dispatch(
-      itwWalletInstanceAttestationStore(context.walletInstanceAttestation)
-    );
   };
+});
 
-  /**
-   * Handles the session expired event by dispatching the session expired action and navigating back to the credential details screen
-   */
-  const handleSessionExpired = () => {
-    store.dispatch(checkCurrentSession.success({ isSessionValid: false }));
-    navigation.pop();
-  };
+export const storeWalletInstanceAttestationAction = ({
+  context
+}: ActionArgs<Context, TrustmarkEvents, TrustmarkEvents>) => {
+  assert(
+    context.walletInstanceAttestation,
+    "walletInstanceAttestation is undefined"
+  );
+  context.deps.store.dispatch(
+    itwWalletInstanceAttestationStore(context.walletInstanceAttestation)
+  );
+};
 
-  /**
-   * Shows a failure toast
-   */
-  const showRetryFailureToast = ({
-    context
-  }: ActionArgs<Context, TrustmarkEvents, TrustmarkEvents>) => {
-    const timeDiffInSeconds = differenceInSeconds(
-      context.nextAttemptAt || new Date(),
-      new Date()
-    );
+/**
+ * Handles the session expired event by dispatching the session expired action and navigating back to the credential details screen
+ */
+export const handleSessionExpiredAction = ({
+  context
+}: ActionArgs<Context, TrustmarkEvents, TrustmarkEvents>) => {
+  context.deps.store.dispatch(
+    checkCurrentSession.success({ isSessionValid: false })
+  );
+  context.deps.navigation.pop();
+};
 
-    const time =
-      timeDiffInSeconds > 60
-        ? Math.ceil(timeDiffInSeconds / 60)
-        : timeDiffInSeconds;
+/**
+ * Shows a failure toast
+ */
+export const showRetryFailureToastAction = ({
+  context
+}: ActionArgs<Context, TrustmarkEvents, TrustmarkEvents>) => {
+  const timeDiffInSeconds = differenceInSeconds(
+    context.nextAttemptAt || new Date(),
+    new Date()
+  );
 
-    const timeString = I18n.t(
-      timeDiffInSeconds > 60 ? "date.time.minutes" : "date.time.seconds",
-      {
-        count: time
-      }
-    );
+  const time =
+    timeDiffInSeconds > 60
+      ? Math.ceil(timeDiffInSeconds / 60)
+      : timeDiffInSeconds;
 
-    toast.error(
-      I18n.t("features.itWallet.trustmark.failure.toast", {
-        time: timeString
-      })
-    );
-  };
+  const timeString = I18n.t(
+    timeDiffInSeconds > 60 ? "date.time.minutes" : "date.time.seconds",
+    {
+      count: time
+    }
+  );
 
-  const trackTrustmarkFailure = ({
-    context
-  }: ActionArgs<Context, TrustmarkEvents, TrustmarkEvents>) => {
-    trackItwTrustmarkRenewFailure(
-      getMixPanelCredential(context.credentialType, false)
-    );
-  };
+  context.deps.toast.error(
+    I18n.t("features.itWallet.trustmark.failure.toast", {
+      time: timeString
+    })
+  );
+};
 
-  return {
-    onInit,
-    storeWalletInstanceAttestation,
-    handleSessionExpired,
-    showRetryFailureToast,
-    trackTrustmarkFailure
-  };
+export const trackTrustmarkFailureAction = ({
+  context
+}: ActionArgs<Context, TrustmarkEvents, TrustmarkEvents>) => {
+  trackItwTrustmarkRenewFailure(
+    getMixPanelCredential(context.credentialType, false)
+  );
 };

--- a/apps/main-app/ts/features/itwallet/trustmark/machine/actors.ts
+++ b/apps/main-app/ts/features/itwallet/trustmark/machine/actors.ts
@@ -1,17 +1,16 @@
-import { ItwVersion } from "@pagopa/io-react-native-wallet";
 import { fromPromise } from "xstate";
 
-import { useIOStore } from "../../../../store/hooks";
 import { assert } from "../../../../utils/assert";
 import { sessionTokenSelector } from "../../../authentication/common/store/selectors";
-import { Env } from "../../common/utils/environment";
 import * as itwAttestationUtils from "../../common/utils/itwAttestationUtils";
 import { CredentialMetadata } from "../../common/utils/itwTypesUtils";
 import { itwIntegrityKeyTagSelector } from "../../issuance/store/selectors";
 import * as itwTrustmarkUtils from "../utils";
+import { TrustmarkMachineDeps } from "./input";
 
 export type GetCredentialTrustmarkUrlActorInput = {
   credential?: CredentialMetadata;
+  deps: TrustmarkMachineDeps;
   walletInstanceAttestation?: string;
 };
 
@@ -19,64 +18,54 @@ export type GetCredentialTrustmarkUrlActorOutput = Awaited<
   ReturnType<typeof itwTrustmarkUtils.getCredentialTrustmark>
 >;
 
+export type GetWalletAttestationActorInput = {
+  deps: TrustmarkMachineDeps;
+};
+
 export type GetWalletAttestationActorOutput = Awaited<
   ReturnType<typeof itwAttestationUtils.getWalletInstanceAttestation>
 >;
 
 /**
- * Creates the actors for the itwTrustmarkMachine
- * @param env - The environment to use for the IT Wallet API calls
- * @param store the IOStore
- * @returns the actors
+ * Gets the wallet instance attestation in case it's expired.
  */
-export const createItwTrustmarkActorsImplementation = (
-  env: Env,
-  itwVersion: ItwVersion,
-  store: ReturnType<typeof useIOStore>
-) => {
-  /**
-   * This actor gets the wallet instance attestation in case it's expired
-   */
-  const getWalletAttestationActor =
-    fromPromise<GetWalletAttestationActorOutput>(async () => {
-      const sessionToken = sessionTokenSelector(store.getState());
-      const integrityKeyTag = itwIntegrityKeyTagSelector(store.getState());
+export const getWalletAttestationActor = fromPromise<
+  GetWalletAttestationActorOutput,
+  GetWalletAttestationActorInput
+>(async ({ input }) => {
+  const { env, itwVersion, store } = input.deps;
+  const sessionToken = sessionTokenSelector(store.getState());
+  const integrityKeyTag = itwIntegrityKeyTagSelector(store.getState());
 
-      assert(sessionToken, "sessionToken is undefined");
-      assert(integrityKeyTag, "integrityKeyTag is not present");
+  assert(sessionToken, "sessionToken is undefined");
+  assert(integrityKeyTag, "integrityKeyTag is not present");
 
-      /**
-       * Get the wallet instance attestation
-       */
-      return await itwAttestationUtils.getWalletInstanceAttestation(
-        env,
-        itwVersion,
-        integrityKeyTag,
-        sessionToken
-      );
-    });
+  return await itwAttestationUtils.getWalletInstanceAttestation(
+    env,
+    itwVersion,
+    integrityKeyTag,
+    sessionToken
+  );
+});
 
-  const getCredentialTrustmarkActor = fromPromise<
-    GetCredentialTrustmarkUrlActorOutput,
-    GetCredentialTrustmarkUrlActorInput
-  >(async ({ input }) => {
-    assert(
-      input.walletInstanceAttestation,
-      "walletInstanceAttestation is undefined"
-    );
-    assert(input.credential, "credential is undefined");
+/**
+ * Generates the trustmark url to be presented.
+ */
+export const getCredentialTrustmarkActor = fromPromise<
+  GetCredentialTrustmarkUrlActorOutput,
+  GetCredentialTrustmarkUrlActorInput
+>(async ({ input }) => {
+  const { env, itwVersion } = input.deps;
+  assert(
+    input.walletInstanceAttestation,
+    "walletInstanceAttestation is undefined"
+  );
+  assert(input.credential, "credential is undefined");
 
-    // Generate trustmark url to be presented
-    return await itwTrustmarkUtils.getCredentialTrustmark(
-      env,
-      itwVersion,
-      input.walletInstanceAttestation,
-      input.credential
-    );
-  });
-
-  return {
-    getWalletAttestationActor,
-    getCredentialTrustmarkActor
-  };
-};
+  return await itwTrustmarkUtils.getCredentialTrustmark(
+    env,
+    itwVersion,
+    input.walletInstanceAttestation,
+    input.credential
+  );
+});

--- a/apps/main-app/ts/features/itwallet/trustmark/machine/context.ts
+++ b/apps/main-app/ts/features/itwallet/trustmark/machine/context.ts
@@ -3,6 +3,7 @@ import {
   WalletInstanceAttestations
 } from "../../common/utils/itwTypesUtils";
 import { TrustmarkFailure } from "./failure";
+import { TrustmarkMachineDeps } from "./input";
 
 export type Context = {
   /**
@@ -17,6 +18,10 @@ export type Context = {
    * The credential type to get the trustmark for
    */
   credentialType: string;
+  /**
+   * Runtime dependencies injected via machine input
+   */
+  deps: TrustmarkMachineDeps;
   /**
    * The expiration date of the trustmark
    */

--- a/apps/main-app/ts/features/itwallet/trustmark/machine/guards.ts
+++ b/apps/main-app/ts/features/itwallet/trustmark/machine/guards.ts
@@ -1,21 +1,23 @@
-import { ItwVersion } from "@pagopa/io-react-native-wallet";
 import { AnyEventObject } from "xstate";
 
 import { ItwSessionExpiredError } from "../../api/client";
 import { isWalletInstanceAttestationValid } from "../../common/utils/itwAttestationUtils";
 import { Context } from "./context";
 
-export const createItwTrustmarkGuardsImplementation = (
-  itwVersion: ItwVersion
-) => ({
-  isSessionExpired: ({ event }: { event: AnyEventObject }) =>
-    "error" in event && event.error instanceof ItwSessionExpiredError,
+type GuardArgs = {
+  context: Context;
+  event: AnyEventObject;
+};
 
-  hasValidWalletInstanceAttestation: ({ context }: { context: Context }) => {
-    const attestation = context.walletInstanceAttestation?.jwt;
-    return (
-      attestation !== undefined &&
-      isWalletInstanceAttestationValid(itwVersion, attestation)
-    );
-  }
-});
+export const isSessionExpiredGuard = ({ event }: GuardArgs) =>
+  "error" in event && event.error instanceof ItwSessionExpiredError;
+
+export const hasValidWalletInstanceAttestationGuard = ({
+  context
+}: GuardArgs) => {
+  const attestation = context.walletInstanceAttestation?.jwt;
+  return (
+    attestation !== undefined &&
+    isWalletInstanceAttestationValid(context.deps.itwVersion, attestation)
+  );
+};

--- a/apps/main-app/ts/features/itwallet/trustmark/machine/input.ts
+++ b/apps/main-app/ts/features/itwallet/trustmark/machine/input.ts
@@ -1,9 +1,11 @@
-import { useIOToast } from "@io-app/design-system";
 import { ItwVersion } from "@pagopa/io-react-native-wallet";
 
-import { useIONavigation } from "../../../../navigation/params/AppParamsList";
-import { useIOStore } from "../../../../store/hooks";
 import { Env } from "../../common/utils/environment";
+import {
+  MachineNavigation,
+  MachineStore,
+  MachineToast
+} from "../../machine/utils/deps";
 
 export type Input = {
   /**
@@ -19,7 +21,7 @@ export type Input = {
 export type TrustmarkMachineDeps = {
   env: Env;
   itwVersion: ItwVersion;
-  navigation: ReturnType<typeof useIONavigation>;
-  store: ReturnType<typeof useIOStore>;
-  toast: ReturnType<typeof useIOToast>;
+  navigation: MachineNavigation;
+  store: MachineStore;
+  toast: MachineToast;
 };

--- a/apps/main-app/ts/features/itwallet/trustmark/machine/machine.ts
+++ b/apps/main-app/ts/features/itwallet/trustmark/machine/machine.ts
@@ -7,7 +7,8 @@ import { displayingTrustmarkState } from "./state/displayingTrustmark";
 export const itwTrustmarkMachine = itwTrustmarkMachineSetup.createMachine({
   id: "itwTrustmarkMachine",
   context: ({ input }) => ({
-    credentialType: input.credentialType
+    credentialType: input.credentialType,
+    deps: input.deps
   }),
   entry: "onInit",
   initial: "CheckingWalletInstanceAttestation",
@@ -30,6 +31,7 @@ export const itwTrustmarkMachine = itwTrustmarkMachineSetup.createMachine({
       tags: [ItwTags.Loading],
       invoke: {
         src: "getWalletAttestationActor",
+        input: ({ context }) => ({ deps: context.deps }),
         onDone: {
           target: "RefreshingTrustmark",
           actions: [
@@ -58,6 +60,7 @@ export const itwTrustmarkMachine = itwTrustmarkMachineSetup.createMachine({
         src: "getCredentialTrustmarkActor",
         input: ({ context }) => ({
           credential: context.credential,
+          deps: context.deps,
           walletInstanceAttestation: context.walletInstanceAttestation?.jwt
         }),
         onDone: {

--- a/apps/main-app/ts/features/itwallet/trustmark/machine/provider.tsx
+++ b/apps/main-app/ts/features/itwallet/trustmark/machine/provider.tsx
@@ -9,9 +9,6 @@ import {
   selectItwSpecsVersion
 } from "../../common/store/selectors/environment";
 import { getEnv } from "../../common/utils/environment";
-import { createItwTrustmarkActionsImplementation } from "./actions";
-import { createItwTrustmarkActorsImplementation } from "./actors";
-import { createItwTrustmarkGuardsImplementation } from "./guards";
 import { itwTrustmarkMachine } from "./machine";
 
 type Props = PropsWithChildren<{
@@ -32,16 +29,15 @@ export const ItwTrustmarkMachineProvider = ({
   const env = getEnv(useIOSelector(selectItwEnv));
   const itwVersion = useIOSelector(selectItwSpecsVersion);
 
-  const trustmarkMachine = itwTrustmarkMachine.provide({
-    actions: createItwTrustmarkActionsImplementation(store, navigation, toast),
-    actors: createItwTrustmarkActorsImplementation(env, itwVersion, store),
-    guards: createItwTrustmarkGuardsImplementation(itwVersion)
-  });
-
   return (
     <ItwTrustmarkMachineContext.Provider
-      logic={trustmarkMachine}
-      options={{ input: { credentialType } }}
+      logic={itwTrustmarkMachine}
+      options={{
+        input: {
+          credentialType,
+          deps: { env, itwVersion, navigation, store, toast }
+        }
+      }}
     >
       {children}
     </ItwTrustmarkMachineContext.Provider>

--- a/apps/main-app/ts/features/itwallet/trustmark/machine/setup.ts
+++ b/apps/main-app/ts/features/itwallet/trustmark/machine/setup.ts
@@ -1,19 +1,25 @@
 import { addSeconds, differenceInSeconds, isPast } from "date-fns";
-import { assign, fromPromise, setup } from "xstate";
+import { assign, setup } from "xstate";
 
 import {
-  GetCredentialTrustmarkUrlActorInput,
-  GetCredentialTrustmarkUrlActorOutput,
-  GetWalletAttestationActorOutput
+  handleSessionExpiredAction,
+  onInitAction,
+  showRetryFailureToastAction,
+  storeWalletInstanceAttestationAction,
+  trackTrustmarkFailureAction
+} from "./actions";
+import {
+  getCredentialTrustmarkActor,
+  getWalletAttestationActor
 } from "./actors";
 import { Context } from "./context";
 import { TrustmarkEvents } from "./events";
 import { mapEventToFailure } from "./failure";
+import {
+  hasValidWalletInstanceAttestationGuard,
+  isSessionExpiredGuard
+} from "./guards";
 import { Input } from "./input";
-
-const notImplemented = () => {
-  throw new Error("Not implemented");
-};
 
 /**
  * Amount in seconds to wait before retrying
@@ -29,9 +35,9 @@ export const itwTrustmarkMachineSetup = setup({
     events: {} as TrustmarkEvents
   },
   actions: {
-    onInit: notImplemented,
-    storeWalletInstanceAttestation: notImplemented,
-    handleSessionExpired: notImplemented,
+    onInit: onInitAction,
+    storeWalletInstanceAttestation: storeWalletInstanceAttestationAction,
+    handleSessionExpired: handleSessionExpiredAction,
     updateExpirationSeconds: assign(({ context }) => ({
       expirationSeconds: context.expirationDate
         ? differenceInSeconds(context.expirationDate, new Date())
@@ -58,22 +64,18 @@ export const itwTrustmarkMachineSetup = setup({
     setFailure: assign({
       failure: ({ event }) => mapEventToFailure(event)
     }),
-    showRetryFailureToast: notImplemented,
-    trackTrustmarkFailure: notImplemented
+    showRetryFailureToast: showRetryFailureToastAction,
+    trackTrustmarkFailure: trackTrustmarkFailureAction
   },
   actors: {
-    getWalletAttestationActor:
-      fromPromise<GetWalletAttestationActorOutput>(notImplemented),
-    getCredentialTrustmarkActor: fromPromise<
-      GetCredentialTrustmarkUrlActorOutput,
-      GetCredentialTrustmarkUrlActorInput
-    >(notImplemented)
+    getWalletAttestationActor,
+    getCredentialTrustmarkActor
   },
   guards: {
     isTrustmarkExpired: ({ context }) =>
       context.expirationDate ? isPast(context.expirationDate) : true,
-    isSessionExpired: notImplemented,
-    hasValidWalletInstanceAttestation: notImplemented,
+    isSessionExpired: isSessionExpiredGuard,
+    hasValidWalletInstanceAttestation: hasValidWalletInstanceAttestationGuard,
     hasBackoffTimePassed: ({ context }) =>
       context.nextAttemptAt ? isPast(context.nextAttemptAt) : true
   }


### PR DESCRIPTION
Depends on #8502.

## Short description
Inject IT Wallet XState runtime deps through machine `input` (`context.deps`) and wire actors, actions, and guards as named functions instead of provider factory closures.

## List of changes proposed in this pull request
- Add `input.ts` / nested `context.deps` for eID, credential, upgrade, remote, proximity, and trustmark machines.
- Export named `*Actor` / `*Action` / `*Guard` functions that read `context.deps`; keep XState setup keys unsuffixed.
- Remove `create*Implementation` factories; providers pass the machine as `logic` with no `.provide({ guards })`.
- Update machine and screen tests for `input.deps`.

## How to test
- Non-regression for the same IT Wallet flows as #8502:
  - Wallet activation (L2 and L3)
  - Wallet upgrade to L3 including credentials upgrade
  - Wallet reissuance (L2 and L3)
  - Credential obtainment
  - Proximity presentation, both BLE and NFC
  - Remote presentation
  - Credential offer
- Confirm machine tests and related screen tests pass.
