### PR TITLE
fix(IT-Wallet): [SIW-4861] Prevent tracking proximity start on open transitions

### DIFF
--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/__tests__/machine.test.ts
@@ -264,7 +264,7 @@ describe("itwProximityMachine", () => {
     await waitFor(actor, snapshot =>
       snapshot.matches({ Presentment: "Starting" })
     );
-    expect(trackProximityStart).toHaveBeenCalledTimes(1);
+    expect(trackProximityStart).not.toHaveBeenCalled();
     expect(actor.getSnapshot().context.engagementMode).toEqual("qrcode");
   });
 
@@ -398,7 +398,7 @@ describe("itwProximityMachine", () => {
     );
     expect(actor.getSnapshot().context.engagementMode).toEqual("nfc");
     expect(navigateToNfcPresentmentScreen).toHaveBeenCalledTimes(1);
-    expect(trackProximityStart).toHaveBeenCalledTimes(1);
+    expect(trackProximityStart).not.toHaveBeenCalled();
   });
 
   it("handles the happy path in Presentment", async () => {
@@ -470,6 +470,7 @@ describe("itwProximityMachine", () => {
     expect(actor.getSnapshot().value).toStrictEqual({
       Presentment: "Connecting"
     });
+    expect(trackProximityStart).not.toHaveBeenCalled();
     expect(navigateToClaimsDisclosureScreen).toHaveBeenCalledTimes(1);
   });
 
@@ -487,8 +488,26 @@ describe("itwProximityMachine", () => {
     expect(actor.getSnapshot().value).toStrictEqual({
       Presentment: "Connecting"
     });
+    expect(trackProximityStart).not.toHaveBeenCalled();
     expect(navigateToClaimsDisclosureScreen).not.toHaveBeenCalled();
   });
+
+  test.each(["qrcode", "nfc"] as const)(
+    "tracks %s proximity start when verifier connects",
+    engagementMode => {
+      const actor = createActor(mockedMachine, {
+        snapshot: makeSnapshot(
+          { Presentment: "Connecting" },
+          { engagementMode }
+        )
+      });
+
+      actor.start();
+      actor.send({ type: "device-connected" });
+
+      expect(trackProximityStart).toHaveBeenCalledTimes(1);
+    }
+  );
 
   it("close from Presentment.AwaitingConnection calls closeProximity", () => {
     const actor = createActor(mockedMachine, {

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/machine/machine.ts
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/machine/machine.ts
@@ -179,7 +179,7 @@ export const itwProximityMachine = setup({
       },
       onDone: {
         target: "#itwProximityMachine.Presentment",
-        actions: ["navigateToPresentmentScreen", "trackProximityStart"]
+        actions: "navigateToPresentmentScreen"
       }
     },
     Nfc: {
@@ -229,8 +229,7 @@ export const itwProximityMachine = setup({
         target: "#itwProximityMachine.Presentment",
         actions: [
           assign({ engagementMode: "nfc" }),
-          "navigateToNfcPresentmentScreen",
-          "trackProximityStart"
+          "navigateToNfcPresentmentScreen"
         ]
       }
     },
@@ -260,7 +259,8 @@ export const itwProximityMachine = setup({
           target: "Presentment.Connecting"
         },
         "device-connected": {
-          target: "Presentment.Connected"
+          target: "Presentment.Connected",
+          actions: "trackProximityStart"
         },
         "device-document-request-received": [
           {


### PR DESCRIPTION
## Short description
This PR prevents proximity tracking event `ITW_PROXIMITY_START` to be triggered on initial phase, but only after engagement with the verifier.
## List of changes proposed in this pull request
- Delete `trackProximityStart` action during proximity initial tap
- Added `trackProximityStart` acton during proximity engagement with the verifier
- Added unit tests

## How to test
1. Start a proximity flow
2. Verify `ITW_PROXIMITY_START` is not triggered
3. Tap "Avvia verifica contactless" and verify `ITW_PROXIMITY_START` is not triggered
4. Frame the QR code or connect the verifier device using NFC, and verify the event is triggered correctly and only once in mixpanel dashboard