### PR TITLE
refactor: [IOPID-4188] remove fp-ts from authentication common utils

### DIFF
--- a/apps/main-app/ts/features/authentication/activeSessionLogin/screens/spid/ActiveSessionIdpLoginScreen.tsx
+++ b/apps/main-app/ts/features/authentication/activeSessionLogin/screens/spid/ActiveSessionIdpLoginScreen.tsx
@@ -231,9 +231,9 @@ const ActiveSessionIdpLoginScreen = () => {
       const url = event.url;
       // if an intent is coming from the IDP login form, extract the fallbackUrl and use it in Linking.openURL
       const idpIntent = getIntentFallbackUrl(url);
-      if (O.isSome(idpIntent)) {
+      if (idpIntent != null) {
         void trackSpidLoginIntent(selectedIdp, "reauth");
-        void Linking.openURL(idpIntent.value);
+        void Linking.openURL(idpIntent);
         return false;
       }
 

--- a/apps/main-app/ts/features/authentication/common/components/IdpWebViewLogin.tsx
+++ b/apps/main-app/ts/features/authentication/common/components/IdpWebViewLogin.tsx
@@ -1,5 +1,4 @@
 import { IdpData } from "@io-app/api-types/generated/definitions/content/IdpData";
-import * as O from "fp-ts/lib/Option";
 import I18n from "i18next";
 import { memo, useCallback, useMemo, useRef } from "react";
 import { Linking, StyleSheet, View } from "react-native";
@@ -137,9 +136,9 @@ export const IdpWebViewLogin = memo(
         const url = event.url;
         // if an intent is coming from the IDP login form, extract the fallbackUrl and use it in Linking.openURL
         const idpIntent = getIntentFallbackUrl(url);
-        if (O.isSome(idpIntent)) {
+        if (idpIntent != null) {
           void trackSpidLoginIntent(idp, flow);
-          void Linking.openURL(idpIntent.value);
+          void Linking.openURL(idpIntent);
           return false;
         }
 

--- a/apps/main-app/ts/features/authentication/common/utils/__tests__/login.test.ts
+++ b/apps/main-app/ts/features/authentication/common/utils/__tests__/login.test.ts
@@ -1,5 +1,4 @@
 import { PublicKey } from "@pagopa/io-react-native-crypto";
-import * as O from "fp-ts/lib/Option";
 
 import { extractLoginResult, getIntentFallbackUrl, getLoginHeaders } from "..";
 
@@ -129,30 +128,30 @@ describe("hook the login outcome from the url", () => {
 });
 
 describe("getIntentFallbackUrl", () => {
-  const isIntentSchemeCases: ReadonlyArray<[string, O.Option<string>]> = [
-    ["", O.none],
-    ["https://www.google.com", O.none],
-    ["intent:", O.none],
-    ["intent://", O.none],
+  const isIntentSchemeCases: ReadonlyArray<[string, string | undefined]> = [
+    ["", undefined],
+    ["https://www.google.com", undefined],
+    ["intent:", undefined],
+    ["intent://", undefined],
     [
       "intent://domain.test.it/?tranId=abc#Intent;scheme=https;package=com.test.it;S.browser_fallback_url=https://domain.it/?tranId=acb;end",
-      O.some("https://domain.it/?tranId=acb")
+      "https://domain.it/?tranId=acb"
     ],
     [
       "intent://domain.test.it/?tranId=abc#Intent;scheme=https;package=com.test.it;S.browser_fallback_url=https://domain.it/?tranId=acb",
-      O.none
+      undefined
     ],
     [
       "intent://domain.test.it/?tranId=abc#Intent;scheme=https;package=com.test.it;end",
-      O.none
+      undefined
     ],
     [
       "intent://domain.test.it/?tranId=abc#Intent;scheme=https;package=com.test.it;fallback_url=https://domain.it/?tranId=acb;end",
-      O.none
+      undefined
     ],
     [
       "intent:/domain.test.it/?tranId=abc#Intent;scheme=https;package=com.test.it;S.browser_fallback_url=https://domain.it/?tranId=acb;end",
-      O.none
+      undefined
     ]
   ];
   test.each(isIntentSchemeCases)(

--- a/apps/main-app/ts/features/authentication/common/utils/index.tsx
+++ b/apps/main-app/ts/features/authentication/common/utils/index.tsx
@@ -1,6 +1,5 @@
 import { IdpData } from "@io-app/api-types/generated/definitions/content/IdpData";
 import { PublicKey } from "@pagopa/io-react-native-crypto";
-import * as O from "fp-ts/lib/Option";
 import { WebViewNavigation } from "react-native-webview/lib/WebViewTypes";
 import URLParse from "url-parse";
 
@@ -29,22 +28,22 @@ type LoginSuccess = {
 };
 
 /**
- * return some(intentFallbackUrl) if the given input is a valid intent and it has the fallback url
+ * return string if the given input is a valid intent and it has the fallback url
  * more info https://developer.chrome.com/docs/multidevice/android/intents/
  * @param intentUrl
  */
-export const getIntentFallbackUrl = (intentUrl: string): O.Option<string> => {
+export const getIntentFallbackUrl = (intentUrl: string): string | undefined => {
   const intentProtocol = URLParse.extractProtocol(intentUrl);
   if (intentProtocol.protocol !== "intent:" || !intentProtocol.slashes) {
-    return O.none;
+    return undefined;
   }
   const hook = "S.browser_fallback_url=";
   const hookIndex = intentUrl.indexOf(hook);
   const endIndex = intentUrl.indexOf(";end", hookIndex + hook.length);
   if (hookIndex !== -1 && endIndex !== -1) {
-    return O.some(intentUrl.substring(hookIndex + hook.length, endIndex));
+    return intentUrl.substring(hookIndex + hook.length, endIndex);
   }
-  return O.none;
+  return undefined;
 };
 
 /**

--- a/apps/main-app/ts/features/authentication/login/idp/screens/IdpLoginScreen.tsx
+++ b/apps/main-app/ts/features/authentication/login/idp/screens/IdpLoginScreen.tsx
@@ -221,9 +221,9 @@ const IdpLoginScreen = () => {
       const url = event.url;
       // if an intent is coming from the IDP login form, extract the fallbackUrl and use it in Linking.openURL
       const idpIntent = getIntentFallbackUrl(url);
-      if (O.isSome(idpIntent)) {
+      if (idpIntent != null) {
         void trackSpidLoginIntent(loggedOutWithIdpAuth?.idp);
-        void Linking.openURL(idpIntent.value);
+        void Linking.openURL(idpIntent);
         return false;
       }
 

--- a/apps/main-app/ts/features/itwallet/identification/spid/screens/ItwSpidIdpLoginScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/identification/spid/screens/ItwSpidIdpLoginScreen.tsx
@@ -1,4 +1,3 @@
-import * as O from "fp-ts/lib/Option";
 import I18n from "i18next";
 import { memo, useCallback, useMemo, useState } from "react";
 import { Linking, StyleSheet, View } from "react-native";
@@ -60,11 +59,10 @@ const ItwSpidIdpLoginScreen = () => {
   const handleShouldStartLoading = useCallback(
     (event: WebViewNavigation): boolean => {
       const url = event.url;
-      // `getIntentFallbackUrl` belongs to the authentication feature, which still returns an
-      // fp-ts Option: unwrap it here, at the boundary.
-      const idpIntentUrl = O.toUndefined(getIntentFallbackUrl(url));
 
-      if (idpIntentUrl === undefined) {
+      const idpIntentUrl = getIntentFallbackUrl(url);
+
+      if (idpIntentUrl == null) {
         return true;
       }
 

--- a/apps/main-app/ts/features/payments/common/components/PaymentWebView.tsx
+++ b/apps/main-app/ts/features/payments/common/components/PaymentWebView.tsx
@@ -1,4 +1,3 @@
-import * as O from "fp-ts/lib/Option";
 import { useRef, useState } from "react";
 import { Linking } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -87,8 +86,8 @@ const PaymentWebView = <T,>({
             return false;
           }
           const intent = getIntentFallbackUrl(url);
-          if (O.isSome(intent)) {
-            void Linking.openURL(decodeURIComponent(intent.value));
+          if (intent != null) {
+            void Linking.openURL(decodeURIComponent(intent));
             return false;
           }
           return true;


### PR DESCRIPTION
## Short description
Removes `fp-ts` (`Option`) from `authentication/common/utils`, replacing it with native TypeScript, and updates all consumers.

## List of changes proposed in this pull request
- Replace `O.Option<string>` return type of `getIntentFallbackUrl` with `string | undefined`
- Update consumers in `IdpWebViewLogin`, `ActiveSessionIdpLoginScreen`, `IdpLoginScreen`, `ItwSpidIdpLoginScreen`, `PaymentWebView` to handle the new return type
- Update `login.test.ts` unit tests accordingly

## How to test
- Run `pnpm nx run main-app:test-dev` on `apps/main-app/ts/features/authentication/common/utils/__tests__/login.test.ts` 
- Verify SPID/CIE login flows and intent-fallback deep link handling still work in the app (WebView login, IT-Wallet identification, payment WebView)