### PR TITLE
feat: [IOPID-4123] Add CieID login flow via OneIdentity

### DIFF
--- a/apps/main-app/ts/features/authentication/activeSessionLogin/screens/cieId/ActiveSessionCieIdLoginScreen.tsx
+++ b/apps/main-app/ts/features/authentication/activeSessionLogin/screens/cieId/ActiveSessionCieIdLoginScreen.tsx
@@ -24,12 +24,12 @@ import {
   onLoginUriChanged,
   originSchemasWhiteList
 } from "../../../common/utils";
-import { LoadingOverlay } from "../../../login/cie/shared/LoadingSpinnerOverlay";
 import {
   CieIdLoginProps,
   defaultUserAgent,
   WHITELISTED_DOMAINS
-} from "../../../login/cie/shared/utils";
+} from "../../../common/utils/cie";
+import { LoadingOverlay } from "../../../login/cie/shared/LoadingSpinnerOverlay";
 import {
   getCieIdEnvironment,
   getCieIDLoginUri,

--- a/apps/main-app/ts/features/authentication/activeSessionLogin/screens/cieId/OneIdentityActiveSessionCieIdLoginScreen.tsx
+++ b/apps/main-app/ts/features/authentication/activeSessionLogin/screens/cieId/OneIdentityActiveSessionCieIdLoginScreen.tsx
@@ -1,0 +1,138 @@
+import { useCallback } from "react";
+
+import { useHeaderSecondLevel } from "../../../../../hooks/useHeaderSecondLevel";
+import { IOStackNavigationRouteProps } from "../../../../../navigation/params/AppParamsList";
+import { useIODispatch } from "../../../../../store/hooks";
+import { trackLoginFailure } from "../../../common/analytics";
+import { trackLoginSpidError } from "../../../common/analytics/spidAnalytics";
+import { AUTH_ERRORS } from "../../../common/components/AuthErrorComponent";
+import {
+  CieIdWebViewLogin,
+  CieIdWebViewLoginEvent
+} from "../../../common/components/CieIdWebViewLogin";
+import { useCieIdWebViewLoginNavigation } from "../../../common/hooks/useCieIdWebViewLoginNavigation";
+import { AuthenticationParamsList } from "../../../common/navigation/params/AuthenticationParamsList";
+import { AUTHENTICATION_ROUTES } from "../../../common/navigation/routes";
+import { isValidCallbackUrl } from "../../../common/utils";
+import { IdpCIE_ID } from "../../../login/hooks/useNavigateToLoginMethod";
+import {
+  activeSessionLoginFailure,
+  activeSessionLoginSuccess,
+  setFinishedActiveSessionLoginFlow
+} from "../../store/actions";
+import useActiveSessionLoginNavigation from "../../utils/useActiveSessionLoginNavigation";
+
+type OneIdentityActiveSessionCieIdLoginScreenProps =
+  IOStackNavigationRouteProps<
+    AuthenticationParamsList,
+    typeof AUTHENTICATION_ROUTES.CIE_ID_ACTIVE_SESSION_LOGIN
+  >;
+
+export const OneIdentityActiveSessionCieIdLoginScreen = ({
+  navigation,
+  route
+}: OneIdentityActiveSessionCieIdLoginScreenProps) => {
+  const { spidLevel: authLevel, isUat } = route.params;
+
+  const dispatch = useIODispatch();
+
+  const { forceLogoutAndNavigateToLanding } = useActiveSessionLoginNavigation();
+
+  const {
+    navigateToCieIdAuthenticationError,
+    navigateToCieIdAuthUrlError,
+    navigateToAuthErrorScreen
+  } = useCieIdWebViewLoginNavigation({ authLevel, isUat });
+
+  const handleLoginFailure = useCallback(
+    (reason: string, code?: string, message?: string) => {
+      const errorCodeOrMessage = code ?? message;
+
+      if (code !== AUTH_ERRORS.ERROR_1004) {
+        dispatch(activeSessionLoginFailure());
+      }
+
+      trackLoginFailure({ reason, idp: "cieid", flow: "reauth" });
+      trackLoginSpidError(errorCodeOrMessage, {
+        idp: IdpCIE_ID.id,
+        flow: "reauth",
+        "error message": message
+      });
+      navigateToAuthErrorScreen(errorCodeOrMessage);
+    },
+    [dispatch, navigateToAuthErrorScreen]
+  );
+
+  const handleLoginSuccess = useCallback(
+    (token: string) => {
+      dispatch(activeSessionLoginSuccess(token));
+    },
+    [dispatch]
+  );
+
+  const handleEvent = useCallback(
+    (event: CieIdWebViewLoginEvent) => {
+      switch (event.type) {
+        case "CANCEL":
+        case "ONE_IDENTITY_LOGIN_FAILURE":
+        case "WEBVIEW_ERROR": {
+          navigateToCieIdAuthenticationError();
+          break;
+        }
+        case "LOGIN_FAILURE": {
+          const { code, message, reason } = event.payload;
+          handleLoginFailure(reason, code, message);
+          break;
+        }
+        case "LOGIN_SUCCESS": {
+          const { token } = event.payload;
+          handleLoginSuccess(token);
+          break;
+        }
+        case "NOT_ALLOWED_URL": {
+          const { url } = event.payload;
+          navigateToCieIdAuthUrlError(url);
+          break;
+        }
+        case "WEBVIEW_HTTP_ERROR": {
+          const { url, statusCode } = event.payload;
+
+          if (isValidCallbackUrl(url)) {
+            // The callback URL failed to load: force a logout.
+            forceLogoutAndNavigateToLanding();
+            break;
+          }
+          if (statusCode !== 403) {
+            navigateToAuthErrorScreen();
+            break;
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [
+      forceLogoutAndNavigateToLanding,
+      handleLoginFailure,
+      handleLoginSuccess,
+      navigateToAuthErrorScreen,
+      navigateToCieIdAuthUrlError,
+      navigateToCieIdAuthenticationError
+    ]
+  );
+
+  const handleGoBack = useCallback(() => {
+    dispatch(setFinishedActiveSessionLoginFlow());
+    navigation.popToTop();
+  }, [dispatch, navigation]);
+
+  useHeaderSecondLevel({
+    title: "",
+    goBack: handleGoBack
+  });
+
+  return (
+    <CieIdWebViewLogin flow="reauth" isUat={isUat} onEvent={handleEvent} />
+  );
+};

--- a/apps/main-app/ts/features/authentication/activeSessionLogin/screens/cieId/__tests__/OneIdentityActiveSessionCieIdLoginScreen.test.tsx
+++ b/apps/main-app/ts/features/authentication/activeSessionLogin/screens/cieId/__tests__/OneIdentityActiveSessionCieIdLoginScreen.test.tsx
@@ -1,0 +1,260 @@
+import { fireEvent } from "@testing-library/react-native";
+import { ComponentProps } from "react";
+import { createStore } from "redux";
+
+import { apiUrlPrefix } from "../../../../../../config";
+import { useHeaderSecondLevel } from "../../../../../../hooks/useHeaderSecondLevel";
+import { applicationChangeState } from "../../../../../../store/actions/application";
+import * as IOHooks from "../../../../../../store/hooks";
+import { appReducer } from "../../../../../../store/reducers";
+import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper";
+import { AUTH_ERRORS } from "../../../../common/components/AuthErrorComponent";
+import { AUTHENTICATION_ROUTES } from "../../../../common/navigation/routes";
+import { AUTH_LEVELS, AuthLevel } from "../../../../common/utils";
+import {
+  activeSessionLoginFailure,
+  activeSessionLoginSuccess,
+  setFinishedActiveSessionLoginFlow
+} from "../../../store/actions";
+import * as useActiveSessionLoginNavigationModule from "../../../utils/useActiveSessionLoginNavigation";
+import { OneIdentityActiveSessionCieIdLoginScreen } from "../OneIdentityActiveSessionCieIdLoginScreen";
+
+jest.mock("../../../../common/components/CieIdWebViewLogin", () => {
+  const { View } = require("react-native");
+
+  return {
+    CieIdWebViewLogin: (props: any) => (
+      <View testID="cie-id-webview-login-mock" {...props} />
+    )
+  };
+});
+
+const mockReplace = jest.fn();
+jest.mock("@react-navigation/native", () => {
+  const actualNav = jest.requireActual("@react-navigation/native");
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      replace: mockReplace
+    })
+  };
+});
+
+jest.mock("../../../../../../hooks/useHeaderSecondLevel", () => ({
+  useHeaderSecondLevel: jest.fn()
+}));
+
+jest.mock("../../../../common/analytics", () => ({
+  trackLoginFailure: jest.fn(),
+  trackSessionTokenSource: jest.fn(),
+  trackSessionTokenFragmentFailure: jest.fn()
+}));
+
+jest.mock("../../../../common/analytics/spidAnalytics", () => ({
+  trackLoginSpidError: jest.fn()
+}));
+
+const MOCK_AUTH_LEVEL_L2: AuthLevel = AUTH_LEVELS.L2;
+const MOCK_CALLBACK_URL = `${apiUrlPrefix}/api/auth/v2/callback`;
+
+const mockForceLogoutAndNavigateToLanding = jest.fn();
+
+describe("OneIdentityActiveSessionCieIdLoginScreen", () => {
+  const mockDispatch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.spyOn(IOHooks, "useIODispatch").mockReturnValue(mockDispatch);
+
+    jest
+      .spyOn(useActiveSessionLoginNavigationModule, "default")
+      .mockReturnValue({
+        navigateToAuthenticationScreen: jest.fn(),
+        navigateToCieCardReaderScreen: jest.fn(),
+        navigateToCieConsentDataUsage: jest.fn(),
+        forceLogoutAndNavigateToLanding: mockForceLogoutAndNavigateToLanding
+      });
+  });
+
+  it("should render the CieIdWebViewLogin component", () => {
+    const { getByTestId } = renderComponent();
+
+    expect(getByTestId("cie-id-webview-login-mock")).toBeTruthy();
+  });
+
+  it("should dispatch activeSessionLoginSuccess on LOGIN_SUCCESS event", () => {
+    const { getByTestId } = renderComponent();
+    const cieIdLoginMock = getByTestId("cie-id-webview-login-mock");
+
+    fireEvent(cieIdLoginMock, "event", {
+      type: "LOGIN_SUCCESS",
+      payload: { token: "session-token" }
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      activeSessionLoginSuccess("session-token")
+    );
+  });
+
+  it("should dispatch activeSessionLoginFailure and navigate to AuthErrorScreen on LOGIN_FAILURE event", () => {
+    const { getByTestId } = renderComponent();
+    const cieIdLoginMock = getByTestId("cie-id-webview-login-mock");
+
+    fireEvent(cieIdLoginMock, "event", {
+      type: "LOGIN_FAILURE",
+      payload: { code: "err-code", reason: "some-reason" }
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(activeSessionLoginFailure());
+    expect(mockReplace).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
+      screen: AUTHENTICATION_ROUTES.AUTH_ERROR_SCREEN,
+      params: {
+        errorCodeOrMessage: "err-code",
+        authMethod: "CIE_ID",
+        authLevel: MOCK_AUTH_LEVEL_L2,
+        params: { spidLevel: MOCK_AUTH_LEVEL_L2, isUat: false }
+      }
+    });
+  });
+
+  it("should not dispatch activeSessionLoginFailure but still navigate to AuthErrorScreen when LOGIN_FAILURE code is ERROR_1004", () => {
+    const { getByTestId } = renderComponent();
+    const cieIdLoginMock = getByTestId("cie-id-webview-login-mock");
+
+    fireEvent(cieIdLoginMock, "event", {
+      type: "LOGIN_FAILURE",
+      payload: { code: AUTH_ERRORS.ERROR_1004, reason: "some-reason" }
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalledWith(activeSessionLoginFailure());
+    expect(mockReplace).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
+      screen: AUTHENTICATION_ROUTES.AUTH_ERROR_SCREEN,
+      params: {
+        errorCodeOrMessage: AUTH_ERRORS.ERROR_1004,
+        authMethod: "CIE_ID",
+        authLevel: MOCK_AUTH_LEVEL_L2,
+        params: { spidLevel: MOCK_AUTH_LEVEL_L2, isUat: false }
+      }
+    });
+  });
+
+  it("should force logout and navigate to landing on WEBVIEW_HTTP_ERROR on the callback URL", () => {
+    const { getByTestId } = renderComponent();
+    const cieIdLoginMock = getByTestId("cie-id-webview-login-mock");
+
+    fireEvent(cieIdLoginMock, "event", {
+      type: "WEBVIEW_HTTP_ERROR",
+      payload: { url: MOCK_CALLBACK_URL, statusCode: 500 }
+    });
+
+    expect(mockForceLogoutAndNavigateToLanding).toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("should navigate to AuthErrorScreen on WEBVIEW_HTTP_ERROR outside the callback URL", () => {
+    const { getByTestId } = renderComponent();
+    const cieIdLoginMock = getByTestId("cie-id-webview-login-mock");
+
+    fireEvent(cieIdLoginMock, "event", {
+      type: "WEBVIEW_HTTP_ERROR",
+      payload: { url: "https://other.example.com", statusCode: 500 }
+    });
+
+    expect(mockForceLogoutAndNavigateToLanding).not.toHaveBeenCalled();
+    expect(mockReplace).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
+      screen: AUTHENTICATION_ROUTES.AUTH_ERROR_SCREEN,
+      params: {
+        errorCodeOrMessage: undefined,
+        authMethod: "CIE_ID",
+        authLevel: MOCK_AUTH_LEVEL_L2,
+        params: { spidLevel: MOCK_AUTH_LEVEL_L2, isUat: false }
+      }
+    });
+  });
+
+  it("should not navigate anywhere on WEBVIEW_HTTP_ERROR with 403 outside the callback URL", () => {
+    const { getByTestId } = renderComponent();
+    const cieIdLoginMock = getByTestId("cie-id-webview-login-mock");
+
+    fireEvent(cieIdLoginMock, "event", {
+      type: "WEBVIEW_HTTP_ERROR",
+      payload: { url: "https://other.example.com", statusCode: 403 }
+    });
+
+    expect(mockForceLogoutAndNavigateToLanding).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("should navigate to CIE_ID_INCORRECT_URL on NOT_ALLOWED_URL event", () => {
+    const { getByTestId } = renderComponent();
+    const cieIdLoginMock = getByTestId("cie-id-webview-login-mock");
+
+    fireEvent(cieIdLoginMock, "event", {
+      type: "NOT_ALLOWED_URL",
+      payload: { url: "https://not-whitelisted.example.com" }
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
+      screen: AUTHENTICATION_ROUTES.CIE_ID_INCORRECT_URL,
+      params: { url: "https://not-whitelisted.example.com" }
+    });
+  });
+
+  it.each(["CANCEL", "ONE_IDENTITY_LOGIN_FAILURE", "WEBVIEW_ERROR"] as const)(
+    "should navigate to CIE_ID_ERROR on %s event",
+    eventType => {
+      const { getByTestId } = renderComponent();
+      const cieIdLoginMock = getByTestId("cie-id-webview-login-mock");
+
+      fireEvent(cieIdLoginMock, "event", { type: eventType });
+
+      expect(mockReplace).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
+        screen: AUTHENTICATION_ROUTES.CIE_ID_ERROR
+      });
+    }
+  );
+
+  it("should dispatch setFinishedActiveSessionLoginFlow and popToTop on header goBack", () => {
+    const mockPopToTop = jest.fn();
+
+    renderComponent({ popToTop: mockPopToTop });
+
+    const { goBack } = jest.mocked(useHeaderSecondLevel).mock.calls[0][0];
+
+    goBack?.();
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      setFinishedActiveSessionLoginFlow()
+    );
+    expect(mockPopToTop).toHaveBeenCalled();
+  });
+});
+
+const renderComponent = (
+  navigationOverrides: Partial<
+    ComponentProps<
+      typeof OneIdentityActiveSessionCieIdLoginScreen
+    >["navigation"]
+  > = {}
+) => {
+  const initialState = appReducer(undefined, applicationChangeState("active"));
+  const store = createStore(appReducer, initialState as any);
+
+  return renderScreenWithNavigationStoreContext(
+    (
+      props: ComponentProps<typeof OneIdentityActiveSessionCieIdLoginScreen>
+    ) => (
+      <OneIdentityActiveSessionCieIdLoginScreen
+        {...props}
+        navigation={{
+          ...props.navigation,
+          ...navigationOverrides
+        }}
+      />
+    ),
+    AUTHENTICATION_ROUTES.CIE_ID_ACTIVE_SESSION_LOGIN,
+    { spidLevel: MOCK_AUTH_LEVEL_L2, isUat: false },
+    store
+  );
+};

--- a/apps/main-app/ts/features/authentication/activeSessionLogin/screens/spid/OneIdentityActiveSessionIdpLoginScreen.tsx
+++ b/apps/main-app/ts/features/authentication/activeSessionLogin/screens/spid/OneIdentityActiveSessionIdpLoginScreen.tsx
@@ -17,15 +17,14 @@ import {
   WebViewLoginEvent
 } from "../../../common/components/IdpWebViewLogin";
 import { AUTHENTICATION_ROUTES } from "../../../common/navigation/routes";
-import { AUTH_LEVELS, CALLBACK_PATH } from "../../../common/utils";
+import { AUTH_LEVELS, isValidCallbackUrl } from "../../../common/utils";
 import {
   activeSessionLoginFailure,
   activeSessionLoginSuccess
 } from "../../store/actions";
 import {
   activeSessionUserLoggedSelector,
-  idpSelectedActiveSessionLoginSelector,
-  remoteApiLoginUrlPrefixSelector
+  idpSelectedActiveSessionLoginSelector
 } from "../../store/selectors";
 import useActiveSessionLoginNavigation from "../../utils/useActiveSessionLoginNavigation";
 
@@ -68,11 +67,6 @@ const OneIdentityActiveSessionIdpLoginScreenContent = ({
 }: OneIdentityActiveSessionIdpLoginScreenContentProps) => {
   const dispatch = useIODispatch();
   const navigation = useIONavigation();
-
-  const remoteApiLoginUrlPrefix = useIOSelector(
-    remoteApiLoginUrlPrefixSelector
-  );
-  const callbackUrl = `${remoteApiLoginUrlPrefix}${CALLBACK_PATH}`;
 
   const { forceLogoutAndNavigateToLanding } = useActiveSessionLoginNavigation();
 
@@ -134,7 +128,7 @@ const OneIdentityActiveSessionIdpLoginScreenContent = ({
         case "WEBVIEW_HTTP_ERROR": {
           const { url, statusCode } = event.payload;
 
-          if (url.includes(callbackUrl)) {
+          if (isValidCallbackUrl(url)) {
             // The callback URL failed to load: force a logout.
             forceLogoutAndNavigateToLanding();
             break;
@@ -150,7 +144,6 @@ const OneIdentityActiveSessionIdpLoginScreenContent = ({
       }
     },
     [
-      callbackUrl,
       forceLogoutAndNavigateToLanding,
       handleLoginFailure,
       handleLoginSuccess,

--- a/apps/main-app/ts/features/authentication/activeSessionLogin/screens/spid/__tests__/OneIdentityActiveSessionIdpLoginScreen.test.tsx
+++ b/apps/main-app/ts/features/authentication/activeSessionLogin/screens/spid/__tests__/OneIdentityActiveSessionIdpLoginScreen.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent } from "@testing-library/react-native";
 import { createStore } from "redux";
 
+import { apiUrlPrefix } from "../../../../../../config";
 import { applicationChangeState } from "../../../../../../store/actions/application";
 import * as IOHooks from "../../../../../../store/hooks";
 import { appReducer } from "../../../../../../store/reducers";
@@ -8,7 +9,7 @@ import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/
 import * as useOneIdentityLoginSourceModule from "../../../../../lollipop/hooks/useOneIdentityLoginSource";
 import { AUTH_ERRORS } from "../../../../common/components/AuthErrorComponent";
 import { AUTHENTICATION_ROUTES } from "../../../../common/navigation/routes";
-import { CALLBACK_PATH } from "../../../../common/utils";
+import { AUTH_LEVELS, AuthLevel } from "../../../../common/utils";
 import {
   activeSessionLoginFailure,
   activeSessionLoginSuccess
@@ -59,8 +60,8 @@ const mockIdp = {
   profileUrl: ""
 };
 
-const remoteApiLoginUrlPrefix = "https://api-app.io.pagopa.it";
-const callbackUrl = `${remoteApiLoginUrlPrefix}${CALLBACK_PATH}`;
+const MOCK_AUTH_LEVEL_L2: AuthLevel = AUTH_LEVELS.L2;
+const MOCK_VALID_CALLBACK_URL = `${apiUrlPrefix}/api/auth/v2/callback`;
 
 const mockForceLogoutAndNavigateToLanding = jest.fn();
 
@@ -89,10 +90,6 @@ describe("OneIdentityActiveSessionIdpLoginScreen", () => {
     jest
       .spyOn(activeSessionSelectors, "activeSessionUserLoggedSelector")
       .mockReturnValue(false);
-
-    jest
-      .spyOn(activeSessionSelectors, "remoteApiLoginUrlPrefixSelector")
-      .mockReturnValue(remoteApiLoginUrlPrefix);
 
     jest
       .spyOn(useActiveSessionLoginNavigationModule, "default")
@@ -148,7 +145,7 @@ describe("OneIdentityActiveSessionIdpLoginScreen", () => {
       params: {
         errorCodeOrMessage: "err-code",
         authMethod: "SPID",
-        authLevel: "L2"
+        authLevel: MOCK_AUTH_LEVEL_L2
       }
     });
   });
@@ -168,7 +165,7 @@ describe("OneIdentityActiveSessionIdpLoginScreen", () => {
       params: {
         errorCodeOrMessage: AUTH_ERRORS.ERROR_1004,
         authMethod: "SPID",
-        authLevel: "L2"
+        authLevel: MOCK_AUTH_LEVEL_L2
       }
     });
   });
@@ -178,11 +175,33 @@ describe("OneIdentityActiveSessionIdpLoginScreen", () => {
     const webview = getByTestId("webview-idp-login-screen");
 
     fireEvent(webview, "onHttpError", {
-      nativeEvent: { url: callbackUrl, statusCode: 500 }
+      nativeEvent: { url: MOCK_VALID_CALLBACK_URL, statusCode: 500 }
     });
 
     expect(mockForceLogoutAndNavigateToLanding).toHaveBeenCalled();
     expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("should navigate to AuthErrorScreen (not force logout) on a HTTP error on a URL that only contains the callback path as a substring", () => {
+    const { getByTestId } = renderComponent();
+    const webview = getByTestId("webview-idp-login-screen");
+
+    fireEvent(webview, "onHttpError", {
+      nativeEvent: {
+        url: `${MOCK_VALID_CALLBACK_URL}/extra-path`,
+        statusCode: 500
+      }
+    });
+
+    expect(mockForceLogoutAndNavigateToLanding).not.toHaveBeenCalled();
+    expect(mockReplace).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
+      screen: AUTHENTICATION_ROUTES.AUTH_ERROR_SCREEN,
+      params: {
+        errorCodeOrMessage: undefined,
+        authMethod: "SPID",
+        authLevel: MOCK_AUTH_LEVEL_L2
+      }
+    });
   });
 
   it("should not navigate to AuthErrorScreen on a HTTP 403 error on a non-callback URL", () => {
@@ -210,7 +229,7 @@ describe("OneIdentityActiveSessionIdpLoginScreen", () => {
       params: {
         errorCodeOrMessage: undefined,
         authMethod: "SPID",
-        authLevel: "L2"
+        authLevel: MOCK_AUTH_LEVEL_L2
       }
     });
     expect(mockForceLogoutAndNavigateToLanding).not.toHaveBeenCalled();
@@ -229,7 +248,7 @@ describe("OneIdentityActiveSessionIdpLoginScreen", () => {
       params: {
         errorCodeOrMessage: undefined,
         authMethod: "SPID",
-        authLevel: "L2"
+        authLevel: MOCK_AUTH_LEVEL_L2
       }
     });
   });

--- a/apps/main-app/ts/features/authentication/common/components/CieIdWebViewLogin.tsx
+++ b/apps/main-app/ts/features/authentication/common/components/CieIdWebViewLogin.tsx
@@ -1,0 +1,211 @@
+import { memo, useCallback, useState } from "react";
+import { StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import WebView, { type WebViewNavigation } from "react-native-webview";
+import {
+  WebViewErrorEvent,
+  WebViewHttpErrorEvent
+} from "react-native-webview/lib/WebViewTypes";
+
+import { useOneIdentityLoginSource } from "../../../lollipop/hooks/useOneIdentityLoginSource";
+import { LoginType } from "../../activeSessionLogin/screens/analytics";
+import { LoadingOverlay } from "../../login/cie/shared/LoadingSpinnerOverlay";
+import { getCieIdpId, isAuthenticationUrl } from "../../login/cie/utils";
+import { useCieIdApp } from "../hooks/useCieIdApp";
+import { AUTH_LEVELS, onLoginUriChanged } from "../utils";
+import {
+  defaultUserAgent,
+  isAllowedUrl,
+  originSchemasWhiteList
+} from "../utils/cie";
+
+export type CieIdWebViewLoginEvent =
+  | {
+      payload: { code?: string; message?: string; reason: string };
+      type: "LOGIN_FAILURE";
+    }
+  | {
+      payload: { reason: string };
+      type: "ONE_IDENTITY_LOGIN_FAILURE";
+    }
+  | {
+      payload: { statusCode: number; url: string };
+      type: "WEBVIEW_HTTP_ERROR";
+    }
+  | { payload: { token: string }; type: "LOGIN_SUCCESS" }
+  | { payload: { url: string }; type: "NOT_ALLOWED_URL" }
+  | { payload: { url: string }; type: "WEBVIEW_ERROR" }
+  | { type: "CANCEL" };
+
+export type CieIdWebViewLoginProps = {
+  /** The login flow this WebView is part of; defaults to a first-time login. */
+  flow?: LoginType;
+  /** Indicates whether the environment is UAT. */
+  isUat: boolean;
+  /** Callback invoked for various authentication-related events. */
+  onEvent: (event: CieIdWebViewLoginEvent) => void;
+};
+
+export const CieIdWebViewLogin = memo(
+  ({ flow = "auth", isUat, onEvent }: CieIdWebViewLoginProps) => {
+    const [authenticatedUrl, setAuthenticatedUrl] = useState<null | string>(
+      null
+    );
+
+    const handleLoginSuccess = useCallback(
+      (token: string) => {
+        onEvent({ type: "LOGIN_SUCCESS", payload: { token } });
+      },
+      [onEvent]
+    );
+
+    const handleLoginFailure = useCallback(
+      (code?: string, message?: string) => {
+        const reason = code
+          ? `login failed with code ${code}`
+          : message
+            ? `login failed with message ${message}`
+            : "login failed with no error code or message available";
+
+        onEvent({
+          type: "LOGIN_FAILURE",
+          payload: { code, message, reason }
+        });
+      },
+      [onEvent]
+    );
+
+    const handleAuthenticationSuccess = useCallback(
+      (url: string) => {
+        if (!isAllowedUrl(url)) {
+          onEvent({ type: "NOT_ALLOWED_URL", payload: { url } });
+          return;
+        }
+        setAuthenticatedUrl(url);
+      },
+      [onEvent]
+    );
+
+    const { startCieIdApp } = useCieIdApp({
+      onFailure: handleLoginFailure,
+      onSuccess: handleAuthenticationSuccess,
+      useUat: isUat
+    });
+
+    const handleFailure = useCallback(
+      (reason: string) => {
+        onEvent({
+          type: "ONE_IDENTITY_LOGIN_FAILURE",
+          payload: { reason }
+        });
+      },
+      [onEvent]
+    );
+
+    const { loginSourceState, shouldBlockUrlNavigationWhileCheckingLollipop } =
+      useOneIdentityLoginSource({
+        idpId: getCieIdpId(isUat),
+        onFailure: handleFailure,
+        minAuthLevel: AUTH_LEVELS.L2
+      });
+
+    const handleOnShouldStartLoadWithRequest = useCallback(
+      (event: WebViewNavigation): boolean => {
+        const url = event.url;
+
+        if (shouldBlockUrlNavigationWhileCheckingLollipop(url)) {
+          return false;
+        }
+
+        if (isAuthenticationUrl(url)) {
+          startCieIdApp(url);
+          return false;
+        }
+
+        const isLoginUrlWithToken = onLoginUriChanged(
+          handleLoginFailure,
+          handleLoginSuccess,
+          "cieid",
+          flow
+        )(event);
+
+        // URL can be loaded if it's not the login URL containing the session token - this avoids
+        // making a (useless) GET request with the session in the URL
+        return !isLoginUrlWithToken;
+      },
+      [
+        shouldBlockUrlNavigationWhileCheckingLollipop,
+        startCieIdApp,
+        handleLoginFailure,
+        handleLoginSuccess,
+        flow
+      ]
+    );
+
+    const handleError = useCallback(
+      (event: WebViewErrorEvent | WebViewHttpErrorEvent): void => {
+        const { nativeEvent } = event;
+
+        if ("statusCode" in nativeEvent) {
+          onEvent({
+            type: "WEBVIEW_HTTP_ERROR",
+            payload: {
+              url: nativeEvent.url,
+              statusCode: nativeEvent.statusCode
+            }
+          });
+          return;
+        }
+
+        onEvent({
+          type: "WEBVIEW_ERROR",
+          payload: { url: nativeEvent.url }
+        });
+      },
+      [onEvent]
+    );
+
+    const handleCancel = useCallback(() => {
+      onEvent({ type: "CANCEL" });
+    }, [onEvent]);
+
+    if (
+      loginSourceState.status === "reserving-public-key" ||
+      loginSourceState.status === "verifying-assertion-ref"
+    ) {
+      return <LoadingOverlay onCancel={handleCancel} />;
+    }
+
+    if (loginSourceState.status === "failure") {
+      return null;
+    }
+
+    const webviewSource = authenticatedUrl
+      ? { uri: authenticatedUrl }
+      : loginSourceState.webviewSource;
+
+    return (
+      <SafeAreaView edges={["bottom"]} style={styles.container}>
+        <WebView
+          onError={handleError}
+          onHttpError={handleError}
+          onShouldStartLoadWithRequest={handleOnShouldStartLoadWithRequest}
+          originWhitelist={originSchemasWhiteList}
+          renderLoading={() => <LoadingOverlay onCancel={handleCancel} />}
+          source={webviewSource}
+          startInLoadingState={true}
+          testID="cie-id-webview"
+          userAgent={defaultUserAgent}
+        />
+      </SafeAreaView>
+    );
+  }
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    marginHorizontal: 16
+  }
+});

--- a/apps/main-app/ts/features/authentication/common/components/IdpWebViewLogin.tsx
+++ b/apps/main-app/ts/features/authentication/common/components/IdpWebViewLogin.tsx
@@ -78,7 +78,7 @@ export const IdpWebViewLogin = memo(
 
     const { loginSourceState, shouldBlockUrlNavigationWhileCheckingLollipop } =
       useOneIdentityLoginSource({
-        idp,
+        idpId: idp.id,
         onFailure: handleFailure,
         minAuthLevel: AUTH_LEVELS.L2
       });

--- a/apps/main-app/ts/features/authentication/common/components/__test__/CieIdWebViewLogin.test.tsx
+++ b/apps/main-app/ts/features/authentication/common/components/__test__/CieIdWebViewLogin.test.tsx
@@ -1,0 +1,279 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import * as useOneIdentityLoginSourceModule from "../../../../lollipop/hooks/useOneIdentityLoginSource";
+import * as useCieIdAppModule from "../../hooks/useCieIdApp";
+import { CieIdWebViewLogin } from "../CieIdWebViewLogin";
+
+jest.mock("react-native-webview", () => {
+  const { forwardRef: reactForwardRef } = jest.requireActual("react");
+  const { View } = jest.requireActual("react-native");
+  const WebView = reactForwardRef((props: object, ref: unknown) => (
+    <View ref={ref as never} {...props} />
+  ));
+  return {
+    WebView,
+    default: WebView,
+    __esModule: true
+  };
+});
+
+const mockShouldBlockUrlNavigationWhileCheckingLollipop = jest.fn(() => false);
+const mockStartCieIdApp = jest.fn();
+
+const mockUseOneIdentityLoginSource = (
+  overrides?: Partial<
+    ReturnType<typeof useOneIdentityLoginSourceModule.useOneIdentityLoginSource>
+  >
+) =>
+  jest
+    .spyOn(useOneIdentityLoginSourceModule, "useOneIdentityLoginSource")
+    .mockReturnValue({
+      loginSourceState: {
+        status: "one-identity-authorize",
+        webviewSource: { uri: "https://example.com/authorize" }
+      },
+      shouldBlockUrlNavigationWhileCheckingLollipop:
+        mockShouldBlockUrlNavigationWhileCheckingLollipop,
+      ...overrides
+    });
+
+describe("CieIdWebViewLogin", () => {
+  const onEvent = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockShouldBlockUrlNavigationWhileCheckingLollipop.mockReturnValue(false);
+    jest.spyOn(useCieIdAppModule, "useCieIdApp").mockReturnValue({
+      startCieIdApp: mockStartCieIdApp
+    });
+  });
+
+  describe("conditional rendering", () => {
+    it.each(["reserving-public-key", "verifying-assertion-ref"] as const)(
+      "should render the loading overlay and no WebView when status is %s",
+      status => {
+        mockUseOneIdentityLoginSource({
+          loginSourceState:
+            status === "reserving-public-key"
+              ? { status: "reserving-public-key" }
+              : {
+                  status: "verifying-assertion-ref",
+                  url: "https://example.com"
+                }
+        });
+
+        const { queryByTestId } = render(
+          <CieIdWebViewLogin isUat={false} onEvent={onEvent} />
+        );
+
+        expect(queryByTestId("cie-id-webview")).toBeNull();
+      }
+    );
+
+    it("should render nothing when status is failure", () => {
+      mockUseOneIdentityLoginSource({
+        loginSourceState: { status: "failure", error: "some error" }
+      });
+
+      const { queryByTestId } = render(
+        <CieIdWebViewLogin isUat={false} onEvent={onEvent} />
+      );
+
+      expect(queryByTestId("cie-id-webview")).toBeNull();
+    });
+
+    it.each(["one-identity-authorize", "assertion-ref-verified"] as const)(
+      "should render the WebView with the loginSourceState's webviewSource when status is %s",
+      status => {
+        const webviewSource = { uri: "https://example.com/authorize" };
+        mockUseOneIdentityLoginSource({
+          loginSourceState: { status, webviewSource }
+        });
+
+        const { getByTestId } = render(
+          <CieIdWebViewLogin isUat={false} onEvent={onEvent} />
+        );
+
+        const webview = getByTestId("cie-id-webview");
+        expect(webview.props.source).toEqual(webviewSource);
+      }
+    );
+  });
+
+  describe("onError / onHttpError", () => {
+    beforeEach(() => {
+      mockUseOneIdentityLoginSource();
+    });
+
+    it("should call onEvent with WEBVIEW_ERROR when there is a WebViewErrorEvent", () => {
+      const { getByTestId } = render(
+        <CieIdWebViewLogin isUat={false} onEvent={onEvent} />
+      );
+
+      const webview = getByTestId("cie-id-webview");
+      const nativeEvent = { url: "https://example.com/error" };
+      fireEvent(webview, "onError", { nativeEvent });
+
+      expect(onEvent).toHaveBeenCalledWith({
+        type: "WEBVIEW_ERROR",
+        payload: { url: nativeEvent.url }
+      });
+    });
+
+    it("should call onEvent with WEBVIEW_HTTP_ERROR when there is a WebViewHttpErrorEvent", () => {
+      const { getByTestId } = render(
+        <CieIdWebViewLogin isUat={false} onEvent={onEvent} />
+      );
+
+      const webview = getByTestId("cie-id-webview");
+      const nativeEvent = {
+        url: "https://example.com/error",
+        statusCode: 500
+      };
+      fireEvent(webview, "onHttpError", { nativeEvent });
+
+      expect(onEvent).toHaveBeenCalledWith({
+        type: "WEBVIEW_HTTP_ERROR",
+        payload: { url: nativeEvent.url, statusCode: nativeEvent.statusCode }
+      });
+    });
+  });
+
+  describe("onShouldStartLoadWithRequest", () => {
+    beforeEach(() => {
+      mockUseOneIdentityLoginSource();
+    });
+
+    it("should block navigation when LolliPOP is being checked", () => {
+      mockShouldBlockUrlNavigationWhileCheckingLollipop.mockReturnValue(true);
+
+      const { getByTestId } = render(
+        <CieIdWebViewLogin isUat={false} onEvent={onEvent} />
+      );
+
+      const webview = getByTestId("cie-id-webview");
+
+      fireEvent(webview, "onShouldStartLoadWithRequest", {
+        url: "https://idserver.example.com/sso?SAMLRequest=encoded"
+      });
+
+      expect(onEvent).not.toHaveBeenCalled();
+      expect(mockStartCieIdApp).not.toHaveBeenCalled();
+    });
+
+    it("should start the CieID app when the URL is an authentication URL", () => {
+      const { getByTestId } = render(
+        <CieIdWebViewLogin isUat={false} onEvent={onEvent} />
+      );
+
+      const webview = getByTestId("cie-id-webview");
+      const authUrl =
+        "https://idserver.servizicie.interno.gov.it/idp/login/livello2?value=e1s2";
+
+      fireEvent(webview, "onShouldStartLoadWithRequest", { url: authUrl });
+
+      expect(mockStartCieIdApp).toHaveBeenCalledWith(authUrl);
+      expect(onEvent).not.toHaveBeenCalled();
+    });
+
+    it("should call onEvent with LOGIN_SUCCESS on a successful login URL", () => {
+      const { getByTestId } = render(
+        <CieIdWebViewLogin isUat={false} onEvent={onEvent} />
+      );
+
+      const webview = getByTestId("cie-id-webview");
+
+      const successUrl =
+        "https://io.italia.it/profile.html#token=session-token-123";
+
+      fireEvent(webview, "onShouldStartLoadWithRequest", {
+        url: successUrl
+      });
+
+      expect(onEvent).toHaveBeenCalledWith({
+        type: "LOGIN_SUCCESS",
+        payload: { token: "session-token-123" }
+      });
+    });
+
+    it("should call onEvent with LOGIN_FAILURE on a failed login URL", () => {
+      const { getByTestId } = render(
+        <CieIdWebViewLogin isUat={false} onEvent={onEvent} />
+      );
+
+      const webview = getByTestId("cie-id-webview");
+
+      const failureUrl =
+        "https://io.italia.it/error.html?errorCode=19&errorMessage=annullato";
+      fireEvent(webview, "onShouldStartLoadWithRequest", {
+        url: failureUrl
+      });
+
+      expect(onEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "LOGIN_FAILURE",
+          payload: {
+            code: "19",
+            message: "annullato",
+            reason: expect.any(String)
+          }
+        })
+      );
+    });
+  });
+
+  describe("useCieIdApp callbacks", () => {
+    beforeEach(() => {
+      mockUseOneIdentityLoginSource();
+    });
+
+    it("should call onEvent with INVALID_URL when the CieID app returns an untrusted URL", () => {
+      render(<CieIdWebViewLogin isUat={false} onEvent={onEvent} />);
+
+      const { onSuccess } = jest.mocked(useCieIdAppModule.useCieIdApp).mock
+        .calls[0][0];
+
+      onSuccess("https://not-allowed.example.com/callback");
+
+      expect(onEvent).toHaveBeenCalledWith({
+        type: "NOT_ALLOWED_URL",
+        payload: { url: "https://not-allowed.example.com/callback" }
+      });
+    });
+
+    it("should call onEvent with LOGIN_FAILURE when the CieID app fails", () => {
+      render(<CieIdWebViewLogin isUat={false} onEvent={onEvent} />);
+
+      const { onFailure } = jest.mocked(useCieIdAppModule.useCieIdApp).mock
+        .calls[0][0];
+
+      onFailure("some-error-code");
+
+      expect(onEvent).toHaveBeenCalledWith({
+        type: "LOGIN_FAILURE",
+        payload: {
+          code: "some-error-code",
+          message: undefined,
+          reason: expect.any(String)
+        }
+      });
+    });
+  });
+
+  describe("onCancel", () => {
+    it("should call onEvent with CANCEL when the loading overlay's cancel button is pressed", () => {
+      mockUseOneIdentityLoginSource({
+        loginSourceState: { status: "reserving-public-key" }
+      });
+
+      const { getByTestId } = render(
+        <CieIdWebViewLogin isUat={false} onEvent={onEvent} />
+      );
+
+      fireEvent.press(getByTestId("loadingSpinnerOverlayCancelButton"));
+
+      expect(onEvent).toHaveBeenCalledWith({ type: "CANCEL" });
+    });
+  });
+});

--- a/apps/main-app/ts/features/authentication/common/hooks/__test__/useCieIdApp.test.ts
+++ b/apps/main-app/ts/features/authentication/common/hooks/__test__/useCieIdApp.test.ts
@@ -1,0 +1,243 @@
+import { openCieIdApp } from "@pagopa/io-react-native-cieid";
+import { renderHook, waitFor } from "@testing-library/react-native";
+import { Linking } from "react-native";
+
+import { useCieIdApp } from "../useCieIdApp";
+
+jest.mock("@pagopa/io-react-native-cieid", () => ({
+  openCieIdApp: jest.fn()
+}));
+
+const mockedOpenCieIdApp = jest.mocked(openCieIdApp);
+
+jest.mock("../../../../../utils/platform", () => ({
+  isAndroid: false,
+  isIos: false
+}));
+
+const platformMock = jest.requireMock("../../../../../utils/platform") as {
+  isAndroid: boolean;
+  isIos: boolean;
+};
+
+const IO_LOGIN_CIE_URL_SCHEME = "iologincie:";
+
+const setPlatform = (platform: "android" | "ios" | "none") => {
+  // eslint-disable-next-line functional/immutable-data
+  platformMock.isAndroid = platform === "android";
+  // eslint-disable-next-line functional/immutable-data
+  platformMock.isIos = platform === "ios";
+};
+
+describe("useCieIdApp", () => {
+  const onFailure = jest.fn();
+  const onSuccess = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setPlatform("none");
+
+    jest.spyOn(Linking, "addEventListener").mockReturnValue({
+      remove: jest.fn()
+    } as unknown as ReturnType<typeof Linking.addEventListener>);
+  });
+
+  describe("Linking url listener", () => {
+    it("should subscribe to the url event on mount and remove it on unmount", () => {
+      const removeSpy = jest.fn();
+      const addEventListenerSpy = jest
+        .spyOn(Linking, "addEventListener")
+        .mockReturnValue({ remove: removeSpy } as unknown as ReturnType<
+          typeof Linking.addEventListener
+        >);
+
+      const { unmount } = renderHook(() =>
+        useCieIdApp({ onFailure, onSuccess })
+      );
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith(
+        "url",
+        expect.any(Function)
+      );
+      unmount();
+      expect(removeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("should ignore urls that don't match the CIE login url scheme", () => {
+      jest
+        .spyOn(Linking, "addEventListener")
+        .mockImplementation((_type, callback) => {
+          callback({ url: "https://example.com" });
+
+          return { remove: jest.fn() } as unknown as ReturnType<
+            typeof Linking.addEventListener
+          >;
+        });
+
+      renderHook(() => useCieIdApp({ onFailure, onSuccess }));
+
+      expect(onSuccess).not.toHaveBeenCalled();
+      expect(onFailure).not.toHaveBeenCalled();
+    });
+
+    it("should call onFailure with the extracted error message when the url contains a CIE ID error", () => {
+      jest
+        .spyOn(Linking, "addEventListener")
+        .mockImplementation((_type, callback) => {
+          callback({
+            url: `${IO_LOGIN_CIE_URL_SCHEME}cieiderror?cieid_error_message=generic_error`
+          });
+          return { remove: jest.fn() } as unknown as ReturnType<
+            typeof Linking.addEventListener
+          >;
+        });
+
+      renderHook(() => useCieIdApp({ onFailure, onSuccess }));
+
+      expect(onFailure).toHaveBeenCalledWith("generic_error");
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it("should call onSuccess with the continuation url when there is no CIE ID error", () => {
+      jest
+        .spyOn(Linking, "addEventListener")
+        .mockImplementation((_type, callback) => {
+          callback({
+            url: `${IO_LOGIN_CIE_URL_SCHEME}//continue-url`
+          });
+          return { remove: jest.fn() } as unknown as ReturnType<
+            typeof Linking.addEventListener
+          >;
+        });
+
+      renderHook(() => useCieIdApp({ onFailure, onSuccess }));
+
+      expect(onSuccess).toHaveBeenCalledWith("//continue-url");
+      expect(onFailure).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("startCieIdApp on Android", () => {
+    beforeEach(() => {
+      setPlatform("android");
+    });
+
+    it("should call openCieIdApp with the production environment by default", () => {
+      const { result } = renderHook(() =>
+        useCieIdApp({ onFailure, onSuccess })
+      );
+
+      result.current.startCieIdApp("https://example.com/auth");
+
+      expect(mockedOpenCieIdApp).toHaveBeenCalledWith(
+        "https://example.com/auth",
+        expect.any(Function),
+        "production"
+      );
+    });
+
+    it("should call openCieIdApp with the preprod environment when useUat is true", () => {
+      const { result } = renderHook(() =>
+        useCieIdApp({ onFailure, onSuccess, useUat: true })
+      );
+
+      result.current.startCieIdApp("https://example.com/auth");
+
+      expect(mockedOpenCieIdApp).toHaveBeenCalledWith(
+        "https://example.com/auth",
+        expect.any(Function),
+        "preprod"
+      );
+    });
+
+    it("should call onSuccess with the returned url when openCieIdApp succeeds", () => {
+      mockedOpenCieIdApp.mockImplementationOnce((_url, callback) => {
+        callback({ id: "URL", url: "https://example.com/continue" });
+      });
+
+      const { result } = renderHook(() =>
+        useCieIdApp({ onFailure, onSuccess })
+      );
+
+      result.current.startCieIdApp("https://example.com/auth");
+
+      expect(onSuccess).toHaveBeenCalledWith("https://example.com/continue");
+      expect(onFailure).not.toHaveBeenCalled();
+    });
+
+    it("should call onFailure with the error code when openCieIdApp fails", () => {
+      mockedOpenCieIdApp.mockImplementationOnce((_url, callback) => {
+        callback({ id: "ERROR", code: "GENERIC_ERROR" });
+      });
+
+      const { result } = renderHook(() =>
+        useCieIdApp({ onFailure, onSuccess })
+      );
+
+      result.current.startCieIdApp("https://example.com/auth");
+
+      expect(onFailure).toHaveBeenCalledWith("GENERIC_ERROR");
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it("should not call Linking.openURL", () => {
+      const openURLSpy = jest.spyOn(Linking, "openURL");
+
+      const { result } = renderHook(() =>
+        useCieIdApp({ onFailure, onSuccess })
+      );
+
+      result.current.startCieIdApp("https://example.com/auth");
+
+      expect(openURLSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("startCieIdApp on iOS", () => {
+    beforeEach(() => {
+      setPlatform("ios");
+    });
+
+    it("should call Linking.openURL with the CIEID scheme and source app", async () => {
+      const openURLSpy = jest.spyOn(Linking, "openURL").mockResolvedValue(true);
+
+      const { result } = renderHook(() =>
+        useCieIdApp({ onFailure, onSuccess })
+      );
+
+      result.current.startCieIdApp("https://example.com/auth");
+
+      await waitFor(() => {
+        expect(openURLSpy).toHaveBeenCalledWith(
+          "CIEID://https://example.com/auth&sourceApp=iologincie"
+        );
+        expect(onFailure).not.toHaveBeenCalled();
+      });
+    });
+
+    it("should call onFailure when Linking.openURL rejects", async () => {
+      const openURLError = new Error("Unable to open URL");
+      jest.spyOn(Linking, "openURL").mockRejectedValue(openURLError);
+
+      const { result } = renderHook(() =>
+        useCieIdApp({ onFailure, onSuccess })
+      );
+
+      result.current.startCieIdApp("https://example.com/auth");
+
+      await waitFor(() => {
+        expect(onFailure).toHaveBeenCalledWith(openURLError);
+      });
+    });
+
+    it("should not call openCieIdApp", () => {
+      const { result } = renderHook(() =>
+        useCieIdApp({ onFailure, onSuccess })
+      );
+
+      result.current.startCieIdApp("https://example.com/auth");
+
+      expect(mockedOpenCieIdApp).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/main-app/ts/features/authentication/common/hooks/__test__/useCieIdWebViewLoginNavigation.test.ts
+++ b/apps/main-app/ts/features/authentication/common/hooks/__test__/useCieIdWebViewLoginNavigation.test.ts
@@ -1,0 +1,74 @@
+import { renderHook } from "@testing-library/react-native";
+
+import { AUTHENTICATION_ROUTES } from "../../navigation/routes";
+import { AUTH_LEVELS } from "../../utils";
+import { useCieIdWebViewLoginNavigation } from "../useCieIdWebViewLoginNavigation";
+
+const mockReplace = jest.fn();
+const mockSelector = jest.fn();
+
+jest.mock("@react-navigation/native", () => {
+  const actualNav = jest.requireActual("@react-navigation/native");
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      replace: mockReplace
+    })
+  };
+});
+
+jest.mock("../../../../../store/hooks", () => ({
+  useIOSelector: mockSelector
+}));
+
+describe("useCieIdWebViewLoginNavigation", () => {
+  const authLevel = AUTH_LEVELS.L2;
+  const isUat = false;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("navigateToCieIdAuthenticationError should replace with CIE_ID_ERROR", () => {
+    const { result } = renderHook(() =>
+      useCieIdWebViewLoginNavigation({ authLevel, isUat })
+    );
+
+    result.current.navigateToCieIdAuthenticationError();
+
+    expect(mockReplace).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
+      screen: AUTHENTICATION_ROUTES.CIE_ID_ERROR
+    });
+  });
+
+  it("navigateToCieIdAuthUrlError should replace with CIE_ID_INCORRECT_URL and the url param", () => {
+    const { result } = renderHook(() =>
+      useCieIdWebViewLoginNavigation({ authLevel, isUat })
+    );
+
+    result.current.navigateToCieIdAuthUrlError("https://untrusted.example.com");
+
+    expect(mockReplace).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
+      screen: AUTHENTICATION_ROUTES.CIE_ID_INCORRECT_URL,
+      params: { url: "https://untrusted.example.com" }
+    });
+  });
+
+  it("navigateToAuthErrorScreen should replace with AUTH_ERROR_SCREEN and the CIE_ID context parameters", () => {
+    const { result } = renderHook(() =>
+      useCieIdWebViewLoginNavigation({ authLevel, isUat })
+    );
+
+    result.current.navigateToAuthErrorScreen("err-code");
+
+    expect(mockReplace).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
+      screen: AUTHENTICATION_ROUTES.AUTH_ERROR_SCREEN,
+      params: {
+        errorCodeOrMessage: "err-code",
+        authMethod: "CIE_ID",
+        authLevel,
+        params: { spidLevel: authLevel, isUat }
+      }
+    });
+  });
+});

--- a/apps/main-app/ts/features/authentication/common/hooks/useCieIdApp.ts
+++ b/apps/main-app/ts/features/authentication/common/hooks/useCieIdApp.ts
@@ -1,0 +1,104 @@
+import { openCieIdApp } from "@pagopa/io-react-native-cieid";
+import { useCallback, useEffect } from "react";
+import { Linking } from "react-native";
+
+import { isAndroid, isIos } from "../../../../utils/platform";
+import { getCieIdEnvironment } from "../../login/cie/utils";
+import {
+  CIE_ID_ERROR,
+  CIE_ID_ERROR_MESSAGE,
+  IO_LOGIN_CIE_SOURCE_APP,
+  IO_LOGIN_CIE_URL_SCHEME
+} from "../../login/cie/utils/cie";
+
+/**
+ * Extracts the error message from a CIE ID app deep-link (`iologincie://...`)
+ * received via `Linking` after the user returns from the CieID app. The
+ * presence of the `CIE_ID_ERROR` marker in `url` indicates the CieID flow
+ * failed; in that case the error message following `CIE_ID_ERROR_MESSAGE` is
+ * returned. Returns `undefined` when `url` does not represent an error
+ */
+const extractCieIdErrorFromUrl = (url: string): string | undefined => {
+  if (!url.includes(CIE_ID_ERROR)) {
+    return undefined;
+  }
+  const [, errorMessage] = url.split(CIE_ID_ERROR_MESSAGE);
+  return errorMessage;
+};
+
+type UseCieIdApp = (params: {
+  /**
+   * Handler called upon failure of the CIE authentication flow.
+   */
+  onFailure: (error: string) => void;
+  /**
+   * Handler called upon successful CIE authentication flow.
+   */
+  onSuccess: (authenticationUrl: string) => void;
+  /**
+   * Wether to use UAT endpoints for CIE auth operations.
+   */
+  useUat?: boolean;
+}) => {
+  startCieIdApp: (url: string) => void;
+};
+
+export const useCieIdApp: UseCieIdApp = ({
+  useUat = false,
+  onFailure,
+  onSuccess
+}) => {
+  useEffect(() => {
+    const urlListenerSubscription = Linking.addEventListener(
+      "url",
+      ({ url }) => {
+        if (!url.startsWith(IO_LOGIN_CIE_URL_SCHEME)) {
+          return;
+        }
+
+        const [, continueUrl] = url.split(IO_LOGIN_CIE_URL_SCHEME);
+        const cieIdError = extractCieIdErrorFromUrl(continueUrl);
+
+        if (cieIdError) {
+          onFailure(cieIdError);
+          return;
+        }
+
+        onSuccess(continueUrl);
+      }
+    );
+
+    return () => urlListenerSubscription.remove();
+  }, [onFailure, onSuccess]);
+
+  const startCieIdApp = useCallback(
+    (url: string) => {
+      // Use the CieID app-to-app flow on Android
+      if (isAndroid) {
+        openCieIdApp(
+          url,
+          result => {
+            if (result.id === "URL") {
+              onSuccess(result.url);
+            } else {
+              onFailure(result.code);
+            }
+          },
+          getCieIdEnvironment(useUat)
+        );
+      }
+
+      // Try to directly open the CieID app on iOS
+      if (isIos) {
+        Linking.openURL(
+          `CIEID://${url}&sourceApp=${IO_LOGIN_CIE_SOURCE_APP}`
+        ).catch(onFailure);
+      }
+    },
+    [useUat, onFailure, onSuccess]
+  );
+
+  return {
+    startCieIdApp
+  };
+};

--- a/apps/main-app/ts/features/authentication/common/hooks/useCieIdWebViewLoginNavigation.ts
+++ b/apps/main-app/ts/features/authentication/common/hooks/useCieIdWebViewLoginNavigation.ts
@@ -1,0 +1,56 @@
+import { useCallback } from "react";
+
+import { useIONavigation } from "../../../../navigation/params/AppParamsList";
+import { AuthLevel } from "../../common/utils";
+import { AUTHENTICATION_ROUTES } from "../navigation/routes";
+
+type UseCieIdWebViewLoginNavigationProps = {
+  authLevel: AuthLevel;
+  isUat: boolean;
+};
+
+export const useCieIdWebViewLoginNavigation = ({
+  authLevel,
+  isUat
+}: UseCieIdWebViewLoginNavigationProps) => {
+  const navigation = useIONavigation();
+
+  const navigateToCieIdAuthenticationError = useCallback(() => {
+    navigation.replace(AUTHENTICATION_ROUTES.MAIN, {
+      screen: AUTHENTICATION_ROUTES.CIE_ID_ERROR
+    });
+  }, [navigation]);
+
+  const navigateToCieIdAuthUrlError = useCallback(
+    (url: string) => {
+      navigation.replace(AUTHENTICATION_ROUTES.MAIN, {
+        screen: AUTHENTICATION_ROUTES.CIE_ID_INCORRECT_URL,
+        params: { url }
+      });
+    },
+    [navigation]
+  );
+
+  const navigateToAuthErrorScreen = useCallback(
+    (errorCodeOrMessage?: string) => {
+      // The choice was made to use `replace` instead of `navigate` because the former unmounts the current screen,
+      // ensuring the re-execution of the `useOneIdentityLoginSource` hook.
+      navigation.replace(AUTHENTICATION_ROUTES.MAIN, {
+        screen: AUTHENTICATION_ROUTES.AUTH_ERROR_SCREEN,
+        params: {
+          errorCodeOrMessage,
+          authMethod: "CIE_ID",
+          authLevel,
+          params: { spidLevel: authLevel, isUat }
+        }
+      });
+    },
+    [navigation, authLevel, isUat]
+  );
+
+  return {
+    navigateToCieIdAuthenticationError,
+    navigateToCieIdAuthUrlError,
+    navigateToAuthErrorScreen
+  };
+};

--- a/apps/main-app/ts/features/authentication/common/navigation/AuthenticationNavigator.tsx
+++ b/apps/main-app/ts/features/authentication/common/navigation/AuthenticationNavigator.tsx
@@ -13,6 +13,7 @@ import { ActiveSessionLandingScreen } from "../../activeSessionLogin/screens/Act
 import ActiveSessionLoginCieCardReaderScreen from "../../activeSessionLogin/screens/cie/ActiveSessionLoginCieCardReaderScreen";
 import ActiveSessionLoginCieConsentDataUsageScreen from "../../activeSessionLogin/screens/cie/ActiveSessionLoginCieConsentDataUsageScreen";
 import ActiveSessionCieIdLoginScreen from "../../activeSessionLogin/screens/cieId/ActiveSessionCieIdLoginScreen";
+import { OneIdentityActiveSessionCieIdLoginScreen } from "../../activeSessionLogin/screens/cieId/OneIdentityActiveSessionCieIdLoginScreen";
 import ActiveSessionIdpLoginScreen from "../../activeSessionLogin/screens/spid/ActiveSessionIdpLoginScreen";
 import { OneIdentityActiveSessionIdpLoginScreen } from "../../activeSessionLogin/screens/spid/OneIdentityActiveSessionIdpLoginScreen";
 import AuthErrorScreen from "../../login/authError/screens/AuthErrorScreen";
@@ -29,6 +30,7 @@ import CiePinScreen from "../../login/cie/screens/CiePinScreen";
 import CieUnexpectedErrorScreen from "../../login/cie/screens/CieUnexpectedErrorScreen";
 import CieWrongCardScreen from "../../login/cie/screens/CieWrongCardScreen";
 import CieWrongCiePinScreen from "../../login/cie/screens/CieWrongCiePinScreen";
+import { OneIdentityCieIdLoginScreen } from "../../login/cie/screens/OneIdentityCieIdLoginScreen";
 import CieIdWizard from "../../login/cie/screens/wizards/CieIdWizard";
 import CiePinWizard from "../../login/cie/screens/wizards/CiePinWizard";
 import IDActivationWizard from "../../login/cie/screens/wizards/IDActivationWizard";
@@ -150,13 +152,21 @@ const AuthenticationStackNavigator = () => {
       />
 
       <Stack.Screen
-        component={CieIdLoginScreen}
+        component={
+          oneIdentityLoginEnabled
+            ? OneIdentityCieIdLoginScreen
+            : CieIdLoginScreen
+        }
         name={AUTHENTICATION_ROUTES.CIE_ID_LOGIN}
         options={{ headerShown: false }}
       />
 
       <Stack.Screen
-        component={ActiveSessionCieIdLoginScreen}
+        component={
+          oneIdentityLoginEnabled
+            ? OneIdentityActiveSessionCieIdLoginScreen
+            : ActiveSessionCieIdLoginScreen
+        }
         name={AUTHENTICATION_ROUTES.CIE_ID_ACTIVE_SESSION_LOGIN}
         options={{ headerShown: false }}
       />

--- a/apps/main-app/ts/features/authentication/common/navigation/params/AuthenticationParamsList.ts
+++ b/apps/main-app/ts/features/authentication/common/navigation/params/AuthenticationParamsList.ts
@@ -6,9 +6,9 @@ import { CieCardReaderScreenNavigationParams } from "../../../login/cie/screens/
 import { CieConsentDataUsageScreenNavigationParams } from "../../../login/cie/screens/CieConsentDataUsageScreen";
 import { UrlNotCompliant } from "../../../login/cie/screens/CieIdAuthUrlError";
 import { CieWrongCiePinScreenNavigationParams } from "../../../login/cie/screens/CieWrongCiePinScreen";
-import { CieIdLoginProps } from "../../../login/cie/shared/utils";
 import { ChosenIdentifier } from "../../../login/optIn/screens/OptInScreen";
 import { UnlockAccessProps } from "../../../login/unlockAccess/components/UnlockAccessComponent";
+import { CieIdLoginProps } from "../../utils/cie.ts";
 import { AUTHENTICATION_ROUTES } from "../routes";
 
 export type AuthenticationParamsList = {

--- a/apps/main-app/ts/features/authentication/common/utils/__tests__/cie.test.ts
+++ b/apps/main-app/ts/features/authentication/common/utils/__tests__/cie.test.ts
@@ -1,0 +1,141 @@
+import { Platform } from "react-native";
+
+import {
+  defaultUserAgent,
+  iOSUserAgent,
+  isAllowedUrl,
+  WHITELISTED_DOMAINS
+} from "../cie";
+
+describe("isAllowedUrl", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each(WHITELISTED_DOMAINS)(
+    "should return true for the whitelisted domain %s",
+    domain => {
+      expect(isAllowedUrl(domain)).toBe(true);
+    }
+  );
+
+  it.each(WHITELISTED_DOMAINS)(
+    "should return true for the whitelisted domain %s with a path and query string",
+    domain => {
+      expect(isAllowedUrl(`${domain}/some/path?foo=bar`)).toBe(true);
+    }
+  );
+
+  it("should return false for a non-whitelisted domain", () => {
+    expect(isAllowedUrl("https://evil.com")).toBe(false);
+  });
+
+  it("should return false for a domain that merely contains a whitelisted domain as a suffix of its hostname", () => {
+    expect(isAllowedUrl("https://evilidserver.servizicie.interno.gov.it")).toBe(
+      false
+    );
+  });
+
+  it("should return false for a domain that appends a whitelisted domain as a prefix of an unrelated hostname", () => {
+    expect(
+      isAllowedUrl("https://idserver.servizicie.interno.gov.it.evil.com")
+    ).toBe(false);
+  });
+
+  it("should return false when the scheme doesn't match a whitelisted domain (http instead of https)", () => {
+    expect(isAllowedUrl("http://idserver.servizicie.interno.gov.it")).toBe(
+      false
+    );
+  });
+
+  it("should return false for a malformed URL", () => {
+    expect(isAllowedUrl("not-a-url")).toBe(false);
+  });
+
+  it("should return false for an empty string", () => {
+    expect(isAllowedUrl("")).toBe(false);
+  });
+});
+
+describe("defaultUserAgent", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it("should be the iOS user agent on iOS", () => {
+    jest.resetModules();
+    jest
+      .spyOn(Platform, "select")
+      .mockImplementation((spec: Record<string, unknown>) => spec.ios);
+
+    const { defaultUserAgent: iosDefaultUserAgent } = require("../cie");
+
+    expect(iosDefaultUserAgent).toBe(iOSUserAgent);
+  });
+
+  it("should be undefined on non-iOS platforms", () => {
+    jest.resetModules();
+    jest
+      .spyOn(Platform, "select")
+      .mockImplementation((spec: Record<string, unknown>) => spec.default);
+
+    const { defaultUserAgent: androidDefaultUserAgent } = require("../cie");
+
+    expect(androidDefaultUserAgent).toBeUndefined();
+  });
+
+  it("should match the platform-select result for the current test environment", () => {
+    expect(defaultUserAgent).toBe(
+      Platform.select({ ios: iOSUserAgent, default: undefined })
+    );
+  });
+});
+
+describe("originSchemasWhiteList", () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it("should always include the https and iologin schemas", () => {
+    const { originSchemasWhiteList } = require("../cie");
+
+    expect(originSchemasWhiteList).toEqual(
+      expect.arrayContaining(["https://*", "iologin://*"])
+    );
+  });
+
+  it("should also include the http schema when running in a dev environment", () => {
+    jest.doMock("../../../../../utils/environment", () => ({ isDevEnv: true }));
+
+    const { originSchemasWhiteList } = require("../cie");
+
+    expect(originSchemasWhiteList).toEqual(
+      expect.arrayContaining(["https://*", "iologin://*", "http://*"])
+    );
+  });
+
+  it("should not include the http schema when not running in a dev environment", () => {
+    jest.doMock("../../../../../utils/environment", () => ({
+      isDevEnv: false
+    }));
+
+    const { originSchemasWhiteList } = require("../cie");
+
+    expect(originSchemasWhiteList).not.toEqual(
+      expect.arrayContaining(["http://*"])
+    );
+  });
+});
+
+describe("WHITELISTED_DOMAINS", () => {
+  it("should only contain https origins", () => {
+    WHITELISTED_DOMAINS.forEach(domain => {
+      expect(domain.startsWith("https://")).toBe(true);
+    });
+  });
+
+  it("should not contain duplicate entries", () => {
+    expect(new Set(WHITELISTED_DOMAINS).size).toBe(WHITELISTED_DOMAINS.length);
+  });
+});

--- a/apps/main-app/ts/features/authentication/common/utils/__tests__/login.test.ts
+++ b/apps/main-app/ts/features/authentication/common/utils/__tests__/login.test.ts
@@ -1,6 +1,13 @@
 import { PublicKey } from "@pagopa/io-react-native-crypto";
 
-import { extractLoginResult, getIntentFallbackUrl, getLoginHeaders } from "..";
+import {
+  extractLoginResult,
+  getIntentFallbackUrl,
+  getLoginHeaders,
+  isValidCallbackUrl
+} from "..";
+
+const mockApiUrlPrefix = "https://mock-api.io.pagopa.it";
 
 jest.mock("../../../../../utils/environment", () => ({
   isLocalEnv: true
@@ -9,6 +16,11 @@ jest.mock("../../../../../utils/environment", () => ({
 jest.mock("react-native-device-info", () => ({
   getReadableVersion: jest.fn().mockReturnValue("1.2.3.4"),
   getVersion: jest.fn().mockReturnValue("1.2.3.4")
+}));
+
+jest.mock("../../../../../config", () => ({
+  apiUrlPrefix: "https://mock-api.io.pagopa.it",
+  spidRelayState: "mock-relay-state"
 }));
 
 describe("hook the login outcome from the url", () => {
@@ -189,5 +201,39 @@ describe("getLoginHeaders", () => {
       "x-pagopa-login-type": "LV",
       "x-pagopa-idp-id": idpId
     });
+  });
+});
+
+describe("isValidCallbackUrl", () => {
+  const callbackUrlCases: ReadonlyArray<[string, string, boolean]> = [
+    [
+      "v1 callback URL is a valid callback",
+      `${mockApiUrlPrefix}/api/auth/v1/callback`,
+      true
+    ],
+    [
+      "v2 callback URL is a valid callback",
+      `${mockApiUrlPrefix}/api/auth/v2/callback`,
+      true
+    ],
+    [
+      "URL with an unrelated path is not a valid callback",
+      `${mockApiUrlPrefix}/api/auth/v1/login`,
+      false
+    ],
+    [
+      "URL that only contains the callback path as a substring is not a valid callback",
+      `${mockApiUrlPrefix}/api/auth/v1/callback/extra-path`,
+      false
+    ],
+    [
+      "URL with a different host is not a valid callback",
+      "https://evil.com/api/auth/v2/callback",
+      false
+    ]
+  ];
+
+  test.each(callbackUrlCases)("%s", (_, url, expectedResult) => {
+    expect(isValidCallbackUrl(url)).toBe(expectedResult);
   });
 });

--- a/apps/main-app/ts/features/authentication/common/utils/cie.ts
+++ b/apps/main-app/ts/features/authentication/common/utils/cie.ts
@@ -1,7 +1,7 @@
 import { Platform } from "react-native";
 
-import { isDevEnv } from "../../../../../utils/environment";
-import { AuthLevel } from "../../../common/utils";
+import { AuthLevel } from ".";
+import { isDevEnv } from "../../../../utils/environment";
 
 export const iOSUserAgent =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 14_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1";
@@ -23,8 +23,21 @@ export const WHITELISTED_DOMAINS = [
   "https://mtls.oidc.idserver.servizicie.interno.gov.it",
   "https://mtls.idserver.servizicie.interno.gov.it",
   "https://ios.idserver.servizicie.interno.gov.it",
-  "https://ios.oidc.idserver.servizicie.interno.gov.it"
+  "https://ios.oidc.idserver.servizicie.interno.gov.it",
+  "https://preproduzione.idserver.servizicie.interno.gov.it"
 ];
+
+/**
+ * Checks whether `url`'s origin is one of the trusted CIE ID identity server in `WHITELISTED_DOMAINS`.
+ */
+export const isAllowedUrl = (url: string) => {
+  try {
+    const { origin } = new URL(url);
+    return WHITELISTED_DOMAINS.includes(origin);
+  } catch {
+    return false;
+  }
+};
 
 export type CieIdLoginProps = {
   isUat: boolean;

--- a/apps/main-app/ts/features/authentication/common/utils/index.tsx
+++ b/apps/main-app/ts/features/authentication/common/utils/index.tsx
@@ -3,7 +3,7 @@ import { PublicKey } from "@pagopa/io-react-native-crypto";
 import { WebViewNavigation } from "react-native-webview/lib/WebViewTypes";
 import URLParse from "url-parse";
 
-import { spidRelayState } from "../../../../config";
+import { apiUrlPrefix, spidRelayState } from "../../../../config";
 import { getAppVersion } from "../../../../utils/appVersion";
 import { isDevEnv, isLocalEnv } from "../../../../utils/environment";
 import { isStringNullyOrEmpty } from "../../../../utils/strings";
@@ -209,3 +209,16 @@ export const originSchemasWhiteList = [
 ];
 
 export const CALLBACK_PATH = "/api/auth/v2/callback";
+
+/**
+ * Checks whether `url` is an exact match of one of the OIDC callback endpoints
+ * (`v1` or `v2`) exposed by the backend at `apiUrlPrefix`. Both versions are accepted.
+ */
+export const isValidCallbackUrl = (url: string) => {
+  const validUrls = [
+    `${apiUrlPrefix}/api/auth/v1/callback`,
+    `${apiUrlPrefix}/api/auth/v2/callback`
+  ];
+
+  return validUrls.includes(url);
+};

--- a/apps/main-app/ts/features/authentication/login/authError/screens/AuthErrorScreen.tsx
+++ b/apps/main-app/ts/features/authentication/login/authError/screens/AuthErrorScreen.tsx
@@ -18,7 +18,7 @@ import { isActiveSessionLoginSelector } from "../../../activeSessionLogin/store/
 import AuthErrorComponent from "../../../common/components/AuthErrorComponent";
 import { AuthenticationParamsList } from "../../../common/navigation/params/AuthenticationParamsList";
 import { AUTHENTICATION_ROUTES } from "../../../common/navigation/routes";
-import { CieIdLoginProps } from "../../cie/shared/utils";
+import { CieIdLoginProps } from "../../../common/utils/cie";
 import {
   resetSpidLoginState,
   setSpidLoginInLoadingState

--- a/apps/main-app/ts/features/authentication/login/cie/components/CieIdLoginWebView.tsx
+++ b/apps/main-app/ts/features/authentication/login/cie/components/CieIdLoginWebView.tsx
@@ -25,14 +25,14 @@ import { AUTHENTICATION_ROUTES } from "../../../common/navigation/routes";
 import { loginFailure, loginSuccess } from "../../../common/store/actions";
 import { loggedInAuthSelector } from "../../../common/store/selectors";
 import { AUTH_LEVELS, onLoginUriChanged } from "../../../common/utils";
-import { IdpCIE_ID } from "../../hooks/useNavigateToLoginMethod";
-import { LoadingOverlay } from "../shared/LoadingSpinnerOverlay";
 import {
   CieIdLoginProps,
   defaultUserAgent,
   originSchemasWhiteList,
   WHITELISTED_DOMAINS
-} from "../shared/utils";
+} from "../../../common/utils/cie";
+import { IdpCIE_ID } from "../../hooks/useNavigateToLoginMethod";
+import { LoadingOverlay } from "../shared/LoadingSpinnerOverlay";
 import {
   getCieIdEnvironment,
   getCieIDLoginUri,

--- a/apps/main-app/ts/features/authentication/login/cie/screens/OneIdentityCieIdLoginScreen.tsx
+++ b/apps/main-app/ts/features/authentication/login/cie/screens/OneIdentityCieIdLoginScreen.tsx
@@ -1,0 +1,160 @@
+import { useCallback, useMemo } from "react";
+
+import { apiUrlPrefix } from "../../../../../config";
+import {
+  HeaderSecondLevelHookProps,
+  useHeaderSecondLevel
+} from "../../../../../hooks/useHeaderSecondLevel";
+import { IOStackNavigationRouteProps } from "../../../../../navigation/params/AppParamsList";
+import { useIODispatch, useIOSelector } from "../../../../../store/hooks";
+import { useOnboardingAbortAlert } from "../../../../onboarding/hooks/useOnboardingAbortAlert";
+import { trackLoginSpidError } from "../../../common/analytics/spidAnalytics";
+import {
+  CieIdWebViewLogin,
+  CieIdWebViewLoginEvent
+} from "../../../common/components/CieIdWebViewLogin";
+import { IdpSuccessfulAuthentication } from "../../../common/components/IdpSuccessfulAuthentication";
+import { useCieIdWebViewLoginNavigation } from "../../../common/hooks/useCieIdWebViewLoginNavigation";
+import { AuthenticationParamsList } from "../../../common/navigation/params/AuthenticationParamsList";
+import { AUTHENTICATION_ROUTES } from "../../../common/navigation/routes";
+import { loginFailure, loginSuccess } from "../../../common/store/actions";
+import { loggedInAuthSelector } from "../../../common/store/selectors";
+import { AuthLevel } from "../../../common/utils";
+import { IdpCIE_ID } from "../../hooks/useNavigateToLoginMethod";
+
+type OneIdentityCieIdLoginScreenProps = IOStackNavigationRouteProps<
+  AuthenticationParamsList,
+  typeof AUTHENTICATION_ROUTES.CIE_ID_LOGIN
+>;
+
+export const OneIdentityCieIdLoginScreen = ({
+  navigation,
+  route
+}: OneIdentityCieIdLoginScreenProps) => {
+  const { spidLevel: authLevel, isUat } = route.params;
+
+  const loggedInAuth = useIOSelector(loggedInAuthSelector);
+
+  const { showAlert } = useOnboardingAbortAlert();
+
+  const handleGoBack = useCallback(() => {
+    showAlert(() => {
+      navigation.navigate(AUTHENTICATION_ROUTES.MAIN, {
+        screen: AUTHENTICATION_ROUTES.LANDING
+      });
+    });
+  }, [showAlert, navigation]);
+
+  const headerProps: HeaderSecondLevelHookProps = useMemo(() => {
+    if (loggedInAuth) {
+      return { title: "", canGoBack: false };
+    }
+    return {
+      title: "",
+      goBack: handleGoBack
+    };
+  }, [handleGoBack, loggedInAuth]);
+
+  useHeaderSecondLevel(headerProps);
+
+  if (loggedInAuth) {
+    return <IdpSuccessfulAuthentication />;
+  }
+
+  return (
+    <OneIdentityCieIdLoginScreenContent authLevel={authLevel} isUat={isUat} />
+  );
+};
+
+type OneIdentityCieIdLoginScreenContentProps = {
+  authLevel: AuthLevel;
+  isUat: boolean;
+};
+
+const OneIdentityCieIdLoginScreenContent = ({
+  isUat,
+  authLevel
+}: OneIdentityCieIdLoginScreenContentProps) => {
+  const dispatch = useIODispatch();
+
+  const {
+    navigateToCieIdAuthenticationError,
+    navigateToCieIdAuthUrlError,
+    navigateToAuthErrorScreen
+  } = useCieIdWebViewLoginNavigation({ authLevel, isUat });
+
+  const handleLoginFailure = useCallback(
+    (reason: string, code?: string, message?: string) => {
+      const errorCodeOrMessage = code ?? message;
+
+      trackLoginSpidError(errorCodeOrMessage, {
+        idp: IdpCIE_ID.id,
+        flow: "auth",
+        "error message": message
+      });
+
+      dispatch(
+        loginFailure({
+          error: new Error(reason),
+          idp: "cieid"
+        })
+      );
+      navigateToAuthErrorScreen(errorCodeOrMessage);
+    },
+    [dispatch, navigateToAuthErrorScreen]
+  );
+
+  const handleLoginSuccess = useCallback(
+    (token: string) => {
+      dispatch(loginSuccess({ token, idp: "cieid" }));
+    },
+    [dispatch]
+  );
+
+  const handleEvent = useCallback(
+    (event: CieIdWebViewLoginEvent) => {
+      switch (event.type) {
+        case "CANCEL":
+        case "ONE_IDENTITY_LOGIN_FAILURE":
+        case "WEBVIEW_ERROR": {
+          navigateToCieIdAuthenticationError();
+          break;
+        }
+        case "LOGIN_FAILURE": {
+          const { code, message, reason } = event.payload;
+          handleLoginFailure(reason, code, message);
+          break;
+        }
+        case "LOGIN_SUCCESS": {
+          const { token } = event.payload;
+          handleLoginSuccess(token);
+          break;
+        }
+        case "NOT_ALLOWED_URL": {
+          const { url } = event.payload;
+          navigateToCieIdAuthUrlError(url);
+          break;
+        }
+        case "WEBVIEW_HTTP_ERROR": {
+          const { statusCode, url } = event.payload;
+          // Ignore 403 errors for URLs that are not part of the API login URL prefix
+          if (!url.includes(apiUrlPrefix) && statusCode === 403) {
+            break;
+          }
+          navigateToCieIdAuthenticationError();
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    [
+      handleLoginFailure,
+      handleLoginSuccess,
+      navigateToCieIdAuthUrlError,
+      navigateToCieIdAuthenticationError
+    ]
+  );
+
+  return <CieIdWebViewLogin flow="auth" isUat={isUat} onEvent={handleEvent} />;
+};

--- a/apps/main-app/ts/features/authentication/login/cie/screens/__test__/OneIdentityCieIdLoginScreen.test.tsx
+++ b/apps/main-app/ts/features/authentication/login/cie/screens/__test__/OneIdentityCieIdLoginScreen.test.tsx
@@ -1,0 +1,172 @@
+import { fireEvent } from "@testing-library/react-native";
+import { createStore } from "redux";
+
+import { applicationChangeState } from "../../../../../../store/actions/application";
+import * as IOHooks from "../../../../../../store/hooks";
+import { appReducer } from "../../../../../../store/reducers";
+import { renderScreenWithNavigationStoreContext } from "../../../../../../utils/testWrapper";
+import * as useOneIdentityLoginSourceModule from "../../../../../lollipop/hooks/useOneIdentityLoginSource";
+import * as useCieIdAppModule from "../../../../common/hooks/useCieIdApp";
+import { AUTHENTICATION_ROUTES } from "../../../../common/navigation/routes";
+import { loginFailure, loginSuccess } from "../../../../common/store/actions";
+import * as commonStoreSelector from "../../../../common/store/selectors";
+import { AUTH_LEVELS } from "../../../../common/utils";
+import { OneIdentityCieIdLoginScreen } from "../OneIdentityCieIdLoginScreen";
+
+jest.mock("react-native-webview", () => {
+  const { forwardRef } = jest.requireActual("react");
+  const { View } = jest.requireActual("react-native");
+  const WebView = forwardRef((props: object, ref: unknown) => (
+    <View ref={ref as never} {...props} />
+  ));
+  return {
+    WebView,
+    default: WebView,
+    __esModule: true
+  };
+});
+
+const mockReplace = jest.fn();
+jest.mock("@react-navigation/native", () => {
+  const actualNav = jest.requireActual("@react-navigation/native");
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      replace: mockReplace,
+      navigate: jest.fn()
+    })
+  };
+});
+
+jest.mock("../../../../../../hooks/useHeaderSecondLevel", () => ({
+  useHeaderSecondLevel: jest.fn()
+}));
+
+jest.mock("../../../../common/analytics/spidAnalytics", () => ({
+  trackLoginSpidError: jest.fn()
+}));
+
+jest.mock("../../../../../onboarding/hooks/useOnboardingAbortAlert", () => ({
+  useOnboardingAbortAlert: () => ({ showAlert: jest.fn() })
+}));
+
+describe("OneIdentityCieIdLoginScreen", () => {
+  const mockDispatch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.spyOn(IOHooks, "useIODispatch").mockReturnValue(mockDispatch);
+    jest
+      .spyOn(commonStoreSelector, "loggedInAuthSelector")
+      .mockReturnValue(undefined);
+    jest
+      .spyOn(useOneIdentityLoginSourceModule, "useOneIdentityLoginSource")
+      .mockReturnValue({
+        loginSourceState: {
+          status: "one-identity-authorize",
+          webviewSource: { uri: "https://example.com/authorize" }
+        },
+        shouldBlockUrlNavigationWhileCheckingLollipop: jest.fn(() => false)
+      });
+    jest.spyOn(useCieIdAppModule, "useCieIdApp").mockReturnValue({
+      startCieIdApp: jest.fn()
+    });
+  });
+
+  it("should render the IdpSuccessfulAuthentication screen when logged in", () => {
+    jest.spyOn(commonStoreSelector, "loggedInAuthSelector").mockReturnValue({
+      kind: "LoggedInWithSessionInfo",
+      idp: { id: "cieid", name: "cieid", logo: { light: { uri: "" } } },
+      sessionInfo: {},
+      sessionToken: "mock-session-token"
+    } as any);
+
+    const { getByTestId } = renderComponent();
+
+    expect(getByTestId("idp-successful-authentication")).toBeTruthy();
+  });
+
+  it("should render the WebView", () => {
+    const { getByTestId } = renderComponent();
+
+    expect(getByTestId("cie-id-webview")).toBeTruthy();
+  });
+
+  it("should dispatch loginSuccess on a successful login URL", () => {
+    const { getByTestId } = renderComponent();
+    const webview = getByTestId("cie-id-webview");
+
+    fireEvent(webview, "onShouldStartLoadWithRequest", {
+      url: "https://example.it/profile.html#token=session-token"
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      loginSuccess({ token: "session-token", idp: "cieid" })
+    );
+  });
+
+  it("should dispatch loginFailure and navigate to AuthErrorScreen on a failed login URL", () => {
+    const { getByTestId } = renderComponent();
+    const webview = getByTestId("cie-id-webview");
+
+    fireEvent(webview, "onShouldStartLoadWithRequest", {
+      url: "https://example.it/error.html?errorCode=err-code"
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      loginFailure({
+        error: expect.any(Error),
+        idp: "cieid"
+      })
+    );
+
+    expect(mockReplace).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
+      screen: AUTHENTICATION_ROUTES.AUTH_ERROR_SCREEN,
+      params: {
+        errorCodeOrMessage: "err-code",
+        authMethod: "CIE_ID",
+        authLevel: AUTH_LEVELS.L2,
+        params: { spidLevel: AUTH_LEVELS.L2, isUat: false }
+      }
+    });
+  });
+
+  it("should navigate to CIE_ID_INCORRECT_URL when the CieID app returns an untrusted URL", () => {
+    renderComponent();
+
+    const { onSuccess } = jest.mocked(useCieIdAppModule.useCieIdApp).mock
+      .calls[0][0];
+    onSuccess("https://not-whitelisted.example.com");
+
+    expect(mockReplace).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
+      screen: AUTHENTICATION_ROUTES.CIE_ID_INCORRECT_URL,
+      params: { url: "https://not-whitelisted.example.com" }
+    });
+  });
+
+  it("should navigate to CIE_ID_ERROR on a generic WebView error", () => {
+    const { getByTestId } = renderComponent();
+    const webview = getByTestId("cie-id-webview");
+
+    fireEvent(webview, "onError", {
+      nativeEvent: { url: "https://example.com/authorize" }
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith(AUTHENTICATION_ROUTES.MAIN, {
+      screen: AUTHENTICATION_ROUTES.CIE_ID_ERROR
+    });
+  });
+});
+
+const renderComponent = () => {
+  const initialState = appReducer(undefined, applicationChangeState("active"));
+  const store = createStore(appReducer, initialState as any);
+
+  return renderScreenWithNavigationStoreContext(
+    OneIdentityCieIdLoginScreen,
+    AUTHENTICATION_ROUTES.CIE_ID_LOGIN,
+    { spidLevel: AUTH_LEVELS.L2, isUat: false },
+    store
+  );
+};

--- a/apps/main-app/ts/features/authentication/login/cie/utils/__tests__/index.test.ts
+++ b/apps/main-app/ts/features/authentication/login/cie/utils/__tests__/index.test.ts
@@ -10,7 +10,7 @@ describe("isAuthenticationUrl", () => {
     "http://localhost/livello1?id=1",
     "http://localhost/livello2",
     "http://localhost/nextUrl?id=1",
-    "http://localhost/openApp/test"
+    "http://localhost/OpenApp/test"
   ];
 
   it.each(NOT_AUTH_URLS)("should be false -> %s", url => {

--- a/apps/main-app/ts/features/authentication/login/cie/utils/index.ts
+++ b/apps/main-app/ts/features/authentication/login/cie/utils/index.ts
@@ -7,6 +7,17 @@ import { AuthLevel, SPID_AUTH_LEVEL_MAP } from "../../../common/utils";
 export const cieFlowForDevServerEnabled =
   isDevEnv && cieLoginFlowWithDevServerEnabled;
 
+const CIE_IDP_ID_MAP: Record<"prod" | "uat", string> = {
+  prod: "https://idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO",
+  uat: "https://preproduzione.idserver.servizicie.interno.gov.it/idp/profile/SAML2/POST/SSO"
+};
+
+/**
+ * Returns the CIE Identity Provider ID based on the UAT flag.
+ */
+export const getCieIdpId = (useUat: boolean) =>
+  useUat ? CIE_IDP_ID_MAP.uat : CIE_IDP_ID_MAP.prod;
+
 /**
  * Maps the CIE login UAT flag to the CieID app environment to open.
  */
@@ -32,7 +43,7 @@ export const getCieIDLoginUri = (
  * @returns a `boolean`
  */
 export const isAuthenticationUrl = (url: string) => {
-  const authUrlRegex = /\/(livello1|livello2|nextUrl|openApp)(\/|\?|$)/;
+  const authUrlRegex = /\/(livello1|livello2|nextUrl|OpenApp)(\/|\?|$)/;
 
   return authUrlRegex.test(url);
 };

--- a/apps/main-app/ts/features/authentication/login/optIn/screens/OptInScreen.tsx
+++ b/apps/main-app/ts/features/authentication/login/optIn/screens/OptInScreen.tsx
@@ -31,6 +31,7 @@ import { setFastLoginOptSessionLogin } from "../../../activeSessionLogin/store/a
 import { isActiveSessionLoginSelector } from "../../../activeSessionLogin/store/selectors";
 import { AuthenticationParamsList } from "../../../common/navigation/params/AuthenticationParamsList";
 import { AUTHENTICATION_ROUTES } from "../../../common/navigation/routes";
+import { CieIdLoginProps } from "../../../common/utils/cie";
 import {
   trackLoginSessionOptIn,
   trackLoginSessionOptIn30,
@@ -38,7 +39,6 @@ import {
   trackLoginSessionOptInInfo
 } from "../../../fastLogin/analytics/optinAnalytics";
 import { setFastLoginOptIn } from "../../../fastLogin/store/actions/optInActions";
-import { CieIdLoginProps } from "../../cie/shared/utils";
 
 export enum Identifier {
   CIE = "CIE",

--- a/apps/main-app/ts/features/lollipop/hooks/__tests__/useOneIdentityLoginSource.test.tsx
+++ b/apps/main-app/ts/features/lollipop/hooks/__tests__/useOneIdentityLoginSource.test.tsx
@@ -84,7 +84,7 @@ const setupTest = ({
   const utils = renderHook(
     () =>
       useOneIdentityLoginSource({
-        idp: mockIdp,
+        idpId: mockIdp.id,
         onFailure,
         minAuthLevel
       }),

--- a/apps/main-app/ts/features/lollipop/hooks/useOneIdentityLoginSource.tsx
+++ b/apps/main-app/ts/features/lollipop/hooks/useOneIdentityLoginSource.tsx
@@ -9,7 +9,6 @@ import { useIODispatch, useIOSelector } from "../../../store/hooks";
 import { hashedProfileFiscalCodeSelector } from "../../../store/reducers/crossSessions";
 import { isMixpanelEnabled } from "../../../store/reducers/persistedPreferences";
 import { trackLollipopIdpLoginFailure } from "../../../utils/analytics";
-import { SpidIdp } from "../../../utils/idps";
 import {
   isActiveSessionFastLoginEnabledSelector,
   isActiveSessionLoginSelector
@@ -134,9 +133,9 @@ const buildWebviewSource = (
 
 export type UseOneIdentityLoginSource = (params: {
   /**
-   * The identity provider the user selected to login with.
+   * The ID of the identity provider the user selected to login with.
    */
-  idp: SpidIdp;
+  idpId: string;
   /**
    * The minimum required SPID level for the authentication flow. Defaults to "L2".
    */
@@ -158,7 +157,7 @@ export type UseOneIdentityLoginSource = (params: {
 };
 
 export const useOneIdentityLoginSource: UseOneIdentityLoginSource = ({
-  idp,
+  idpId,
   onFailure,
   minAuthLevel = AUTH_LEVELS.L2
 }) => {
@@ -281,7 +280,7 @@ export const useOneIdentityLoginSource: UseOneIdentityLoginSource = ({
 
     const authorizationUrl = buildAuthorizationUrl(
       result.value,
-      idp.id,
+      idpId,
       minAuthLevel
     );
 
@@ -290,7 +289,7 @@ export const useOneIdentityLoginSource: UseOneIdentityLoginSource = ({
       webviewSource: buildWebviewSource(authorizationUrl, publicKey)
     });
   }, [
-    idp,
+    idpId,
     ephemeralKeyTag,
     mixpanelEnabled,
     dispatch,


### PR DESCRIPTION
## Short description
This PR implements the CieID authentication flow using OneIdentity.

## List of changes proposed in this pull request
- Updated the `useOneIdentityLoginSource` hook, along with its test suite and related imports. It now accepts the IdP `id` as an input parameter.
- Added the `CieIdWebViewLogin` component to encapsulate the WebView logic for CieID authentication. It communicates with its parent component by emitting specific events.
- Added the `useCieIdApp` hook to handle interactions and communication with the external CieID app.
- Added `OneIdentityCieIdLoginScreen` and `OneIdentityActiveSessionCieIdLoginScreen` to manage UI state, header configuration and navigation. These implement a new event-driven architecture to handle login successes, failures and WebView errors.
- Added the `useCieIdWebViewLoginNavigation` hook to centralize and share routing logic between the `OneIdentityCieIdLoginScreen` and `OneIdentityActiveSessionCieIdLoginScreen screens.
- Updated the SPID login screens and its tests to use the new callback URL validation logic

## How to test
1. Download the CieID Pre-production app and register your CIE (L3).
2. Open the IO app, enable OneIdentity, and toggle on the CIE UAT env.
3. Proceed with the CieID login flow.
4. Verify that the session token is successfully issued at the end of the process.
