### PR TITLE
chore(IT-Wallet): [SIW-4918] Fix third-party and wallet list credential properties handling

### DIFF
--- a/apps/main-app/ts/features/itwallet/analytics/properties/__tests__/basePropertyBuilder.test.ts
+++ b/apps/main-app/ts/features/itwallet/analytics/properties/__tests__/basePropertyBuilder.test.ts
@@ -135,17 +135,6 @@ describe("buildThirdPartyCredentialProperty", () => {
 
     expect(buildThirdPartyCredentialProperty(state)).toBe("not_available");
   });
-
-  it("does not consider historical L2 credentials as third-party credentials", () => {
-    const credential = getMockedCredential(CredentialType.DRIVING_LICENSE, {
-      origin: "credentialOffer"
-    });
-    const state = getStateWithCredentials({
-      [credential.credentialId]: credential
-    });
-
-    expect(buildThirdPartyCredentialProperty(state)).toBe("not_available");
-  });
 });
 
 describe("buildWalletListCredentialProperty", () => {
@@ -195,16 +184,12 @@ describe("buildWalletListCredentialProperty", () => {
     expect(buildWalletListCredentialProperty(state)).toBe("not_available");
   });
 
-  it("does not consider PID or historical L2 credentials as wallet list credentials", () => {
+  it("does not consider PID as a wallet list credential", () => {
     const pid = getMockedCredential(CredentialType.PID, {
       origin: "catalogue"
     });
-    const l2Credential = getMockedCredential(CredentialType.DRIVING_LICENSE, {
-      origin: "catalogue"
-    });
     const state = getStateWithCredentials({
-      [pid.credentialId]: pid,
-      [l2Credential.credentialId]: l2Credential
+      [pid.credentialId]: pid
     });
 
     expect(buildWalletListCredentialProperty(state)).toBe("not_available");
@@ -223,6 +208,47 @@ describe("buildWalletListCredentialProperty", () => {
     expect(buildWalletListCredentialProperty(state)).toBe("valid");
   });
 });
+describe("Documenti su IO aggregate credential properties", () => {
+  const scenarios = [
+    CredentialType.DRIVING_LICENSE,
+    CredentialType.EUROPEAN_HEALTH_INSURANCE_CARD,
+    CredentialType.EUROPEAN_DISABILITY_CARD
+  ].flatMap(credentialType =>
+    (["catalogue", "credentialOffer"] as const).flatMap(origin =>
+      (["valid", "invalid"] as const).map(status => ({
+        name: `${credentialType} from ${origin} with ${status} status`,
+        credentialType,
+        origin,
+        status
+      }))
+    )
+  );
+
+  it.each(scenarios)(
+    "tracks $name without IT-Wallet activation",
+    ({ credentialType, origin, status }) => {
+      const credential = getMockedCredential(credentialType, {
+        origin,
+        validity:
+          status === "invalid"
+            ? { type: "status_assertion", status }
+            : undefined
+      });
+      const state = getStateWithCredentials({
+        [credential.credentialId]: credential
+      });
+      const expectedStatus = status === "valid" ? "valid" : "not_valid";
+
+      expect(buildItwBaseProperties(state)).toMatchObject({
+        ITW_THIRD_PARTY_CREDENTIAL:
+          origin === "credentialOffer" ? expectedStatus : "not_available",
+        ITW_WALLET_LIST_CREDENTIAL:
+          origin === "catalogue" ? expectedStatus : "not_available"
+      });
+    }
+  );
+});
+
 describe("computeItwStatus", () => {
   it.each`
     scenario                                        | authLevel    | identificationMode | isItwL3  | expected

--- a/apps/main-app/ts/features/itwallet/analytics/properties/basePropertyBuilder.ts
+++ b/apps/main-app/ts/features/itwallet/analytics/properties/basePropertyBuilder.ts
@@ -4,10 +4,7 @@ import {
   itwIdentificationModeSelector
 } from "../../common/store/selectors/preferences";
 import { getCredentialStatus } from "../../common/utils/itwCredentialStatusUtils";
-import {
-  isL2Credential,
-  validCredentialStatuses
-} from "../../common/utils/itwCredentialUtils.ts";
+import { validCredentialStatuses } from "../../common/utils/itwCredentialUtils.ts";
 import { CredentialType } from "../../common/utils/itwMocksUtils";
 import { CredentialMetadata } from "../../common/utils/itwTypesUtils";
 import {
@@ -161,8 +158,8 @@ export const computeItwStatus = (
 
 /**
  * Builds the aggregate Mixpanel status for third-party credentials, i.e. credentials
- * obtained through a third-party credential offer (deeplink/QR code). Ignores PID and
- * historical L2 credentials, which are tracked by their own dedicated properties.
+ * obtained through a third-party credential offer (deeplink/QR code), including
+ * Documenti su IO credential types. PID is excluded.
  */
 export const buildThirdPartyCredentialProperty = (
   state: GlobalState
@@ -184,8 +181,7 @@ export const buildThirdPartyCredentialProperty = (
 
 /**
  * Builds the aggregate Mixpanel status for credentials obtained through the credentials
- * catalogue/list. Ignores PID and historical L2 credentials, which are tracked by their
- * own dedicated properties.
+ * catalogue/list, including Documenti su IO credentials. PID is excluded.
  */
 export const buildWalletListCredentialProperty = (
   state: GlobalState
@@ -209,14 +205,10 @@ const isThirdPartyCredential = ({
   credentialType,
   origin
 }: CredentialMetadata) =>
-  credentialType !== CredentialType.PID &&
-  !isL2Credential(credentialType) &&
-  origin === "credentialOffer";
+  credentialType !== CredentialType.PID && origin === "credentialOffer";
 
 const isWalletListCredential = ({
   credentialType,
   origin
 }: CredentialMetadata) =>
-  credentialType !== CredentialType.PID &&
-  !isL2Credential(credentialType) &&
-  origin === "catalogue";
+  credentialType !== CredentialType.PID && origin === "catalogue";


### PR DESCRIPTION
## Short description

This PR fix `ITW_WALLET_LIST_CREDENTIAL` and `ITW_THIRD_PARTY_CREDENTIAL` excluding mdL, TS and CED, including documents held by users who have not activated IT-Wallet.

## List of changes proposed in this pull request

- Remove the exclusion of Documenti su IO credential types from both aggregate properties.
- Updated documentation and added units tests

## How to test

1. Disable L3 whitelist
2. Add a valid mdL from the catalogue.
3. Check the Mixpanel profile:
   - `ITW_WALLET_LIST_CREDENTIAL` is `valid`.
   - `ITW_THIRD_PARTY_CREDENTIAL` is `not_available`.
4. Refresh the wallet or restart the app and verify that these values remain correct.
5. Remove the last catalogue document: `ITW_WALLET_LIST_CREDENTIAL` should become `not_available`.

For Documenti su IO there is no possibility to add a credentials from a third party in the actual state