### PR TITLE
fix(IT-Wallet): [SIW-000] prevent NFC proximity crash on session end

### DIFF
--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/machine.test.ts
@@ -630,13 +630,66 @@ describe("itwProximityMachine", () => {
     actor.start();
     actor.send({ type: "close" });
 
-    expect(actor.getSnapshot().value).toBe("Failure");
+    expect(actor.getSnapshot().matches("Failure")).toBe(true);
     expect(actor.getSnapshot().context.failure?.type).toBe(
       ProximityFailureType.CONSENT_DENIED
     );
     expect(navigateToFailureScreen).toHaveBeenCalledTimes(1);
     expect(terminateSession).toHaveBeenCalledTimes(1);
     expect(closeProximity).not.toHaveBeenCalled();
+  });
+
+  it("NFC close from ClaimsDisclosure after teardown does not terminate the session again", async () => {
+    terminateSession.mockResolvedValue(undefined);
+    const actor = createActor(mockedMachine, {
+      snapshot: makeSnapshot(
+        { Presentment: "Connected" },
+        { engagementMode: "nfc" }
+      )
+    });
+
+    actor.start();
+    actor.send({
+      type: "device-document-request-received",
+      proximityDetails: T_PROXIMITY_DETAILS,
+      verifierRequest: T_VERIFIER_REQUEST,
+      retrievalMethod: "nfc"
+    });
+
+    await waitFor(actor, snapshot =>
+      snapshot.matches({ Presentment: "ClaimsDisclosure" })
+    );
+    expect(actor.getSnapshot().context.sessionTerminated).toBe(true);
+
+    actor.send({ type: "close" });
+
+    await waitFor(actor, snapshot => snapshot.matches("Failure"));
+    expect(actor.getSnapshot().context.failure?.type).toBe(
+      ProximityFailureType.CONSENT_DENIED
+    );
+    expect(terminateSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("NFC retry after consent resets sessionTerminated so a new engagement can terminate", async () => {
+    startEngagement.mockReturnValue(new Promise(() => {}));
+    const actor = createActor(mockedMachine, {
+      snapshot: makeSnapshot(
+        { Presentment: "StoreConsent" },
+        {
+          retrievalMethod: "nfc",
+          sessionTerminated: true,
+          proximityDetails: T_PROXIMITY_DETAILS
+        }
+      )
+    });
+
+    actor.start();
+    actor.send({ type: "continue" });
+
+    await waitFor(actor, snapshot =>
+      snapshot.matches({ Presentment: "Starting" })
+    );
+    expect(actor.getSnapshot().context.sessionTerminated).toBe(false);
   });
 
   it("holder-consent with NFC retrieval moves to StoreConsent", () => {
@@ -659,6 +712,77 @@ describe("itwProximityMachine", () => {
       )
     );
     expect(navigateToStoreconsentScreen).toHaveBeenCalledTimes(1);
+  });
+
+  it("duplicate document request during NFC ClaimsDisclosure does not re-terminate the session", async () => {
+    terminateSession.mockResolvedValue(undefined);
+    const actor = createActor(mockedMachine, {
+      snapshot: makeSnapshot(
+        { Presentment: "Connected" },
+        { engagementMode: "nfc" }
+      )
+    });
+
+    actor.start();
+    actor.send({
+      type: "device-document-request-received",
+      proximityDetails: T_PROXIMITY_DETAILS,
+      verifierRequest: T_VERIFIER_REQUEST,
+      retrievalMethod: "nfc"
+    });
+
+    await waitFor(actor, snapshot =>
+      snapshot.matches({ Presentment: "ClaimsDisclosure" })
+    );
+
+    actor.send({
+      type: "device-document-request-received",
+      proximityDetails: T_PROXIMITY_DETAILS_B,
+      verifierRequest: T_VERIFIER_REQUEST,
+      retrievalMethod: "ble"
+    });
+
+    expect(actor.getSnapshot().value).toStrictEqual({
+      Presentment: "ClaimsDisclosure"
+    });
+    expect(actor.getSnapshot().context.proximityDetails).toBe(
+      T_PROXIMITY_DETAILS
+    );
+    expect(terminateSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("duplicate document request during TerminatingForConsent does not re-invoke terminateSession", async () => {
+    terminateSession.mockReturnValue(new Promise(() => {}));
+    const actor = createActor(mockedMachine, {
+      snapshot: makeSnapshot(
+        { Presentment: "Connected" },
+        { engagementMode: "nfc" }
+      )
+    });
+
+    actor.start();
+    actor.send({
+      type: "device-document-request-received",
+      proximityDetails: T_PROXIMITY_DETAILS,
+      verifierRequest: T_VERIFIER_REQUEST,
+      retrievalMethod: "nfc"
+    });
+
+    await waitFor(actor, snapshot =>
+      snapshot.matches({ Presentment: "TerminatingForConsent" })
+    );
+
+    actor.send({
+      type: "device-document-request-received",
+      proximityDetails: T_PROXIMITY_DETAILS_B,
+      verifierRequest: T_VERIFIER_REQUEST,
+      retrievalMethod: "ble"
+    });
+
+    expect(actor.getSnapshot().value).toStrictEqual({
+      Presentment: "TerminatingForConsent"
+    });
+    expect(terminateSession).toHaveBeenCalledTimes(1);
   });
 
   it("NFC document request without consent terminates the session before disclosing claims", async () => {
@@ -914,7 +1038,7 @@ describe("itwProximityMachine", () => {
 
   it("close from Failure returns to Idle", () => {
     const actor = createActor(mockedMachine, {
-      snapshot: makeSnapshot("Failure")
+      snapshot: makeSnapshot({ Failure: "Idle" })
     });
 
     actor.start();

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/context.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/context.ts
@@ -39,6 +39,12 @@ export type Context = {
    */
   retrievalMethod?: ISO18013_5.RetrievalMethod;
   /**
+   * Whether SESSION_TERMINATED was already sent for the current engagement.
+   * IOWalletProximity NFC `CheckedContinuation` is consume-once: a second
+   * terminateSession on the same native session is a fatal SIGTRAP.
+   */
+  sessionTerminated: boolean;
+  /**
    * The Verifier Request returned from the Relying Party
    */
   verifierRequest?: VerifierRequest;
@@ -49,5 +55,6 @@ export const InitialContext: Context = {
   engagementMode: "qrcode",
   failure: undefined,
   proximityDetails: undefined,
+  sessionTerminated: false,
   verifierRequest: undefined
 };

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/machine.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/machine.ts
@@ -37,6 +37,8 @@ export const itwProximityMachine = setup({
      */
 
     setFailure: assign(({ event }) => ({ failure: mapEventToFailure(event) })),
+    markSessionTerminated: assign(() => ({ sessionTerminated: true })),
+    resetSessionTerminated: assign(() => ({ sessionTerminated: false })),
 
     /**
      * Navigation
@@ -88,6 +90,7 @@ export const itwProximityMachine = setup({
     hasFailure: ({ context }) => !!context.failure,
     isNfcRetrieval: ({ context }) => context.retrievalMethod === "nfc",
     isNfcEngagement: ({ context }) => context.engagementMode === "nfc",
+    hasTerminatedSession: ({ context }) => context.sessionTerminated,
     hasGrantedConsent: notImplemented
   }
 }).createMachine({
@@ -259,14 +262,29 @@ export const itwProximityMachine = setup({
         "device-connected": {
           target: "Presentment.Connected"
         },
-        "device-document-request-received": {
-          actions: assign(({ event }) => ({
-            proximityDetails: event.proximityDetails,
-            verifierRequest: event.verifierRequest,
-            retrievalMethod: event.retrievalMethod
-          })),
-          target: "Presentment.EvaluatingConsent"
-        },
+        "device-document-request-received": [
+          {
+            // NFC engagement also starts BLE retrieval. A late BLE copy of the
+            // same request during consent teardown would re-enter
+            // EvaluatingConsent and invoke terminateSession again, double-resuming
+            // IOWalletProximity's NFC CheckedContinuation (fatal SIGTRAP).
+            guard: or([
+              stateIn("Presentment.TerminatingForConsent"),
+              stateIn("Presentment.ClaimsDisclosure"),
+              stateIn("Presentment.StoreConsent"),
+              stateIn("Presentment.SendingDocuments"),
+              stateIn("Presentment.Terminating")
+            ])
+          },
+          {
+            actions: assign(({ event }) => ({
+              proximityDetails: event.proximityDetails,
+              verifierRequest: event.verifierRequest,
+              retrievalMethod: event.retrievalMethod
+            })),
+            target: "Presentment.EvaluatingConsent"
+          }
+        ],
         "device-disconnected": [
           {
             // END (0x02) flag received AFTER sendDocuments: verification complete
@@ -322,6 +340,7 @@ export const itwProximityMachine = setup({
         Starting: {
           description: "Start the native engagement session",
           tags: [ItwPresentationTags.Loading],
+          entry: "resetSessionTerminated",
           always: {
             guard: "isNfcRetrieval",
             actions: "navigateToNfcPresentmentScreen"
@@ -447,6 +466,7 @@ export const itwProximityMachine = setup({
           description:
             "NFC retrieval: terminate the live session and release the SDK before asking for consent, without leaving the proximity flow",
           tags: [ItwPresentationTags.Loading],
+          entry: "markSessionTerminated",
           invoke: {
             id: "terminateSession",
             src: "terminateSession",
@@ -496,6 +516,7 @@ export const itwProximityMachine = setup({
         Terminating: {
           tags: [ItwPresentationTags.Loading],
           description: "Send the session-termination signal to the verifier",
+          entry: "markSessionTerminated",
           invoke: {
             id: "terminateSession",
             src: "terminateSession",
@@ -527,20 +548,44 @@ export const itwProximityMachine = setup({
     Failure: {
       description: "An error occurred, captured in context.failure",
       entry: "navigateToFailureScreen",
-      invoke: {
-        id: "terminateSession",
-        src: "terminateSession",
-        onDone: {
-          // Attempt termination ignoring result
+      initial: "EnsureTerminated",
+      states: {
+        EnsureTerminated: {
+          always: [
+            {
+              // NFC consent teardown already sent SESSION_TERMINATED.
+              // A second native sendErrorResponse double-resumes the
+              // IOWalletProximity CheckedContinuation (fatal SIGTRAP).
+              guard: "hasTerminatedSession",
+              target: "Idle"
+            },
+            {
+              target: "Terminating"
+            }
+          ]
         },
-        onError: {
-          // Attempt termination ignoring any failure
+        Terminating: {
+          invoke: {
+            id: "terminateSession",
+            src: "terminateSession",
+            onDone: {
+              actions: "markSessionTerminated",
+              target: "Idle"
+            },
+            onError: {
+              actions: "markSessionTerminated",
+              target: "Idle"
+            }
+          }
+        },
+        Idle: {
+          description: "Termination attempted or skipped for this engagement"
         }
       },
       on: {
         close: {
           actions: "closeProximity",
-          target: "Idle"
+          target: "#itwProximityMachine.Idle"
         }
       }
     }

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityFailureScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityFailureScreen.test.tsx
@@ -37,7 +37,7 @@ const renderComponent = (failure: ProximityFailure) => {
 
   const snapshot: typeof initialSnapshot = {
     ...initialSnapshot,
-    value: "Failure",
+    value: { Failure: "Idle" },
     context: { ...initialSnapshot.context, failure }
   };
 


### PR DESCRIPTION
## Short description
Stop a native iOS crash during NFC proximity presentment: after engagement, while the user is on the consent screen, a second `SESSION_TERMINATED` on the same `IOWalletProximity` NFC session double-resumes a Swift `CheckedContinuation` and kills the app (`EXC_BREAKPOINT` / SIGTRAP).

## List of changes proposed in this pull request
- Track `sessionTerminated` on the proximity machine context (no mutable `let` in actors)
- Mark the session terminated when entering `TerminatingForConsent` / `Terminating`
- Skip `terminateSession` on `Failure` if it was already sent for this engagement
- Reset the flag when starting a new engagement (NFC retry after consent)
- Ignore late duplicate document requests (BLE copy of the same NFC request) during consent teardown
- Regression tests for once-per-engagement termination, duplicate requests, and retry reset

## How to test
### Steps to Reproduce
1. Start an NFC proximity presentment (engagement + NFC retrieval).
2. Complete engagement so the verifier sends a document request.
3. Wait for the claims/consent screen (session is torn down before consent).
4. Either stay on the screen (late BLE request) or deny consent.

**Before:** app can crash (`CheckedContinuation.resume(throwing:)` in `IOWalletProximity`).
**After:** consent screen stays up; deny consent shows the failure screen without a second native terminate.

### Expected
- `SESSION_TERMINATED` is sent at most once per engagement
- A new engagement after stored consent can terminate again
- QR/BLE-only failure still terminates the session
