### PR TITLE
perf(IT-Wallet): [SIW-000] Improve proximity QR code screen performance

### DIFF
--- a/apps/main-app/ts/features/itwallet/presentation/proximity/components/ItwProximityQrCodeImage.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/components/ItwProximityQrCodeImage.tsx
@@ -9,9 +9,9 @@ import {
 } from "@io-app/design-system";
 import { useFocusEffect } from "@react-navigation/native";
 import I18n from "i18next";
-import { useCallback } from "react";
+import { memo, startTransition, useCallback, useEffect, useState } from "react";
 import { Dimensions, StyleSheet, View } from "react-native";
-import QRCode from "react-native-qrcode-skia";
+import QRCode, { type ShapeOptions } from "react-native-qrcode-skia";
 import Animated, { FadeIn } from "react-native-reanimated";
 
 import ItwIcon from "../../../../../../img/features/itWallet/brand/itw_icon.svg";
@@ -28,6 +28,24 @@ import { selectFailure, selectQRCodeString } from "../machine/selectors";
 import { shouldShowExpiredProximityCredentialsBannerSelector } from "../store/selectors/credentials";
 
 const QR_CODE_LOGO_SIZE = 52;
+const QR_CODE_LOGO_AREA_SIZE = 88;
+const QR_CODE_LOGO_AREA_RADIUS = 8;
+const QR_CODE_ERROR_CORRECTION_LEVEL = "H";
+
+/**
+ * Module-level so react-native-qrcode-skia's path memo is not reset
+ * by a new object/element identity on every parent render.
+ */
+const QR_SHAPE_OPTIONS: ShapeOptions = {
+  shape: "circle",
+  eyePatternShape: "rounded",
+  eyePatternGap: 0,
+  gap: 0
+};
+
+const QR_CODE_LOGO = (
+  <ItwIcon height={QR_CODE_LOGO_SIZE} width={QR_CODE_LOGO_SIZE} />
+);
 
 /**
  * For the QR Code size, we start from the window width and subtract the horizontal padding.
@@ -41,6 +59,28 @@ const QR_CODE_SIZE =
   WINDOW_WIDTH -
   IOVisualCostants.appMarginDefault * 2 - // Subtracting the horizontal screen padding (both sides)
   ITW_BRANDED_BOX_PADDING * 2; // Subtracting the branded box padding (both sides)
+
+type SkiaQrCodeProps = {
+  color: string;
+  value: string;
+};
+
+/**
+ * Isolated so parent re-renders (machine, debug overlay) do not recreate
+ * react-native-qrcode-skia's SVG path.
+ */
+const ProximitySkiaQrCode = memo(({ color, value }: SkiaQrCodeProps) => (
+  <QRCode
+    color={color}
+    errorCorrectionLevel={QR_CODE_ERROR_CORRECTION_LEVEL}
+    logo={QR_CODE_LOGO}
+    logoAreaBorderRadius={QR_CODE_LOGO_AREA_RADIUS}
+    logoAreaSize={QR_CODE_LOGO_AREA_SIZE}
+    shapeOptions={QR_SHAPE_OPTIONS}
+    size={QR_CODE_SIZE}
+    value={value}
+  />
+));
 
 type Props = {
   source?: ItwProximityQrCodeTracking["source"];
@@ -56,6 +96,23 @@ export const ItwProximityQrCodeImage = ({ source }: Props) => {
   const shouldShowExpiredBanner = useIOSelector(
     shouldShowExpiredProximityCredentialsBannerSelector
   );
+
+  const [shouldRenderQr, setShouldRenderQr] = useState(false);
+
+  useEffect(() => {
+    if (!qrCodeString) {
+      setShouldRenderQr(false);
+      return;
+    }
+    // Keep the skeleton on screen for this paint, then mount QRCode on the
+    // next frame so path generation does not hitch the string-arrival commit.
+    const frame = requestAnimationFrame(() => {
+      startTransition(() => {
+        setShouldRenderQr(true);
+      });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [qrCodeString]);
 
   useDebugInfo({
     qrCodeString
@@ -100,35 +157,30 @@ export const ItwProximityQrCodeImage = ({ source }: Props) => {
     );
   }
 
-  if (!qrCodeString) {
-    return <IOSkeleton radius={16} shape="square" size={QR_CODE_SIZE} />;
-  }
+  const qrColor = theme["textBody-default"];
 
   return (
-    <Animated.View
-      accessibilityLabel={I18n.t(
-        "features.itWallet.presentation.proximity.engagement.qrCode.accessibilityLabel"
-      )}
-      accessibilityRole="image"
-      accessible={true}
-      entering={FadeIn.duration(200)}
+    <View
+      accessibilityLabel={
+        qrCodeString
+          ? I18n.t(
+              "features.itWallet.presentation.proximity.engagement.qrCode.accessibilityLabel"
+            )
+          : undefined
+      }
+      accessibilityRole={qrCodeString ? "image" : undefined}
+      accessible={!!qrCodeString}
+      style={styles.qrSlot}
+      testID="itwProximityQrSlotTestID"
     >
-      <QRCode
-        color={theme["textBody-default"]}
-        errorCorrectionLevel="H"
-        logo={<ItwIcon height={QR_CODE_LOGO_SIZE} width={QR_CODE_LOGO_SIZE} />}
-        logoAreaBorderRadius={8}
-        logoAreaSize={88}
-        shapeOptions={{
-          shape: "circle",
-          eyePatternShape: "rounded",
-          eyePatternGap: 0,
-          gap: 0
-        }}
-        size={QR_CODE_SIZE}
-        value={qrCodeString}
-      />
-    </Animated.View>
+      {shouldRenderQr && qrCodeString ? (
+        <Animated.View entering={FadeIn.duration(300)}>
+          <ProximitySkiaQrCode color={qrColor} value={qrCodeString} />
+        </Animated.View>
+      ) : (
+        <IOSkeleton radius={16} shape="square" size={QR_CODE_SIZE} />
+      )}
+    </View>
   );
 };
 
@@ -147,6 +199,10 @@ const StatusBox = ({ iconName, description, action }: StatusBoxProps) => (
 );
 
 const styles = StyleSheet.create({
+  qrSlot: {
+    width: QR_CODE_SIZE,
+    height: QR_CODE_SIZE
+  },
   statusBox: {
     backgroundColor: IOColors["grey-50"],
     alignItems: "center",

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwProximityPresentmentScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwProximityPresentmentScreen.tsx
@@ -89,7 +89,7 @@ export const ItwProximityPresentmentScreen = ({
     });
   }, [machineRef]);
 
-  useMaxBrightness({ useSmoothTransition: true });
+  useMaxBrightness();
 
   useLayoutEffect(() => {
     navigation.setOptions({

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityQrCodeScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwProximityQrCodeScreen.test.tsx
@@ -66,6 +66,24 @@ describe("ItwProximityPresentmentScreen", () => {
     expect(component).toMatchSnapshot();
   });
 
+  it("should keep the same QR slot size while loading and when ready", () => {
+    const loading = renderComponent(
+      { machineState: "loading" },
+      { source: "WALLET_HOME" }
+    );
+    const ready = renderComponent(
+      {
+        machineState: "displayQrCode",
+        qrCodeString: "mock-qr-code-string"
+      },
+      { source: "WALLET_HOME" }
+    );
+
+    expect(loading.getByTestId("itwProximityQrSlotTestID").props.style).toEqual(
+      ready.getByTestId("itwProximityQrSlotTestID").props.style
+    );
+  });
+
   it("should render error state when QR code generation fails", () => {
     expect(
       renderComponent({ machineState: "error" }, { source: "WALLET_HOME" })

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/__snapshots__/ItwProximityQrCodeScreen.test.tsx.snap
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/__snapshots__/ItwProximityQrCodeScreen.test.tsx.snap
@@ -669,28 +669,67 @@ exports[`ItwProximityPresentmentScreen should render QR code when ready 1`] = `
                                 accessibilityLabel="Immagine del codice QR da mostrare a chi verifica i documenti digitali"
                                 accessibilityRole="image"
                                 accessible={true}
-                                collapsable={false}
-                                entering={
-                                  FadeIn {
-                                    "build": [Function],
-                                    "durationV": 200,
-                                    "randomizeDelay": false,
-                                    "reduceMotionV": "system",
-                                  }
-                                }
-                                jestAnimatedProps={
+                                style={
                                   {
-                                    "value": {},
+                                    "height": 670,
+                                    "width": 670,
                                   }
                                 }
-                                jestAnimatedStyle={
-                                  {
-                                    "value": {},
-                                  }
-                                }
+                                testID="itwProximityQrSlotTestID"
                               >
                                 <View
-                                  testID="qrcode"
+                                  collapsable={false}
+                                  jestAnimatedProps={
+                                    {
+                                      "value": {},
+                                    }
+                                  }
+                                  jestAnimatedStyle={
+                                    {
+                                      "value": {},
+                                    }
+                                  }
+                                  jestInlineStyle={
+                                    [
+                                      {
+                                        "backgroundColor": "#E8EBF1",
+                                        "borderCurve": "continuous",
+                                        "borderRadius": 16,
+                                        "height": 670,
+                                        "width": 670,
+                                      },
+                                      {
+                                        "animationDuration": "1250ms",
+                                        "animationIterationCount": "infinite",
+                                        "animationName": {
+                                          "0%, 100%": {
+                                            "opacity": 0.75,
+                                          },
+                                          "50%": {
+                                            "opacity": 0.35,
+                                          },
+                                        },
+                                        "animationTimingFunction": CubicBezierEasing {
+                                          "x1": 0.37,
+                                          "x2": 0.63,
+                                          "y1": 0,
+                                          "y2": 1,
+                                        },
+                                      },
+                                    ]
+                                  }
+                                  style={
+                                    [
+                                      {
+                                        "backgroundColor": "#E8EBF1",
+                                        "borderCurve": "continuous",
+                                        "borderRadius": 16,
+                                        "height": 670,
+                                        "width": 670,
+                                      },
+                                      {},
+                                    ]
+                                  }
                                 />
                               </View>
                             </View>
@@ -2082,7 +2121,7 @@ exports[`ItwProximityPresentmentScreen should render error state when QR code ge
               <View
                 collapsable={false}
                 enabled={false}
-                handlerTag={3}
+                handlerTag={5}
                 handlerType="PanGestureHandler"
                 needsOffscreenAlphaCompositing={false}
                 onGestureHandlerEvent={[Function]}
@@ -4771,59 +4810,70 @@ exports[`ItwProximityPresentmentScreen should render loading skeleton when machi
                                 </Text>
                               </View>
                               <View
-                                collapsable={false}
-                                jestAnimatedProps={
-                                  {
-                                    "value": {},
-                                  }
-                                }
-                                jestAnimatedStyle={
-                                  {
-                                    "value": {},
-                                  }
-                                }
-                                jestInlineStyle={
-                                  [
-                                    {
-                                      "backgroundColor": "#E8EBF1",
-                                      "borderCurve": "continuous",
-                                      "borderRadius": 16,
-                                      "height": 670,
-                                      "width": 670,
-                                    },
-                                    {
-                                      "animationDuration": "1250ms",
-                                      "animationIterationCount": "infinite",
-                                      "animationName": {
-                                        "0%, 100%": {
-                                          "opacity": 0.75,
-                                        },
-                                        "50%": {
-                                          "opacity": 0.35,
-                                        },
-                                      },
-                                      "animationTimingFunction": CubicBezierEasing {
-                                        "x1": 0.37,
-                                        "x2": 0.63,
-                                        "y1": 0,
-                                        "y2": 1,
-                                      },
-                                    },
-                                  ]
-                                }
+                                accessible={false}
                                 style={
-                                  [
-                                    {
-                                      "backgroundColor": "#E8EBF1",
-                                      "borderCurve": "continuous",
-                                      "borderRadius": 16,
-                                      "height": 670,
-                                      "width": 670,
-                                    },
-                                    {},
-                                  ]
+                                  {
+                                    "height": 670,
+                                    "width": 670,
+                                  }
                                 }
-                              />
+                                testID="itwProximityQrSlotTestID"
+                              >
+                                <View
+                                  collapsable={false}
+                                  jestAnimatedProps={
+                                    {
+                                      "value": {},
+                                    }
+                                  }
+                                  jestAnimatedStyle={
+                                    {
+                                      "value": {},
+                                    }
+                                  }
+                                  jestInlineStyle={
+                                    [
+                                      {
+                                        "backgroundColor": "#E8EBF1",
+                                        "borderCurve": "continuous",
+                                        "borderRadius": 16,
+                                        "height": 670,
+                                        "width": 670,
+                                      },
+                                      {
+                                        "animationDuration": "1250ms",
+                                        "animationIterationCount": "infinite",
+                                        "animationName": {
+                                          "0%, 100%": {
+                                            "opacity": 0.75,
+                                          },
+                                          "50%": {
+                                            "opacity": 0.35,
+                                          },
+                                        },
+                                        "animationTimingFunction": CubicBezierEasing {
+                                          "x1": 0.37,
+                                          "x2": 0.63,
+                                          "y1": 0,
+                                          "y2": 1,
+                                        },
+                                      },
+                                    ]
+                                  }
+                                  style={
+                                    [
+                                      {
+                                        "backgroundColor": "#E8EBF1",
+                                        "borderCurve": "continuous",
+                                        "borderRadius": 16,
+                                        "height": 670,
+                                        "width": 670,
+                                      },
+                                      {},
+                                    ]
+                                  }
+                                />
+                              </View>
                             </View>
                           </View>
                           <View
@@ -6213,7 +6263,7 @@ exports[`ItwProximityPresentmentScreen when credentials are expired should rende
               <View
                 collapsable={false}
                 enabled={false}
-                handlerTag={6}
+                handlerTag={8}
                 handlerType="PanGestureHandler"
                 needsOffscreenAlphaCompositing={false}
                 onGestureHandlerEvent={[Function]}
@@ -6984,28 +7034,67 @@ exports[`ItwProximityPresentmentScreen when credentials are expired should rende
                                 accessibilityLabel="Immagine del codice QR da mostrare a chi verifica i documenti digitali"
                                 accessibilityRole="image"
                                 accessible={true}
-                                collapsable={false}
-                                entering={
-                                  FadeIn {
-                                    "build": [Function],
-                                    "durationV": 200,
-                                    "randomizeDelay": false,
-                                    "reduceMotionV": "system",
-                                  }
-                                }
-                                jestAnimatedProps={
+                                style={
                                   {
-                                    "value": {},
+                                    "height": 670,
+                                    "width": 670,
                                   }
                                 }
-                                jestAnimatedStyle={
-                                  {
-                                    "value": {},
-                                  }
-                                }
+                                testID="itwProximityQrSlotTestID"
                               >
                                 <View
-                                  testID="qrcode"
+                                  collapsable={false}
+                                  jestAnimatedProps={
+                                    {
+                                      "value": {},
+                                    }
+                                  }
+                                  jestAnimatedStyle={
+                                    {
+                                      "value": {},
+                                    }
+                                  }
+                                  jestInlineStyle={
+                                    [
+                                      {
+                                        "backgroundColor": "#E8EBF1",
+                                        "borderCurve": "continuous",
+                                        "borderRadius": 16,
+                                        "height": 670,
+                                        "width": 670,
+                                      },
+                                      {
+                                        "animationDuration": "1250ms",
+                                        "animationIterationCount": "infinite",
+                                        "animationName": {
+                                          "0%, 100%": {
+                                            "opacity": 0.75,
+                                          },
+                                          "50%": {
+                                            "opacity": 0.35,
+                                          },
+                                        },
+                                        "animationTimingFunction": CubicBezierEasing {
+                                          "x1": 0.37,
+                                          "x2": 0.63,
+                                          "y1": 0,
+                                          "y2": 1,
+                                        },
+                                      },
+                                    ]
+                                  }
+                                  style={
+                                    [
+                                      {
+                                        "backgroundColor": "#E8EBF1",
+                                        "borderCurve": "continuous",
+                                        "borderRadius": 16,
+                                        "height": 670,
+                                        "width": 670,
+                                      },
+                                      {},
+                                    ]
+                                  }
                                 />
                               </View>
                             </View>


### PR DESCRIPTION
## Short description
Reduce hitching when opening the IT Wallet proximity QR code screen, while still rendering the QR with `react-native-qrcode-skia`.

## List of changes proposed in this pull request
- Defer mounting `react-native-qrcode-skia` until after the skeleton has painted, so SVG path generation does not block the first frame
- Memoize QR props (`shapeOptions`, logo, size) so the path is built once instead of on every parent re-render
- Keep a fixed-size QR slot so the branded box does not jump between skeleton and QR
- Set max brightness immediately on the presentment screen (no 1.5s JS brightness ramp)
- Add a regression test that skeleton and QR share the same slot size

## How to test
1. Open the wallet home with presentable credentials
2. Tap **Avvia verifica**
3. Confirm the QR screen opens without flicker: skeleton stays until the QR is ready, then the Skia QR appears
4. Confirm the QR still scans and the IT Wallet logo is in the center
5. Open the screen twice and confirm the second open does not rebuild the path on unrelated re-renders
6. Optional: React DevTools profiler on the open
   - String-arrival commit should stay cheap (~1ms)
   - `QRCode` first mount still does the library's SVG path work (~120ms), isolated after the skeleton paint