### PR TITLE
fix(IT-Wallet): [SIW-4983] Remove contextual help on selected ITW routes

### DIFF
--- a/apps/main-app/ts/features/itwallet/discovery/components/ItwDiscoveryInfoComponent.tsx
+++ b/apps/main-app/ts/features/itwallet/discovery/components/ItwDiscoveryInfoComponent.tsx
@@ -13,7 +13,6 @@ import {
   IOMarkdownLite,
   useIOTheme,
   useIOThemeContext,
-  useIOToast,
   VSpacer,
   VStack
 } from "@io-app/design-system";
@@ -60,7 +59,6 @@ export const ItwDiscoveryInfoComponent = ({ credentialType }: Props) => {
   const mixPanelCredentialDetails = useIOSelector(
     itwMixPanelCredentialDetailsSelector
   );
-  const toast = useIOToast();
 
   useOnFirstRender(
     useCallback(() => {
@@ -74,15 +72,11 @@ export const ItwDiscoveryInfoComponent = ({ credentialType }: Props) => {
   );
 
   useHeaderSecondLevel({
-    supportRequest: true,
+    supportRequest: false,
     title: "",
     goBack: () => {
       trackItwIntroBack("L3");
       machineRef.send({ type: "close", surveyStep: "intro" });
-    },
-    onStartSupportRequest: () => {
-      toast.info(I18n.t("features.itWallet.generic.featureUnavailable.title"));
-      return false;
     }
   });
 

--- a/apps/main-app/ts/features/itwallet/identification/cie/screens/ItwCiePinScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/identification/cie/screens/ItwCiePinScreen.tsx
@@ -19,7 +19,10 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-import { useHeaderSecondLevel } from "../../../../../hooks/useHeaderSecondLevel";
+import {
+  HeaderSecondLevelHookProps,
+  useHeaderSecondLevel
+} from "../../../../../hooks/useHeaderSecondLevel";
 import { useIOSelector } from "../../../../../store/hooks";
 import { setAccessibilityFocus } from "../../../../../utils/accessibility";
 import { usePreventScreenCapture } from "../../../../../utils/hooks/usePreventScreenCapture";
@@ -67,10 +70,19 @@ export const ItwCiePinScreen = () => {
     }, [itw_flow])
   );
 
-  useHeaderSecondLevel({
-    title: withTrailingPoliceCarLightEmojii("", useCieUat),
-    supportRequest: true
-  });
+  // The contextual help (?) icon is only removed for the IT-Wallet (L3) flow;
+  // the L2 "Documenti su IO" flow keeps the support request entry point.
+  const headerProps: HeaderSecondLevelHookProps = isL3Enabled
+    ? {
+        title: withTrailingPoliceCarLightEmojii("", useCieUat),
+        supportRequest: false
+      }
+    : {
+        title: withTrailingPoliceCarLightEmojii("", useCieUat),
+        supportRequest: true
+      };
+
+  useHeaderSecondLevel(headerProps);
 
   const onPinChanged = (value: string) => {
     setPin(value);


### PR DESCRIPTION
## Short description
Removes the contextual help (?) icon from the IT-Wallet (L3) identity activation intro screen and, conditionally, from the CIE PIN entry screen — only for the ITW flow. The L2 "Documenti su IO" flow is untouched.

## List of changes proposed in this pull request
- `ItwDiscoveryInfoComponent` (ITW L3 intro): removed `supportRequest`, dropped the now-unused fake `onStartSupportRequest` toast handler.
- `ItwCiePinScreen` (shared `ITW_IDENTIFICATION_CIE_PIN_SCREEN` route): help icon now shown only when `isL3Enabled` is `false` (L2), hidden for L3/ITW.
- No changes to L2/"Documenti su IO" screens (`ItwDiscoveryInfoFallbackComponent`, `ItwDiscoveryInfoLegacyComponent`) or to `ITW_IDENTIFICATION_CIE_PIN_PREPARATION_SCREEN` (already had no help icon).

## How to test
1. Start the IT-Wallet (L3) activation flow → on the intro screen and CIE PIN screen, verify the `(?)` help icon is **not** shown.
2. Start the "Documenti su IO" (L2) activation flow → on the intro screen and CIE PIN screen, verify the `(?)` help icon is still shown and opens support as before.
