### PR TITLE
chore(IT-Wallet): [SIW-4892] Remove helper tooltip from CIE+PIN auth flow

### DIFF
--- a/apps/main-app/ts/features/itwallet/identification/cie/components/ItwCiePreparationScreenContent.tsx
+++ b/apps/main-app/ts/features/itwallet/identification/cie/components/ItwCiePreparationScreenContent.tsx
@@ -41,7 +41,6 @@ export const ItwCiePreparationScreenContent = ({
       actions={actions}
       description={description}
       goBack={goBack}
-      headerActionsProp={{ showHelp: true }}
       title={{ label: title }}
     >
       <ContentWrapper>


### PR DESCRIPTION
## Short description
This PR removes the helper tooltip from the CIE+PIN authentication flow of the IT-Wallet Issuance.

## List of changes proposed in this pull request
- Removed the `showHelp` header action prop from `ItwCiePreparationScreenContent.tsx`

## How to test
1. Start an IT-Wallet Issuance flow
2. Choose the CIE+PIN authentication method
3. Verify that the "?" icon is absent from the upper-right corner of the screen