### PR TITLE
refactor: [IOPID-4175] remove fp ts from identification saga

### DIFF
--- a/apps/main-app/ts/features/authentication/fastLogin/saga/__test__/tokenRefreshSaga.test.ts
+++ b/apps/main-app/ts/features/authentication/fastLogin/saga/__test__/tokenRefreshSaga.test.ts
@@ -1,5 +1,4 @@
 import * as E from "fp-ts/lib/Either";
-import * as O from "fp-ts/lib/Option";
 import { call, delay, put, take, takeLatest } from "typed-redux-saga/macro";
 
 import { fastLoginMaxRetries } from "../../../../../config";
@@ -85,7 +84,7 @@ describe("tokenRefreshSaga", () => {
       const gen = handleRefreshSessionToken(action);
       expect(gen.next().value).toEqual(call(dismissSupport));
       expect(gen.next(null).value).toEqual(call(getPin));
-      expect(gen.next(O.none).value).toEqual(put(refreshTokenNoPinError()));
+      expect(gen.next(undefined).value).toEqual(put(refreshTokenNoPinError()));
       expect(gen.next().done).toBe(true);
     });
 
@@ -100,7 +99,7 @@ describe("tokenRefreshSaga", () => {
 
       expect(gen.next().value).toEqual(call(dismissSupport));
       expect(gen.next(null).value).toEqual(call(getPin));
-      expect(gen.next(O.none).value).toEqual(
+      expect(gen.next(undefined).value).toEqual(
         put(logoutRequest({ withApiCall: false }))
       );
       expect(gen.next().done).toBe(true);
@@ -117,7 +116,7 @@ describe("tokenRefreshSaga", () => {
 
       expect(gen.next().value).toEqual(call(dismissSupport));
       expect(gen.next(null).value).toEqual(call(getPin));
-      expect(gen.next(O.some("147493")).value).toEqual(
+      expect(gen.next("147493").value).toEqual(
         put(askUserToRefreshSessionToken.request())
       );
 
@@ -135,7 +134,7 @@ describe("tokenRefreshSaga", () => {
     });
 
     it('should navigate and dispatch identificationRequest if user says "no"', () => {
-      (getPin as jest.Mock).mockReturnValue(O.some("mocked-pin"));
+      (getPin as jest.Mock).mockReturnValue("mocked-pin");
 
       const action = createAction({
         withUserInteraction: true,
@@ -147,7 +146,7 @@ describe("tokenRefreshSaga", () => {
 
       expect(gen.next().value).toEqual(call(dismissSupport));
       expect(gen.next(null).value).toEqual(call(getPin));
-      expect(gen.next(O.some("mocked-pin")).value).toEqual(
+      expect(gen.next("mocked-pin").value).toEqual(
         put(askUserToRefreshSessionToken.request())
       );
       expect(gen.next().value).toEqual(
@@ -165,7 +164,7 @@ describe("tokenRefreshSaga", () => {
     });
 
     it("should call doRefreshTokenSaga directly if withUserInteraction is false and pin is present", () => {
-      (getPin as jest.Mock).mockReturnValue(O.some("mocked-pin"));
+      (getPin as jest.Mock).mockReturnValue("mocked-pin");
 
       const action = createAction({
         withUserInteraction: false,
@@ -177,13 +176,13 @@ describe("tokenRefreshSaga", () => {
 
       expect(gen.next().value).toEqual(call(dismissSupport));
       expect(gen.next(null).value).toEqual(call(getPin));
-      expect(gen.next(O.some("mocked-pin")).value).toEqual(
+      expect(gen.next("mocked-pin").value).toEqual(
         call(doRefreshTokenSaga, action)
       );
     });
 
     it("should NOT call doRefreshTokenSaga if identification fails", () => {
-      (getPin as jest.Mock).mockReturnValue(O.some("mocked-pin"));
+      (getPin as jest.Mock).mockReturnValue("mocked-pin");
 
       const action = createAction({
         withUserInteraction: true,
@@ -195,7 +194,7 @@ describe("tokenRefreshSaga", () => {
 
       expect(gen.next().value).toEqual(call(dismissSupport));
       expect(gen.next(null).value).toEqual(call(getPin));
-      expect(gen.next(O.some("mocked-pin")).value).toEqual(
+      expect(gen.next("mocked-pin").value).toEqual(
         put(askUserToRefreshSessionToken.request())
       );
       expect(gen.next().value).toEqual(
@@ -214,7 +213,7 @@ describe("tokenRefreshSaga", () => {
     });
 
     it("should call doRefreshTokenSaga if identification succeeds", () => {
-      (getPin as jest.Mock).mockReturnValue(O.some("mocked-pin"));
+      (getPin as jest.Mock).mockReturnValue("mocked-pin");
 
       const action = createAction({
         withUserInteraction: true,
@@ -226,7 +225,7 @@ describe("tokenRefreshSaga", () => {
 
       expect(gen.next().value).toEqual(call(dismissSupport));
       expect(gen.next(null).value).toEqual(call(getPin));
-      expect(gen.next(O.some("mocked-pin")).value).toEqual(
+      expect(gen.next("mocked-pin").value).toEqual(
         put(askUserToRefreshSessionToken.request())
       );
       expect(gen.next().value).toEqual(

--- a/apps/main-app/ts/features/authentication/fastLogin/saga/tokenRefreshSaga.ts
+++ b/apps/main-app/ts/features/authentication/fastLogin/saga/tokenRefreshSaga.ts
@@ -68,8 +68,8 @@ function* handleRefreshSessionToken(
   // Dismiss Zendesk Support Screen if it is visible
   yield* call(dismissSupport);
 
-  const isPinAvailable = O.isSome(yield* call(getPin));
-
+  const maybePin = yield* call(getPin);
+  const isPinAvailable = maybePin != null;
   const { withUserInteraction } = refreshSessionTokenRequestAction.payload;
 
   if (!isPinAvailable) {

--- a/apps/main-app/ts/features/identification/sagas/__tests__/identificationSaga.test.ts
+++ b/apps/main-app/ts/features/identification/sagas/__tests__/identificationSaga.test.ts
@@ -1,4 +1,3 @@
-import * as O from "fp-ts/lib/Option";
 import { testSaga } from "redux-saga-test-plan";
 
 import { testable as IdentificationSagaModule } from "../";
@@ -168,7 +167,7 @@ describe("Identification Saga", () => {
     testSaga(testableModule.startAndHandleIdentificationResult, action)
       .next()
       .call(getPin)
-      .next(O.some(pin))
+      .next(pin)
       .put(
         identificationStart(
           pin,
@@ -194,7 +193,7 @@ describe("Identification Saga", () => {
     testSaga(testableModule.startAndHandleIdentificationResult, action)
       .next()
       .call(getPin)
-      .next(O.some(pin))
+      .next(pin)
       .put(
         identificationStart(
           pin,
@@ -220,7 +219,7 @@ describe("Identification Saga", () => {
     testSaga(testableModule.startAndHandleIdentificationResult, action)
       .next()
       .call(getPin)
-      .next(O.none)
+      .next(undefined)
       .isDone();
   });
 
@@ -240,7 +239,7 @@ describe("Identification Saga", () => {
     testSaga(testableModule.startAndHandleIdentificationResult, action)
       .next()
       .call(getPin)
-      .next(O.some(pin))
+      .next(pin)
       .put(
         identificationStart(
           pin,

--- a/apps/main-app/ts/features/identification/sagas/index.ts
+++ b/apps/main-app/ts/features/identification/sagas/index.ts
@@ -1,4 +1,3 @@
-import * as O from "fp-ts/lib/Option";
 import { call, put, select, take, takeLatest } from "typed-redux-saga/macro";
 import { ActionType, getType } from "typesafe-actions";
 
@@ -82,12 +81,12 @@ function* startAndHandleIdentificationResult(
   identificationRequestAction: ActionType<typeof identificationRequest>
 ) {
   const pin: SagaCallReturnType<typeof getPin> = yield* call(getPin);
-  if (O.isNone(pin)) {
+  if (pin == null) {
     return;
   }
   yield* put(
     identificationStart(
-      pin.value,
+      pin,
       identificationRequestAction.payload.canResetPin,
       identificationRequestAction.payload.isValidatingTask,
       identificationRequestAction.payload.identificationGenericData,

--- a/apps/main-app/ts/sagas/startup.ts
+++ b/apps/main-app/ts/sagas/startup.ts
@@ -534,7 +534,7 @@ export function* initializeApplicationSaga(
 
   // yield* delay(0 as Millisecond);
   const hasPreviousSessionAndPin =
-    previousSessionToken && O.isSome(maybeStoredPin);
+    previousSessionToken && maybeStoredPin != null;
   if (hasPreviousSessionAndPin && showIdentificationModal) {
     // we ask the user to identify using the unlock code.
     // FIXME: This is an unsafe cast caused by a wrongly described type.
@@ -542,7 +542,7 @@ export function* initializeApplicationSaga(
       typeof startAndReturnIdentificationResult
     > = yield* call(
       startAndReturnIdentificationResult,
-      maybeStoredPin.value,
+      maybeStoredPin,
       undefined,
       undefined,
       undefined,

--- a/apps/main-app/ts/sagas/startup/__tests__/checkConfiguredPinSaga.test.ts
+++ b/apps/main-app/ts/sagas/startup/__tests__/checkConfiguredPinSaga.test.ts
@@ -1,5 +1,4 @@
 import { CommonActions } from "@react-navigation/native";
-import * as O from "fp-ts/lib/Option";
 import { testSaga } from "redux-saga-test-plan";
 
 import { isFastLoginEnabledSelector } from "../../../features/authentication/fastLogin/store/selectors";
@@ -20,7 +19,7 @@ describe("checkConfiguredPinSaga", () => {
     testSaga(checkConfiguredPinSaga)
       .next()
       .call(getPin)
-      .next(O.some(validPin))
+      .next(validPin)
       .select(isFastLoginEnabledSelector)
       .next(false)
       .returns(validPin);
@@ -30,7 +29,7 @@ describe("checkConfiguredPinSaga", () => {
     testSaga(checkConfiguredPinSaga)
       .next()
       .call(getPin)
-      .next(O.some(validPolicyPin))
+      .next(validPolicyPin)
       .select(isFastLoginEnabledSelector)
       .next(true)
       .returns(validPolicyPin);
@@ -42,7 +41,7 @@ describe("checkConfiguredPinSaga", () => {
     testSaga(checkConfiguredPinSaga)
       .next()
       .call(getPin)
-      .next(O.some(invalidPin))
+      .next(invalidPin)
       .select(isFastLoginEnabledSelector)
       .next(true)
       .call(navigateToOnboardingPinScreenAction)
@@ -66,7 +65,7 @@ describe("checkConfiguredPinSaga", () => {
     testSaga(checkConfiguredPinSaga)
       .next()
       .call(getPin)
-      .next(O.none)
+      .next(undefined)
       .call(navigateToOnboardingPinScreenAction)
       .next()
       .take(createPinSuccess)

--- a/apps/main-app/ts/sagas/startup/__tests__/checkConfiguredPinSaga.test.ts
+++ b/apps/main-app/ts/sagas/startup/__tests__/checkConfiguredPinSaga.test.ts
@@ -1,0 +1,84 @@
+import { CommonActions } from "@react-navigation/native";
+import * as O from "fp-ts/lib/Option";
+import { testSaga } from "redux-saga-test-plan";
+
+import { isFastLoginEnabledSelector } from "../../../features/authentication/fastLogin/store/selectors";
+import { createPinSuccess } from "../../../features/settings/security/store/actions/pinset";
+import NavigationService from "../../../navigation/NavigationService";
+import ROUTES from "../../../navigation/routes";
+import { navigateToOnboardingPinScreenAction } from "../../../store/actions/navigation";
+import { PinString } from "../../../types/PinString";
+import { getPin } from "../../../utils/keychain";
+import { checkConfiguredPinSaga } from "../checkConfiguredPinSaga";
+
+const validPin = "123456" as PinString;
+const validPolicyPin = "246813" as PinString;
+const invalidPin = "12" as PinString;
+
+describe("checkConfiguredPinSaga", () => {
+  it("should return the pin when it is present and fast login is disabled", () => {
+    testSaga(checkConfiguredPinSaga)
+      .next()
+      .call(getPin)
+      .next(O.some(validPin))
+      .select(isFastLoginEnabledSelector)
+      .next(false)
+      .returns(validPin);
+  });
+
+  it("should return the pin when it is present, fast login is enabled and the pin is valid", () => {
+    testSaga(checkConfiguredPinSaga)
+      .next()
+      .call(getPin)
+      .next(O.some(validPolicyPin))
+      .select(isFastLoginEnabledSelector)
+      .next(true)
+      .returns(validPolicyPin);
+  });
+
+  it("should go through the onboarding pin flow when fast login is enabled and the stored pin is not valid", () => {
+    const resultAction = createPinSuccess(validPin);
+
+    testSaga(checkConfiguredPinSaga)
+      .next()
+      .call(getPin)
+      .next(O.some(invalidPin))
+      .select(isFastLoginEnabledSelector)
+      .next(true)
+      .call(navigateToOnboardingPinScreenAction)
+      .next()
+      .take(createPinSuccess)
+      .next(resultAction)
+      .call(
+        NavigationService.dispatchNavigationAction,
+        CommonActions.navigate({
+          name: ROUTES.MAIN,
+          merge: true
+        })
+      )
+      .next()
+      .returns(validPin);
+  });
+
+  it("should go through the onboarding pin flow when no pin is stored", () => {
+    const resultAction = createPinSuccess(validPin);
+
+    testSaga(checkConfiguredPinSaga)
+      .next()
+      .call(getPin)
+      .next(O.none)
+      .call(navigateToOnboardingPinScreenAction)
+      .next()
+      .take(createPinSuccess)
+      .next(resultAction)
+      .call(
+        NavigationService.dispatchNavigationAction,
+        CommonActions.navigate({
+          name: ROUTES.MAIN,
+          merge: true
+        })
+      )
+      .next()
+      .returns(validPin);
+  });
+});

--- a/apps/main-app/ts/sagas/startup/checkConfiguredPinSaga.ts
+++ b/apps/main-app/ts/sagas/startup/checkConfiguredPinSaga.ts
@@ -1,5 +1,4 @@
 import { CommonActions } from "@react-navigation/native";
-import * as O from "fp-ts/lib/Option";
 import { call, select, take } from "typed-redux-saga/macro";
 
 import { isFastLoginEnabledSelector } from "../../features/authentication/fastLogin/store/selectors";
@@ -21,14 +20,14 @@ export function* checkConfiguredPinSaga(): Generator<
   // it from the Keychain
   const pinCode = yield* call(getPin);
 
-  if (O.isSome(pinCode)) {
+  if (pinCode != null) {
     const isFastLoginEnabled = yield* select(isFastLoginEnabledSelector);
     if (isFastLoginEnabled) {
-      if (isValidPinNumber(pinCode.value)) {
-        return pinCode.value;
+      if (isValidPinNumber(pinCode)) {
+        return pinCode;
       }
     } else {
-      return pinCode.value;
+      return pinCode;
     }
   }
 

--- a/apps/main-app/ts/sagas/startup/checkConfiguredPinSaga.ts
+++ b/apps/main-app/ts/sagas/startup/checkConfiguredPinSaga.ts
@@ -22,11 +22,7 @@ export function* checkConfiguredPinSaga(): Generator<
 
   if (pinCode != null) {
     const isFastLoginEnabled = yield* select(isFastLoginEnabledSelector);
-    if (isFastLoginEnabled) {
-      if (isValidPinNumber(pinCode)) {
-        return pinCode;
-      }
-    } else {
+    if (!isFastLoginEnabled || isValidPinNumber(pinCode)) {
       return pinCode;
     }
   }

--- a/apps/main-app/ts/utils/__tests__/keychain.test.ts
+++ b/apps/main-app/ts/utils/__tests__/keychain.test.ts
@@ -1,4 +1,3 @@
-import * as O from "fp-ts/lib/Option";
 import * as Keychain from "react-native-keychain";
 
 import { PinString } from "../../types/PinString";
@@ -25,7 +24,7 @@ describe("getPin", () => {
     jest.clearAllMocks();
   });
 
-  it("should return some(pin) when a valid pin is stored", async () => {
+  it("should return the pin when a valid pin is stored", async () => {
     mockGetGenericPassword.mockResolvedValue({
       username: "PIN",
       password: validPin,
@@ -34,11 +33,10 @@ describe("getPin", () => {
     } as unknown as Awaited<ReturnType<typeof Keychain.getGenericPassword>>);
 
     const result = await getPin();
-    expect(O.isSome(result)).toBe(true);
-    expect(O.toUndefined(result)).toBe(validPin);
+    expect(result).toBe(validPin);
   });
 
-  it("should return none when the stored password does not match the pin pattern", async () => {
+  it("should return undefined when the stored password does not match the pin pattern", async () => {
     mockGetGenericPassword.mockResolvedValue({
       username: "PIN",
       password: "not-a-pin",
@@ -47,10 +45,10 @@ describe("getPin", () => {
     } as unknown as Awaited<ReturnType<typeof Keychain.getGenericPassword>>);
 
     const result = await getPin();
-    expect(O.isNone(result)).toBe(true);
+    expect(result).toBeUndefined();
   });
 
-  it("should return none when the stored password is empty", async () => {
+  it("should return undefined when the stored password is empty", async () => {
     mockGetGenericPassword.mockResolvedValue({
       username: "PIN",
       password: "",
@@ -59,14 +57,14 @@ describe("getPin", () => {
     } as unknown as Awaited<ReturnType<typeof Keychain.getGenericPassword>>);
 
     const result = await getPin();
-    expect(O.isNone(result)).toBe(true);
+    expect(result).toBeUndefined();
   });
 
-  it("should return none when there is no credential stored", async () => {
+  it("should return undefined when there is no credential stored", async () => {
     mockGetGenericPassword.mockResolvedValue(false);
 
     const result = await getPin();
-    expect(O.isNone(result)).toBe(true);
+    expect(result).toBeUndefined();
   });
 });
 

--- a/apps/main-app/ts/utils/__tests__/keychain.test.ts
+++ b/apps/main-app/ts/utils/__tests__/keychain.test.ts
@@ -1,0 +1,107 @@
+import * as O from "fp-ts/lib/Option";
+import * as Keychain from "react-native-keychain";
+
+import { PinString } from "../../types/PinString";
+import { deletePin, getPin, setPin } from "../keychain";
+
+jest.mock("react-native-keychain", () => ({
+  ACCESSIBLE: {
+    WHEN_UNLOCKED_THIS_DEVICE_ONLY: "WHEN_UNLOCKED_THIS_DEVICE_ONLY"
+  },
+  STORAGE_TYPE: { AES_GCM_NO_AUTH: "AES_GCM_NO_AUTH" },
+  getGenericPassword: jest.fn(),
+  setGenericPassword: jest.fn(),
+  resetGenericPassword: jest.fn()
+}));
+
+const mockGetGenericPassword = jest.mocked(Keychain.getGenericPassword);
+const mockSetGenericPassword = jest.mocked(Keychain.setGenericPassword);
+const mockResetGenericPassword = jest.mocked(Keychain.resetGenericPassword);
+
+const validPin = "123456" as PinString;
+
+describe("getPin", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return some(pin) when a valid pin is stored", async () => {
+    mockGetGenericPassword.mockResolvedValue({
+      username: "PIN",
+      password: validPin,
+      service: "service",
+      storage: "storage"
+    } as unknown as Awaited<ReturnType<typeof Keychain.getGenericPassword>>);
+
+    const result = await getPin();
+    expect(O.isSome(result)).toBe(true);
+    expect(O.toUndefined(result)).toBe(validPin);
+  });
+
+  it("should return none when the stored password does not match the pin pattern", async () => {
+    mockGetGenericPassword.mockResolvedValue({
+      username: "PIN",
+      password: "not-a-pin",
+      service: "service",
+      storage: "storage"
+    } as unknown as Awaited<ReturnType<typeof Keychain.getGenericPassword>>);
+
+    const result = await getPin();
+    expect(O.isNone(result)).toBe(true);
+  });
+
+  it("should return none when the stored password is empty", async () => {
+    mockGetGenericPassword.mockResolvedValue({
+      username: "PIN",
+      password: "",
+      service: "service",
+      storage: "storage"
+    } as unknown as Awaited<ReturnType<typeof Keychain.getGenericPassword>>);
+
+    const result = await getPin();
+    expect(O.isNone(result)).toBe(true);
+  });
+
+  it("should return none when there is no credential stored", async () => {
+    mockGetGenericPassword.mockResolvedValue(false);
+
+    const result = await getPin();
+    expect(O.isNone(result)).toBe(true);
+  });
+});
+
+describe("setPin", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return true when the pin is saved successfully", async () => {
+    mockSetGenericPassword.mockResolvedValue({
+      service: "service",
+      storage: "storage"
+    } as unknown as Awaited<ReturnType<typeof Keychain.setGenericPassword>>);
+
+    const result = await setPin(validPin);
+    expect(result).toBe(true);
+  });
+
+  it("should return false when saving the pin fails", async () => {
+    mockSetGenericPassword.mockResolvedValue(false);
+
+    const result = await setPin(validPin);
+    expect(result).toBe(false);
+  });
+});
+
+describe("deletePin", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return the result of Keychain.resetGenericPassword", async () => {
+    mockResetGenericPassword.mockResolvedValue(true);
+
+    const result = await deletePin();
+    expect(result).toBe(true);
+  });
+});

--- a/apps/main-app/ts/utils/keychain.ts
+++ b/apps/main-app/ts/utils/keychain.ts
@@ -6,7 +6,7 @@
  * @see https://github.com/oblador/react-native-keychain#options
  */
 
-import * as O from "fp-ts/lib/Option";
+import * as E from "fp-ts/lib/Either";
 import * as Keychain from "react-native-keychain";
 
 import { PinString } from "../types/PinString";
@@ -25,12 +25,13 @@ export async function deletePin(): Promise<boolean> {
  *
  * The promise fails when there is no valid unlock code stored.
  */
-export async function getPin(): Promise<O.Option<PinString>> {
+export async function getPin(): Promise<PinString | undefined> {
   const credentials = await Keychain.getGenericPassword();
   if (typeof credentials !== "boolean" && credentials.password.length > 0) {
-    return O.fromEither(PinString.decode(credentials.password));
+    const decoded = PinString.decode(credentials.password);
+    return E.isRight(decoded) ? decoded.right : undefined;
   } else {
-    return O.none;
+    return undefined;
   }
 }
 


### PR DESCRIPTION
## Short description
Removes fp-ts from `features/identification/saga/*`. Since `identification/sagas/index.ts` calls `getPin()` (in `utils/keychain.ts`), removing `Option` from its return type required propagating the change to every other caller across the codebase to keep the build green.

## List of changes proposed in this pull request
- `utils/keychain.ts`: `getPin()` now returns `PinString | undefined` instead of `Promise<O.Option<PinString>>` (still uses `E.isRight` internally to read the io-ts `.decode()` result — a library boundary, not our own fp-ts usage)
- `features/identification/sagas/index.ts`: updated to the new `getPin` return type, `O.isNone`/`.value` replaced with a plain null check
- `features/authentication/fastLogin/saga/tokenRefreshSaga.ts`: updated to the new `getPin` return type
- `sagas/startup/checkConfiguredPinSaga.ts`: updated to the new `getPin` return type
- `sagas/startup.ts` (`initializeApplicationSaga`): updated to the new `getPin` return type
- Added test coverage that didn't exist before this change: `utils/__tests__/keychain.test.ts`, `sagas/startup/__tests__/checkConfiguredPinSaga.test.ts`
- Updated existing tests to match the new return type: `identificationSaga.test.ts`, `tokenRefreshSaga.test.ts`


## How to test
Run the dev-api-server and the application on the iOS simulator. Login/logout operations and fast-login operations should succeed, including: PIN configuration at first startup, PIN identification/lock screen on app resume, and session refresh when the stored PIN is missing or invalid.