### PR TITLE
feat(IT-Wallet): [SIW-4862] Fix wrong banner_id analytics property

### DIFF
--- a/apps/main-app/ts/features/itwallet/common/components/ItwEidLifecycleAlert.tsx
+++ b/apps/main-app/ts/features/itwallet/common/components/ItwEidLifecycleAlert.tsx
@@ -58,6 +58,7 @@ export const ItwEidLifecycleAlert = ({
   const isOffline = offlineAccessReason !== undefined;
 
   const { trackAlertTap } = useItwEidLifecycleAlertTracking({
+    isItwCredential: isItw,
     maybeEidStatus,
     navigation,
     skipViewTracking,

--- a/apps/main-app/ts/features/itwallet/common/components/__tests__/ItwEidLifecycleAlert.test.tsx
+++ b/apps/main-app/ts/features/itwallet/common/components/__tests__/ItwEidLifecycleAlert.test.tsx
@@ -69,7 +69,8 @@ describe("ItwEidLifecycleAlert", () => {
 
     expect(trackingSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        currentScreenName: expectedRoute
+        currentScreenName: expectedRoute,
+        isItwCredential: true
       })
     );
   });

--- a/apps/main-app/ts/features/itwallet/common/hooks/__tests__/useItwEidLifecycleAlertTracking.test.tsx
+++ b/apps/main-app/ts/features/itwallet/common/hooks/__tests__/useItwEidLifecycleAlertTracking.test.tsx
@@ -1,0 +1,82 @@
+import { act, renderHook } from "@testing-library/react-native";
+
+import {
+  trackItwBannerTap,
+  trackItwBannerVisualized
+} from "../../../analytics";
+import { ItwJwtCredentialStatus } from "../../utils/itwTypesUtils";
+import { useItwEidLifecycleAlertTracking } from "../useItwEidLifecycleAlertTracking";
+
+jest.mock("../../../analytics", () => ({
+  trackItwBannerTap: jest.fn(),
+  trackItwBannerVisualized: jest.fn()
+}));
+
+type Scenario = {
+  bannerId: string;
+  isItwCredential: boolean;
+  name: string;
+  status: ItwJwtCredentialStatus;
+};
+
+const scenarios: ReadonlyArray<Scenario> = [
+  {
+    name: "expiring PID",
+    status: "jwtExpiring",
+    isItwCredential: true,
+    bannerId: "itwExpiringPidBanner"
+  },
+  {
+    name: "expired PID",
+    status: "jwtExpired",
+    isItwCredential: true,
+    bannerId: "itwExpiredPidBanner"
+  },
+  {
+    name: "expiring eID",
+    status: "jwtExpiring",
+    isItwCredential: false,
+    bannerId: "itwExpiringIdBanner"
+  },
+  {
+    name: "expired eID",
+    status: "jwtExpired",
+    isItwCredential: false,
+    bannerId: "itwExpiredIdBanner"
+  }
+];
+
+describe("useItwEidLifecycleAlertTracking", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test.each(scenarios)("tracks the $name banner", scenario => {
+    const addListener = jest.fn().mockReturnValue(jest.fn());
+    const navigation = { addListener } as any;
+    const { result } = renderHook(() =>
+      useItwEidLifecycleAlertTracking({
+        isItwCredential: scenario.isItwCredential,
+        maybeEidStatus: scenario.status,
+        navigation
+      })
+    );
+    const onFocus = addListener.mock.calls.find(
+      ([event]) => event === "focus"
+    )?.[1];
+
+    act(() => {
+      onFocus();
+    });
+
+    expect(trackItwBannerVisualized).toHaveBeenCalledWith(
+      expect.objectContaining({ banner_id: scenario.bannerId })
+    );
+
+    act(() => result.current.trackAlertTap());
+
+    expect(trackItwBannerTap).toHaveBeenCalledWith(
+      expect.objectContaining({ banner_id: scenario.bannerId })
+    );
+  });
+});

--- a/apps/main-app/ts/features/itwallet/common/hooks/useItwEidLifecycleAlertTracking.ts
+++ b/apps/main-app/ts/features/itwallet/common/hooks/useItwEidLifecycleAlertTracking.ts
@@ -7,14 +7,30 @@ import { ItwJwtCredentialStatus } from "../utils/itwTypesUtils";
 
 type Props = {
   currentScreenName?: string;
+  isItwCredential: boolean;
   isOffline?: boolean;
   maybeEidStatus: ItwJwtCredentialStatus | undefined;
   navigation: ReturnType<typeof useIONavigation>;
   skipViewTracking?: boolean;
 };
 
+const getLifecycleBannerId = (
+  status: ItwJwtCredentialStatus | undefined,
+  isItwCredential: boolean
+) => {
+  if (isItwCredential) {
+    return status === "jwtExpiring"
+      ? "itwExpiringPidBanner"
+      : "itwExpiredPidBanner";
+  }
+
+  return status === "jwtExpiring"
+    ? "itwExpiringIdBanner"
+    : "itwExpiredIdBanner";
+};
+
 /**
- * Hook for tracking eID lifecycle alerts.
+ * Hook for tracking eID and PID lifecycle alerts.
  *
  * This hook handles two types of analytics events:
  * 1. Banner visualized event: triggered the first time the alert becomes visible
@@ -24,10 +40,10 @@ type Props = {
  *
  * Tracking rules:
  * - If `skipViewTracking` is true, only the visualized event is skipped.
- * - If the eID status is valid, no visualized event is sent.
- * - If `isItw` is true, no tracking is sent at all.
+ * - If the credential status is valid, no visualized event is sent.
  *
- * @param maybeEidStatus The current eID status
+ * @param isItwCredential Whether the credential is an IT-Wallet PID
+ * @param maybeEidStatus The current credential status
  * @param navigation Navigation object to listen for focus/blur events
  * @param skipViewTracking Flag to disable only the view tracking (visualized)
  * @param currentScreenName Optional screen name to include in tracking
@@ -35,6 +51,7 @@ type Props = {
  * @returns trackAlertTap callback to track tap interactions on the alert
  */
 export const useItwEidLifecycleAlertTracking = ({
+  isItwCredential,
   maybeEidStatus,
   navigation,
   skipViewTracking = false,
@@ -49,16 +66,13 @@ export const useItwEidLifecycleAlertTracking = ({
 
   const trackingProperties = useMemo(
     () => ({
-      banner_id:
-        maybeEidStatus === "jwtExpiring"
-          ? "itwExpiringIdBanner"
-          : "itwExpiredIdBanner",
+      banner_id: getLifecycleBannerId(maybeEidStatus, isItwCredential),
       banner_page: currentScreenName ?? "not_available",
       banner_landing: isOffline
         ? "not_available"
         : ITW_IDENTIFICATION_SCREENVIEW_EVENTS.ITW_ID_METHOD
     }),
-    [maybeEidStatus, currentScreenName, isOffline]
+    [maybeEidStatus, currentScreenName, isOffline, isItwCredential]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Short description

Fix the `banner_id` analytics property for expiring and expired PID lifecycle banners while preserving the existing values for legacy eID banners.

## List of changes proposed in this pull request

- Use `itwExpiringPidBanner` and `itwExpiredPidBanner` for PID lifecycle banners.
- Preserve `itwExpiringIdBanner` and `itwExpiredIdBanner` for legacy eID banners.
- Add parametrized tests covering visualization and tap events for all PID/eID lifecycle states.
- Update the tracking hook documentation.

## How to test

Manually verify the analytics events from both the wallet and ID detail:
- Expiring PID sends `banner_id: itwExpiringPidBanner`.
- Expired PID sends `banner_id: itwExpiredPidBanner`.
- Expiring legacy eID still sends `banner_id: itwExpiringIdBanner`.
- Expired legacy eID still sends `banner_id: itwExpiredIdBanner`.