### PR TITLE
fix(IT-Wallet): [SIW-4921] Pass credential name to Qualtrics exit survey URL

### DIFF
--- a/apps/main-app/ts/features/itwallet/common/hooks/useItwActivationExitSurveyBottomSheet.tsx
+++ b/apps/main-app/ts/features/itwallet/common/hooks/useItwActivationExitSurveyBottomSheet.tsx
@@ -83,8 +83,8 @@ export const useItwActivationExitSurveyBottomSheet = () => {
               onPress={() => {
                 skipDeclinedEvent.current = true;
                 trackItwSurveyRequestAccepted(trackingProps);
-                openWebUrl(surveyUrl);
                 dismiss();
+                openWebUrl(surveyUrl);
               }}
               variant="solid"
             />
@@ -103,6 +103,7 @@ export const useItwActivationExitSurveyBottomSheet = () => {
       </VStack>
     ),
     onDismiss: () => {
+      dispatch(itwSetActivationExitSurvey(undefined));
       if (!skipDeclinedEvent.current) {
         trackItwSurveyRequestDeclined(trackingProps);
       }
@@ -124,9 +125,8 @@ export const useItwActivationExitSurveyBottomSheet = () => {
     useCallback(() => {
       if (activationExitSurveyState) {
         presentSurvey();
-        dispatch(itwSetActivationExitSurvey(undefined));
       }
-    }, [activationExitSurveyState, dispatch, presentSurvey])
+    }, [activationExitSurveyState, presentSurvey])
   );
 
   return { bottomSheet };

--- a/apps/main-app/ts/features/itwallet/common/hooks/useItwCredentialExitSurveyBottomSheet.tsx
+++ b/apps/main-app/ts/features/itwallet/common/hooks/useItwCredentialExitSurveyBottomSheet.tsx
@@ -79,8 +79,8 @@ export const useItwCredentialExitSurveyBottomSheet = () => {
               onPress={() => {
                 skipDeclinedEvent.current = true;
                 trackItwSurveyRequestAccepted(trackingProps);
-                openWebUrl(surveyUrl);
                 dismiss();
+                openWebUrl(surveyUrl);
               }}
               variant="solid"
             />
@@ -99,6 +99,7 @@ export const useItwCredentialExitSurveyBottomSheet = () => {
       </VStack>
     ),
     onDismiss: () => {
+      dispatch(itwSetCredentialExitSurvey(undefined));
       if (!skipDeclinedEvent.current) {
         trackItwSurveyRequestDeclined(trackingProps);
       }
@@ -119,9 +120,8 @@ export const useItwCredentialExitSurveyBottomSheet = () => {
     useCallback(() => {
       if (credentialExitSurveyState) {
         presentSurvey();
-        dispatch(itwSetCredentialExitSurvey(undefined));
       }
-    }, [credentialExitSurveyState, dispatch, presentSurvey])
+    }, [credentialExitSurveyState, presentSurvey])
   );
 
   return { bottomSheet };


### PR DESCRIPTION
## Short description
This PR fixes a race condition in the exit survey hooks causing the `itWallet.ui` slice to be reset as soon as the survey bottom sheet is presented, clearing data needed to properly build the Qualtrics URL.

## List of changes proposed in this pull request
- Moved the `itwSetActivationExitSurvey` reset action from present to dismiss

## How to test
Select a credential from the catalogue then leave the flow. Press on the survey CTA to open the browser and check the question.

|Before|After|
|------|-----|
|<img width="240" src="https://github.com/user-attachments/assets/6a9fa4bb-ff40-4b47-acc9-a83054206d48" />|<img width="240" src="https://github.com/user-attachments/assets/db86280f-21b1-467a-8304-067280832db7" />|

