### PR TITLE
fix(IT-Wallet): [SIW-4994] Handle WebView errors in CIE PIN identification, display Issuer generic failure screen 

### DIFF
--- a/apps/main-app/ts/features/itwallet/common/utils/itwFailureUtils.ts
+++ b/apps/main-app/ts/features/itwallet/common/utils/itwFailureUtils.ts
@@ -6,6 +6,14 @@ import {
 import { Errors, Trust } from "@pagopa/io-react-native-wallet";
 import { z } from "zod";
 
+import {
+  WEBVIEW_ERROR_CODE_PREFIX,
+  WEBVIEW_HTTP_ERROR_CODE_PREFIX
+} from "../../identification/cie/utils/constants";
+import {
+  type WebViewError,
+  webViewError
+} from "../../identification/cie/utils/error";
 import { WithCredentialMetadata } from "./ItwFailureTypes";
 
 /**
@@ -111,3 +119,17 @@ export const statusAssertionFailure = z.object({
   error: z.string(),
   error_description: z.string().optional()
 });
+
+/**
+ * Type guard for errors originated from WebViews. CieID and CIE PIN WebView errors
+ * are handled slighly different, so two checks are needed here.
+ */
+export const isWebViewError = (e: unknown): e is Error | WebViewError => {
+  if (e instanceof Error) {
+    return (
+      e.message.includes(WEBVIEW_ERROR_CODE_PREFIX) ||
+      e.message.includes(WEBVIEW_HTTP_ERROR_CODE_PREFIX)
+    );
+  }
+  return webViewError.safeParse(e).success;
+};

--- a/apps/main-app/ts/features/itwallet/identification/cie/utils/constants.ts
+++ b/apps/main-app/ts/features/itwallet/identification/cie/utils/constants.ts
@@ -2,3 +2,11 @@ import { Millisecond } from "@pagopa/ts-commons/lib/units";
 
 export const WAIT_TIMEOUT_NAVIGATION = 1700 as Millisecond;
 export const WAIT_TIMEOUT_NAVIGATION_ACCESSIBILITY = 5000 as Millisecond;
+
+/**
+ * Prefixes of the error codes reported when the WebView fails to load a page.
+ * These codes end up in the support modal, in the Zendesk ticket and in the Mixpanel
+ * KO event, so they must stay stable and readable to keep failures diagnosable.
+ */
+export const WEBVIEW_ERROR_CODE_PREFIX = "CIEID_WEBVIEW_ERROR";
+export const WEBVIEW_HTTP_ERROR_CODE_PREFIX = "CIEID_WEBVIEW_HTTP_ERROR";

--- a/apps/main-app/ts/features/itwallet/identification/cie/utils/error.ts
+++ b/apps/main-app/ts/features/itwallet/identification/cie/utils/error.ts
@@ -1,10 +1,12 @@
 import { NfcError } from "@pagopa/io-react-native-cie";
+import z from "zod";
 
 // Custom error for webview
-export type WebViewError = {
-  message: string;
-  name: "WEBVIEW_ERROR";
-};
+export const webViewError = z.object({
+  name: z.literal("WEBVIEW_ERROR"),
+  message: z.string()
+});
+export type WebViewError = z.output<typeof webViewError>;
 
 // Utiltiy that verifies if the failure is an NfcError
 export const isNfcError = (

--- a/apps/main-app/ts/features/itwallet/identification/cieId/screens/ItwCieIdLoginScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/identification/cieId/screens/ItwCieIdLoginScreen.tsx
@@ -20,6 +20,10 @@ import {
 import { getEnv } from "../../../common/utils/environment";
 import { ItwEidIssuanceMachineContext } from "../../../machine/eid/provider";
 import { selectAuthUrl } from "../../../machine/eid/selectors";
+import {
+  WEBVIEW_ERROR_CODE_PREFIX,
+  WEBVIEW_HTTP_ERROR_CODE_PREFIX
+} from "../../cie/utils/constants";
 import { useCieIdApp } from "../hooks/useCieIdApp";
 
 // To ensure the server recognizes the client as a valid mobile device, we use a custom user agent header.
@@ -34,14 +38,6 @@ const isAuthenticationUrl = (url: string) => {
   const authUrlRegex = /\/(livello[123]|nextUrl|openApp|app)(\/|\?|$)/;
   return authUrlRegex.test(url);
 };
-
-/**
- * Prefixes of the error codes reported when the WebView fails to load a page.
- * These codes end up in the support modal, in the Zendesk ticket and in the Mixpanel
- * KO event, so they must stay stable and readable to keep failures diagnosable.
- */
-const WEBVIEW_ERROR_CODE_PREFIX = "CIEID_WEBVIEW_ERROR";
-const WEBVIEW_HTTP_ERROR_CODE_PREFIX = "CIEID_WEBVIEW_HTTP_ERROR";
 
 /**
  * This component renders a WebView that loads the URL obtained from the startAuthFlow.

--- a/apps/main-app/ts/features/itwallet/identification/spid/screens/ItwSpidIdpLoginScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/identification/spid/screens/ItwSpidIdpLoginScreen.tsx
@@ -2,6 +2,10 @@ import I18n from "i18next";
 import { memo, useCallback, useMemo, useState } from "react";
 import { Linking, StyleSheet, View } from "react-native";
 import { WebView, WebViewNavigation } from "react-native-webview";
+import {
+  WebViewErrorEvent,
+  WebViewHttpErrorEvent
+} from "react-native-webview/lib/WebViewTypes";
 
 import LoadingSpinnerOverlay from "../../../../../components/LoadingSpinnerOverlay";
 import {
@@ -52,9 +56,16 @@ const ItwSpidIdpLoginScreen = () => {
     setWebViewLoading(false);
   }, []);
 
-  const onError = useCallback(() => {
-    machineRef.send({ type: "error", scope: "spid-login" });
-  }, [machineRef]);
+  const onError = useCallback(
+    (error: WebViewErrorEvent | WebViewHttpErrorEvent) => {
+      machineRef.send({
+        type: "error",
+        scope: "spid-login",
+        error: { name: "WEBVIEW_ERROR", message: error.nativeEvent.title }
+      });
+    },
+    [machineRef]
+  );
 
   const handleShouldStartLoading = useCallback(
     (event: WebViewNavigation): boolean => {

--- a/apps/main-app/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/__tests__/machine.test.ts
@@ -3065,6 +3065,78 @@ describe("itwEidIssuanceMachine", () => {
     );
     expect(createWalletInstance).not.toHaveBeenCalled();
   });
+
+  it("Should transition to the Issuer generic failure state if a WebView error is received during CIE PIN identification", () => {
+    const initialSnapshot = createActor(itwEidIssuanceMachine, {
+      input: { deps: T_DEPS }
+    }).getSnapshot();
+
+    const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
+      value: { UserIdentification: { CiePin: "StartingCieAuthFlow" } },
+      context: {
+        level: "l3",
+        mode: "issuance",
+        integrityKeyTag: T_INTEGRITY_KEY,
+        walletInstanceAttestation: { jwt: T_WIA },
+        identification: { level: "L3", mode: "ciePin", pin: "123456" },
+        authenticationContext: {}
+      }
+    } as MachineSnapshot);
+
+    const actor = createActor(mockedMachine, {
+      snapshot,
+      input: { deps: T_DEPS }
+    });
+
+    actor.start();
+
+    actor.send({
+      type: "error",
+      scope: "cie-auth",
+      error: { name: "WEBVIEW_ERROR", message: "500 Internal Server Error" }
+    });
+
+    expect(actor.getSnapshot().value).toEqual("Failure");
+    expect(actor.getSnapshot().context.failure?.type).toEqual(
+      IssuanceFailureType.ISSUER_GENERIC
+    );
+  });
+
+  it("Should transition to the Issuer generic failure state if a WebView error is received during CieID identification", () => {
+    const initialSnapshot = createActor(itwEidIssuanceMachine, {
+      input: { deps: T_DEPS }
+    }).getSnapshot();
+
+    const snapshot: MachineSnapshot = _.merge(undefined, initialSnapshot, {
+      value: { UserIdentification: { CiePin: "StartingCieAuthFlow" } },
+      context: {
+        level: "l3",
+        mode: "issuance",
+        integrityKeyTag: T_INTEGRITY_KEY,
+        walletInstanceAttestation: { jwt: T_WIA },
+        identification: { level: "L3", mode: "cieId" },
+        authenticationContext: {}
+      }
+    } as MachineSnapshot);
+
+    const actor = createActor(mockedMachine, {
+      snapshot,
+      input: { deps: T_DEPS }
+    });
+
+    actor.start();
+
+    actor.send({
+      type: "error",
+      scope: "cieid-login",
+      error: new Error("CIEID_WEBVIEW_HTTP_ERROR_500")
+    });
+
+    expect(actor.getSnapshot().value).toEqual("Failure");
+    expect(actor.getSnapshot().context.failure?.type).toEqual(
+      IssuanceFailureType.ISSUER_GENERIC
+    );
+  });
 });
 
 describe("itwEidIssuanceMachine itwVersion routing", () => {

--- a/apps/main-app/ts/features/itwallet/machine/eid/failure.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/failure.ts
@@ -10,6 +10,7 @@ import {
   isMrtdTaxIdCodeMismatchFailure,
   isWebViewError
 } from "../../common/utils/itwFailureUtils";
+import { type WebViewError } from "../../identification/cie/utils/error";
 import { type EidIssuanceEvents } from "./events";
 
 const {
@@ -47,7 +48,10 @@ type ReasonTypeByFailure = {
   [IssuanceFailureType.CIE_NOT_MATCHING_AUTHENTICATION_IDENTITY]: Errors.IssuerResponseError;
   [IssuanceFailureType.CIE_NOT_REGISTERED]: string;
   [IssuanceFailureType.HARDWARE_KEY_INVALID]: IntegrityError;
-  [IssuanceFailureType.ISSUER_GENERIC]: Errors.IssuerResponseError | string;
+  [IssuanceFailureType.ISSUER_GENERIC]:
+    | Error
+    | Errors.IssuerResponseError
+    | WebViewError;
   [IssuanceFailureType.MRTD_CHALLENGE_INIT_ERROR]: Errors.IssuerResponseError;
   [IssuanceFailureType.NOT_MATCHING_IDENTITY]: string;
   [IssuanceFailureType.PID_ANPR_CREDENTIAL_NOT_FOUND]: Errors.IssuerResponseError;
@@ -134,7 +138,7 @@ export const mapEventToFailure = (
   if (isWebViewError(error)) {
     return {
       type: IssuanceFailureType.ISSUER_GENERIC,
-      reason: error.message
+      reason: error
     };
   }
 

--- a/apps/main-app/ts/features/itwallet/machine/eid/failure.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/failure.ts
@@ -7,7 +7,8 @@ import {
   isAssertionGenerationError,
   isFederationError,
   isLocalIntegrityError,
-  isMrtdTaxIdCodeMismatchFailure
+  isMrtdTaxIdCodeMismatchFailure,
+  isWebViewError
 } from "../../common/utils/itwFailureUtils";
 import { type EidIssuanceEvents } from "./events";
 
@@ -46,7 +47,7 @@ type ReasonTypeByFailure = {
   [IssuanceFailureType.CIE_NOT_MATCHING_AUTHENTICATION_IDENTITY]: Errors.IssuerResponseError;
   [IssuanceFailureType.CIE_NOT_REGISTERED]: string;
   [IssuanceFailureType.HARDWARE_KEY_INVALID]: IntegrityError;
-  [IssuanceFailureType.ISSUER_GENERIC]: Errors.IssuerResponseError;
+  [IssuanceFailureType.ISSUER_GENERIC]: Errors.IssuerResponseError | string;
   [IssuanceFailureType.MRTD_CHALLENGE_INIT_ERROR]: Errors.IssuerResponseError;
   [IssuanceFailureType.NOT_MATCHING_IDENTITY]: string;
   [IssuanceFailureType.PID_ANPR_CREDENTIAL_NOT_FOUND]: Errors.IssuerResponseError;
@@ -126,6 +127,14 @@ export const mapEventToFailure = (
     return {
       type: IssuanceFailureType.ISSUER_GENERIC,
       reason: error
+    };
+  }
+
+  // A WebView error during the eID issuance can be attributed to the Issuer
+  if (isWebViewError(error)) {
+    return {
+      type: IssuanceFailureType.ISSUER_GENERIC,
+      reason: error.message
     };
   }
 

--- a/apps/main-app/ts/features/itwallet/machine/eid/state/ciePin.ts
+++ b/apps/main-app/ts/features/itwallet/machine/eid/state/ciePin.ts
@@ -154,7 +154,11 @@ export const ciePinState = itwEidIssuanceMachineSetup.createStateConfig({
         ],
         target: "#itwEidIssuanceMachine.UserIdentification.CieID"
       }
-    ]
+    ],
+    error: {
+      actions: "setFailure",
+      target: "#itwEidIssuanceMachine.Failure"
+    }
   },
   onDone: {
     target: "#itwEidIssuanceMachine.UserIdentification.Completed"


### PR DESCRIPTION
## Short description
This PR fixes an issue during the CIE PIN identification, where WebView errors are not handled by the machine and an infinite loading screen is displayed.

Additionally, since WebViews are only used in the Issuer related flows, their errors are now mapped to the Issuer generic failure screen instead of the unexpected screen.

## List of changes proposed in this pull request
- Handled the `error` event in the user's identification `CiePin` state
- Mapped WebView errors to the Issuer generic failure screen

## How to test
Test an issuance flow that causes an error in the WebView.

Ensure no regressions have been introduced.

| Before (CIE PIN infinite loading) | After |
|---|---|
|<img width="240" src="https://github.com/user-attachments/assets/d19ab3c9-addd-4048-bc5f-0cc736c30211" />|<img width="240" src="https://github.com/user-attachments/assets/c06e4602-5666-4284-b293-895ea81a750e" />|

| Before (CieId) | After |
|---|---|
|<img width="240" src="https://github.com/user-attachments/assets/fde6094c-33c0-49aa-a3f1-dfc8710ba43b" />|<img width="240" src="https://github.com/user-attachments/assets/c06e4602-5666-4284-b293-895ea81a750e" />|