### PR TITLE
refactor: [IOPID-4183] Adopt neverthrow `Result` for `jsonFetchToSchema`

### DIFF
--- a/apps/main-app/ts/features/authentication/common/utils/__tests__/jsonFetchToSchema.test.ts
+++ b/apps/main-app/ts/features/authentication/common/utils/__tests__/jsonFetchToSchema.test.ts
@@ -1,3 +1,4 @@
+import { err, ok } from "neverthrow";
 import { z } from "zod";
 
 import { FetchResponse } from "../fetch";
@@ -19,10 +20,9 @@ describe("jsonFetchToSchema", () => {
       response: jsonResponse(200, ["a", "b"])
     });
 
-    await expect(jsonFetchToSchema(requestPromise, schema)).resolves.toEqual({
-      ok: true,
-      data: ["a", "b"]
-    });
+    await expect(jsonFetchToSchema(requestPromise, schema)).resolves.toEqual(
+      ok(["a", "b"])
+    );
   });
 
   it("should return the failure message when the request fails at the transport level", async () => {
@@ -32,10 +32,9 @@ describe("jsonFetchToSchema", () => {
       message: "Network Error"
     });
 
-    await expect(jsonFetchToSchema(requestPromise, schema)).resolves.toEqual({
-      ok: false,
-      error: "Network Error"
-    });
+    await expect(jsonFetchToSchema(requestPromise, schema)).resolves.toEqual(
+      err("Network Error")
+    );
   });
 
   it("should return a message when the HTTP response status is not ok", async () => {
@@ -44,10 +43,9 @@ describe("jsonFetchToSchema", () => {
       response: jsonResponse(500, ["a", "b"])
     });
 
-    await expect(jsonFetchToSchema(requestPromise, schema)).resolves.toEqual({
-      ok: false,
-      error: "Unexpected HTTP status 500"
-    });
+    await expect(jsonFetchToSchema(requestPromise, schema)).resolves.toEqual(
+      err("Unexpected HTTP status 500")
+    );
   });
 
   it("should return a message when the body cannot be parsed as JSON", async () => {
@@ -62,10 +60,9 @@ describe("jsonFetchToSchema", () => {
       response
     });
 
-    await expect(jsonFetchToSchema(requestPromise, schema)).resolves.toEqual({
-      ok: false,
-      error: expect.stringContaining("Invalid JSON")
-    });
+    await expect(jsonFetchToSchema(requestPromise, schema)).resolves.toEqual(
+      err(expect.stringContaining("Invalid JSON"))
+    );
   });
 
   it("should return a prettified message when the body does not match the schema", async () => {
@@ -74,9 +71,8 @@ describe("jsonFetchToSchema", () => {
       response: jsonResponse(200, { something: "wrong" })
     });
 
-    await expect(jsonFetchToSchema(requestPromise, schema)).resolves.toEqual({
-      ok: false,
-      error: expect.stringContaining("Invalid input")
-    });
+    await expect(jsonFetchToSchema(requestPromise, schema)).resolves.toEqual(
+      err(expect.stringContaining("Invalid input"))
+    );
   });
 });

--- a/apps/main-app/ts/features/authentication/common/utils/jsonFetchToSchema.ts
+++ b/apps/main-app/ts/features/authentication/common/utils/jsonFetchToSchema.ts
@@ -1,37 +1,51 @@
+import { err, ok, Result } from "neverthrow";
 import { z } from "zod";
 
 import { unknownToString } from "../../../../utils/errors";
 import { FetchResponse, isFailureResponse } from "./fetch";
 
-export type AsyncResult<T> =
-  | { data: T; ok: true }
-  | { error: string; ok: false };
+/**
+ * Parses an unknown value against a Zod schema and lifts the outcome into a `neverthrow` Result.
+ *
+ * @param schema - The Zod schema describing the expected shape of the data.
+ * @param value - The unknown value to validate.
+ * @returns An `Ok` containing the safely parsed data, or an `Err` containing a prettified validation error string.
+ */
+const parseWithSchema = <S extends z.ZodType>(
+  schema: S,
+  value: unknown
+): Result<z.output<S>, string> => {
+  const result = schema.safeParse(value);
+  return result.success ? ok(result.data) : err(z.prettifyError(result.error));
+};
 
+/**
+ * Resolves a fetch request, extracts the JSON body, and validates it against a Zod schema.
+ *
+ * This pipeline safely handles transport-level failures, non-2xx HTTP status codes,
+ * JSON parsing exceptions, and schema validation errors, wrapping any failure into a predictable `Result`.
+ *
+ * @param requestPromise - A promise resolving to a custom `FetchResponse`.
+ * @param schema - The Zod schema used to validate the extracted JSON body.
+ * @returns A Promise resolving to an `Ok` with the strictly typed data, or an `Err` with a descriptive error message.
+ */
 export const jsonFetchToSchema = async <TSchema extends z.ZodType>(
   requestPromise: Promise<FetchResponse>,
   schema: TSchema
-): Promise<AsyncResult<z.infer<TSchema>>> => {
+): Promise<Result<z.infer<TSchema>, string>> => {
   const responseResult = await requestPromise;
   if (isFailureResponse(responseResult)) {
-    return { ok: false, error: responseResult.message };
+    return err(responseResult.message);
   }
+
   if (!responseResult.response.ok) {
-    return {
-      ok: false,
-      error: `Unexpected HTTP status ${responseResult.response.status}`
-    };
+    return err(`Unexpected HTTP status ${responseResult.response.status}`);
   }
 
   try {
     const json = await responseResult.response.json();
-    const parsingResult = schema.safeParse(json);
-
-    if (!parsingResult.success) {
-      return { ok: false, error: z.prettifyError(parsingResult.error) };
-    }
-
-    return { ok: true, data: parsingResult.data };
+    return parseWithSchema(schema, json);
   } catch (error) {
-    return { ok: false, error: unknownToString(error) };
+    return err(unknownToString(error));
   }
 };

--- a/apps/main-app/ts/features/authentication/login/idp/hooks/useGetIdps.ts
+++ b/apps/main-app/ts/features/authentication/login/idp/hooks/useGetIdps.ts
@@ -26,14 +26,16 @@ export const useGetIdps: UseGetIdps = () => {
     const controller = new AbortController();
 
     const fetchIdpList = async () => {
+      setState({ status: "loading" });
+
       const requestPromise = fetchIdps(idpsUrl, { signal: controller.signal });
       const result = await jsonFetchToSchema(requestPromise, IdpsSchema);
 
-      if (!result.ok) {
+      if (result.isErr()) {
         setState({ status: "failure", error: result.error });
         return;
       }
-      setState({ status: "success", data: result.data });
+      setState({ status: "success", data: result.value });
     };
     void fetchIdpList();
 

--- a/apps/main-app/ts/features/lollipop/hooks/useOneIdentityLoginSource.tsx
+++ b/apps/main-app/ts/features/lollipop/hooks/useOneIdentityLoginSource.tsx
@@ -267,14 +267,14 @@ export const useOneIdentityLoginSource: UseOneIdentityLoginSource = ({
     // Clear the abort controller reference as the request has completed.
     abortControllerRef.current = null;
 
-    if (!result.ok) {
+    if (result.isErr()) {
       setLoginSourceState({ status: "failure", error: result.error });
       onFailure(result.error);
       return;
     }
 
     const authorizationUrl = buildAuthorizationUrl(
-      result.data,
+      result.value,
       idp.id,
       minAuthLevel
     );


### PR DESCRIPTION
## Short description
This PR refactors the `jsonFetchToSchema` utility and its usage across the authentication feature to use the neverthrow `Result` type. This replaces the custom { ok, data, error } object wrapper.

## List of changes proposed in this pull request
- Replaces the custom `AsyncResult` type with `neverthrow`'s `Result`, adds a helper `parseWithSchema` for schema validation and updates the function to return `ok`/`err` results throughout.
- Updates all tests
- Updates handling of the result from `jsonFetchToSchema` to use `isErr()`/`value` instead of `ok`/`data`.

## How to test
Verify that all tests pass.