### PR TITLE
fix(IT-Wallet): [SIW-3634] remove redundant case for 'valid' state in credential date claim

### DIFF
--- a/apps/main-app/ts/features/itwallet/common/components/ItwCredentialClaim.tsx
+++ b/apps/main-app/ts/features/itwallet/common/components/ItwCredentialClaim.tsx
@@ -202,7 +202,6 @@ const DateClaimItem = ({
         };
       case "expiring":
       case "jwtExpiring":
-      case "valid":
         return {
           type: "badge",
           componentProps: {
@@ -222,6 +221,8 @@ const DateClaimItem = ({
             )
           }
         };
+      // "valid" is the default state, so no badge is shown for it
+      case "valid":
       default:
         return undefined;
     }

--- a/apps/main-app/ts/features/itwallet/common/components/ItwCredentialClaim.tsx
+++ b/apps/main-app/ts/features/itwallet/common/components/ItwCredentialClaim.tsx
@@ -185,53 +185,66 @@ const DateClaimItem = ({
     ? getHiddenClaimAccessibilityText()
     : realValue;
 
+  // Localized description of the claim's validity status. It is used to build the
+  // visible badge (when shown) and also to inform screen reader users of the "valid"
+  // state, which otherwise has no visible badge.
+  const statusText = useMemo(() => {
+    switch (status) {
+      case "expired":
+        return I18n.t(
+          "features.itWallet.presentation.credentialDetails.status.expired"
+        );
+      case "expiring":
+      case "jwtExpiring":
+      case "valid":
+        return I18n.t(
+          "features.itWallet.presentation.credentialDetails.status.valid"
+        );
+      case "invalid":
+        return I18n.t(
+          "features.itWallet.presentation.credentialDetails.status.invalid"
+        );
+      default:
+        return undefined;
+    }
+  }, [status]);
+
   const endElement: ListItemInfo["endElement"] = useMemo(() => {
-    if (hidden) {
+    if (hidden || !statusText) {
       return undefined;
     }
     switch (status) {
       case "expired":
         return {
           type: "badge",
-          componentProps: {
-            variant: "error",
-            text: I18n.t(
-              "features.itWallet.presentation.credentialDetails.status.expired"
-            )
-          }
+          componentProps: { variant: "error", text: statusText }
         };
       case "expiring":
       case "jwtExpiring":
         return {
           type: "badge",
-          componentProps: {
-            variant: "success",
-            text: I18n.t(
-              "features.itWallet.presentation.credentialDetails.status.valid"
-            )
-          }
+          componentProps: { variant: "success", text: statusText }
         };
       case "invalid":
         return {
           type: "badge",
-          componentProps: {
-            variant: "error",
-            text: I18n.t(
-              "features.itWallet.presentation.credentialDetails.status.invalid"
-            )
-          }
+          componentProps: { variant: "error", text: statusText }
         };
       // "valid" is the default state, so no badge is shown for it
       case "valid":
       default:
         return undefined;
     }
-  }, [status, hidden]);
+  }, [status, hidden, statusText]);
 
   return (
     <ListItemInfo
       accessibilityLabel={
-        hidden ? `${label} ${accessibilityStateText}` : undefined
+        hidden
+          ? `${label} ${accessibilityStateText}`
+          : statusText && !endElement
+            ? [label, displayValue, statusText].join("; ")
+            : undefined
       }
       endElement={endElement}
       key={`${label}-${displayValue}`}


### PR DESCRIPTION
## Short description
Fix: the "Valida" (Valid) badge was shown next to expiration date claims even when the credential status was "valid" (the default state). Since "valid" is the default, no badge is needed in that case.

## List of changes proposed in this pull request
- Removed the `"valid"` case from the badge rendering logic in `DateClaimItem` (`ItwCredentialClaim.tsx`), so no badge is displayed when the credential status is the default "valid" state.
- Kept "expiring"/"jwtExpiring" (still shown as success badge), "expired" and "invalid" badges unchanged.
- This fix applies to all claims using this shared component, not just the administrative expiration date claim.

## How to test
1. Open a credential detail screen with an administrative expiration date claim (e.g. mDL, TS) whose status is "valid".
2. Verify no badge is shown next to the expiration date.
3. Verify credentials with "expired" or "invalid" status still show their respective badges, and "expiring"/"jwtExpiring" still show the success badge.