### PR TITLE
fix(IT-Wallet): [SIW-4936] Update credential status logic to handle expiration date

### DIFF
--- a/apps/main-app/ts/features/itwallet/common/utils/__tests__/itwCredentialStatusUtils.test.ts
+++ b/apps/main-app/ts/features/itwallet/common/utils/__tests__/itwCredentialStatusUtils.test.ts
@@ -104,6 +104,32 @@ describe("getCredentialStatus", () => {
         "jwtExpired"
       );
     });
+
+    // A physical document is still valid on its expiration day, it only becomes
+    // "expired" starting the day after
+    it("should return the physical document expiring status, not expired, when the expiration date is today", () => {
+      MockDate.set(new Date(2024, 0, 20));
+
+      const mockCredential: CredentialMetadata = {
+        ...ItwStoredCredentialsMocks.mdl,
+        jwt: {
+          expiration: "2025-01-20T00:00:00Z" // Still valid
+        },
+        parsedCredential: {
+          expiry_date: {
+            name: { "en-US": "Expiry date", "it-IT": "Scadenza" },
+            value: "2024-01-20" // Expires today
+          }
+        },
+        validity: {
+          type: "status_assertion",
+          status: "valid",
+          statusAssertion: {} as any
+        }
+      };
+
+      expect(getCredentialStatus(mockCredential, options)).toEqual("expiring");
+    });
   });
 
   describe("expiring", () => {

--- a/apps/main-app/ts/features/itwallet/common/utils/itwCredentialStatusUtils.ts
+++ b/apps/main-app/ts/features/itwallet/common/utils/itwCredentialStatusUtils.ts
@@ -50,7 +50,9 @@ export const getCredentialStatus = (
     validity?.status === "invalid" &&
     validity.errorCode === "credential_expired";
 
-  if (isIssuerAttestedExpired || documentExpireDays <= 0) {
+  // The physical document is still valid on its expiration day (documentExpireDays === 0),
+  // it only becomes "expired" the day after.
+  if (isIssuerAttestedExpired || documentExpireDays < 0) {
     return "expired";
   }
 


### PR DESCRIPTION
## Short description
Fix the credential expiration status logic in IT Wallet: a physical document was shown as "expired" on its actual expiry day. It's now treated as still valid (or "expiring") through the end of that day, and only marked "expired" starting the day after — matching how physical documents work in real life.

## List of changes proposed in this pull request
- `itwCredentialStatusUtils.ts`: changed physical document expiry check from `documentExpireDays <= 0` to `documentExpireDays < 0` in `getCredentialStatus`.
- JWT technical expiration logic (`jwtExpireDays`) left unchanged.
- Added test case covering expiry date = today → status is `expiring`, not `expired`.

## How to test
1. Mock/add a credential with `expiry_date` (or `date_of_expiry`) equal to today's date.
2. Check the credential status label in the wallet: expect `expiring` (or `valid`), **not** `expired`.
3. Set the expiry date to yesterday: expect `expired`.