### PR TITLE
fix(IT-Wallet): [SIW-000] restore identity confirmation CTA in remote presentation

### DIFF
--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/actions.test.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/__tests__/actions.test.ts
@@ -1,6 +1,7 @@
 import { CredentialType } from "../../../../common/utils/itwMocksUtils";
 import { CredentialMetadata } from "../../../../common/utils/itwTypesUtils";
 import { itwCredentialsConsumeInstance } from "../../../../credentials/store/actions";
+import { ITW_ROUTES } from "../../../../navigation/routes";
 import { createRemoteActionsImplementation } from "../actions";
 import { Context, InitialContext } from "../context";
 
@@ -114,5 +115,22 @@ describe("createRemoteActionsImplementation - consumePresentedBatchCredentials",
     } as never);
 
     expect(dispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("createRemoteActionsImplementation - navigateToIdentificationModeScreen", () => {
+  it("navigates to the eID reissuance identification mode selection screen", () => {
+    const navigate = jest.fn();
+    const actions = createRemoteActionsImplementation(
+      { navigate } as never,
+      { getState: jest.fn(), dispatch: jest.fn() } as never
+    );
+
+    actions.navigateToIdentificationModeScreen();
+
+    expect(navigate).toHaveBeenCalledWith(ITW_ROUTES.MAIN, {
+      screen: ITW_ROUTES.IDENTIFICATION.MODE_SELECTION,
+      params: { eidReissuing: true, level: "l3" }
+    });
   });
 });

--- a/apps/main-app/ts/features/itwallet/presentation/remote/machine/actions.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/remote/machine/actions.ts
@@ -64,6 +64,13 @@ export const createRemoteActionsImplementation = (
     });
   },
 
+  navigateToIdentificationModeScreen: () => {
+    navigation.navigate(ITW_ROUTES.MAIN, {
+      screen: ITW_ROUTES.IDENTIFICATION.MODE_SELECTION,
+      params: { eidReissuing: true, level: "l3" }
+    });
+  },
+
   navigateToBarcodeScanScreen: () => {
     navigation.navigate(ROUTES.BARCODE_SCAN, undefined);
   },


### PR DESCRIPTION
## Short description

In the **Remote Presentation** flow, tapping **"Conferma identità"** on the invalid-PID failure screen crashed the app with `Not implemented`.

The `navigateToIdentificationModeScreen` action was declared in `itwRemoteMachine` and dispatched by the failure screen, but its implementation was accidentally dropped from the actions provider.

The user is now correctly routed to the eID reissuance flow, as per Figma.
## List of changes proposed in this pull request

- Restored `navigateToIdentificationModeScreen` in `presentation/remote/machine/actions.ts`, navigating to `ITW_IDENTIFICATION_MODE_SELECTION` with `eidReissuing: true` and `level: "l3"`
- Added a non-regression test

## How to test

1. Activate IT-Wallet (L3)
2. Set the **PID** status to `Invalid` and the **Driving License** to `valid`
3. Start a Remote Presentation requesting the Driving License
4. On the "È necessaria una conferma della tua identità" screen, tap **"Conferma identità"**

**Expected:** no crash, navigation to the PID reissuance identification mode selection screen. After reissuance, the presentation succeeds