### PR TITLE
chore: [IEG-3027] Align `iOSCookieDisabledServiceIds` to services metadata

### DIFF
--- a/apps/dev-api-server/src/payloads/backend.ts
+++ b/apps/dev-api-server/src/payloads/backend.ts
@@ -114,7 +114,11 @@ export const backendStatus: BackendStatus = {
           service_name: "Carta della Cultura - Onboarding"
         }
       ],
-      iOSCookieDisabledServiceIds: ["01JV4M365CHAZN5C0FDR62DCVD"]
+      iOSCookieDisabledServiceIds: [
+        "01JV4M365CHAZN5C0FDR62DCVD",
+        "01KTXJ47AAJMZFRJPA4V4TX5D0",
+        "01KTXHQSA4GPSVDJQWC2NYCJK5"
+      ]
     },
     premiumMessages: {
       opt_in_out_enabled: true


### PR DESCRIPTION
## Short description
This PR is aligning dev server to [metadata](https://github.com/pagopa/io-services-metadata/pull/1223)

## List of changes proposed in this pull request
- Add service id to iOSCookieDisabledServiceIds

## How to test
N/A
