### PR TITLE
feat: [IOPID-4172] error screen for IDP list loading failure

### DIFF
--- a/apps/main-app/locales/it/index.json
+++ b/apps/main-app/locales/it/index.json
@@ -269,8 +269,15 @@
       "contextualHelpTitle": "Chi è il tuo Identity Provider",
       "idps": {
         "loadingAccessibilityLabel": "Caricamento Identity Provider"
+      },
+      "loadingError": {
+        "description": "Riprova più tardi oppure entra su IO con la tua Carta d’Identità Elettronica (CIE).",
+        "title": "Non riusciamo a caricare la lista dei gestori SPID",
+        "primaryAction": "Entra con CIE",
+        "secondaryAction": "Chiudi"
       }
     },
+
     "landing": {
       "accessibility": {
         "carousel": {

--- a/apps/main-app/ts/features/authentication/activeSessionLogin/__tests__/ActiveSessionLandingScreen.test.tsx
+++ b/apps/main-app/ts/features/authentication/activeSessionLogin/__tests__/ActiveSessionLandingScreen.test.tsx
@@ -5,7 +5,6 @@ import { applicationChangeState } from "../../../../store/actions/application";
 import { appReducer } from "../../../../store/reducers";
 import { renderScreenWithNavigationStoreContext } from "../../../../utils/testWrapper";
 import { AUTHENTICATION_ROUTES } from "../../common/navigation/routes";
-import { AUTH_LEVELS } from "../../common/utils";
 import { ActiveSessionLandingScreen } from "../screens/ActiveSessionLandingScreen";
 
 const mockNavigateToCieIdLoginScreen = jest.fn();
@@ -58,40 +57,6 @@ describe("ActiveSessionLandingScreen", () => {
     });
 
     expect(mockNavigateToCieIdLoginScreen).not.toHaveBeenCalled();
-  });
-
-  it("Should call navigateToCieIdLoginScreen from bottom sheet", async () => {
-    const { getByTestId } = renderComponent();
-
-    const loginWithCie = getByTestId("landing-button-login-cie");
-    await act(async () => {
-      fireEvent.press(loginWithCie);
-    });
-
-    const loginWithCieID = getByTestId("bottom-sheet-login-with-cie-id");
-    await act(async () => {
-      fireEvent.press(loginWithCieID);
-    });
-
-    expect(mockNavigateToCieIdLoginScreen).toHaveBeenCalledWith(AUTH_LEVELS.L2);
-  });
-
-  it("Should navigate to the wizard screen from banner", async () => {
-    const { getByTestId } = renderComponent();
-
-    const loginWithCie = getByTestId("landing-button-login-cie");
-    await act(async () => {
-      fireEvent.press(loginWithCie);
-    });
-
-    const wizardsBanner = getByTestId("bottom-sheet-login-wizards");
-    await act(async () => {
-      fireEvent.press(wizardsBanner);
-    });
-
-    expect(mockNavigate).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
-      screen: AUTHENTICATION_ROUTES.CIE_ID_WIZARD
-    });
   });
 });
 

--- a/apps/main-app/ts/features/authentication/activeSessionLogin/screens/ActiveSessionLandingScreen.tsx
+++ b/apps/main-app/ts/features/authentication/activeSessionLogin/screens/ActiveSessionLandingScreen.tsx
@@ -3,11 +3,9 @@
  * It includes a carousel with highlights on the app functionalities
  */
 import {
-  Banner,
   ContentWrapper,
   HeaderSecondLevel,
   IOButton,
-  ModuleNavigation,
   VSpacer
 } from "@io-app/design-system";
 import { useFocusEffect } from "@react-navigation/native";
@@ -23,16 +21,8 @@ import SectionStatusComponent from "../../../../components/SectionStatus";
 import { useIONavigation } from "../../../../navigation/params/AppParamsList";
 import { useIODispatch, useIOSelector } from "../../../../store/hooks";
 import { setAccessibilityFocus } from "../../../../utils/accessibility";
-import { useIOBottomSheetModal } from "../../../../utils/hooks/bottomSheet";
 import { useOnFirstRender } from "../../../../utils/hooks/useOnFirstRender";
-import {
-  loginCieWizardSelected,
-  trackCieBottomSheetScreenView,
-  trackLoginCieIdSelected,
-  trackLoginCiePinSelected
-} from "../../common/analytics";
-import { AUTHENTICATION_ROUTES } from "../../common/navigation/routes";
-import { AUTH_LEVELS, AuthLevel } from "../../common/utils";
+import { useCieLoginMethodSelection } from "../../common/hooks/useCieLoginMethodSelection";
 import { isCieLoginUatEnabledSelector } from "../../login/cie/store/selectors";
 import useNavigateToLoginMethod from "../../login/hooks/useNavigateToLoginMethod";
 import { LandingSessionExpiredComponent } from "../../login/landing/components/LandingSessionExpiredComponent";
@@ -46,97 +36,25 @@ import {
 
 const SPACE_BETWEEN_BUTTONS = 8;
 const SPACE_AROUND_BUTTON_LINK = 16;
-const AUTH_LEVEL_L2: AuthLevel = AUTH_LEVELS.L2;
 
 export const ActiveSessionLandingScreen = () => {
   const insets = useSafeAreaInsets();
   const dispatch = useIODispatch();
+  const navigation = useIONavigation();
 
   const accessibilityFirstFocuseViewRef = useRef<View>(null);
+  const { navigateToIdpSelection } = useNavigateToLoginMethod();
+
   const {
-    navigateToIdpSelection,
-    navigateToCiePinInsertion,
-    navigateToCieIdLoginScreen,
-    isCieSupported
-  } = useNavigateToLoginMethod();
-
-  const handleNavigateToCiePinScreen = useCallback(() => {
-    void trackLoginCiePinSelected("reauth");
-    navigateToCiePinInsertion();
-  }, [navigateToCiePinInsertion]);
-
-  const handleNavigateToCieIdLoginScreen = useCallback(() => {
-    void trackLoginCieIdSelected(AUTH_LEVEL_L2, "reauth");
-    navigateToCieIdLoginScreen(AUTH_LEVEL_L2);
-  }, [navigateToCieIdLoginScreen]);
+    bottomSheet,
+    dismiss: dismissBottomSheet,
+    handleCieLoginRequested
+  } = useCieLoginMethodSelection({ mode: "reauth" });
 
   useOnFirstRender(() => {
     void trackLoginReauthEngagement();
     dispatch(setActiveSessionLoginBlockingScreenHasBeenVisualized());
   });
-
-  const {
-    present,
-    dismiss: dismissBottomSheet,
-    bottomSheet
-  } = useIOBottomSheetModal({
-    title: I18n.t("authentication.landing.cie_bottom_sheet.title"),
-    component: (
-      <View>
-        <ModuleNavigation
-          icon="fiscalCodeIndividual"
-          onPress={handleNavigateToCiePinScreen}
-          subtitle={I18n.t(
-            "authentication.landing.cie_bottom_sheet.module_cie_pin.subtitle"
-          )}
-          testID="bottom-sheet-login-with-cie-pin"
-          title={I18n.t(
-            "authentication.landing.cie_bottom_sheet.module_cie_pin.title"
-          )}
-        />
-        <VSpacer size={8} />
-        <ModuleNavigation
-          badge={{
-            variant: "highlight",
-            text: I18n.t(
-              "authentication.landing.cie_bottom_sheet.module_cie_id.badge"
-            )
-          }}
-          icon="device"
-          onPress={handleNavigateToCieIdLoginScreen}
-          subtitle={I18n.t(
-            "authentication.landing.cie_bottom_sheet.module_cie_id.subtitle"
-          )}
-          testID="bottom-sheet-login-with-cie-id"
-          title={I18n.t(
-            "authentication.landing.cie_bottom_sheet.module_cie_id.title"
-          )}
-        />
-        <VSpacer size={24} />
-        <Banner
-          action={I18n.t(
-            "authentication.landing.cie_bottom_sheet.help_banner.action"
-          )}
-          color="turquoise"
-          onPress={() => {
-            void loginCieWizardSelected("reauth");
-            navigation.navigate(AUTHENTICATION_ROUTES.MAIN, {
-              screen: AUTHENTICATION_ROUTES.CIE_ID_WIZARD
-            });
-          }}
-          pictogramName="help"
-          testID="bottom-sheet-login-wizards"
-          title={I18n.t(
-            "authentication.landing.cie_bottom_sheet.help_banner.title"
-          )}
-        />
-        <VSpacer />
-      </View>
-    ),
-    snapPoint: [400]
-  });
-
-  const navigation = useIONavigation();
 
   const isCieUatEnabled = useIOSelector(isCieLoginUatEnabledSelector);
 
@@ -150,13 +68,8 @@ export const ActiveSessionLandingScreen = () => {
 
   const navigateToCiePinScreen = useCallback(() => {
     void trackLoginReauthEngagementCieSelected();
-    if (isCieSupported) {
-      void trackCieBottomSheetScreenView("reauth");
-      present();
-    } else {
-      handleNavigateToCieIdLoginScreen();
-    }
-  }, [isCieSupported, present, handleNavigateToCieIdLoginScreen]);
+    handleCieLoginRequested();
+  }, [handleCieLoginRequested]);
 
   const handleClosePress = useCallback(() => {
     void trackLoginReauthEngagementDismissed();

--- a/apps/main-app/ts/features/authentication/activeSessionLogin/screens/ActiveSessionLandingScreen.tsx
+++ b/apps/main-app/ts/features/authentication/activeSessionLogin/screens/ActiveSessionLandingScreen.tsx
@@ -49,7 +49,7 @@ export const ActiveSessionLandingScreen = () => {
     bottomSheet,
     dismiss: dismissBottomSheet,
     handleCieLoginRequested
-  } = useCieLoginMethodSelection({ mode: "reauth" });
+  } = useCieLoginMethodSelection({ flow: "reauth" });
 
   useOnFirstRender(() => {
     void trackLoginReauthEngagement();

--- a/apps/main-app/ts/features/authentication/common/analytics/__test__/index.test.ts
+++ b/apps/main-app/ts/features/authentication/common/analytics/__test__/index.test.ts
@@ -58,48 +58,76 @@ describe("analytics/index.ts", () => {
     });
   });
 
-  it("tracks cie pin login selected and updates profile", async () => {
-    const updateMixpanelProfilePropertiesSpyOn = jest
-      .spyOn(PROFILEPROPERTIES, "updateMixpanelProfileProperties")
-      .mockImplementation(_state => new Promise(resolve => resolve()));
+  const flowScenarios = [
+    { name: "auth", flow: "auth" as const, shouldUpdateProfile: true },
+    { name: "reauth", flow: "reauth" as const, shouldUpdateProfile: false }
+  ];
 
-    const state = { mock: "state" } as any;
-    await trackCiePinLoginSelected(state);
+  it.each(flowScenarios)(
+    "tracks cie pin login selected ($name)",
+    async ({ flow, shouldUpdateProfile }) => {
+      const updateMixpanelProfilePropertiesSpyOn = jest
+        .spyOn(PROFILEPROPERTIES, "updateMixpanelProfileProperties")
+        .mockImplementation(_state => new Promise(resolve => resolve()));
 
-    expect(mixpanelTrackSpyOn).toHaveBeenCalledTimes(1);
-    expect(mixpanelTrackSpyOn).toHaveBeenCalledWith("LOGIN_CIE_PIN_SELECTED", {
-      event_category: "UX",
-      event_type: "action",
-      flow: "auth"
-    });
+      const state = { mock: "state" } as any;
+      await trackCiePinLoginSelected(state, flow);
 
-    expect(updateMixpanelProfilePropertiesSpyOn).toHaveBeenCalledWith(state, {
-      property: "LOGIN_METHOD",
-      value: IdpCIE.id
-    });
-  });
+      expect(mixpanelTrackSpyOn).toHaveBeenCalledTimes(1);
+      expect(mixpanelTrackSpyOn).toHaveBeenCalledWith(
+        "LOGIN_CIE_PIN_SELECTED",
+        {
+          event_category: "UX",
+          event_type: "action",
+          flow
+        }
+      );
 
-  it("tracks cieID login selected with spid level", async () => {
-    const updateMixpanelProfilePropertiesSpyOn = jest
-      .spyOn(PROFILEPROPERTIES, "updateMixpanelProfileProperties")
-      .mockImplementation(_state => new Promise(resolve => resolve()));
+      if (shouldUpdateProfile) {
+        expect(updateMixpanelProfilePropertiesSpyOn).toHaveBeenCalledWith(
+          state,
+          {
+            property: "LOGIN_METHOD",
+            value: IdpCIE.id
+          }
+        );
+      } else {
+        expect(updateMixpanelProfilePropertiesSpyOn).not.toHaveBeenCalled();
+      }
+    }
+  );
 
-    const state = { mock: "state" } as any;
-    await trackCieIDLoginSelected(state, AUTH_LEVELS.L2);
+  it.each(flowScenarios)(
+    "tracks cieID login selected with spid level ($name)",
+    async ({ flow, shouldUpdateProfile }) => {
+      const updateMixpanelProfilePropertiesSpyOn = jest
+        .spyOn(PROFILEPROPERTIES, "updateMixpanelProfileProperties")
+        .mockImplementation(_state => new Promise(resolve => resolve()));
 
-    expect(mixpanelTrackSpyOn).toHaveBeenCalledTimes(1);
-    expect(mixpanelTrackSpyOn).toHaveBeenCalledWith("LOGIN_CIEID_SELECTED", {
-      event_category: "UX",
-      event_type: "action",
-      flow: "auth",
-      security_level: "L2"
-    });
+      const state = { mock: "state" } as any;
+      await trackCieIDLoginSelected(state, AUTH_LEVELS.L2, flow);
 
-    expect(updateMixpanelProfilePropertiesSpyOn).toHaveBeenCalledWith(state, {
-      property: "LOGIN_METHOD",
-      value: IdpCIE_ID.id
-    });
-  });
+      expect(mixpanelTrackSpyOn).toHaveBeenCalledTimes(1);
+      expect(mixpanelTrackSpyOn).toHaveBeenCalledWith("LOGIN_CIEID_SELECTED", {
+        event_category: "UX",
+        event_type: "action",
+        flow,
+        security_level: "L2"
+      });
+
+      if (shouldUpdateProfile) {
+        expect(updateMixpanelProfilePropertiesSpyOn).toHaveBeenCalledWith(
+          state,
+          {
+            property: "LOGIN_METHOD",
+            value: IdpCIE_ID.id
+          }
+        );
+      } else {
+        expect(updateMixpanelProfilePropertiesSpyOn).not.toHaveBeenCalled();
+      }
+    }
+  );
 
   it("tracks cie bottom sheet screen", async () => {
     await trackCieBottomSheetScreenView();

--- a/apps/main-app/ts/features/authentication/common/analytics/index.ts
+++ b/apps/main-app/ts/features/authentication/common/analytics/index.ts
@@ -30,11 +30,22 @@ export async function trackCieIDLoginSelected(
   authLevel: AuthLevel,
   flow: LoginType = "auth"
 ) {
-  trackLoginCieIdSelected(authLevel, flow);
-  await updateMixpanelProfileProperties(state, {
-    property: "LOGIN_METHOD",
-    value: IdpCIE_ID.id
-  });
+  void mixpanelTrack(
+    "LOGIN_CIEID_SELECTED",
+    buildEventProperties("UX", "action", {
+      security_level: authLevel,
+      flow
+    })
+  );
+
+  // Only the first login (auth) should update the LOGIN_METHOD profile
+  // property: a reauth doesn't change how the user normally logs in.
+  if (flow === "auth") {
+    await updateMixpanelProfileProperties(state, {
+      property: "LOGIN_METHOD",
+      value: IdpCIE_ID.id
+    });
+  }
 }
 // As in the `trackCieIDLoginSelected` event, there should be a `security_level` property;
 // however, this value might differ from the one selected before,
@@ -72,31 +83,21 @@ export async function trackCiePinLoginSelected(
   state: GlobalState,
   flow: LoginType = "auth"
 ) {
-  trackLoginCiePinSelected(flow);
-  await updateMixpanelProfileProperties(state, {
-    property: "LOGIN_METHOD",
-    value: IdpCIE.id
-  });
-}
-export function trackLoginCieIdSelected(
-  authLevel: AuthLevel,
-  flow: LoginType = "auth"
-) {
-  void mixpanelTrack(
-    "LOGIN_CIEID_SELECTED",
-    buildEventProperties("UX", "action", {
-      security_level: authLevel,
-      flow
-    })
-  );
-}
-export function trackLoginCiePinSelected(flow: LoginType = "auth") {
   void mixpanelTrack(
     "LOGIN_CIE_PIN_SELECTED",
     buildEventProperties("UX", "action", {
       flow
     })
   );
+
+  // Only the first login (auth) should update the LOGIN_METHOD profile
+  // property: a reauth doesn't change how the user normally logs in.
+  if (flow === "auth") {
+    await updateMixpanelProfileProperties(state, {
+      property: "LOGIN_METHOD",
+      value: IdpCIE.id
+    });
+  }
 }
 
 export function trackLoginEnded(

--- a/apps/main-app/ts/features/authentication/common/hooks/__tests__/useCieLoginMethodSelection.test.tsx
+++ b/apps/main-app/ts/features/authentication/common/hooks/__tests__/useCieLoginMethodSelection.test.tsx
@@ -81,115 +81,105 @@ describe("useCieLoginMethodSelection", () => {
   };
 
   const modeScenarios = [
-    { name: "auth", mode: "auth" as const, flow: "auth" as const },
-    { name: "reauth", mode: "reauth" as const, flow: "reauth" as const }
+    { name: "auth", flow: "auth" as const },
+    { name: "reauth", flow: "reauth" as const }
   ];
 
-  describe("CIE pin option", () => {
-    test.each(modeScenarios)(
-      "should navigate to CIE pin insertion and track the selection ($name)",
-      ({ mode, flow }) => {
-        const { getByTestId } = renderComponent(mode);
+  test.each(modeScenarios)(
+    "should navigate to CIE pin insertion and track the selection ($name)",
+    ({ flow }) => {
+      const { getByTestId } = renderComponent(flow);
 
-        fireEvent.press(getByTestId("bottom-sheet-login-with-cie-pin"));
+      fireEvent.press(getByTestId("bottom-sheet-login-with-cie-pin"));
 
-        expect(mockNavigateToCiePinInsertion).toHaveBeenCalled();
-        expect(mockNavigateToCieIdLoginScreen).not.toHaveBeenCalled();
-        expect(mockNavigate).not.toHaveBeenCalled();
-        expect(analytics.trackCiePinLoginSelected).toHaveBeenCalledWith(
-          expect.anything(),
-          flow
-        );
-      }
-    );
-  });
+      expect(mockNavigateToCiePinInsertion).toHaveBeenCalled();
+      expect(mockNavigateToCieIdLoginScreen).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(analytics.trackCiePinLoginSelected).toHaveBeenCalledWith(
+        expect.anything(),
+        flow
+      );
+    }
+  );
 
-  describe("CIE ID option", () => {
-    test.each(modeScenarios)(
-      "should navigate to CIE ID login screen and track the selection ($name)",
-      ({ mode, flow }) => {
-        const { getByTestId } = renderComponent(mode);
+  test.each(modeScenarios)(
+    "should navigate to CIE ID login screen and track the selection ($name)",
+    ({ flow }) => {
+      const { getByTestId } = renderComponent(flow);
 
-        fireEvent.press(getByTestId("bottom-sheet-login-with-cie-id"));
+      fireEvent.press(getByTestId("bottom-sheet-login-with-cie-id"));
 
-        expect(mockNavigateToCieIdLoginScreen).toHaveBeenCalledWith(
-          AUTH_LEVELS.L2
-        );
-        expect(mockNavigateToCiePinInsertion).not.toHaveBeenCalled();
-        expect(mockNavigate).not.toHaveBeenCalled();
-        expect(analytics.trackCieIDLoginSelected).toHaveBeenCalledWith(
-          expect.anything(),
-          AUTH_LEVELS.L2,
-          flow
-        );
-      }
-    );
-  });
+      expect(mockNavigateToCieIdLoginScreen).toHaveBeenCalledWith(
+        AUTH_LEVELS.L2
+      );
+      expect(mockNavigateToCiePinInsertion).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(analytics.trackCieIDLoginSelected).toHaveBeenCalledWith(
+        expect.anything(),
+        AUTH_LEVELS.L2,
+        flow
+      );
+    }
+  );
 
-  describe("CIE ID wizard banner", () => {
-    test.each(modeScenarios)(
-      "should navigate to the wizard and track the selection ($name)",
-      ({ mode, flow }) => {
-        const { getByTestId } = renderComponent(mode);
+  test.each(modeScenarios)(
+    "should navigate to the wizard and track the selection ($name)",
+    ({ flow }) => {
+      const { getByTestId } = renderComponent(flow);
 
-        fireEvent.press(getByTestId("bottom-sheet-login-wizards"));
+      fireEvent.press(getByTestId("bottom-sheet-login-wizards"));
 
-        expect(mockNavigate).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
-          screen: AUTHENTICATION_ROUTES.CIE_ID_WIZARD
-        });
-        expect(analytics.loginCieWizardSelected).toHaveBeenCalledWith(flow);
-        expect(mockNavigateToCiePinInsertion).not.toHaveBeenCalled();
-        expect(mockNavigateToCieIdLoginScreen).not.toHaveBeenCalled();
-      }
-    );
-  });
+      expect(mockNavigate).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
+        screen: AUTHENTICATION_ROUTES.CIE_ID_WIZARD
+      });
+      expect(analytics.loginCieWizardSelected).toHaveBeenCalledWith(flow);
+      expect(mockNavigateToCiePinInsertion).not.toHaveBeenCalled();
+      expect(mockNavigateToCieIdLoginScreen).not.toHaveBeenCalled();
+    }
+  );
 
-  describe("handleCieLoginRequested", () => {
-    test.each(modeScenarios)(
-      "should present the bottom sheet and track the screen view when CIE is supported ($name)",
-      ({ mode, flow }) => {
-        mockIsCieSupported.mockReturnValue(true);
-        const { getByTestId } = renderComponent(mode);
+  test.each(modeScenarios)(
+    "should present the bottom sheet and track the screen view when CIE is supported ($name)",
+    ({ flow }) => {
+      mockIsCieSupported.mockReturnValue(true);
+      const { getByTestId } = renderComponent(flow);
 
-        fireEvent.press(getByTestId("trigger"));
+      fireEvent.press(getByTestId("trigger"));
 
-        expect(mockPresent).toHaveBeenCalled();
-        expect(analytics.trackCieBottomSheetScreenView).toHaveBeenCalledWith(
-          flow
-        );
-        expect(mockNavigateToCieIdLoginScreen).not.toHaveBeenCalled();
-      }
-    );
+      expect(mockPresent).toHaveBeenCalled();
+      expect(analytics.trackCieBottomSheetScreenView).toHaveBeenCalledWith(
+        flow
+      );
+      expect(mockNavigateToCieIdLoginScreen).not.toHaveBeenCalled();
+    }
+  );
 
-    test.each(modeScenarios)(
-      "should skip the bottom sheet, navigate directly to CIE ID and track the selection when CIE is not supported ($name)",
-      ({ mode, flow }) => {
-        mockIsCieSupported.mockReturnValue(false);
-        const { getByTestId } = renderComponent(mode);
+  test.each(modeScenarios)(
+    "should skip the bottom sheet, navigate directly to CIE ID and track the selection when CIE is not supported ($name)",
+    ({ flow }) => {
+      mockIsCieSupported.mockReturnValue(false);
+      const { getByTestId } = renderComponent(flow);
 
-        fireEvent.press(getByTestId("trigger"));
+      fireEvent.press(getByTestId("trigger"));
 
-        expect(mockPresent).not.toHaveBeenCalled();
-        expect(analytics.trackCieBottomSheetScreenView).not.toHaveBeenCalled();
-        expect(mockNavigateToCieIdLoginScreen).toHaveBeenCalledWith(
-          AUTH_LEVELS.L2
-        );
-        expect(analytics.trackCieIDLoginSelected).toHaveBeenCalledWith(
-          expect.anything(),
-          AUTH_LEVELS.L2,
-          flow
-        );
-      }
-    );
-  });
+      expect(mockPresent).not.toHaveBeenCalled();
+      expect(analytics.trackCieBottomSheetScreenView).not.toHaveBeenCalled();
+      expect(mockNavigateToCieIdLoginScreen).toHaveBeenCalledWith(
+        AUTH_LEVELS.L2
+      );
+      expect(analytics.trackCieIDLoginSelected).toHaveBeenCalledWith(
+        expect.anything(),
+        AUTH_LEVELS.L2,
+        flow
+      );
+    }
+  );
 
-  describe("dismiss", () => {
-    it("should forward the dismiss function returned by the bottom sheet", () => {
-      const { getDismiss } = renderComponent("auth");
+  it("should forward the dismiss function returned by the bottom sheet", () => {
+    const { getDismiss } = renderComponent("auth");
 
-      getDismiss()();
+    getDismiss()();
 
-      expect(mockDismiss).toHaveBeenCalled();
-    });
+    expect(mockDismiss).toHaveBeenCalled();
   });
 });

--- a/apps/main-app/ts/features/authentication/common/hooks/__tests__/useCieLoginMethodSelection.test.tsx
+++ b/apps/main-app/ts/features/authentication/common/hooks/__tests__/useCieLoginMethodSelection.test.tsx
@@ -81,7 +81,7 @@ describe("useCieLoginMethodSelection", () => {
   };
 
   const modeScenarios = [
-    { name: "auth", mode: "auth" as const, flow: undefined },
+    { name: "auth", mode: "auth" as const, flow: "auth" as const },
     { name: "reauth", mode: "reauth" as const, flow: "reauth" as const }
   ];
 
@@ -96,13 +96,10 @@ describe("useCieLoginMethodSelection", () => {
         expect(mockNavigateToCiePinInsertion).toHaveBeenCalled();
         expect(mockNavigateToCieIdLoginScreen).not.toHaveBeenCalled();
         expect(mockNavigate).not.toHaveBeenCalled();
-        if (mode === "reauth") {
-          expect(analytics.trackLoginCiePinSelected).toHaveBeenCalledWith(flow);
-          expect(analytics.trackCiePinLoginSelected).not.toHaveBeenCalled();
-        } else {
-          expect(analytics.trackCiePinLoginSelected).toHaveBeenCalled();
-          expect(analytics.trackLoginCiePinSelected).not.toHaveBeenCalled();
-        }
+        expect(analytics.trackCiePinLoginSelected).toHaveBeenCalledWith(
+          expect.anything(),
+          flow
+        );
       }
     );
   });
@@ -120,16 +117,11 @@ describe("useCieLoginMethodSelection", () => {
         );
         expect(mockNavigateToCiePinInsertion).not.toHaveBeenCalled();
         expect(mockNavigate).not.toHaveBeenCalled();
-        if (mode === "reauth") {
-          expect(analytics.trackLoginCieIdSelected).toHaveBeenCalledWith(
-            AUTH_LEVELS.L2,
-            flow
-          );
-          expect(analytics.trackCieIDLoginSelected).not.toHaveBeenCalled();
-        } else {
-          expect(analytics.trackCieIDLoginSelected).toHaveBeenCalled();
-          expect(analytics.trackLoginCieIdSelected).not.toHaveBeenCalled();
-        }
+        expect(analytics.trackCieIDLoginSelected).toHaveBeenCalledWith(
+          expect.anything(),
+          AUTH_LEVELS.L2,
+          flow
+        );
       }
     );
   });
@@ -182,14 +174,11 @@ describe("useCieLoginMethodSelection", () => {
         expect(mockNavigateToCieIdLoginScreen).toHaveBeenCalledWith(
           AUTH_LEVELS.L2
         );
-        if (mode === "reauth") {
-          expect(analytics.trackLoginCieIdSelected).toHaveBeenCalledWith(
-            AUTH_LEVELS.L2,
-            flow
-          );
-        } else {
-          expect(analytics.trackCieIDLoginSelected).toHaveBeenCalled();
-        }
+        expect(analytics.trackCieIDLoginSelected).toHaveBeenCalledWith(
+          expect.anything(),
+          AUTH_LEVELS.L2,
+          flow
+        );
       }
     );
   });

--- a/apps/main-app/ts/features/authentication/common/hooks/__tests__/useCieLoginMethodSelection.test.tsx
+++ b/apps/main-app/ts/features/authentication/common/hooks/__tests__/useCieLoginMethodSelection.test.tsx
@@ -1,0 +1,206 @@
+import { fireEvent } from "@testing-library/react-native";
+import { Text } from "react-native";
+import { createStore } from "redux";
+
+import { applicationChangeState } from "../../../../../store/actions/application";
+import { appReducer } from "../../../../../store/reducers";
+import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
+import * as analytics from "../../analytics";
+import { AUTHENTICATION_ROUTES } from "../../navigation/routes";
+import { AUTH_LEVELS } from "../../utils";
+import { useCieLoginMethodSelection } from "../useCieLoginMethodSelection";
+
+const mockNavigateToCiePinInsertion = jest.fn();
+const mockNavigateToCieIdLoginScreen = jest.fn();
+const mockNavigate = jest.fn();
+const mockPresent = jest.fn();
+const mockDismiss = jest.fn();
+const mockIsCieSupported = jest.fn();
+
+jest.mock("../../../login/hooks/useNavigateToLoginMethod", () => ({
+  __esModule: true,
+  default: () => ({
+    navigateToCiePinInsertion: mockNavigateToCiePinInsertion,
+    navigateToCieIdLoginScreen: mockNavigateToCieIdLoginScreen,
+    isCieSupported: mockIsCieSupported()
+  })
+}));
+
+jest.mock("../../../../../utils/hooks/bottomSheet", () => ({
+  useIOBottomSheetModal: jest.fn(options => ({
+    present: mockPresent,
+    dismiss: mockDismiss,
+    bottomSheet: <>{options.component}</>
+  }))
+}));
+
+jest.mock("../../../../../navigation/params/AppParamsList", () => ({
+  useIONavigation: () => ({
+    navigate: mockNavigate
+  })
+}));
+
+jest.mock("../../analytics");
+
+describe("useCieLoginMethodSelection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsCieSupported.mockReturnValue(true);
+  });
+
+  const renderComponent = (mode: "auth" | "reauth") => {
+    // eslint-disable-next-line functional/no-let
+    let hookReturnValue: ReturnType<typeof useCieLoginMethodSelection>;
+    const WrapperComponent = () => {
+      hookReturnValue = useCieLoginMethodSelection({ mode });
+      const { bottomSheet, handleCieLoginRequested } = hookReturnValue;
+      return (
+        <>
+          <Text onPress={handleCieLoginRequested} testID="trigger">
+            trigger
+          </Text>
+          {bottomSheet}
+        </>
+      );
+    };
+    const initialState = appReducer(
+      undefined,
+      applicationChangeState("active")
+    );
+    const store = createStore(appReducer, initialState as any);
+    const renderResult = renderScreenWithNavigationStoreContext(
+      () => <WrapperComponent />,
+      "DUMMY",
+      {},
+      store
+    );
+    return {
+      ...renderResult,
+      getDismiss: () => hookReturnValue.dismiss
+    };
+  };
+
+  const modeScenarios = [
+    { name: "auth", mode: "auth" as const, flow: undefined },
+    { name: "reauth", mode: "reauth" as const, flow: "reauth" as const }
+  ];
+
+  describe("CIE pin option", () => {
+    test.each(modeScenarios)(
+      "should navigate to CIE pin insertion and track the selection ($name)",
+      ({ mode, flow }) => {
+        const { getByTestId } = renderComponent(mode);
+
+        fireEvent.press(getByTestId("bottom-sheet-login-with-cie-pin"));
+
+        expect(mockNavigateToCiePinInsertion).toHaveBeenCalled();
+        expect(mockNavigateToCieIdLoginScreen).not.toHaveBeenCalled();
+        expect(mockNavigate).not.toHaveBeenCalled();
+        if (mode === "reauth") {
+          expect(analytics.trackLoginCiePinSelected).toHaveBeenCalledWith(flow);
+          expect(analytics.trackCiePinLoginSelected).not.toHaveBeenCalled();
+        } else {
+          expect(analytics.trackCiePinLoginSelected).toHaveBeenCalled();
+          expect(analytics.trackLoginCiePinSelected).not.toHaveBeenCalled();
+        }
+      }
+    );
+  });
+
+  describe("CIE ID option", () => {
+    test.each(modeScenarios)(
+      "should navigate to CIE ID login screen and track the selection ($name)",
+      ({ mode, flow }) => {
+        const { getByTestId } = renderComponent(mode);
+
+        fireEvent.press(getByTestId("bottom-sheet-login-with-cie-id"));
+
+        expect(mockNavigateToCieIdLoginScreen).toHaveBeenCalledWith(
+          AUTH_LEVELS.L2
+        );
+        expect(mockNavigateToCiePinInsertion).not.toHaveBeenCalled();
+        expect(mockNavigate).not.toHaveBeenCalled();
+        if (mode === "reauth") {
+          expect(analytics.trackLoginCieIdSelected).toHaveBeenCalledWith(
+            AUTH_LEVELS.L2,
+            flow
+          );
+          expect(analytics.trackCieIDLoginSelected).not.toHaveBeenCalled();
+        } else {
+          expect(analytics.trackCieIDLoginSelected).toHaveBeenCalled();
+          expect(analytics.trackLoginCieIdSelected).not.toHaveBeenCalled();
+        }
+      }
+    );
+  });
+
+  describe("CIE ID wizard banner", () => {
+    test.each(modeScenarios)(
+      "should navigate to the wizard and track the selection ($name)",
+      ({ mode, flow }) => {
+        const { getByTestId } = renderComponent(mode);
+
+        fireEvent.press(getByTestId("bottom-sheet-login-wizards"));
+
+        expect(mockNavigate).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
+          screen: AUTHENTICATION_ROUTES.CIE_ID_WIZARD
+        });
+        expect(analytics.loginCieWizardSelected).toHaveBeenCalledWith(flow);
+        expect(mockNavigateToCiePinInsertion).not.toHaveBeenCalled();
+        expect(mockNavigateToCieIdLoginScreen).not.toHaveBeenCalled();
+      }
+    );
+  });
+
+  describe("handleCieLoginRequested", () => {
+    test.each(modeScenarios)(
+      "should present the bottom sheet and track the screen view when CIE is supported ($name)",
+      ({ mode, flow }) => {
+        mockIsCieSupported.mockReturnValue(true);
+        const { getByTestId } = renderComponent(mode);
+
+        fireEvent.press(getByTestId("trigger"));
+
+        expect(mockPresent).toHaveBeenCalled();
+        expect(analytics.trackCieBottomSheetScreenView).toHaveBeenCalledWith(
+          flow
+        );
+        expect(mockNavigateToCieIdLoginScreen).not.toHaveBeenCalled();
+      }
+    );
+
+    test.each(modeScenarios)(
+      "should skip the bottom sheet, navigate directly to CIE ID and track the selection when CIE is not supported ($name)",
+      ({ mode, flow }) => {
+        mockIsCieSupported.mockReturnValue(false);
+        const { getByTestId } = renderComponent(mode);
+
+        fireEvent.press(getByTestId("trigger"));
+
+        expect(mockPresent).not.toHaveBeenCalled();
+        expect(analytics.trackCieBottomSheetScreenView).not.toHaveBeenCalled();
+        expect(mockNavigateToCieIdLoginScreen).toHaveBeenCalledWith(
+          AUTH_LEVELS.L2
+        );
+        if (mode === "reauth") {
+          expect(analytics.trackLoginCieIdSelected).toHaveBeenCalledWith(
+            AUTH_LEVELS.L2,
+            flow
+          );
+        } else {
+          expect(analytics.trackCieIDLoginSelected).toHaveBeenCalled();
+        }
+      }
+    );
+  });
+
+  describe("dismiss", () => {
+    it("should forward the dismiss function returned by the bottom sheet", () => {
+      const { getDismiss } = renderComponent("auth");
+
+      getDismiss()();
+
+      expect(mockDismiss).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/main-app/ts/features/authentication/common/hooks/__tests__/useCieLoginMethodSelection.test.tsx
+++ b/apps/main-app/ts/features/authentication/common/hooks/__tests__/useCieLoginMethodSelection.test.tsx
@@ -48,11 +48,11 @@ describe("useCieLoginMethodSelection", () => {
     mockIsCieSupported.mockReturnValue(true);
   });
 
-  const renderComponent = (mode: "auth" | "reauth") => {
+  const renderComponent = (flow: "auth" | "reauth") => {
     // eslint-disable-next-line functional/no-let
     let hookReturnValue: ReturnType<typeof useCieLoginMethodSelection>;
     const WrapperComponent = () => {
-      hookReturnValue = useCieLoginMethodSelection({ mode });
+      hookReturnValue = useCieLoginMethodSelection({ flow });
       const { bottomSheet, handleCieLoginRequested } = hookReturnValue;
       return (
         <>

--- a/apps/main-app/ts/features/authentication/common/hooks/useCieLoginMethodSelection.tsx
+++ b/apps/main-app/ts/features/authentication/common/hooks/useCieLoginMethodSelection.tsx
@@ -105,12 +105,12 @@ export const useCieLoginMethodSelection = ({
   });
 
   const handleCieLoginRequested = useCallback(() => {
-    if (isCieSupported) {
-      void trackCieBottomSheetScreenView(flow);
-      present();
-    } else {
+    if (!isCieSupported) {
       handleNavigateToCieIdLoginScreen();
+      return;
     }
+    void trackCieBottomSheetScreenView(flow);
+    present();
   }, [isCieSupported, flow, present, handleNavigateToCieIdLoginScreen]);
 
   return { bottomSheet, dismiss, handleCieLoginRequested };

--- a/apps/main-app/ts/features/authentication/common/hooks/useCieLoginMethodSelection.tsx
+++ b/apps/main-app/ts/features/authentication/common/hooks/useCieLoginMethodSelection.tsx
@@ -21,12 +21,12 @@ import { AUTH_LEVELS, AuthLevel } from "../utils";
 type CieLoginMethodSelectionMode = "auth" | "reauth";
 
 type UseCieLoginMethodSelectionParams = {
-  mode: CieLoginMethodSelectionMode;
+  flow: CieLoginMethodSelectionMode;
 };
 const AUTH_LEVEL_L2: AuthLevel = AUTH_LEVELS.L2;
 
 export const useCieLoginMethodSelection = ({
-  mode
+  flow
 }: UseCieLoginMethodSelectionParams) => {
   const store = useIOStore();
   const navigation = useIONavigation();
@@ -37,7 +37,7 @@ export const useCieLoginMethodSelection = ({
     isCieSupported
   } = useNavigateToLoginMethod();
 
-  const isReauth = mode === "reauth";
+  const isReauth = flow === "reauth";
 
   const handleNavigateToCiePinScreen = useCallback(() => {
     if (isReauth) {

--- a/apps/main-app/ts/features/authentication/common/hooks/useCieLoginMethodSelection.tsx
+++ b/apps/main-app/ts/features/authentication/common/hooks/useCieLoginMethodSelection.tsx
@@ -11,9 +11,7 @@ import {
   loginCieWizardSelected,
   trackCieBottomSheetScreenView,
   trackCieIDLoginSelected,
-  trackCiePinLoginSelected,
-  trackLoginCieIdSelected,
-  trackLoginCiePinSelected
+  trackCiePinLoginSelected
 } from "../analytics";
 import { AUTHENTICATION_ROUTES } from "../navigation/routes";
 import { AUTH_LEVELS, AuthLevel } from "../utils";
@@ -37,32 +35,22 @@ export const useCieLoginMethodSelection = ({
     isCieSupported
   } = useNavigateToLoginMethod();
 
-  const isReauth = flow === "reauth";
-
   const handleNavigateToCiePinScreen = useCallback(() => {
-    if (isReauth) {
-      void trackLoginCiePinSelected("reauth");
-    } else {
-      void trackCiePinLoginSelected(store.getState());
-    }
+    void trackCiePinLoginSelected(store.getState(), flow);
     navigateToCiePinInsertion();
-  }, [isReauth, navigateToCiePinInsertion, store]);
+  }, [flow, navigateToCiePinInsertion, store]);
 
   const handleNavigateToCieIdLoginScreen = useCallback(() => {
-    if (isReauth) {
-      void trackLoginCieIdSelected(AUTH_LEVEL_L2, "reauth");
-    } else {
-      void trackCieIDLoginSelected(store.getState(), AUTH_LEVEL_L2);
-    }
+    void trackCieIDLoginSelected(store.getState(), AUTH_LEVEL_L2, flow);
     navigateToCieIdLoginScreen(AUTH_LEVEL_L2);
-  }, [isReauth, navigateToCieIdLoginScreen, store]);
+  }, [flow, navigateToCieIdLoginScreen, store]);
 
   const handleNavigateToCieIdWizard = useCallback(() => {
-    void loginCieWizardSelected(isReauth ? "reauth" : undefined);
+    void loginCieWizardSelected(flow);
     navigation.navigate(AUTHENTICATION_ROUTES.MAIN, {
       screen: AUTHENTICATION_ROUTES.CIE_ID_WIZARD
     });
-  }, [isReauth, navigation]);
+  }, [flow, navigation]);
 
   const { present, dismiss, bottomSheet } = useIOBottomSheetModal({
     title: I18n.t("authentication.landing.cie_bottom_sheet.title"),
@@ -118,12 +106,12 @@ export const useCieLoginMethodSelection = ({
 
   const handleCieLoginRequested = useCallback(() => {
     if (isCieSupported) {
-      void trackCieBottomSheetScreenView(isReauth ? "reauth" : undefined);
+      void trackCieBottomSheetScreenView(flow);
       present();
     } else {
       handleNavigateToCieIdLoginScreen();
     }
-  }, [isCieSupported, isReauth, present, handleNavigateToCieIdLoginScreen]);
+  }, [isCieSupported, flow, present, handleNavigateToCieIdLoginScreen]);
 
   return { bottomSheet, dismiss, handleCieLoginRequested };
 };

--- a/apps/main-app/ts/features/authentication/common/hooks/useCieLoginMethodSelection.tsx
+++ b/apps/main-app/ts/features/authentication/common/hooks/useCieLoginMethodSelection.tsx
@@ -1,0 +1,129 @@
+import { Banner, ModuleNavigation, VSpacer } from "@io-app/design-system";
+import I18n from "i18next";
+import { useCallback } from "react";
+import { View } from "react-native";
+
+import { useIONavigation } from "../../../../navigation/params/AppParamsList";
+import { useIOStore } from "../../../../store/hooks";
+import { useIOBottomSheetModal } from "../../../../utils/hooks/bottomSheet";
+import useNavigateToLoginMethod from "../../login/hooks/useNavigateToLoginMethod";
+import {
+  loginCieWizardSelected,
+  trackCieBottomSheetScreenView,
+  trackCieIDLoginSelected,
+  trackCiePinLoginSelected,
+  trackLoginCieIdSelected,
+  trackLoginCiePinSelected
+} from "../analytics";
+import { AUTHENTICATION_ROUTES } from "../navigation/routes";
+import { AUTH_LEVELS, AuthLevel } from "../utils";
+
+type CieLoginMethodSelectionMode = "auth" | "reauth";
+
+type UseCieLoginMethodSelectionParams = {
+  mode: CieLoginMethodSelectionMode;
+};
+const AUTH_LEVEL_L2: AuthLevel = AUTH_LEVELS.L2;
+
+export const useCieLoginMethodSelection = ({
+  mode
+}: UseCieLoginMethodSelectionParams) => {
+  const store = useIOStore();
+  const navigation = useIONavigation();
+
+  const {
+    navigateToCiePinInsertion,
+    navigateToCieIdLoginScreen,
+    isCieSupported
+  } = useNavigateToLoginMethod();
+
+  const isReauth = mode === "reauth";
+
+  const handleNavigateToCiePinScreen = useCallback(() => {
+    if (isReauth) {
+      void trackLoginCiePinSelected("reauth");
+    } else {
+      void trackCiePinLoginSelected(store.getState());
+    }
+    navigateToCiePinInsertion();
+  }, [isReauth, navigateToCiePinInsertion, store]);
+
+  const handleNavigateToCieIdLoginScreen = useCallback(() => {
+    if (isReauth) {
+      void trackLoginCieIdSelected(AUTH_LEVEL_L2, "reauth");
+    } else {
+      void trackCieIDLoginSelected(store.getState(), AUTH_LEVEL_L2);
+    }
+    navigateToCieIdLoginScreen(AUTH_LEVEL_L2);
+  }, [isReauth, navigateToCieIdLoginScreen, store]);
+
+  const handleNavigateToCieIdWizard = useCallback(() => {
+    void loginCieWizardSelected(isReauth ? "reauth" : undefined);
+    navigation.navigate(AUTHENTICATION_ROUTES.MAIN, {
+      screen: AUTHENTICATION_ROUTES.CIE_ID_WIZARD
+    });
+  }, [isReauth, navigation]);
+
+  const { present, dismiss, bottomSheet } = useIOBottomSheetModal({
+    title: I18n.t("authentication.landing.cie_bottom_sheet.title"),
+    component: (
+      <View>
+        <ModuleNavigation
+          icon="fiscalCodeIndividual"
+          onPress={handleNavigateToCiePinScreen}
+          subtitle={I18n.t(
+            "authentication.landing.cie_bottom_sheet.module_cie_pin.subtitle"
+          )}
+          testID="bottom-sheet-login-with-cie-pin"
+          title={I18n.t(
+            "authentication.landing.cie_bottom_sheet.module_cie_pin.title"
+          )}
+        />
+        <VSpacer size={8} />
+        <ModuleNavigation
+          badge={{
+            variant: "highlight",
+            text: I18n.t(
+              "authentication.landing.cie_bottom_sheet.module_cie_id.badge"
+            )
+          }}
+          icon="device"
+          onPress={handleNavigateToCieIdLoginScreen}
+          subtitle={I18n.t(
+            "authentication.landing.cie_bottom_sheet.module_cie_id.subtitle"
+          )}
+          testID="bottom-sheet-login-with-cie-id"
+          title={I18n.t(
+            "authentication.landing.cie_bottom_sheet.module_cie_id.title"
+          )}
+        />
+        <VSpacer size={24} />
+        <Banner
+          action={I18n.t(
+            "authentication.landing.cie_bottom_sheet.help_banner.action"
+          )}
+          color="turquoise"
+          onPress={handleNavigateToCieIdWizard}
+          pictogramName="help"
+          testID="bottom-sheet-login-wizards"
+          title={I18n.t(
+            "authentication.landing.cie_bottom_sheet.help_banner.title"
+          )}
+        />
+        <VSpacer />
+      </View>
+    ),
+    snapPoint: [400]
+  });
+
+  const handleCieLoginRequested = useCallback(() => {
+    if (isCieSupported) {
+      void trackCieBottomSheetScreenView(isReauth ? "reauth" : undefined);
+      present();
+    } else {
+      handleNavigateToCieIdLoginScreen();
+    }
+  }, [isCieSupported, isReauth, present, handleNavigateToCieIdLoginScreen]);
+
+  return { bottomSheet, dismiss, handleCieLoginRequested };
+};

--- a/apps/main-app/ts/features/authentication/common/hooks/useCieLoginMethodSelection.tsx
+++ b/apps/main-app/ts/features/authentication/common/hooks/useCieLoginMethodSelection.tsx
@@ -18,10 +18,10 @@ import {
 import { AUTHENTICATION_ROUTES } from "../navigation/routes";
 import { AUTH_LEVELS, AuthLevel } from "../utils";
 
-type CieLoginMethodSelectionMode = "auth" | "reauth";
+type LoginFlow = "auth" | "reauth";
 
 type UseCieLoginMethodSelectionParams = {
-  flow: CieLoginMethodSelectionMode;
+  flow: LoginFlow;
 };
 const AUTH_LEVEL_L2: AuthLevel = AUTH_LEVELS.L2;
 

--- a/apps/main-app/ts/features/authentication/login/idp/components/OneIdentityIdpSelectionFailureContent.tsx
+++ b/apps/main-app/ts/features/authentication/login/idp/components/OneIdentityIdpSelectionFailureContent.tsx
@@ -1,0 +1,82 @@
+import { useFocusEffect } from "@react-navigation/core";
+import I18n from "i18next";
+import { useCallback, useRef } from "react";
+import { View } from "react-native";
+
+import { OperationResultScreenContent } from "../../../../../components/screens/OperationResultScreenContent";
+import { useIONavigation } from "../../../../../navigation/params/AppParamsList";
+import { setAccessibilityFocus } from "../../../../../utils/accessibility";
+import { trackLoginReauthEngagementCieSelected } from "../../../activeSessionLogin/screens/analytics";
+import { trackCieLoginSelected } from "../../../common/analytics";
+import { useCieLoginMethodSelection } from "../../../common/hooks/useCieLoginMethodSelection";
+import { AUTHENTICATION_ROUTES } from "../../../common/navigation/routes";
+
+type OneIdentityIdpSelectionFailureContentProps = {
+  isActiveSessionLogin: boolean;
+};
+
+export const OneIdentityIdpSelectionFailureContent = ({
+  isActiveSessionLogin
+}: OneIdentityIdpSelectionFailureContentProps) => {
+  const navigation = useIONavigation();
+  const accessibilityFirstFocuseViewRef = useRef<View>(null);
+
+  const {
+    bottomSheet,
+    dismiss: dismissBottomSheet,
+    handleCieLoginRequested
+  } = useCieLoginMethodSelection({
+    flow: isActiveSessionLogin ? "reauth" : "auth"
+  });
+
+  useFocusEffect(
+    useCallback(() => {
+      setAccessibilityFocus(accessibilityFirstFocuseViewRef);
+
+      return dismissBottomSheet;
+    }, [dismissBottomSheet])
+  );
+
+  const navigateToCiePinScreen = useCallback(() => {
+    if (isActiveSessionLogin) {
+      void trackLoginReauthEngagementCieSelected();
+    } else {
+      void trackCieLoginSelected();
+    }
+    handleCieLoginRequested();
+  }, [isActiveSessionLogin, handleCieLoginRequested]);
+
+  const navigateToLandingScreen = useCallback(() => {
+    navigation.navigate(AUTHENTICATION_ROUTES.MAIN, {
+      screen: AUTHENTICATION_ROUTES.LANDING
+    });
+  }, [navigation]);
+
+  return (
+    <>
+      <OperationResultScreenContent
+        action={{
+          label: I18n.t(
+            "authentication.idp_selection.loadingError.primaryAction"
+          ),
+          onPress: navigateToCiePinScreen,
+          testID: "idp-loading-error-primary-action"
+        }}
+        pictogram="umbrella"
+        ref={accessibilityFirstFocuseViewRef}
+        secondaryAction={{
+          label: I18n.t(
+            "authentication.idp_selection.loadingError.secondaryAction"
+          ),
+          onPress: navigateToLandingScreen,
+          testID: "idp-loading-error-secondary-action"
+        }}
+        subtitle={I18n.t(
+          "authentication.idp_selection.loadingError.description"
+        )}
+        title={I18n.t("authentication.idp_selection.loadingError.title")}
+      />
+      {bottomSheet}
+    </>
+  );
+};

--- a/apps/main-app/ts/features/authentication/login/idp/components/__test__/OneIdentityIdpSelectionFailureContent.test.tsx
+++ b/apps/main-app/ts/features/authentication/login/idp/components/__test__/OneIdentityIdpSelectionFailureContent.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent } from "@testing-library/react-native";
+import { createStore } from "redux";
+
+import { applicationChangeState } from "../../../../../../store/actions/application";
+import { appReducer } from "../../../../../../store/reducers";
+import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper";
+import * as activeSessionLoginAnalytics from "../../../../activeSessionLogin/screens/analytics";
+import * as commonAnalytics from "../../../../common/analytics";
+import { AUTHENTICATION_ROUTES } from "../../../../common/navigation/routes";
+import { OneIdentityIdpSelectionFailureContent } from "../OneIdentityIdpSelectionFailureContent";
+
+const mockDismiss = jest.fn();
+const mockHandleCieLoginRequested = jest.fn();
+jest.mock("../../../../common/hooks/useCieLoginMethodSelection", () => ({
+  useCieLoginMethodSelection: () => ({
+    bottomSheet: null,
+    dismiss: mockDismiss,
+    handleCieLoginRequested: mockHandleCieLoginRequested
+  })
+}));
+
+const mockNavigate = jest.fn();
+jest.mock("../../../../../../navigation/params/AppParamsList", () => ({
+  ...jest.requireActual("../../../../../../navigation/params/AppParamsList"),
+  useIONavigation: () => ({ navigate: mockNavigate })
+}));
+
+describe("OneIdentityIdpSelectionFailureContent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest
+      .spyOn(commonAnalytics, "trackCieLoginSelected")
+      .mockImplementation(jest.fn());
+    jest
+      .spyOn(
+        activeSessionLoginAnalytics,
+        "trackLoginReauthEngagementCieSelected"
+      )
+      .mockImplementation(jest.fn());
+  });
+
+  const renderComponent = (isActiveSessionLogin = false) => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+
+    return renderScreenWithNavigationStoreContext(
+      () => (
+        <OneIdentityIdpSelectionFailureContent
+          isActiveSessionLogin={isActiveSessionLogin}
+        />
+      ),
+      AUTHENTICATION_ROUTES.IDP_SELECTION,
+      {},
+      store
+    );
+  };
+
+  it("should render the loading error content", () => {
+    const { queryByTestId } = renderComponent();
+
+    expect(queryByTestId("idp-loading-error-primary-action")).toBeTruthy();
+    expect(queryByTestId("idp-loading-error-secondary-action")).toBeTruthy();
+  });
+
+  it("should navigate to the landing screen when pressing the secondary action", () => {
+    const { getByTestId } = renderComponent();
+
+    fireEvent.press(getByTestId("idp-loading-error-secondary-action"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
+      screen: AUTHENTICATION_ROUTES.LANDING
+    });
+  });
+
+  it("should track trackCieLoginSelected and request the CIE login when pressing the primary action while not in an active session", () => {
+    const { getByTestId } = renderComponent();
+
+    fireEvent.press(getByTestId("idp-loading-error-primary-action"));
+
+    expect(commonAnalytics.trackCieLoginSelected).toHaveBeenCalled();
+    expect(
+      activeSessionLoginAnalytics.trackLoginReauthEngagementCieSelected
+    ).not.toHaveBeenCalled();
+    expect(mockHandleCieLoginRequested).toHaveBeenCalled();
+  });
+
+  it("should track trackLoginReauthEngagementCieSelected and request the CIE login when pressing the primary action during an active session", () => {
+    const { getByTestId } = renderComponent(true);
+
+    fireEvent.press(getByTestId("idp-loading-error-primary-action"));
+
+    expect(
+      activeSessionLoginAnalytics.trackLoginReauthEngagementCieSelected
+    ).toHaveBeenCalled();
+    expect(commonAnalytics.trackCieLoginSelected).not.toHaveBeenCalled();
+    expect(mockHandleCieLoginRequested).toHaveBeenCalled();
+  });
+});

--- a/apps/main-app/ts/features/authentication/login/idp/screens/OneIdentityIdpSelectionScreen.tsx
+++ b/apps/main-app/ts/features/authentication/login/idp/screens/OneIdentityIdpSelectionScreen.tsx
@@ -1,10 +1,7 @@
 import { Banner, useIOToast, VSpacer } from "@io-app/design-system";
-import { useFocusEffect } from "@react-navigation/core";
 import I18n from "i18next";
-import { useCallback, useMemo, useRef } from "react";
-import { View } from "react-native";
+import { useCallback, useMemo } from "react";
 
-import { OperationResultScreenContent } from "../../../../../components/screens/OperationResultScreenContent";
 import { helpCenterHowToLoginWithSpidUrl } from "../../../../../config";
 import { useHeaderSecondLevel } from "../../../../../hooks/useHeaderSecondLevel";
 import { IOStackNavigationRouteProps } from "../../../../../navigation/params/AppParamsList";
@@ -14,7 +11,6 @@ import {
   useIOStore
 } from "../../../../../store/hooks";
 import { assistanceToolConfigSelector } from "../../../../../store/reducers/backendStatus/remoteConfig";
-import { setAccessibilityFocus } from "../../../../../utils/accessibility";
 import { trackHelpCenterCtaTapped } from "../../../../../utils/analytics";
 import { useOnFirstRender } from "../../../../../utils/hooks/useOnFirstRender";
 import { SpidIdp } from "../../../../../utils/idps";
@@ -23,19 +19,15 @@ import {
   handleSendAssistanceLog
 } from "../../../../../utils/supportAssistance";
 import { openWebUrl } from "../../../../../utils/url";
-import { trackLoginReauthEngagementCieSelected } from "../../../activeSessionLogin/screens/analytics";
 import { setIdpSelectedActiveSessionLogin } from "../../../activeSessionLogin/store/actions";
 import { isActiveSessionLoginSelector } from "../../../activeSessionLogin/store/selectors";
-import {
-  trackCieLoginSelected,
-  trackSpidLoginIdpSelection
-} from "../../../common/analytics";
+import { trackSpidLoginIdpSelection } from "../../../common/analytics";
 import { trackLoginSpidIdpSelected } from "../../../common/analytics/spidAnalytics";
-import { useCieLoginMethodSelection } from "../../../common/hooks/useCieLoginMethodSelection";
 import { AuthenticationParamsList } from "../../../common/navigation/params/AuthenticationParamsList";
 import { AUTHENTICATION_ROUTES } from "../../../common/navigation/routes";
 import { idpSelected } from "../../../common/store/actions";
 import IdpsGrid, { IdpsGridSkeleton } from "../components/IdpsGrid";
+import { OneIdentityIdpSelectionFailureContent } from "../components/OneIdentityIdpSelectionFailureContent";
 import { useGetIdps } from "../hooks/useGetIdps";
 import { fromIdpToLocalSpidIdp, randomOrderIdps } from "../utils/idps";
 
@@ -48,8 +40,6 @@ export const OneIdentityIdpSelectionScreen = ({
   navigation,
   route
 }: OneIdentityIdpSelectionScreenProps) => {
-  const accessibilityFirstFocuseViewRef = useRef<View>(null);
-
   const dispatch = useIODispatch();
   const store = useIOStore();
   const toast = useIOToast();
@@ -59,11 +49,6 @@ export const OneIdentityIdpSelectionScreen = ({
   const { state } = useGetIdps();
 
   const loginFlow = isActiveSessionLogin ? "reauth" : "auth";
-  const {
-    bottomSheet,
-    dismiss: dismissBottomSheet,
-    handleCieLoginRequested
-  } = useCieLoginMethodSelection({ mode: loginFlow });
   const choosenTool = assistanceToolRemoteConfig(assistanceToolConfig);
 
   const shuffledIdps = useMemo(() => {
@@ -129,56 +114,12 @@ export const OneIdentityIdpSelectionScreen = ({
   );
 
   const ListEmptyComponent = useCallback(() => <IdpsGridSkeleton />, []);
-  useFocusEffect(
-    useCallback(() => {
-      setAccessibilityFocus(accessibilityFirstFocuseViewRef);
-
-      return dismissBottomSheet;
-    }, [dismissBottomSheet])
-  );
-
-  const navigateToCiePinScreen = useCallback(() => {
-    if (isActiveSessionLogin) {
-      void trackLoginReauthEngagementCieSelected();
-    } else {
-      void trackCieLoginSelected();
-    }
-    handleCieLoginRequested();
-  }, [isActiveSessionLogin, handleCieLoginRequested]);
-
-  const navigateToLandingScreen = useCallback(() => {
-    navigation.navigate(AUTHENTICATION_ROUTES.MAIN, {
-      screen: AUTHENTICATION_ROUTES.LANDING
-    });
-  }, [navigation]);
 
   if (state.status === "failure") {
     return (
-      <>
-        <OperationResultScreenContent
-          action={{
-            label: I18n.t(
-              "authentication.idp_selection.loadingError.primaryAction"
-            ),
-            onPress: navigateToCiePinScreen,
-            testID: "idp-loading-error-primary-action"
-          }}
-          pictogram="umbrella"
-          ref={accessibilityFirstFocuseViewRef}
-          secondaryAction={{
-            label: I18n.t(
-              "authentication.idp_selection.loadingError.secondaryAction"
-            ),
-            onPress: navigateToLandingScreen,
-            testID: "idp-loading-error-secondary-action"
-          }}
-          subtitle={I18n.t(
-            "authentication.idp_selection.loadingError.description"
-          )}
-          title={I18n.t("authentication.idp_selection.loadingError.title")}
-        />
-        {bottomSheet}
-      </>
+      <OneIdentityIdpSelectionFailureContent
+        isActiveSessionLogin={isActiveSessionLogin}
+      />
     );
   }
 

--- a/apps/main-app/ts/features/authentication/login/idp/screens/OneIdentityIdpSelectionScreen.tsx
+++ b/apps/main-app/ts/features/authentication/login/idp/screens/OneIdentityIdpSelectionScreen.tsx
@@ -1,7 +1,10 @@
 import { Banner, useIOToast, VSpacer } from "@io-app/design-system";
+import { useFocusEffect } from "@react-navigation/core";
 import I18n from "i18next";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
+import { View } from "react-native";
 
+import { OperationResultScreenContent } from "../../../../../components/screens/OperationResultScreenContent";
 import { helpCenterHowToLoginWithSpidUrl } from "../../../../../config";
 import { useHeaderSecondLevel } from "../../../../../hooks/useHeaderSecondLevel";
 import { IOStackNavigationRouteProps } from "../../../../../navigation/params/AppParamsList";
@@ -11,6 +14,7 @@ import {
   useIOStore
 } from "../../../../../store/hooks";
 import { assistanceToolConfigSelector } from "../../../../../store/reducers/backendStatus/remoteConfig";
+import { setAccessibilityFocus } from "../../../../../utils/accessibility";
 import { trackHelpCenterCtaTapped } from "../../../../../utils/analytics";
 import { useOnFirstRender } from "../../../../../utils/hooks/useOnFirstRender";
 import { SpidIdp } from "../../../../../utils/idps";
@@ -19,10 +23,15 @@ import {
   handleSendAssistanceLog
 } from "../../../../../utils/supportAssistance";
 import { openWebUrl } from "../../../../../utils/url";
+import { trackLoginReauthEngagementCieSelected } from "../../../activeSessionLogin/screens/analytics";
 import { setIdpSelectedActiveSessionLogin } from "../../../activeSessionLogin/store/actions";
 import { isActiveSessionLoginSelector } from "../../../activeSessionLogin/store/selectors";
-import { trackSpidLoginIdpSelection } from "../../../common/analytics";
+import {
+  trackCieLoginSelected,
+  trackSpidLoginIdpSelection
+} from "../../../common/analytics";
 import { trackLoginSpidIdpSelected } from "../../../common/analytics/spidAnalytics";
+import { useCieLoginMethodSelection } from "../../../common/hooks/useCieLoginMethodSelection";
 import { AuthenticationParamsList } from "../../../common/navigation/params/AuthenticationParamsList";
 import { AUTHENTICATION_ROUTES } from "../../../common/navigation/routes";
 import { idpSelected } from "../../../common/store/actions";
@@ -39,6 +48,8 @@ export const OneIdentityIdpSelectionScreen = ({
   navigation,
   route
 }: OneIdentityIdpSelectionScreenProps) => {
+  const accessibilityFirstFocuseViewRef = useRef<View>(null);
+
   const dispatch = useIODispatch();
   const store = useIOStore();
   const toast = useIOToast();
@@ -48,6 +59,11 @@ export const OneIdentityIdpSelectionScreen = ({
   const { state } = useGetIdps();
 
   const loginFlow = isActiveSessionLogin ? "reauth" : "auth";
+  const {
+    bottomSheet,
+    dismiss: dismissBottomSheet,
+    handleCieLoginRequested
+  } = useCieLoginMethodSelection({ mode: loginFlow });
   const choosenTool = assistanceToolRemoteConfig(assistanceToolConfig);
 
   const shuffledIdps = useMemo(() => {
@@ -63,7 +79,7 @@ export const OneIdentityIdpSelectionScreen = ({
 
   useHeaderSecondLevel(
     state.status === "failure"
-      ? { title: "", supportRequest: false, canGoBack: false }
+      ? { title: "", headerShown: false }
       : { title: "", supportRequest: true }
   );
 
@@ -113,10 +129,57 @@ export const OneIdentityIdpSelectionScreen = ({
   );
 
   const ListEmptyComponent = useCallback(() => <IdpsGridSkeleton />, []);
+  useFocusEffect(
+    useCallback(() => {
+      setAccessibilityFocus(accessibilityFirstFocuseViewRef);
 
-  // TODO: handle error state and show a proper error message
+      return dismissBottomSheet;
+    }, [dismissBottomSheet])
+  );
+
+  const navigateToCiePinScreen = useCallback(() => {
+    if (isActiveSessionLogin) {
+      void trackLoginReauthEngagementCieSelected();
+    } else {
+      void trackCieLoginSelected();
+    }
+    handleCieLoginRequested();
+  }, [isActiveSessionLogin, handleCieLoginRequested]);
+
+  const navigateToLandingScreen = useCallback(() => {
+    navigation.navigate(AUTHENTICATION_ROUTES.MAIN, {
+      screen: AUTHENTICATION_ROUTES.LANDING
+    });
+  }, [navigation]);
+
   if (state.status === "failure") {
-    return null;
+    return (
+      <>
+        <OperationResultScreenContent
+          action={{
+            label: I18n.t(
+              "authentication.idp_selection.loadingError.primaryAction"
+            ),
+            onPress: navigateToCiePinScreen,
+            testID: "idp-loading-error-primary-action"
+          }}
+          pictogram="umbrella"
+          ref={accessibilityFirstFocuseViewRef}
+          secondaryAction={{
+            label: I18n.t(
+              "authentication.idp_selection.loadingError.secondaryAction"
+            ),
+            onPress: navigateToLandingScreen,
+            testID: "idp-loading-error-secondary-action"
+          }}
+          subtitle={I18n.t(
+            "authentication.idp_selection.loadingError.description"
+          )}
+          title={I18n.t("authentication.idp_selection.loadingError.title")}
+        />
+        {bottomSheet}
+      </>
+    );
   }
 
   return (

--- a/apps/main-app/ts/features/authentication/login/idp/screens/__test__/OneIdentityIdpSelectionScreen.test.tsx
+++ b/apps/main-app/ts/features/authentication/login/idp/screens/__test__/OneIdentityIdpSelectionScreen.test.tsx
@@ -9,7 +9,9 @@ import * as IOHooks from "../../../../../../store/hooks";
 import { appReducer } from "../../../../../../store/reducers";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper";
+import * as activeSessionLoginAnalytics from "../../../../activeSessionLogin/screens/analytics";
 import { setIdpSelectedActiveSessionLogin } from "../../../../activeSessionLogin/store/actions";
+import * as commonAnalytics from "../../../../common/analytics";
 import * as analytics from "../../../../common/analytics/spidAnalytics";
 import { AUTHENTICATION_ROUTES } from "../../../../common/navigation/routes";
 import { idpSelected } from "../../../../common/store/actions";
@@ -20,6 +22,21 @@ const mockUseGetIdps = jest.fn();
 jest.mock("../../hooks/useGetIdps", () => ({
   useGetIdps: () => mockUseGetIdps()
 }));
+
+const mockNavigateToCiePinInsertion = jest.fn();
+const mockNavigateToCieIdLoginScreen = jest.fn();
+jest.mock("../../../hooks/useNavigateToLoginMethod", () => ({
+  __esModule: true,
+  default: () => ({
+    navigateToCiePinInsertion: mockNavigateToCiePinInsertion,
+    navigateToCieIdLoginScreen: mockNavigateToCieIdLoginScreen,
+    isCieSupported: true
+  })
+}));
+
+jest.mock("@gorhom/bottom-sheet", () =>
+  jest.requireActual("../../../../../../__mocks__/@gorhom/bottom-sheet")
+);
 
 const mockNavigate = jest.fn();
 
@@ -59,7 +76,7 @@ describe("OneIdentityIdpSelectionScreen", () => {
     expect(skeletonItems.length).toBe(5);
   });
 
-  it("should render nothing when the fetch fails", () => {
+  it("should render the loading error screen when the fetch fails", () => {
     mockUseGetIdps.mockReturnValue({
       state: { status: "failure", error: new Error("network error") }
     });
@@ -67,6 +84,73 @@ describe("OneIdentityIdpSelectionScreen", () => {
     const { queryByTestId } = renderComponent();
 
     expect(queryByTestId("idps-grid")).toBeNull();
+    expect(queryByTestId("idp-loading-error-primary-action")).toBeTruthy();
+    expect(queryByTestId("idp-loading-error-secondary-action")).toBeTruthy();
+  });
+
+  it("should navigate to the landing screen when pressing the secondary action on the loading error screen", () => {
+    mockUseGetIdps.mockReturnValue({
+      state: { status: "failure", error: new Error("network error") }
+    });
+
+    const { getByTestId } = renderComponent();
+
+    fireEvent.press(getByTestId("idp-loading-error-secondary-action"));
+
+    expect(mockNavigate).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
+      screen: AUTHENTICATION_ROUTES.LANDING
+    });
+  });
+
+  it("should track trackCieLoginSelected and open the CIE bottom sheet when pressing the primary action on the loading error screen while not in an active session", () => {
+    jest
+      .spyOn(commonAnalytics, "trackCieLoginSelected")
+      .mockImplementation(jest.fn());
+    jest
+      .spyOn(
+        activeSessionLoginAnalytics,
+        "trackLoginReauthEngagementCieSelected"
+      )
+      .mockImplementation(jest.fn());
+
+    mockUseGetIdps.mockReturnValue({
+      state: { status: "failure", error: new Error("network error") }
+    });
+
+    const { getByTestId } = renderComponent();
+
+    fireEvent.press(getByTestId("idp-loading-error-primary-action"));
+
+    expect(commonAnalytics.trackCieLoginSelected).toHaveBeenCalled();
+    expect(
+      activeSessionLoginAnalytics.trackLoginReauthEngagementCieSelected
+    ).not.toHaveBeenCalled();
+    expect(getByTestId("bottom-sheet-login-with-cie-pin")).toBeTruthy();
+  });
+
+  it("should track trackLoginReauthEngagementCieSelected when pressing the primary action on the loading error screen during an active session", () => {
+    jest
+      .spyOn(commonAnalytics, "trackCieLoginSelected")
+      .mockImplementation(jest.fn());
+    jest
+      .spyOn(
+        activeSessionLoginAnalytics,
+        "trackLoginReauthEngagementCieSelected"
+      )
+      .mockImplementation(jest.fn());
+
+    mockUseGetIdps.mockReturnValue({
+      state: { status: "failure", error: new Error("network error") }
+    });
+
+    const { getByTestId } = renderComponent({ isActiveSessionLogin: true });
+
+    fireEvent.press(getByTestId("idp-loading-error-primary-action"));
+
+    expect(
+      activeSessionLoginAnalytics.trackLoginReauthEngagementCieSelected
+    ).toHaveBeenCalled();
+    expect(commonAnalytics.trackCieLoginSelected).not.toHaveBeenCalled();
   });
 
   it("should render the fetched IDPs on success", () => {

--- a/apps/main-app/ts/features/authentication/login/idp/screens/__test__/OneIdentityIdpSelectionScreen.test.tsx
+++ b/apps/main-app/ts/features/authentication/login/idp/screens/__test__/OneIdentityIdpSelectionScreen.test.tsx
@@ -9,9 +9,7 @@ import * as IOHooks from "../../../../../../store/hooks";
 import { appReducer } from "../../../../../../store/reducers";
 import { GlobalState } from "../../../../../../store/reducers/types";
 import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper";
-import * as activeSessionLoginAnalytics from "../../../../activeSessionLogin/screens/analytics";
 import { setIdpSelectedActiveSessionLogin } from "../../../../activeSessionLogin/store/actions";
-import * as commonAnalytics from "../../../../common/analytics";
 import * as analytics from "../../../../common/analytics/spidAnalytics";
 import { AUTHENTICATION_ROUTES } from "../../../../common/navigation/routes";
 import { idpSelected } from "../../../../common/store/actions";
@@ -23,20 +21,15 @@ jest.mock("../../hooks/useGetIdps", () => ({
   useGetIdps: () => mockUseGetIdps()
 }));
 
-const mockNavigateToCiePinInsertion = jest.fn();
-const mockNavigateToCieIdLoginScreen = jest.fn();
-jest.mock("../../../hooks/useNavigateToLoginMethod", () => ({
-  __esModule: true,
-  default: () => ({
-    navigateToCiePinInsertion: mockNavigateToCiePinInsertion,
-    navigateToCieIdLoginScreen: mockNavigateToCieIdLoginScreen,
-    isCieSupported: true
-  })
-}));
-
-jest.mock("@gorhom/bottom-sheet", () =>
-  jest.requireActual("../../../../../../__mocks__/@gorhom/bottom-sheet")
+const mockOneIdentityIdpSelectionFailureContent = jest.fn(
+  (_props: { isActiveSessionLogin: boolean }) =>
+    "OneIdentityIdpSelectionFailureContent"
 );
+jest.mock("../../components/OneIdentityIdpSelectionFailureContent", () => ({
+  OneIdentityIdpSelectionFailureContent: (props: {
+    isActiveSessionLogin: boolean;
+  }) => mockOneIdentityIdpSelectionFailureContent(props)
+}));
 
 const mockNavigate = jest.fn();
 
@@ -76,7 +69,7 @@ describe("OneIdentityIdpSelectionScreen", () => {
     expect(skeletonItems.length).toBe(5);
   });
 
-  it("should render the loading error screen when the fetch fails", () => {
+  it("should render the loading error content when the fetch fails", () => {
     mockUseGetIdps.mockReturnValue({
       state: { status: "failure", error: new Error("network error") }
     });
@@ -84,73 +77,21 @@ describe("OneIdentityIdpSelectionScreen", () => {
     const { queryByTestId } = renderComponent();
 
     expect(queryByTestId("idps-grid")).toBeNull();
-    expect(queryByTestId("idp-loading-error-primary-action")).toBeTruthy();
-    expect(queryByTestId("idp-loading-error-secondary-action")).toBeTruthy();
+    expect(mockOneIdentityIdpSelectionFailureContent.mock.calls[0][0]).toEqual({
+      isActiveSessionLogin: false
+    });
   });
 
-  it("should navigate to the landing screen when pressing the secondary action on the loading error screen", () => {
+  it("should pass isActiveSessionLogin to the failure content when the fetch fails during an active session", () => {
     mockUseGetIdps.mockReturnValue({
       state: { status: "failure", error: new Error("network error") }
     });
 
-    const { getByTestId } = renderComponent();
+    renderComponent({ isActiveSessionLogin: true });
 
-    fireEvent.press(getByTestId("idp-loading-error-secondary-action"));
-
-    expect(mockNavigate).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
-      screen: AUTHENTICATION_ROUTES.LANDING
+    expect(mockOneIdentityIdpSelectionFailureContent.mock.calls[0][0]).toEqual({
+      isActiveSessionLogin: true
     });
-  });
-
-  it("should track trackCieLoginSelected and open the CIE bottom sheet when pressing the primary action on the loading error screen while not in an active session", () => {
-    jest
-      .spyOn(commonAnalytics, "trackCieLoginSelected")
-      .mockImplementation(jest.fn());
-    jest
-      .spyOn(
-        activeSessionLoginAnalytics,
-        "trackLoginReauthEngagementCieSelected"
-      )
-      .mockImplementation(jest.fn());
-
-    mockUseGetIdps.mockReturnValue({
-      state: { status: "failure", error: new Error("network error") }
-    });
-
-    const { getByTestId } = renderComponent();
-
-    fireEvent.press(getByTestId("idp-loading-error-primary-action"));
-
-    expect(commonAnalytics.trackCieLoginSelected).toHaveBeenCalled();
-    expect(
-      activeSessionLoginAnalytics.trackLoginReauthEngagementCieSelected
-    ).not.toHaveBeenCalled();
-    expect(getByTestId("bottom-sheet-login-with-cie-pin")).toBeTruthy();
-  });
-
-  it("should track trackLoginReauthEngagementCieSelected when pressing the primary action on the loading error screen during an active session", () => {
-    jest
-      .spyOn(commonAnalytics, "trackCieLoginSelected")
-      .mockImplementation(jest.fn());
-    jest
-      .spyOn(
-        activeSessionLoginAnalytics,
-        "trackLoginReauthEngagementCieSelected"
-      )
-      .mockImplementation(jest.fn());
-
-    mockUseGetIdps.mockReturnValue({
-      state: { status: "failure", error: new Error("network error") }
-    });
-
-    const { getByTestId } = renderComponent({ isActiveSessionLogin: true });
-
-    fireEvent.press(getByTestId("idp-loading-error-primary-action"));
-
-    expect(
-      activeSessionLoginAnalytics.trackLoginReauthEngagementCieSelected
-    ).toHaveBeenCalled();
-    expect(commonAnalytics.trackCieLoginSelected).not.toHaveBeenCalled();
   });
 
   it("should render the fetched IDPs on success", () => {

--- a/apps/main-app/ts/features/authentication/login/idp/screens/__test__/OneIdentityIdpSelectionScreen.test.tsx
+++ b/apps/main-app/ts/features/authentication/login/idp/screens/__test__/OneIdentityIdpSelectionScreen.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent } from "@testing-library/react-native";
 import I18n from "i18next";
 import _, { merge } from "lodash";
 import { ComponentProps } from "react";
+import { View } from "react-native";
 import { createStore } from "redux";
 
 import { applicationChangeState } from "../../../../../../store/actions/application";
@@ -13,6 +14,7 @@ import { setIdpSelectedActiveSessionLogin } from "../../../../activeSessionLogin
 import * as analytics from "../../../../common/analytics/spidAnalytics";
 import { AUTHENTICATION_ROUTES } from "../../../../common/navigation/routes";
 import { idpSelected } from "../../../../common/store/actions";
+import { OneIdentityIdpSelectionFailureContent } from "../../components/OneIdentityIdpSelectionFailureContent";
 import { Idps } from "../../types/idps";
 import { OneIdentityIdpSelectionScreen } from "../OneIdentityIdpSelectionScreen";
 
@@ -21,15 +23,12 @@ jest.mock("../../hooks/useGetIdps", () => ({
   useGetIdps: () => mockUseGetIdps()
 }));
 
-const mockOneIdentityIdpSelectionFailureContent = jest.fn(
-  (_props: { isActiveSessionLogin: boolean }) =>
-    "OneIdentityIdpSelectionFailureContent"
+jest.mock("../../components/OneIdentityIdpSelectionFailureContent");
+const mockedOneIdentityIdpSelectionFailureContent =
+  OneIdentityIdpSelectionFailureContent as jest.Mock;
+mockedOneIdentityIdpSelectionFailureContent.mockReturnValue(
+  <View testID="one-identity-idp-selection-failure-content" />
 );
-jest.mock("../../components/OneIdentityIdpSelectionFailureContent", () => ({
-  OneIdentityIdpSelectionFailureContent: (props: {
-    isActiveSessionLogin: boolean;
-  }) => mockOneIdentityIdpSelectionFailureContent(props)
-}));
 
 const mockNavigate = jest.fn();
 
@@ -74,24 +73,12 @@ describe("OneIdentityIdpSelectionScreen", () => {
       state: { status: "failure", error: new Error("network error") }
     });
 
-    const { queryByTestId } = renderComponent();
+    const { queryByTestId, getByTestId } = renderComponent();
 
     expect(queryByTestId("idps-grid")).toBeNull();
-    expect(mockOneIdentityIdpSelectionFailureContent.mock.calls[0][0]).toEqual({
-      isActiveSessionLogin: false
-    });
-  });
-
-  it("should pass isActiveSessionLogin to the failure content when the fetch fails during an active session", () => {
-    mockUseGetIdps.mockReturnValue({
-      state: { status: "failure", error: new Error("network error") }
-    });
-
-    renderComponent({ isActiveSessionLogin: true });
-
-    expect(mockOneIdentityIdpSelectionFailureContent.mock.calls[0][0]).toEqual({
-      isActiveSessionLogin: true
-    });
+    expect(
+      getByTestId("one-identity-idp-selection-failure-content")
+    ).toBeTruthy();
   });
 
   it("should render the fetched IDPs on success", () => {

--- a/apps/main-app/ts/features/authentication/login/landing/__tests__/LandingScreen.test.tsx
+++ b/apps/main-app/ts/features/authentication/login/landing/__tests__/LandingScreen.test.tsx
@@ -5,7 +5,6 @@ import { applicationChangeState } from "../../../../../store/actions/application
 import { appReducer } from "../../../../../store/reducers";
 import { renderScreenWithNavigationStoreContext } from "../../../../../utils/testWrapper";
 import { AUTHENTICATION_ROUTES } from "../../../common/navigation/routes";
-import { AUTH_LEVELS } from "../../../common/utils";
 import { LandingScreen } from "../screens/LandingScreen";
 
 const mockNavigateToCiePinInsertion = jest.fn();
@@ -51,7 +50,7 @@ describe(LandingScreen, () => {
 
     expect(component).toMatchSnapshot();
   });
-  it("Should present the modal", async () => {
+  it("Should not navigate anywhere when the CIE button is pressed and CIE is supported", async () => {
     const { getByTestId } = renderComponent();
 
     const loginWithCie = getByTestId("landing-button-login-cie");
@@ -62,71 +61,6 @@ describe(LandingScreen, () => {
     expect(mockNavigateToCiePinInsertion).not.toHaveBeenCalled();
     expect(mockNavigateToIdpSelection).not.toHaveBeenCalled();
     expect(mockNavigateToCieIdLoginScreen).not.toHaveBeenCalled();
-  });
-  it("Should call navigateToCiePinInsertion", async () => {
-    const { getByTestId } = renderComponent();
-
-    const loginWithCie = getByTestId("landing-button-login-cie");
-    await act(async () => {
-      fireEvent.press(loginWithCie);
-    });
-
-    expect(mockNavigateToCiePinInsertion).not.toHaveBeenCalled();
-    expect(mockNavigateToIdpSelection).not.toHaveBeenCalled();
-    expect(mockNavigateToCieIdLoginScreen).not.toHaveBeenCalled();
-
-    const loginWithCiePin = getByTestId("bottom-sheet-login-with-cie-pin");
-    await act(async () => {
-      fireEvent.press(loginWithCiePin);
-    });
-
-    expect(mockNavigateToIdpSelection).not.toHaveBeenCalled();
-    expect(mockNavigateToCieIdLoginScreen).not.toHaveBeenCalled();
-    expect(mockNavigateToCiePinInsertion).toHaveBeenCalled();
-  });
-  it("Should call navigateToCieIdLoginScreen", async () => {
-    const { getByTestId } = renderComponent();
-
-    const loginWithCie = getByTestId("landing-button-login-cie");
-    await act(async () => {
-      fireEvent.press(loginWithCie);
-    });
-
-    expect(mockNavigateToCiePinInsertion).not.toHaveBeenCalled();
-    expect(mockNavigateToIdpSelection).not.toHaveBeenCalled();
-    expect(mockNavigateToCieIdLoginScreen).not.toHaveBeenCalled();
-
-    const loginWithCieID = getByTestId("bottom-sheet-login-with-cie-id");
-    await act(async () => {
-      fireEvent.press(loginWithCieID);
-    });
-
-    expect(mockNavigateToCiePinInsertion).not.toHaveBeenCalled();
-    expect(mockNavigateToIdpSelection).not.toHaveBeenCalled();
-    expect(mockNavigateToCieIdLoginScreen).toHaveBeenCalledWith(AUTH_LEVELS.L2);
-  });
-  it("Should navigate to the wizards screens", async () => {
-    const { getByTestId } = renderComponent();
-
-    const loginWithCie = getByTestId("landing-button-login-cie");
-    await act(async () => {
-      fireEvent.press(loginWithCie);
-    });
-    expect(mockNavigateToCiePinInsertion).not.toHaveBeenCalled();
-    expect(mockNavigateToIdpSelection).not.toHaveBeenCalled();
-    expect(mockNavigateToCieIdLoginScreen).not.toHaveBeenCalled();
-
-    const wizardsBanner = getByTestId("bottom-sheet-login-wizards");
-    await act(async () => {
-      fireEvent.press(wizardsBanner);
-    });
-
-    expect(mockNavigateToCiePinInsertion).not.toHaveBeenCalled();
-    expect(mockNavigateToIdpSelection).not.toHaveBeenCalled();
-    expect(mockNavigateToCieIdLoginScreen).not.toHaveBeenCalled();
-    expect(mockNavigate).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
-      screen: AUTHENTICATION_ROUTES.CIE_ID_WIZARD
-    });
   });
   it("Should navigate to the idp selection", () => {
     const { getByTestId } = renderComponent();

--- a/apps/main-app/ts/features/authentication/login/landing/screens/LandingScreen.tsx
+++ b/apps/main-app/ts/features/authentication/login/landing/screens/LandingScreen.tsx
@@ -1,8 +1,6 @@
 import {
-  Banner,
   ContentWrapper,
   IOButton,
-  ModuleNavigation,
   useIOToast,
   VSpacer
 } from "@io-app/design-system";
@@ -29,17 +27,12 @@ import { useHeaderSecondLevel } from "../../../../../hooks/useHeaderSecondLevel"
 import { mixpanelTrack } from "../../../../../mixpanel";
 import { useIONavigation } from "../../../../../navigation/params/AppParamsList";
 import { startupLoadSuccess } from "../../../../../store/actions/startup";
-import {
-  useIODispatch,
-  useIOSelector,
-  useIOStore
-} from "../../../../../store/hooks";
+import { useIODispatch, useIOSelector } from "../../../../../store/hooks";
 import { continueWithRootOrJailbreakSelector } from "../../../../../store/reducers/persistedPreferences";
 import { StartupStatusEnum } from "../../../../../store/reducers/startup";
 import { setAccessibilityFocus } from "../../../../../utils/accessibility";
 import { trackHelpCenterCtaTapped } from "../../../../../utils/analytics";
 import { isTablet } from "../../../../../utils/device";
-import { useIOBottomSheetModal } from "../../../../../utils/hooks/bottomSheet";
 import { useOnFirstRender } from "../../../../../utils/hooks/useOnFirstRender";
 import { openWebUrl } from "../../../../../utils/url";
 import { identificationRequest } from "../../../../identification/store/actions";
@@ -47,14 +40,11 @@ import { setOfflineAccessReason } from "../../../../ingress/store/actions";
 import { OfflineAccessReasonEnum } from "../../../../ingress/store/reducer";
 import { itwOfflineAccessAvailableSelector } from "../../../../itwallet/common/store/selectors";
 import {
-  loginCieWizardSelected,
-  trackCieBottomSheetScreenView,
-  trackCieIDLoginSelected,
   trackCieLoginSelected,
-  trackCiePinLoginSelected,
   trackSpidLoginSelected
 } from "../../../common/analytics";
 import { Carousel } from "../../../common/components/Carousel";
+import { useCieLoginMethodSelection } from "../../../common/hooks/useCieLoginMethodSelection";
 import { AUTHENTICATION_ROUTES } from "../../../common/navigation/routes";
 import {
   sessionCorrupted,
@@ -64,7 +54,6 @@ import {
   isSessionCorruptedSelector,
   isSessionExpiredSelector
 } from "../../../common/store/selectors";
-import { AUTH_LEVELS, AuthLevel } from "../../../common/utils";
 import { isCieLoginUatEnabledSelector } from "../../cie/store/selectors";
 import useNavigateToLoginMethod from "../../hooks/useNavigateToLoginMethod";
 import { LandingSessionExpiredComponent } from "../components/LandingSessionExpiredComponent";
@@ -72,7 +61,6 @@ import { useInfoBottomsheetComponent } from "../hooks/useInfoBottomsheetComponen
 
 const SPACE_BETWEEN_BUTTONS = 8;
 const SPACE_AROUND_BUTTON_LINK = 16;
-const AUTH_LEVEL_L2: AuthLevel = AUTH_LEVELS.L2;
 
 /**
  * A screen where the user can choose to login with SPID or get more informations.
@@ -80,93 +68,21 @@ const AUTH_LEVEL_L2: AuthLevel = AUTH_LEVELS.L2;
  */
 export const LandingScreen = () => {
   const { error } = useIOToast();
-  const store = useIOStore();
 
   const itwOfflineAccessAvailable = useIOSelector(
     itwOfflineAccessAvailableSelector
   );
   const accessibilityFirstFocuseViewRef = useRef<View>(null);
+  const { navigateToIdpSelection } = useNavigateToLoginMethod();
+
   const {
-    navigateToIdpSelection,
-    navigateToCiePinInsertion,
-    navigateToCieIdLoginScreen,
-    isCieSupported
-  } = useNavigateToLoginMethod();
-
-  const handleNavigateToCiePinScreen = useCallback(() => {
-    void trackCiePinLoginSelected(store.getState());
-    navigateToCiePinInsertion();
-  }, [store, navigateToCiePinInsertion]);
-
-  const handleNavigateToCieIdLoginScreen = useCallback(() => {
-    void trackCieIDLoginSelected(store.getState(), AUTH_LEVEL_L2);
-    navigateToCieIdLoginScreen(AUTH_LEVEL_L2);
-  }, [store, navigateToCieIdLoginScreen]);
+    bottomSheet,
+    dismiss: dismissBottomSheet,
+    handleCieLoginRequested
+  } = useCieLoginMethodSelection({ mode: "auth" });
 
   const { presentInfoBottomsheet, infoBottomsheetComponent } =
     useInfoBottomsheetComponent();
-
-  const {
-    present,
-    dismiss: dismissBottomSheet,
-    bottomSheet
-  } = useIOBottomSheetModal({
-    title: I18n.t("authentication.landing.cie_bottom_sheet.title"),
-    component: (
-      <View>
-        <ModuleNavigation
-          icon="fiscalCodeIndividual"
-          onPress={handleNavigateToCiePinScreen}
-          subtitle={I18n.t(
-            "authentication.landing.cie_bottom_sheet.module_cie_pin.subtitle"
-          )}
-          testID="bottom-sheet-login-with-cie-pin"
-          title={I18n.t(
-            "authentication.landing.cie_bottom_sheet.module_cie_pin.title"
-          )}
-        />
-        <VSpacer size={8} />
-        <ModuleNavigation
-          badge={{
-            variant: "highlight",
-            text: I18n.t(
-              "authentication.landing.cie_bottom_sheet.module_cie_id.badge"
-            )
-          }}
-          icon="device"
-          onPress={handleNavigateToCieIdLoginScreen}
-          subtitle={I18n.t(
-            "authentication.landing.cie_bottom_sheet.module_cie_id.subtitle"
-          )}
-          testID="bottom-sheet-login-with-cie-id"
-          title={I18n.t(
-            "authentication.landing.cie_bottom_sheet.module_cie_id.title"
-          )}
-        />
-        <VSpacer size={24} />
-        <Banner
-          action={I18n.t(
-            "authentication.landing.cie_bottom_sheet.help_banner.action"
-          )}
-          color="turquoise"
-          onPress={() => {
-            void loginCieWizardSelected();
-
-            navigation.navigate(AUTHENTICATION_ROUTES.MAIN, {
-              screen: AUTHENTICATION_ROUTES.CIE_ID_WIZARD
-            });
-          }}
-          pictogramName="help"
-          testID="bottom-sheet-login-wizards"
-          title={I18n.t(
-            "authentication.landing.cie_bottom_sheet.help_banner.title"
-          )}
-        />
-        <VSpacer />
-      </View>
-    ),
-    snapPoint: [400]
-  });
 
   const [isRootedOrJailbroken, setIsRootedOrJailbroken] = useState<
     O.Option<boolean>
@@ -220,13 +136,8 @@ export const LandingScreen = () => {
 
   const navigateToCiePinScreen = useCallback(() => {
     void trackCieLoginSelected();
-    if (isCieSupported) {
-      void trackCieBottomSheetScreenView();
-      present();
-    } else {
-      handleNavigateToCieIdLoginScreen();
-    }
-  }, [present, isCieSupported, handleNavigateToCieIdLoginScreen]);
+    handleCieLoginRequested();
+  }, [handleCieLoginRequested]);
 
   const navigateToLoginConfigScreen = useCallback(() => {
     navigation.navigate(AUTHENTICATION_ROUTES.MAIN, {

--- a/apps/main-app/ts/features/authentication/login/landing/screens/LandingScreen.tsx
+++ b/apps/main-app/ts/features/authentication/login/landing/screens/LandingScreen.tsx
@@ -79,7 +79,7 @@ export const LandingScreen = () => {
     bottomSheet,
     dismiss: dismissBottomSheet,
     handleCieLoginRequested
-  } = useCieLoginMethodSelection({ mode: "auth" });
+  } = useCieLoginMethodSelection({ flow: "auth" });
 
   const { presentInfoBottomsheet, infoBottomsheetComponent } =
     useInfoBottomsheetComponent();


### PR DESCRIPTION
## Short description
Adds a proper error screen when the Identity Provider list fails to load, with a CIE-based fallback so the user is not stuck. As a preliminary step, extracts the duplicated CIE login method bottom sheet (shared by `LandingScreen` and `ActiveSessionLandingScreen`) into a reusable hook, which is then reused here too.

## List of changes proposed in this pull request

- Extract `useCieLoginMethodSelection` hook: encapsulates the CIE PIN/CIE ID bottom sheet (title, options, wizard banner) and the auth/reauth-aware analytics that were previously duplicated identically in `LandingScreen` and `ActiveSessionLandingScreen`
- Migrate `LandingScreen` and `ActiveSessionLandingScreen` to the new hook
- Implement the loading-error state in `OneIdentityIdpSelectionScreen` : shows `OperationResultScreenContent` with a primary action to log in with CIE (via the shared hook) and a secondary action back to the landing screen
- Track the CIE button press on the error screen with the correct auth/reauth-aware analytics event, mirroring the existing landing screens
- Add Italian copy for the new error screen `(authentication.idp_selection.loadingError.*`)
- Add/update tests: new `useCieLoginMethodSelection` test suite, slimmed down `LandingScreen`/`ActiveSessionLandingScreen` tests, new `OneIdentityIdpSelectionScreen` tests covering the error screen and its auth/reauth tracking

## How to test

- `pnpm nx run main-app:test-dev`
- Force the IDP list to fail loading and verify: the error screen appears, the CIE button opens the bottom sheet (or navigates directly to CIE ID), and the secondary button navigates back to the landing screen
- Repeat during an active session (reauth) and verify the tracking is correct
- Verify both landing screens still open the same, unchanged CIE bottom sheet
