### PR TITLE
fix(IT-Wallet): [SIW-4935] Improve WebView error handling with meaningful error codes

### DIFF
--- a/apps/main-app/ts/features/itwallet/identification/cieId/screens/ItwCieIdLoginScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/identification/cieId/screens/ItwCieIdLoginScreen.tsx
@@ -3,6 +3,10 @@ import I18n from "i18next";
 import { memo, useCallback, useMemo, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { WebView, WebViewNavigation } from "react-native-webview";
+import {
+  WebViewErrorEvent,
+  WebViewHttpErrorEvent
+} from "react-native-webview/lib/WebViewTypes";
 
 import LoadingSpinnerOverlay from "../../../../../components/LoadingSpinnerOverlay";
 import { useHeaderSecondLevel } from "../../../../../hooks/useHeaderSecondLevel";
@@ -30,6 +34,14 @@ const isAuthenticationUrl = (url: string) => {
   const authUrlRegex = /\/(livello[123]|nextUrl|openApp|app)(\/|\?|$)/;
   return authUrlRegex.test(url);
 };
+
+/**
+ * Prefixes of the error codes reported when the WebView fails to load a page.
+ * These codes end up in the support modal, in the Zendesk ticket and in the Mixpanel
+ * KO event, so they must stay stable and readable to keep failures diagnosable.
+ */
+const WEBVIEW_ERROR_CODE_PREFIX = "CIEID_WEBVIEW_ERROR";
+const WEBVIEW_HTTP_ERROR_CODE_PREFIX = "CIEID_WEBVIEW_HTTP_ERROR";
 
 /**
  * This component renders a WebView that loads the URL obtained from the startAuthFlow.
@@ -90,6 +102,34 @@ const ItwCieIdLoginScreen = () => {
     [startCieIdAppAuthentication, cieIdEnvironment]
   );
 
+  /**
+   * Converts the WebView failure events into meaningful errors. Without this
+   * conversion the raw native event object reaches the state machine and is
+   * stringified into an unusable "[object Object]" error code.
+   */
+  const handleWebViewError = useCallback(
+    ({ nativeEvent }: WebViewErrorEvent) => {
+      const { code, description } = nativeEvent;
+      handleAuthenticationFailure(
+        new Error(
+          `${WEBVIEW_ERROR_CODE_PREFIX}_${code}${
+            description ? `: ${description}` : ""
+          }`
+        )
+      );
+    },
+    [handleAuthenticationFailure]
+  );
+
+  const handleWebViewHttpError = useCallback(
+    ({ nativeEvent }: WebViewHttpErrorEvent) => {
+      handleAuthenticationFailure(
+        new Error(`${WEBVIEW_HTTP_ERROR_CODE_PREFIX}_${nativeEvent.statusCode}`)
+      );
+    },
+    [handleAuthenticationFailure]
+  );
+
   const handleNavigationStateChange = useCallback(
     (event: WebViewNavigation) => {
       const authRedirectUrl = event.url;
@@ -116,8 +156,8 @@ const ItwCieIdLoginScreen = () => {
           cacheEnabled={false}
           javaScriptEnabled
           mediaPlaybackRequiresUserAction
-          onError={handleAuthenticationFailure}
-          onHttpError={handleAuthenticationFailure}
+          onError={handleWebViewError}
+          onHttpError={handleWebViewHttpError}
           onLoadEnd={onLoadEnd}
           onNavigationStateChange={handleNavigationStateChange}
           onShouldStartLoadWithRequest={handleShouldStartLoading}
@@ -132,7 +172,8 @@ const ItwCieIdLoginScreen = () => {
       webViewSource,
       handleNavigationStateChange,
       handleShouldStartLoading,
-      handleAuthenticationFailure,
+      handleWebViewError,
+      handleWebViewHttpError,
       onLoadEnd
     ]
   );

--- a/apps/main-app/ts/features/itwallet/identification/cieId/screens/__tests__/ItwCieIdLoginScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/identification/cieId/screens/__tests__/ItwCieIdLoginScreen.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, waitFor } from "@testing-library/react-native";
 import _ from "lodash";
 import { Linking } from "react-native";
 import { createStore } from "redux";
-import { createActor } from "xstate";
+import { ActorRefFrom, createActor } from "xstate";
 
 import { applicationChangeState } from "../../../../../../store/actions/application";
 import { appReducer } from "../../../../../../store/reducers";
@@ -93,17 +93,78 @@ describe("ItwCieIdLoginScreen", () => {
     expect(openCieIdApp).not.toHaveBeenCalled();
     expect(Linking.openURL).toHaveBeenCalledTimes(1);
   });
+
+  // Regression tests: the raw WebView native event used to be forwarded to the state
+  // machine, where it was stringified into an unusable "[object Object]" error code.
+  describe("when the webview fails to load", () => {
+    const webViewErrorScenarios = [
+      {
+        name: "network error with a description",
+        event: "onError",
+        nativeEvent: {
+          code: -2,
+          description: "net::ERR_NAME_NOT_RESOLVED",
+          url: "https://idserver.servizicie.interno.gov.it"
+        },
+        expectedMessage: "CIEID_WEBVIEW_ERROR_-2: net::ERR_NAME_NOT_RESOLVED"
+      },
+      {
+        name: "network error without a description",
+        event: "onError",
+        nativeEvent: {
+          code: -1,
+          description: "",
+          url: "https://idserver.servizicie.interno.gov.it"
+        },
+        expectedMessage: "CIEID_WEBVIEW_ERROR_-1"
+      },
+      {
+        name: "http error",
+        event: "onHttpError",
+        nativeEvent: {
+          statusCode: 502,
+          description: "Bad Gateway",
+          url: "https://idserver.servizicie.interno.gov.it"
+        },
+        expectedMessage: "CIEID_WEBVIEW_HTTP_ERROR_502"
+      }
+    ];
+
+    it.each(webViewErrorScenarios)(
+      "should report a meaningful error code for a $name",
+      ({ event, nativeEvent, expectedMessage }) => {
+        (isCieIdAvailable as jest.Mock).mockImplementation(() => true);
+        mockIsAndroid = true;
+        mockIsIOS = false;
+
+        const { getByTestId, getFailure } = renderComponent();
+
+        fireEvent(getByTestId("cieid-webview"), event, { nativeEvent });
+
+        const failure = getFailure();
+        expect(failure?.reason).toBeInstanceOf(Error);
+        expect((failure?.reason as Error).message).toBe(expectedMessage);
+      }
+    );
+  });
 });
 
 const renderComponent = () => {
   const globalState = appReducer(undefined, applicationChangeState("active"));
 
   const logic = itwEidIssuanceMachine.provide({
-    actions: { onInit: jest.fn() }
+    actions: { onInit: jest.fn(), navigateToFailureScreen: jest.fn() }
   });
 
   const initialSnapshot = createActor(itwEidIssuanceMachine).getSnapshot();
-  return renderScreenWithNavigationStoreContext<GlobalState>(
+
+  let machineRef: ActorRefFrom<typeof itwEidIssuanceMachine> | undefined;
+  const CaptureMachineRef = () => {
+    machineRef = ItwEidIssuanceMachineContext.useActorRef();
+    return null;
+  };
+
+  const rendered = renderScreenWithNavigationStoreContext<GlobalState>(
     () => (
       <ItwEidIssuanceMachineContext.Provider
         logic={logic}
@@ -116,6 +177,7 @@ const renderComponent = () => {
           })
         }}
       >
+        <CaptureMachineRef />
         <ItwCieIdLoginScreen />
       </ItwEidIssuanceMachineContext.Provider>
     ),
@@ -123,4 +185,9 @@ const renderComponent = () => {
     {},
     createStore(appReducer, globalState as any)
   );
+
+  return {
+    ...rendered,
+    getFailure: () => machineRef?.getSnapshot().context.failure
+  };
 };


### PR DESCRIPTION
## Short description
On Android, a WebView failure during the CieID login in "Documenti su IO" surfaced `[object Object]` as the error code in the support bottom sheet (and in the Zendesk ticket / Mixpanel KO event), making the failure impossible to diagnose.

The raw `nativeEvent` was passed straight to `handleAuthenticationFailure`, which fell through to `convertUnknownToError` and stringified the object.

## List of changes proposed in this pull request
- Convert the WebView `onError` / `onHttpError` native events into meaningful `Error`s in `ItwCieIdLoginScreen`, producing stable codes (`CIEID_WEBVIEW_ERROR_<code>: <description>`, `CIEID_WEBVIEW_HTTP_ERROR_<statusCode>`)
- Add regression tests covering network errors (with and without description) and HTTP errors

## How to test
Manual (Android, CieID installed):
1. Start the eID issuance and pick CieID as identification method
2. While the WebView is loading, force a load failure (enable airplane mode, or point the IdP URL to an unreachable host)
3. On the KO screen open the support bottom sheet
4. **Expected:** "Codice errore" shows e.g. `CIEID_WEBVIEW_ERROR_-2: net::some_sort_of_error` instead of `[object Object]