### PR TITLE
chore: [IOPLT-2038] Remove haptic feedback from snap scroll in `ServicesCarousel`

### DIFF
--- a/apps/main-app/ts/features/services/home/components/FeaturedServicesCarousel.tsx
+++ b/apps/main-app/ts/features/services/home/components/FeaturedServicesCarousel.tsx
@@ -1,17 +1,9 @@
 import {
   HSpacer,
   IOSpacingScale,
-  IOVisualCostants,
-  triggerHaptic
+  IOVisualCostants
 } from "@io-app/design-system";
-import { useCallback, useRef } from "react";
-import {
-  FlatList,
-  FlatListProps,
-  NativeScrollEvent,
-  NativeSyntheticEvent,
-  StyleSheet
-} from "react-native";
+import { FlatList, FlatListProps, StyleSheet } from "react-native";
 
 import { TestID, WithTestID } from "../../../../types/WithTestID";
 import {
@@ -62,35 +54,13 @@ const FeaturedServicesCarouselBaseComponent = <T,>({
 const FeaturedServicesCarousel = ({
   services,
   testID
-}: FeaturedServicesCarouselProps) => {
-  const snappedOffsetRef = useRef(0);
-
-  /**
-   * A tap on the carousel also drags it by a few pixels, so the snap animation
-   * settles back on the very same card: comparing the offsets keeps the
-   * feedback tied to an actual card change.
-   */
-  const handleMomentumScrollEnd = useCallback(
-    ({ nativeEvent }: NativeSyntheticEvent<NativeScrollEvent>) => {
-      const { x } = nativeEvent.contentOffset;
-
-      if (x !== snappedOffsetRef.current) {
-        snappedOffsetRef.current = x;
-        triggerHaptic("impactLight");
-      }
-    },
-    []
-  );
-
-  return (
-    <FeaturedServicesCarouselBaseComponent
-      data={services}
-      onMomentumScrollEnd={handleMomentumScrollEnd}
-      renderItem={({ item }) => <FeaturedServiceCard {...item} />}
-      testID={testID}
-    />
-  );
-};
+}: FeaturedServicesCarouselProps) => (
+  <FeaturedServicesCarouselBaseComponent
+    data={services}
+    renderItem={({ item }) => <FeaturedServiceCard {...item} />}
+    testID={testID}
+  />
+);
 
 const FeaturedServicesCarouselSkeleton = ({ testID }: TestID) => (
   <FeaturedServicesCarouselBaseComponent

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,7 +9,7 @@ pre-commit:
       stage_fixed: true
 
     - name: lint staged files
-      run: pnpm eslint --flag v10_config_lookup_from_file --fix {staged_files}
+      run: pnpm eslint --fix {staged_files}
       glob: "*.{ts,tsx}"
       stage_fixed: true
 


### PR DESCRIPTION
## Short description
Remove the haptic feedback from snap scroll in `ServicesCarousel`, added in the following PR:
* https://github.com/pagopa/io-app/pull/8350

This haptic feedback was added to provide additional feedback when scrolling through cards. However, it did not work as expected and instead gave the impression that something was broken. So we ruthless remove it without particular regrets.

## List of changes proposed in this pull request
- Remove haptic feedback triggered by `handleMomentumScrollEnd`

## How to test
N/A