### PR TITLE
feat(IT-Wallet): [SIW-4724] Track NFC consent management events

### DIFF
--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwConsentManagementDetailScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwConsentManagementDetailScreen.tsx
@@ -124,7 +124,6 @@ export const ItwConsentManagementDetailScreen = ({ route }: Props) => {
       "features.itWallet.presentation.proximity.consentManagement.alert.cancel"
     );
 
-    trackItwRevokeConsent();
     trackItwRevokeConsentOperationBlock();
     Alert.alert(
       I18n.t(
@@ -168,7 +167,10 @@ export const ItwConsentManagementDetailScreen = ({ route }: Props) => {
           label: I18n.t(
             "features.itWallet.presentation.proximity.consentManagement.detail.revokeAction"
           ),
-          onPress: showRevokeAlert,
+          onPress: () => {
+            trackItwRevokeConsent();
+            showRevokeAlert();
+          },
           testID: "revoke-consent-action"
         }
       }}

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwConsentManagementScreen.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/ItwConsentManagementScreen.tsx
@@ -21,7 +21,12 @@ import { useItwCredentialName } from "../../../common/hooks/useItwCredentialName
 import { itwLifecycleIsITWalletValidSelector } from "../../../lifecycle/store/selectors";
 import { ItwParamsList } from "../../../navigation/ItwParamsList";
 import { ITW_ROUTES } from "../../../navigation/routes";
-import { trackItwConsentManagement } from "../analytics";
+import {
+  trackItwConsentManagement,
+  trackItwRevokeConsent,
+  trackItwRevokeConsentOperationBlock,
+  trackItwRevokeConsentOperationBlockAction
+} from "../analytics";
 import { ItwConsentManagementListItem } from "../components/ItwConsentManagementListItem";
 import { itwRevokeProximityConsentsByCredentialType } from "../store/actions";
 import { itwProximityConsentsEntriesByCredentialTypeSelector } from "../store/selectors/consents";
@@ -79,6 +84,7 @@ export const ItwConsentManagementScreen = ({ route }: Props) => {
   );
 
   const showRevokeAllAlert = () => {
+    trackItwRevokeConsentOperationBlock();
     Alert.alert(
       I18n.t(
         "features.itWallet.presentation.proximity.consentManagement.revokeAll.alert.title"
@@ -90,6 +96,7 @@ export const ItwConsentManagementScreen = ({ route }: Props) => {
         {
           onPress: () => {
             isRevoking.current = true;
+            trackItwRevokeConsentOperationBlockAction("confirm");
             dispatch(
               itwRevokeProximityConsentsByCredentialType(credentialType)
             );
@@ -108,6 +115,7 @@ export const ItwConsentManagementScreen = ({ route }: Props) => {
           )
         },
         {
+          onPress: () => trackItwRevokeConsentOperationBlockAction("cancel"),
           style: "cancel",
           text: I18n.t(
             "features.itWallet.presentation.proximity.consentManagement.alert.cancel"
@@ -158,7 +166,10 @@ export const ItwConsentManagementScreen = ({ route }: Props) => {
               label={I18n.t(
                 "features.itWallet.presentation.proximity.consentManagement.revokeAll.action"
               )}
-              onPress={showRevokeAllAlert}
+              onPress={() => {
+                trackItwRevokeConsent();
+                showRevokeAllAlert();
+              }}
               testID="revoke-all-consents-action"
               variant="danger"
             />

--- a/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwConsentManagementScreen.test.tsx
+++ b/apps/main-app/ts/features/itwallet/presentation/proximity/screens/__tests__/ItwConsentManagementScreen.test.tsx
@@ -42,6 +42,15 @@ describe("ItwConsentManagementScreen", () => {
     jest
       .spyOn(analytics, "trackItwConsentManagement")
       .mockImplementation(jest.fn());
+    jest
+      .spyOn(analytics, "trackItwRevokeConsent")
+      .mockImplementation(jest.fn());
+    jest
+      .spyOn(analytics, "trackItwRevokeConsentOperationBlock")
+      .mockImplementation(jest.fn());
+    jest
+      .spyOn(analytics, "trackItwRevokeConsentOperationBlockAction")
+      .mockImplementation(jest.fn());
   });
 
   it("returns to the document without showing an empty state when no consents exist", async () => {
@@ -109,11 +118,20 @@ describe("ItwConsentManagementScreen", () => {
       await fireEventAsync.press(
         component.getByTestId("revoke-all-consents-action")
       );
+
+      expect(analytics.trackItwRevokeConsent).toHaveBeenCalledTimes(1);
+      expect(
+        analytics.trackItwRevokeConsentOperationBlock
+      ).toHaveBeenCalledTimes(1);
+
       const alertButtons = (Alert.alert as jest.Mock).mock.calls[0][2];
       await act(async () => {
         alertButtons[0].onPress();
       });
 
+      expect(
+        analytics.trackItwRevokeConsentOperationBlockAction
+      ).toHaveBeenCalledWith("confirm");
       expect(store.getState().features.itWallet.proximity.consents).toEqual({
         unrelated
       });
@@ -142,6 +160,9 @@ describe("ItwConsentManagementScreen", () => {
     await act(async () => {
       cancelButton.onPress?.();
     });
+    expect(
+      analytics.trackItwRevokeConsentOperationBlockAction
+    ).toHaveBeenCalledWith("cancel");
     expect(store.getState().features.itWallet.proximity.consents).toEqual(
       consents
     );


### PR DESCRIPTION
## Short description
Add Mixpanel analytics tracking for the NFC/proximity consent management flow.

## List of changes proposed in this pull request
- Track `ITW_REVOKE_CONSENT` on the tap of the revoke CTA, both in the consent management list screen ("revoke all") and in the saved-consent detail screen
- Track `ITW_REVOKE_CONSENT_OPERATION_BLOCK` when the blocking confirmation alert is shown, and `ITW_REVOKE_CONSENT_OPERATION_BLOCK_ACTION` with the `user_action` property for the confirm/cancel choice
- Add test coverage for the new tracking calls in `ItwConsentManagementScreen.test.tsx`

## How to test
1. Open a document detail screen for a credential that has saved proximity/NFC consents
2. Tap "Manage consents" → verify `ITW_CREDENTIAL_MANAGE_CONSENT` and `ITW_CONSENT_MANAGEMENT` fire
3. Tap a saved consent → verify `ITW_CONSENT_MANAGEMENT_DETAIL` fires
4. Tap "Revoke" in the detail screen → verify `ITW_REVOKE_CONSENT` and `ITW_REVOKE_CONSENT_OPERATION_BLOCK` fire, then confirm/cancel and verify `ITW_REVOKE_CONSENT_OPERATION_BLOCK_ACTION` fires with `user_action: "confirm"` / `"cancel"`
5. Repeat step 4 from the "Revoke all" CTA in the consent management list screen