### PR TITLE
fix(IT-Wallet): [SIW-000] BLE permissions regressions on proximity flow

### DIFF
--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwBluetoothPermissionsScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwBluetoothPermissionsScreen.tsx
@@ -13,6 +13,7 @@ import {
   trackItwProximityBluetoothAccessGoToSettings
 } from "../analytics";
 import { ItwProximityMachineContext } from "../machine/provider";
+import { checkBluetoothPermissions } from "../utils/ble";
 
 export const ItwBluetoothPermissionsScreen = () => {
   const machineRef = ItwProximityMachineContext.useActorRef();
@@ -32,7 +33,8 @@ export const ItwBluetoothPermissionsScreen = () => {
   );
 
   const handleContinue = async () => {
-    if (false) {
+    const isPermissionGranted = await checkBluetoothPermissions();
+    if (isPermissionGranted) {
       machineRef.send({ type: "continue" });
       return;
     }

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/utils/ble.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/utils/ble.ts
@@ -9,6 +9,8 @@ import {
   RESULTS
 } from "react-native-permissions";
 
+import { promiseWithTimeout } from "./presentation";
+
 const BLUETOOTH_PERMISSIONS: Array<Permission> =
   Platform.OS === "android"
     ? Platform.Version >= 31
@@ -20,6 +22,18 @@ const BLUETOOTH_PERMISSIONS: Array<Permission> =
       : [PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION] // Android 9 to Android 11: Only location permission is required for BLE.
     : [PERMISSIONS.IOS.BLUETOOTH];
 
+// This workaround ensures that the BleManager instance is created lazily,
+// preventing the Bluetooth permission prompt from appearing immediately upon module import.
+// eslint-disable-next-line functional/no-let
+let bleManager: BleManager | undefined;
+
+const getBleManager = () => {
+  if (!bleManager) {
+    bleManager = new BleManager();
+  }
+  return bleManager;
+};
+
 /**
  * Checks and requests necessary Bluetooth permissions based on the platform
  * and OS version.
@@ -28,6 +42,12 @@ const BLUETOOTH_PERMISSIONS: Array<Permission> =
  * granted, or false otherwise.
  */
 export const checkBluetoothPermissions = async () => {
+  // Warm up the native adapter as soon as the Bluetooth gate starts, so its
+  // state has time to settle (see checkBluetoothActivation below) while the
+  // user is responding to the permission prompt, instead of only starting
+  // once we actually need to read the activation state.
+  getBleManager();
+
   // Check current permission status
   const statuses = await checkMultiple(BLUETOOTH_PERMISSIONS);
 
@@ -51,24 +71,34 @@ export const checkBluetoothPermissions = async () => {
   return true;
 };
 
-// This workaround ensures that the BleManager instance is created lazily,
-// preventing the Bluetooth permission prompt from appearing immediately upon module import.
-// eslint-disable-next-line functional/no-let
-let bleManager: BleManager | undefined;
+// Right after the (lazy) BleManager is created, the native adapter has not
+// necessarily reported its real state yet: both CoreBluetooth and Android's
+// BluetoothAdapter briefly report "Unknown" until their first state update
+// fires. A single `state()` snapshot taken in that window can therefore
+// return "Unknown" even when Bluetooth is actually on, so we wait for the
+// first non-transient state instead of trusting an immediate snapshot.
+const BLUETOOTH_STATE_TIMEOUT_MS = 2000;
 
-const getBleManager = () => {
-  if (!bleManager) {
-    bleManager = new BleManager();
-  }
-  return bleManager;
-};
+const getSettledBluetoothState = () =>
+  new Promise<State>(resolve => {
+    const subscription = getBleManager().onStateChange(state => {
+      if (state === State.Unknown) {
+        return;
+      }
+      subscription.remove();
+      resolve(state);
+    }, true);
+  });
 
 /**
  * Checks if Bluetooth is currently activated on the device.
  * @returns A promise that resolves to true if Bluetooth is powered on, or false otherwise.
  */
 export const checkBluetoothActivation = async () => {
-  const bluetoothState = await getBleManager().state();
+  const bluetoothState = await promiseWithTimeout(
+    getSettledBluetoothState(),
+    BLUETOOTH_STATE_TIMEOUT_MS
+  );
   return bluetoothState === State.PoweredOn;
 };
 


### PR DESCRIPTION
## Short description
Fixes a regression in the IT Wallet proximity (BLE) flow where users who granted the Bluetooth permission were still routed to the "Activate Bluetooth" screen even when Bluetooth was already powered on, and fixes a dead-code path that prevented the permission screen's "continue" action from ever re-checking granted permissions.

## List of changes proposed in this pull request
- `ItwBluetoothPermissionsScreen`: replaced a dead `if (false)` branch with an actual re-check of `checkBluetoothPermissions()` before sending the `continue` event to the machine, mirroring the existing pattern in `ItwBluetoothActivationScreen`.
- `checkBluetoothActivation`: replaced the single `BleManager.state()` snapshot with a wait for the first non-transient (`!== "Unknown"`) state via `onStateChange`, bounded by a 2s timeout. This avoids false negatives caused by CoreBluetooth/Android briefly reporting `"Unknown"` right after the (lazily created) `BleManager` instance is initialized.
- `checkBluetoothPermissions`: now eagerly warms up the `BleManager` instance (fire-and-forget) as soon as the Bluetooth gate starts, so the native adapter has time to settle its state while the user is responding to the OS permission prompt, further reducing the chance of hitting the 2s timeout fallback.

## How to test
1. On a device, reset the app's Bluetooth permission (Settings > App > Permissions) and turn Bluetooth off.
2. Start the IT Wallet proximity presentation flow.
3. Grant the Bluetooth permission when prompted, then turn Bluetooth on when asked to activate it — verify you land on the presentment screen without extra loops.
4. Repeat with Bluetooth already ON at the time permission is granted — verify the app does **not** show the "Activate Bluetooth" screen (this was the regression).
5. On the permission screen, deny permission, go to Settings and grant it manually, return to the app and tap "Continua" — verify the flow now proceeds instead of showing the denial alert again.