### PR TITLE
chore(IT-Wallet): [SIW-4915] Update credential tracking in BackToWallet flow

### DIFF
--- a/apps/main-app/ts/features/itwallet/issuance/analytics/types.ts
+++ b/apps/main-app/ts/features/itwallet/issuance/analytics/types.ts
@@ -12,7 +12,7 @@ export type AddCredentialFailure = {
 };
 
 export type BackToWallet = {
-  credential: Extract<MixPanelCredential, "ITW_ID_V2">;
+  credential: Extract<MixPanelCredential, "ITW_ID_V2" | "ITW_PID">;
   exit_page: string;
 };
 

--- a/apps/main-app/ts/features/itwallet/issuance/screens/ItwIssuanceEidResultScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/issuance/screens/ItwIssuanceEidResultScreen.tsx
@@ -90,7 +90,7 @@ export const ItwIssuanceEidResultScreen = () => {
     handleBackToWallet();
     trackBackToWallet({
       exit_page: route.name,
-      credential: "ITW_ID_V2"
+      credential: isL3IssuanceFlow ? "ITW_PID" : "ITW_ID_V2"
     });
   };
 
@@ -185,7 +185,6 @@ const ItwEidSuccessResultContent = ({
   onGoToWallet: () => void;
   showBanner?: boolean;
 }) => {
-  const route = useRoute();
   const identification =
     ItwEidIssuanceMachineContext.useSelector(selectIdentification);
   const authMethod = toSurveyAuthMethod(identification);
@@ -220,10 +219,7 @@ const ItwEidSuccessResultContent = ({
     <ItwIssuanceEidIssuanceResultContent
       docStatus={docStatus}
       onAddCredential={onAddDocument}
-      onBackToWallet={() => {
-        onGoToWallet();
-        trackBackToWallet({ exit_page: route.name, credential: "ITW_ID_V2" });
-      }}
+      onBackToWallet={onGoToWallet}
       showBanner={showBanner}
     />
   );
@@ -304,7 +300,7 @@ const ItwIssuanceEidUpgradeResultContent = ({
     handleBackToWallet();
     trackBackToWallet({
       exit_page: route.name,
-      credential: "ITW_ID_V2"
+      credential: "ITW_PID"
     });
   };
 

--- a/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceEidResultScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/issuance/screens/__tests__/ItwIssuanceEidResultScreen.test.tsx
@@ -12,11 +12,18 @@ import { Context, EidIssuanceLevel } from "../../../machine/eid/context";
 import { itwEidIssuanceMachine } from "../../../machine/eid/machine";
 import { ItwEidIssuanceMachineContext } from "../../../machine/eid/provider";
 import { ITW_ROUTES } from "../../../navigation/routes";
+import { trackBackToWallet } from "../../analytics";
 import { ItwIssuanceEidResultScreen } from "../ItwIssuanceEidResultScreen";
 
 const mockSend = jest.fn();
 const mockCredentialSend = jest.fn();
 const mockHasResolvedCredentialOffer = jest.fn();
+
+jest.mock("../../analytics", () => ({
+  trackAddFirstCredential: jest.fn(),
+  trackBackToWallet: jest.fn(),
+  trackItwCredentialReissuingFailed: jest.fn()
+}));
 
 jest.mock("../../../../../components/screens/LoadingScreenContent", () => ({
   __esModule: true,
@@ -170,6 +177,11 @@ describe("ItwIssuanceEidResultScreen", () => {
         );
 
         expect(mockSend).toHaveBeenCalledWith({ type: "go-to-wallet" });
+        expect(trackBackToWallet).toHaveBeenCalledWith({
+          credential: "ITW_PID",
+          exit_page: ITW_ROUTES.ISSUANCE.EID_RESULT
+        });
+        expect(trackBackToWallet).toHaveBeenCalledTimes(1);
       });
     });
   });
@@ -199,6 +211,18 @@ describe("ItwIssuanceEidResultScreen", () => {
           I18n.t("features.itWallet.issuance.eidResult.success.secondaryAction")
         )
       ).toBeTruthy();
+
+      fireEvent.press(
+        getByText(
+          I18n.t("features.itWallet.issuance.eidResult.success.secondaryAction")
+        )
+      );
+
+      expect(trackBackToWallet).toHaveBeenCalledWith({
+        credential: "ITW_PID",
+        exit_page: ITW_ROUTES.ISSUANCE.EID_RESULT
+      });
+      expect(trackBackToWallet).toHaveBeenCalledTimes(1);
     });
 
     it("renders the 'explore IT-Wallet' TYP when the upgraded wallet has no documents", () => {
@@ -257,6 +281,21 @@ describe("ItwIssuanceEidResultScreen", () => {
           I18n.t("features.itWallet.issuance.eidResult.success.itw.title")
         )
       ).toBeNull();
+    });
+
+    it("tracks ITW_ID_V2 when returning to the wallet", () => {
+      const { getByText } = renderComponent("l2");
+
+      fireEvent.press(
+        getByText(
+          I18n.t("features.itWallet.issuance.eidResult.success.secondaryAction")
+        )
+      );
+
+      expect(trackBackToWallet).toHaveBeenCalledWith({
+        credential: "ITW_ID_V2",
+        exit_page: ITW_ROUTES.ISSUANCE.EID_RESULT
+      });
     });
   });
 


### PR DESCRIPTION
## Short description
This PR fixes incorrect tracking for the **Back to Wallet** event in the IT-Wallet issuance flow.

## List of changes proposed in this pull request
- Added a check to distinguish `credential` type between the `ITW_BACK_TO_WALLET` event in the IT-Wallet and Documenti su IO flows.
- Extended the types for `BackToWallet`.
- Removed the duplicated tracking event from `ItwIssuanceEidIssuanceResultContent.tsx` in `onBackToWallet()`.
- Added unit tests.

## How to test

### IT-Wallet flow
1. Start PID issuance for the IT-Wallet/L3 flow.
2. Complete the issuance successfully.
3. On the result screen, tap **"Esplora il wallet"**.
4. Check the Mixpanel event `ITW_BACK_TO_WALLET`.

```json
{
  "credential": "ITW_PID"
}
````

The event must be emitted exactly once.

### Documenti su IO flow

1. Start eID issuance for the Documenti su IO/L2 flow.
2. Complete the issuance successfully.
3. On the result screen, tap **"Esplora il wallet"**.
4. Check the Mixpanel event `ITW_BACK_TO_WALLET`.

```json
{
  "credential": "ITW_ID_V2"
}
```

The event must be emitted exactly once.

### Upgrade flow

1. Activate IT-Wallet by upgrading an existing Documenti su IO wallet.
2. Complete the upgrade successfully.
3. Tap **"Esplora il wallet"**.
4. Check the Mixpanel event `ITW_BACK_TO_WALLET`.

```json
{
  "credential": "ITW_PID"
}
```

The event must be emitted exactly once.

