### PR TITLE
chore(IT-Wallet): [SIW-5014] Bump `io-react-native-wallet` from `3.7.1` to `3.7.2`

### DIFF
--- a/apps/main-app/package.json
+++ b/apps/main-app/package.json
@@ -59,7 +59,7 @@
     "@pagopa/io-react-native-jwt": "^2.2.0",
     "@pagopa/io-react-native-login-utils": "1.2.0",
     "@pagopa/io-react-native-secure-storage": "^0.2.1",
-    "@pagopa/io-react-native-wallet": "3.7.1",
+    "@pagopa/io-react-native-wallet": "3.7.2",
     "@pagopa/io-react-native-zendesk": "^0.3.30",
     "@pagopa/react-native-cie": "^1.5.0",
     "@pagopa/ts-commons": "^10.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -388,8 +388,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1(react-native@0.83.10(@babel/core@7.29.0(supports-color@8.1.1))(@react-native-community/cli@20.0.0(supports-color@8.1.1)(typescript@6.0.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.16)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
       '@pagopa/io-react-native-wallet':
-        specifier: 3.7.1
-        version: 3.7.1(93ee64fd53d75631576dc5558ab8691c)
+        specifier: 3.7.2
+        version: 3.7.2(93ee64fd53d75631576dc5558ab8691c)
       '@pagopa/io-react-native-zendesk':
         specifier: ^0.3.30
         version: 0.3.30(react-native@0.83.10(@babel/core@7.29.0(supports-color@8.1.1))(@react-native-community/cli@20.0.0(supports-color@8.1.1)(typescript@6.0.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.16)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
@@ -3311,8 +3311,8 @@ packages:
       react: '*'
       react-native: '*'
 
-  '@pagopa/io-react-native-wallet@3.7.1':
-    resolution: {integrity: sha512-hJVWnHOqscraXvZN8hlnd+uU9x747rSefy9t5izHE1Ov3Vyl9dVeOtzU6Azjsxp/5ikEp3ult9Pu3ig3d4PE7g==}
+  '@pagopa/io-react-native-wallet@3.7.2':
+    resolution: {integrity: sha512-4/+BlheeWvKsUgcg7pcOmoX/epJAha2bIsYofI+GXPhCLLxA2K1QYYtnNxX7YP1gzDrcbPDX4giKlIPmH1zKUw==}
     engines: {node: '>= 16.0.0'}
     peerDependencies:
       '@pagopa/io-react-native-crypto': '*'
@@ -3329,20 +3329,20 @@ packages:
       react: '*'
       react-native: '*'
 
-  '@pagopa/io-wallet-oauth2@1.5.4':
-    resolution: {integrity: sha512-LPNoZbrSc/Nj0ax5hAO6+r+lQnRPMDabmKPSFhS5bhc7685h5kW2KuC4QjS1Y6HyBvKgZeYohYW9BDcbbPfm1g==}
+  '@pagopa/io-wallet-oauth2@1.5.6':
+    resolution: {integrity: sha512-7/4Hw/BKxsPqnnbUkv/IwjrHeuIFISbxmxdXWvN2NdTPte+eL+UFMMkzH6MgYDwJbshd9DaJQlVQgECGZHEWFw==}
 
-  '@pagopa/io-wallet-oid-federation@1.5.4':
-    resolution: {integrity: sha512-G3HWvDBl1favjWuFDg+OAcLu99NFuf9ZNCmONejbWOVXbzhvzTCl4k6qCEY3GtwMaMdVP11lUdkfYbNowOoWCg==}
+  '@pagopa/io-wallet-oid-federation@1.5.6':
+    resolution: {integrity: sha512-ZdvLdEi1sqLg6we6Ca/wI99V1b6KCjYGZHzYYeRSCm1vyk7E0Du91HlZ4IYCYQ4+tfbQ+8amfHSh6uklM4+U7A==}
 
-  '@pagopa/io-wallet-oid4vci@1.5.4':
-    resolution: {integrity: sha512-dapcXkVpD0wqxHZwhQUrJtE1eST0fRTxAuqrHzgU5XQo4fiEPfpse39uPRu+rec7kKVZbx7gw0uhoqVFLgGdaw==}
+  '@pagopa/io-wallet-oid4vci@1.5.6':
+    resolution: {integrity: sha512-+lMK3xuPRanduGfLlgtCydyPctnqn+3ulrGckvWviJ7iV6Xsxp1DVVTqets4UJUPMXX143sAldRZmvD5NtN1LQ==}
 
-  '@pagopa/io-wallet-oid4vp@1.5.4':
-    resolution: {integrity: sha512-QnVkEHVNUHMQnUTxAaAVHkK06PjPTsF9g1EUNOxr/KsATjYa5exN5dz31lNdl7DupIBX/ponBS7pRxDsTMdxpw==}
+  '@pagopa/io-wallet-oid4vp@1.5.6':
+    resolution: {integrity: sha512-NrZBw92v/vLX0BnvoxeNzIxBDbdUdRXv1xIlY2D+sreNGhGzeidCaMgWJpFKoSNiYOPWOFZiqBcA6ozho35h9w==}
 
-  '@pagopa/io-wallet-utils@1.5.4':
-    resolution: {integrity: sha512-wX1WGFQedLJutBGOcz7QdQqp7N710ii/MEITJypxfiaJQFsXTUZUsux4ZWH1FYPhZUC6WVBX+0s+APyRRsZCew==}
+  '@pagopa/io-wallet-utils@1.5.6':
+    resolution: {integrity: sha512-T0UjR7P5fqE7IRAa7GUFFRfSFsd1GbsAy1XUx9cckVKd8dysFoOpW94i74Yuzo3iZRi9nVSn5Q3uuem1du7kLA==}
 
   '@pagopa/openapi-codegen-ts@14.2.0':
     resolution: {integrity: sha512-sop1+MxfLP2Od2sxDvHxJ7poVmZKBP0REVMQDPrCpNe9Wv1vvLJN8WqonUjkLfL3fLmKM0B6AS4B67Nigm1uKA==}
@@ -15517,16 +15517,16 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.10(@babel/core@7.29.0(supports-color@8.1.1))(@react-native-community/cli@20.0.0(supports-color@8.1.1)(typescript@6.0.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.16)(react@19.2.0)(supports-color@8.1.1)
 
-  '@pagopa/io-react-native-wallet@3.7.1(93ee64fd53d75631576dc5558ab8691c)':
+  '@pagopa/io-react-native-wallet@3.7.2(93ee64fd53d75631576dc5558ab8691c)':
     dependencies:
       '@pagopa/io-react-native-crypto': 1.2.5(react-native@0.83.10(@babel/core@7.29.0(supports-color@8.1.1))(@react-native-community/cli@20.0.0(supports-color@8.1.1)(typescript@6.0.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.16)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
       '@pagopa/io-react-native-iso18013': 0.8.4(react-native@0.83.10(@babel/core@7.29.0(supports-color@8.1.1))(@react-native-community/cli@20.0.0(supports-color@8.1.1)(typescript@6.0.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.16)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
       '@pagopa/io-react-native-jwt': 2.2.0(react-native@0.83.10(@babel/core@7.29.0(supports-color@8.1.1))(@react-native-community/cli@20.0.0(supports-color@8.1.1)(typescript@6.0.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.16)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
-      '@pagopa/io-wallet-oauth2': 1.5.4
-      '@pagopa/io-wallet-oid-federation': 1.5.4
-      '@pagopa/io-wallet-oid4vci': 1.5.4
-      '@pagopa/io-wallet-oid4vp': 1.5.4
-      '@pagopa/io-wallet-utils': 1.5.4
+      '@pagopa/io-wallet-oauth2': 1.5.6
+      '@pagopa/io-wallet-oid-federation': 1.5.6
+      '@pagopa/io-wallet-oid4vci': 1.5.6
+      '@pagopa/io-wallet-oid4vp': 1.5.6
+      '@pagopa/io-wallet-utils': 1.5.6
       '@sd-jwt/core': 0.19.0
       '@sd-jwt/crypto-nodejs': 0.19.0
       '@sd-jwt/jwt-status-list': 0.19.0
@@ -15550,43 +15550,43 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.10(@babel/core@7.29.0(supports-color@8.1.1))(@react-native-community/cli@20.0.0(supports-color@8.1.1)(typescript@6.0.3))(@react-native/metro-config@0.83.10(@babel/core@7.29.0(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.16)(react@19.2.0)(supports-color@8.1.1)
 
-  '@pagopa/io-wallet-oauth2@1.5.4':
+  '@pagopa/io-wallet-oauth2@1.5.6':
     dependencies:
       '@openid4vc/oauth2': 0.4.3
       '@openid4vc/utils': 0.4.3
-      '@pagopa/io-wallet-oid-federation': 1.5.4
-      '@pagopa/io-wallet-utils': 1.5.4
+      '@pagopa/io-wallet-oid-federation': 1.5.6
+      '@pagopa/io-wallet-utils': 1.5.6
       js-base64: 3.7.8
       zod: 4.3.6
 
-  '@pagopa/io-wallet-oid-federation@1.5.4':
+  '@pagopa/io-wallet-oid-federation@1.5.6':
     dependencies:
-      '@pagopa/io-wallet-utils': 1.5.4
+      '@pagopa/io-wallet-utils': 1.5.6
       buffer: 6.0.3
       zod: 4.3.6
 
-  '@pagopa/io-wallet-oid4vci@1.5.4':
+  '@pagopa/io-wallet-oid4vci@1.5.6':
     dependencies:
       '@openid4vc/oauth2': 0.4.3
       '@openid4vc/openid4vci': 0.4.3
       '@openid4vc/utils': 0.4.3
-      '@pagopa/io-wallet-oauth2': 1.5.4
-      '@pagopa/io-wallet-oid-federation': 1.5.4
-      '@pagopa/io-wallet-oid4vp': 1.5.4
-      '@pagopa/io-wallet-utils': 1.5.4
+      '@pagopa/io-wallet-oauth2': 1.5.6
+      '@pagopa/io-wallet-oid-federation': 1.5.6
+      '@pagopa/io-wallet-oid4vp': 1.5.6
+      '@pagopa/io-wallet-utils': 1.5.6
       zod: 4.3.6
 
-  '@pagopa/io-wallet-oid4vp@1.5.4':
+  '@pagopa/io-wallet-oid4vp@1.5.6':
     dependencies:
       '@openid4vc/oauth2': 0.4.3
       '@openid4vc/openid4vp': 0.4.3
       '@openid4vc/utils': 0.4.3
-      '@pagopa/io-wallet-oauth2': 1.5.4
-      '@pagopa/io-wallet-oid-federation': 1.5.4
-      '@pagopa/io-wallet-utils': 1.5.4
+      '@pagopa/io-wallet-oauth2': 1.5.6
+      '@pagopa/io-wallet-oid-federation': 1.5.6
+      '@pagopa/io-wallet-utils': 1.5.6
       zod: 4.3.6
 
-  '@pagopa/io-wallet-utils@1.5.4':
+  '@pagopa/io-wallet-utils@1.5.6':
     dependencies:
       '@openid4vc/oauth2': 0.4.3
       '@openid4vc/utils': 0.4.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -83,3 +83,11 @@ catalog:
   react-native-reanimated: "4.3.1"
   react-native-safe-area-context: "^5.6.2"
   react-native-svg: "^15.14.0"
+
+minimumReleaseAgeExclude:
+  - '@pagopa/io-react-native-wallet@3.7.2'
+  - '@pagopa/io-wallet-oauth2@1.5.6'
+  - '@pagopa/io-wallet-oid-federation@1.5.6'
+  - '@pagopa/io-wallet-oid4vci@1.5.6'
+  - '@pagopa/io-wallet-oid4vp@1.5.6'
+  - '@pagopa/io-wallet-utils@1.5.6'


### PR DESCRIPTION
## Short description
This PR bumps `@pagopa/io-react-native-wallet` from `3.7.1` to `3.7.2`. 

Version `3.7.2` introduces the anonymization of Personally Identifiable Information (PII) to prevent sensitive data from being exposed if a credential issuer accidentally includes it in an error response.

## List of changes proposed in this pull request

* Upgraded `@pagopa/io-react-native-wallet` from version `3.7.1` to `3.7.2` in `package.json`, `pnpm-lock.yaml`, and `pnpm-workspace.yaml` to include the latest fixes and features. 
* Upgraded related wallet packages (`@pagopa/io-wallet-oauth2`, `@pagopa/io-wallet-oid-federation`, `@pagopa/io-wallet-oid4vci`, `@pagopa/io-wallet-oid4vp`, and `@pagopa/io-wallet-utils`) from version `1.5.4` to `1.5.6` in `pnpm-lock.yaml` and `pnpm-workspace.yaml`. 

## How to test
- **Regression Check:** Verify that no regressions have been introduced in either the *Documenti su IO* or *IT-Wallet* flows.
- **Anonymization Check:** 
  1. Force (or mock) an issuer error response during the credential issuance phase.
  2. Ensure the mocked error response contains an Italian Fiscal Code in the `reason` property.
  3. Verify that the resulting error object successfully redacts the Fiscal Code.