### PR TITLE
fix: [IOPLT-000] Missing lefthook `eslint` update

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,7 +9,7 @@ pre-commit:
       stage_fixed: true
 
     - name: lint staged files
-      run: pnpm eslint --flag v10_config_lookup_from_file --fix {staged_files}
+      run: pnpm eslint --fix {staged_files}
       glob: "*.{ts,tsx}"
       stage_fixed: true
 


### PR DESCRIPTION
## Short description
This pull request makes a small update to pre-commit hooks making ESLint run with its default configuration as done [here](https://github.com/pagopa/io-app/pull/8473) 

## List of changes proposed in this pull request
- removes the `--flag v10_config_lookup_from_file` option from the ESLint command

## How to test
If you try to commit something in a published branch without these changes, a lint error should appear denying the commit.
<img width="604" height="233" alt="Screenshot 2026-08-31 at 12 44 16" src="https://github.com/user-attachments/assets/f26bb4d2-8119-4dc5-a0cd-b0f2c05ef284" />

Applying these changes, the error should not be visible now